### PR TITLE
Switch decl_state to an arg for modifier functions

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -66,8 +66,8 @@ cc_library(
     hdrs = [
         "context.h",
         "convert.h",
+        "decl_introducer_state.h",
         "decl_name_stack.h",
-        "decl_state.h",
         "diagnostic_helpers.h",
         "eval.h",
         "function.h",

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -8,8 +8,8 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "toolchain/check/decl_introducer_state.h"
 #include "toolchain/check/decl_name_stack.h"
-#include "toolchain/check/decl_state.h"
 #include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/inst_block_stack.h"
 #include "toolchain/check/node_stack.h"
@@ -335,7 +335,9 @@ class Context {
 
   auto decl_name_stack() -> DeclNameStack& { return decl_name_stack_; }
 
-  auto decl_state_stack() -> DeclStateStack& { return decl_state_stack_; }
+  auto decl_introducer_state_stack() -> DeclIntroducerStateStack& {
+    return decl_introducer_state_stack_;
+  }
 
   auto scope_stack() -> ScopeStack& { return scope_stack_; }
 
@@ -447,7 +449,7 @@ class Context {
   DeclNameStack decl_name_stack_;
 
   // The stack of declarations that could have modifiers.
-  DeclStateStack decl_state_stack_;
+  DeclIntroducerStateStack decl_introducer_state_stack_;
 
   // The stack of scopes we are currently within.
   ScopeStack scope_stack_;

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -30,12 +30,12 @@ auto HandleAlias(Context& context, Parse::AliasId /*node_id*/) -> bool {
   auto name_context = context.decl_name_stack().FinishName(
       PopNameComponentWithoutParams(context, Lex::TokenKind::Alias));
 
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Alias);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Access,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::Access,
                        Lex::TokenKind::Alias);
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
 

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -15,7 +15,7 @@ namespace Carbon::Check {
 
 auto HandleExportIntroducer(Context& context,
                             Parse::ExportIntroducerId /*node_id*/) -> bool {
-  context.decl_state_stack().Push(DeclState::Export);
+  context.decl_introducer_state_stack().Push(DeclIntroducerState::Export);
   // TODO: Probably need to update DeclNameStack to restrict to only namespaces.
   context.decl_name_stack().PushScopeAndStartName();
   return true;
@@ -26,9 +26,10 @@ auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
       PopNameComponentWithoutParams(context, Lex::TokenKind::Export));
   context.decl_name_stack().PopScope();
 
-  LimitModifiersOnDecl(context, KeywordModifierSet::None,
+  auto decl_state =
+      context.decl_introducer_state_stack().Pop(DeclIntroducerState::Export);
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::None,
                        Lex::TokenKind::Export);
-  context.decl_state_stack().Pop(DeclState::Export);
 
   if (name_context.state == DeclNameStack::NameContext::State::Error) {
     // Should already be diagnosed.

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -26,9 +26,9 @@ auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
       PopNameComponentWithoutParams(context, Lex::TokenKind::Export));
   context.decl_name_stack().PopScope();
 
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Export);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::None,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::None,
                        Lex::TokenKind::Export);
 
   if (name_context.state == DeclNameStack::NameContext::State::Error) {

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -45,23 +45,23 @@ auto HandleReturnType(Context& context, Parse::ReturnTypeId node_id) -> bool {
   return true;
 }
 
-static auto DiagnoseModifiers(Context& context, DeclIntroducerState& decl_state,
+static auto DiagnoseModifiers(Context& context, DeclIntroducerState& introducer,
                               bool is_definition,
                               SemIR::InstId parent_scope_inst_id,
                               std::optional<SemIR::Inst> parent_scope_inst)
     -> void {
-  CheckAccessModifiersOnDecl(context, decl_state, Lex::TokenKind::Fn,
+  CheckAccessModifiersOnDecl(context, introducer, Lex::TokenKind::Fn,
                              parent_scope_inst);
-  LimitModifiersOnDecl(context, decl_state,
+  LimitModifiersOnDecl(context, introducer,
                        KeywordModifierSet::Access | KeywordModifierSet::Extern |
                            KeywordModifierSet::Method |
                            KeywordModifierSet::Interface,
                        Lex::TokenKind::Fn);
-  RestrictExternModifierOnDecl(context, decl_state, Lex::TokenKind::Fn,
+  RestrictExternModifierOnDecl(context, introducer, Lex::TokenKind::Fn,
                                parent_scope_inst, is_definition);
-  CheckMethodModifiersOnFunction(context, decl_state, parent_scope_inst_id,
+  CheckMethodModifiersOnFunction(context, introducer, parent_scope_inst_id,
                                  parent_scope_inst);
-  RequireDefaultFinalOnlyInInterfaces(context, decl_state, Lex::TokenKind::Fn,
+  RequireDefaultFinalOnlyInInterfaces(context, introducer, Lex::TokenKind::Fn,
                                       parent_scope_inst);
 }
 
@@ -227,23 +227,23 @@ static auto BuildFunctionDecl(Context& context,
   // Process modifiers.
   auto [parent_scope_inst_id, parent_scope_inst] =
       context.name_scopes().GetInstIfValid(name_context.parent_scope_id);
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Fn);
-  DiagnoseModifiers(context, decl_state, is_definition, parent_scope_inst_id,
+  DiagnoseModifiers(context, introducer, is_definition, parent_scope_inst_id,
                     parent_scope_inst);
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
-  bool is_extern = decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Method)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Decl),
+  bool is_extern = introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Method)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Decl),
                  "method modifier");
   }
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
     // TODO: Once we are saving the modifiers for a function, add check that
     // the function may only be defined if it is marked `default` or `final`.
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Decl),
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Decl),
                  "interface modifier");
   }
 

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -192,9 +192,9 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   // Process modifiers.
   // TODO: Should we somehow permit access specifiers on `impl`s?
   // TODO: Handle `final` modifier.
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Impl);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::ImplDecl,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::ImplDecl,
                        Lex::TokenKind::Impl);
 
   // Finish processing the name, which should be empty, but might have
