### PR TITLE
Switch AddInst struct init style.

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -25,9 +25,10 @@ static auto PerformCallToGenericClass(Context& context, Parse::NodeId node_id,
       context, node_id, /*self_id=*/SemIR::InstId::Invalid, arg_ids,
       /*return_storage_id=*/SemIR::InstId::Invalid, class_info.decl_id,
       class_info.implicit_param_refs_id, class_info.param_refs_id);
-  return context.AddInst(
-      {node_id,
-       SemIR::ClassType{SemIR::TypeId::TypeType, class_id, converted_args_id}});
+  return context.AddInst<SemIR::ClassType>(node_id,
+                                           {.type_id = SemIR::TypeId::TypeType,
+                                            .class_id = class_id,
+                                            .args_id = converted_args_id});
 }
 
 auto PerformCall(Context& context, Parse::NodeId node_id,
@@ -73,8 +74,8 @@ auto PerformCall(Context& context, Parse::NodeId node_id,
     case SemIR::Function::ReturnSlot::Present:
       // Tentatively put storage for a temporary in the function's return slot.
       // This will be replaced if necessary when we perform initialization.
-      return_storage_id = context.AddInst(
-          {node_id, SemIR::TemporaryStorage{callable.return_type_id}});
+      return_storage_id = context.AddInst<SemIR::TemporaryStorage>(
+          node_id, {.type_id = callable.return_type_id});
       break;
     case SemIR::Function::ReturnSlot::Absent:
       break;
@@ -91,8 +92,10 @@ auto PerformCall(Context& context, Parse::NodeId node_id,
       ConvertCallArgs(context, node_id, callee_function.self_id, arg_ids,
                       return_storage_id, callable.decl_id,
                       callable.implicit_param_refs_id, callable.param_refs_id);
-  auto call_inst_id = context.AddInst(
-      {node_id, SemIR::Call{type_id, callee_id, converted_args_id}});
+  auto call_inst_id =
+      context.AddInst<SemIR::Call>(node_id, {.type_id = type_id,
+                                             .callee_id = callee_id,
+                                             .args_id = converted_args_id});
 
   return call_inst_id;
 }

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -323,10 +323,10 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info,
       SemIR::NameScopeId::Invalid);
   CARBON_CHECK(package_scope_id == SemIR::NameScopeId::Package);
 
-  auto package_inst_id = context.AddInst(
-      {Parse::NodeId::Invalid,
-       SemIR::Namespace{namespace_type_id, SemIR::NameScopeId::Package,
-                        SemIR::InstId::Invalid}});
+  auto package_inst_id = context.AddInst<SemIR::Namespace>(
+      Parse::NodeId::Invalid, {.type_id = namespace_type_id,
+                               .name_scope_id = SemIR::NameScopeId::Package,
+                               .import_id = SemIR::InstId::Invalid});
   CARBON_CHECK(package_inst_id == SemIR::InstId::PackageNamespace);
 
   // If there is an implicit `api` import, set it first so that it uses the

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -44,9 +44,21 @@ class Context {
   // Adds an instruction to the current block, returning the produced ID.
   auto AddInst(SemIR::LocIdAndInst loc_id_and_inst) -> SemIR::InstId;
 
+  // Convenience for AddInst on specific instruction types.
+  template <typename InstT>
+  auto AddInst(SemIR::LocId loc_id, InstT inst) -> SemIR::InstId {
+    return AddInst({.loc_id = loc_id, .inst = inst});
+  }
+
   // Adds an instruction in no block, returning the produced ID. Should be used
   // rarely.
   auto AddInstInNoBlock(SemIR::LocIdAndInst loc_id_and_inst) -> SemIR::InstId;
+
+  // Convenience for AddInstInNoBlock on specific instruction types.
+  template <typename InstT>
+  auto AddInstInNoBlock(SemIR::LocId loc_id, InstT inst) -> SemIR::InstId {
+    return AddInstInNoBlock({.loc_id = loc_id, .inst = inst});
+  }
 
   // Adds an instruction to the current block, returning the produced ID. The
   // instruction is a placeholder that is expected to be replaced by
@@ -64,7 +76,11 @@ class Context {
 
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
   // result. Only valid if the LocId is for a NodeId.
-  auto AddInstAndPush(SemIR::LocIdAndInst loc_id_and_inst) -> void;
+  template <typename InstT>
+  auto AddInstAndPush(SemIR::LocId loc_id, InstT inst) -> void {
+    auto inst_id = AddInst(loc_id, inst);
+    node_stack_.Push(loc_id.node_id(), inst_id);
+  }
 
   // Replaces the instruction `inst_id` with `loc_id_and_inst`. The instruction
   // is required to not have been used in any constant evaluation, either

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -45,9 +45,9 @@ class Context {
   auto AddInst(SemIR::LocIdAndInst loc_id_and_inst) -> SemIR::InstId;
 
   // Convenience for AddInst on specific instruction types.
-  template <typename InstT>
-  auto AddInst(SemIR::LocId loc_id, InstT inst) -> SemIR::InstId {
-    return AddInst({.loc_id = loc_id, .inst = inst});
+  template <typename InstT, typename LocT>
+  auto AddInst(LocT loc_id, InstT inst) -> SemIR::InstId {
+    return AddInst(SemIR::LocIdAndInst(loc_id, inst));
   }
 
   // Adds an instruction in no block, returning the produced ID. Should be used
@@ -55,9 +55,9 @@ class Context {
   auto AddInstInNoBlock(SemIR::LocIdAndInst loc_id_and_inst) -> SemIR::InstId;
 
   // Convenience for AddInstInNoBlock on specific instruction types.
-  template <typename InstT>
-  auto AddInstInNoBlock(SemIR::LocId loc_id, InstT inst) -> SemIR::InstId {
-    return AddInstInNoBlock({.loc_id = loc_id, .inst = inst});
+  template <typename InstT, typename LocT>
+  auto AddInstInNoBlock(LocT loc_id, InstT inst) -> SemIR::InstId {
+    return AddInstInNoBlock(SemIR::LocIdAndInst(loc_id, inst));
   }
 
   // Adds an instruction to the current block, returning the produced ID. The
@@ -76,10 +76,11 @@ class Context {
 
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
   // result. Only valid if the LocId is for a NodeId.
-  template <typename InstT>
-  auto AddInstAndPush(SemIR::LocId loc_id, InstT inst) -> void {
-    auto inst_id = AddInst(loc_id, inst);
-    node_stack_.Push(loc_id.node_id(), inst_id);
+  template <typename InstT, typename LocT>
+  auto AddInstAndPush(LocT loc_id, InstT inst) -> void {
+    SemIR::LocIdAndInst arg(loc_id, inst);
+    auto inst_id = AddInst(arg);
+    node_stack_.Push(arg.loc_id.node_id(), inst_id);
   }
 
   // Replaces the instruction `inst_id` with `loc_id_and_inst`. The instruction

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -46,10 +46,11 @@ auto HandleArrayExpr(Context& context, Parse::ArrayExprId node_id) -> bool {
     return true;
   }
 
-  context.AddInstAndPush(
-      {node_id, SemIR::ArrayType{SemIR::TypeId::TypeType, bound_inst_id,
-                                 ExprAsType(context, element_type_node_id,
-                                            element_type_inst_id)}});
+  context.AddInstAndPush<SemIR::ArrayType>(
+      node_id, {.type_id = SemIR::TypeId::TypeType,
+                .bound_id = bound_inst_id,
+                .element_type_id = ExprAsType(context, element_type_node_id,
+                                              element_type_inst_id)});
   return true;
 }
 

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -46,15 +46,15 @@ auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
                            : SemIR::CompileTimeBindIndex::Invalid});
     if (is_generic) {
       // TODO: Create a `BindTemplateName` instead inside a `template` pattern.
-      return {.loc_id = name_node,
-              .inst = SemIR::BindSymbolicName{.type_id = type_id,
-                                              .bind_name_id = bind_name_id,
-                                              .value_id = value_id}};
+      return SemIR::LocIdAndInst(
+          name_node, SemIR::BindSymbolicName{.type_id = type_id,
+                                             .bind_name_id = bind_name_id,
+                                             .value_id = value_id});
     } else {
-      return {.loc_id = name_node,
-              .inst = SemIR::BindName{.type_id = type_id,
-                                      .bind_name_id = bind_name_id,
-                                      .value_id = value_id}};
+      return SemIR::LocIdAndInst(name_node,
+                                 SemIR::BindName{.type_id = type_id,
+                                                 .bind_name_id = bind_name_id,
+                                                 .value_id = value_id});
     }
   };
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -11,6 +11,7 @@
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -215,7 +216,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
                                      .class_id = SemIR::ClassId::Invalid,
                                      .decl_block_id = decl_block_id};
   auto class_decl_id =
-      context.AddPlaceholderInst({.loc_id = node_id, .inst = class_decl});
+      context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, class_decl));
 
   // TODO: Store state regarding is_extern.
   SemIR::Class class_info = {

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -67,10 +67,10 @@ auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
     return true;
   }
 
-  auto export_id = context.AddInst(
-      {node_id, SemIR::ExportDecl{.type_id = import_ref->type_id,
-                                  .bind_name_id = import_ref->bind_name_id,
-                                  .value_id = inst_id}});
+  auto export_id = context.AddInst<SemIR::ExportDecl>(
+      node_id, {.type_id = import_ref->type_id,
+                .bind_name_id = import_ref->bind_name_id,
+                .value_id = inst_id});
   context.AddExport(export_id);
 
   // Replace the ImportRef in name lookup, both for the above duplicate

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -39,8 +39,8 @@ auto HandleReturnType(Context& context, Parse::ReturnTypeId node_id) -> bool {
   auto [type_node_id, type_inst_id] = context.node_stack().PopExprWithNodeId();
   auto type_id = ExprAsType(context, type_node_id, type_inst_id);
   // TODO: Use a dedicated instruction rather than VarStorage here.
-  context.AddInstAndPush(
-      {node_id, SemIR::VarStorage{type_id, SemIR::NameId::ReturnSlot}});
+  context.AddInstAndPush<SemIR::VarStorage>(
+      node_id, {.type_id = type_id, .name_id = SemIR::NameId::ReturnSlot});
   return true;
 }
 
@@ -254,7 +254,8 @@ static auto BuildFunctionDecl(Context& context,
   auto function_info = SemIR::Function{
       .name_id = name_context.name_id_for_new_inst(),
       .enclosing_scope_id = name_context.enclosing_scope_id_for_new_inst(),
-      .decl_id = context.AddPlaceholderInst({node_id, function_decl}),
+      .decl_id = context.AddPlaceholderInst(
+          {.loc_id = node_id, .inst = function_decl}),
       .implicit_param_refs_id = name.implicit_params_id,
       .param_refs_id = name.params_id,
       .return_type_id = return_type_id,
@@ -406,7 +407,7 @@ auto HandleFunctionDefinition(Context& context,
           "Missing `return` at end of function with declared return type.");
       context.emitter().Emit(TokenOnly(node_id), MissingReturnStatement);
     } else {
-      context.AddInst({node_id, SemIR::Return{}});
+      context.AddInst<SemIR::Return>(node_id, {});
     }
   }
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -255,7 +255,7 @@ static auto BuildFunctionDecl(Context& context,
       .name_id = name_context.name_id_for_new_inst(),
       .enclosing_scope_id = name_context.enclosing_scope_id_for_new_inst(),
       .decl_id = context.AddPlaceholderInst(
-          {.loc_id = node_id, .inst = function_decl}),
+          SemIR::LocIdAndInst(node_id, function_decl)),
       .implicit_param_refs_id = name.implicit_params_id,
       .param_refs_id = name.params_id,
       .return_type_id = return_type_id,

--- a/toolchain/check/handle_if_statement.cpp
+++ b/toolchain/check/handle_if_statement.cpp
@@ -52,7 +52,7 @@ auto HandleIfStatement(Context& context, Parse::IfStatementId node_id) -> bool {
       // block.
       auto else_block_id =
           context.node_stack().Pop<Parse::NodeKind::IfCondition>();
-      context.AddInst({node_id, SemIR::Branch{else_block_id}});
+      context.AddInst<SemIR::Branch>(node_id, {.target_id = else_block_id});
       context.inst_block_stack().Pop();
       context.inst_block_stack().Push(else_block_id);
       break;

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -208,8 +208,8 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   // TODO: Does lookup in an impl file need to look for a prior impl declaration
   // in the api file?
   auto impl_id = context.impls().LookupOrAdd(self_type_id, constraint_type_id);
-  auto impl_decl = SemIR::ImplDecl{impl_id, decl_block_id};
-  auto impl_decl_id = context.AddInst({node_id, impl_decl});
+  SemIR::ImplDecl impl_decl = {impl_id, decl_block_id};
+  auto impl_decl_id = context.AddInst(node_id, impl_decl);
 
   // For an `extend impl` declaration, mark the impl as extending this `impl`.
   if (context.decl_state_stack().innermost().modifier_set.HasAnyOf(

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -208,7 +208,8 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   // TODO: Does lookup in an impl file need to look for a prior impl declaration
   // in the api file?
   auto impl_id = context.impls().LookupOrAdd(self_type_id, constraint_type_id);
-  SemIR::ImplDecl impl_decl = {.impl_id = impl_id, .decl_block_id = decl_block_id};
+  SemIR::ImplDecl impl_decl = {.impl_id = impl_id,
+                               .decl_block_id = decl_block_id};
   auto impl_decl_id = context.AddInst(node_id, impl_decl);
 
   // For an `extend impl` declaration, mark the impl as extending this `impl`.

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -208,7 +208,7 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   // TODO: Does lookup in an impl file need to look for a prior impl declaration
   // in the api file?
   auto impl_id = context.impls().LookupOrAdd(self_type_id, constraint_type_id);
-  SemIR::ImplDecl impl_decl = {impl_id, decl_block_id};
+  SemIR::ImplDecl impl_decl = {.impl_id = impl_id, .decl_block_id = decl_block_id};
   auto impl_decl_id = context.AddInst(node_id, impl_decl);
 
   // For an `extend impl` declaration, mark the impl as extending this `impl`.

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -52,14 +52,15 @@ auto HandleIndexExpr(Context& context, Parse::IndexExprId node_id) -> bool {
       if (array_cat == SemIR::ExprCategory::Value) {
         // If the operand is an array value, convert it to an ephemeral
         // reference to an array so we can perform a primitive indexing into it.
-        operand_inst_id = context.AddInst(
-            {node_id, SemIR::ValueAsRef{operand_type_id, operand_inst_id}});
+        operand_inst_id = context.AddInst<SemIR::ValueAsRef>(
+            node_id, {.type_id = operand_type_id, .value_id = operand_inst_id});
       }
       // Constant evaluation will perform a bounds check on this array indexing
       // if the index is constant.
-      auto elem_id = context.AddInst(
-          {node_id, SemIR::ArrayIndex{array_type.element_type_id,
-                                      operand_inst_id, cast_index_id}});
+      auto elem_id = context.AddInst<SemIR::ArrayIndex>(
+          node_id, {.type_id = array_type.element_type_id,
+                    .array_id = operand_inst_id,
+                    .index_id = cast_index_id});
       if (array_cat != SemIR::ExprCategory::DurableRef) {
         // Indexing a durable reference gives a durable reference expression.
         // Indexing anything else gives a value expression.
@@ -97,9 +98,10 @@ auto HandleIndexExpr(Context& context, Parse::IndexExprId node_id) -> bool {
           index_inst_id = SemIR::InstId::BuiltinError;
         }
       }
-      context.AddInstAndPush(
-          {node_id,
-           SemIR::TupleIndex{element_type_id, operand_inst_id, index_inst_id}});
+      context.AddInstAndPush<SemIR::TupleIndex>(node_id,
+                                                {.type_id = element_type_id,
+                                                 .tuple_id = operand_inst_id,
+                                                 .index_id = index_inst_id});
       return true;
     }
     default: {

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -57,7 +57,7 @@ static auto BuildInterfaceDecl(Context& context,
   auto interface_decl = SemIR::InterfaceDecl{
       SemIR::TypeId::TypeType, SemIR::InterfaceId::Invalid, decl_block_id};
   auto interface_decl_id =
-      context.AddPlaceholderInst({node_id, interface_decl});
+      context.AddPlaceholderInst({.loc_id = node_id, .inst = interface_decl});
 
   // Check whether this is a redeclaration.
   auto existing_id = context.decl_name_stack().LookupOrAddName(

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -57,7 +57,7 @@ static auto BuildInterfaceDecl(Context& context,
   auto interface_decl = SemIR::InterfaceDecl{
       SemIR::TypeId::TypeType, SemIR::InterfaceId::Invalid, decl_block_id};
   auto interface_decl_id =
-      context.AddPlaceholderInst({.loc_id = node_id, .inst = interface_decl});
+      context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, interface_decl));
 
   // Check whether this is a redeclaration.
   auto existing_id = context.decl_name_stack().LookupOrAddName(

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -10,19 +10,17 @@ namespace Carbon::Check {
 
 auto HandleBoolLiteralFalse(Context& context, Parse::BoolLiteralFalseId node_id)
     -> bool {
-  context.AddInstAndPush(
-      {node_id,
-       SemIR::BoolLiteral{context.GetBuiltinType(SemIR::BuiltinKind::BoolType),
-                          SemIR::BoolValue::False}});
+  context.AddInstAndPush<SemIR::BoolLiteral>(
+      node_id, {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::BoolType),
+                .value = SemIR::BoolValue::False});
   return true;
 }
 
 auto HandleBoolLiteralTrue(Context& context, Parse::BoolLiteralTrueId node_id)
     -> bool {
-  context.AddInstAndPush(
-      {node_id,
-       SemIR::BoolLiteral{context.GetBuiltinType(SemIR::BuiltinKind::BoolType),
-                          SemIR::BoolValue::True}});
+  context.AddInstAndPush<SemIR::BoolLiteral>(
+      node_id, {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::BoolType),
+                .value = SemIR::BoolValue::True});
   return true;
 }
 
@@ -41,10 +39,9 @@ static auto MakeI32Literal(Context& context, Parse::NodeId node_id,
   }
   // Literals are always represented as unsigned, so zero-extend if needed.
   auto i32_val = val.zextOrTrunc(32);
-  return context.AddInst(
-      {node_id,
-       SemIR::IntLiteral{context.GetBuiltinType(SemIR::BuiltinKind::IntType),
-                         context.ints().Add(i32_val)}});
+  return context.AddInst<SemIR::IntLiteral>(
+      node_id, {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::IntType),
+                .int_id = context.ints().Add(i32_val)});
 }
 
 auto HandleIntLiteral(Context& context, Parse::IntLiteralId node_id) -> bool {
@@ -94,20 +91,20 @@ auto HandleRealLiteral(Context& context, Parse::RealLiteralId node_id) -> bool {
                                real_value.exponent.getSExtValue());
 
   auto float_id = context.sem_ir().floats().Add(llvm::APFloat(double_val));
-  context.AddInstAndPush(
-      {node_id,
-       SemIR::FloatLiteral{
-           context.GetBuiltinType(SemIR::BuiltinKind::FloatType), float_id}});
+  context.AddInstAndPush<SemIR::FloatLiteral>(
+      node_id,
+      {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::FloatType),
+       .float_id = float_id});
   return true;
 }
 
 auto HandleStringLiteral(Context& context, Parse::StringLiteralId node_id)
     -> bool {
-  context.AddInstAndPush(
-      {node_id, SemIR::StringLiteral{
-                    context.GetBuiltinType(SemIR::BuiltinKind::StringType),
-                    context.tokens().GetStringLiteralValue(
-                        context.parse_tree().node_token(node_id))}});
+  context.AddInstAndPush<SemIR::StringLiteral>(
+      node_id,
+      {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::StringType),
+       .string_literal_id = context.tokens().GetStringLiteralValue(
+           context.parse_tree().node_token(node_id))});
   return true;
 }
 

--- a/toolchain/check/handle_loop_statement.cpp
+++ b/toolchain/check/handle_loop_statement.cpp
@@ -58,7 +58,7 @@ auto HandleWhileStatement(Context& context, Parse::WhileStatementId node_id)
   context.break_continue_stack().pop_back();
 
   // Add the loop backedge.
-  context.AddInst({node_id, SemIR::Branch{loop_header_id}});
+  context.AddInst<SemIR::Branch>(node_id, {.target_id = loop_header_id});
   context.inst_block_stack().Pop();
 
   // Start emitting the loop exit block.
@@ -100,7 +100,8 @@ auto HandleBreakStatementStart(Context& context,
                       "`break` can only be used in a loop.");
     context.emitter().Emit(node_id, BreakOutsideLoop);
   } else {
-    context.AddInst({node_id, SemIR::Branch{stack.back().break_target}});
+    context.AddInst<SemIR::Branch>(node_id,
+                                   {.target_id = stack.back().break_target});
   }
 
   context.inst_block_stack().Pop();
@@ -125,7 +126,8 @@ auto HandleContinueStatementStart(Context& context,
                       "`continue` can only be used in a loop.");
     context.emitter().Emit(node_id, ContinueOutsideLoop);
   } else {
-    context.AddInst({node_id, SemIR::Branch{stack.back().continue_target}});
+    context.AddInst<SemIR::Branch>(node_id,
+                                   {.target_id = stack.back().continue_target});
   }
 
   context.inst_block_stack().Pop();

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -80,8 +80,9 @@ static auto HandleNameAsExpr(Context& context, Parse::NodeId node_id,
                              SemIR::NameId name_id) -> bool {
   auto value_id = context.LookupUnqualifiedName(node_id, name_id);
   auto value = context.insts().Get(value_id);
-  context.AddInstAndPush(
-      {node_id, SemIR::NameRef{value.type_id(), name_id, value_id}});
+  context.AddInstAndPush<SemIR::NameRef>(
+      node_id,
+      {.type_id = value.type_id(), .name_id = name_id, .value_id = value_id});
   return true;
 }
 
@@ -133,11 +134,11 @@ auto HandleNameQualifier(Context& context, Parse::NameQualifierId /*node_id*/)
 }
 
 auto HandlePackageExpr(Context& context, Parse::PackageExprId node_id) -> bool {
-  context.AddInstAndPush(
-      {node_id,
-       SemIR::NameRef{context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
-                      SemIR::NameId::PackageNamespace,
-                      SemIR::InstId::PackageNamespace}});
+  context.AddInstAndPush<SemIR::NameRef>(
+      node_id,
+      {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
+       .name_id = SemIR::NameId::PackageNamespace,
+       .value_id = SemIR::InstId::PackageNamespace});
   return true;
 }
 

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -7,6 +7,7 @@
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 
@@ -27,7 +28,7 @@ auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
       context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
       SemIR::NameScopeId::Invalid, SemIR::InstId::Invalid};
   auto namespace_id =
