### PR TITLE
Fix PR labeling and generate nightly build notes from them.

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -15,19 +15,20 @@ changelog:
         - proposal
       exclude.labels:
         - bot
-    - title: 'Toolchain changes :hammer_and_wrench:'
+    - title: 'Toolchain and implementation changes :hammer_and_wrench:'
       labels:
         - toolchain
-      exclude.labels:
-        - bot
-    - title: 'Explorer changes :telescope:'
-      labels:
         - explorer
       exclude.labels:
         - bot
     - title: 'Documentation changes :memo:'
       labels:
         - documentation
+      exclude.labels:
+        - bot
+    - title: 'Utilities :triangular_ruler:'
+      labels:
+        - utilities
       exclude.labels:
         - bot
     - title: 'Infrastructure changes :building_construction:'

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,43 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Provide the configuration and categorization for generated release notes.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+
+  categories:
+    - title: Proposals Accepted and Merged 📜
+      labels:
+        - proposal
+      exclude.labels:
+        - automated
+    - title: Toolchain Changes 🛠
+      labels:
+        - toolchain
+      exclude.labels:
+        - automated
+    - title: Explorer Changes 🔭
+      labels:
+        - explorer
+      exclude.labels:
+        - automated
+    - title: Documentation Changes 🖺
+      labels:
+        - documentation
+      exclude.labels:
+        - automated
+    - title: Infrastructure Changes 🏗
+      labels:
+        - infrastructure
+      exclude.labels:
+        - automated
+    - title: Automated Updates 🤖
+      labels:
+        - automated
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -10,34 +10,34 @@ changelog:
       - ignore-for-release
 
   categories:
-    - title: Proposals Accepted and Merged 📜
+    - title: 'Proposals accepted and merged :scroll:'
       labels:
         - proposal
       exclude.labels:
-        - automated
-    - title: Toolchain Changes 🛠
+        - bot
+    - title: 'Toolchain changes :hammer_and_wrench:'
       labels:
         - toolchain
       exclude.labels:
-        - automated
-    - title: Explorer Changes 🔭
+        - bot
+    - title: 'Explorer changes :telescope:'
       labels:
         - explorer
       exclude.labels:
-        - automated
-    - title: Documentation Changes 🖺
+        - bot
+    - title: 'Documentation changes :memo:'
       labels:
         - documentation
       exclude.labels:
-        - automated
-    - title: Infrastructure Changes 🏗
+        - bot
+    - title: 'Infrastructure changes :building_construction:'
       labels:
         - infrastructure
       exclude.labels:
-        - automated
-    - title: Automated Updates 🤖
+        - bot
+    - title: 'Automated robot PRs :robot:'
       labels:
-        - automated
-    - title: Other Changes
+        - bot
+    - title: 'Other changes'
       labels:
         - '*'

--- a/.github/workflows/label_prs.yaml
+++ b/.github/workflows/label_prs.yaml
@@ -28,9 +28,11 @@ jobs:
               - 'docs/**'
               - 'examples/**'
               - 'third_party/examples/**'
+
             explorer:
               - 'explorer/**'
               - 'installers/**'
+
             infrastructure:
               - '*.bzl'
               - '*.cfg'
@@ -44,14 +46,23 @@ jobs:
               - 'github_tools/**'
               - 'proposal/scripts/**'
               - 'scripts/**'
+
+            # Here we only want the `proposal` label when a *new* file is added
+            # directly in this directory. We use `added` and a single level glob
+            # to achieve that.
             proposal:
               - added: 'proposals/*'
+
+            # We include common, shared code into the toolchain label for
+            # convenience. Essentially, this is everything we intend to ship as
+            # part of the reference implementation of the language.
             toolchain:
               - 'common/**'
               - 'core/**'
               - 'language_server/**'
               - 'testing/**'
               - 'toolchain/**'
+
             utilities:
               - 'utils/**'
 

--- a/.github/workflows/label_prs.yaml
+++ b/.github/workflows/label_prs.yaml
@@ -27,8 +27,10 @@ jobs:
               - '*.md'
               - 'docs/**'
               - 'examples/**'
+              - 'third_party/examples/**'
             explorer:
               - 'explorer/**'