@@ -216,8 +216,8 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   auto impl_decl_id = context.AddInst(node_id, impl_decl);
 
   // For an `extend impl` declaration, mark the impl as extending this `impl`.
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Extend)) {
-    auto extend_node = decl_state.modifier_node_id(ModifierOrder::Decl);
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extend)) {
+    auto extend_node = introducer.modifier_node_id(ModifierOrder::Decl);
     ExtendImpl(context, extend_node, node_id, self_type_node, self_type_id,
                params_node, constraint_type_id);
   }

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -24,7 +24,7 @@ auto HandleImplIntroducer(Context& context, Parse::ImplIntroducerId node_id)
   context.node_stack().Push(node_id);
 
   // Optional modifiers follow.
-  context.decl_state_stack().Push(DeclState::Impl);
+  context.decl_introducer_state_stack().Push(DeclIntroducerState::Impl);
 
   // An impl doesn't have a name per se, but it makes the processing more
   // consistent to imagine that it does. This also gives us a scope for implicit
@@ -192,7 +192,9 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   // Process modifiers.
   // TODO: Should we somehow permit access specifiers on `impl`s?
   // TODO: Handle `final` modifier.
-  LimitModifiersOnDecl(context, KeywordModifierSet::ImplDecl,
+  auto decl_state =
+      context.decl_introducer_state_stack().Pop(DeclIntroducerState::Impl);
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::ImplDecl,
                        Lex::TokenKind::Impl);
 
   // Finish processing the name, which should be empty, but might have
@@ -214,15 +216,11 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id)
   auto impl_decl_id = context.AddInst(node_id, impl_decl);
 
   // For an `extend impl` declaration, mark the impl as extending this `impl`.
-  if (context.decl_state_stack().innermost().modifier_set.HasAnyOf(
-          KeywordModifierSet::Extend)) {
-    auto extend_node = context.decl_state_stack().innermost().modifier_node_id(
-        ModifierOrder::Decl);
+  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Extend)) {
+    auto extend_node = decl_state.modifier_node_id(ModifierOrder::Decl);
     ExtendImpl(context, extend_node, node_id, self_type_node, self_type_id,
                params_node, constraint_type_id);
   }
-
-  context.decl_state_stack().Pop(DeclState::Impl);
 
   return {impl_decl.impl_id, impl_decl_id};
 }

--- a/toolchain/check/handle_import_and_package.cpp
+++ b/toolchain/check/handle_import_and_package.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
-#include "toolchain/check/decl_state.h"
+#include "toolchain/check/decl_introducer_state.h"
 #include "toolchain/check/handle.h"
 #include "toolchain/check/modifiers.h"
 
