### PR TITLE
Add `-Wmissing-prototypes` and fix issues it finds.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,6 +28,21 @@ build --experimental_guard_against_concurrent_changes
 build --per_file_copt=external/.*\.(c|cc|cpp|cxx)$@-w
 build --host_per_file_copt=external/.*\.(c|cc|cpp|cxx)$@-w
 
+# The `rules_treesitter` synthesized libraries don't allow us to inject flags,
+# and compile generated code where we can't fix warnings.
+build --per_file_copt=utils/treesitter/_treesitter.tree_sitter/.*\.c$@-w
+build --host_per_file_copt=utils/treesitter/_treesitter.tree_sitter/.*\.c$@-w
+
+# The `cc_proto_library` rule doesn't allow providing `copts`:
+# https://github.com/bazelbuild/bazel/issues/22610
+#
+# We unfortunately need to work around issues with `-Wmissing-prototypes` in
+# generated protobuf code, so pass the `copt` manually here. The warning issue
+# is likely part of:
+# https://github.com/llvm/llvm-project/issues/94138
+build --per_file_copt=.*\.pb\.cc$@-Wno-missing-prototypes
+build --host_per_file_copt=.*\.pb\.cc$@-Wno-missing-prototypes
+
 # Default dynamic linking to off. While this can help build performance in some
 # edge cases with very large linked executables and a slow linker, between using
 # fast linkers on all platforms (LLD and the Apple linker), as well as having

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -142,6 +142,7 @@ def _impl(ctx):
                             "-Wimplicit-fallthrough",
                             "-Wctad-maybe-unsupported",
                             "-Wextra-semi",
+                            "-Wmissing-prototypes",
                             "-Wzero-as-null-pointer-constant",
                             # Don't warn on external code as we can't
                             # necessarily patch it easily. Note that these have