+              - 'installers/**'
             infrastructure:
               - '*.bzl'
               - '*.cfg'
@@ -39,20 +41,19 @@ jobs:
               - 'MODULE.*'
               - 'WORKSPACE'
               - 'bazel/**'
-              - 'common/**'
               - 'github_tools/**'
-              - 'installers/**'
-              - 'language_server/**'
               - 'proposal/scripts/**'
               - 'scripts/**'
-              - 'testing/**'
-              - 'third_party/**'
-              - 'utils/**'
             proposal:
               - added: 'proposals/*'
             toolchain:
+              - 'common/**'
               - 'core/**'
+              - 'language_server/**'
+              - 'testing/**'
               - 'toolchain/**'
+            utilities:
+              - 'utils/**'
 
       - id: documentation
         if: steps.filter.outputs.documentation == 'true'
@@ -94,6 +95,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
 
+      - id: utilities
+        if: steps.filter.outputs.utilities == 'true'
+        run: |
+          gh pr edit "${PR}" --add-label "utilities"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+
+      # Note that this is not a path-based label, but an *author* based label,
+      # and it applies orthogonally to the others.
       - id: automated
         if:
           contains(fromJSON('["CarbonInfraBot", "dependabot"]'),

--- a/.github/workflows/label_prs.yaml
+++ b/.github/workflows/label_prs.yaml
@@ -26,20 +26,36 @@ jobs:
             documentation:
               - '*.md'
               - 'docs/**'
+              - 'examples/**'
             explorer:
               - 'explorer/**'
             infrastructure:
-              - 'BUILD'
-              - 'WORKSPACE'
+              - '*.bzl'
+              - '*.cfg'
+              - '*.toml'
               - '.*'
               - '.*/**'
+              - 'BUILD'
+              - 'MODULE.*'
+              - 'WORKSPACE'
               - 'bazel/**'
+              - 'common/**'
+              - 'github_tools/**'
+              - 'installers/**'
+              - 'language_server/**'
+              - 'proposal/scripts/**'
               - 'scripts/**'
+              - 'testing/**'
+              - 'third_party/**'
+              - 'utils/**'
+            proposal:
+              - added: 'proposals/*'
             toolchain:
+              - 'core/**'
               - 'toolchain/**'
 
       - id: documentation
-        if: steps.filter.outputs.docs == 'true'
+        if: steps.filter.outputs.documentation == 'true'
         run: |
           gh pr edit "${PR}" --add-label "documentation"
         env:
@@ -55,9 +71,17 @@ jobs:
           PR: ${{ github.event.pull_request.html_url }}
 
       - id: infrastructure
-        if: steps.filter.outputs.docs == 'true'
+        if: steps.filter.outputs.infrastructure == 'true'
         run: |
           gh pr edit "${PR}" --add-label "infrastructure"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+
+      - id: proposal
+        if: steps.filter.outputs.proposal == 'true'
+        run: |
+          gh pr edit "${PR}" --add-label "proposal"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
@@ -66,6 +90,16 @@ jobs:
         if: steps.filter.outputs.toolchain == 'true'
         run: |
           gh pr edit "${PR}" --add-label "toolchain"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+
+      - id: automated
+        if:
+          contains(fromJSON('["CarbonInfraBot", "dependabot"]'),
+          github.event.pull_request.user.login)
+        run: |
+          gh pr edit "${PR}" --add-label "automated"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           gh release create \
             --title "Nightly build ${{ env.nightly_date }}" \
-            --notes 'A nightly development build of Carbon.' \
+            --generate-notes \
             --prerelease \
             v${{ env.release_version }} \
             "bazel-bin/toolchain/install/carbon_toolchain-${{ env.release_version }}.tar.gz"


### PR DESCRIPTION
This configures the nightly build to generate release notes and provides a template for organizing them. The organization is done through labeling of PRs and categorizing them based on those labels. I've tried to provide a rough categorization that seems reasonable for folks.

While doing this I looked at our PR labeling and found a few bugs that were preventing many labels form being attached. I've fixed those and significantly expanded the coverage of file-based labeling. I've also added code to do author-based labeling for automated PRs so those can be separated out from human PRs.