@@ -14,43 +14,48 @@ namespace Carbon::Check {
 
 auto HandleImportIntroducer(Context& context,
                             Parse::ImportIntroducerId /*node_id*/) -> bool {
-  context.decl_state_stack().Push(DeclState::Import);
+  context.decl_introducer_state_stack().Push(DeclIntroducerState::Import);
   return true;
 }
 
 auto HandleImportDecl(Context& context, Parse::ImportDeclId /*node_id*/)
     -> bool {
-  LimitModifiersOnDecl(context, KeywordModifierSet::Export,
+  auto decl_state =
+      context.decl_introducer_state_stack().Pop(DeclIntroducerState::Import);
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Export,
                        Lex::TokenKind::Import);
-  context.decl_state_stack().Pop(DeclState::Import);
   return true;
 }
 
 auto HandleLibraryIntroducer(Context& context,
                              Parse::LibraryIntroducerId /*node_id*/) -> bool {
-  context.decl_state_stack().Push(DeclState::PackageOrLibrary);
+  context.decl_introducer_state_stack().Push(
+      DeclIntroducerState::PackageOrLibrary);
   return true;
 }
 
 auto HandleLibraryDecl(Context& context, Parse::LibraryDeclId /*node_id*/)
     -> bool {
-  LimitModifiersOnDecl(context, KeywordModifierSet::Impl,
+  auto decl_state = context.decl_introducer_state_stack().Pop(
+      DeclIntroducerState::PackageOrLibrary);
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Impl,
                        Lex::TokenKind::Library);
-  context.decl_state_stack().Pop(DeclState::PackageOrLibrary);
   return true;
 }
 
 auto HandlePackageIntroducer(Context& context,
                              Parse::PackageIntroducerId /*node_id*/) -> bool {
-  context.decl_state_stack().Push(DeclState::PackageOrLibrary);
+  context.decl_introducer_state_stack().Push(
+      DeclIntroducerState::PackageOrLibrary);
   return true;
 }
 
 auto HandlePackageDecl(Context& context, Parse::PackageDeclId /*node_id*/)
     -> bool {
-  LimitModifiersOnDecl(context, KeywordModifierSet::Impl,
+  auto decl_state = context.decl_introducer_state_stack().Pop(
+      DeclIntroducerState::PackageOrLibrary);
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Impl,
                        Lex::TokenKind::Package);
-  context.decl_state_stack().Pop(DeclState::PackageOrLibrary);
   return true;
 }
 

--- a/toolchain/check/handle_import_and_package.cpp
+++ b/toolchain/check/handle_import_and_package.cpp
@@ -20,9 +20,9 @@ auto HandleImportIntroducer(Context& context,
 
 auto HandleImportDecl(Context& context, Parse::ImportDeclId /*node_id*/)
     -> bool {
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Import);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Export,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::Export,
                        Lex::TokenKind::Import);
   return true;
 }
