### PR TITLE
Add growth API to the new hashtables.

### DIFF
--- a/common/map.h
+++ b/common/map.h
@@ -333,8 +333,8 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   // number based on the maximum load factor. If a specific number of insertions
   // need to be achieved without triggering growth, use the `GrowForInsertCount`
   // method.
-  auto Grow(ssize_t target_alloc_size, KeyContextT key_context = KeyContextT())
-      -> void;
+  auto GrowToAllocSize(ssize_t target_alloc_size,
+                       KeyContextT key_context = KeyContextT()) -> void;
 
   // Grow the map sufficiently to allow inserting the specified number of keys.
   auto GrowForInsertCount(ssize_t count,
@@ -551,9 +551,9 @@ MapBase<InputKeyT, InputValueT, InputKeyContextT>::Update(
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
-void MapBase<InputKeyT, InputValueT, InputKeyContextT>::Grow(
+void MapBase<InputKeyT, InputValueT, InputKeyContextT>::GrowToAllocSize(
     ssize_t target_alloc_size, KeyContextT key_context) {
-  this->GrowImpl(target_alloc_size, key_context);
+  this->GrowToAllocSizeImpl(target_alloc_size, key_context);
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>

--- a/common/map.h
+++ b/common/map.h
@@ -325,6 +325,21 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
              std::invocable<InsertCallbackT, LookupKeyT, void*, void*> &&
              std::invocable<UpdateCallbackT, KeyT&, ValueT&>);
 
+  // Grow the map to a specific allocation size.
+  //
+  // This will grow the map's hashtable if necessary for it to have an
+  // allocation size of `target_alloc_size` which must be a power of two. Note
+  // that this will not allow that many keys to be inserted, but a smaller
+  // number based on the maximum load factor. If a specific number of insertions
+  // need to be achieved without triggering growth, use the `GrowForInsertCount`
+  // method.
+  auto Grow(ssize_t target_alloc_size, KeyContextT key_context = KeyContextT())
+      -> void;
+
+  // Grow the map sufficiently to allow inserting the specified number of keys.
+  auto GrowForInsertCount(ssize_t count,
+                          KeyContextT key_context = KeyContextT()) -> void;
+
   // Erase a key from the map.
   template <typename LookupKeyT>
   auto Erase(LookupKeyT lookup_key, KeyContextT key_context = KeyContextT())
@@ -533,6 +548,18 @@ MapBase<InputKeyT, InputValueT, InputKeyContextT>::Update(
   insert_cb(lookup_key, static_cast<void*>(&entry->key_storage),
             static_cast<void*>(&entry->value_storage));
   return InsertKVResult(true, *entry);
+}
+
+template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
+void MapBase<InputKeyT, InputValueT, InputKeyContextT>::Grow(
+    ssize_t target_alloc_size, KeyContextT key_context) {
+  this->GrowImpl(target_alloc_size, key_context);
+}
+
+template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
+void MapBase<InputKeyT, InputValueT, InputKeyContextT>::GrowForInsertCount(
+    ssize_t count, KeyContextT key_context) {
+  this->GrowForInsertCountImpl(count, key_context);
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>

--- a/common/map_test.cpp
+++ b/common/map_test.cpp
@@ -250,7 +250,8 @@ TYPED_TEST(MapTest, GrowToAllocSize) {
   // No further growth triggered.
   EXPECT_EQ(storage_bytes, m.ComputeMetrics().storage_bytes);
 
-  // Get a couple of doubling based growths.
+  // Get a few doubling based growths, and at least one beyond the largest small
+  // size.
   m.GrowToAllocSize(64);
   ExpectMapElementsAre(
       m, MakeKeyValues([](int k) { return k * 100; }, llvm::seq(8, 24)));
@@ -316,14 +317,14 @@ TYPED_TEST(MapTest, GrowForInsert) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     ASSERT_TRUE(m.Erase(i));
   }
-  m.GrowForInsertCount(1717);
+  m.GrowForInsertCount(321);
   storage_bytes = m.ComputeMetrics().storage_bytes;
-  for (int i : llvm::seq(128, 1717 + 128)) {
+  for (int i : llvm::seq(128, 321 + 128)) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     ASSERT_TRUE(m.Insert(i, i * 100).is_inserted());
   }
   ExpectMapElementsAre(m, MakeKeyValues([](int k) { return k * 100; },
-                                        llvm::seq(128, 1717 + 128)));
+                                        llvm::seq(128, 321 + 128)));
   EXPECT_EQ(storage_bytes, m.ComputeMetrics().storage_bytes);
 }
 

--- a/common/map_test.cpp
+++ b/common/map_test.cpp
@@ -226,12 +226,12 @@ TYPED_TEST(MapTest, Conversions) {
   EXPECT_EQ(104, *cmv3[4]);
 }
 
-TYPED_TEST(MapTest, Grow) {
+TYPED_TEST(MapTest, GrowToAllocSize) {
   using MapT = TypeParam;
 
   MapT m;
   // Grow when empty. May be a no-op for some small sizes.
-  m.Grow(32);
+  m.GrowToAllocSize(32);
 
   // Add some elements that will need to be propagated through subsequent
   // growths. Also delete some.
@@ -245,15 +245,15 @@ TYPED_TEST(MapTest, Grow) {
   }
 
   // No-op.
-  m.Grow(16);
+  m.GrowToAllocSize(16);
   ExpectMapElementsAre(
       m, MakeKeyValues([](int k) { return k * 100; }, llvm::seq(8, 24)));
 
   // Get a couple of doubling based growths.
-  m.Grow(64);
+  m.GrowToAllocSize(64);
   ExpectMapElementsAre(
       m, MakeKeyValues([](int k) { return k * 100; }, llvm::seq(8, 24)));
-  m.Grow(128);
+  m.GrowToAllocSize(128);
   ExpectMapElementsAre(
       m, MakeKeyValues([](int k) { return k * 100; }, llvm::seq(8, 24)));
 
@@ -267,7 +267,7 @@ TYPED_TEST(MapTest, Grow) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     ASSERT_TRUE(m.Erase(i));
   }
-  m.Grow(1024);
+  m.GrowToAllocSize(1024);
   ExpectMapElementsAre(
       m, MakeKeyValues([](int k) { return k * 100; }, llvm::seq(16, 48)));
 }

--- a/common/raw_hashtable.h
+++ b/common/raw_hashtable.h
@@ -846,7 +846,7 @@ template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
 BaseImpl<InputKeyT, InputValueT, InputKeyContextT>::GrowImpl(
     ssize_t target_alloc_size, KeyContextT key_context) -> void {
   CARBON_CHECK(llvm::isPowerOf2_64(target_alloc_size));
-  if (target_alloc_size < alloc_size()) {
+  if (target_alloc_size <= alloc_size()) {
     return;
   }
 
@@ -864,7 +864,7 @@ BaseImpl<InputKeyT, InputValueT, InputKeyContextT>::GrowImpl(
   uint8_t* old_metadata = metadata();
   EntryT* old_entries = entries();
 
-  // Configure for the new size allocate the new storage.
+  // Configure for the new size and allocate the new storage.
   alloc_size() = target_alloc_size;
   storage() = Allocate(target_alloc_size);
   std::memset(metadata(), 0, target_alloc_size);
@@ -1098,7 +1098,7 @@ auto BaseImpl<InputKeyT, InputValueT,
 
 // Optimized routine for growing to the next alloc size.
 //
-// A particularly common and important to optimize path is growing to the next
+// A particularly common and important-to-optimize path is growing to the next
 // alloc size, which will always be a doubling of the allocated size. This
 // allows an important optimization -- we're adding exactly one more high bit to
 // the hash-computed index for each entry. This in turn means we can classify
@@ -1161,7 +1161,7 @@ auto BaseImpl<InputKeyT, InputValueT, InputKeyContextT>::GrowToNextAllocSize(
       << ", size: " << old_size;
 #endif
 
-  // Configure for the new size allocate the new storage.
+  // Configure for the new size and allocate the new storage.
   ssize_t new_size = ComputeNextAllocSize(old_size);
   alloc_size() = new_size;
   storage() = Allocate(new_size);

--- a/common/set.h
+++ b/common/set.h
@@ -230,8 +230,8 @@ class SetBase
   // number based on the maximum load factor. If a specific number of insertions
   // need to be achieved without triggering growth, use the `GrowForInsertCount`
   // method.
-  auto Grow(ssize_t target_alloc_size, KeyContextT key_context = KeyContextT())
-      -> void;
+  auto GrowToAllocSize(ssize_t target_alloc_size,
+                       KeyContextT key_context = KeyContextT()) -> void;
 
   // Grow the set sufficiently to allow inserting the specified number of keys.
   auto GrowForInsertCount(ssize_t count,
@@ -351,9 +351,9 @@ auto SetBase<InputKeyT, InputKeyContextT>::Insert(LookupKeyT lookup_key,
 }
 
 template <typename InputKeyT, typename InputKeyContextT>
-void SetBase<InputKeyT, InputKeyContextT>::Grow(ssize_t target_alloc_size,
-                                                KeyContextT key_context) {
-  this->GrowImpl(target_alloc_size, key_context);
+void SetBase<InputKeyT, InputKeyContextT>::GrowToAllocSize(
+    ssize_t target_alloc_size, KeyContextT key_context) {
+  this->GrowToAllocSizeImpl(target_alloc_size, key_context);
 }
 
 template <typename InputKeyT, typename InputKeyContextT>

--- a/common/set.h
+++ b/common/set.h
@@ -222,6 +222,21 @@ class SetBase
               KeyContextT key_context = KeyContextT()) -> InsertResult
     requires std::invocable<InsertCallbackT, LookupKeyT, void*>;
 
+  // Grow the set to a specific allocation size.
+  //
+  // This will grow the set's hashtable if necessary for it to have an
+  // allocation size of `target_alloc_size` which must be a power of two. Note
+  // that this will not allow that many keys to be inserted, but a smaller
+  // number based on the maximum load factor. If a specific number of insertions
+  // need to be achieved without triggering growth, use the `GrowForInsertCount`
+  // method.
+  auto Grow(ssize_t target_alloc_size, KeyContextT key_context = KeyContextT())
+      -> void;
+
+  // Grow the set sufficiently to allow inserting the specified number of keys.
+  auto GrowForInsertCount(ssize_t count,
+                          KeyContextT key_context = KeyContextT()) -> void;
+
   // Erase a key from the set.
   template <typename LookupKeyT>
   auto Erase(LookupKeyT lookup_key, KeyContextT key_context = KeyContextT())
@@ -333,6 +348,18 @@ auto SetBase<InputKeyT, InputKeyContextT>::Insert(LookupKeyT lookup_key,
 
   insert_cb(lookup_key, static_cast<void*>(&entry->key_storage));
   return InsertResult(true, entry->key());
+}
+
+template <typename InputKeyT, typename InputKeyContextT>
+void SetBase<InputKeyT, InputKeyContextT>::Grow(ssize_t target_alloc_size,
+                                                KeyContextT key_context) {
+  this->GrowImpl(target_alloc_size, key_context);
+}
+
+template <typename InputKeyT, typename InputKeyContextT>
+void SetBase<InputKeyT, InputKeyContextT>::GrowForInsertCount(
+    ssize_t count, KeyContextT key_context) {
+  this->GrowForInsertCountImpl(count, key_context);
 }
 
 template <typename InputKeyT, typename InputKeyContextT>

--- a/common/set_test.cpp
+++ b/common/set_test.cpp
@@ -176,12 +176,12 @@ TYPED_TEST(SetTest, Conversions) {
   EXPECT_TRUE(csv2.Contains(3));
 }
 
-TYPED_TEST(SetTest, Grow) {
+TYPED_TEST(SetTest, GrowToAllocSize) {
   using SetT = TypeParam;
 
   SetT s;
   // Grow when empty. May be a no-op for some small sizes.
-  s.Grow(32);
+  s.GrowToAllocSize(32);
 
   // Add some elements that will need to be propagated through subsequent
   // growths. Also delete some.
@@ -195,13 +195,13 @@ TYPED_TEST(SetTest, Grow) {
   }
 
   // No-op.
-  s.Grow(16);
+  s.GrowToAllocSize(16);
   ExpectSetElementsAre(s, MakeElements(llvm::seq(8, 24)));
 
   // Get a couple of doubling based growths.
-  s.Grow(64);
+  s.GrowToAllocSize(64);
   ExpectSetElementsAre(s, MakeElements(llvm::seq(8, 24)));
-  s.Grow(128);
+  s.GrowToAllocSize(128);
   ExpectSetElementsAre(s, MakeElements(llvm::seq(8, 24)));
 
   // Add some more, but not enough to trigger further growth, and then grow by
@@ -214,7 +214,7 @@ TYPED_TEST(SetTest, Grow) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     ASSERT_TRUE(s.Erase(i));
   }
-  s.Grow(1024);
+  s.GrowToAllocSize(1024);
   ExpectSetElementsAre(s, MakeElements(llvm::seq(16, 48)));
 }
 


### PR DESCRIPTION
This adds two different growth APIs. This is instead of the more conventional STL `reserve` method. One allows users that aren't trying to grow in anticipation of an *exact* count of insertions, but generally trying to size the table to the correct ballpark with a power-of-two estimate.

The other API allows pre-growing to allow a specific number of insertions to be performed without further growth. This API takes the maximum load factor and other implementation details into account.