### PR TITLE
Fix our system header classification.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -143,8 +143,20 @@ def _impl(ctx):
                             "-Wctad-maybe-unsupported",
                             "-Wdelete-non-virtual-dtor",
                             # Don't warn on external code as we can't
-                            # necessarily patch it easily.
-                            "--system-header-prefix=external/",
+                            # necessarily patch it easily. Note that these have
+                            # to be initial directories in the `#include` line.
+                            "--system-header-prefix=absl/",
+                            "--system-header-prefix=benchmark/",
+                            "--system-header-prefix=clang-tools-extra/",
+                            "--system-header-prefix=clang/",
+                            "--system-header-prefix=gmock/",
+                            "--system-header-prefix=google/protobuf/",
+                            "--system-header-prefix=gtest/",
+                            "--system-header-prefix=libfuzzer/",
+                            "--system-header-prefix=llvm/",
+                            "--system-header-prefix=re2/",
+                            "--system-header-prefix=tools/cpp/",
+                            "--system-header-prefix=tree_sitter/",
                             # Compile actions shouldn't link anything.
                             "-c",
                         ] + missing_field_init_flags,


### PR DESCRIPTION
I misunderstood how this flag worked, which explains why it didn't work. Oops. Sorry about that. So far we've been lucky to not bump into this, but we've had to work around it with updating libraries, etc.

Moreover, there are quite a few warnings that seem useful for us to enable, but doing so would cause lots of friction without this working. The added warnings will be separate PRs along with their cleanups.