### PR TITLE
Add a build of `boost_unordered` for benchmarking.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -95,6 +95,16 @@ git_override(
     remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
 )
 
+boost_unordered_version = "1.85.0"
+
+http_archive(
+    name = "boost_unordered",
+    build_file = "@//:third_party/boost_unordered/BUILD.bazel",
+    integrity = "sha256-2dQ4IQH/xFiK1iWCkrMYLeR8zsSQqGchKOdTuf1u0zI=",
+    strip_prefix = "boost_unordered-{0}".format(boost_unordered_version),
+    urls = ["https://github.com/MikePopoloski/boost_unordered/archive/v{0}.tar.gz".format(boost_unordered_version)],
+)
+
 # Required for llvm-project.
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.1", repo_name = "llvm_zlib")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "439583f1efb19cfa4ef173e2ac4774602be6be5061bc14218f9856f4beb33e07",
+  "moduleFileHash": "2229e2fa995d00859c76832081e78c1260d43da826c71273e51f34182539eafd",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -37,6 +37,7 @@
           },
           "imports": {
             "com_google_libprotobuf_mutator": "com_google_libprotobuf_mutator",
+            "boost_unordered": "boost_unordered",
             "llvm-raw": "llvm-raw"
           },
           "devImports": [],
@@ -62,6 +63,24 @@
             {
               "tagName": "@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
               "attributeValues": {
+                "build_file": "@//:third_party/boost_unordered/BUILD.bazel",
+                "integrity": "sha256-2dQ4IQH/xFiK1iWCkrMYLeR8zsSQqGchKOdTuf1u0zI=",
+                "strip_prefix": "boost_unordered-1.85.0",
+                "urls": [
+                  "https://github.com/MikePopoloski/boost_unordered/archive/v1.85.0.tar.gz"
+                ],
+                "name": "boost_unordered"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "@@//:MODULE.bazel",
+                "line": 100,
+                "column": 13
+              }
+            },
+            {
+              "tagName": "@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+              "attributeValues": {
                 "build_file_content": "# empty",
                 "patch_args": [
                   "-p1"
@@ -80,7 +99,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 113,
+                "line": 123,
                 "column": 13
               }
             }
@@ -111,7 +130,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 127,
+            "line": 137,
             "column": 29
           },
           "imports": {
@@ -128,7 +147,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 139,
+            "line": 149,
             "column": 23
           },
           "imports": {
@@ -144,7 +163,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 140,
+                "line": 150,
                 "column": 17
               }
             }

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -149,6 +149,7 @@ def _impl(ctx):
                             # to be initial directories in the `#include` line.
                             "--system-header-prefix=absl/",
                             "--system-header-prefix=benchmark/",
+                            "--system-header-prefix=boost/",
                             "--system-header-prefix=clang-tools-extra/",
                             "--system-header-prefix=clang/",
                             "--system-header-prefix=gmock/",

--- a/common/BUILD
+++ b/common/BUILD
@@ -264,6 +264,7 @@ cc_binary(
         ":raw_hashtable_benchmark_helpers",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/random",
+        "@boost_unordered",
         "@google_benchmark//:benchmark_main",
         "@llvm-project//llvm:Support",
     ],

--- a/scripts/fix_cc_deps.py
+++ b/scripts/fix_cc_deps.py
@@ -71,6 +71,12 @@ EXTERNAL_REPOS: Dict[str, ExternalRepo] = {
         ":gtest",
         use_system_include=True,
     ),
+    # All of the `boost_unordered` headers are in a single rule.
+    "@boost_unordered": ExternalRepo(
+        lambda x: re.sub("^(.*:include)/", "", x),
+        ":boost_unordered",
+        use_system_include=True,
+    ),
 }
 
 # TODO: proto rules are aspect-based and their generated files don't show up in

--- a/third_party/boost_unordered/BUILD.bazel
+++ b/third_party/boost_unordered/BUILD.bazel
@@ -1,0 +1,14 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "boost_unordered",
+    hdrs = glob(["include/boost/**/*.hpp"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This uses a header-only extraction of the Boost unordered hashtable project to allow a trivial Bazel build and for us to benchmark against it effectively.