### PR TITLE
Fix quirks in debug printing

### DIFF
--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -13,7 +13,9 @@
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        builtin_insts.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
@@ -39,12 +39,12 @@ fn B() {}
 // CHECK:STDOUT:     type1:           {constant: template inst+2, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:     type2:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:   type_blocks:
-// CHECK:STDOUT:     typeBlock0:      {}
+// CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
 // CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
 // CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
 // CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: empty, type: type1}
 // CHECK:STDOUT:     'inst+5':          {kind: Return}
 // CHECK:STDOUT:   constant_values:
@@ -102,12 +102,12 @@ fn B() {}
 // CHECK:STDOUT:     type1:           {constant: template inst+2, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:     type2:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:   type_blocks:
-// CHECK:STDOUT:     typeBlock0:      {}
+// CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
 // CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
 // CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
 // CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: empty, type: type1}
 // CHECK:STDOUT:     'inst+5':          {kind: Return}
 // CHECK:STDOUT:   constant_values:

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
@@ -20,12 +20,18 @@ fn A() {}
 // --- b.carbon
 package B;
 
-fn B() {}
+import A;
+
+fn B() {
+  A.A();
+}
 
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -88,44 +94,74 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:     ir1:             {node_id: 4, is_export: false}
+// CHECK:STDOUT:   import_ir_insts:
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst+1}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst+1}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
-// CHECK:STDOUT:   bind_names:      {}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst+1, name0: inst+2}}
+// CHECK:STDOUT:     name_scope1:     {inst: inst+1, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:   bind_names:
+// CHECK:STDOUT:     bind_name0:      {name: name1, parent_scope: name_scope1, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: empty, body: [block3]}
+// CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1, param_refs: empty}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   generic_instances: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}
-// CHECK:STDOUT:     type1:           {constant: template inst+2, value_rep: {kind: none, type: type2}}
-// CHECK:STDOUT:     type2:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
+// CHECK:STDOUT:     type1:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
+// CHECK:STDOUT:     type2:           {constant: template inst+4, value_rep: {kind: none, type: type2}}
+// CHECK:STDOUT:     type3:           {constant: template inst+9, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
-// CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
-// CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: empty, type: type1}
-// CHECK:STDOUT:     'inst+5':          {kind: Return}
+// CHECK:STDOUT:     'inst+1':          {kind: Namespace, arg0: name_scope1, arg1: inst<invalid>, type: type0}
+// CHECK:STDOUT:     'inst+2':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
+// CHECK:STDOUT:     'inst+3':          {kind: FunctionType, arg0: function0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+4':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+5':          {kind: StructValue, arg0: empty, type: type1}
+// CHECK:STDOUT:     'inst+6':          {kind: NameRef, arg0: name1, arg1: inst+1, type: type0}
+// CHECK:STDOUT:     'inst+7':          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: bind_name0, type: type3}
+// CHECK:STDOUT:     'inst+8':          {kind: FunctionDecl, arg0: function1, arg1: empty, type: type3}
+// CHECK:STDOUT:     'inst+9':          {kind: FunctionType, arg0: function1, type: typeTypeType}
+// CHECK:STDOUT:     'inst+10':         {kind: StructValue, arg0: empty, type: type3}
+// CHECK:STDOUT:     'inst+11':         {kind: NameRef, arg0: name1, arg1: inst+7, type: type3}
+// CHECK:STDOUT:     'inst+12':         {kind: Call, arg0: inst+11, arg1: block4, type: type2}
+// CHECK:STDOUT:     'inst+13':         {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     'inst+0':          template inst+0
-// CHECK:STDOUT:     'inst+1':          template inst+4
-// CHECK:STDOUT:     'inst+2':          template inst+2
+// CHECK:STDOUT:     'inst+1':          template inst+1
+// CHECK:STDOUT:     'inst+2':          template inst+5
 // CHECK:STDOUT:     'inst+3':          template inst+3
 // CHECK:STDOUT:     'inst+4':          template inst+4