-      context.AddPlaceholderInst({.loc_id = node_id, .inst = namespace_inst});
+      context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, namespace_inst));
   namespace_inst.name_scope_id = context.name_scopes().Add(
       namespace_id, name_context.name_id_for_new_inst(),
       name_context.enclosing_scope_id_for_new_inst());

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -26,7 +26,8 @@ auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
   auto namespace_inst = SemIR::Namespace{
       context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
       SemIR::NameScopeId::Invalid, SemIR::InstId::Invalid};
-  auto namespace_id = context.AddPlaceholderInst({node_id, namespace_inst});
+  auto namespace_id =
+      context.AddPlaceholderInst({.loc_id = node_id, .inst = namespace_inst});
   namespace_inst.name_scope_id = context.name_scopes().Add(
       namespace_id, name_context.name_id_for_new_inst(),
       name_context.enclosing_scope_id_for_new_inst());

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -44,9 +44,11 @@ auto HandleStructField(Context& context, Parse::StructFieldId node_id) -> bool {
   auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
 
   // Store the name for the type.
-  context.args_type_info_stack().AddInstId(context.AddInstInNoBlock(
-      {name_node, SemIR::StructTypeField{
-                      name_id, context.insts().Get(value_inst_id).type_id()}}));
+  context.args_type_info_stack().AddInstId(
+      context.AddInstInNoBlock<SemIR::StructTypeField>(
+          name_node,
+          {.name_id = name_id,
+           .field_type_id = context.insts().Get(value_inst_id).type_id()}));
 
   // Push the value back on the stack as an argument.
   context.node_stack().Push(node_id, value_inst_id);
@@ -60,8 +62,8 @@ auto HandleStructTypeField(Context& context, Parse::StructTypeFieldId node_id)
 
   auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
 
-  auto inst_id = context.AddInst(
-      {name_node, SemIR::StructTypeField{name_id, cast_type_id}});
+  auto inst_id = context.AddInst<SemIR::StructTypeField>(
+      name_node, {.name_id = name_id, .field_type_id = cast_type_id});
   context.node_stack().Push(node_id, inst_id);
   return true;
 }
