### PR TITLE
Remove a stale data dependency.

### DIFF
--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -114,15 +114,6 @@ cc_library(
     ],
 )
 
-# Build up some trees of data to use in testing our install detection.
-symlink_filegroup(
-    name = "test_installed_data",
-    testonly = 1,
-    srcs = ["//toolchain/install:install_data"],
-    out_prefix = "test_installed_root/",
-    remove_prefix = "toolchain/install/prefix_root/",
-)
-
 cc_binary(
     name = "test_binary",
     testonly = 1,
@@ -137,7 +128,6 @@ cc_test(
     data = [
         ":install_data",
         ":test_binary",
-        ":test_installed_data",
     ],
     deps = [
         ":install_paths",


### PR DESCRIPTION
Jon correctly pointed out that this wasn't being used any more. Originally, the code needed a different tree for the install prefix in order to test different code paths of detection, but since those are now explicit in the code it is already using a single tree. But I never updated the actual BUILD file to stop building and depending on the extra prefix.