### PR TITLE
Remove another hashtable iteration order dependency.

### DIFF
--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -147,9 +147,12 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id,
           context_->AddExport(target_id);
         }
 
-        auto [_, success] = name_scope.names.insert(
-            {name_context.unresolved_name_id,
-             {.inst_id = target_id, .access_kind = access_kind}});
+        int scope_index = name_scope.names.size();
+        name_scope.names.push_back({.name_id = name_context.unresolved_name_id,
+                                    .inst_id = target_id,
+                                    .access_kind = access_kind});
+        auto [_, success] = name_scope.name_map.insert(
+            {name_context.unresolved_name_id, scope_index});
         CARBON_CHECK(success)
             << "Duplicate names should have been resolved previously: "
             << name_context.unresolved_name_id << " in "

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -77,10 +77,11 @@ auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
   // Replace the ImportRef in name lookup, both for the above duplicate
   // diagnostic and so that cross-package imports can find it easily.
   auto bind_name = context.bind_names().Get(import_ref->bind_name_id);
-  auto& names = context.name_scopes().Get(bind_name.parent_scope_id).names;
-  auto it = names.find(bind_name.name_id);
-  CARBON_CHECK(it->second.inst_id == inst_id);
-  it->second.inst_id = export_id;
+  auto& parent_scope = context.name_scopes().Get(bind_name.parent_scope_id);
+  auto it = parent_scope.name_map.find(bind_name.name_id);
+  auto& scope_inst_id = parent_scope.names[it->second].inst_id;
+  CARBON_CHECK(scope_inst_id == inst_id);
+  scope_inst_id = export_id;
 
   return true;
 }

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -595,15 +595,13 @@ class ImportRefResolver {
   // lookup.
   auto AddNameScopeImportRefs(const SemIR::NameScope& import_scope,
                               SemIR::NameScope& new_scope) -> void {
-    for (auto [entry_name_id, entry] : import_scope.names) {
+    for (auto entry : import_scope.names) {
       auto ref_id = AddImportRef(
           context_, {.ir_id = import_ir_id_, .inst_id = entry.inst_id},
           SemIR::BindNameId::Invalid);
-      CARBON_CHECK(
-          new_scope.names
-              .insert({GetLocalNameId(entry_name_id),
-                       {.inst_id = ref_id, .access_kind = entry.access_kind}})
-              .second);
+      new_scope.AddRequired({.name_id = GetLocalNameId(entry.name_id),
+                             .inst_id = ref_id,
+                             .access_kind = entry.access_kind});
     }
   }
 

--- a/toolchain/check/merge.cpp
+++ b/toolchain/check/merge.cpp
@@ -123,10 +123,10 @@ auto CheckIsAllowedRedecl(Context& context, Lex::TokenKind decl_kind,
 auto ReplacePrevInstForMerge(Context& context, SemIR::NameScopeId scope_id,
                              SemIR::NameId name_id, SemIR::InstId new_inst_id)
     -> void {
-  auto& names = context.name_scopes().Get(scope_id).names;
-  auto it = names.find(name_id);
-  if (it != names.end()) {
-    it->second.inst_id = new_inst_id;
+  auto& scope = context.name_scopes().Get(scope_id);
+  auto it = scope.name_map.find(name_id);
+  if (it != scope.name_map.end()) {
+    scope.names[it->second].inst_id = new_inst_id;
   }
 }
 

--- a/toolchain/check/testdata/alias/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/export_name.carbon
@@ -122,8 +122,8 @@ var d: D* = &c;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .D = %import_ref.2
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .D = %import_ref.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded

--- a/toolchain/check/testdata/alias/no_prelude/import_order.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import_order.carbon
@@ -97,8 +97,8 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+14, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.4: type = import_ref ir1, inst+16, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+18, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.6: %.4 = import_ref ir1, inst+7, loaded [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.7: %.4 = import_ref ir1, inst+7, loaded [template = imports.%.1]
 // CHECK:STDOUT:   %d.ref: type = name_ref d, %import_ref.5 [template = constants.%C]
 // CHECK:STDOUT:   %d_val.var: ref %C = var d_val
 // CHECK:STDOUT:   %d_val: ref %C = bind_name d_val, %d_val.var
@@ -115,8 +115,8 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .v = file.%import_ref.6
-// CHECK:STDOUT:   .Self = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.6
+// CHECK:STDOUT:   .v = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -130,7 +130,7 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc7_25: init %C = converted %.loc7_24.1, %.loc7_24.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%d_val.var, %.loc7_25
 // CHECK:STDOUT:   %d_val.ref: ref %C = name_ref d_val, file.%d_val
-// CHECK:STDOUT:   %v.ref.loc8: %.4 = name_ref v, file.%import_ref.6 [template = imports.%.1]
+// CHECK:STDOUT:   %v.ref.loc8: %.4 = name_ref v, file.%import_ref.7 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_27.1: ref %.1 = class_element_access %d_val.ref, element0
 // CHECK:STDOUT:   %.loc8_29.1: %.2 = struct_literal (%.loc8_27.1)
 // CHECK:STDOUT:   %.loc8_29.2: ref %.1 = class_element_access file.%c_val.var, element0
@@ -140,7 +140,7 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc8_30: init %C = converted %.loc8_29.1, %.loc8_29.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c_val.var, %.loc8_30
 // CHECK:STDOUT:   %c_val.ref: ref %C = name_ref c_val, file.%c_val
-// CHECK:STDOUT:   %v.ref.loc9: %.4 = name_ref v, file.%import_ref.6 [template = imports.%.1]
+// CHECK:STDOUT:   %v.ref.loc9: %.4 = name_ref v, file.%import_ref.7 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc9_27.1: ref %.1 = class_element_access %c_val.ref, element0
 // CHECK:STDOUT:   %.loc9_29.1: %.2 = struct_literal (%.loc9_27.1)
 // CHECK:STDOUT:   %.loc9_29.2: ref %.1 = class_element_access file.%b_val.var, element0
@@ -150,7 +150,7 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc9_30: init %C = converted %.loc9_29.1, %.loc9_29.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%b_val.var, %.loc9_30
 // CHECK:STDOUT:   %b_val.ref: ref %C = name_ref b_val, file.%b_val
-// CHECK:STDOUT:   %v.ref.loc10: %.4 = name_ref v, file.%import_ref.6 [template = imports.%.1]
+// CHECK:STDOUT:   %v.ref.loc10: %.4 = name_ref v, file.%import_ref.7 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc10_27.1: ref %.1 = class_element_access %b_val.ref, element0
 // CHECK:STDOUT:   %.loc10_29.1: %.2 = struct_literal (%.loc10_27.1)
 // CHECK:STDOUT:   %.loc10_29.2: ref %.1 = class_element_access file.%a_val.var, element0

--- a/toolchain/check/testdata/class/extern.carbon
+++ b/toolchain/check/testdata/class/extern.carbon
@@ -558,8 +558,8 @@ extern class C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -576,8 +576,8 @@ extern class C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -595,8 +595,8 @@ extern class C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -618,8 +618,8 @@ extern class C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -198,10 +198,10 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .CompleteClass = %import_ref.2
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .Class = %Class.decl
+// CHECK:STDOUT:     .CompleteClass = %import_ref.2
 // CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: %Class.type = import_ref ir0, inst+5, loaded [template = constants.%Class.1]
 // CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref ir0, inst+12, loaded [template = constants.%CompleteClass.1]

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -178,11 +178,11 @@ fn Run() {
 // CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+6, unloaded
 // CHECK:STDOUT:   %import_ref.7: %.7 = import_ref ir1, inst+17, loaded [template = imports.%.1]
 // CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+22, unloaded
-// CHECK:STDOUT:   %import_ref.9: %G.type = import_ref ir1, inst+36, loaded [template = constants.%G]
-// CHECK:STDOUT:   %import_ref.10: %F.type = import_ref ir1, inst+27, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.9: %F.type = import_ref ir1, inst+27, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.10: %G.type = import_ref ir1, inst+36, loaded [template = constants.%G]
 // CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+22, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+27, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+27, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+36, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Empty {
@@ -199,15 +199,15 @@ fn Run() {
 // CHECK:STDOUT: class @ForwardDeclared.1 {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = file.%import_ref.8
-// CHECK:STDOUT:   .G = file.%import_ref.9
-// CHECK:STDOUT:   .F = file.%import_ref.10
+// CHECK:STDOUT:   .F = file.%import_ref.9
+// CHECK:STDOUT:   .G = file.%import_ref.10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @ForwardDeclared.2 {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = file.%import_ref.11
-// CHECK:STDOUT:   .G = file.%import_ref.12
-// CHECK:STDOUT:   .F = file.%import_ref.13
+// CHECK:STDOUT:   .F = file.%import_ref.12
+// CHECK:STDOUT:   .G = file.%import_ref.13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;
@@ -244,12 +244,12 @@ fn Run() {
 // CHECK:STDOUT:   %.loc12_30: init %ForwardDeclared.1 = converted %.loc12_29.1, %.loc12_29.2 [template = constants.%struct.3]
 // CHECK:STDOUT:   assign %c.var, %.loc12_30
 // CHECK:STDOUT:   %c.ref.loc13: ref %ForwardDeclared.1 = name_ref c, %c
-// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%import_ref.10 [template = constants.%F]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%import_ref.9 [template = constants.%F]
 // CHECK:STDOUT:   %.loc13_4: <bound method> = bound_method %c.ref.loc13, %F.ref
 // CHECK:STDOUT:   %.loc13_3: %ForwardDeclared.1 = bind_value %c.ref.loc13
 // CHECK:STDOUT:   %F.call: init %.1 = call %.loc13_4(%.loc13_3)
 // CHECK:STDOUT:   %c.ref.loc14: ref %ForwardDeclared.1 = name_ref c, %c
-// CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%import_ref.9 [template = constants.%G]
+// CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%import_ref.10 [template = constants.%G]
 // CHECK:STDOUT:   %.loc14_4: <bound method> = bound_method %c.ref.loc14, %G.ref
 // CHECK:STDOUT:   %.loc14_3: %.9 = addr_of %c.ref.loc14
 // CHECK:STDOUT:   %G.call: init %.1 = call %.loc14_4(%.loc14_3)

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -148,10 +148,10 @@ fn Run() {
 // CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+37, loaded [template = constants.%Child]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {}
-// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref ir1, inst+7, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.5: %.11 = import_ref ir1, inst+26, loaded [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+14, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref ir1, inst+7, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+14, unloaded
+// CHECK:STDOUT:   %import_ref.6: %.11 = import_ref ir1, inst+26, loaded [template = imports.%.1]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+33, unloaded
 // CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+38, unloaded
 // CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+42, unloaded
@@ -166,10 +166,10 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = file.%import_ref.3
-// CHECK:STDOUT:   .Self = file.%import_ref.4
-// CHECK:STDOUT:   .x = file.%import_ref.5
-// CHECK:STDOUT:   .Unused = file.%import_ref.6
+// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .F = file.%import_ref.4
+// CHECK:STDOUT:   .Unused = file.%import_ref.5
+// CHECK:STDOUT:   .x = file.%import_ref.6
 // CHECK:STDOUT:   .unused = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -193,14 +193,14 @@ fn Run() {
 // CHECK:STDOUT:   %.loc7_49: init %Child = converted %.loc7_48.1, %.loc7_48.4 [template = constants.%struct.2]
 // CHECK:STDOUT:   assign %a.var, %.loc7_49
 // CHECK:STDOUT:   %a.ref.loc8: ref %Child = name_ref a, %a
-// CHECK:STDOUT:   %x.ref: %.11 = name_ref x, file.%import_ref.5 [template = imports.%.1]
+// CHECK:STDOUT:   %x.ref: %.11 = name_ref x, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_4.1: ref %Base = class_element_access %a.ref.loc8, element0
 // CHECK:STDOUT:   %.loc8_4.2: ref %Base = converted %a.ref.loc8, %.loc8_4.1
 // CHECK:STDOUT:   %.loc8_4.3: ref i32 = class_element_access %.loc8_4.2, element0
 // CHECK:STDOUT:   %.loc8_9: i32 = int_literal 2 [template = constants.%.12]
 // CHECK:STDOUT:   assign %.loc8_4.3, %.loc8_9
 // CHECK:STDOUT:   %a.ref.loc9: ref %Child = name_ref a, %a
-// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%import_ref.3 [template = constants.%F]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%import_ref.4 [template = constants.%F]
 // CHECK:STDOUT:   %.loc9_4: <bound method> = bound_method %a.ref.loc9, %F.ref
 // CHECK:STDOUT:   %.loc9_6.1: ref %Base = class_element_access %a.ref.loc9, element0
 // CHECK:STDOUT:   %.loc9_6.2: ref %Base = converted %a.ref.loc9, %.loc9_6.1

--- a/toolchain/check/testdata/class/import_forward_decl.carbon
+++ b/toolchain/check/testdata/class/import_forward_decl.carbon
@@ -47,8 +47,8 @@ class ForwardDecl {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .ForwardDecl = %ForwardDecl.decl
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: type = import_ref ir0, inst+2, loaded [template = constants.%ForwardDecl]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}

--- a/toolchain/check/testdata/class/import_member_cycle.carbon
+++ b/toolchain/check/testdata/class/import_member_cycle.carbon
@@ -74,14 +74,14 @@ fn Run() {
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%Cycle]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Cycle {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .a = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
+++ b/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
@@ -151,15 +151,15 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .F = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- d.carbon
@@ -186,8 +186,8 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+7, loaded [template = constants.%C]
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+6, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
@@ -234,14 +234,14 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref %.1 = var x
 // CHECK:STDOUT:   %x: ref %.1 = bind_name x, %x.var
-// CHECK:STDOUT:   %import_ref.2: %F.type = import_ref ir2, inst+3, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref ir2, inst+3, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .F = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
@@ -249,7 +249,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%import_ref.1 [template = constants.%C]
-// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%import_ref.2 [template = constants.%F]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%import_ref.3 [template = constants.%F]
 // CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
 // CHECK:STDOUT:   assign file.%x.var, %F.call
 // CHECK:STDOUT:   return
@@ -275,8 +275,8 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref %.1 = var x
 // CHECK:STDOUT:   %x: ref %.1 = bind_name x, %x.var
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref ir1, inst+5, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref ir1, inst+6, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
@@ -316,8 +316,8 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref %.1 = var x
 // CHECK:STDOUT:   %x: ref %.1 = bind_name x, %x.var
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref ir2, inst+5, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref ir2, inst+6, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -663,12 +663,12 @@ import library "extern_api";
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %NS
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:     .D = %D.decl
+// CHECK:STDOUT:     .NS = %NS
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b.loc13
 // CHECK:STDOUT:     .c = %c.loc14
@@ -807,12 +807,12 @@ import library "extern_api";
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %NS
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:     .D = %D.decl
+// CHECK:STDOUT:     .NS = %NS
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b.loc13
 // CHECK:STDOUT:     .c = %c.loc14
@@ -1168,13 +1168,13 @@ import library "extern_api";
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:     .B = %import_ref.2
 // CHECK:STDOUT:     .C = %import_ref.3
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
-// CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: %A.type = import_ref ir1, inst+2, loaded [template = constants.%A]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+21, unloaded
@@ -1272,13 +1272,13 @@ import library "extern_api";
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:     .B = %import_ref.2
 // CHECK:STDOUT:     .C = %import_ref.3
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
-// CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: %A.type = import_ref ir1, inst+2, loaded [template = constants.%A]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+21, unloaded

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -295,11 +295,11 @@ fn D() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:     .C = %import_ref.3
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:     .Core = %Core
-// CHECK:STDOUT:     .A = %A.decl
-// CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: %A.type = import_ref ir1, inst+2, loaded [template = constants.%A]
 // CHECK:STDOUT:   %import_ref.2: %B.type = import_ref ir1, inst+22, loaded [template = constants.%B]
@@ -341,8 +341,8 @@ fn D() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A.decl.loc6
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: %A.type = import_ref ir1, inst+2, loaded [template = constants.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -368,8 +368,8 @@ fn D() {}
 // CHECK:STDOUT:     .A = %import_ref.1
 // CHECK:STDOUT:     .B = %import_ref.2
 // CHECK:STDOUT:     .C = %import_ref.3
-// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .D = %D.decl.loc13
+// CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+22, unloaded

--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -123,8 +123,8 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Impl: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %import_ref.1 = import_ref ir8, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.2: %.5 = import_ref ir8, inst+11, loaded [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir8, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir8, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.3: %.5 = import_ref ir8, inst+11, loaded [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.4 = import_ref ir8, inst+6, unloaded
 // CHECK:STDOUT:   %import_ref.5: <witness> = import_ref ir8, inst+22, loaded [template = constants.%.7]
 // CHECK:STDOUT:   %import_ref.6: type = import_ref ir8, inst+13, loaded [template = constants.%C]
@@ -140,8 +140,8 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .F = file.%import_ref.3
 // CHECK:STDOUT:   witness = (file.%import_ref.4)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -157,7 +157,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
 // CHECK:STDOUT:   %Impl.ref: <namespace> = name_ref Impl, file.%Impl [template = file.%Impl]
 // CHECK:STDOUT:   %HasF.ref: type = name_ref HasF, file.%import_ref.7 [template = constants.%.2]
-// CHECK:STDOUT:   %F.ref: %.5 = name_ref F, file.%import_ref.2 [template = constants.%.6]
+// CHECK:STDOUT:   %F.ref: %.5 = name_ref F, file.%import_ref.3 [template = constants.%.6]
 // CHECK:STDOUT:   %.1: %F.type.1 = interface_witness_access file.%import_ref.5, element0 [template = constants.%F.2]
 // CHECK:STDOUT:   %F.call: init %.3 = call %.1()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -119,8 +119,8 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Impl: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.2: %.5 = import_ref ir1, inst+10, loaded [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: %.5 = import_ref ir1, inst+10, loaded [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+5, unloaded
 // CHECK:STDOUT:   %import_ref.5: <witness> = import_ref ir1, inst+21, loaded [template = constants.%.7]
 // CHECK:STDOUT:   %import_ref.6: type = import_ref ir1, inst+12, loaded [template = constants.%C]
@@ -136,8 +136,8 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .F = file.%import_ref.3
 // CHECK:STDOUT:   witness = (file.%import_ref.4)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -153,7 +153,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
 // CHECK:STDOUT:   %Impl.ref: <namespace> = name_ref Impl, file.%Impl [template = file.%Impl]
 // CHECK:STDOUT:   %HasF.ref: type = name_ref HasF, file.%import_ref.7 [template = constants.%.2]
-// CHECK:STDOUT:   %F.ref: %.5 = name_ref F, file.%import_ref.2 [template = constants.%.6]
+// CHECK:STDOUT:   %F.ref: %.5 = name_ref F, file.%import_ref.3 [template = constants.%.6]
 // CHECK:STDOUT:   %.1: %F.type.1 = interface_witness_access file.%import_ref.5, element0 [template = constants.%F.2]
 // CHECK:STDOUT:   %F.call: init %.3 = call %.1()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/impl/no_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_self.carbon
@@ -101,8 +101,8 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: %.4 = import_ref ir1, inst+24, loaded [template = constants.%.5]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: %.4 = import_ref ir1, inst+24, loaded [template = constants.%.5]
 // CHECK:STDOUT:   %import_ref.4: %Op.type.2 = import_ref ir1, inst+19, loaded [template = constants.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %.loc6_7.1: %.1 = tuple_literal ()
@@ -127,8 +127,8 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Op = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .Op = file.%import_ref.3
 // CHECK:STDOUT:   witness = (file.%import_ref.4)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -164,7 +164,7 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.ref: %.1 = name_ref x, %x
 // CHECK:STDOUT:   %Add.ref: type = name_ref Add, file.%import_ref.1 [template = constants.%.2]
-// CHECK:STDOUT:   %Op.ref: %.4 = name_ref Op, file.%import_ref.2 [template = constants.%.5]
+// CHECK:STDOUT:   %Op.ref: %.4 = name_ref Op, file.%import_ref.3 [template = constants.%.5]
 // CHECK:STDOUT:   %.1: %Op.type.2 = interface_witness_access @impl.%.1, element0 [template = constants.%Op.1]
 // CHECK:STDOUT:   %.loc11_11: <bound method> = bound_method %x.ref, %.1
 // CHECK:STDOUT:   %y.ref: %.1 = name_ref y, %y

--- a/toolchain/check/testdata/interface/no_prelude/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_duplicate.carbon
@@ -76,8 +76,8 @@ interface Class { }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = <error>
 // CHECK:STDOUT:   .Self = <unexpected instref inst+3>
+// CHECK:STDOUT:   .F = <error>
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import.carbon
@@ -189,8 +189,8 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     @UseEmpty.%e: %.1 = bind_name e, %e.loc6_13.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.7: %.7 = import_ref ir1, inst+18, loaded [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.8: %.5 = import_ref ir1, inst+11, loaded [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.7: %.5 = import_ref ir1, inst+11, loaded [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.8: %.7 = import_ref ir1, inst+18, loaded [template = constants.%.8]
 // CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+9, unloaded
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+13, unloaded
 // CHECK:STDOUT:   %UseBasic.decl: %UseBasic.type = fn_decl @UseBasic [template = constants.%UseBasic] {
@@ -199,8 +199,8 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     @UseBasic.%e: %.3 = bind_name e, %e.loc7_13.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+22, unloaded
-// CHECK:STDOUT:   %import_ref.12: %.11 = import_ref ir1, inst+32, loaded [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.13: %.9 = import_ref ir1, inst+26, loaded [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.12: %.9 = import_ref ir1, inst+26, loaded [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.13: %.11 = import_ref ir1, inst+32, loaded [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.14 = import_ref ir1, inst+24, unloaded
 // CHECK:STDOUT:   %import_ref.15 = import_ref ir1, inst+28, unloaded
 // CHECK:STDOUT:   %UseForwardDeclared.decl: %UseForwardDeclared.type = fn_decl @UseForwardDeclared [template = constants.%UseForwardDeclared] {
@@ -210,20 +210,20 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Basic.ref.loc10: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
 // CHECK:STDOUT:   %import_ref.16 = import_ref ir1, inst+9, unloaded
-// CHECK:STDOUT:   %T.ref.loc10: %.5 = name_ref T, %import_ref.8 [template = constants.%.6]
-// CHECK:STDOUT:   %UseBasicT: %.5 = bind_alias UseBasicT, %import_ref.8 [template = constants.%.6]
+// CHECK:STDOUT:   %T.ref.loc10: %.5 = name_ref T, %import_ref.7 [template = constants.%.6]
+// CHECK:STDOUT:   %UseBasicT: %.5 = bind_alias UseBasicT, %import_ref.7 [template = constants.%.6]
 // CHECK:STDOUT:   %Basic.ref.loc11: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
 // CHECK:STDOUT:   %import_ref.17 = import_ref ir1, inst+13, unloaded
-// CHECK:STDOUT:   %F.ref.loc11: %.7 = name_ref F, %import_ref.7 [template = constants.%.8]
-// CHECK:STDOUT:   %UseBasicF: %.7 = bind_alias UseBasicF, %import_ref.7 [template = constants.%.8]
+// CHECK:STDOUT:   %F.ref.loc11: %.7 = name_ref F, %import_ref.8 [template = constants.%.8]
+// CHECK:STDOUT:   %UseBasicF: %.7 = bind_alias UseBasicF, %import_ref.8 [template = constants.%.8]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc13: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.18 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %T.ref.loc13: %.9 = name_ref T, %import_ref.13 [template = constants.%.10]
-// CHECK:STDOUT:   %UseForwardDeclaredT: %.9 = bind_alias UseForwardDeclaredT, %import_ref.13 [template = constants.%.10]
+// CHECK:STDOUT:   %T.ref.loc13: %.9 = name_ref T, %import_ref.12 [template = constants.%.10]
+// CHECK:STDOUT:   %UseForwardDeclaredT: %.9 = bind_alias UseForwardDeclaredT, %import_ref.12 [template = constants.%.10]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc14: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.19 = import_ref ir1, inst+28, unloaded
-// CHECK:STDOUT:   %F.ref.loc14: %.11 = name_ref F, %import_ref.12 [template = constants.%.12]
-// CHECK:STDOUT:   %UseForwardDeclaredF: %.11 = bind_alias UseForwardDeclaredF, %import_ref.12 [template = constants.%.12]
+// CHECK:STDOUT:   %F.ref.loc14: %.11 = name_ref F, %import_ref.13 [template = constants.%.12]
+// CHECK:STDOUT:   %UseForwardDeclaredF: %.11 = bind_alias UseForwardDeclaredF, %import_ref.13 [template = constants.%.12]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc16: type = ptr_type %.4 [template = constants.%.13]
 // CHECK:STDOUT:   %f.var: ref %.13 = var f
@@ -239,16 +239,16 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: interface @Basic {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = file.%import_ref.6
-// CHECK:STDOUT:   .F = file.%import_ref.7
-// CHECK:STDOUT:   .T = file.%import_ref.8
+// CHECK:STDOUT:   .T = file.%import_ref.7
+// CHECK:STDOUT:   .F = file.%import_ref.8
 // CHECK:STDOUT:   witness = (file.%import_ref.9, file.%import_ref.10)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ForwardDeclared {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = file.%import_ref.11
-// CHECK:STDOUT:   .F = file.%import_ref.12
-// CHECK:STDOUT:   .T = file.%import_ref.13
+// CHECK:STDOUT:   .T = file.%import_ref.12
+// CHECK:STDOUT:   .F = file.%import_ref.13
 // CHECK:STDOUT:   witness = (file.%import_ref.14, file.%import_ref.15)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -132,11 +132,11 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir6, inst+51, loaded [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: %.8 = import_ref ir6, inst+93, loaded [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir6, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.4: %.12 = import_ref ir6, inst+133, loaded [template = constants.%.13]
-// CHECK:STDOUT:   %import_ref.5: %.6 = import_ref ir6, inst+73, loaded [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: %.10 = import_ref ir6, inst+113, loaded [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir6, inst+53, unloaded
+// CHECK:STDOUT:   %import_ref.3: %.6 = import_ref ir6, inst+73, loaded [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.4: %.8 = import_ref ir6, inst+93, loaded [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.5: %.10 = import_ref ir6, inst+113, loaded [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.6: %.12 = import_ref ir6, inst+133, loaded [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7: %Less.type.2 = import_ref ir6, inst+69, loaded [template = constants.%Less.2]
 // CHECK:STDOUT:   %import_ref.8: %LessOrEquivalent.type.2 = import_ref ir6, inst+89, loaded [template = constants.%LessOrEquivalent.2]
 // CHECK:STDOUT:   %import_ref.9: %Greater.type.2 = import_ref ir6, inst+109, loaded [template = constants.%Greater.2]
@@ -214,11 +214,11 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .LessOrEquivalent = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
-// CHECK:STDOUT:   .GreaterOrEquivalent = file.%import_ref.4
-// CHECK:STDOUT:   .Less = file.%import_ref.5
-// CHECK:STDOUT:   .Greater = file.%import_ref.6
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .Less = file.%import_ref.3
+// CHECK:STDOUT:   .LessOrEquivalent = file.%import_ref.4
+// CHECK:STDOUT:   .Greater = file.%import_ref.5
+// CHECK:STDOUT:   .GreaterOrEquivalent = file.%import_ref.6
 // CHECK:STDOUT:   witness = (file.%import_ref.7, file.%import_ref.8, file.%import_ref.9, file.%import_ref.10)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -414,11 +414,11 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.2: type = import_ref ir6, inst+51, loaded [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.3: %.7 = import_ref ir6, inst+93, loaded [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir6, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.5: %.11 = import_ref ir6, inst+133, loaded [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.6: %.5 = import_ref ir6, inst+73, loaded [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.7: %.9 = import_ref ir6, inst+113, loaded [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir6, inst+53, unloaded
+// CHECK:STDOUT:   %import_ref.4: %.5 = import_ref ir6, inst+73, loaded [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.5: %.7 = import_ref ir6, inst+93, loaded [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.6: %.9 = import_ref ir6, inst+113, loaded [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.7: %.11 = import_ref ir6, inst+133, loaded [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.8 = import_ref ir6, inst+69, unloaded
 // CHECK:STDOUT:   %import_ref.9 = import_ref ir6, inst+89, unloaded
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir6, inst+109, unloaded
@@ -473,11 +473,11 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .LessOrEquivalent = file.%import_ref.3
-// CHECK:STDOUT:   .Self = file.%import_ref.4
-// CHECK:STDOUT:   .GreaterOrEquivalent = file.%import_ref.5
-// CHECK:STDOUT:   .Less = file.%import_ref.6
-// CHECK:STDOUT:   .Greater = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Less = file.%import_ref.4
+// CHECK:STDOUT:   .LessOrEquivalent = file.%import_ref.5
+// CHECK:STDOUT:   .Greater = file.%import_ref.6
+// CHECK:STDOUT:   .GreaterOrEquivalent = file.%import_ref.7
 // CHECK:STDOUT:   witness = (file.%import_ref.8, file.%import_ref.9, file.%import_ref.10, file.%import_ref.11)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/export_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_import.carbon
@@ -260,8 +260,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -269,8 +269,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -303,8 +303,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -312,8 +312,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -346,8 +346,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -355,8 +355,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -389,8 +389,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -398,8 +398,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -432,8 +432,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -441,8 +441,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -475,8 +475,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -484,8 +484,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -518,8 +518,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -527,8 +527,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -561,8 +561,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -570,8 +570,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -604,8 +604,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -613,8 +613,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -657,8 +657,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -666,8 +666,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.2
-// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .Self = file.%import_ref.2
+// CHECK:STDOUT:   .x = file.%import_ref.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -702,8 +702,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+13, unloaded
 // CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.2 [template = constants.%C]
 // CHECK:STDOUT:   %indirect_c.var: ref %C = var indirect_c
 // CHECK:STDOUT:   %indirect_c: ref %C = bind_name indirect_c, %indirect_c.var
@@ -711,8 +711,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.3
-// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .x = file.%import_ref.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {

--- a/toolchain/check/testdata/packages/no_prelude/export_mixed.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_mixed.carbon
@@ -175,20 +175,20 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .D = %import_ref.2
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .D = %import_ref.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.3
-// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .x = file.%import_ref.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_name.carbon
@@ -201,20 +201,20 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .D = %import_ref.2
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .D = %import_ref.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.3
-// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .Self = file.%import_ref.3
+// CHECK:STDOUT:   .x = file.%import_ref.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_name_then_import.carbon
@@ -243,8 +243,8 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+10, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -286,8 +286,8 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+10, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -329,8 +329,8 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+10, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -398,8 +398,8 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+10, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -448,8 +448,8 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+11, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2: type = import_ref ir5, inst+11, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+10, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var

--- a/toolchain/check/testdata/packages/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_name.carbon
@@ -260,8 +260,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+11, loaded
@@ -269,8 +269,8 @@ private export C;
 // CHECK:STDOUT:     .NSC = %NSC
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+12, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+13, unloaded
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+17, unloaded
@@ -279,8 +279,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.4
-// CHECK:STDOUT:   .Self = file.%import_ref.5
+// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .x = file.%import_ref.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
@@ -316,8 +316,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+13, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+3, loaded
@@ -325,11 +325,11 @@ private export C;
 // CHECK:STDOUT:     .NSC = %NSC
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+21, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+12, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+20, unloaded
 // CHECK:STDOUT:   %NSC: type = export NSC, %import_ref.3 [template = constants.%NSC]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -341,8 +341,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .y = file.%import_ref.6
-// CHECK:STDOUT:   .Self = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.6
+// CHECK:STDOUT:   .y = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_in_impl.carbon
@@ -379,14 +379,14 @@ private export C;
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+21, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+12, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, %NS [template = %NS]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+20, unloaded
 // CHECK:STDOUT:   %NSC.ref: type = name_ref NSC, %import_ref.3 [template = constants.%NSC]
 // CHECK:STDOUT:   %nsc.var: ref %NSC = var nsc
 // CHECK:STDOUT:   %nsc: ref %NSC = bind_name nsc, %nsc.var
@@ -400,8 +400,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .y = file.%import_ref.6
-// CHECK:STDOUT:   .Self = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.6
+// CHECK:STDOUT:   .y = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -474,8 +474,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .y = file.%import_ref.6
-// CHECK:STDOUT:   .Self = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.6
+// CHECK:STDOUT:   .y = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -548,8 +548,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .y = file.%import_ref.6
-// CHECK:STDOUT:   .Self = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.6
+// CHECK:STDOUT:   .y = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -626,14 +626,14 @@ private export C;
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.4
-// CHECK:STDOUT:   .Self = file.%import_ref.5
+// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .x = file.%import_ref.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- import_both.carbon
@@ -664,8 +664,8 @@ private export C;
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+12, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -679,8 +679,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.4
-// CHECK:STDOUT:   .Self = file.%import_ref.5
+// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .x = file.%import_ref.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
@@ -738,14 +738,14 @@ private export C;
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+21, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+12, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, %NS [template = %NS]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+20, unloaded
 // CHECK:STDOUT:   %NSC.ref: type = name_ref NSC, %import_ref.3 [template = constants.%NSC]
 // CHECK:STDOUT:   %nsc.var: ref %NSC = var nsc
 // CHECK:STDOUT:   %nsc: ref %NSC = bind_name nsc, %nsc.var
@@ -759,8 +759,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @NSC {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .y = file.%import_ref.6
-// CHECK:STDOUT:   .Self = file.%import_ref.7
+// CHECK:STDOUT:   .Self = file.%import_ref.6
+// CHECK:STDOUT:   .y = file.%import_ref.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -807,8 +807,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+11, loaded
@@ -816,15 +816,15 @@ private export C;
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.4
-// CHECK:STDOUT:   .Self = file.%import_ref.5
+// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .x = file.%import_ref.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- use_repeat_export.carbon
@@ -844,8 +844,8 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+13, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+12, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref %C = var c
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
@@ -880,8 +880,8 @@ private export C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .C = %C
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%C]
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+11, loaded
@@ -889,14 +889,14 @@ private export C;
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %C: type = export C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .x = file.%import_ref.4
-// CHECK:STDOUT:   .Self = file.%import_ref.5
+// CHECK:STDOUT:   .Self = file.%import_ref.4
+// CHECK:STDOUT:   .x = file.%import_ref.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -332,21 +332,11 @@ class Formatter {
       out_ << label;
     }
 
-    // Name scopes aren't kept in any particular order. Sort the entries before
-    // we print them for stability and consistency.
-    llvm::SmallVector<std::pair<NameScope::Entry, NameId>> entries;
-    for (auto [name_id, entry] : scope.names) {
-      entries.push_back({entry, name_id});
-    }
-    llvm::sort(entries, [](auto a, auto b) {
-      return a.first.inst_id.index < b.first.inst_id.index;
-    });
-
-    for (auto [entry, name_id] : entries) {
+    for (auto [name_id, inst_id, access_kind] : scope.names) {
       Indent();
       out_ << ".";
       FormatName(name_id);
-      switch (entry.access_kind) {
+      switch (access_kind) {
         case SemIR::AccessKind::Public:
           break;
         case SemIR::AccessKind::Protected:
@@ -357,7 +347,7 @@ class Formatter {
           break;
       }
       out_ << " = ";
-      FormatInstName(entry.inst_id);
+      FormatInstName(inst_id);
       out_ << "\n";
     }
 

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -19,6 +19,7 @@ enum class AccessKind : int8_t {
 
 struct NameScope : Printable<NameScope> {
   struct Entry {
+    NameId name_id;
     InstId inst_id;
     AccessKind access_kind;
   };
@@ -35,24 +36,35 @@ struct NameScope : Printable<NameScope> {
     out << "]";
 
     out << ", names: {";
-    // Sort name keys to get stable output.
-    llvm::SmallVector<NameId> keys;
-    for (auto [key, _] : names) {
-      keys.push_back(key);
-    }
-    llvm::sort(keys,
-               [](NameId lhs, NameId rhs) { return lhs.index < rhs.index; });
-    llvm::ListSeparator key_sep;
-    for (auto key : keys) {
-      out << key_sep << key << ": " << names.find(key)->second.inst_id;
+    llvm::ListSeparator sep;
+    for (auto entry : names) {
+      out << sep << entry.name_id << ": " << entry.inst_id;
     }
     out << "}";
 
     out << "}";
   }
 
-  // Names in the scope.
-  llvm::DenseMap<NameId, Entry> names = llvm::DenseMap<NameId, Entry>();
+  // Adds a name to the scope that must not already exist.
+  auto AddRequired(Entry name_entry) -> void {
+    int index = names.size();
+    names.push_back(name_entry);
+    auto success = name_map.insert({name_entry.name_id, index}).second;
+    CARBON_CHECK(success) << "Failed to add required name: "
+                          << name_entry.name_id;
+  }
+
+  // Names in the scope. We store both an insertion-orderd vector for iterating
+  // and a map from `NameId` to the index of that vector for name lookup.
+  //
+  // Optimization notes: this is somewhat memory inefficient. If this ends up
+  // either hot or a significant source of memory allocation, we should consider
+  // switching to a SOA model where the `AccessKind` is stored in a separate
+  // vector so that these can pack densely. If this ends up both cold and memory
+  // intensive, we can also switch the lookup to a set of indices into the
+  // vector rather than a map from `NameId` to index.
+  llvm::SmallVector<Entry> names;
+  llvm::DenseMap<NameId, int> name_map = llvm::DenseMap<NameId, int>();
 
   // Scopes extended by this scope.
   //
@@ -114,10 +126,9 @@ class NameScopeStore {
   // These must never conflict.
   auto AddRequiredName(NameScopeId scope_id, NameId name_id, InstId inst_id)
       -> void {
-    NameScope::Entry entry = {.inst_id = inst_id,
-                              .access_kind = AccessKind::Public};
-    auto success = Get(scope_id).names.insert({name_id, entry}).second;
-    CARBON_CHECK(success) << "Failed to add required name: " << name_id;
+    Get(scope_id).AddRequired({.name_id = name_id,
+                               .inst_id = inst_id,
+                               .access_kind = AccessKind::Public});
   }
 
   // Returns the requested name scope.

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -54,7 +54,7 @@ struct NameScope : Printable<NameScope> {
                           << name_entry.name_id;
   }
 
-  // Names in the scope. We store both an insertion-orderd vector for iterating
+  // Names in the scope. We store both an insertion-ordered vector for iterating
   // and a map from `NameId` to the index of that vector for name lookup.
   //
   // Optimization notes: this is somewhat memory inefficient. If this ends up


### PR DESCRIPTION
Name scopes store the names in their scope in a `DenseMap`. Several places reasonably avoid depending on the iteration order by sorting the names -- they're in the formatting code path where that's a solid approach.

Unfortunately, when we're importing one scope into another, we also need to walk the entire scope and do something for each name. =[ This doesn't seem like a great place to sort things to stabilize them.

I've switched to a fairly simplistic solution of having a vector of name entries that can be iterated stably, and a separate map for lookups. I didn't use the set-of-indices trick here because it's not clear that's the right trade-off for a scope: likely a lot of small scopes here with relatively hot name lookups. And the key here isn't a large or dynamically sized thing that we're canonicalizing, it's a `NameId`. That made me lean towards duplicating the name in the hashtable for lookup and the vector for iteration.

I thought about a fancy approach of sorting the hashtable keys by their values (the indices), but that would still require a bit of copying and more code.

I also thought a bit about other optimizations, but decided to leave a comment for now -- it's not obvious to me exactly how hot this is and whether it's better served by faster lookups, being more memory dense, etc. And that might involve more of an SOA layout change or some other approach. Rather than do that here, and especially before switching hashtables, I stuck with a simple approach to address the ordering.