@@ -109,8 +111,8 @@ auto HandleStructLiteral(Context& context, Parse::StructLiteralId node_id)
 
   auto type_id = context.GetStructType(type_block_id);
 
-  auto value_id =
-      context.AddInst({node_id, SemIR::StructLiteral{type_id, refs_id}});
+  auto value_id = context.AddInst<SemIR::StructLiteral>(
+      node_id, {.type_id = type_id, .elements_id = refs_id});
   context.node_stack().Push(node_id, value_id);
   return true;
 }
@@ -131,8 +133,8 @@ auto HandleStructTypeLiteral(Context& context,
     context.node_stack().Push(node_id, SemIR::InstId::BuiltinError);
     return true;
   }
-  context.AddInstAndPush(
-      {node_id, SemIR::StructType{SemIR::TypeId::TypeType, refs_id}});
+  context.AddInstAndPush<SemIR::StructType>(
+      node_id, {.type_id = SemIR::TypeId::TypeType, .fields_id = refs_id});
   return true;
 }
 

--- a/toolchain/check/handle_tuple_literal.cpp
+++ b/toolchain/check/handle_tuple_literal.cpp
@@ -34,8 +34,8 @@ auto HandleTupleLiteral(Context& context, Parse::TupleLiteralId node_id)
   }
   auto type_id = context.GetTupleType(type_ids);
 