@@ -36,9 +36,9 @@ auto HandleLibraryIntroducer(Context& context,
 
 auto HandleLibraryDecl(Context& context, Parse::LibraryDeclId /*node_id*/)
     -> bool {
-  auto decl_state = context.decl_introducer_state_stack().Pop(
+  auto introducer = context.decl_introducer_state_stack().Pop(
       DeclIntroducerState::PackageOrLibrary);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Impl,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::Impl,
                        Lex::TokenKind::Library);
   return true;
 }
@@ -52,9 +52,9 @@ auto HandlePackageIntroducer(Context& context,
 
 auto HandlePackageDecl(Context& context, Parse::PackageDeclId /*node_id*/)
     -> bool {
-  auto decl_state = context.decl_introducer_state_stack().Pop(
+  auto introducer = context.decl_introducer_state_stack().Pop(
       DeclIntroducerState::PackageOrLibrary);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Impl,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::Impl,
                        Lex::TokenKind::Package);
   return true;
 }

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -19,7 +19,7 @@ auto HandleInterfaceIntroducer(Context& context,
   // Push the bracketing node.
   context.node_stack().Push(node_id);
   // Optional modifiers and the name follow.
-  context.decl_state_stack().Push(DeclState::Interface);
+  context.decl_introducer_state_stack().Push(DeclIntroducerState::Interface);
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }
@@ -39,18 +39,17 @@ static auto BuildInterfaceDecl(Context& context,
   // Process modifiers.
   auto [_, parent_scope_inst] =
       context.name_scopes().GetInstIfValid(name_context.parent_scope_id);
-  CheckAccessModifiersOnDecl(context, Lex::TokenKind::Interface,
+  auto decl_state =
+      context.decl_introducer_state_stack().Pop(DeclIntroducerState::Interface);
+  CheckAccessModifiersOnDecl(context, decl_state, Lex::TokenKind::Interface,
                              parent_scope_inst);
-  LimitModifiersOnDecl(context, KeywordModifierSet::Access,
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Access,
                        Lex::TokenKind::Interface);
 
-  auto modifiers = context.decl_state_stack().innermost().modifier_set;
-  if (modifiers.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(context.decl_state_stack().innermost().modifier_node_id(
-                     ModifierOrder::Access),
+  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
-  context.decl_state_stack().Pop(DeclState::Interface);
 
   auto decl_block_id = context.inst_block_stack().Pop();
 

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -39,15 +39,15 @@ static auto BuildInterfaceDecl(Context& context,
   // Process modifiers.
   auto [_, parent_scope_inst] =
       context.name_scopes().GetInstIfValid(name_context.parent_scope_id);
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Interface);
-  CheckAccessModifiersOnDecl(context, decl_state, Lex::TokenKind::Interface,
+  CheckAccessModifiersOnDecl(context, introducer, Lex::TokenKind::Interface,
                              parent_scope_inst);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Access,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::Access,
                        Lex::TokenKind::Interface);
 
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
 

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -82,23 +82,23 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   auto [parent_scope_inst_id, parent_scope_inst] =
       context.name_scopes().GetInstIfValid(
           context.scope_stack().PeekNameScopeId());
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Let);
-  CheckAccessModifiersOnDecl(context, decl_state, Lex::TokenKind::Let,
+  CheckAccessModifiersOnDecl(context, introducer, Lex::TokenKind::Let,
                              parent_scope_inst);
-  RequireDefaultFinalOnlyInInterfaces(context, decl_state, Lex::TokenKind::Let,
+  RequireDefaultFinalOnlyInInterfaces(context, introducer, Lex::TokenKind::Let,
                                       parent_scope_inst);
   LimitModifiersOnDecl(
-      context, decl_state,
+      context, introducer,
       KeywordModifierSet::Access | KeywordModifierSet::Interface,
       Lex::TokenKind::Let);
 
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Decl),
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Decl),
                  "interface modifier");
   }
 

--- a/toolchain/check/handle_loop_statement.cpp
+++ b/toolchain/check/handle_loop_statement.cpp
@@ -77,7 +77,7 @@ auto HandleForHeaderStart(Context& context, Parse::ForHeaderStartId node_id)
 }
 
 auto HandleForIn(Context& context, Parse::ForInId node_id) -> bool {
-  context.decl_state_stack().Pop(DeclState::Var);
+  context.decl_introducer_state_stack().Pop(DeclIntroducerState::Var);
   return context.TODO(node_id, "HandleForIn");
 }
 

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
-#include "toolchain/check/decl_state.h"
+#include "toolchain/check/decl_introducer_state.h"
 #include "toolchain/check/handle.h"
 #include "toolchain/lex/token_kind.h"
 
@@ -36,7 +36,7 @@ static auto DiagnoseNotAllowedWith(Context& context, Parse::NodeId first_node,
 
 static auto HandleModifier(Context& context, Parse::NodeId node_id,
                            KeywordModifierSet keyword) -> bool {
-  auto& s = context.decl_state_stack().innermost();
+  auto& s = context.decl_introducer_state_stack().innermost();
 
   ModifierOrder order;
   KeywordModifierSet later_modifiers;

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -24,9 +24,9 @@ auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
   auto name_context = context.decl_name_stack().FinishName(
       PopNameComponentWithoutParams(context, Lex::TokenKind::Namespace));
 
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Namespace);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::None,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::None,
                        Lex::TokenKind::Namespace);
 
   auto namespace_inst = SemIR::Namespace{

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -13,7 +13,7 @@ auto HandleVariableIntroducer(Context& context,
                               Parse::VariableIntroducerId node_id) -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(node_id);
-  context.decl_state_stack().Push(DeclState::Var);
+  context.decl_introducer_state_stack().Push(DeclIntroducerState::Var);
   return true;
 }
 
@@ -101,17 +101,16 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
   // of the name introduced in the declaration. See #2590.
   auto [_, parent_scope_inst] = context.name_scopes().GetInstIfValid(
       context.scope_stack().PeekNameScopeId());
-  CheckAccessModifiersOnDecl(context, Lex::TokenKind::Var, parent_scope_inst);
-  LimitModifiersOnDecl(context, KeywordModifierSet::Access,
+  auto decl_state =
+      context.decl_introducer_state_stack().Pop(DeclIntroducerState::Var);
+  CheckAccessModifiersOnDecl(context, decl_state, Lex::TokenKind::Var,
+                             parent_scope_inst);
+  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Access,
                        Lex::TokenKind::Var);
-  auto modifiers = context.decl_state_stack().innermost().modifier_set;
-  if (modifiers.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(context.decl_state_stack().innermost().modifier_node_id(
-                     ModifierOrder::Access),
+  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
-
-  context.decl_state_stack().Pop(DeclState::Var);
 
   return true;
 }

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -101,14 +101,14 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
   // of the name introduced in the declaration. See #2590.
   auto [_, parent_scope_inst] = context.name_scopes().GetInstIfValid(
       context.scope_stack().PeekNameScopeId());
-  auto decl_state =
+  auto introducer =
       context.decl_introducer_state_stack().Pop(DeclIntroducerState::Var);
-  CheckAccessModifiersOnDecl(context, decl_state, Lex::TokenKind::Var,
+  CheckAccessModifiersOnDecl(context, introducer, Lex::TokenKind::Var,
                              parent_scope_inst);
-  LimitModifiersOnDecl(context, decl_state, KeywordModifierSet::Access,
+  LimitModifiersOnDecl(context, introducer, KeywordModifierSet::Access,
                        Lex::TokenKind::Var);
-  if (decl_state.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
-    context.TODO(decl_state.modifier_node_id(ModifierOrder::Access),
+  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Access)) {
+    context.TODO(introducer.modifier_node_id(ModifierOrder::Access),
                  "access modifier");
   }
 

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -4,7 +4,7 @@
 
 #include "toolchain/check/modifiers.h"
 
-#include "toolchain/check/decl_state.h"
+#include "toolchain/check/decl_introducer_state.h"
 
 namespace Carbon::Check {
 
@@ -38,12 +38,12 @@ static auto ModifierOrderAsSet(ModifierOrder order) -> KeywordModifierSet {
   }
 }
 
-auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
+auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& decl_state,
+                           KeywordModifierSet forbidden,
                            Lex::TokenKind decl_kind,
                            llvm::StringRef context_string,
                            SemIR::LocId context_loc_id) -> void {
-  auto& s = context.decl_state_stack().innermost();
-  auto not_allowed = s.modifier_set & forbidden;
+  auto not_allowed = decl_state.modifier_set & forbidden;
   if (not_allowed.empty()) {
     return;
   }
@@ -52,16 +52,18 @@ auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
        order_index <= static_cast<int8_t>(ModifierOrder::Last); ++order_index) {
     auto order = static_cast<ModifierOrder>(order_index);
     if (not_allowed.HasAnyOf(ModifierOrderAsSet(order))) {
-      DiagnoseNotAllowed(context, s.modifier_node_id(order), decl_kind,
+      DiagnoseNotAllowed(context, decl_state.modifier_node_id(order), decl_kind,
                          context_string, context_loc_id);
-      s.set_modifier_node_id(order, Parse::NodeId::Invalid);
+      decl_state.set_modifier_node_id(order, Parse::NodeId::Invalid);
     }
   }
 
-  s.modifier_set.Remove(forbidden);
+  decl_state.modifier_set.Remove(forbidden);
 }
 
-auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
+auto CheckAccessModifiersOnDecl(Context& context,
+                                DeclIntroducerState& decl_state,
+                                Lex::TokenKind decl_kind,
                                 std::optional<SemIR::Inst> parent_scope_inst)
     -> void {
   if (parent_scope_inst) {
@@ -71,7 +73,7 @@ auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
       // the parents of the target scope to determine whether we're at file
       // scope.
       ForbidModifiersOnDecl(
-          context, KeywordModifierSet::Protected, decl_kind,
+          context, decl_state, KeywordModifierSet::Protected, decl_kind,
           " at file scope, `protected` is only allowed on class members");
       return;
     }
@@ -83,15 +85,17 @@ auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
   }
 
   // Otherwise neither `private` nor `protected` allowed.
-  ForbidModifiersOnDecl(context, KeywordModifierSet::Protected, decl_kind,
+  ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Protected,
+                        decl_kind,
                         ", `protected` is only allowed on class members");
   ForbidModifiersOnDecl(
-      context, KeywordModifierSet::Private, decl_kind,
+      context, decl_state, KeywordModifierSet::Private, decl_kind,
       ", `private` is only allowed on class members and at file scope");
 }
 
 auto CheckMethodModifiersOnFunction(
-    Context& context, SemIR::InstId parent_scope_inst_id,
+    Context& context, DeclIntroducerState& decl_state,
+    SemIR::InstId parent_scope_inst_id,
     std::optional<SemIR::Inst> parent_scope_inst) -> void {
   const Lex::TokenKind decl_kind = Lex::TokenKind::Fn;
   if (parent_scope_inst) {
@@ -99,12 +103,14 @@ auto CheckMethodModifiersOnFunction(
       auto inheritance_kind =
           context.classes().Get(class_decl->class_id).inheritance_kind;
       if (inheritance_kind == SemIR::Class::Final) {
-        ForbidModifiersOnDecl(context, KeywordModifierSet::Virtual, decl_kind,
+        ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Virtual,
+                              decl_kind,
                               " in a non-abstract non-base `class` definition",
                               context.insts().GetLocId(parent_scope_inst_id));
       }
       if (inheritance_kind != SemIR::Class::Abstract) {
-        ForbidModifiersOnDecl(context, KeywordModifierSet::Abstract, decl_kind,
+        ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Abstract,
+                              decl_kind,
                               " in a non-abstract `class` definition",
                               context.insts().GetLocId(parent_scope_inst_id));
       }
@@ -112,32 +118,34 @@ auto CheckMethodModifiersOnFunction(
     }
   }
 
-  ForbidModifiersOnDecl(context, KeywordModifierSet::Method, decl_kind,
-                        " outside of a class");
+  ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Method,
+                        decl_kind, " outside of a class");
 }
 
-auto RestrictExternModifierOnDecl(Context& context, Lex::TokenKind decl_kind,
+auto RestrictExternModifierOnDecl(Context& context,
+                                  DeclIntroducerState& decl_state,
+                                  Lex::TokenKind decl_kind,
                                   std::optional<SemIR::Inst> parent_scope_inst,
                                   bool is_definition) -> void {
   if (is_definition) {
-    ForbidModifiersOnDecl(context, KeywordModifierSet::Extern, decl_kind,
-                          " that provides a definition");
+    ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Extern,
+                          decl_kind, " that provides a definition");
   }
   if (parent_scope_inst && !parent_scope_inst->Is<SemIR::Namespace>()) {
-    ForbidModifiersOnDecl(context, KeywordModifierSet::Extern, decl_kind,
-                          " that is a member");
+    ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Extern,
+                          decl_kind, " that is a member");
   }
 }
 
 auto RequireDefaultFinalOnlyInInterfaces(
-    Context& context, Lex::TokenKind decl_kind,
+    Context& context, DeclIntroducerState& decl_state, Lex::TokenKind decl_kind,
     std::optional<SemIR::Inst> parent_scope_inst) -> void {
   if (parent_scope_inst && parent_scope_inst->Is<SemIR::InterfaceDecl>()) {
     // Both `default` and `final` allowed in an interface definition.
     return;
   }
-  ForbidModifiersOnDecl(context, KeywordModifierSet::Interface, decl_kind,
-                        " outside of an interface");
+  ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Interface,
+                        decl_kind, " outside of an interface");
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -38,12 +38,12 @@ static auto ModifierOrderAsSet(ModifierOrder order) -> KeywordModifierSet {
   }
 }
 
-auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& decl_state,
+auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& introducer,
                            KeywordModifierSet forbidden,
                            Lex::TokenKind decl_kind,
                            llvm::StringRef context_string,
                            SemIR::LocId context_loc_id) -> void {
-  auto not_allowed = decl_state.modifier_set & forbidden;
+  auto not_allowed = introducer.modifier_set & forbidden;
   if (not_allowed.empty()) {
     return;
   }
@@ -52,17 +52,17 @@ auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& decl_state,
        order_index <= static_cast<int8_t>(ModifierOrder::Last); ++order_index) {
     auto order = static_cast<ModifierOrder>(order_index);
     if (not_allowed.HasAnyOf(ModifierOrderAsSet(order))) {
-      DiagnoseNotAllowed(context, decl_state.modifier_node_id(order), decl_kind,
+      DiagnoseNotAllowed(context, introducer.modifier_node_id(order), decl_kind,
                          context_string, context_loc_id);
-      decl_state.set_modifier_node_id(order, Parse::NodeId::Invalid);
+      introducer.set_modifier_node_id(order, Parse::NodeId::Invalid);
     }
   }
 
-  decl_state.modifier_set.Remove(forbidden);
+  introducer.modifier_set.Remove(forbidden);
 }
 
 auto CheckAccessModifiersOnDecl(Context& context,
-                                DeclIntroducerState& decl_state,
+                                DeclIntroducerState& introducer,
                                 Lex::TokenKind decl_kind,
                                 std::optional<SemIR::Inst> parent_scope_inst)
     -> void {
@@ -73,7 +73,7 @@ auto CheckAccessModifiersOnDecl(Context& context,
       // the parents of the target scope to determine whether we're at file
       // scope.
       ForbidModifiersOnDecl(
-          context, decl_state, KeywordModifierSet::Protected, decl_kind,
+          context, introducer, KeywordModifierSet::Protected, decl_kind,
           " at file scope, `protected` is only allowed on class members");
       return;
     }
@@ -85,16 +85,16 @@ auto CheckAccessModifiersOnDecl(Context& context,
   }
 
   // Otherwise neither `private` nor `protected` allowed.
-  ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Protected,
+  ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Protected,
                         decl_kind,
                         ", `protected` is only allowed on class members");
   ForbidModifiersOnDecl(
-      context, decl_state, KeywordModifierSet::Private, decl_kind,
+      context, introducer, KeywordModifierSet::Private, decl_kind,
       ", `private` is only allowed on class members and at file scope");
 }
 
 auto CheckMethodModifiersOnFunction(
-    Context& context, DeclIntroducerState& decl_state,
+    Context& context, DeclIntroducerState& introducer,
     SemIR::InstId parent_scope_inst_id,
     std::optional<SemIR::Inst> parent_scope_inst) -> void {
   const Lex::TokenKind decl_kind = Lex::TokenKind::Fn;
@@ -103,13 +103,13 @@ auto CheckMethodModifiersOnFunction(
       auto inheritance_kind =
           context.classes().Get(class_decl->class_id).inheritance_kind;
       if (inheritance_kind == SemIR::Class::Final) {
-        ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Virtual,
+        ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Virtual,
                               decl_kind,
                               " in a non-abstract non-base `class` definition",
                               context.insts().GetLocId(parent_scope_inst_id));
       }
       if (inheritance_kind != SemIR::Class::Abstract) {
-        ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Abstract,
+        ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Abstract,
                               decl_kind,
                               " in a non-abstract `class` definition",
                               context.insts().GetLocId(parent_scope_inst_id));
@@ -118,33 +118,33 @@ auto CheckMethodModifiersOnFunction(
     }
   }
 
