### PR TITLE
Hack in a unique IDs counter to source stats.

### DIFF
--- a/scripts/source_stats.py
+++ b/scripts/source_stats.py
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
 from alive_progress import alive_bar  # type:ignore
+import math
 from multiprocessing import Pool
 import re
 import termplotlib as tpl  # type:ignore
@@ -70,6 +71,9 @@ class Stats:
     identifiers: int = 0
     identifier_widths: Counter[int] = field(default_factory=lambda: Counter())
     ids_per_line: Counter[int] = field(default_factory=lambda: Counter())
+    unique_ids_per_ten_lines: Counter[int] = field(
+        default_factory=lambda: Counter()
+    )
 
     def accumulate(self, other: Stats) -> None:
         self.lines += other.lines
@@ -93,11 +97,13 @@ class Stats:
         self.identifiers += other.identifiers
         self.identifier_widths.update(other.identifier_widths)
         self.ids_per_line.update(other.ids_per_line)
+        self.unique_ids_per_ten_lines.update(other.unique_ids_per_ten_lines)
 
 
 def scan_file(file: Path) -> Stats:
     """Scans the provided file and accumulates stats."""
     stats = Stats()
+    unique_ids = set()
     for line in file.open():
         # Strip off the line endings.
         line = line.rstrip("\r\n")
@@ -152,6 +158,7 @@ def scan_file(file: Path) -> Stats:
                 )
                 line_identifiers += 1
                 stats.identifier_widths[len(m.group("id"))] += 1
+                unique_ids.add(m.group("id"))
         stats.string_literals += line_string_literals
         stats.string_literals_per_line[line_string_literals] += 1
         stats.int_literals += line_int_literals
@@ -164,6 +171,10 @@ def scan_file(file: Path) -> Stats:
         stats.keywords_per_line[line_keywords] += 1
         stats.identifiers += line_identifiers
         stats.ids_per_line[line_identifiers] += 1
+    if stats.lines > 0:
+        stats.unique_ids_per_ten_lines[
+            math.ceil((len(unique_ids) * 10) / stats.lines)
+        ] += 1
     return stats
 
 
@@ -281,6 +292,11 @@ Fraction IDs: {stats.identifiers / tokens}
 
     print_histogram("## ID widths ##", stats.identifier_widths, "%d characters")
     print_histogram("## IDs per line ##", stats.ids_per_line, "%d ids")
+    print_histogram(
+        "## Unique IDs per 10 lines ##",
+        stats.unique_ids_per_ten_lines,
+        "%d ids",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is awkward to track... Probably it would be best done by tracking the ratio of unique IDs to lines as a floating point and plot them and see what a best fit distribution curve looks like. But none of the histogram printing or stats tracking stuff already in use here makes it easy to do any of that...

So this does what I hope is a reasonable rough approximation by counting the ceiling of unique identifiers per 10 lines of code, and plotting that discreet histogram. Shape of the histogram is exactly what I would expect: one centered distribution, vaguely normal looking. And the center for a bunch of different codebases, including our toolchain, is exactly at 5, which would mean 0.5 unique IDs per line. And the distribution is pretty reliably bounded above by 10 or 1 unique ID per line. Which almost seems to clean to be true? Slightly worried about confirmation bias making me think this code is working because the results look so pretty.

Here is the output for the toolchain:
```
  ## Unique IDs per 10 lines ## (median: 6)
  2 ids   [ 2]  █▎
  3 ids   [19]  ████████████▎
  4 ids   [32]  ████████████████████▋
  5 ids   [55]  ███████████████████████████████████▌
  6 ids   [62]  ████████████████████████████████████████
  7 ids   [44]  ████████████████████████████▍
  8 ids   [22]  ██████████████▎
  9 ids   [11]  ███████▏
  10 ids  [ 7]  ████▌
  11 ids  [ 2]  █▎
```

And here is the output for llvm-project/*/{lib,include} (to avoid tests):
```
  # Unique IDs per 10 lines ## (median: 5)
  1 ids   [  29]  ▍
  2 ids   [ 282]  ███▊
  3 ids   [1492]  ███████████████████▉
  4 ids   [2674]  ███████████████████████████████████▌
  5 ids   [3011]  ████████████████████████████████████████
  6 ids   [2267]  ██████████████████████████████▏
  7 ids   [1549]  ████████████████████▋
  8 ids   [ 817]  ██████████▉
  9 ids   [ 301]  ████
  10 ids  [  98]  █▎
  11 ids  [  61]  ▊
  12 ids  [  50]  ▋
  13 ids  [  25]  ▍
  14 ids  [  33]  ▌
  15 ids  [  14]  ▏
  16 ids  [  15]  ▎
  17 ids  [   9]  ▏
  18 ids  [   8]  ▏
  19 ids  [  12]  ▏
  20 ids  [  15]  ▎
  21 ids  [   3]
  22 ids  [   8]  ▏
  23 ids  [   3]
  24 ids  [   3]
  25 ids  [   6]  ▏
  26 ids  [   0]
  27 ids  [   2]
  28 ids  [   0]
  29 ids  [   0]
  30 ids  [   3]
  31 ids  [   1]
  32 ids  [   1]
```