### PR TITLE
Rename enclosing scope to parent scope

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -497,10 +497,10 @@ class DeferredDefinitionWorklist {
   // Push a task to re-enter a function scope, so that functions defined within
   // it are type-checked in the right context.
   auto PushEnterDeferredDefinitionScope(Context& context) -> void {
-    bool nested = !ancestor_scopes_.empty() &&
-                  ancestor_scopes_.back().scope_index ==
+    bool nested = !entered_scopes_.empty() &&
+                  entered_scopes_.back().scope_index ==
                       context.decl_name_stack().PeekInitialScopeIndex();
-    ancestor_scopes_.push_back(
+    entered_scopes_.push_back(
         {.worklist_start_index = worklist_.size(),
          .scope_index = context.scope_stack().PeekIndex()});
     worklist_.push_back(
@@ -543,7 +543,7 @@ class DeferredDefinitionWorklist {
 
   // CHECK that the work list has no further work.
   auto VerifyEmpty() {
-    CARBON_CHECK(worklist_.empty() && ancestor_scopes_.empty())
+    CARBON_CHECK(worklist_.empty() && entered_scopes_.empty())
         << "Tasks left behind on worklist.";
   }
 
@@ -558,7 +558,7 @@ class DeferredDefinitionWorklist {
   llvm::SmallVector<Task, 0> worklist_;
 
   // A deferred definition scope that is currently still open.
-  struct AncestorScope {
+  struct EnteredScope {
     // The index in worklist_ of the EnterDeferredDefinitionScope task.
     size_t worklist_start_index;
     // The corresponding lexical scope index.
@@ -566,13 +566,13 @@ class DeferredDefinitionWorklist {
   };
 
   // The deferred definition scopes for the current checking actions.
-  llvm::SmallVector<AncestorScope> ancestor_scopes_;
+  llvm::SmallVector<EnteredScope> entered_scopes_;
 };
 }  // namespace
 
 auto DeferredDefinitionWorklist::SuspendFinishedScopeAndPush(Context& context)
     -> bool {
-  auto start_index = ancestor_scopes_.pop_back_val().worklist_start_index;
+  auto start_index = entered_scopes_.pop_back_val().worklist_start_index;
 
   // If we've not found any deferred definitions in this scope, clean up the
   // stack.

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -255,7 +255,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
   // Find the results from ancestor lexical scopes. These will be combined with
   // results from non-lexical scopes such as namespaces and classes.
   auto [lexical_result, non_lexical_scopes] =
-      scope_stack().LookupInAcestorScopes(name_id);
+      scope_stack().LookupInAncestorScopes(name_id);
 
   // Walk the non-lexical scopes and perform lookups into each of them.
   for (auto [index, name_scope_id] : llvm::reverse(non_lexical_scopes)) {

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -255,7 +255,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
   // Find the results from ancestor lexical scopes. These will be combined with
   // results from non-lexical scopes such as namespaces and classes.
   auto [lexical_result, non_lexical_scopes] =
-      scope_stack().LookupInAncestorScopes(name_id);
+      scope_stack().LookupInLexicalScopes(name_id);
 
   // Walk the non-lexical scopes and perform lookups into each of them.
   for (auto [index, name_scope_id] : llvm::reverse(non_lexical_scopes)) {

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -88,14 +88,14 @@ auto DeclNameStack::Suspend() -> SuspendedName {
       << "Missing call to FinishName before Suspend";
   SuspendedName result = {.name_context = decl_name_stack_.pop_back_val(),
                           .scopes = {}};
-  auto parent_index = result.name_context.initial_scope_index;
+  auto scope_index = result.name_context.initial_scope_index;
   auto& scope_stack = context_->scope_stack();
-  while (scope_stack.PeekIndex() > parent_index) {
+  while (scope_stack.PeekIndex() > scope_index) {
     result.scopes.push_back(scope_stack.Suspend());
   }
-  CARBON_CHECK(scope_stack.PeekIndex() == parent_index)
-      << "Scope index " << parent_index
-      << " does not enclose the current scope " << scope_stack.PeekIndex();
+  CARBON_CHECK(scope_stack.PeekIndex() == scope_index)
+      << "Scope index " << scope_index << " does not enclose the current scope "
+      << scope_stack.PeekIndex();
   return result;
 }
 

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -38,7 +38,7 @@ auto DeclNameStack::NameContext::prev_inst_id() -> SemIR::InstId {
 auto DeclNameStack::MakeEmptyNameContext() -> NameContext {
   return NameContext{
       .initial_scope_index = context_->scope_stack().PeekIndex(),
-      .enclosing_scope_id = context_->scope_stack().PeekNameScopeId()};
+      .parent_scope_id = context_->scope_stack().PeekNameScopeId()};
 }
 
 auto DeclNameStack::MakeUnqualifiedName(SemIR::LocId loc_id,
@@ -88,19 +88,19 @@ auto DeclNameStack::Suspend() -> SuspendedName {
       << "Missing call to FinishName before Suspend";
   SuspendedName result = {.name_context = decl_name_stack_.pop_back_val(),
                           .scopes = {}};
-  auto enclosing_index = result.name_context.initial_scope_index;
+  auto parent_index = result.name_context.initial_scope_index;
   auto& scope_stack = context_->scope_stack();
-  while (scope_stack.PeekIndex() > enclosing_index) {
+  while (scope_stack.PeekIndex() > parent_index) {
     result.scopes.push_back(scope_stack.Suspend());
   }
-  CARBON_CHECK(scope_stack.PeekIndex() == enclosing_index)
-      << "Scope index " << enclosing_index
+  CARBON_CHECK(scope_stack.PeekIndex() == parent_index)
+      << "Scope index " << parent_index
       << " does not enclose the current scope " << scope_stack.PeekIndex();
   return result;
 }
 
 auto DeclNameStack::Restore(SuspendedName sus) -> void {
-  // The enclosing state must be the same when a name is restored.
+  // The parent state must be the same when a name is restored.
   CARBON_CHECK(context_->scope_stack().PeekIndex() ==
                sus.name_context.initial_scope_index)
       << "Name restored at the wrong position in the name stack.";
@@ -121,11 +121,11 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id)
       return;
 
     case NameContext::State::Unresolved:
-      if (!name_context.enclosing_scope_id.is_valid()) {
+      if (!name_context.parent_scope_id.is_valid()) {
         context_->AddNameToLookup(name_context.unresolved_name_id, target_id);
       } else {
         auto& name_scope =
-            context_->name_scopes().Get(name_context.enclosing_scope_id);
+            context_->name_scopes().Get(name_context.parent_scope_id);
         if (name_context.has_qualifiers) {
           auto inst = context_->insts().Get(name_scope.inst_id);
           if (!inst.Is<SemIR::Namespace>()) {
@@ -150,7 +150,7 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id)
         CARBON_CHECK(success)
             << "Duplicate names should have been resolved previously: "
             << name_context.unresolved_name_id << " in "
-            << name_context.enclosing_scope_id;
+            << name_context.parent_scope_id;
       }
       break;
 
@@ -210,7 +210,7 @@ auto DeclNameStack::ApplyAndLookupName(NameContext& name_context,
 
   // For identifier nodes, we need to perform a lookup on the identifier.
   auto resolved_inst_id = context_->LookupNameInDecl(
-      name_context.loc_id, name_id, name_context.enclosing_scope_id);
+      name_context.loc_id, name_id, name_context.parent_scope_id);
   if (!resolved_inst_id.is_valid()) {
     // Invalid indicates an unresolved name. Store it and return.
     name_context.unresolved_name_id = name_id;
@@ -255,7 +255,7 @@ auto DeclNameStack::UpdateScopeIfNeeded(NameContext& name_context,
       const auto& class_info = context_->classes().Get(resolved_inst.class_id);
       if (class_info.is_defined()) {
         name_context.state = NameContext::State::Resolved;
-        name_context.enclosing_scope_id = class_info.scope_id;
+        name_context.parent_scope_id = class_info.scope_id;
         if (!is_unqualified) {
           PushNameQualifierScope(*context_, name_context.resolved_inst_id,
                                  class_info.scope_id);
@@ -270,7 +270,7 @@ auto DeclNameStack::UpdateScopeIfNeeded(NameContext& name_context,
           context_->interfaces().Get(resolved_inst.interface_id);
       if (interface_info.is_defined()) {
         name_context.state = NameContext::State::Resolved;
-        name_context.enclosing_scope_id = interface_info.scope_id;
+        name_context.parent_scope_id = interface_info.scope_id;
         if (!is_unqualified) {
           PushNameQualifierScope(*context_, name_context.resolved_inst_id,
                                  interface_info.scope_id);
@@ -283,7 +283,7 @@ auto DeclNameStack::UpdateScopeIfNeeded(NameContext& name_context,
     case CARBON_KIND(SemIR::Namespace resolved_inst): {
       auto scope_id = resolved_inst.name_scope_id;
       name_context.state = NameContext::State::Resolved;
-      name_context.enclosing_scope_id = scope_id;
+      name_context.parent_scope_id = scope_id;
       auto& scope = context_->name_scopes().Get(scope_id);
       if (scope.is_closed_import) {
         CARBON_DIAGNOSTIC(QualifiedDeclOutsidePackage, Error,

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -39,9 +39,9 @@ class Context;
 // fn ClassA.ClassB(T:! U).Fn() { var x: V; }
 // ```
 //
-// the lookup for `U` looks in `ClassA`, and the lookup for `V` looks in
-// `ClassA.ClassB` then in its enclosing scope `ClassA`. Scopes entered as part
-// of processing the name are exited when the name is popped from the stack.
+// the lookup for `U` looks in `ClassA`; the lookup for `V` looks first in
+// `ClassA.ClassB`, then its parent scope `ClassA`. Scopes entered as part of
+// processing the name are exited when the name is popped from the stack.
 //
 // Example state transitions:
 //
@@ -102,10 +102,10 @@ class DeclNameStack {
                                         : SemIR::NameId::Invalid;
     }
 
-    // Returns the enclosing_scope_id for a new instruction. This is invalid
+    // Returns the parent_scope_id for a new instruction. This is invalid
     // when the name resolved.
-    auto enclosing_scope_id_for_new_inst() -> SemIR::NameScopeId {
-      return state == State::Unresolved ? enclosing_scope_id
+    auto parent_scope_id_for_new_inst() -> SemIR::NameScopeId {
+      return state == State::Unresolved ? parent_scope_id
                                         : SemIR::NameScopeId::Invalid;
     }
 
@@ -121,7 +121,7 @@ class DeclNameStack {
     // The scope which qualified names are added to. For unqualified names in
     // an unnamed scope, this will be Invalid to indicate the current scope
     // should be used.
-    SemIR::NameScopeId enclosing_scope_id;
+    SemIR::NameScopeId parent_scope_id;
 
     // The last location ID used.
     SemIR::LocId loc_id = SemIR::LocId::Invalid;
@@ -191,13 +191,13 @@ class DeclNameStack {
   // This should be called at the end of the declaration.
   auto PopScope() -> void;
 
-  // Peeks the current enclosing scope of the name on top of the stack. Note
+  // Peeks the current parent scope of the name on top of the stack. Note
   // that if we're still processing the name qualifiers, this can change before
   // the name is completed. Also, if the name up to this point was already
   // declared and is a scope, this will be that scope, rather than the scope
-  // enclosing it.
-  auto PeekEnclosingScopeId() const -> SemIR::NameScopeId {
-    return decl_name_stack_.back().enclosing_scope_id;
+  // containing it.
+  auto PeekParentScopeId() const -> SemIR::NameScopeId {
+    return decl_name_stack_.back().parent_scope_id;
   }
 
   // Peeks the resolution scope index of the name on top of the stack.

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -41,7 +41,7 @@ auto HandleAlias(Context& context, Parse::AliasId /*node_id*/) -> bool {
 
   auto bind_name_id = context.bind_names().Add(
       {.name_id = name_context.name_id_for_new_inst(),
-       .enclosing_scope_id = name_context.enclosing_scope_id_for_new_inst(),
+       .parent_scope_id = name_context.parent_scope_id_for_new_inst(),
        .bind_index = SemIR::CompileTimeBindIndex::Invalid});
 
   auto alias_type_id = SemIR::TypeId::Invalid;

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -76,7 +76,7 @@ auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
   // Replace the ImportRef in name lookup, both for the above duplicate
   // diagnostic and so that cross-package imports can find it easily.
   auto bind_name = context.bind_names().Get(import_ref->bind_name_id);
-  auto& names = context.name_scopes().Get(bind_name.enclosing_scope_id).names;
+  auto& names = context.name_scopes().Get(bind_name.parent_scope_id).names;
   auto it = names.find(bind_name.name_id);
   CARBON_CHECK(it->second == inst_id);
   it->second = export_id;

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -36,10 +36,10 @@ static auto BuildInterfaceDecl(Context& context,
       .PopAndDiscardSoloNodeId<Parse::NodeKind::InterfaceIntroducer>();
 
   // Process modifiers.
-  auto [_, enclosing_scope_inst] =
-      context.name_scopes().GetInstIfValid(name_context.enclosing_scope_id);
+  auto [_, parent_scope_inst] =
+      context.name_scopes().GetInstIfValid(name_context.parent_scope_id);
   CheckAccessModifiersOnDecl(context, Lex::TokenKind::Interface,
-                             enclosing_scope_inst);
+                             parent_scope_inst);
   LimitModifiersOnDecl(context, KeywordModifierSet::Access,
                        Lex::TokenKind::Interface);
 
@@ -84,7 +84,7 @@ static auto BuildInterfaceDecl(Context& context,
     // invalid.
     interface_decl.interface_id = context.interfaces().Add(
         {.name_id = name_context.name_id_for_new_inst(),
-         .enclosing_scope_id = name_context.enclosing_scope_id_for_new_inst(),
+         .parent_scope_id = name_context.parent_scope_id_for_new_inst(),
          .decl_id = interface_decl_id});
   }
 
@@ -121,7 +121,7 @@ auto HandleInterfaceDefinitionStart(Context& context,
     interface_info.definition_id = interface_decl_id;
     interface_info.scope_id =
         context.name_scopes().Add(interface_decl_id, SemIR::NameId::Invalid,
-                                  interface_info.enclosing_scope_id);
+                                  interface_info.parent_scope_id);
   }
 
   // Enter the interface scope.
@@ -145,7 +145,7 @@ auto HandleInterfaceDefinitionStart(Context& context,
     // the `value_id` on the `BindSymbolicName`.
     auto bind_name_id = context.bind_names().Add(
         {.name_id = SemIR::NameId::SelfType,
-         .enclosing_scope_id = interface_info.scope_id,
+         .parent_scope_id = interface_info.scope_id,
          .bind_index = context.scope_stack().AddCompileTimeBinding()});
     interface_info.self_param_id = context.AddInst<SemIR::BindSymbolicName>(
         SemIR::LocId::Invalid, {.type_id = self_type_id,

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -78,13 +78,12 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   // Process declaration modifiers.
   // TODO: For a qualified `let` declaration, this should use the target scope
   // of the name introduced in the declaration. See #2590.
-  auto [enclosing_scope_inst_id, enclosing_scope_inst] =
+  auto [parent_scope_inst_id, parent_scope_inst] =
       context.name_scopes().GetInstIfValid(
           context.scope_stack().PeekNameScopeId());
-  CheckAccessModifiersOnDecl(context, Lex::TokenKind::Let,
-                             enclosing_scope_inst);
+  CheckAccessModifiersOnDecl(context, Lex::TokenKind::Let, parent_scope_inst);
   RequireDefaultFinalOnlyInInterfaces(context, Lex::TokenKind::Let,
-                                      enclosing_scope_inst);
+                                      parent_scope_inst);
   LimitModifiersOnDecl(
       context, KeywordModifierSet::Access | KeywordModifierSet::Interface,
       Lex::TokenKind::Let);
@@ -140,7 +139,7 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   // Add the name of the binding to the current scope.
   auto name_id = context.bind_names().Get(bind_name.bind_name_id).name_id;
   context.AddNameToLookup(name_id, pattern_id);
-  if (enclosing_scope_inst_id == SemIR::InstId::PackageNamespace) {
+  if (parent_scope_inst_id == SemIR::InstId::PackageNamespace) {
     context.AddExport(pattern_id);
   }
   return true;

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -31,7 +31,7 @@ auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, namespace_inst));
   namespace_inst.name_scope_id = context.name_scopes().Add(
       namespace_id, name_context.name_id_for_new_inst(),
-      name_context.enclosing_scope_id_for_new_inst());
+      name_context.parent_scope_id_for_new_inst());
   context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);
 
   auto existing_inst_id =

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -98,10 +98,9 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
   // Process declaration modifiers.
   // TODO: For a qualified `var` declaration, this should use the target scope
   // of the name introduced in the declaration. See #2590.
-  auto [_, enclosing_scope_inst] = context.name_scopes().GetInstIfValid(
+  auto [_, parent_scope_inst] = context.name_scopes().GetInstIfValid(
       context.scope_stack().PeekNameScopeId());
-  CheckAccessModifiersOnDecl(context, Lex::TokenKind::Var,
-                             enclosing_scope_inst);
+  CheckAccessModifiersOnDecl(context, Lex::TokenKind::Var, parent_scope_inst);
   LimitModifiersOnDecl(context, KeywordModifierSet::Access,
                        Lex::TokenKind::Var);
   auto modifiers = context.decl_state_stack().innermost().modifier_set;

--- a/toolchain/check/modifiers.h
+++ b/toolchain/check/modifiers.h
@@ -10,22 +10,22 @@
 namespace Carbon::Check {
 
 // Reports a diagnostic if access control modifiers on this are not allowed for
-// a declaration in `enclosing_scope_inst`, and updates the declaration state in
+// a declaration in `parent_scope_inst`, and updates the declaration state in
 // `context`.
 //
-// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
+// `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
-                                std::optional<SemIR::Inst> enclosing_scope_inst)
+                                std::optional<SemIR::Inst> parent_scope_inst)
     -> void;
 
 // Reports a diagnostic if the method function modifiers `abstract`, `virtual`,
 // or `impl` are present but not permitted on a function declaration in
-// `enclosing_scope_inst`.
+// `parent_scope_inst`.
 //
-// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
+// `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto CheckMethodModifiersOnFunction(
-    Context& context, SemIR::InstId enclosing_scope_inst_id,
-    std::optional<SemIR::Inst> enclosing_scope_inst) -> void;
+    Context& context, SemIR::InstId parent_scope_inst_id,
+    std::optional<SemIR::Inst> parent_scope_inst) -> void;
 
 // Like `LimitModifiersOnDecl`, except says which modifiers are forbidden, and a
 // `context_string` (and optional `context_loc_id`) specifying the context in
@@ -50,20 +50,19 @@ inline auto LimitModifiersOnDecl(Context& context, KeywordModifierSet allowed,
 // - `extern` on a definition.
 // - `extern` on a scoped entity.
 //
-// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
-auto RestrictExternModifierOnDecl(
-    Context& context, Lex::TokenKind decl_kind,
-    std::optional<SemIR::Inst> enclosing_scope_inst, bool is_definition)
-    -> void;
+// `parent_scope_inst` may be nullopt for a declaration in a block scope.
+auto RestrictExternModifierOnDecl(Context& context, Lex::TokenKind decl_kind,
+                                  std::optional<SemIR::Inst> parent_scope_inst,
+                                  bool is_definition) -> void;
 
 // Report a diagonostic if `default` and `final` modifiers are used on
 // declarations where they are not allowed. Right now they are only allowed
 // inside interfaces.
 //
-// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
+// `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto RequireDefaultFinalOnlyInInterfaces(
     Context& context, Lex::TokenKind decl_kind,
-    std::optional<SemIR::Inst> enclosing_scope_inst) -> void;
+    std::optional<SemIR::Inst> parent_scope_inst) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -81,7 +81,7 @@ auto ScopeStack::LookupInCurrentScope(SemIR::NameId name_id) -> SemIR::InstId {
   return result.inst_id;
 }
 
-auto ScopeStack::LookupInAcestorScopes(SemIR::NameId name_id)
+auto ScopeStack::LookupInAncestorScopes(SemIR::NameId name_id)
     -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>> {
   // Find the results from parent lexical scopes. These will be combined with
   // results from non-lexical scopes such as namespaces and classes.

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -81,10 +81,10 @@ auto ScopeStack::LookupInCurrentScope(SemIR::NameId name_id) -> SemIR::InstId {
   return result.inst_id;
 }
 
-auto ScopeStack::LookupInAncestorScopes(SemIR::NameId name_id)
+auto ScopeStack::LookupInLexicalScopes(SemIR::NameId name_id)
     -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>> {
-  // Find the results from parent lexical scopes. These will be combined with
-  // results from non-lexical scopes such as namespaces and classes.
+  // Find the results from lexical scopes. These will be combined with results
+  // from non-lexical scopes such as namespaces and classes.
   llvm::ArrayRef<LexicalLookup::Result> lexical_results =
       lexical_lookup_.Get(name_id);
 

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -81,9 +81,9 @@ auto ScopeStack::LookupInCurrentScope(SemIR::NameId name_id) -> SemIR::InstId {
   return result.inst_id;
 }
 
-auto ScopeStack::LookupInEnclosingScopes(SemIR::NameId name_id)
+auto ScopeStack::LookupInAcestorScopes(SemIR::NameId name_id)
     -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>> {
-  // Find the results from enclosing lexical scopes. These will be combined with
+  // Find the results from parent lexical scopes. These will be combined with
   // results from non-lexical scopes such as namespaces and classes.
   llvm::ArrayRef<LexicalLookup::Result> lexical_results =
       lexical_lookup_.Get(name_id);

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -102,11 +102,11 @@ class ScopeStack {
   // lookup result, if any.
   auto LookupInCurrentScope(SemIR::NameId name_id) -> SemIR::InstId;
 
-  // Looks up the name `name_id` in the current scope and its ancestor scopes.
-  // Returns the innermost lexical lookup result, if any, along with a list of
-  // non-lexical scopes in which lookup should also be performed, ordered from
-  // outermost to innermost.
-  auto LookupInAncestorScopes(SemIR::NameId name_id)
+  // Looks up the name `name_id` in the current scope and related lexical
+  // scopes. Returns the innermost lexical lookup result, if any, along with a
+  // list of non-lexical scopes in which lookup should also be performed,
+  // ordered from outermost to innermost.
+  auto LookupInLexicalScopes(SemIR::NameId name_id)
       -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>>;
 
   // Looks up the name `name_id` in the current scope. Returns the existing

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -102,11 +102,11 @@ class ScopeStack {
   // lookup result, if any.
   auto LookupInCurrentScope(SemIR::NameId name_id) -> SemIR::InstId;
 
-  // Looks up the name `name_id` in the current scope and its enclosing scopes.
+  // Looks up the name `name_id` in the current scope and its ancestor scopes.
   // Returns the innermost lexical lookup result, if any, along with a list of
   // non-lexical scopes in which lookup should also be performed, ordered from
   // outermost to innermost.
-  auto LookupInEnclosingScopes(SemIR::NameId name_id)
+  auto LookupInAcestorScopes(SemIR::NameId name_id)
       -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>>;
 
   // Looks up the name `name_id` in the current scope. Returns the existing
@@ -159,7 +159,7 @@ class ScopeStack {
     // The next compile-time binding index to allocate in this scope.
     SemIR::CompileTimeBindIndex next_compile_time_bind_index;
 
-    // Whether lexical_lookup_ has load errors from this scope or an enclosing
+    // Whether lexical_lookup_ has load errors from this scope or an ancestor
     // scope.
     bool lexical_lookup_has_load_error;
 

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -106,7 +106,7 @@ class ScopeStack {
   // Returns the innermost lexical lookup result, if any, along with a list of
   // non-lexical scopes in which lookup should also be performed, ordered from
   // outermost to innermost.
-  auto LookupInAcestorScopes(SemIR::NameId name_id)
+  auto LookupInAncestorScopes(SemIR::NameId name_id)
       -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>>;
 
   // Looks up the name `name_id` in the current scope. Returns the existing

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -11,7 +11,7 @@
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   bind_names:      {}
 // CHECK:STDOUT:   functions:       {}
 // CHECK:STDOUT:   classes:         {}

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
@@ -23,10 +23,10 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: empty, body: [block3]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: empty, body: [block3]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -84,10 +84,10 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: empty, body: [block3]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: empty, body: [block3]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
@@ -23,10 +23,10 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: empty, body: [block3]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: empty, body: [block3]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -63,10 +63,10 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: empty, body: [block3]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: empty, body: [block3]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}

--- a/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
@@ -17,11 +17,11 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:
-// CHECK:STDOUT:     bindName0:       {name: name1, enclosing_scope: name_scope<invalid>, index: compTimeBind<invalid>}
+// CHECK:STDOUT:     bindName0:       {name: name1, parent_scope: name_scope<invalid>, index: compTimeBind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}

--- a/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
@@ -17,11 +17,11 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:
-// CHECK:STDOUT:     bindName0:       {name: name1, enclosing_scope: name_scope<invalid>, index: compTimeBind<invalid>}
+// CHECK:STDOUT:     bindName0:       {name: name1, parent_scope: name_scope<invalid>, index: compTimeBind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -123,7 +123,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
   // Don't lower associated functions.
   // TODO: We shouldn't lower any function that has generic parameters.
   if (sem_ir().insts().Is<SemIR::InterfaceDecl>(
-          sem_ir().name_scopes().Get(function.enclosing_scope_id).inst_id)) {
+          sem_ir().name_scopes().Get(function.parent_scope_id).inst_id)) {
     return nullptr;
   }
 

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -470,7 +470,7 @@ auto Context::AddFunctionDefinitionStart(Lex::TokenIndex token,
                                          int subtree_start, bool has_error)
     -> void {
   if (ParsingInDeferredDefinitionScope(*this)) {
-    enclosing_deferred_definition_stack_.push_back(
+    parent_deferred_definition_stack_.push_back(
         tree_->deferred_definitions_.Add(
             {.start_id = FunctionDefinitionStartId(
                  NodeId(tree_->node_impls_.size()))}));
@@ -482,7 +482,7 @@ auto Context::AddFunctionDefinitionStart(Lex::TokenIndex token,
 auto Context::AddFunctionDefinition(Lex::TokenIndex token, int subtree_start,
                                     bool has_error) -> void {
   if (ParsingInDeferredDefinitionScope(*this)) {
-    auto definition_index = enclosing_deferred_definition_stack_.pop_back_val();
+    auto definition_index = parent_deferred_definition_stack_.pop_back_val();
     auto& definition = tree_->deferred_definitions_.Get(definition_index);
     definition.definition_id =
         FunctionDefinitionId(NodeId(tree_->node_impls_.size()));

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -470,10 +470,9 @@ auto Context::AddFunctionDefinitionStart(Lex::TokenIndex token,
                                          int subtree_start, bool has_error)
     -> void {
   if (ParsingInDeferredDefinitionScope(*this)) {
-    parent_deferred_definition_stack_.push_back(
-        tree_->deferred_definitions_.Add(
-            {.start_id = FunctionDefinitionStartId(
-                 NodeId(tree_->node_impls_.size()))}));
+    deferred_definition_stack_.push_back(tree_->deferred_definitions_.Add(
+        {.start_id =
+             FunctionDefinitionStartId(NodeId(tree_->node_impls_.size()))}));
   }
 
   AddNode(NodeKind::FunctionDefinitionStart, token, subtree_start, has_error);
@@ -482,7 +481,7 @@ auto Context::AddFunctionDefinitionStart(Lex::TokenIndex token,
 auto Context::AddFunctionDefinition(Lex::TokenIndex token, int subtree_start,
                                     bool has_error) -> void {
   if (ParsingInDeferredDefinitionScope(*this)) {
-    auto definition_index = parent_deferred_definition_stack_.pop_back_val();
+    auto definition_index = deferred_definition_stack_.pop_back_val();
     auto& definition = tree_->deferred_definitions_.Get(definition_index);
     definition.definition_id =
         FunctionDefinitionId(NodeId(tree_->node_impls_.size()));

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -376,8 +376,7 @@ class Context {
 
   // The deferred definition indexes of functions whose definitions have begun
   // but not yet finished.
-  llvm::SmallVector<DeferredDefinitionIndex>
-      enclosing_deferred_definition_stack_;
+  llvm::SmallVector<DeferredDefinitionIndex> parent_deferred_definition_stack_;
 
   // The current packaging state, whether `import`/`package` are allowed.
   PackagingState packaging_state_ = PackagingState::FileStart;

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -376,7 +376,7 @@ class Context {
 
   // The deferred definition indexes of functions whose definitions have begun
   // but not yet finished.
-  llvm::SmallVector<DeferredDefinitionIndex> parent_deferred_definition_stack_;
+  llvm::SmallVector<DeferredDefinitionIndex> deferred_definition_stack_;
 
   // The current packaging state, whether `import`/`package` are allowed.
   PackagingState packaging_state_ = PackagingState::FileStart;

--- a/toolchain/sem_ir/bind_name.h
+++ b/toolchain/sem_ir/bind_name.h
@@ -13,14 +13,14 @@ namespace Carbon::SemIR {
 
 struct BindNameInfo : public Printable<BindNameInfo> {
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{name: " << name_id << ", enclosing_scope: " << enclosing_scope_id
+    out << "{name: " << name_id << ", parent_scope: " << parent_scope_id
         << ", index: " << bind_index << "}";
   }
 
   // The name.
   NameId name_id;
-  // The enclosing scope.
-  NameScopeId enclosing_scope_id;
+  // The parent scope.
+  NameScopeId parent_scope_id;
   // The index for a compile-time binding. Invalid for a runtime binding.
   CompileTimeBindIndex bind_index;
 };
@@ -37,13 +37,13 @@ inline auto CarbonHashValue(const BindNameInfo& value, uint64_t seed)
 struct BindNameInfoDenseMapInfo {
   static auto getEmptyKey() -> BindNameInfo {
     return BindNameInfo{.name_id = NameId::Invalid,
-                        .enclosing_scope_id = NameScopeId::Invalid,
+                        .parent_scope_id = NameScopeId::Invalid,
                         .bind_index = CompileTimeBindIndex(
                             CompileTimeBindIndex::InvalidIndex - 1)};
   }
   static auto getTombstoneKey() -> BindNameInfo {
     return BindNameInfo{.name_id = NameId::Invalid,
-                        .enclosing_scope_id = NameScopeId::Invalid,
+                        .parent_scope_id = NameScopeId::Invalid,
                         .bind_index = CompileTimeBindIndex(
                             CompileTimeBindIndex::InvalidIndex - 2)};
   }

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -21,8 +21,7 @@ struct Class : public Printable<Class> {
   };
 
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{name: " << name_id << ", enclosing_scope: " << enclosing_scope_id
-        << "}";
+    out << "{name: " << name_id << ", parent_scope: " << parent_scope_id << "}";
   }
 
   // Determines whether this class has been fully defined. This is false until
@@ -39,8 +38,8 @@ struct Class : public Printable<Class> {
 
   // The class name.
   NameId name_id;
-  // The enclosing scope.
-  NameScopeId enclosing_scope_id;
+  // The parent scope.
+  NameScopeId parent_scope_id;
   // A block containing a single reference instruction per implicit parameter.
   InstBlockId implicit_param_refs_id;
   // A block containing a single reference instruction per parameter.

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -28,7 +28,7 @@ struct Function : public Printable<Function> {
   };
 
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{name: " << name_id << ", enclosing_scope: " << enclosing_scope_id
+    out << "{name: " << name_id << ", parent_scope: " << parent_scope_id
         << ", param_refs: " << param_refs_id;
     if (return_type_id.is_valid()) {
       out << ", return_type: " << return_type_id;
@@ -79,8 +79,8 @@ struct Function : public Printable<Function> {
 
   // The function name.
   NameId name_id;
-  // The enclosing scope.
-  NameScopeId enclosing_scope_id;
+  // The parent scope.
+  NameScopeId parent_scope_id;
   // The first declaration of the function. This is a FunctionDecl.
   InstId decl_id;
   // A block containing a single reference instruction per implicit parameter.

--- a/toolchain/sem_ir/interface.h
+++ b/toolchain/sem_ir/interface.h
@@ -12,8 +12,7 @@ namespace Carbon::SemIR {
 // An interface.
 struct Interface : public Printable<Interface> {
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{name: " << name_id << ", enclosing_scope: " << enclosing_scope_id
-        << "}";
+    out << "{name: " << name_id << ", parent_scope: " << parent_scope_id << "}";
   }
 
   // Determines whether this interface has been fully defined. This is false
@@ -31,8 +30,8 @@ struct Interface : public Printable<Interface> {
 
   // The interface name.
   NameId name_id;
-  // The enclosing scope.
-  NameScopeId enclosing_scope_id;
+  // The parent scope.
+  NameScopeId parent_scope_id;
   // The first declaration of the interface. This is a InterfaceDecl.
   InstId decl_id;
 

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -12,7 +12,7 @@ namespace Carbon::SemIR {
 
 struct NameScope : Printable<NameScope> {
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{inst: " << inst_id << ", enclosing_scope: " << enclosing_scope_id
+    out << "{inst: " << inst_id << ", parent_scope: " << parent_scope_id
         << ", has_error: " << (has_error ? "true" : "false");
 
     out << ", extended_scopes: [";
@@ -66,8 +66,8 @@ struct NameScope : Printable<NameScope> {
   // When the scope is a namespace, the name. Otherwise, invalid.
   NameId name_id;
 
-  // The scope enclosing this one.
-  NameScopeId enclosing_scope_id;
+  // The parent scope.
+  NameScopeId parent_scope_id;
 
   // Whether we have diagnosed an error in a construct that would have added
   // names to this scope. For example, this can happen if an `import` failed or
@@ -91,11 +91,11 @@ class NameScopeStore {
   explicit NameScopeStore(InstStore* insts) : insts_(insts) {}
 
   // Adds a name scope, returning an ID to reference it.
-  auto Add(InstId inst_id, NameId name_id, NameScopeId enclosing_scope_id)
+  auto Add(InstId inst_id, NameId name_id, NameScopeId parent_scope_id)
       -> NameScopeId {
     return values_.Add({.inst_id = inst_id,
                         .name_id = name_id,
-                        .enclosing_scope_id = enclosing_scope_id});
+                        .parent_scope_id = parent_scope_id});
   }
 
   // Returns the requested name scope.


### PR DESCRIPTION
Following up on discussion from #3948, doing a general rename of "enclosing scope" to "parent scope" (and "enclosing scopes" to "ancestor scopes"). The intent is to improve understandability and collide less with C++ terminology for "enclosing scope". Note this changes most uses of "enclosing", but leaves behind a few like "enclosing function" and "enclosing block".

Note this does create some "parent class" mentions for "adapt" and "var" (the class they're within), which is maybe unfortunate, but we'd probably say "base class" if we meant inheritance so perhaps that's okay. Along the same lines, these are the only `parent_class` uses I see now, and we do have a few `base_class`.