### PR TITLE
Switch to using a Python rule for `gen_tmpl.py`.

### DIFF
--- a/bazel/version/BUILD
+++ b/bazel/version/BUILD
@@ -3,10 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//toolchain/install:__pkg__"])
 
-exports_files(["gen_tmpl.py"])
+py_binary(
+    name = "gen_tmpl",
+    srcs = ["gen_tmpl.py"],
+    python_version = "PY3",
+)
 
 # Several flags are provided for customizing the exact version used for the
 # build of Carbon. Each of these is documented here, but rather than using the

--- a/bazel/version/rules.bzl
+++ b/bazel/version/rules.bzl
@@ -119,8 +119,8 @@ expand_version_build_info_internal = rule(
         "_alpha_number_flag": attr.label(default = ":alpha_number"),
         "_beta_number_flag": attr.label(default = ":beta_number"),
         "_gen_tmpl_tool": attr.label(
-            default = Label("//bazel/version:gen_tmpl.py"),
-            allow_single_file = True,
+            default = Label("//bazel/version:gen_tmpl"),
+            allow_files = True,
             executable = True,
             cfg = "exec",
         ),


### PR DESCRIPTION
This ensures that the Python we have configured with Bazel is used and not some other system install.