### PR TITLE
Remove return_type_id from Function.

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -86,7 +86,7 @@ auto PerformCall(Context& context, Parse::NodeId node_id,
 
   // For functions with an implicit return type, the return type is the empty
   // tuple type.
-  SemIR::TypeId type_id = callable.return_type_id;
+  SemIR::TypeId type_id = callable.declared_return_type(context.sem_ir());
   if (!type_id.is_valid()) {
     type_id = context.GetTupleType({});
   }
@@ -107,7 +107,7 @@ auto PerformCall(Context& context, Parse::NodeId node_id,
       // Tentatively put storage for a temporary in the function's return slot.
       // This will be replaced if necessary when we perform initialization.
       return_storage_id = context.AddInst<SemIR::TemporaryStorage>(
-          node_id, {.type_id = callable.return_type_id});
+          node_id, {.type_id = type_id});
       break;
     case SemIR::Function::ReturnSlot::Absent:
       break;

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -631,7 +631,6 @@ auto Context::FinalizeGlobalInit() -> void {
          .decl_id = SemIR::InstId::Invalid,
          .implicit_param_refs_id = SemIR::InstBlockId::Invalid,
          .param_refs_id = SemIR::InstBlockId::Empty,
-         .return_type_id = SemIR::TypeId::Invalid,
          .return_storage_id = SemIR::InstId::Invalid,
          .is_extern = false,
          .return_slot = SemIR::Function::ReturnSlot::Absent,

--- a/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
@@ -25,7 +25,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   bind_names:
 // CHECK:STDOUT:     bindName0:       {name: name1, parent_scope: name_scope<invalid>, index: compTimeBind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}

--- a/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
@@ -25,7 +25,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   bind_names:
 // CHECK:STDOUT:     bindName0:       {name: name1, parent_scope: name_scope<invalid>, index: compTimeBind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -142,10 +142,11 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
       sem_ir().inst_blocks().GetOrEmpty(function.implicit_param_refs_id);
   // TODO: Include parameters corresponding to positional parameters.
   auto param_refs = sem_ir().inst_blocks().GetOrEmpty(function.param_refs_id);
+  auto return_type_id = function.declared_return_type(sem_ir());
 
   SemIR::InitRepr return_rep =
-      function.return_type_id.is_valid()
-          ? SemIR::GetInitRepr(sem_ir(), function.return_type_id)
+      return_type_id.is_valid()
+          ? SemIR::GetInitRepr(sem_ir(), return_type_id)
           : SemIR::InitRepr{.kind = SemIR::InitRepr::None};
   CARBON_CHECK(return_rep.has_return_slot() == has_return_slot);
 
@@ -160,7 +161,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
   param_types.reserve(max_llvm_params);
   param_inst_ids.reserve(max_llvm_params);
   if (has_return_slot) {
-    param_types.push_back(GetType(function.return_type_id)->getPointerTo());
+    param_types.push_back(GetType(return_type_id)->getPointerTo());
     param_inst_ids.push_back(function.return_storage_id);
   }
   for (auto param_ref_id :
@@ -187,7 +188,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
   // If the initializing representation doesn't produce a value, set the return
   // type to void.
   llvm::Type* return_type = return_rep.kind == SemIR::InitRepr::ByCopy
-                                ? GetType(function.return_type_id)
+                                ? GetType(return_type_id)
                                 : llvm::Type::getVoidTy(llvm_context());
 
   std::string mangled_name;
@@ -216,7 +217,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
     if (inst_id == function.return_storage_id) {
       name_id = SemIR::NameId::ReturnSlot;
       arg.addAttr(llvm::Attribute::getWithStructRetType(
-          llvm_context(), GetType(function.return_type_id)));
+          llvm_context(), GetType(return_type_id)));
     } else {
       name_id = SemIR::Function::GetParamFromParamRefId(sem_ir(), inst_id)
                     .second.name_id;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -246,13 +246,13 @@ class Formatter {
       out_ << ")";
     }
 
-    if (fn.return_type_id.is_valid()) {
+    if (fn.return_storage_id.is_valid()) {
       out_ << " -> ";
       if (!fn.body_block_ids.empty() && fn.has_return_slot()) {
         FormatInstName(fn.return_storage_id);
         out_ << ": ";
       }
-      FormatType(fn.return_type_id);
+      FormatType(sem_ir_.insts().Get(fn.return_storage_id).type_id());
     }
 
     if (fn.builtin_kind != BuiltinFunctionKind::None) {

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -38,4 +38,11 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id) -> CalleeFunction {
   return result;
 }
 
+auto Function::declared_return_type(const File& file) const -> TypeId {
+  if (!return_storage_id.is_valid()) {
+    return TypeId::Invalid;
+  }
+  return file.insts().Get(return_storage_id).type_id();
+}
+
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -30,9 +30,6 @@ struct Function : public Printable<Function> {
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{name: " << name_id << ", parent_scope: " << parent_scope_id
         << ", param_refs: " << param_refs_id;
-    if (return_type_id.is_valid()) {
-      out << ", return_type: " << return_type_id;
-    }
     if (return_storage_id.is_valid()) {
       out << ", return_storage: " << return_storage_id;
       out << ", return_slot: ";
@@ -65,6 +62,10 @@ struct Function : public Printable<Function> {
   static auto GetParamFromParamRefId(const File& sem_ir, InstId param_ref_id)
       -> std::pair<InstId, Param>;
 
+  // Gets the declared return type of the function. Returns `Invalid` if no
+  // return type was specified,
+  auto declared_return_type(const File& file) const -> TypeId;
+
   // Returns whether the function has a return slot. Can only be called for a
   // function that has either been called or defined, otherwise this is not
   // known.
@@ -87,11 +88,10 @@ struct Function : public Printable<Function> {
   InstBlockId implicit_param_refs_id;
   // A block containing a single reference instruction per parameter.
   InstBlockId param_refs_id;
-  // The return type. This will be invalid if the return type wasn't specified.
-  TypeId return_type_id;
   // The storage for the return value, which is a reference expression whose
   // type is the return type of the function. This may or may not be used by the
-  // function, depending on whether the return type needs a return slot.
+  // function, depending on whether the return type needs a return slot, but is
+  // always present if the function has a declared return type.
   InstId return_storage_id;
   // Whether the declaration is extern.
   bool is_extern;


### PR DESCRIPTION
Instead of redundantly storing both the `return_type_id` and `return_storage_id`, where the declared return type is just the type of the return storage, store only the `return_storage_id`.

Add a convenience property to get the declared return type of the function.

In addition to avoiding storing redundant information, this is a preparatory step for an upcoming change for generics support that will make it more expensive and awkward to store `TypeId`s in places other than the type of an instruction.