### PR TITLE
Remove `inst_id` from the public interface of `ConstantId`.

### DIFF
--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -302,7 +302,8 @@ static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
   auto builder = context.emitter().Build(
       loc, QualifiedDeclInUndefinedInterfaceScope,
       context.sem_ir().StringifyTypeExpr(
-          context.sem_ir().constant_values().Get(interface_inst_id).inst_id()));
+          context.sem_ir().constant_values().GetConstantInstId(
+              interface_inst_id)));
   context.NoteUndefinedInterface(interface_id, builder);
   builder.Emit();
 }

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -113,7 +113,7 @@ static auto GetConstantValue(Context& context, SemIR::InstId inst_id,
                              Phase* phase) -> SemIR::InstId {
   auto const_id = context.constant_values().Get(inst_id);
   *phase = LatestPhase(*phase, GetPhase(const_id));
-  return const_id.inst_id();
+  return context.constant_values().GetInstId(const_id);
 }
 
 // A type is always constant, but we still need to extract its phase.
@@ -1122,8 +1122,8 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
       auto const_id = context.constant_values().Get(typed_inst.operand_id);
       auto phase = GetPhase(const_id);
       if (phase == Phase::Template) {
-        auto value =
-            context.insts().GetAs<SemIR::BoolLiteral>(const_id.inst_id());
+        auto value = context.insts().GetAs<SemIR::BoolLiteral>(
+            context.constant_values().GetInstId(const_id));
         return MakeBoolResult(context, value.type_id, !value.value.ToBool());
       }
       if (phase == Phase::UnknownDueToError) {
@@ -1138,7 +1138,9 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
       auto inner_id = context.constant_values().Get(
           context.types().GetInstId(typed_inst.inner_id));
       if (inner_id.is_constant() &&
-          context.insts().Get(inner_id.inst_id()).Is<SemIR::ConstType>()) {
+          context.insts()
+              .Get(context.constant_values().GetInstId(inner_id))
+              .Is<SemIR::ConstType>()) {
         return inner_id;
       }
       return MakeConstantResult(context, inst, GetPhase(inner_id));

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -145,8 +145,8 @@ static auto MergeOrAddName(Context& context, Parse::AnyClassDeclId node_id,
       }
 
       // Use the constant value to get the ID.
-      auto decl_value =
-          context.insts().Get(context.constant_values().Get(prev_id).inst_id());
+      auto decl_value = context.insts().Get(
+          context.constant_values().GetConstantInstId(prev_id));
       if (auto class_type = decl_value.TryAs<SemIR::ClassType>()) {
         prev_class_id = class_type->class_id;
         prev_import_ir_id = import_ir_inst.ir_id;

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -164,7 +164,7 @@ static auto TryMergeRedecl(Context& context, Parse::AnyFunctionDeclId node_id,
 
       // Use the type to get the ID.
       if (auto struct_value = context.insts().TryGetAs<SemIR::StructValue>(
-              context.constant_values().Get(prev_id).inst_id())) {
+              context.constant_values().GetConstantInstId(prev_id))) {
         if (auto function_type = context.types().TryGetAs<SemIR::FunctionType>(
                 struct_value->type_id)) {
           prev_function_id = function_type->function_id;

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -88,8 +88,8 @@ auto HandleIndexExpr(Context& context, Parse::IndexExprId node_id) -> bool {
         context.emitter().Emit(node_id, TupleIndexNotConstant);
         index_inst_id = SemIR::InstId::BuiltinError;
       } else {
-        auto index_literal =
-            context.insts().GetAs<SemIR::IntLiteral>(index_const_id.inst_id());
+        auto index_literal = context.insts().GetAs<SemIR::IntLiteral>(
+            context.constant_values().GetInstId(index_const_id));
         auto type_block = context.type_blocks().Get(tuple_type.elements_id);
         if (const auto* index_val =
                 ValidateTupleIndex(context, node_id, operand_inst,

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -92,9 +92,9 @@ static auto BuildInterfaceWitness(
 
   for (auto decl_id : assoc_entities) {
     LoadImportRef(context, decl_id);
-    auto const_id = context.constant_values().Get(decl_id);
-    CARBON_CHECK(const_id.is_constant()) << "Non-constant associated entity";
-    auto decl = context.insts().Get(const_id.inst_id());
+    decl_id = context.constant_values().GetConstantInstId(decl_id);
+    CARBON_CHECK(decl_id.is_valid()) << "Non-constant associated entity";
+    auto decl = context.insts().Get(decl_id);
     CARBON_KIND_SWITCH(decl) {
       case CARBON_KIND(SemIR::StructValue struct_value): {
         if (struct_value.type_id == SemIR::TypeId::Error) {

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -365,6 +365,16 @@ class ImportRefResolver {
     return const_id;
   }
 
+  // Returns the local constant InstId for an imported InstId.
+  auto GetLocalConstantInstId(SemIR::InstId inst_id) -> SemIR::InstId {
+    auto const_id = import_ir_constant_values().Get(inst_id);
+    if (!const_id.is_valid()) {
+      work_stack_.push_back({.inst_id = inst_id});
+      return SemIR::InstId::Invalid;
+    }
+    return context_.constant_values().GetInstId(const_id);
+  }
+
   // Returns the ConstantId for a TypeId. Adds unresolved constants to
   // work_stack_.
   auto GetLocalConstantId(SemIR::TypeId type_id) -> SemIR::ConstantId {
@@ -385,7 +395,7 @@ class ImportRefResolver {
     inst_ids.reserve(import_block.size());
     for (auto import_inst_id : import_block) {
       auto const_id = GetLocalConstantId(import_inst_id);
-      inst_ids.push_back(const_id.inst_id_if_valid());
+      inst_ids.push_back(context_.constant_values().GetInstIdIfValid(const_id));
     }
 
     return inst_ids;
@@ -488,7 +498,7 @@ class ImportRefResolver {
           case SemIR::BindSymbolicName::Kind: {
             // The symbolic name will be created on first reference, so might
             // already exist. Update the value in it to refer to the parameter.
-            auto new_bind_inst_id = GetLocalConstantId(bind_id).inst_id();
+            auto new_bind_inst_id = GetLocalConstantInstId(bind_id);
             auto new_bind_inst =
                 context_.insts().GetAs<SemIR::BindSymbolicName>(
                     new_bind_inst_id);
@@ -540,11 +550,11 @@ class ImportRefResolver {
       // TODO: Import the scope for an `impl` definition.
       return SemIR::NameScopeId::Invalid;
     }
-    auto const_id = GetLocalConstantId(inst_id);
-    if (!const_id.is_valid()) {
+    auto const_inst_id = GetLocalConstantInstId(inst_id);
+    if (!const_inst_id.is_valid()) {
       return SemIR::NameScopeId::Invalid;
     }
-    auto name_scope_inst = context_.insts().Get(const_id.inst_id());
+    auto name_scope_inst = context_.insts().Get(const_inst_id);
     CARBON_KIND_SWITCH(name_scope_inst) {
       case CARBON_KIND(SemIR::Namespace inst): {
         return inst.name_scope_id;
@@ -571,7 +581,7 @@ class ImportRefResolver {
         break;
       }
       default: {
-        if (const_id == SemIR::ConstantId::Error) {
+        if (const_inst_id == SemIR::InstId::BuiltinError) {
           return SemIR::NameScopeId::Invalid;
         }
         break;
@@ -761,7 +771,7 @@ class ImportRefResolver {
 
     auto initial_work = work_stack_.size();
     auto entity_type_const_id = GetLocalConstantId(inst.entity_type_id);
-    auto interface_const_id = GetLocalConstantId(
+    auto interface_inst_id = GetLocalConstantInstId(
         import_ir_.interfaces().Get(inst.interface_id).decl_id);
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry();
@@ -769,10 +779,9 @@ class ImportRefResolver {
 
     return ResolveAs<SemIR::AssociatedEntityType>(
         {.type_id = SemIR::TypeId::TypeType,
-         .interface_id =
-             context_.insts()
-                 .GetAs<SemIR::InterfaceType>(interface_const_id.inst_id())
-                 .interface_id,
+         .interface_id = context_.insts()
+                             .GetAs<SemIR::InterfaceType>(interface_inst_id)
+                             .interface_id,
          .entity_type_id =
              context_.GetTypeIdForTypeConstant(entity_type_const_id)});
   }
@@ -871,7 +880,7 @@ class ImportRefResolver {
   auto AddClassDefinition(const SemIR::Class& import_class,
                           SemIR::Class& new_class,
                           SemIR::ConstantId object_repr_const_id,
-                          SemIR::ConstantId base_const_id) -> void {
+                          SemIR::InstId base_id) -> void {
     new_class.definition_id = new_class.decl_id;
 
     new_class.object_repr_id =
@@ -889,7 +898,7 @@ class ImportRefResolver {
     new_class.body_block_id = context_.inst_block_stack().Pop();
 
     if (import_class.base_id.is_valid()) {
-      new_class.base_id = base_const_id.inst_id();
+      new_class.base_id = base_id;
       // Add the base scope to extended scopes.
       auto base_inst_id = context_.types().GetInstId(
           context_.insts()
@@ -918,7 +927,8 @@ class ImportRefResolver {
     } else {
       // On the second pass, compute the class ID from the constant value of the
       // declaration.
-      auto class_const_inst = context_.insts().Get(class_const_id.inst_id());
+      auto class_const_inst = context_.insts().Get(
+          context_.constant_values().GetInstId(class_const_id));
       if (auto class_type = class_const_inst.TryAs<SemIR::ClassType>()) {
         class_id = class_type->class_id;
       } else {
@@ -942,9 +952,9 @@ class ImportRefResolver {
         import_class.object_repr_id.is_valid()
             ? GetLocalConstantId(import_class.object_repr_id)
             : SemIR::ConstantId::Invalid;
-    auto base_const_id = import_class.base_id.is_valid()
-                             ? GetLocalConstantId(import_class.base_id)
-                             : SemIR::ConstantId::Invalid;
+    auto base_id = import_class.base_id.is_valid()
+                       ? GetLocalConstantInstId(import_class.base_id)
+                       : SemIR::InstId::Invalid;
 
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry(class_const_id);
@@ -960,7 +970,7 @@ class ImportRefResolver {
 
     if (import_class.is_defined()) {
       AddClassDefinition(import_class, new_class, object_repr_const_id,
-                         base_const_id);
+                         base_id);
     }
 
     return {.const_id = class_const_id};
@@ -979,7 +989,8 @@ class ImportRefResolver {
     // Find the corresponding class type. For a non-generic class, this is the
     // type of the class declaration. For a generic class, build a class type
     // referencing this specialization of the generic class.
-    auto class_const_inst = context_.insts().Get(class_const_id.inst_id());
+    auto class_const_inst = context_.insts().Get(
+        context_.constant_values().GetInstId(class_const_id));
     if (class_const_inst.Is<SemIR::ClassType>()) {
       return {.const_id = class_const_id};
     } else {
@@ -1098,12 +1109,12 @@ class ImportRefResolver {
   auto TryResolveTypedInst(SemIR::FunctionType inst) -> ResolveResult {
     auto initial_work = work_stack_.size();
     CARBON_CHECK(inst.type_id == SemIR::TypeId::TypeType);
-    auto fn_const_id = GetLocalConstantId(
+    auto fn_val_id = GetLocalConstantInstId(
         import_ir_.functions().Get(inst.function_id).decl_id);
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry();
     }
-    auto fn_val = context_.insts().Get(fn_const_id.inst_id());
+    auto fn_val = context_.insts().Get(fn_val_id);
     CARBON_CHECK(context_.types().Is<SemIR::FunctionType>(fn_val.type_id()));
     return {.const_id = context_.types().GetConstantId(fn_val.type_id())};
   }
@@ -1111,12 +1122,12 @@ class ImportRefResolver {
   auto TryResolveTypedInst(SemIR::GenericClassType inst) -> ResolveResult {
     auto initial_work = work_stack_.size();
     CARBON_CHECK(inst.type_id == SemIR::TypeId::TypeType);
-    auto class_const_id =
-        GetLocalConstantId(import_ir_.classes().Get(inst.class_id).decl_id);
+    auto class_val_id =
+        GetLocalConstantInstId(import_ir_.classes().Get(inst.class_id).decl_id);
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry();
     }
-    auto class_val = context_.insts().Get(class_const_id.inst_id());
+    auto class_val = context_.insts().Get(class_val_id);
     CARBON_CHECK(
         context_.types().Is<SemIR::GenericClassType>(class_val.type_id()));
     return {.const_id = context_.types().GetConstantId(class_val.type_id())};
@@ -1125,12 +1136,12 @@ class ImportRefResolver {
   auto TryResolveTypedInst(SemIR::GenericInterfaceType inst) -> ResolveResult {
     auto initial_work = work_stack_.size();
     CARBON_CHECK(inst.type_id == SemIR::TypeId::TypeType);
-    auto interface_const_id = GetLocalConstantId(
+    auto interface_val_id = GetLocalConstantInstId(
         import_ir_.interfaces().Get(inst.interface_id).decl_id);
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry();
     }
-    auto interface_val = context_.insts().Get(interface_const_id.inst_id());
+    auto interface_val = context_.insts().Get(interface_val_id);
     CARBON_CHECK(context_.types().Is<SemIR::GenericInterfaceType>(
         interface_val.type_id()));
     return {.const_id =
@@ -1151,7 +1162,8 @@ class ImportRefResolver {
       return {.const_id = SemIR::ConstantId::Error};
     }
 
-    auto new_constant_id = GetLocalConstantId(constant_id.inst_id());
+    auto new_constant_id =
+        GetLocalConstantId(import_ir_.constant_values().GetInstId(constant_id));
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry();
     }
@@ -1205,7 +1217,7 @@ class ImportRefResolver {
   // declaration.
   auto AddInterfaceDefinition(const SemIR::Interface& import_interface,
                               SemIR::Interface& new_interface,
-                              SemIR::ConstantId self_param_id) -> void {
+                              SemIR::InstId self_param_id) -> void {
     new_interface.scope_id = context_.name_scopes().Add(
         new_interface.decl_id, SemIR::NameId::Invalid,
         new_interface.parent_scope_id);
@@ -1219,7 +1231,7 @@ class ImportRefResolver {
     new_interface.associated_entities_id =
         AddAssociatedEntities(import_interface.associated_entities_id);
     new_interface.body_block_id = context_.inst_block_stack().Pop();
-    new_interface.self_param_id = self_param_id.inst_id();
+    new_interface.self_param_id = self_param_id;
 
     CARBON_CHECK(import_scope.extended_scopes.empty())
         << "Interfaces don't currently have extended scopes to support.";
@@ -1239,8 +1251,8 @@ class ImportRefResolver {
     } else {
       // On the second pass, compute the interface ID from the constant value of
       // the declaration.
-      auto interface_const_inst =
-          context_.insts().Get(interface_const_id.inst_id());
+      auto interface_const_inst = context_.insts().Get(
+          context_.constant_values().GetInstId(interface_const_id));
       if (auto interface_type =
               interface_const_inst.TryAs<SemIR::InterfaceType>()) {
         interface_id = interface_type->interface_id;
@@ -1260,7 +1272,7 @@ class ImportRefResolver {
         GetLocalParamConstantIds(import_interface.implicit_param_refs_id);
     llvm::SmallVector<SemIR::ConstantId> param_const_ids =
         GetLocalParamConstantIds(import_interface.param_refs_id);
-    auto self_param_id = GetLocalConstantId(import_interface.self_param_id);
+    auto self_param_id = GetLocalConstantInstId(import_interface.self_param_id);
 
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry(interface_const_id);
@@ -1293,8 +1305,8 @@ class ImportRefResolver {
     // is the type of the interface declaration. For a generic interface, build
     // a interface type referencing this specialization of the generic
     // interface.
-    auto interface_const_inst =
-        context_.insts().Get(interface_const_id.inst_id());
+    auto interface_const_inst = context_.insts().Get(
+        context_.constant_values().GetInstId(interface_const_id));
     if (interface_const_inst.Is<SemIR::InterfaceType>()) {
       return {.const_id = interface_const_id};
     } else {
@@ -1311,22 +1323,12 @@ class ImportRefResolver {
 
   auto TryResolveTypedInst(SemIR::InterfaceWitness inst) -> ResolveResult {
     auto initial_work = work_stack_.size();
-    llvm::SmallVector<SemIR::InstId> elements;
-    auto import_elements = import_ir_.inst_blocks().Get(inst.elements_id);
-    elements.reserve(import_elements.size());
-    for (auto import_elem_id : import_elements) {
-      if (auto const_id = GetLocalConstantId(import_elem_id);
-          const_id.is_valid()) {
-        elements.push_back(const_id.inst_id());
-      }
-    }
+    auto elements = GetLocalInstBlockContents(inst.elements_id);
     if (HasNewWork(initial_work)) {
       return ResolveResult::Retry();
     }
-    CARBON_CHECK(elements.size() == import_elements.size())
-        << "Failed to import an element without adding new work.";
 
-    auto elements_id = context_.inst_blocks().Add(elements);
+    auto elements_id = GetLocalCanonicalInstBlockId(inst.elements_id, elements);
     return ResolveAs<SemIR::InterfaceWitness>(
         {.type_id = context_.GetBuiltinType(SemIR::BuiltinKind::WitnessType),
          .elements_id = elements_id});

--- a/toolchain/check/operator.cpp
+++ b/toolchain/check/operator.cpp
@@ -47,7 +47,7 @@ static auto GetOperatorOpFunction(Context& context, Parse::AnyExprId node_id,
   }
 
   // Look through import_refs and aliases.
-  op_id = context.constant_values().Get(op_id).inst_id();
+  op_id = context.constant_values().GetConstantInstId(op_id);
 
   // We expect it to be an associated function.
   if (context.insts().Is<SemIR::AssociatedEntity>(op_id)) {

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -148,7 +148,7 @@ static auto Rebuild(Context& context, Worklist& worklist, SemIR::InstId inst_id)
   auto result_id = TryEvalInst(context, SemIR::InstId::Invalid, inst);
   CARBON_CHECK(result_id.is_constant())
       << "Substitution into constant produced non-constant";
-  return result_id.inst_id();
+  return context.constant_values().GetInstId(result_id);
 }
 
 auto SubstConstant(Context& context, SemIR::ConstantId const_id,
@@ -165,7 +165,7 @@ auto SubstConstant(Context& context, SemIR::ConstantId const_id,
     return const_id;
   }
 
-  Worklist worklist(const_id.inst_id());
+  Worklist worklist(context.constant_values().GetInstId(const_id));
 
   // For each instruction that forms part of the constant, we will visit it
   // twice:
@@ -208,7 +208,7 @@ auto SubstConstant(Context& context, SemIR::ConstantId const_id,
         if (context.bind_names().Get(bind->bind_name_id).bind_index ==
             bind_index) {
           // This is the binding we're replacing. Perform substitution.
-          item.inst_id = replacement_id.inst_id();
+          item.inst_id = context.constant_values().GetInstId(replacement_id);
           break;
         }
       }

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -70,11 +70,13 @@ auto FileContext::GetGlobal(SemIR::InstId inst_id) -> llvm::Value* {
 
   auto const_id = sem_ir().constant_values().Get(inst_id);
   if (const_id.is_template()) {
+    auto const_inst_id = sem_ir().constant_values().GetInstId(const_id);
+
     // For value expressions and initializing expressions, the value produced by
     // a constant instruction is a value representation of the constant. For
     // initializing expressions, `FinishInit` will perform a copy if needed.
     // TODO: Handle reference expression constants.
-    auto* const_value = constants_[const_id.inst_id().index];
+    auto* const_value = constants_[const_inst_id.index];
 
     // If we want a pointer to the constant, materialize a global to hold it.
     // TODO: We could reuse the same global if the constant is used more than
@@ -86,7 +88,7 @@ auto FileContext::GetGlobal(SemIR::InstId inst_id) -> llvm::Value* {
       llvm::StringRef const_name;
       llvm::StringRef use_name;
       if (inst_namer_) {
-        const_name = inst_namer_->GetUnscopedNameFor(const_id.inst_id());
+        const_name = inst_namer_->GetUnscopedNameFor(const_inst_id);
         use_name = inst_namer_->GetUnscopedNameFor(inst_id);
       }
 

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -37,6 +37,24 @@ class ConstantValueStore {
     values_[inst_id.index] = const_id;
   }
 
+  // Gets the instruction ID that defines the value of the given constant.
+  // Returns Invalid if the constant ID is non-constant. Requires is_valid.
+  auto GetInstId(ConstantId const_id) const -> InstId {
+    return const_id.inst_id();
+  }
+
+  // Gets the instruction ID that defines the value of the given constant.
+  // Returns Invalid if the constant ID is non-constant or invalid.
+  auto GetInstIdIfValid(ConstantId const_id) const -> InstId {
+    return const_id.is_valid() ? GetInstId(const_id) : InstId::Invalid;
+  }
+
+  // Given an instruction, returns the unique constant instruction that is
+  // equivalent to it. Returns Invalid for a non-constant instruction.
+  auto GetConstantInstId(InstId inst_id) const -> InstId {
+    return GetInstId(Get(inst_id));
+  }
+
   // Returns the constant values mapping as an ArrayRef whose keys are
   // instruction indexes. Some of the elements in this mapping may be Invalid or
   // NotConstant.

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -496,6 +496,11 @@ auto File::StringifyType(TypeId type_id) const -> std::string {
   return StringifyTypeExprImpl(*this, types().GetInstId(type_id));
 }
 
+auto File::StringifyType(ConstantId type_const_id) const -> std::string {
+  return StringifyTypeExprImpl(*this,
+                               constant_values().GetInstId(type_const_id));
+}
+
 auto File::StringifyTypeExpr(InstId outer_inst_id) const -> std::string {
   return StringifyTypeExprImpl(*this, outer_inst_id);
 }

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -80,6 +80,9 @@ class File : public Printable<File> {
   // Produces a string version of a type.
   auto StringifyType(TypeId type_id) const -> std::string;
 
+  // Same, but with a constant ID rather than a type ID.
+  auto StringifyType(ConstantId type_const_id) const -> std::string;
+
   // Same as `StringifyType`, but starting with an instruction representing a
   // type expression rather than a canonical type.
   auto StringifyTypeExpr(InstId outer_inst_id) const -> std::string;
@@ -238,7 +241,7 @@ class File : public Printable<File> {
   ConstantStore constants_;
 
   // Descriptions of types used in this file.
-  TypeStore types_ = TypeStore(&insts_);
+  TypeStore types_ = TypeStore(&insts_, &constant_values_);
 
   // Types that were completed in this file.
   llvm::SmallVector<TypeId> complete_types_;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -401,7 +401,7 @@ class Formatter {
     out_ << InstT::Kind.ir_name();
     pending_constant_value_ = sem_ir_.constant_values().Get(inst_id);
     pending_constant_value_is_self_ =
-        pending_constant_value_.inst_id() == inst_id;
+        sem_ir_.constant_values().GetInstId(pending_constant_value_) == inst_id;
     FormatInstructionRHS(inst);
     FormatPendingConstantValue(AddSpace::Before);
     out_ << "\n";
@@ -433,7 +433,8 @@ class Formatter {
       out_ << (pending_constant_value_.is_symbolic() ? "symbolic" : "template");
       if (!pending_constant_value_is_self_) {
         out_ << " = ";
-        FormatInstName(pending_constant_value_.inst_id());
+        FormatInstName(
+            sem_ir_.constant_values().GetInstId(pending_constant_value_));
       }
     } else {
       out_ << pending_constant_value_;

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -19,11 +19,11 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id) -> CalleeFunction {
   }
 
   // Identify the function we're calling.
-  auto val_id = sem_ir.constant_values().Get(callee_id);
-  if (!val_id.is_constant()) {
+  auto val_id = sem_ir.constant_values().GetConstantInstId(callee_id);
+  if (!val_id.is_valid()) {
     return result;
   }
-  auto val_inst = sem_ir.insts().Get(val_id.inst_id());
+  auto val_inst = sem_ir.insts().Get(val_id);
   auto struct_val = val_inst.TryAs<StructValue>();
   if (!struct_val) {
     result.is_error = val_inst.type_id() == SemIR::TypeId::Error;

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -457,9 +457,11 @@ auto InstNamer::CollectNamesInBlock(ScopeId scope_id,
         // a block. Constants that refer to them need to be separately
         // named.
         auto const_id = sem_ir_.constant_values().Get(inst_id);
-        if (const_id.is_valid() && const_id.is_template() &&
-            !insts[const_id.inst_id().index].second) {
-          CollectNamesInBlock(ScopeId::ImportRef, const_id.inst_id());
+        if (const_id.is_valid() && const_id.is_template()) {
+          auto const_inst_id = sem_ir_.constant_values().GetInstId(const_id);
+          if (!insts[const_inst_id.index].second) {
+            CollectNamesInBlock(ScopeId::ImportRef, const_inst_id);
+          }
         }
         continue;
       }

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_SEM_IR_TYPE_H_
 
 #include "toolchain/base/value_store.h"
+#include "toolchain/sem_ir/constant.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/type_info.h"
@@ -15,7 +16,8 @@ namespace Carbon::SemIR {
 // Provides a ValueStore wrapper with an API specific to types.
 class TypeStore : public ValueStore<TypeId> {
  public:
-  explicit TypeStore(InstStore* insts) : insts_(insts) {}
+  explicit TypeStore(InstStore* insts, ConstantValueStore* constants)
+      : insts_(insts), constants_(constants) {}
 
   // Returns the ID of the constant used to define the specified type.
   auto GetConstantId(TypeId type_id) const -> ConstantId {
@@ -33,7 +35,7 @@ class TypeStore : public ValueStore<TypeId> {
 
   // Returns the ID of the instruction used to define the specified type.
   auto GetInstId(TypeId type_id) const -> InstId {
-    return GetConstantId(type_id).inst_id();
+    return constants_->GetInstId(GetConstantId(type_id));
   }
 
   // Returns the instruction used to define the specified type.
@@ -56,7 +58,8 @@ class TypeStore : public ValueStore<TypeId> {
       return GetAsInst(type_id).As<InstT>();
     } else {
       // The type is not a builtin, so no need to check for special values.
-      return insts_->Get(Get(type_id).constant_id.inst_id()).As<InstT>();
+      auto inst_id = constants_->GetInstId(Get(type_id).constant_id);
+      return insts_->GetAs<InstT>(inst_id);
     }
   }
 
@@ -95,6 +98,7 @@ class TypeStore : public ValueStore<TypeId> {
 
  private:
   InstStore* insts_;
+  ConstantValueStore* constants_;
 };
 
 }  // namespace Carbon::SemIR


### PR DESCRIPTION
Require mapping from a `ConstantId` to an `InstId` to go through the `ConstantValueStore`.

This is a preparatory step for an upcoming generics change where symbolic `ConstantId`s are no longer just a thin wrapper around an `InstId` but instead are indexes into a table with additional information about the symbolic constant beyond its `InstId`.