+// CHECK:STDOUT:     'inst+5':          template inst+5
+// CHECK:STDOUT:     'inst+6':          template inst+1
+// CHECK:STDOUT:     'inst+7':          template inst+10
+// CHECK:STDOUT:     'inst+8':          template inst+10
+// CHECK:STDOUT:     'inst+9':          template inst+9
+// CHECK:STDOUT:     'inst+10':         template inst+10
+// CHECK:STDOUT:     'inst+11':         template inst+10
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst+2
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     block3:
-// CHECK:STDOUT:       0:               inst+5
-// CHECK:STDOUT:     block4:
+// CHECK:STDOUT:       0:               inst+6
+// CHECK:STDOUT:       1:               inst+11
+// CHECK:STDOUT:       2:               inst+12
+// CHECK:STDOUT:       3:               inst+13
+// CHECK:STDOUT:     block4:          {}
+// CHECK:STDOUT:     block5:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+1
+// CHECK:STDOUT:       2:               inst+2
+// CHECK:STDOUT:       3:               inst+7
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
@@ -134,17 +170,27 @@ fn B() {}
 // CHECK:STDOUT:   %B.type: type = fn_type @B [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %B: %B.type = struct_value () [template]
+// CHECK:STDOUT:   %A.type: type = fn_type @A [template]
+// CHECK:STDOUT:   %A: %A.type = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B [template = constants.%B] {}
+// CHECK:STDOUT:   %import_ref: %A.type = import_ref ir1, inst+1, loaded [template = constants.%A]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() {
 // CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref.loc6_3: <namespace> = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %A.ref.loc6_4: %A.type = name_ref A, file.%import_ref [template = constants.%A]
+// CHECK:STDOUT:   %A.call: init %.1 = call %A.ref.loc6_4()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
@@ -20,12 +20,18 @@ fn A() {}
 // --- b.carbon
 package B;
 
-fn B() {}
+import A;
+
+fn B() {
+  A.A();
+}
 
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -67,42 +73,72 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:     ir1:             {node_id: 4, is_export: false}
+// CHECK:STDOUT:   import_ir_insts:
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst+1}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst+1}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
-// CHECK:STDOUT:   bind_names:      {}
+// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst+1, name0: inst+2}}
+// CHECK:STDOUT:     name_scope1:     {inst: inst+1, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:   bind_names:
+// CHECK:STDOUT:     bind_name0:      {name: name1, parent_scope: name_scope1, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: empty, body: [block3]}
+// CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1, param_refs: empty}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   generic_instances: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}
-// CHECK:STDOUT:     type1:           {constant: template inst+2, value_rep: {kind: none, type: type2}}
-// CHECK:STDOUT:     type2:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
+// CHECK:STDOUT:     type1:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
+// CHECK:STDOUT:     type2:           {constant: template inst+4, value_rep: {kind: none, type: type2}}
+// CHECK:STDOUT:     type3:           {constant: template inst+9, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
-// CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
-// CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: empty, type: type1}
-// CHECK:STDOUT:     'inst+5':          {kind: Return}
+// CHECK:STDOUT:     'inst+1':          {kind: Namespace, arg0: name_scope1, arg1: inst<invalid>, type: type0}
+// CHECK:STDOUT:     'inst+2':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
+// CHECK:STDOUT:     'inst+3':          {kind: FunctionType, arg0: function0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+4':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+5':          {kind: StructValue, arg0: empty, type: type1}
+// CHECK:STDOUT:     'inst+6':          {kind: NameRef, arg0: name1, arg1: inst+1, type: type0}
+// CHECK:STDOUT:     'inst+7':          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: bind_name0, type: type3}
+// CHECK:STDOUT:     'inst+8':          {kind: FunctionDecl, arg0: function1, arg1: empty, type: type3}
+// CHECK:STDOUT:     'inst+9':          {kind: FunctionType, arg0: function1, type: typeTypeType}
+// CHECK:STDOUT:     'inst+10':         {kind: StructValue, arg0: empty, type: type3}
+// CHECK:STDOUT:     'inst+11':         {kind: NameRef, arg0: name1, arg1: inst+7, type: type3}
+// CHECK:STDOUT:     'inst+12':         {kind: Call, arg0: inst+11, arg1: block4, type: type2}
+// CHECK:STDOUT:     'inst+13':         {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     'inst+0':          template inst+0
-// CHECK:STDOUT:     'inst+1':          template inst+4
-// CHECK:STDOUT:     'inst+2':          template inst+2
+// CHECK:STDOUT:     'inst+1':          template inst+1
+// CHECK:STDOUT:     'inst+2':          template inst+5
 // CHECK:STDOUT:     'inst+3':          template inst+3
 // CHECK:STDOUT:     'inst+4':          template inst+4
