### PR TITLE
Collect more detailed metrics on hashtables.

### DIFF
--- a/common/map.h
+++ b/common/map.h
@@ -121,8 +121,8 @@ class MapView
   // benchmarking or logging of performance anomalies. The specific metrics
   // returned have no specific guarantees beyond being informative in
   // benchmarks.
-  auto GetMetrics(KeyContextT key_context = KeyContextT()) -> MetricsT {
-    return ImplT::GetMetrics(key_context);
+  auto ComputeMetrics(KeyContextT key_context = KeyContextT()) -> MetricsT {
+    return ImplT::ComputeMetricsImpl(key_context);
   }
 
  private:
@@ -231,8 +231,9 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   }
 
   // Convenience forwarder to the view type.
-  auto GetMetrics(KeyContextT key_context = KeyContextT()) const -> MetricsT {
-    return ViewT(*this).GetMetrics(key_context);
+  auto ComputeMetrics(KeyContextT key_context = KeyContextT()) const
+      -> MetricsT {
+    return ViewT(*this).ComputeMetrics(key_context);
   }
 
   // Insert a key and value into the map. If the key is already present, the new

--- a/common/map.h
+++ b/common/map.h
@@ -66,6 +66,7 @@ class MapView
   using KeyT = typename ImplT::KeyT;
   using ValueT = typename ImplT::ValueT;
   using KeyContextT = typename ImplT::KeyContextT;
+  using MetricsT = typename ImplT::MetricsT;
 
   // This type represents the result of lookup operations. It encodes whether
   // the lookup was a success as well as accessors for the key and value.
@@ -117,15 +118,11 @@ class MapView
     requires(std::invocable<CallbackT, KeyT&, ValueT&>);
 
   // This routine is relatively inefficient and only intended for use in
-  // benchmarking or logging of performance anomalies. The specific count
-  // returned has no specific guarantees beyond being informative in benchmarks.
-  // It counts how many of the keys in the hashtable have required probing
-  // beyond their initial group of slots.
-  //
-  // TODO: Replace with a more general metrics routine that covers other
-  // important aspects such as load factor, and average probe *distance*.
-  auto CountProbedKeys(KeyContextT key_context = KeyContextT()) -> ssize_t {
-    return ImplT::CountProbedKeys(key_context);
+  // benchmarking or logging of performance anomalies. The specific metrics
+  // returned have no specific guarantees beyond being informative in
+  // benchmarks.
+  auto GetMetrics(KeyContextT key_context = KeyContextT()) -> MetricsT {
+    return ImplT::GetMetrics(key_context);
   }
 
  private:
@@ -165,6 +162,7 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   using KeyContextT = typename ImplT::KeyContextT;
   using ViewT = MapView<KeyT, ValueT, KeyContextT>;
   using LookupKVResult = typename ViewT::LookupKVResult;
+  using MetricsT = typename ImplT::MetricsT;
 
   // The result type for insertion operations both indicates whether an insert
   // was needed (as opposed to finding an existing element), and provides access
@@ -233,9 +231,8 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   }
 
   // Convenience forwarder to the view type.
-  auto CountProbedKeys(KeyContextT key_context = KeyContextT()) const
-      -> ssize_t {
-    return ViewT(*this).CountProbedKeys(key_context);
+  auto GetMetrics(KeyContextT key_context = KeyContextT()) const -> MetricsT {
+    return ViewT(*this).GetMetrics(key_context);
   }
 
   // Insert a key and value into the map. If the key is already present, the new

--- a/common/map_benchmark.cpp
+++ b/common/map_benchmark.cpp
@@ -159,6 +159,41 @@ template <typename MapT>
 using MapWrapper =
     MapWrapperOverride<MapT, MapOverride::CARBON_MAP_BENCH_OVERRIDE>;
 
+template <typename MapT>
+auto ReportMetrics(const MapWrapper<MapT>& m_wrapper, benchmark::State& state)
+    -> void {
+  using MapWrapperT = MapWrapper<MapT>;
+  using KT = typename MapWrapperT::KeyT;
+  using VT = typename MapWrapperT::ValueT;
+
+  const auto& m = m_wrapper.m;
+
+  // Report some extra statistics about the Carbon type.
+  if constexpr (IsCarbonMap<MapT>) {
+    // While this count is "iteration invariant" (it should be exactly the same
+    // for every iteration as the set of keys is the same), we don't use that
+    // because it will scale this by the number of iterations. We want to
+    // display the metrics for this benchmark *parameter*, not what resulted
+    // from the number of iterations. That means we use the normal counter API
+    // without flags.
+    auto metrics = m.GetMetrics();
+    state.counters["P-compares"] = metrics.probe_avg_compares;
+    state.counters["P-distance"] = metrics.probe_avg_distance;
+    state.counters["P-fraction"] =
+        static_cast<double>(metrics.probed_key_count) / metrics.key_count;
+    state.counters["Pmax-distance"] = metrics.probe_max_distance;
+    state.counters["Pmax-compares"] = metrics.probe_max_compares;
+    state.counters["Probed"] = metrics.probed_key_count;
+
+    state.counters["Storage"] = metrics.storage_bytes;
+    // Also compute how 'efficient' the storage is, 1.0 being zero bytes outside
+    // of key and value.
+    state.counters["Storage eff"] =
+        static_cast<double>(metrics.key_count * (sizeof(KT) + sizeof(VT))) /
+        metrics.storage_bytes;
+  }
+}
+
 // NOLINTBEGIN(bugprone-macro-parentheses): Parentheses are incorrect here.
 #define MAP_BENCHMARK_ONE_OP_SIZE(NAME, APPLY, KT, VT)        \
   BENCHMARK(NAME<Map<KT, VT>>)->Apply(APPLY);                 \
@@ -223,6 +258,8 @@ static void BM_MapContainsHit(benchmark::State& state) {
       i += static_cast<ssize_t>(result);
     }
   }
+
+  ReportMetrics(m, state);
 }
 MAP_BENCHMARK_ONE_OP(BM_MapContainsHit, HitArgs);
 