--- a/common/check_internal.cpp
+++ b/common/check_internal.cpp
@@ -10,7 +10,7 @@
 namespace Carbon::Internal {
 
 // Prints the buffered message.
-auto PrintAfterStackTrace(void* str) -> void {
+static auto PrintAfterStackTrace(void* str) -> void {
   llvm::errs() << reinterpret_cast<char*>(str);
 }
 

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -1042,7 +1042,7 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
 
 // Returns true if the two values are known to be equal and are written in the
 // same way at the top level.
-auto ValueStructurallyEqual(
+static auto ValueStructurallyEqual(
     Nonnull<const Value*> v1, Nonnull<const Value*> v2,
     std::optional<Nonnull<const EqualityContext*>> equality_ctx) -> bool {
   if (v1 == v2) {

--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -110,6 +110,7 @@ cc_fuzz_test(
     name = "explorer_fuzzer",
     size = "small",
     srcs = ["explorer_fuzzer.cpp"],
+    copts = ["-Wno-missing-prototypes"],
     corpus = glob(["fuzzer_corpus/*"]),
     shard_count = 8,
     tags = [

--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -110,6 +110,8 @@ cc_fuzz_test(
     name = "explorer_fuzzer",
     size = "small",
     srcs = ["explorer_fuzzer.cpp"],
+    # Uses a macro-based fuzzing library that triggers this warning. And
+    # explorer is currently feature frozen, so just disable the warning.
     copts = ["-Wno-missing-prototypes"],
     corpus = glob(["fuzzer_corpus/*"]),
     shard_count = 8,

--- a/explorer/fuzzing/ast_to_proto_main.cpp
+++ b/explorer/fuzzing/ast_to_proto_main.cpp
@@ -21,7 +21,7 @@
 
 namespace Carbon::Testing {
 
-auto Main(int argc, char** argv) -> ErrorOr<Success> {
+static auto Main(int argc, char** argv) -> ErrorOr<Success> {
   SetWorkingDirForBazel();
 
   if (argc != 2) {

--- a/explorer/interpreter/resolve_control_flow.cpp
+++ b/explorer/interpreter/resolve_control_flow.cpp
@@ -170,8 +170,9 @@ static auto ResolveControlFlow(Nonnull<TraceStream*> trace_stream,
   }
 }
 
-auto ResolveControlFlow(Nonnull<TraceStream*> trace_stream,
-                        Nonnull<Declaration*> declaration) -> ErrorOr<Success> {
+static auto ResolveControlFlow(Nonnull<TraceStream*> trace_stream,
+                               Nonnull<Declaration*> declaration)
+    -> ErrorOr<Success> {
   switch (declaration->kind()) {
     case DeclarationKind::DestructorDeclaration:
     case DeclarationKind::FunctionDeclaration: {

--- a/testing/fuzzing/BUILD
+++ b/testing/fuzzing/BUILD
@@ -18,6 +18,14 @@ cc_proto_library(
     deps = [":carbon_proto"],
 )
 
+# Header for LibFuzzer, does not provide the implementation which should come
+# from some other source such as a fuzz test target.
+cc_library(
+    name = "libfuzzer_header",
+    testonly = 1,
+    hdrs = ["libfuzzer.h"],
+)
+
 cc_library(
     name = "proto_to_carbon_lib",
     testonly = 1,

--- a/testing/fuzzing/libfuzzer.h
+++ b/testing/fuzzing/libfuzzer.h
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TESTING_FUZZING_LIBFUZZER_H_
+#define CARBON_TESTING_FUZZING_LIBFUZZER_H_
+
+#include <cstddef>
+
+namespace Carbon::Testing {
+
+// Declaration for the LLVM libfuzzer API that we implement in our fuzz tests.
+// This is useful to ensure we get the API correct and avoid warnings about
+// defining an undeclared extern function due to a Clang warning bug:
+// https://github.com/llvm/llvm-project/issues/94138
+// NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
+                                      std::size_t size);
+
+}  // namespace Carbon::Testing
+
+#endif  // CARBON_TESTING_FUZZING_LIBFUZZER_H_

--- a/testing/fuzzing/proto_to_carbon_main.cpp
+++ b/testing/fuzzing/proto_to_carbon_main.cpp
@@ -17,7 +17,7 @@
 
 namespace Carbon {
 
-auto Main(int argc, char** argv) -> ErrorOr<Success> {
+static auto Main(int argc, char** argv) -> ErrorOr<Success> {
   Carbon::SetWorkingDirForBazel();
 
   if (argc != 2) {

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -152,6 +152,7 @@ cc_fuzz_test(
     srcs = ["check_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/*"]),
     deps = [
+        "//testing/fuzzing:libfuzzer_header",
         "//toolchain/driver",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/check/check_fuzzer.cpp
+++ b/toolchain/check/check_fuzzer.cpp
@@ -5,6 +5,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/VirtualFileSystem.h"
+#include "testing/fuzzing/libfuzzer.h"
 #include "toolchain/driver/driver.h"
 
 namespace Carbon::Testing {

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -317,8 +317,8 @@ static auto PerformAggregateIndex(Context& context, SemIR::Inst inst)
 }
 
 // Enforces that an integer type has a valid bit width.
-auto ValidateIntType(Context& context, SemIRLoc loc, SemIR::IntType result)
-    -> bool {
+static auto ValidateIntType(Context& context, SemIRLoc loc,
+                            SemIR::IntType result) -> bool {
   auto bit_width =
       context.insts().TryGetAs<SemIR::IntLiteral>(result.bit_width_id);
   if (!bit_width) {
@@ -381,8 +381,8 @@ static auto ValidateFloatBitWidth(Context& context, SemIRLoc loc,
 }
 
 // Enforces that a float type has a valid bit width.
-auto ValidateFloatType(Context& context, SemIRLoc loc, SemIR::FloatType result)
-    -> bool {
+static auto ValidateFloatType(Context& context, SemIRLoc loc,
+                              SemIR::FloatType result) -> bool {
   auto bit_width =
       context.insts().TryGetAs<SemIR::IntLiteral>(result.bit_width_id);
   if (!bit_width) {

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"
 #include "toolchain/parse/node_ids.h"

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/parse/node_kind.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -4,14 +4,15 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/return.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 
-auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
-                             bool is_generic) -> bool {
+static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
+                                    bool is_generic) -> bool {
   auto [type_node, parsed_type_id] = context.node_stack().PopExprWithNodeId();
   auto cast_type_id = ExprAsType(context, type_node, parsed_type_id);
 

--- a/toolchain/check/handle_call_expr.cpp
+++ b/toolchain/check/handle_call_expr.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/call.h"
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_choice.cpp
+++ b/toolchain/check/handle_choice.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -7,6 +7,7 @@
 #include "toolchain/check/convert.h"
 #include "toolchain/check/decl_name_stack.h"
 #include "toolchain/check/eval.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/merge.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"

--- a/toolchain/check/handle_codeblock.cpp
+++ b/toolchain/check/handle_codeblock.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/decl_name_stack.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"
 #include "toolchain/parse/typed_nodes.h"

--- a/toolchain/check/handle_expr_statement.cpp
+++ b/toolchain/check/handle_expr_statement.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_file.cpp
+++ b/toolchain/check/handle_file.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -8,6 +8,7 @@
 #include "toolchain/check/decl_name_stack.h"
 #include "toolchain/check/decl_state.h"
 #include "toolchain/check/function.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/interface.h"
 #include "toolchain/check/merge.h"
 #include "toolchain/check/modifiers.h"

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -379,10 +379,10 @@ auto HandleFunctionDefinitionSuspend(Context& context,
 
 auto HandleFunctionDefinitionResume(Context& context,
                                     Parse::FunctionDefinitionStartId node_id,
-                                    SuspendedFunction sus_fn) -> void {
-  context.decl_name_stack().Restore(sus_fn.saved_name_state);
-  HandleFunctionDefinitionAfterSignature(context, node_id, sus_fn.function_id,
-                                         sus_fn.decl_id);
+                                    SuspendedFunction suspended_fn) -> void {
+  context.decl_name_stack().Restore(suspended_fn.saved_name_state);
+  HandleFunctionDefinitionAfterSignature(
+      context, node_id, suspended_fn.function_id, suspended_fn.decl_id);
 }
 
 auto HandleFunctionDefinitionStart(Context& context,

--- a/toolchain/check/handle_if_expr.cpp
+++ b/toolchain/check/handle_if_expr.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_if_statement.cpp
+++ b/toolchain/check/handle_if_statement.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/check/decl_name_stack.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/impl.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/parse/typed_nodes.h"

--- a/toolchain/check/handle_import_and_package.cpp
+++ b/toolchain/check/handle_import_and_package.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/decl_state.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/modifiers.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/interface.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/interface.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/call.h"
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_loop_statement.cpp
+++ b/toolchain/check/handle_loop_statement.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_match.cpp
+++ b/toolchain/check/handle_match.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/decl_state.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/lex/token_kind.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/member_access.h"
 #include "toolchain/check/name_component.h"
 #include "toolchain/check/pointer_dereference.h"

--- a/toolchain/check/handle_named_constraint.cpp
+++ b/toolchain/check/handle_named_constraint.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/decl_state.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_component.h"
 #include "toolchain/sem_ir/ids.h"

--- a/toolchain/check/handle_noop.cpp
+++ b/toolchain/check/handle_noop.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/operator.h"
 #include "toolchain/check/pointer_dereference.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"

--- a/toolchain/check/handle_paren_expr.cpp
+++ b/toolchain/check/handle_paren_expr.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_pattern_list.cpp
+++ b/toolchain/check/handle_pattern_list.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_return_statement.cpp
+++ b/toolchain/check/handle_return_statement.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/return.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_tuple_literal.cpp
+++ b/toolchain/check/handle_tuple_literal.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/handle.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
+#include "toolchain/check/handle.h"
 #include "toolchain/check/modifiers.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "toolchain/check/member_access.h"
+
 #include "llvm/ADT/STLExtras.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"

--- a/toolchain/check/pointer_dereference.cpp
+++ b/toolchain/check/pointer_dereference.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "toolchain/check/pointer_dereference.h"
+
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "toolchain/check/return.h"
+
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -110,6 +110,7 @@ cc_fuzz_test(
     deps = [
         ":driver",
         "//testing/base:test_raw_ostream",
+        "//testing/fuzzing:libfuzzer_header",
         "//toolchain/install:install_paths",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/driver/driver_fuzzer.cpp
+++ b/toolchain/driver/driver_fuzzer.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include "testing/base/test_raw_ostream.h"
+#include "testing/fuzzing/libfuzzer.h"
 #include "toolchain/driver/driver.h"
 #include "toolchain/install/install_paths.h"
 

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -115,6 +115,7 @@ cc_fuzz_test(
     corpus = glob(["fuzzer_corpus/numeric_literal/*"]),
     deps = [
         ":numeric_literal",
+        "//testing/fuzzing:libfuzzer_header",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:null_diagnostics",
         "@llvm-project//llvm:Support",
@@ -170,6 +171,7 @@ cc_fuzz_test(
     deps = [
         ":string_literal",
         "//common:check",
+        "//testing/fuzzing:libfuzzer_header",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:null_diagnostics",
         "@llvm-project//llvm:Support",
@@ -269,6 +271,7 @@ cc_fuzz_test(
     deps = [
         ":lex",
         "//common:check",
+        "//testing/fuzzing:libfuzzer_header",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:null_diagnostics",

--- a/toolchain/lex/numeric_literal_fuzzer.cpp
+++ b/toolchain/lex/numeric_literal_fuzzer.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "llvm/ADT/StringRef.h"
+#include "testing/fuzzing/libfuzzer.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/numeric_literal.h"
 

--- a/toolchain/lex/string_literal_fuzzer.cpp
+++ b/toolchain/lex/string_literal_fuzzer.cpp
@@ -6,6 +6,7 @@
 
 #include "common/check.h"
 #include "llvm/ADT/StringRef.h"
+#include "testing/fuzzing/libfuzzer.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/string_literal.h"
 

--- a/toolchain/lex/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lex/tokenized_buffer_fuzzer.cpp
@@ -6,6 +6,7 @@
 
 #include "common/check.h"
 #include "llvm/ADT/StringRef.h"
+#include "testing/fuzzing/libfuzzer.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/lex.h"

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "toolchain/lower/constant.h"
+
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Constants.h"

--- a/toolchain/lower/handle_aggregates.cpp
+++ b/toolchain/lower/handle_aggregates.cpp
@@ -167,8 +167,9 @@ auto HandleStructLiteral(FunctionContext& /*context*/,
 
 // Emits the value representation for a struct or tuple whose elements are the
 // contents of `refs_id`.
-auto EmitAggregateValueRepr(FunctionContext& context, SemIR::TypeId type_id,
-                            SemIR::InstBlockId refs_id) -> llvm::Value* {
+static auto EmitAggregateValueRepr(FunctionContext& context,
+                                   SemIR::TypeId type_id,
+                                   SemIR::InstBlockId refs_id) -> llvm::Value* {
   auto value_rep = SemIR::GetValueRepr(context.sem_ir(), type_id);
   switch (value_rep.kind) {
     case SemIR::ValueRepr::Unknown:

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -75,7 +75,10 @@ cc_library(
     glob([
         "handle_*.cpp",
     ]),
-    hdrs = ["parse.h"],
+    hdrs = [
+        "handle.h",
+        "parse.h",
+    ],
     deps = [
         ":context",
         ":node_kind",
@@ -147,6 +150,7 @@ cc_fuzz_test(
     deps = [
         ":parse",
         "//common:check",
+        "//testing/fuzzing:libfuzzer_header",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:null_diagnostics",

--- a/toolchain/parse/handle.h
+++ b/toolchain/parse/handle.h
@@ -2,18 +2,17 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef CARBON_TOOLCHAIN_PARSE_HANDLE_H_
+#define CARBON_TOOLCHAIN_PARSE_HANDLE_H_
+
 #include "toolchain/parse/context.h"
-#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 
-auto HandlePattern(Context& context) -> void {
-  context.PopAndDiscardState();
-  if (context.PositionKind() == Lex::TokenKind::OpenParen) {
-    context.PushState(State::PatternListAsTuple);
-  } else {
-    context.PushState(State::BindingPattern);
-  }
-}
+// Declare handlers for each parse state.
+#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context) -> void;
+#include "toolchain/parse/state.def"
 
 }  // namespace Carbon::Parse
+
+#endif  // CARBON_TOOLCHAIN_PARSE_HANDLE_H_

--- a/toolchain/parse/handle_adapt.cpp
+++ b/toolchain/parse/handle_adapt.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_alias.cpp
+++ b/toolchain/parse/handle_alias.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/state.h"
 

--- a/toolchain/parse/handle_array_expr.cpp
+++ b/toolchain/parse/handle_array_expr.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/state.h"
 

--- a/toolchain/parse/handle_base.cpp
+++ b/toolchain/parse/handle_base.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_binding_pattern.cpp
+++ b/toolchain/parse/handle_binding_pattern.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_brace_expr.cpp
+++ b/toolchain/parse/handle_brace_expr.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_call_expr.cpp
+++ b/toolchain/parse/handle_call_expr.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_choice.cpp
+++ b/toolchain/parse/handle_choice.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 auto HandleChoiceIntroducer(Context& context) -> void {

--- a/toolchain/parse/handle_code_block.cpp
+++ b/toolchain/parse/handle_code_block.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_decl_definition.cpp
+++ b/toolchain/parse/handle_decl_definition.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_decl_name_and_params.cpp
+++ b/toolchain/parse/handle_decl_name_and_params.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_decl_scope_loop.cpp
+++ b/toolchain/parse/handle_decl_scope_loop.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 #include "toolchain/parse/node_kind.h"
 
 namespace Carbon::Parse {

--- a/toolchain/parse/handle_expr.cpp
+++ b/toolchain/parse/handle_expr.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_function.cpp
+++ b/toolchain/parse/handle_function.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_impl.cpp
+++ b/toolchain/parse/handle_impl.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -6,6 +6,7 @@
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/node_kind.h"
 

--- a/toolchain/parse/handle_index_expr.cpp
+++ b/toolchain/parse/handle_index_expr.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_let.cpp
+++ b/toolchain/parse/handle_let.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_match.cpp
+++ b/toolchain/parse/handle_match.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_namespace.cpp
+++ b/toolchain/parse/handle_namespace.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_paren_condition.cpp
+++ b/toolchain/parse/handle_paren_condition.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_paren_expr.cpp
+++ b/toolchain/parse/handle_paren_expr.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_pattern_list.cpp
+++ b/toolchain/parse/handle_pattern_list.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_period.cpp
+++ b/toolchain/parse/handle_period.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_statement.cpp
+++ b/toolchain/parse/handle_statement.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_type.cpp
+++ b/toolchain/parse/handle_type.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/handle_var.cpp
+++ b/toolchain/parse/handle_var.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -2,16 +2,15 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "toolchain/parse/parse.h"
+
 #include "common/check.h"
 #include "toolchain/base/pretty_stack_trace_function.h"
 #include "toolchain/parse/context.h"
+#include "toolchain/parse/handle.h"
 #include "toolchain/parse/node_kind.h"
 
 namespace Carbon::Parse {
-
-// Declare handlers for each parse state.
-#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context) -> void;
-#include "toolchain/parse/state.def"
 
 auto HandleInvalid(Context& context) -> void {
   CARBON_FATAL() << "The Invalid state shouldn't be on the stack: "

--- a/toolchain/parse/parse_fuzzer.cpp
+++ b/toolchain/parse/parse_fuzzer.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "llvm/ADT/StringRef.h"
+#include "testing/fuzzing/libfuzzer.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/lex.h"

--- a/utils/treesitter/src/scanner.c
+++ b/utils/treesitter/src/scanner.c
@@ -10,6 +10,12 @@ enum TokenType {
   STRING,
 };
 
+// This is part of a special rule that doesn't allow `copts` in Bazel, so we
+// disable warnings using `#pragma`s here.
+#pragma clang diagnostic push
+// The tree_sitter build uses C functions without prototypes.
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 // our scanner is stateless
 void* tree_sitter_carbon_external_scanner_create(void) { return NULL; }
 


### PR DESCRIPTION
Most of these are places where we failed to include a header file and
simply never got an error about this. The fix is to include the header
file.

Most other cases are functions that should have been marked `static` but
were not. Finding all of these was a main motivation for me enabling the
warning despite how much work it is.

One complicating factor was that we weren't including the `handle.h` for
all the state-based handler functions. While this isn't a tiny amount of
code, it is just declarations and doesn't add any extra dependencies. It
also lets us have the checking for which functions need to be `static`
and which don't. For the `parse` library I had to add the `handle.h`
header as well, I tried to match the design of it in `check`.

I have also had to work around a bug in the warning, but given the value
it seems to be providing, that seems reasonable. I've filed the bug
upstream: https://github.com/llvm/llvm-project/issues/94138

I also had to use some hacks to work around limitations of Bazel rules
that wrap `cc_library` rules and don't expose `copts`. I filed a bug for
`cc_proto_library` specifically:
~https://github.com/bazelbuild/bazel/issues/22610~ 
https://github.com/bazelbuild/bazel/issues/4446