+// CHECK:STDOUT:     'inst+5':          template inst+5
+// CHECK:STDOUT:     'inst+6':          template inst+1
+// CHECK:STDOUT:     'inst+7':          template inst+10
+// CHECK:STDOUT:     'inst+8':          template inst+10
+// CHECK:STDOUT:     'inst+9':          template inst+9
+// CHECK:STDOUT:     'inst+10':         template inst+10
+// CHECK:STDOUT:     'inst+11':         template inst+10
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst+2
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     block3:
-// CHECK:STDOUT:       0:               inst+5
-// CHECK:STDOUT:     block4:
+// CHECK:STDOUT:       0:               inst+6
+// CHECK:STDOUT:       1:               inst+11
+// CHECK:STDOUT:       2:               inst+12
+// CHECK:STDOUT:       3:               inst+13
+// CHECK:STDOUT:     block4:          {}
+// CHECK:STDOUT:     block5:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+1
+// CHECK:STDOUT:       2:               inst+2
+// CHECK:STDOUT:       3:               inst+7
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
@@ -39,12 +39,12 @@ fn B() {}
 // CHECK:STDOUT:     type1:           {constant: template inst+2, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:     type2:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:   type_blocks:
-// CHECK:STDOUT:     typeBlock0:      {}
+// CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
 // CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
 // CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
 // CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: empty, type: type1}
 // CHECK:STDOUT:     'inst+5':          {kind: Return}
 // CHECK:STDOUT:   constant_values:
@@ -81,12 +81,12 @@ fn B() {}
 // CHECK:STDOUT:     type1:           {constant: template inst+2, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:     type2:           {constant: template inst+3, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:   type_blocks:
-// CHECK:STDOUT:     typeBlock0:      {}
+// CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
 // CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: empty, type: type1}
 // CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
 // CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: empty, type: type1}
 // CHECK:STDOUT:     'inst+5':          {kind: Return}
 // CHECK:STDOUT:   constant_values:

--- a/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
@@ -23,7 +23,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:
-// CHECK:STDOUT:     bindName0:       {name: name1, parent_scope: name_scope<invalid>, index: compTimeBind<invalid>}
+// CHECK:STDOUT:     bind_name0:      {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block3, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}
@@ -36,20 +36,20 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     type3:           {constant: template inst+15, value_rep: {kind: none, type: type1}}
 // CHECK:STDOUT:     type4:           {constant: template inst+17, value_rep: {kind: copy, type: type4}}
 // CHECK:STDOUT:   type_blocks:
-// CHECK:STDOUT:     typeBlock0:      {}
-// CHECK:STDOUT:     typeBlock1:
+// CHECK:STDOUT:     type_block0:     {}
+// CHECK:STDOUT:     type_block1:
 // CHECK:STDOUT:       0:               type1
 // CHECK:STDOUT:       1:               type1
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
-// CHECK:STDOUT:     'inst+1':          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+1':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
 // CHECK:STDOUT:     'inst+2':          {kind: TupleLiteral, arg0: empty, type: type1}
 // CHECK:STDOUT:     'inst+3':          {kind: Converted, arg0: inst+2, arg1: inst+1, type: typeTypeType}
 // CHECK:STDOUT:     'inst+4':          {kind: Param, arg0: name1, type: type1}
-// CHECK:STDOUT:     'inst+5':          {kind: BindName, arg0: bindName0, arg1: inst+4, type: type1}
+// CHECK:STDOUT:     'inst+5':          {kind: BindName, arg0: bind_name0, arg1: inst+4, type: type1}
 // CHECK:STDOUT:     'inst+6':          {kind: TupleLiteral, arg0: empty, type: type1}
 // CHECK:STDOUT:     'inst+7':          {kind: TupleLiteral, arg0: empty, type: type1}
-// CHECK:STDOUT:     'inst+8':          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
+// CHECK:STDOUT:     'inst+8':          {kind: TupleType, arg0: type_block1, type: typeTypeType}
 // CHECK:STDOUT:     'inst+9':          {kind: TupleLiteral, arg0: block4, type: type2}
 // CHECK:STDOUT:     'inst+10':         {kind: Converted, arg0: inst+6, arg1: inst+1, type: typeTypeType}
 // CHECK:STDOUT:     'inst+11':         {kind: Converted, arg0: inst+7, arg1: inst+1, type: typeTypeType}

--- a/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
@@ -19,7 +19,9 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_and_textual_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
@@ -23,8 +23,8 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+16}}
 // CHECK:STDOUT:   bind_names:
-// CHECK:STDOUT:     bindName0:       {name: name1, parent_scope: name_scope<invalid>, index: compTimeBind0}
-// CHECK:STDOUT:     bindName1:       {name: name2, parent_scope: name_scope<invalid>, index: compTimeBind<invalid>}
+// CHECK:STDOUT:     bind_name0:      {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind0}
+// CHECK:STDOUT:     bind_name1:      {name: name2, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block4, return_storage: inst+15, return_slot: present, body: [block8]}
 // CHECK:STDOUT:   classes:         {}
@@ -40,28 +40,28 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     type5:           {constant: template inst+17, value_rep: {kind: none, type: type2}}
 // CHECK:STDOUT:     type6:           {constant: symbolic inst+19, value_rep: {kind: copy, type: type6}}
 // CHECK:STDOUT:   type_blocks:
-// CHECK:STDOUT:     typeBlock0:      {}
-// CHECK:STDOUT:     typeBlock1:
+// CHECK:STDOUT:     type_block0:     {}
+// CHECK:STDOUT:     type_block1:
 // CHECK:STDOUT:       0:               typeTypeType
 // CHECK:STDOUT:       1:               type2
-// CHECK:STDOUT:     typeBlock2:
+// CHECK:STDOUT:     type_block2:
 // CHECK:STDOUT:       0:               type1
 // CHECK:STDOUT:       1:               type2
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
 // CHECK:STDOUT:     'inst+1':          {kind: Param, arg0: name1, type: typeTypeType}
-// CHECK:STDOUT:     'inst+2':          {kind: BindSymbolicName, arg0: bindName0, arg1: inst+1, type: typeTypeType}
-// CHECK:STDOUT:     'inst+3':          {kind: BindSymbolicName, arg0: bindName0, arg1: inst<invalid>, type: typeTypeType}
+// CHECK:STDOUT:     'inst+2':          {kind: BindSymbolicName, arg0: bind_name0, arg1: inst+1, type: typeTypeType}
+// CHECK:STDOUT:     'inst+3':          {kind: BindSymbolicName, arg0: bind_name0, arg1: inst<invalid>, type: typeTypeType}
 // CHECK:STDOUT:     'inst+4':          {kind: NameRef, arg0: name1, arg1: inst+2, type: typeTypeType}
 // CHECK:STDOUT:     'inst+5':          {kind: Param, arg0: name2, type: type1}
-// CHECK:STDOUT:     'inst+6':          {kind: BindName, arg0: bindName1, arg1: inst+5, type: type1}
+// CHECK:STDOUT:     'inst+6':          {kind: BindName, arg0: bind_name1, arg1: inst+5, type: type1}
 // CHECK:STDOUT:     'inst+7':          {kind: NameRef, arg0: name1, arg1: inst+2, type: typeTypeType}
-// CHECK:STDOUT:     'inst+8':          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     'inst+8':          {kind: TupleType, arg0: type_block0, type: typeTypeType}
 // CHECK:STDOUT:     'inst+9':          {kind: TupleLiteral, arg0: empty, type: type2}
-// CHECK:STDOUT:     'inst+10':         {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
+// CHECK:STDOUT:     'inst+10':         {kind: TupleType, arg0: type_block1, type: typeTypeType}
 // CHECK:STDOUT:     'inst+11':         {kind: TupleLiteral, arg0: block5, type: type3}
 // CHECK:STDOUT:     'inst+12':         {kind: Converted, arg0: inst+9, arg1: inst+8, type: typeTypeType}
-// CHECK:STDOUT:     'inst+13':         {kind: TupleType, arg0: typeBlock2, type: typeTypeType}
+// CHECK:STDOUT:     'inst+13':         {kind: TupleType, arg0: type_block2, type: typeTypeType}
 // CHECK:STDOUT:     'inst+14':         {kind: Converted, arg0: inst+11, arg1: inst+13, type: typeTypeType}
 // CHECK:STDOUT:     'inst+15':         {kind: VarStorage, arg0: nameReturnSlot, type: type4}
 // CHECK:STDOUT:     'inst+16':         {kind: FunctionDecl, arg0: function0, arg1: block6, type: type5}