@@ -250,6 +287,8 @@ static void BM_MapContainsMiss(benchmark::State& state) {
       i += static_cast<ssize_t>(!result);
     }
   }
+
+  ReportMetrics(m, state);
 }
 MAP_BENCHMARK_ONE_OP(BM_MapContainsMiss, SizeArgs);
 
@@ -302,6 +341,8 @@ static void BM_MapLookupHit(benchmark::State& state) {
       i += static_cast<ssize_t>(result);
     }
   }
+
+  ReportMetrics(m, state);
 }
 MAP_BENCHMARK_ONE_OP(BM_MapLookupHit, HitArgs);
 
@@ -339,6 +380,8 @@ static void BM_MapUpdateHit(benchmark::State& state) {
       CARBON_DCHECK(!inserted);
     }
   }
+
+  ReportMetrics(m, state);
 }
 MAP_BENCHMARK_ONE_OP(BM_MapUpdateHit, HitArgs);
 
@@ -454,19 +497,13 @@ static void BM_MapInsertSeq(benchmark::State& state) {
   if constexpr (IsCarbonMap<MapT>) {
     // Re-build a map outside of the timing loop to look at the statistics
     // rather than the timing.
-    MapT m;
+    MapWrapperT m;
     for (auto k : keys) {
-      bool inserted = m.Insert(k, MakeValue<VT>()).is_inserted();
+      bool inserted = m.BenchInsert(k, MakeValue<VT>());
       CARBON_DCHECK(inserted) << "Must be a successful insert!";
     }
 
-    // While this count is "iteration invariant" (it should be exactly the same
-    // for every iteration as the set of keys is the same), we don't use that
-    // because it will scale this by the number of iterations. We want to
-    // display the probe count of this benchmark *parameter*, not the probe
-    // count that resulted from the number of iterations. That means we use the
-    // normal counter API without flags.
-    state.counters["Probed"] = m.CountProbedKeys();
+    ReportMetrics(m, state);
 
     // Uncomment this call to print out statistics about the index-collisions
     // among these keys for debugging:

--- a/common/raw_hashtable.h
+++ b/common/raw_hashtable.h
@@ -372,7 +372,7 @@ class ViewImpl {
   // Returns a collection of informative metrics on the the current state of the
   // table, useful for performance analysis. These include relatively slow to
   // compute metrics requiring deep inspection of the table's state.
-  auto GetMetrics(KeyContextT key_context) const -> MetricsT;
+  auto ComputeMetricsImpl(KeyContextT key_context) const -> MetricsT;
 
  private:
   ViewImpl(ssize_t alloc_size, Storage* storage)
@@ -747,7 +747,7 @@ ViewImpl<InputKeyT, InputValueT, InputKeyContextT>::ForEachEntry(
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
-auto ViewImpl<InputKeyT, InputValueT, InputKeyContextT>::GetMetrics(
+auto ViewImpl<InputKeyT, InputValueT, InputKeyContextT>::ComputeMetricsImpl(
     KeyContextT key_context) const -> Metrics {
   uint8_t* local_metadata = metadata();
   EntryT* local_entries = entries();

--- a/common/raw_hashtable_benchmark_helpers.h
+++ b/common/raw_hashtable_benchmark_helpers.h
@@ -211,7 +211,7 @@ auto ReportTableMetrics(const TableT& table, benchmark::State& state) -> void {
   // display the metrics for this benchmark *parameter*, not what resulted
   // from the number of iterations. That means we use the normal counter API
   // without flags.
-  auto metrics = table.GetMetrics();
+  auto metrics = table.ComputeMetrics();
   state.counters["P-compares"] = metrics.probe_avg_compares;
   state.counters["P-distance"] = metrics.probe_avg_distance;
   state.counters["P-fraction"] =

--- a/common/raw_hashtable_benchmark_helpers.h
+++ b/common/raw_hashtable_benchmark_helpers.h
@@ -203,6 +203,39 @@ struct CarbonHashDI<llvm::StringRef> {
   }
 };
 
+template <typename TableT>
+auto ReportTableMetrics(const TableT& table, benchmark::State& state) -> void {
+  // While this count is "iteration invariant" (it should be exactly the same
+  // for every iteration as the set of keys is the same), we don't use that
+  // because it will scale this by the number of iterations. We want to
+  // display the metrics for this benchmark *parameter*, not what resulted
+  // from the number of iterations. That means we use the normal counter API
+  // without flags.
+  auto metrics = table.GetMetrics();
+  state.counters["P-compares"] = metrics.probe_avg_compares;
+  state.counters["P-distance"] = metrics.probe_avg_distance;
+  state.counters["P-fraction"] =
+      static_cast<double>(metrics.probed_key_count) / metrics.key_count;
+  state.counters["Pmax-distance"] = metrics.probe_max_distance;
+  state.counters["Pmax-compares"] = metrics.probe_max_compares;
+  state.counters["Probed"] = metrics.probed_key_count;
+
+  state.counters["Storage"] = metrics.storage_bytes;
+
+  // Also compute how 'efficient' the storage is, 1.0 being zero bytes outside
+  // of key and value.
+  ssize_t element_size;
+  if constexpr (requires { TableT::ValueT; }) {
+    element_size =
+        sizeof(typename TableT::KeyT) + sizeof(typename TableT::ValueT);
+  } else {
+    element_size = sizeof(typename TableT::KeyT);
+  }
+  state.counters["Storage eff"] =
+      static_cast<double>(metrics.key_count * element_size) /
+      metrics.storage_bytes;
+}
+
 }  // namespace Carbon::RawHashtable
 
 #endif  // CARBON_COMMON_RAW_HASHTABLE_BENCHMARK_HELPERS_H_

--- a/common/set.h
+++ b/common/set.h
@@ -59,6 +59,7 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
  public:
   using KeyT = typename ImplT::KeyT;
   using KeyContextT = typename ImplT::KeyContextT;
+  using MetricsT = typename ImplT::MetricsT;
 
   // This type represents the result of lookup operations. It encodes whether
   // the lookup was a success as well as accessors for the key.
@@ -97,15 +98,11 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
     requires(std::invocable<CallbackT, KeyT&>);
 
   // This routine is relatively inefficient and only intended for use in
-  // benchmarking or logging of performance anomalies. The specific count
-  // returned has no specific guarantees beyond being informative in benchmarks.
-  // It counts how many of the keys in the hashtable have required probing
-  // beyond their initial group of slots.
-  //
-  // TODO: Replace with a more general metrics routine that covers other
-  // important aspects such as load factor, and average probe *distance*.
-  auto CountProbedKeys(KeyContextT key_context = KeyContextT()) -> ssize_t {
-    return ImplT::CountProbedKeys(key_context);
+  // benchmarking or logging of performance anomalies. The specific metrics
+  // returned have no specific guarantees beyond being informative in
+  // benchmarks.
+  auto GetMetrics(KeyContextT key_context = KeyContextT()) -> MetricsT {
+    return ImplT::GetMetrics(key_context);
   }
 
  private:
@@ -140,6 +137,7 @@ class SetBase
   using KeyContextT = typename ImplT::KeyContextT;
   using ViewT = SetView<KeyT, KeyContextT>;
   using LookupResult = typename ViewT::LookupResult;
+  using MetricsT = typename ImplT::MetricsT;
 
   // The result type for insertion operations both indicates whether an insert
   // was needed (as opposed to the key already being in the set), and provides
@@ -193,9 +191,8 @@ class SetBase
   }
 
   // Convenience forwarder to the view type.
-  auto CountProbedKeys(KeyContextT key_context = KeyContextT()) const
-      -> ssize_t {
-    return ViewT(*this).CountProbedKeys(key_context);
+  auto GetMetrics(KeyContextT key_context = KeyContextT()) const -> MetricsT {
+    return ViewT(*this).GetMetrics(key_context);
   }
 
   // Insert a key into the set. If the key is already present, no insertion is

--- a/common/set.h
+++ b/common/set.h
@@ -101,8 +101,8 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
   // benchmarking or logging of performance anomalies. The specific metrics
   // returned have no specific guarantees beyond being informative in
   // benchmarks.
-  auto GetMetrics(KeyContextT key_context = KeyContextT()) -> MetricsT {
-    return ImplT::GetMetrics(key_context);
+  auto ComputeMetrics(KeyContextT key_context = KeyContextT()) -> MetricsT {
+    return ImplT::ComputeMetricsImpl(key_context);
   }
 
  private:
@@ -191,8 +191,9 @@ class SetBase
   }
 
   // Convenience forwarder to the view type.
-  auto GetMetrics(KeyContextT key_context = KeyContextT()) const -> MetricsT {
-    return ViewT(*this).GetMetrics(key_context);
+  auto ComputeMetrics(KeyContextT key_context = KeyContextT()) const
+      -> MetricsT {
+    return ViewT(*this).ComputeMetrics(key_context);
   }
 
   // Insert a key into the set. If the key is already present, no insertion is

--- a/common/set_benchmark.cpp
+++ b/common/set_benchmark.cpp
@@ -369,6 +369,7 @@ static void BM_SetInsertSeq(benchmark::State& state) {
     // from the number of iterations. That means we use the normal counter API
     // without flags.
     auto metrics = s.GetMetrics();
+    CARBON_CHECK(metrics.key_count == static_cast<ssize_t>(keys.size()));
     state.counters["P-compares"] = metrics.probe_avg_compares;
     state.counters["P-distance"] = metrics.probe_avg_distance;
     state.counters["P-fraction"] =

--- a/common/set_benchmark.cpp
+++ b/common/set_benchmark.cpp
@@ -16,6 +16,7 @@ using RawHashtable::CarbonHashDI;
 using RawHashtable::GetKeysAndHitKeys;
 using RawHashtable::GetKeysAndMissKeys;
 using RawHashtable::HitArgs;
+using RawHashtable::ReportTableMetrics;
 using RawHashtable::SizeArgs;
 using RawHashtable::ValueToBool;
 
@@ -362,27 +363,7 @@ static void BM_SetInsertSeq(benchmark::State& state) {
       CARBON_DCHECK(inserted) << "Must be a successful insert!";
     }
 
-    // While this count is "iteration invariant" (it should be exactly the same
-    // for every iteration as the set of keys is the same), we don't use that
-    // because it will scale this by the number of iterations. We want to
-    // display the metrics for this benchmark *parameter*, not what resulted
-    // from the number of iterations. That means we use the normal counter API
-    // without flags.
-    auto metrics = s.GetMetrics();
-    CARBON_CHECK(metrics.key_count == static_cast<ssize_t>(keys.size()));
-    state.counters["P-compares"] = metrics.probe_avg_compares;
-    state.counters["P-distance"] = metrics.probe_avg_distance;
-    state.counters["P-fraction"] =
-        static_cast<double>(metrics.probed_key_count) / keys.size();
-    state.counters["Pmax-distance"] = metrics.probe_max_distance;
-    state.counters["Pmax-compares"] = metrics.probe_max_compares;
-    state.counters["Probed"] = metrics.probed_key_count;
-
-    state.counters["Storage"] = metrics.storage_bytes;
-    // Also compute how 'efficient' the storage is, 1.0 being zero bytes outside
-    // of keys.
-    state.counters["Storage eff"] =
-        static_cast<double>(keys.size() * sizeof(KT)) / metrics.storage_bytes;
+    ReportTableMetrics(s, state);
 
     // Uncomment this call to print out statistics about the index-collisions
     // among these keys for debugging:

--- a/common/set_benchmark.cpp
+++ b/common/set_benchmark.cpp
@@ -365,10 +365,23 @@ static void BM_SetInsertSeq(benchmark::State& state) {
     // While this count is "iteration invariant" (it should be exactly the same
     // for every iteration as the set of keys is the same), we don't use that
     // because it will scale this by the number of iterations. We want to
-    // display the probe count of this benchmark *parameter*, not the probe
-    // count that resulted from the number of iterations. That means we use the
-    // normal counter API without flags.
-    state.counters["Probed"] = s.CountProbedKeys();
+    // display the metrics for this benchmark *parameter*, not what resulted
+    // from the number of iterations. That means we use the normal counter API
+    // without flags.
+    auto metrics = s.GetMetrics();
+    state.counters["P-compares"] = metrics.probe_avg_compares;
+    state.counters["P-distance"] = metrics.probe_avg_distance;
+    state.counters["P-fraction"] =
+        static_cast<double>(metrics.probed_key_count) / keys.size();
+    state.counters["Pmax-distance"] = metrics.probe_max_distance;
+    state.counters["Pmax-compares"] = metrics.probe_max_compares;
+    state.counters["Probed"] = metrics.probed_key_count;
+
+    state.counters["Storage"] = metrics.storage_bytes;
+    // Also compute how 'efficient' the storage is, 1.0 being zero bytes outside
+    // of keys.
+    state.counters["Storage eff"] =
+        static_cast<double>(keys.size() * sizeof(KT)) / metrics.storage_bytes;
 
     // Uncomment this call to print out statistics about the index-collisions
     // among these keys for debugging:


### PR DESCRIPTION
Previously we just looked at the raw count of probed keys. Now, we compute the average and max of both the probe _distance_ measured in the number of _groups_ probed, and the number of probe _compares_ measured in the compares required _before_ finding the matching entry.

This lets us understand the relative impact of probe-distance vs. tag collisions on a given set of benchmark keys. Some of this is motivated by considering additional optimization techniques similar to those used in Boost's table and the F14 table from Facebook/Meta.