-  auto value_id =
-      context.AddInst({node_id, SemIR::TupleLiteral{type_id, refs_id}});
+  auto value_id = context.AddInst<SemIR::TupleLiteral>(
+      node_id, {.type_id = type_id, .elements_id = refs_id});
   context.node_stack().Push(node_id, value_id);
   return true;
 }

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -84,7 +84,8 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
       init_id = Initialize(context, node_id, value_id, *init_id);
       // TODO: Consider using different instruction kinds for assignment versus
       // initialization.
-      context.AddInst({node_id, SemIR::Assign{value_id, *init_id}});
+      context.AddInst<SemIR::Assign>(node_id,
+                                     {.lhs_id = value_id, .rhs_id = *init_id});
     }
     if (context.scope_stack().PeekIndex() == ScopeIndex::Package) {
       context.inst_block_stack().PopGlobalInit();

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -138,8 +138,9 @@ static auto BuildInterfaceWitness(
   }
 
   auto table_id = context.inst_blocks().Add(table);
-  return context.AddInst(SemIR::LocIdAndInst::NoLoc(SemIR::InterfaceWitness{
-      context.GetBuiltinType(SemIR::BuiltinKind::WitnessType), table_id}));
+  return context.AddInst(SemIR::LocIdAndInst::NoLoc<SemIR::InterfaceWitness>(
+      {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::WitnessType),
+       .elements_id = table_id}));
 }
 
 auto BuildImplWitness(Context& context, SemIR::ImplId impl_id)

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -104,7 +104,7 @@ static auto AddNamespace(
       namespace_type_id, SemIR::NameScopeId::Invalid, import_id};
   // Use the invalid node because there's no node to associate with.
   auto namespace_id =