-  ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Method,
+  ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Method,
                         decl_kind, " outside of a class");
 }
 
 auto RestrictExternModifierOnDecl(Context& context,
-                                  DeclIntroducerState& decl_state,
+                                  DeclIntroducerState& introducer,
                                   Lex::TokenKind decl_kind,
                                   std::optional<SemIR::Inst> parent_scope_inst,
                                   bool is_definition) -> void {
   if (is_definition) {
-    ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Extern,
+    ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Extern,
                           decl_kind, " that provides a definition");
   }
   if (parent_scope_inst && !parent_scope_inst->Is<SemIR::Namespace>()) {
-    ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Extern,
+    ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Extern,
                           decl_kind, " that is a member");
   }
 }
 
 auto RequireDefaultFinalOnlyInInterfaces(
-    Context& context, DeclIntroducerState& decl_state, Lex::TokenKind decl_kind,
+    Context& context, DeclIntroducerState& introducer, Lex::TokenKind decl_kind,
     std::optional<SemIR::Inst> parent_scope_inst) -> void {
   if (parent_scope_inst && parent_scope_inst->Is<SemIR::InterfaceDecl>()) {
     // Both `default` and `final` allowed in an interface definition.
     return;
   }
-  ForbidModifiersOnDecl(context, decl_state, KeywordModifierSet::Interface,
+  ForbidModifiersOnDecl(context, introducer, KeywordModifierSet::Interface,
                         decl_kind, " outside of an interface");
 }
 

--- a/toolchain/check/modifiers.h
+++ b/toolchain/check/modifiers.h
@@ -10,11 +10,11 @@
 namespace Carbon::Check {
 
 // Reports a diagnostic if access control modifiers on this are not allowed for
-// a declaration in `parent_scope_inst`, and updates `decl_state`.
+// a declaration in `parent_scope_inst`, and updates `introducer`.
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto CheckAccessModifiersOnDecl(Context& context,
-                                DeclIntroducerState& decl_state,
+                                DeclIntroducerState& introducer,
                                 Lex::TokenKind decl_kind,
                                 std::optional<SemIR::Inst> parent_scope_inst)
     -> void;
@@ -25,7 +25,7 @@ auto CheckAccessModifiersOnDecl(Context& context,
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto CheckMethodModifiersOnFunction(
-    Context& context, DeclIntroducerState& decl_state,
+    Context& context, DeclIntroducerState& introducer,
     SemIR::InstId parent_scope_inst_id,
     std::optional<SemIR::Inst> parent_scope_inst) -> void;
 
@@ -33,7 +33,7 @@ auto CheckMethodModifiersOnFunction(
 // `context_string` (and optional `context_loc_id`) specifying the context in
 // which those modifiers are forbidden.
 // TODO: Take another look at diagnostic phrasing for callers.
-auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& decl_state,
+auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& introducer,
                            KeywordModifierSet forbidden,
                            Lex::TokenKind decl_kind,
                            llvm::StringRef context_string,
@@ -41,12 +41,12 @@ auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& decl_state,
     -> void;
 
 // Reports a diagnostic (using `decl_kind`) if modifiers on this declaration are
-// not in `allowed`. Updates `decl_state`.
+// not in `allowed`. Updates `introducer`.
 inline auto LimitModifiersOnDecl(Context& context,
-                                 DeclIntroducerState& decl_state,
+                                 DeclIntroducerState& introducer,
                                  KeywordModifierSet allowed,
                                  Lex::TokenKind decl_kind) -> void {
-  ForbidModifiersOnDecl(context, decl_state, ~allowed, decl_kind, "");
+  ForbidModifiersOnDecl(context, introducer, ~allowed, decl_kind, "");
 }
 
 // Restricts the `extern` modifier to only be used on namespace-scoped
@@ -56,7 +56,7 @@ inline auto LimitModifiersOnDecl(Context& context,
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto RestrictExternModifierOnDecl(Context& context,
-                                  DeclIntroducerState& decl_state,
+                                  DeclIntroducerState& introducer,
                                   Lex::TokenKind decl_kind,
                                   std::optional<SemIR::Inst> parent_scope_inst,
                                   bool is_definition) -> void;
@@ -67,7 +67,7 @@ auto RestrictExternModifierOnDecl(Context& context,
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto RequireDefaultFinalOnlyInInterfaces(
-    Context& context, DeclIntroducerState& decl_state, Lex::TokenKind decl_kind,
+    Context& context, DeclIntroducerState& introducer, Lex::TokenKind decl_kind,
     std::optional<SemIR::Inst> parent_scope_inst) -> void;
 
 }  // namespace Carbon::Check

--- a/toolchain/check/modifiers.h
+++ b/toolchain/check/modifiers.h
@@ -10,11 +10,12 @@
 namespace Carbon::Check {
 
 // Reports a diagnostic if access control modifiers on this are not allowed for
-// a declaration in `parent_scope_inst`, and updates the declaration state in
-// `context`.
+// a declaration in `parent_scope_inst`, and updates `decl_state`.
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
-auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
+auto CheckAccessModifiersOnDecl(Context& context,
+                                DeclIntroducerState& decl_state,
+                                Lex::TokenKind decl_kind,
                                 std::optional<SemIR::Inst> parent_scope_inst)
     -> void;
 
@@ -24,25 +25,28 @@ auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto CheckMethodModifiersOnFunction(
-    Context& context, SemIR::InstId parent_scope_inst_id,
+    Context& context, DeclIntroducerState& decl_state,
+    SemIR::InstId parent_scope_inst_id,
     std::optional<SemIR::Inst> parent_scope_inst) -> void;
 
 // Like `LimitModifiersOnDecl`, except says which modifiers are forbidden, and a
 // `context_string` (and optional `context_loc_id`) specifying the context in
 // which those modifiers are forbidden.
 // TODO: Take another look at diagnostic phrasing for callers.
-auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
+auto ForbidModifiersOnDecl(Context& context, DeclIntroducerState& decl_state,
+                           KeywordModifierSet forbidden,
                            Lex::TokenKind decl_kind,
                            llvm::StringRef context_string,
                            SemIR::LocId context_loc_id = SemIR::LocId::Invalid)
     -> void;
 
 // Reports a diagnostic (using `decl_kind`) if modifiers on this declaration are
-// not in `allowed`. Updates the declaration state in
-// `context.decl_state_stack()`.
-inline auto LimitModifiersOnDecl(Context& context, KeywordModifierSet allowed,
+// not in `allowed`. Updates `decl_state`.
+inline auto LimitModifiersOnDecl(Context& context,
+                                 DeclIntroducerState& decl_state,
+                                 KeywordModifierSet allowed,
                                  Lex::TokenKind decl_kind) -> void {
-  ForbidModifiersOnDecl(context, ~allowed, decl_kind, "");
+  ForbidModifiersOnDecl(context, decl_state, ~allowed, decl_kind, "");
 }
 
 // Restricts the `extern` modifier to only be used on namespace-scoped
@@ -51,7 +55,9 @@ inline auto LimitModifiersOnDecl(Context& context, KeywordModifierSet allowed,
 // - `extern` on a scoped entity.
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
-auto RestrictExternModifierOnDecl(Context& context, Lex::TokenKind decl_kind,
+auto RestrictExternModifierOnDecl(Context& context,
+                                  DeclIntroducerState& decl_state,
+                                  Lex::TokenKind decl_kind,
                                   std::optional<SemIR::Inst> parent_scope_inst,
                                   bool is_definition) -> void;
 
@@ -61,7 +67,7 @@ auto RestrictExternModifierOnDecl(Context& context, Lex::TokenKind decl_kind,
 //
 // `parent_scope_inst` may be nullopt for a declaration in a block scope.
 auto RequireDefaultFinalOnlyInInterfaces(
-    Context& context, Lex::TokenKind decl_kind,
+    Context& context, DeclIntroducerState& decl_state, Lex::TokenKind decl_kind,
     std::optional<SemIR::Inst> parent_scope_inst) -> void;
 
 }  // namespace Carbon::Check


### PR DESCRIPTION
With private modifiers, we'll want to start checking modifiers later, e.g. after a name conflict is detected (and potentially merged). I think we've agreed to be more explicit about whether the modifier functions are manipulating state, versus trying to keep the state on the stack a little longer (moving Pop to the end of these functions).

Removing FileScope from the stack and renaming it to DeclIntroducerStack to better reflect the usage and behavior. The FileScope mostly reflects an approach that wasn't ultimately adopted.