### PR TITLE
Teach fuzzers to initialize their installs from runfiles.

### DIFF
--- a/testing/fuzzing/libfuzzer.h
+++ b/testing/fuzzing/libfuzzer.h
@@ -17,6 +17,11 @@ namespace Carbon::Testing {
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                       std::size_t size);
 
+// Optional API that can be implemented but isn't required. This allows fuzzers
+// to observe the `argv` during initialization.
+// NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv);
+
 }  // namespace Carbon::Testing
 
 #endif  // CARBON_TESTING_FUZZING_LIBFUZZER_H_

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -152,6 +152,7 @@ cc_fuzz_test(
     srcs = ["check_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/*"]),
     deps = [
+        "//common:exe_path",
         "//testing/fuzzing:libfuzzer_header",
         "//toolchain/driver",
         "@llvm-project//llvm:Support",

--- a/toolchain/check/check_fuzzer.cpp
+++ b/toolchain/check/check_fuzzer.cpp
@@ -2,6 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "common/exe_path.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -9,6 +10,18 @@
 #include "toolchain/driver/driver.h"
 
 namespace Carbon::Testing {
+
+static InstallPaths install_paths;
+
+// NOLINTNEXTLINE(readability-non-const-parameter): External API required types.
+extern "C" auto LLVMFuzzerInitialize(int* argc, char*** argv) -> int {
+  std::string exe_path;
+  if (*argc >= 1) {
+    exe_path = FindExecutablePath((*argv)[0]);
+    install_paths = InstallPaths::MakeForBazelRunfiles(exe_path);
+  }
+  return 0;
+}
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
@@ -27,8 +40,6 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
       llvm::MemoryBuffer::getMemBuffer(data_ref, /*BufferName=*/TestFileName,
                                        /*RequiresNullTerminator=*/false)));
 
-  // TODO: We should try to thread the executable path into here.
-  const auto install_paths = InstallPaths::Make("");
   llvm::raw_null_ostream null_ostream;
   Driver driver(fs, &install_paths, null_ostream, null_ostream);
 

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -109,6 +109,7 @@ cc_fuzz_test(
     corpus = glob(["fuzzer_corpus/*"]),
     deps = [
         ":driver",
+        "//common:exe_path",
         "//testing/base:test_raw_ostream",
         "//testing/fuzzing:libfuzzer_header",
         "//toolchain/install:install_paths",

--- a/toolchain/install/install_paths.h
+++ b/toolchain/install/install_paths.h
@@ -82,9 +82,6 @@ class InstallPaths {
   // using Carbon in an environment with an unusual path to the installed files.
   static auto Make(llvm::StringRef install_prefix) -> InstallPaths;
 
-  // Constructor only used in errors or globals prior to initialization.
-  InstallPaths() { SetError("No prefix provided!"); }
-
   // Check for an error detecting the install paths correctly.
   //
   // A nullopt return means no errors encountered and the paths should work
@@ -108,6 +105,7 @@ class InstallPaths {
   auto llvm_install_bin() const -> std::string;
 
  private:
+  InstallPaths() { SetError("No prefix provided!"); }
   explicit InstallPaths(llvm::StringRef prefix) : prefix_(prefix) {}
 
   // Set an error message on the install paths and reset the prefix to empty,

--- a/toolchain/install/install_paths.h
+++ b/toolchain/install/install_paths.h
@@ -82,6 +82,9 @@ class InstallPaths {
   // using Carbon in an environment with an unusual path to the installed files.
   static auto Make(llvm::StringRef install_prefix) -> InstallPaths;
 
+  // Constructor only used in errors or globals prior to initialization.
+  InstallPaths() { SetError("No prefix provided!"); }
+
   // Check for an error detecting the install paths correctly.
   //
   // A nullopt return means no errors encountered and the paths should work
@@ -105,7 +108,6 @@ class InstallPaths {
   auto llvm_install_bin() const -> std::string;
 
  private:
-  InstallPaths() : error_("No prefix provided!") {}
   explicit InstallPaths(llvm::StringRef prefix) : prefix_(prefix) {}
 
   // Set an error message on the install paths and reset the prefix to empty,


### PR DESCRIPTION
This also allows us to default construct installs in an error state, which is useful for cases like fuzzers where we want to default construct a global, but then re-initilaize it That said, happy to consider alternative designs here.