-      context.AddPlaceholderInst({.loc_id = node_id, .inst = namespace_inst});
+      context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, namespace_inst));
   namespace_inst.name_scope_id =
       context.name_scopes().Add(namespace_id, name_id, enclosing_scope_id);
   context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -103,7 +103,8 @@ static auto AddNamespace(
   auto namespace_inst = SemIR::Namespace{
       namespace_type_id, SemIR::NameScopeId::Invalid, import_id};
   // Use the invalid node because there's no node to associate with.
-  auto namespace_id = context.AddPlaceholderInst({node_id, namespace_inst});
+  auto namespace_id =
+      context.AddPlaceholderInst({.loc_id = node_id, .inst = namespace_inst});
   namespace_inst.name_scope_id =
       context.name_scopes().Add(namespace_id, name_id, enclosing_scope_id);
   context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);
@@ -147,11 +148,10 @@ static auto CopySingleNameScopeFromImportIR(
          .bind_index = SemIR::CompileTimeBindIndex::Invalid});
     auto import_ir_inst_id = context.import_ir_insts().Add(
         {.ir_id = ir_id, .inst_id = import_inst_id});
-    return context.AddInst(
-        {import_ir_inst_id,
-         SemIR::ImportRefLoaded{.type_id = namespace_type_id,
-                                .import_ir_inst_id = import_ir_inst_id,
-                                .bind_name_id = bind_name_id}});
+    return context.AddInst<SemIR::ImportRefLoaded>(
+        import_ir_inst_id, {.type_id = namespace_type_id,
+                            .import_ir_inst_id = import_ir_inst_id,
+                            .bind_name_id = bind_name_id});
   };
   auto [namespace_scope_id, namespace_const_id, _] =
       AddNamespace(context, namespace_type_id, Parse::NodeId::Invalid, name_id,

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -59,7 +59,7 @@ auto AddImportRef(Context& context, SemIR::ImportIRInst import_ir_inst,
   SemIR::ImportRefUnloaded inst = {.import_ir_inst_id = import_ir_inst_id,
                                    .bind_name_id = bind_name_id};
   auto import_ref_id = context.AddPlaceholderInstInNoBlock(
-      {.loc_id = import_ir_inst_id, .inst = inst});
+      SemIR::LocIdAndInst(import_ir_inst_id, inst));
 
   // We can't insert this instruction into whatever block we happen to be in,
   // because this function is typically called by name lookup in the middle of
@@ -759,7 +759,7 @@ class ImportRefResolver {
         SemIR::ClassDecl{SemIR::TypeId::TypeType, SemIR::ClassId::Invalid,
                          SemIR::InstBlockId::Empty};
     auto class_decl_id = context_.AddPlaceholderInstInNoBlock(
-        {.loc_id = AddImportIRInst(import_class.decl_id), .inst = class_decl});
+        SemIR::LocIdAndInst(AddImportIRInst(import_class.decl_id), class_decl));
     // Regardless of whether ClassDecl is a complete type, we first need an
     // incomplete type so that any references have something to point at.
     class_decl.class_id = context_.classes().Add({
@@ -966,7 +966,7 @@ class ImportRefResolver {
                                                  ? function.definition_id
                                                  : function.decl_id);
     auto function_decl_id = context_.AddPlaceholderInstInNoBlock(
-        {.loc_id = import_ir_inst_id, .inst = function_decl});
+        SemIR::LocIdAndInst(import_ir_inst_id, function_decl));
 
     auto new_return_type_id =
         return_type_const_id.is_valid()
@@ -1060,9 +1060,9 @@ class ImportRefResolver {
     auto interface_decl = SemIR::InterfaceDecl{SemIR::TypeId::TypeType,
                                                SemIR::InterfaceId::Invalid,
                                                SemIR::InstBlockId::Empty};
-    auto interface_decl_id = context_.AddPlaceholderInstInNoBlock(
-        {.loc_id = AddImportIRInst(import_interface.decl_id),
-         .inst = interface_decl});
+    auto interface_decl_id =
+        context_.AddPlaceholderInstInNoBlock(SemIR::LocIdAndInst(
+            AddImportIRInst(import_interface.decl_id), interface_decl));
 
     // Start with an incomplete interface.
     SemIR::Interface new_interface = {

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -30,8 +30,9 @@ auto BuildAssociatedEntity(Context& context, SemIR::InterfaceId interface_id,
   // not the declaration itself.
   auto type_id = context.GetAssociatedEntityType(
       interface_id, context.insts().Get(decl_id).type_id());
-  return context.AddInst({context.insts().GetLocId(decl_id),
-                          SemIR::AssociatedEntity{type_id, index, decl_id}});
+  return context.AddInst<SemIR::AssociatedEntity>(
+      context.insts().GetLocId(decl_id),
+      {.type_id = type_id, .index = index, .decl_id = decl_id});
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -39,8 +39,9 @@ class PendingBlock {
     size_t size_;
   };
 
-  auto AddInst(SemIR::LocIdAndInst loc_id_and_inst) -> SemIR::InstId {
-    auto inst_id = context_.AddInstInNoBlock(loc_id_and_inst);
+  template <typename InstT>
+  auto AddInst(SemIR::LocId loc_id, InstT inst) -> SemIR::InstId {
+    auto inst_id = context_.AddInstInNoBlock(loc_id, inst);
     insts_.push_back(inst_id);
     return inst_id;
   }

--- a/toolchain/check/pointer_dereference.cpp
+++ b/toolchain/check/pointer_dereference.cpp
@@ -30,7 +30,8 @@ auto PerformPointerDereference(
   } else if (type_id != SemIR::TypeId::Error) {
     diagnose_not_pointer(type_id);
   }
-  return context.AddInst({node_id, SemIR::Deref{result_type_id, base_id}});
+  return context.AddInst<SemIR::Deref>(
+      node_id, {.type_id = result_type_id, .pointer_id = base_id});
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -84,7 +84,8 @@ auto CheckReturnedVar(Context& context, Parse::NodeId returned_node,
   if (function.has_return_slot()) {
     return function.return_storage_id;
   }
-  return context.AddInst({name_node, SemIR::VarStorage{type_id, name_id}});
+  return context.AddInst<SemIR::VarStorage>(
+      name_node, {.type_id = type_id, .name_id = name_id});
 }
 
 auto RegisterReturnedVar(Context& context, SemIR::InstId bind_id) -> void {
@@ -111,7 +112,7 @@ auto BuildReturnWithNoExpr(Context& context, Parse::ReturnStatementId node_id)
     diag.Emit();
   }
 
-  context.AddInst({node_id, SemIR::Return{}});
+  context.AddInst<SemIR::Return>(node_id, {});
 }
 
 auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
@@ -147,7 +148,8 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
                                    function.return_type_id);
   }
 
-  context.AddInst({node_id, SemIR::ReturnExpr{expr_id, return_slot_id}});
+  context.AddInst<SemIR::ReturnExpr>(
+      node_id, {.expr_id = expr_id, .dest_id = return_slot_id});
 }
 
 auto BuildReturnVar(Context& context, Parse::ReturnStatementId node_id)
@@ -170,8 +172,8 @@ auto BuildReturnVar(Context& context, Parse::ReturnStatementId node_id)
     return_slot_id = SemIR::InstId::Invalid;
   }
 
-  context.AddInst(
-      {node_id, SemIR::ReturnExpr{returned_var_id, return_slot_id}});
+  context.AddInst<SemIR::ReturnExpr>(
+      node_id, {.expr_id = returned_var_id, .dest_id = return_slot_id});
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -301,15 +301,39 @@ inline auto operator<<(llvm::raw_ostream& out, TypedInst inst)
 // Associates a LocId and Inst in order to provide type-checking that the
 // TypedNodeId corresponds to the InstT.
 struct LocIdAndInst {
-  // For cases with no location.
   template <typename InstT>
-    requires(!Internal::HasNodeId<InstT>)
   static auto NoLoc(InstT inst) -> LocIdAndInst {
-    return {.loc_id = LocId::Invalid, .inst = inst};
+    return LocIdAndInst(LocId::Invalid, inst, /*is_untyped=*/true);
   }
 
+  // Construction for the common case with a typed node.
+  template <typename InstT>
+    requires(Internal::HasNodeId<InstT>)
+  LocIdAndInst(decltype(InstT::Kind)::TypedNodeId node_id, InstT inst)
+      : loc_id(node_id), inst(inst) {}
+
+  // If TypedNodeId is Parse::NodeId, allow construction with a LocId.
+  // TODO: This is somewhat historical due to fetching the NodeId from insts()
+  // for things like Temporary; should we require Untyped in these cases?
+  template <typename InstT>
+    requires(std::same_as<typename decltype(InstT::Kind)::TypedNodeId,
+                          Parse::NodeId>)
+  LocIdAndInst(LocId loc_id, InstT inst) : loc_id(loc_id), inst(inst) {}
+
+  // Imports can pass an ImportIRInstId instead of another location.
+  template <typename InstT>
+  LocIdAndInst(ImportIRInstId import_ir_inst_id, InstT inst)
+      : loc_id(import_ir_inst_id), inst(inst) {}
   LocId loc_id;
   Inst inst;
+
+ private:
+  // Expose the internal constructor for GetWithLocId.
+  friend class InstStore;
+
+  // Note `is_untyped` serves to disambiguate from public constructors.
+  explicit LocIdAndInst(LocId loc_id, Inst inst, bool /*is_untyped*/)
+      : loc_id(loc_id), inst(inst) {}
 };
 
 // Provides a ValueStore wrapper for an API specific to instructions.
@@ -330,7 +354,7 @@ class InstStore {
 
   // Returns the requested instruction and its location ID.
   auto GetWithLocId(InstId inst_id) const -> LocIdAndInst {
-    return {.loc_id = GetLocId(inst_id), .inst = Get(inst_id)};
+    return LocIdAndInst(GetLocId(inst_id), Get(inst_id), /*is_untyped=*/true);
   }
 
   // Returns whether the requested instruction is the specified type.


### PR DESCRIPTION
Trying to conform with #4009. Changes SemIR::LocIdAndInst construction to root out struct init cases with AddInst and related functions. I'm using templating of AddInst functions in order to avoid `AddInst(loc_id, InstName{...})` and instead have `AddInst<InstName>(loc_id, {...})` with I think similar readability results. There are a couple cases where inst construction is templated and so designated initializers couldn't be used, so this may be better for those in particular due to the extra type enforcement.

This probably doesn't clean up every last case, but I was trying to get the bulk at once without bleeding over into less related changes.