--- a/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
@@ -19,7 +19,9 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs:
+// CHECK:STDOUT:     ir0:             {node_id: <invalid>, is_export: false}
+// CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+16}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -135,7 +135,8 @@ auto File::OutputYaml(bool include_builtins) const -> Yaml::OutputMapping {
     map.Add("filename", filename_);
     map.Add(
         "sem_ir", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-          map.Add("import_irs_size", Yaml::OutputScalar(import_irs_.size()));
+          map.Add("import_irs", import_irs_.OutputYaml());
+          map.Add("import_ir_insts", import_ir_insts_.OutputYaml());
           map.Add("name_scopes", name_scopes_.OutputYaml());
           map.Add("bind_names", bind_names_.OutputYaml());
           map.Add("functions", functions_.OutputYaml());

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -183,7 +183,7 @@ struct BindNameId : public IdBase, public Printable<BindNameId> {
 
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "bindName";
+    out << "bind_name";
     IdBase::Print(out);
   }
 };
@@ -201,7 +201,7 @@ struct CompileTimeBindIndex : public IndexBase,
   using IndexBase::IndexBase;
 
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "compTimeBind";
+    out << "comp_time_bind";
     IndexBase::Print(out);
   }
 };
@@ -584,7 +584,7 @@ struct TypeBlockId : public IdBase, public Printable<TypeBlockId> {
 
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "typeBlock";
+    out << "type_block";
     IdBase::Print(out);
   }
 };
@@ -601,13 +601,18 @@ struct ElementIndex : public IndexBase, public Printable<ElementIndex> {
 };
 
 // The ID of an ImportIRInst.
-struct ImportIRInstId : public IdBase, public Printable<InstId> {
+struct ImportIRInstId : public IdBase, public Printable<ImportIRInstId> {
   using ValueType = ImportIRInst;
 
   // An explicitly invalid ID.
   static const ImportIRInstId Invalid;
 
   using IdBase::IdBase;
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "import_ir_inst";
+    IdBase::Print(out);
+  }
 };
 
 constexpr ImportIRInstId ImportIRInstId::Invalid = ImportIRInstId(InvalidIndex);

--- a/toolchain/sem_ir/import_ir.h
+++ b/toolchain/sem_ir/import_ir.h
@@ -13,7 +13,10 @@ namespace Carbon::SemIR {
 
 // A reference to an imported IR.
 struct ImportIR : public Printable<ImportIR> {
-  auto Print(llvm::raw_ostream& out) const -> void { out << node_id; }
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "{node_id: " << node_id
+        << ", is_export: " << (is_export ? "true" : "false") << "}";
+  }
 
   // The node ID for the import.
   Parse::ImportDeclId node_id;
@@ -27,7 +30,7 @@ struct ImportIR : public Printable<ImportIR> {
 // LocId.
 struct ImportIRInst : public Printable<ImportIRInst> {
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << ir_id << ":" << inst_id;
+    out << "{ir_id: " << ir_id << ", inst_id: " << inst_id << "}";
   }
 
   auto operator==(const ImportIRInst& rhs) const -> bool {

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -57,7 +57,8 @@ TEST(SemIRTest, YAML) {
                                          Pair("value_rep", Yaml::Mapping(_)))));
 
   auto file = Yaml::Mapping(ElementsAre(
-      Pair("import_irs_size", "1"),
+      Pair("import_irs", Yaml::Mapping(SizeIs(1))),
+      Pair("import_ir_insts", Yaml::Mapping(SizeIs(0))),
       Pair("name_scopes", Yaml::Mapping(SizeIs(1))),
       Pair("bind_names", Yaml::Mapping(SizeIs(1))),
       Pair("functions", Yaml::Mapping(SizeIs(1))),

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -46,7 +46,7 @@ TEST(SemIRTest, YAML) {
 
   // Matches the ID of an instruction. Instruction counts may change as various
   // support changes, so this code is only doing loose structural checks.
-  auto type_block_id = Yaml::Scalar(MatchesRegex(R"(typeBlock\d+)"));
+  auto type_block_id = Yaml::Scalar(MatchesRegex(R"(type_block\d+)"));
   auto inst_id = Yaml::Scalar(MatchesRegex(R"(inst\+\d+)"));
   auto constant_id =
       Yaml::Scalar(MatchesRegex(R"((template|symbolic) inst(\w+|\+\d+))"));


### PR DESCRIPTION
So, I noticed that ImportIRInst didn't print properly while trying to debug an issue, and that's where this started. Then I was sort of trying to figure out why we have "type_blocks" but "typeBlock", so trying to make that more consistent. "importIRInst0" felt more odd than "import_ir_inst0" which is why I'm suggesting down this particular route, but let me know if you'd prefer the reverse (but then do we also do "typeBlocks", etc, removing the consistency with the member name?)

Also starting to print more detail on import_irs, and added import_ir_insts (adjusting formatting for that too).