### PR TITLE
Port the toolchain to use the new Carbon hashtable

### DIFF
--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -40,6 +40,7 @@ cc_library(
         "//common:check",
         "//common:hashing",
         "//common:ostream",
+        "//common:set",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -9,7 +9,6 @@
 #include <concepts>
 
 #include "common/ostream.h"
-#include "llvm/ADT/DenseMapInfo.h"
 
 namespace Carbon {
 
@@ -74,31 +73,6 @@ template <typename IndexType>
 auto operator<=>(IndexType lhs, IndexType rhs) -> std::strong_ordering {
   return lhs.index <=> rhs.index;
 }
-
-// Provides base support for use of IdBase types as DenseMap/DenseSet keys.
-//
-// Usage (in global namespace):
-//   template <>
-//   struct llvm::DenseMapInfo<Carbon::MyType>
-//       : public Carbon::IndexMapInfo<Carbon::MyType> {};
-template <typename Index>
-struct IndexMapInfo {
-  static inline auto getEmptyKey() -> Index {
-    return Index(llvm::DenseMapInfo<int32_t>::getEmptyKey());
-  }
-
-  static inline auto getTombstoneKey() -> Index {
-    return Index(llvm::DenseMapInfo<int32_t>::getTombstoneKey());
-  }
-
-  static auto getHashValue(const Index& val) -> unsigned {
-    return llvm::DenseMapInfo<int32_t>::getHashValue(val.index);
-  }
-
-  static auto isEqual(const Index& lhs, const Index& rhs) -> bool {
-    return lhs == rhs;
-  }
-};
 
 }  // namespace Carbon
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -205,7 +205,7 @@ class CanonicalValueStore {
   using ValueType = typename IdT::ValueType;
 
   // Stores a canonical copy of the value and returns an ID to reference it.
-  auto Add(const ValueType& value) -> IdT;
+  auto Add(ValueType value) -> IdT;
 
   // Returns the value for an ID.
   auto Get(IdT id) const -> const ValueType& { return values_.Get(id); }
@@ -254,8 +254,8 @@ class CanonicalValueStore<IdT>::KeyContext
 };
 
 template <typename IdT>
-auto CanonicalValueStore<IdT>::Add(const ValueType& value) -> IdT {
-  auto make_key = [&] { return IdT(values_.Add(value)); };
+auto CanonicalValueStore<IdT>::Add(ValueType value) -> IdT {
+  auto make_key = [&] { return IdT(values_.Add(std::move(value))); };
   return set_.Insert(value, make_key, KeyContext(values_.array_ref())).key();
 }
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -8,11 +8,10 @@
 #include <type_traits>
 
 #include "common/check.h"
-#include "common/hashing.h"
 #include "common/ostream.h"
+#include "common/set.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -76,26 +75,6 @@ struct FloatId : public IdBase, public Printable<FloatId> {
   }
 };
 constexpr FloatId FloatId::Invalid(FloatId::InvalidIndex);
-
-// DenseMapInfo for llvm::APFloat, for use in the canonical float value store.
-// LLVM has an implementation of this but it strangely lives in the non-public
-// header lib/IR/LLVMContextImpl.h, so we use our own.
-// TODO: Remove this once our new hash table is available.
-struct APFloatDenseMapInfo {
-  static auto getEmptyKey() -> llvm::APFloat {
-    return llvm::APFloat(llvm::APFloat::Bogus(), 1);
-  }
-  static auto getTombstoneKey() -> llvm::APFloat {
-    return llvm::APFloat(llvm::APFloat::Bogus(), 2);
-  }
-  static auto getHashValue(const llvm::APFloat& val) -> unsigned {
-    return hash_value(val);
-  }
-  static auto isEqual(const llvm::APFloat& lhs, const llvm::APFloat& rhs)
-      -> bool {
-    return lhs.bitwiseIsEqual(rhs);
-  }
-};
 
 // Corresponds to a Real value.
 struct RealId : public IdBase, public Printable<RealId> {
@@ -220,20 +199,13 @@ class ValueStore
 // to later retrieve the value.
 //
 // IdT::ValueType must represent the type being indexed.
-template <typename IdT,
-          typename DenseMapInfoT = llvm::DenseMapInfo<typename IdT::ValueType>>
+template <typename IdT>
 class CanonicalValueStore {
  public:
   using ValueType = typename IdT::ValueType;
 
   // Stores a canonical copy of the value and returns an ID to reference it.
-  auto Add(ValueType value) -> IdT {
-    auto [it, added] = map_.insert({value, IdT::Invalid});
-    if (added) {
-      it->second = values_.Add(value);
-    }
-    return it->second;
-  }
+  auto Add(const ValueType& value) -> IdT;
 
   // Returns the value for an ID.
   auto Get(IdT id) const -> const ValueType& { return values_.Get(id); }
@@ -241,7 +213,7 @@ class CanonicalValueStore {
   // Reserves space.
   auto Reserve(size_t size) -> void {
     values_.Reserve(size);
-    map_.reserve(size);
+    // map_.reserve(size);
   }
 
   // These are to support printable structures, and are not guaranteed.
@@ -255,17 +227,36 @@ class CanonicalValueStore {
   auto size() const -> size_t { return values_.size(); }
 
  private:
-  // We store two copies of each value: one in the ValueStore for fast mapping
-  // from IdT to value, and another in the DenseMap for the reverse mapping.
-  //
-  // We could avoid this by storing the map instead as a DenseSet<IdT>, but
-  // there's no way to provide a DenseMapInfo that looks the IDs up in the
-  // vector.
-  //
-  // TODO: Switch to a better representation that avoids the duplication.
+  class IdSetContext;
+
   ValueStore<IdT> values_;
-  llvm::DenseMap<ValueType, IdT, DenseMapInfoT> map_;
+  Set<IdT, /*SmallSize=*/0, IdSetContext> set_;
 };
+
+template <typename IdT>
+class CanonicalValueStore<IdT>::IdSetContext
+    : public TranslatingKeyContext<IdSetContext> {
+ public:
+  explicit IdSetContext(llvm::ArrayRef<ValueType> values) : values_(values) {}
+
+  // Note that it is safe to return a `const` reference here as the underlying
+  // object's lifetime is provided by the `store_`.
+  auto TranslateKey(IdT id) const -> const ValueType& {
+    return values_[id.index];
+  }
+
+ private:
+  llvm::ArrayRef<ValueType> values_;
+};
+
+template <typename IdT>
+auto CanonicalValueStore<IdT>::Add(const ValueType& value) -> IdT {
+  return set_
+      .Insert(
+          value, [&] { return IdT(values_.Add(value)); },
+          IdSetContext(values_.array_ref()))
+      .key();
+}
 
 // Storage for StringRefs. The caller is responsible for ensuring storage is
 // allocated.
@@ -275,14 +266,7 @@ class CanonicalValueStore<StringId>
  public:
   // Returns an ID to reference the value. May return an existing ID if the
   // string was previously added.
-  auto Add(llvm::StringRef value) -> StringId {
-    auto [it, inserted] = map_.insert({value, StringId(values_.size())});
-    if (inserted) {
-      CARBON_CHECK(it->second.index >= 0) << "Too many unique strings";
-      values_.push_back(value);
-    }
-    return it->second;
-  }
+  auto Add(llvm::StringRef value) -> StringId;
 
   // Returns the value for an ID.
   auto Get(StringId id) const -> llvm::StringRef {
@@ -291,12 +275,7 @@ class CanonicalValueStore<StringId>
   }
 
   // Returns an ID for the value, or Invalid if not found.
-  auto Lookup(llvm::StringRef value) const -> StringId {
-    if (auto it = map_.find(value); it != map_.end()) {
-      return it->second;
-    }
-    return StringId::Invalid;
-  }
+  auto Lookup(llvm::StringRef value) const -> StringId;
 
   auto OutputYaml() const -> Yaml::OutputMapping {
     return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
@@ -309,11 +288,50 @@ class CanonicalValueStore<StringId>
   auto size() const -> size_t { return values_.size(); }
 
  private:
-  llvm::DenseMap<llvm::StringRef, StringId> map_;
-  // Set inline size to 0 because these will typically be too large for the
+  class IdSetContext;
+
+  // Set inline sizes to 0 because these will typically be too large for the
   // stack, while this does make File smaller.
+  Set<StringId, /*SmallSize=*/0, IdSetContext> set_;
   llvm::SmallVector<llvm::StringRef, 0> values_;
 };
+
+class CanonicalValueStore<StringId>::IdSetContext
+    : public TranslatingKeyContext<IdSetContext> {
+ public:
+  explicit IdSetContext(llvm::ArrayRef<llvm::StringRef> values)
+      : values_(values) {}
+
+  auto TranslateKey(StringId id) const -> llvm::StringRef {
+    return values_[id.index];
+  }
+
+ private:
+  llvm::ArrayRef<llvm::StringRef> values_;
+};
+
+inline auto CanonicalValueStore<StringId>::Add(llvm::StringRef value)
+    -> StringId {
+  return set_
+      .Insert(
+          value,
+          [&] {
+            auto id = static_cast<StringId>(values_.size());
+            CARBON_CHECK(id.index >= 0) << "Too many unique strings";
+            values_.push_back(value);
+            return id;
+          },
+          IdSetContext(values_))
+      .key();
+}
+
+inline auto CanonicalValueStore<StringId>::Lookup(llvm::StringRef value) const
+    -> StringId {
+  if (auto result = set_.Lookup(value, IdSetContext(values_))) {
+    return result.key();
+  }
+  return StringId::Invalid;
+}
 
 // A thin wrapper around a `ValueStore<StringId>` that provides a different IdT,
 // while using a unified storage for values. This avoids potentially
@@ -344,7 +362,7 @@ class StringStoreWrapper : public Printable<StringStoreWrapper<IdT>> {
   CanonicalValueStore<StringId>* values_;
 };
 
-using FloatValueStore = CanonicalValueStore<FloatId, APFloatDenseMapInfo>;
+using FloatValueStore = CanonicalValueStore<FloatId>;
 
 // Stores that will be used across compiler phases for a given compilation unit.
 // This is provided mainly so that they don't need to be passed separately.
@@ -403,15 +421,5 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
 };
 
 }  // namespace Carbon
-
-// Support use of IdentifierId as DenseMap/DenseSet keys.
-// TODO: Remove once NameId is used in checking.
-template <>
-struct llvm::DenseMapInfo<Carbon::IdentifierId>
-    : public Carbon::IndexMapInfo<Carbon::IdentifierId> {};
-// Support use of StringId as DenseMap/DenseSet keys.
-template <>
-struct llvm::DenseMapInfo<Carbon::StringId>
-    : public Carbon::IndexMapInfo<Carbon::StringId> {};
 
 #endif  // CARBON_TOOLCHAIN_BASE_VALUE_STORE_H_

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -52,6 +52,7 @@ cc_library(
     deps = [
         ":node_stack",
         "//common:check",
+        "//common:map",
         "//common:vlog",
         "//toolchain/base:index_base",
         "//toolchain/base:kind_switch",
@@ -95,6 +96,7 @@ cc_library(
         ":sem_ir_diagnostic_converter",
         "//common:check",
         "//common:error",
+        "//common:map",
         "//common:ostream",
         "//common:variant_helpers",
         "//common:vlog",
@@ -183,6 +185,7 @@ cc_library(
     deps = [
         ":context",
         "//common:check",
+        "//common:map",
         "//toolchain/base:kind_switch",
         "//toolchain/parse:node_kind",
         "//toolchain/sem_ir:file",
@@ -281,6 +284,7 @@ cc_library(
     deps = [
         "//common:check",
         "//common:ostream",
+        "//common:set",
         "//common:vlog",
         "//toolchain/base:index_base",
         "//toolchain/sem_ir:file",

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -1039,14 +1039,14 @@ static auto TrackImport(Map<ImportKey, UnitInfo*>& api_map,
   }
 
   // Get the package imports, or create them if this is the first.
-  // auto [package_imports_map_it, is_inserted] =
+  auto create_imports = [&]() -> int32_t {
+    int32_t index = unit_info.package_imports.size();
+    unit_info.package_imports.push_back(
+        UnitInfo::PackageImports(import.package_id, import.node_id));
+    return index;
+  };
   auto insert_result =
-      unit_info.package_imports_map.Insert(import.package_id, [&]() -> int32_t {
-        int32_t index = unit_info.package_imports.size();
-        unit_info.package_imports.push_back(
-            UnitInfo::PackageImports(import.package_id, import.node_id));
-        return index;
-      });
+      unit_info.package_imports_map.Insert(import.package_id, create_imports);
   UnitInfo::PackageImports& package_imports =
       unit_info.package_imports[insert_result.value()];
 

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -8,6 +8,7 @@
 
 #include "common/check.h"
 #include "common/error.h"
+#include "common/map.h"
 #include "common/variant_helpers.h"
 #include "common/vlog.h"
 #include "toolchain/base/kind_switch.h"
@@ -81,7 +82,7 @@ struct UnitInfo {
   llvm::SmallVector<PackageImports> package_imports;
 
   // A map of the package names to the outgoing imports above.
-  llvm::DenseMap<IdentifierId, int32_t> package_imports_map;
+  Map<IdentifierId, int32_t> package_imports_map;
 
   // The remaining number of imports which must be checked before this unit can
   // be processed.
@@ -184,15 +185,15 @@ static auto ImportCurrentPackage(Context& context, UnitInfo& unit_info,
                                  SemIR::InstId package_inst_id,
                                  SemIR::TypeId namespace_type_id) -> void {
   // Add imports from the current package.
-  auto self_import_map_it =
-      unit_info.package_imports_map.find(IdentifierId::Invalid);
-  if (self_import_map_it == unit_info.package_imports_map.end()) {
+  auto import_map_lookup =
+      unit_info.package_imports_map.Lookup(IdentifierId::Invalid);
+  if (!import_map_lookup) {
     // Push the scope; there are no names to add.
     context.scope_stack().Push(package_inst_id, SemIR::NameScopeId::Package);
     return;
   }
   UnitInfo::PackageImports& self_import =
-      unit_info.package_imports[self_import_map_it->second];
+      unit_info.package_imports[import_map_lookup.value()];
 
   if (self_import.has_load_error) {
     context.name_scopes().Get(SemIR::NameScopeId::Package).has_error = true;
@@ -239,11 +240,10 @@ static auto ImportOtherPackages(Context& context, UnitInfo& unit_info,
       // Translate the package ID from the API file to the implementation file.
       auto impl_package_id =
           impl_identifiers.Add(api_identifiers.Get(api_imports.package_id));
-      if (auto it = unit_info.package_imports_map.find(impl_package_id);
-          it != unit_info.package_imports_map.end()) {
+      if (auto lookup = unit_info.package_imports_map.Lookup(impl_package_id)) {
         // On a hit, replace the entry to unify the API and implementation
         // imports.
-        api_imports_list[it->second] = {impl_package_id, api_imports_index};
+        api_imports_list[lookup.value()] = {impl_package_id, api_imports_index};
       } else {
         // On a miss, add the package as API-only.
         api_imports_list.push_back({impl_package_id, api_imports_index});
@@ -938,10 +938,10 @@ static auto RenderImportKey(ImportKey import_key) -> std::string {
 //
 // The ID comparisons between the import and unit are okay because they both
 // come from the same file.
-static auto TrackImport(
-    llvm::DenseMap<ImportKey, UnitInfo*>& api_map,
-    llvm::DenseMap<ImportKey, Parse::NodeId>* explicit_import_map,
-    UnitInfo& unit_info, Parse::Tree::PackagingNames import) -> void {
+static auto TrackImport(Map<ImportKey, UnitInfo*>& api_map,
+                        Map<ImportKey, Parse::NodeId>* explicit_import_map,
+                        UnitInfo& unit_info, Parse::Tree::PackagingNames import)
+    -> void {
   const auto& packaging = unit_info.unit->parse_tree->packaging_decl();
 
   IdentifierId file_package_id =
@@ -957,14 +957,14 @@ static auto TrackImport(
   // that might be valid with syntax fixes.
   if (explicit_import_map) {
     // Diagnose redundant imports.
-    if (auto [insert_it, success] =
-            explicit_import_map->insert({import_key, import.node_id});
-        !success) {
+    if (auto insert_result =
+            explicit_import_map->Insert(import_key, import.node_id);
+        !insert_result.is_inserted()) {
       CARBON_DIAGNOSTIC(RepeatedImport, Error,
                         "Library imported more than once.");
       CARBON_DIAGNOSTIC(FirstImported, Note, "First import here.");
       unit_info.emitter.Build(import.node_id, RepeatedImport)
-          .Note(insert_it->second, FirstImported)
+          .Note(insert_result.value(), FirstImported)
           .Emit();
       return;
     }
@@ -1039,26 +1039,28 @@ static auto TrackImport(
   }
 
   // Get the package imports, or create them if this is the first.
-  auto [package_imports_map_it, is_inserted] =
-      unit_info.package_imports_map.insert(
-          {import.package_id, unit_info.package_imports.size()});
-  if (is_inserted) {
-    unit_info.package_imports.push_back(
-        UnitInfo::PackageImports(import.package_id, import.node_id));
-  }
+  // auto [package_imports_map_it, is_inserted] =
+  auto insert_result =
+      unit_info.package_imports_map.Insert(import.package_id, [&]() -> int32_t {
+        int32_t index = unit_info.package_imports.size();
+        unit_info.package_imports.push_back(
+            UnitInfo::PackageImports(import.package_id, import.node_id));
+        return index;
+      });
   UnitInfo::PackageImports& package_imports =
-      unit_info.package_imports[package_imports_map_it->second];
+      unit_info.package_imports[insert_result.value()];
 
-  if (auto api = api_map.find(import_key); api != api_map.end()) {
+  if (auto api_lookup = api_map.Lookup(import_key)) {
     // Add references between the file and imported api.
-    package_imports.imports.push_back({import, api->second});
+    UnitInfo* api = api_lookup.value();
+    package_imports.imports.push_back({import, api});
     ++unit_info.imports_remaining;
-    api->second->incoming_imports.push_back(&unit_info);
+    api->incoming_imports.push_back(&unit_info);
 
     // If this is the implicit import, note we have it.
     if (!explicit_import_map) {
       CARBON_CHECK(!unit_info.api_for_impl);
-      unit_info.api_for_impl = api->second;
+      unit_info.api_for_impl = api;
     }
   } else {
     // The imported api is missing.
@@ -1078,9 +1080,8 @@ static auto TrackImport(
 // related to the packaging because the strings are loaded as part of getting
 // the ImportKey (which we then do for `impl` files too).
 static auto BuildApiMapAndDiagnosePackaging(
-    llvm::MutableArrayRef<UnitInfo> unit_infos)
-    -> llvm::DenseMap<ImportKey, UnitInfo*> {
-  llvm::DenseMap<ImportKey, UnitInfo*> api_map;
+    llvm::MutableArrayRef<UnitInfo> unit_infos) -> Map<ImportKey, UnitInfo*> {
+  Map<ImportKey, UnitInfo*> api_map;
   for (auto& unit_info : unit_infos) {
     const auto& packaging = unit_info.unit->parse_tree->packaging_decl();
     // An import key formed from the `package` or `library` declaration. Or, for
@@ -1111,10 +1112,10 @@ static auto BuildApiMapAndDiagnosePackaging(
     // where the user forgets (or has syntax errors with) a package line
     // multiple times.
     if (!is_impl) {
-      auto [entry, success] = api_map.insert({import_key, &unit_info});
-      if (!success) {
+      auto insert_result = api_map.Insert(import_key, &unit_info);
+      if (!insert_result.is_inserted()) {
         llvm::StringRef prev_filename =
-            entry->second->unit->tokens->source().filename();
+            insert_result.value()->unit->tokens->source().filename();
         if (packaging) {
           CARBON_DIAGNOSTIC(DuplicateLibraryApi, Error,
                             "Library's API previously provided by `{0}`.",
@@ -1178,7 +1179,7 @@ auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
     node_converters.push_back(&unit_infos.back().converter);
   }
 
-  llvm::DenseMap<ImportKey, UnitInfo*> api_map =
+  Map<ImportKey, UnitInfo*> api_map =
       BuildApiMapAndDiagnosePackaging(unit_infos);
 
   // Mark down imports for all files.
@@ -1193,7 +1194,7 @@ auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
       TrackImport(api_map, nullptr, unit_info, implicit_names);
     }
 
-    llvm::DenseMap<ImportKey, Parse::NodeId> explicit_import_map;
+    Map<ImportKey, Parse::NodeId> explicit_import_map;
 
     // Add the prelude import. It's added to explicit_import_map so that it can
     // conflict with an explicit import of the prelude.

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -5,7 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_CHECK_CONTEXT_H_
 #define CARBON_TOOLCHAIN_CHECK_CONTEXT_H_
 
-#include "llvm/ADT/DenseMap.h"
+#include "common/map.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/decl_introducer_state.h"
@@ -496,7 +496,7 @@ class Context {
   // not clear whether that would result in more or fewer lookups.
   //
   // TODO: Should this be part of the `TypeStore`?
-  llvm::DenseMap<SemIR::ConstantId, SemIR::TypeId> type_ids_for_type_constants_;
+  Map<SemIR::ConstantId, SemIR::TypeId> type_ids_for_type_constants_;
 
   // The list which will form NodeBlockId::Exports.
   llvm::SmallVector<SemIR::InstId> exports_;

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -451,8 +451,9 @@ static auto ConvertStructToStructOrClass(Context& context,
     // Find the matching source field.
     auto src_field_index = i;
     if (src_type.fields_id != dest_type.fields_id) {
-      auto src_field_lookup = src_field_indexes.Lookup(dest_field.name_id);
-      if (!src_field_lookup) {
+      if (auto lookup = src_field_indexes.Lookup(dest_field.name_id)) {
+        src_field_index = lookup.value();
+      } else {
         if (literal_elems_id.is_valid()) {
           CARBON_DIAGNOSTIC(
               StructInitMissingFieldInLiteral, Error,
@@ -471,7 +472,6 @@ static auto ConvertStructToStructOrClass(Context& context,
         }
         return SemIR::InstId::BuiltinError;
       }
-      src_field_index = src_field_lookup.value();
     }
     auto src_field = sem_ir.insts().GetAs<SemIR::StructTypeField>(
         src_elem_fields[src_field_index]);

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -147,19 +147,17 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id,
           context_->AddExport(target_id);
         }
 
-        bool success =
-            name_scope.name_map
-                .Insert(name_context.unresolved_name_id,
-                        [&] {
-                          int index = name_scope.names.size();
-                          name_scope.names.push_back(
-                              {.name_id = name_context.unresolved_name_id,
-                               .inst_id = target_id,
-                               .access_kind = access_kind});
-                          return index;
-                        })
-                .is_inserted();
-        CARBON_CHECK(success)
+        auto add_scope = [&] {
+          int index = name_scope.names.size();
+          name_scope.names.push_back(
+              {.name_id = name_context.unresolved_name_id,
+               .inst_id = target_id,
+               .access_kind = access_kind});
+          return index;
+        };
+        auto result = name_scope.name_map.Insert(
+            name_context.unresolved_name_id, add_scope);
+        CARBON_CHECK(result.is_inserted())
             << "Duplicate names should have been resolved previously: "
             << name_context.unresolved_name_id << " in "
             << name_context.parent_scope_id;

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -147,12 +147,18 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id,
           context_->AddExport(target_id);
         }
 
-        int scope_index = name_scope.names.size();
-        name_scope.names.push_back({.name_id = name_context.unresolved_name_id,
-                                    .inst_id = target_id,
-                                    .access_kind = access_kind});
-        auto [_, success] = name_scope.name_map.insert(
-            {name_context.unresolved_name_id, scope_index});
+        bool success =
+            name_scope.name_map
+                .Insert(name_context.unresolved_name_id,
+                        [&] {
+                          int index = name_scope.names.size();
+                          name_scope.names.push_back(
+                              {.name_id = name_context.unresolved_name_id,
+                               .inst_id = target_id,
+                               .access_kind = access_kind});
+                          return index;
+                        })
+                .is_inserted();
         CARBON_CHECK(success)
             << "Duplicate names should have been resolved previously: "
             << name_context.unresolved_name_id << " in "

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -78,8 +78,8 @@ auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
   // diagnostic and so that cross-package imports can find it easily.
   auto bind_name = context.bind_names().Get(import_ref->bind_name_id);
   auto& parent_scope = context.name_scopes().Get(bind_name.parent_scope_id);
-  auto it = parent_scope.name_map.find(bind_name.name_id);
-  auto& scope_inst_id = parent_scope.names[it->second].inst_id;
+  auto lookup = parent_scope.name_map.Lookup(bind_name.name_id);
+  auto& scope_inst_id = parent_scope.names[lookup.value()].inst_id;
   CARBON_CHECK(scope_inst_id == inst_id);
   scope_inst_id = export_id;
 

--- a/toolchain/check/merge.cpp
+++ b/toolchain/check/merge.cpp
@@ -124,9 +124,8 @@ auto ReplacePrevInstForMerge(Context& context, SemIR::NameScopeId scope_id,
                              SemIR::NameId name_id, SemIR::InstId new_inst_id)
     -> void {
   auto& scope = context.name_scopes().Get(scope_id);
-  auto it = scope.name_map.find(name_id);
-  if (it != scope.name_map.end()) {
-    scope.names[it->second].inst_id = new_inst_id;
+  if (auto lookup = scope.name_map.Lookup(name_id)) {
+    scope.names[lookup.value()].inst_id = new_inst_id;
   }
 }
 

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -39,12 +39,12 @@ auto ScopeStack::Push(SemIR::InstId scope_inst_id, SemIR::NameScopeId scope_id,
 auto ScopeStack::Pop() -> void {
   auto scope = scope_stack_.pop_back_val();
 
-  for (const auto& str_id : scope.names) {
+  scope.names.ForEach([&](SemIR::NameId str_id) {
     auto& lexical_results = lexical_lookup_.Get(str_id);
     CARBON_CHECK(lexical_results.back().scope_index == scope.index)
         << "Inconsistent scope index for name " << str_id;
     lexical_results.pop_back();
-  }
+  });
 
   if (scope.scope_id.is_valid()) {
     CARBON_CHECK(non_lexical_scope_stack_.back().scope_index == scope.index);
@@ -120,12 +120,13 @@ auto ScopeStack::LookupInLexicalScopes(SemIR::NameId name_id)
 
 auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id)
     -> SemIR::InstId {
-  if (!scope_stack_.back().names.insert(name_id).second) {
+  if (!scope_stack_.back().names.Insert(name_id).is_inserted()) {
     auto existing = lexical_lookup_.Get(name_id).back().inst_id;
     CARBON_CHECK(existing.is_valid())
         << "Name in scope but not in lexical lookups";
     return existing;
   }
+  scope_stack_.back().has_names = true;
 
   // TODO: Reject if we previously performed a failed lookup for this name
   // in this scope or a scope nested within it.
@@ -162,20 +163,21 @@ auto ScopeStack::Suspend() -> SuspendedScope {
     non_lexical_scope_stack_.pop_back();
   }
 
-  auto remaining_compile_time_bindings =
-      scope_stack_.empty()
-          ? 0
-          : scope_stack_.back().next_compile_time_bind_index.index;
-
-  result.suspended_items.reserve(result.entry.names.size() +
-                                 compile_time_binding_stack_.size() -
-                                 remaining_compile_time_bindings);
-  for (auto name_id : result.entry.names) {
+  result.entry.names.ForEach([&](SemIR::NameId name_id) {
     auto [index, inst_id] = lexical_lookup_.Suspend(name_id);
     CARBON_CHECK(index !=
                  SuspendedScope::ScopeItem::IndexForCompileTimeBinding);
     result.suspended_items.push_back({.index = index, .inst_id = inst_id});
-  }
+  });
+
+  // Now we can reserve the remaining space needed.
+  auto remaining_compile_time_bindings =
+      scope_stack_.empty()
+          ? 0
+          : scope_stack_.back().next_compile_time_bind_index.index;
+  result.suspended_items.reserve(result.suspended_items.size() +
+                                 compile_time_binding_stack_.size() -
+                                 remaining_compile_time_bindings);
 
   // Move any compile-time bindings into the suspended scope.
   for (auto inst_id : llvm::ArrayRef(compile_time_binding_stack_)

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -64,7 +64,7 @@ class ScopeStack {
 
   // Pops the top scope from scope_stack_ if it contains no names.
   auto PopIfEmpty() -> void {
-    if (!scope_stack_.back().has_names) {
+    if (scope_stack_.back().num_names == 0) {
       Pop();
     }
   }
@@ -179,7 +179,7 @@ class ScopeStack {
     bool has_returned_var = false;
 
     // Whether there are any ids in the `names` set.
-    bool has_names = false;
+    int num_names = 0;
 
     // Names which are registered with lexical_lookup_, and will need to be
     // unregistered when the scope ends.

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -5,7 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_CHECK_SCOPE_STACK_H_
 #define CARBON_TOOLCHAIN_CHECK_SCOPE_STACK_H_
 
-#include "llvm/ADT/DenseSet.h"
+#include "common/set.h"
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/lexical_lookup.h"
 #include "toolchain/check/scope_index.h"
@@ -64,7 +64,7 @@ class ScopeStack {
 
   // Pops the top scope from scope_stack_ if it contains no names.
   auto PopIfEmpty() -> void {
-    if (scope_stack_.back().names.empty()) {
+    if (!scope_stack_.back().has_names) {
       Pop();
     }
   }
@@ -178,9 +178,12 @@ class ScopeStack {
     // unregistered when the scope ends.
     bool has_returned_var = false;
 
+    // Whether there are any ids in the `names` set.
+    bool has_names = false;
+
     // Names which are registered with lexical_lookup_, and will need to be
     // unregistered when the scope ends.
-    llvm::DenseSet<SemIR::NameId> names = {};
+    Set<SemIR::NameId> names = {};
 
     // TODO: This likely needs to track things which need to be destructed.
   };

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -203,12 +203,12 @@ class SelfNestedBadParam {
 
 class SelfNestedBadReturnType {
   impl as SelfNested {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because return type is `[SelfNestedBadParam; 4]`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:10: ERROR: Redeclaration differs at parameter 1.
     // CHECK:STDERR:     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
-    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-21]]:3: Previously declared with return type `[SelfNestedBadReturnType; 4]`.
+    // CHECK:STDERR:          ^
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-21]]:8: Previous declaration's corresponding parameter here.
     // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: i32})) -> [Self; 4];
-    // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:        ^
     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
   }
 }
@@ -297,7 +297,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %.26: type = tuple_type (%.24, %.25) [template]
 // CHECK:STDOUT:   %F.type.15: type = fn_type @F.15 [template]
 // CHECK:STDOUT:   %F.16: %F.type.15 = struct_value () [template]
-// CHECK:STDOUT:   %.27: type = array_type %.14, %SelfNestedBadReturnType [template]
+// CHECK:STDOUT:   %.27: type = tuple_type (%.24, %.25) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -203,12 +203,12 @@ class SelfNestedBadParam {
 
 class SelfNestedBadReturnType {
   impl as SelfNested {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:10: ERROR: Redeclaration differs at parameter 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because return type is `[SelfNestedBadParam; 4]`.
     // CHECK:STDERR:     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
-    // CHECK:STDERR:          ^
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-21]]:8: Previous declaration's corresponding parameter here.
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-21]]:3: Previously declared with return type `[SelfNestedBadReturnType; 4]`.
     // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: i32})) -> [Self; 4];
-    // CHECK:STDERR:        ^
+    // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
   }
 }
@@ -297,7 +297,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %.26: type = tuple_type (%.24, %.25) [template]
 // CHECK:STDOUT:   %F.type.15: type = fn_type @F.15 [template]
 // CHECK:STDOUT:   %F.16: %F.type.15 = struct_value () [template]
-// CHECK:STDOUT:   %.27: type = tuple_type (%.24, %.25) [template]
+// CHECK:STDOUT:   %.27: type = array_type %.14, %SelfNestedBadReturnType [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -29,23 +29,10 @@ interface SelfNested {
 }
 
 impl C as SelfNested {
-  // CHECK:STDERR: self_in_signature.carbon:[[@LINE+7]]:8: ERROR: Redeclaration differs at parameter 1.
-  // CHECK:STDERR:   fn F(x: (C*, {.x: C, .y: ()}));
-  // CHECK:STDERR:        ^
-  // CHECK:STDERR: self_in_signature.carbon:[[@LINE-7]]:8: Previous declaration's corresponding parameter here.
-  // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: ()}));
-  // CHECK:STDERR:        ^
-  // CHECK:STDERR:
   fn F(x: (C*, {.x: C, .y: ()}));
 }
 
 impl D as SelfNested {
-  // CHECK:STDERR: self_in_signature.carbon:[[@LINE+6]]:8: ERROR: Redeclaration differs at parameter 1.
-  // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: ()}));
-  // CHECK:STDERR:        ^
-  // CHECK:STDERR: self_in_signature.carbon:[[@LINE-18]]:8: Previous declaration's corresponding parameter here.
-  // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: ()}));
-  // CHECK:STDERR:        ^
   fn F(x: (Self*, {.x: Self, .y: ()}));
 }
 
@@ -86,13 +73,13 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %.18: type = tuple_type (%.16, %.17) [template]
 // CHECK:STDOUT:   %F.type.5: type = fn_type @F.5 [template]
 // CHECK:STDOUT:   %F.5: %F.type.5 = struct_value () [template]
-// CHECK:STDOUT:   %.19: type = tuple_type (%.16, %.17) [template]
+// CHECK:STDOUT:   %.19: <witness> = interface_witness (%F.5) [template]
 // CHECK:STDOUT:   %.20: type = ptr_type %D [template]
 // CHECK:STDOUT:   %.21: type = struct_type {.x: %D, .y: %.2} [template]
 // CHECK:STDOUT:   %.22: type = tuple_type (%.20, %.21) [template]
 // CHECK:STDOUT:   %F.type.6: type = fn_type @F.6 [template]
 // CHECK:STDOUT:   %F.6: %F.type.6 = struct_value () [template]
-// CHECK:STDOUT:   %.23: type = tuple_type (%.20, %.21) [template]
+// CHECK:STDOUT:   %.23: <witness> = interface_witness (%F.6) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -119,8 +106,8 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %SelfNested.ref.loc31: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.4 {
-// CHECK:STDOUT:     %D.ref.loc42: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %SelfNested.ref.loc42: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
+// CHECK:STDOUT:     %D.ref.loc35: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %SelfNested.ref.loc35: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -214,18 +201,18 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.3: %C as %.9 {
 // CHECK:STDOUT:   %F.decl: %F.type.5 = fn_decl @F.5 [template = constants.%F.5] {
-// CHECK:STDOUT:     %C.ref.loc39_12: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc39_13: type = ptr_type %C [template = constants.%.16]
-// CHECK:STDOUT:     %C.ref.loc39_21: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc39_29.1: %.2 = tuple_literal ()
-// CHECK:STDOUT:     %.loc39_29.2: type = converted %.loc39_29.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc39_30: type = struct_type {.x: %C, .y: %.2} [template = constants.%.17]
-// CHECK:STDOUT:     %.loc39_31.1: %.12 = tuple_literal (%.loc39_13, %.loc39_30)
-// CHECK:STDOUT:     %.loc39_31.2: type = converted %.loc39_31.1, constants.%.18 [template = constants.%.18]
-// CHECK:STDOUT:     %x.loc39_8.1: %.18 = param x
-// CHECK:STDOUT:     %x.loc39_8.2: %.18 = bind_name x, %x.loc39_8.1
+// CHECK:STDOUT:     %C.ref.loc32_12: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %.loc32_13: type = ptr_type %C [template = constants.%.16]
+// CHECK:STDOUT:     %C.ref.loc32_21: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %.loc32_29.1: %.2 = tuple_literal ()
+// CHECK:STDOUT:     %.loc32_29.2: type = converted %.loc32_29.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc32_30: type = struct_type {.x: %C, .y: %.2} [template = constants.%.17]
+// CHECK:STDOUT:     %.loc32_31.1: %.12 = tuple_literal (%.loc32_13, %.loc32_30)
+// CHECK:STDOUT:     %.loc32_31.2: type = converted %.loc32_31.1, constants.%.18 [template = constants.%.18]
+// CHECK:STDOUT:     %x.loc32_8.1: %.18 = param x
+// CHECK:STDOUT:     %x.loc32_8.2: %.18 = bind_name x, %x.loc32_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F.decl) [template = constants.%.19]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F.decl
@@ -234,18 +221,18 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.4: %D as %.9 {
 // CHECK:STDOUT:   %F.decl: %F.type.6 = fn_decl @F.6 [template = constants.%F.6] {
-// CHECK:STDOUT:     %Self.ref.loc49_12: type = name_ref Self, constants.%D [template = constants.%D]
-// CHECK:STDOUT:     %.loc49_16: type = ptr_type %D [template = constants.%.20]
-// CHECK:STDOUT:     %Self.ref.loc49_24: type = name_ref Self, constants.%D [template = constants.%D]
-// CHECK:STDOUT:     %.loc49_35.1: %.2 = tuple_literal ()
-// CHECK:STDOUT:     %.loc49_35.2: type = converted %.loc49_35.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc49_36: type = struct_type {.x: %D, .y: %.2} [template = constants.%.21]
-// CHECK:STDOUT:     %.loc49_37.1: %.12 = tuple_literal (%.loc49_16, %.loc49_36)
-// CHECK:STDOUT:     %.loc49_37.2: type = converted %.loc49_37.1, constants.%.22 [template = constants.%.22]
-// CHECK:STDOUT:     %x.loc49_8.1: %.22 = param x
-// CHECK:STDOUT:     %x.loc49_8.2: %.22 = bind_name x, %x.loc49_8.1
+// CHECK:STDOUT:     %Self.ref.loc36_12: type = name_ref Self, constants.%D [template = constants.%D]
+// CHECK:STDOUT:     %.loc36_16: type = ptr_type %D [template = constants.%.20]
+// CHECK:STDOUT:     %Self.ref.loc36_24: type = name_ref Self, constants.%D [template = constants.%D]
+// CHECK:STDOUT:     %.loc36_35.1: %.2 = tuple_literal ()
+// CHECK:STDOUT:     %.loc36_35.2: type = converted %.loc36_35.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc36_36: type = struct_type {.x: %D, .y: %.2} [template = constants.%.21]
+// CHECK:STDOUT:     %.loc36_37.1: %.12 = tuple_literal (%.loc36_16, %.loc36_36)
+// CHECK:STDOUT:     %.loc36_37.2: type = converted %.loc36_37.1, constants.%.22 [template = constants.%.22]
+// CHECK:STDOUT:     %x.loc36_8.1: %.22 = param x
+// CHECK:STDOUT:     %x.loc36_8.2: %.22 = bind_name x, %x.loc36_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F.decl) [template = constants.%.23]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F.decl
@@ -284,7 +271,7 @@ impl D as SelfNested {
 // CHECK:STDOUT: fn @F.4(@SelfNested.%x.loc28_8.2: %.13)
 // CHECK:STDOUT:     generic [@SelfNested.%Self: %.9];
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.5(@impl.3.%x.loc39_8.2: %.18);
+// CHECK:STDOUT: fn @F.5(@impl.3.%x.loc32_8.2: %.18);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.6(@impl.4.%x.loc49_8.2: %.22);
+// CHECK:STDOUT: fn @F.6(@impl.4.%x.loc36_8.2: %.22);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -29,10 +29,23 @@ interface SelfNested {
 }
 
 impl C as SelfNested {
+  // CHECK:STDERR: self_in_signature.carbon:[[@LINE+7]]:8: ERROR: Redeclaration differs at parameter 1.
+  // CHECK:STDERR:   fn F(x: (C*, {.x: C, .y: ()}));
+  // CHECK:STDERR:        ^
+  // CHECK:STDERR: self_in_signature.carbon:[[@LINE-7]]:8: Previous declaration's corresponding parameter here.
+  // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: ()}));
+  // CHECK:STDERR:        ^
+  // CHECK:STDERR:
   fn F(x: (C*, {.x: C, .y: ()}));
 }
 
 impl D as SelfNested {
+  // CHECK:STDERR: self_in_signature.carbon:[[@LINE+6]]:8: ERROR: Redeclaration differs at parameter 1.
+  // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: ()}));
+  // CHECK:STDERR:        ^
+  // CHECK:STDERR: self_in_signature.carbon:[[@LINE-18]]:8: Previous declaration's corresponding parameter here.
+  // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: ()}));
+  // CHECK:STDERR:        ^
   fn F(x: (Self*, {.x: Self, .y: ()}));
 }
 
@@ -73,13 +86,13 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %.18: type = tuple_type (%.16, %.17) [template]
 // CHECK:STDOUT:   %F.type.5: type = fn_type @F.5 [template]
 // CHECK:STDOUT:   %F.5: %F.type.5 = struct_value () [template]
-// CHECK:STDOUT:   %.19: <witness> = interface_witness (%F.5) [template]
+// CHECK:STDOUT:   %.19: type = tuple_type (%.16, %.17) [template]
 // CHECK:STDOUT:   %.20: type = ptr_type %D [template]
 // CHECK:STDOUT:   %.21: type = struct_type {.x: %D, .y: %.2} [template]
 // CHECK:STDOUT:   %.22: type = tuple_type (%.20, %.21) [template]
 // CHECK:STDOUT:   %F.type.6: type = fn_type @F.6 [template]
 // CHECK:STDOUT:   %F.6: %F.type.6 = struct_value () [template]
-// CHECK:STDOUT:   %.23: <witness> = interface_witness (%F.6) [template]
+// CHECK:STDOUT:   %.23: type = tuple_type (%.20, %.21) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -106,8 +119,8 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %SelfNested.ref.loc31: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.4 {
-// CHECK:STDOUT:     %D.ref.loc35: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %SelfNested.ref.loc35: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
+// CHECK:STDOUT:     %D.ref.loc42: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %SelfNested.ref.loc42: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -201,18 +214,18 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.3: %C as %.9 {
 // CHECK:STDOUT:   %F.decl: %F.type.5 = fn_decl @F.5 [template = constants.%F.5] {
-// CHECK:STDOUT:     %C.ref.loc32_12: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc32_13: type = ptr_type %C [template = constants.%.16]
-// CHECK:STDOUT:     %C.ref.loc32_21: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc32_29.1: %.2 = tuple_literal ()
-// CHECK:STDOUT:     %.loc32_29.2: type = converted %.loc32_29.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc32_30: type = struct_type {.x: %C, .y: %.2} [template = constants.%.17]
-// CHECK:STDOUT:     %.loc32_31.1: %.12 = tuple_literal (%.loc32_13, %.loc32_30)
-// CHECK:STDOUT:     %.loc32_31.2: type = converted %.loc32_31.1, constants.%.18 [template = constants.%.18]
-// CHECK:STDOUT:     %x.loc32_8.1: %.18 = param x
-// CHECK:STDOUT:     %x.loc32_8.2: %.18 = bind_name x, %x.loc32_8.1
+// CHECK:STDOUT:     %C.ref.loc39_12: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %.loc39_13: type = ptr_type %C [template = constants.%.16]
+// CHECK:STDOUT:     %C.ref.loc39_21: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %.loc39_29.1: %.2 = tuple_literal ()
+// CHECK:STDOUT:     %.loc39_29.2: type = converted %.loc39_29.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc39_30: type = struct_type {.x: %C, .y: %.2} [template = constants.%.17]
+// CHECK:STDOUT:     %.loc39_31.1: %.12 = tuple_literal (%.loc39_13, %.loc39_30)
+// CHECK:STDOUT:     %.loc39_31.2: type = converted %.loc39_31.1, constants.%.18 [template = constants.%.18]
+// CHECK:STDOUT:     %x.loc39_8.1: %.18 = param x
+// CHECK:STDOUT:     %x.loc39_8.2: %.18 = bind_name x, %x.loc39_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F.decl) [template = constants.%.19]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F.decl
@@ -221,18 +234,18 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.4: %D as %.9 {
 // CHECK:STDOUT:   %F.decl: %F.type.6 = fn_decl @F.6 [template = constants.%F.6] {
-// CHECK:STDOUT:     %Self.ref.loc36_12: type = name_ref Self, constants.%D [template = constants.%D]
-// CHECK:STDOUT:     %.loc36_16: type = ptr_type %D [template = constants.%.20]
-// CHECK:STDOUT:     %Self.ref.loc36_24: type = name_ref Self, constants.%D [template = constants.%D]
-// CHECK:STDOUT:     %.loc36_35.1: %.2 = tuple_literal ()
-// CHECK:STDOUT:     %.loc36_35.2: type = converted %.loc36_35.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc36_36: type = struct_type {.x: %D, .y: %.2} [template = constants.%.21]
-// CHECK:STDOUT:     %.loc36_37.1: %.12 = tuple_literal (%.loc36_16, %.loc36_36)
-// CHECK:STDOUT:     %.loc36_37.2: type = converted %.loc36_37.1, constants.%.22 [template = constants.%.22]
-// CHECK:STDOUT:     %x.loc36_8.1: %.22 = param x
-// CHECK:STDOUT:     %x.loc36_8.2: %.22 = bind_name x, %x.loc36_8.1
+// CHECK:STDOUT:     %Self.ref.loc49_12: type = name_ref Self, constants.%D [template = constants.%D]
+// CHECK:STDOUT:     %.loc49_16: type = ptr_type %D [template = constants.%.20]
+// CHECK:STDOUT:     %Self.ref.loc49_24: type = name_ref Self, constants.%D [template = constants.%D]
+// CHECK:STDOUT:     %.loc49_35.1: %.2 = tuple_literal ()
+// CHECK:STDOUT:     %.loc49_35.2: type = converted %.loc49_35.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc49_36: type = struct_type {.x: %D, .y: %.2} [template = constants.%.21]
+// CHECK:STDOUT:     %.loc49_37.1: %.12 = tuple_literal (%.loc49_16, %.loc49_36)
+// CHECK:STDOUT:     %.loc49_37.2: type = converted %.loc49_37.1, constants.%.22 [template = constants.%.22]
+// CHECK:STDOUT:     %x.loc49_8.1: %.22 = param x
+// CHECK:STDOUT:     %x.loc49_8.2: %.22 = bind_name x, %x.loc49_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F.decl) [template = constants.%.23]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F.decl
@@ -271,7 +284,7 @@ impl D as SelfNested {
 // CHECK:STDOUT: fn @F.4(@SelfNested.%x.loc28_8.2: %.13)
 // CHECK:STDOUT:     generic [@SelfNested.%Self: %.9];
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.5(@impl.3.%x.loc32_8.2: %.18);
+// CHECK:STDOUT: fn @F.5(@impl.3.%x.loc39_8.2: %.18);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.6(@impl.4.%x.loc36_8.2: %.22);
+// CHECK:STDOUT: fn @F.6(@impl.4.%x.loc49_8.2: %.22);
 // CHECK:STDOUT:

--- a/toolchain/lower/BUILD
+++ b/toolchain/lower/BUILD
@@ -42,6 +42,7 @@ cc_library(
     ],
     deps = [
         "//common:check",
+        "//common:map",
         "//common:vlog",
         "//toolchain/base:kind_switch",
         "//toolchain/sem_ir:entry_point",

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -19,6 +19,7 @@ cc_library(
     hdrs = ["block_value_store.h"],
     deps = [
         "//common:hashing",
+        "//common:set",
         "//toolchain/base:value_store",
         "//toolchain/base:yaml",
         "@llvm-project//llvm:Support",
@@ -117,6 +118,7 @@ cc_library(
         "//common:enum_base",
         "//common:error",
         "//common:hashing",
+        "//common:map",
         "//common:set",
         "//toolchain/base:kind_switch",
         "//toolchain/base:value_store",

--- a/toolchain/sem_ir/bind_name.h
+++ b/toolchain/sem_ir/bind_name.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_SEM_IR_BIND_NAME_H_
 
 #include "common/hashing.h"
+#include "common/set.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/sem_ir/ids.h"
 
@@ -15,6 +16,11 @@ struct BindNameInfo : public Printable<BindNameInfo> {
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{name: " << name_id << ", parent_scope: " << parent_scope_id
         << ", index: " << bind_index << "}";
+  }
+
+  friend auto CarbonHashtableEq(const BindNameInfo& lhs,
+                                const BindNameInfo& rhs) -> bool {
+    return std::memcmp(&lhs, &rhs, sizeof(BindNameInfo)) == 0;
   }
 
   // The name.
@@ -33,43 +39,37 @@ inline auto CarbonHashValue(const BindNameInfo& value, uint64_t seed)
   return static_cast<HashCode>(hasher);
 }
 
-// DenseMapInfo for BindNameInfo.
-struct BindNameInfoDenseMapInfo {
-  static auto getEmptyKey() -> BindNameInfo {
-    return BindNameInfo{.name_id = NameId::Invalid,
-                        .parent_scope_id = NameScopeId::Invalid,
-                        .bind_index = CompileTimeBindIndex(
-                            CompileTimeBindIndex::InvalidIndex - 1)};
-  }
-  static auto getTombstoneKey() -> BindNameInfo {
-    return BindNameInfo{.name_id = NameId::Invalid,
-                        .parent_scope_id = NameScopeId::Invalid,
-                        .bind_index = CompileTimeBindIndex(
-                            CompileTimeBindIndex::InvalidIndex - 2)};
-  }
-  static auto getHashValue(const BindNameInfo& val) -> unsigned {
-    return static_cast<uint64_t>(HashValue(val));
-  }
-  static auto isEqual(const BindNameInfo& lhs, const BindNameInfo& rhs)
-      -> bool {
-    return std::memcmp(&lhs, &rhs, sizeof(BindNameInfo)) == 0;
-  }
-};
-
 // Value store for BindNameInfo. In addition to the regular ValueStore
 // functionality, this can provide optional canonical IDs for BindNameInfos.
 struct BindNameStore : public ValueStore<BindNameId> {
  public:
   // Convert an ID to a canonical ID. All calls to this with equivalent
   // `BindNameInfo`s will return the same `BindNameId`.
-  auto MakeCanonical(BindNameId id) -> BindNameId {
-    return canonical_ids_.insert({Get(id), id}).first->second;
+  auto MakeCanonical(BindNameId id) -> BindNameId;
+
+ private:
+  class KeyContext;
+
+  Set<BindNameId, /*SmallSize=*/0, KeyContext> canonical_ids_;
+};
+
+class BindNameStore::KeyContext : public TranslatingKeyContext<KeyContext> {
+ public:
+  explicit KeyContext(const BindNameStore* store) : store_(store) {}
+
+  // Note that it is safe to return a `const` reference here as the underlying
+  // object's lifetime is provided by the `store_`.
+  auto TranslateKey(BindNameId id) const -> const BindNameInfo& {
+    return store_->Get(id);
   }
 
  private:
-  llvm::DenseMap<BindNameInfo, BindNameId, BindNameInfoDenseMapInfo>
-      canonical_ids_;
+  const BindNameStore* store_;
 };
+
+inline auto BindNameStore::MakeCanonical(BindNameId id) -> BindNameId {
+  return canonical_ids_.Insert(id, KeyContext(this)).key();
+}
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -7,8 +7,7 @@
 
 #include <type_traits>
 
-#include "common/hashing.h"
-#include "llvm/ADT/DenseMap.h"
+#include "common/set.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/base/yaml.h"
 
@@ -51,20 +50,19 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
   // Adds a block or finds an existing canonical block with the given content,
   // and returns an ID to reference it.
   auto AddCanonical(llvm::ArrayRef<ElementType> content) -> IdT {
-    auto [it, added] = canonical_blocks_.insert({{content}, IdT::Invalid});
-    if (added) {
-      auto id = Add(content);
-      it->first.data = Get(id);
-      it->second = id;
-    }
-    return it->second;
+    auto result = canonical_blocks_.Insert(
+        content, [&] { return Add(content); }, KeyContext(this));
+    return result.key();
   }
 
   // Promotes an existing block ID to a canonical block ID, or returns an
   // existing canonical block ID if the block was already added. The specified
   // block must not be modified after this point.
   auto MakeCanonical(IdT id) -> IdT {
-    return canonical_blocks_.insert({{Get(id)}, id}).first->second;
+    return canonical_blocks_
+        .Insert(
+            Get(id), [id] { return id; }, KeyContext(this))
+        .key();
   }
 
   auto OutputYaml() const -> Yaml::OutputMapping {
@@ -95,47 +93,14 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
   }
 
   // Sets the contents of an empty block to the given content.
-  auto Set(IdT block_id, llvm::ArrayRef<ElementType> content) -> void {
+  auto SetContent(IdT block_id, llvm::ArrayRef<ElementType> content) -> void {
     CARBON_CHECK(Get(block_id).empty())
         << "inst block content set more than once";
     values_.Get(block_id) = AllocateCopy(content);
   }
 
  private:
-  // A canonical block, for which we allocate a deduplicated ID.
-  struct CanonicalBlock {
-    // This is mutable so we can repoint it at the allocated data if insertion
-    // succeeds.
-    mutable llvm::ArrayRef<ElementType> data;
-
-    // See common/hashing.h.
-    friend auto CarbonHashValue(CanonicalBlock block, uint64_t seed)
-        -> HashCode {
-      Hasher hasher(seed);
-      hasher.HashSizedBytes(block.data);
-      return static_cast<HashCode>(hasher);
-    }
-  };
-
-  struct CanonicalBlockDenseMapInfo {
-    // Blocks whose data() points to the start of `SpecialData` are used to
-    // represent the special "empty" and "tombstone" states.
-    static constexpr ElementType SpecialData[1] = {ElementType::Invalid};
-    static auto getEmptyKey() -> CanonicalBlock {
-      return CanonicalBlock{
-          llvm::ArrayRef(SpecialData, static_cast<size_t>(0))};
-    }
-    static auto getTombstoneKey() -> CanonicalBlock {
-      return CanonicalBlock{llvm::ArrayRef(SpecialData, 1)};
-    }
-    static auto getHashValue(CanonicalBlock val) -> unsigned {
-      return static_cast<uint64_t>(HashValue(val));
-    }
-    static auto isEqual(CanonicalBlock lhs, CanonicalBlock rhs) -> bool {
-      return lhs.data == rhs.data && (lhs.data.data() == SpecialData) ==
-                                         (rhs.data.data() == SpecialData);
-    }
-  };
+  class KeyContext;
 
   // Allocates an uninitialized array using our slab allocator.
   auto AllocateUninitialized(std::size_t size)
@@ -158,8 +123,21 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
 
   llvm::BumpPtrAllocator* allocator_;
   ValueStore<IdT> values_;
-  llvm::DenseMap<CanonicalBlock, IdT, CanonicalBlockDenseMapInfo>
-      canonical_blocks_;
+  Set<IdT, /*SmallSize=*/0, KeyContext> canonical_blocks_;
+};
+
+template <typename IdT>
+class BlockValueStore<IdT>::KeyContext
+    : public TranslatingKeyContext<KeyContext> {
+ public:
+  explicit KeyContext(const BlockValueStore* store) : store_(store) {}
+
+  auto TranslateKey(IdT id) const -> llvm::ArrayRef<ElementType> {
+    return store_->Get(id);
+  }
+
+ private:
+  const BlockValueStore* store_;
 };
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -59,10 +59,11 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
   // existing canonical block ID if the block was already added. The specified
   // block must not be modified after this point.
   auto MakeCanonical(IdT id) -> IdT {
-    return canonical_blocks_
-        .Insert(
-            Get(id), [id] { return id; }, KeyContext(this))
-        .key();
+    // Get the content first so that we don't have unnecessary translation of
+    // the `id` into the content during insertion.
+    auto result = canonical_blocks_.Insert(
+        Get(id), [id] { return id; }, KeyContext(this));
+    return result.key();
   }
 
   auto OutputYaml() const -> Yaml::OutputMapping {

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -5,7 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_CONSTANT_H_
 #define CARBON_TOOLCHAIN_SEM_IR_CONSTANT_H_
 
-#include "llvm/ADT/FoldingSet.h"
+#include "common/map.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 
@@ -93,7 +93,7 @@ class ConstantStore {
 
  private:
   File& sem_ir_;
-  llvm::DenseMap<Inst, ConstantId> map_;
+  Map<Inst, ConstantId> map_;
   llvm::SmallVector<InstId, 0> constants_;
 };
 

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -208,8 +208,6 @@ struct CompileTimeBindIndex : public IndexBase,
 
 constexpr CompileTimeBindIndex CompileTimeBindIndex::Invalid =
     CompileTimeBindIndex(InvalidIndex);
-// Note that InvalidIndex - 1 and InvalidIndex - 2 are used by
-// DenseMapInfo<BindNameInfo>.
 
 // The ID of a function.
 struct FunctionId : public IdBase, public Printable<FunctionId> {
@@ -673,25 +671,5 @@ struct LocId : public IdBase, public Printable<LocId> {
 constexpr LocId LocId::Invalid = LocId(Parse::NodeId::Invalid);
 
 }  // namespace Carbon::SemIR
-
-// Support use of Id types as DenseMap/DenseSet keys.
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::ConstantId>
-    : public Carbon::IndexMapInfo<Carbon::SemIR::ConstantId> {};
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::InstBlockId>
-    : public Carbon::IndexMapInfo<Carbon::SemIR::InstBlockId> {};
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::InstId>
-    : public Carbon::IndexMapInfo<Carbon::SemIR::InstId> {};
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::NameId>
-    : public Carbon::IndexMapInfo<Carbon::SemIR::NameId> {};
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::NameScopeId>
-    : public Carbon::IndexMapInfo<Carbon::SemIR::NameScopeId> {};
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::TypeId>
-    : public Carbon::IndexMapInfo<Carbon::SemIR::TypeId> {};
 
 #endif  // CARBON_TOOLCHAIN_SEM_IR_IDS_H_

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -5,7 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_IMPL_H_
 #define CARBON_TOOLCHAIN_SEM_IR_IMPL_H_
 
-#include "llvm/ADT/DenseMap.h"
+#include "common/map.h"
 #include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::SemIR {
@@ -58,13 +58,10 @@ class ImplStore {
   // `Impl` if none exists.
   // TODO: Handle parameters.
   auto LookupOrAdd(TypeId self_id, TypeId constraint_id) -> ImplId {
-    auto [it, added] =
-        lookup_.insert({{self_id, constraint_id}, ImplId::Invalid});
-    if (added) {
-      it->second =
-          values_.Add({.self_id = self_id, .constraint_id = constraint_id});
-    }
-    return it->second;
+    auto result = lookup_.Insert(std::pair{self_id, constraint_id}, [&]() {
+      return values_.Add({.self_id = self_id, .constraint_id = constraint_id});
+    });
+    return result.value();
   }
 
   // Returns a mutable value for an ID.
@@ -82,7 +79,7 @@ class ImplStore {
 
  private:
   ValueStore<ImplId> values_;
-  llvm::DenseMap<std::pair<TypeId, TypeId>, ImplId> lookup_;
+  Map<std::pair<TypeId, TypeId>, ImplId> lookup_;
 };
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -139,7 +139,6 @@ class Inst : public Printable<Inst> {
     } else {
       kind_ = TypedInst::Kind.AsInt();
     }
-    CARBON_CHECK(kind_ >= 0) << "Unexpected negative kind value.";
     if constexpr (Internal::HasTypeIdMember<TypedInst>) {
       type_id_ = typed_inst.type_id;
     }

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -139,8 +139,7 @@ class Inst : public Printable<Inst> {
     } else {
       kind_ = TypedInst::Kind.AsInt();
     }
-    CARBON_CHECK(kind_ >= 0)
-        << "Negative kind values are reserved for DenseMapInfo.";
+    CARBON_CHECK(kind_ >= 0) << "Unexpected negative kind value.";
     if constexpr (Internal::HasTypeIdMember<TypedInst>) {
       type_id_ = typed_inst.type_id;
     }
@@ -248,14 +247,17 @@ class Inst : public Printable<Inst> {
 
   auto Print(llvm::raw_ostream& out) const -> void;
 
+  friend auto operator==(Inst lhs, Inst rhs) -> bool {
+    return std::memcmp(&lhs, &rhs, sizeof(Inst)) == 0;
+  }
+
  private:
   friend class InstTestHelper;
-  friend struct llvm::DenseMapInfo<Carbon::SemIR::Inst>;
 
   // Table mapping instruction kinds to their argument kinds.
   static const std::pair<IdKind, IdKind> ArgKindTable[];
 
-  // Raw constructor, used for testing and by DenseMapInfo.
+  // Raw constructor, used for testing.
   explicit Inst(InstKind kind, TypeId type_id, int32_t arg0, int32_t arg1)
       : Inst(kind.AsInt(), type_id, arg0, arg1) {}
   explicit Inst(int32_t kind, TypeId type_id, int32_t arg0, int32_t arg1)
@@ -445,7 +447,7 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
 
   auto Set(InstBlockId block_id, llvm::ArrayRef<InstId> content) -> void {
     CARBON_CHECK(block_id != InstBlockId::Unreachable);
-    BlockValueStore<InstBlockId>::Set(block_id, content);
+    BlockValueStore<InstBlockId>::SetContent(block_id, content);
   }
 
   // Returns the contents of the specified block, or an empty array if the block
@@ -463,22 +465,5 @@ inline auto CarbonHashValue(const Inst& value, uint64_t seed) -> HashCode {
 }
 
 }  // namespace Carbon::SemIR
-
-template <>
-struct llvm::DenseMapInfo<Carbon::SemIR::Inst> {
-  using Inst = Carbon::SemIR::Inst;
-  static auto getEmptyKey() -> Inst {
-    return Inst(-1, Carbon::SemIR::TypeId::Invalid, 0, 0);
-  }
-  static auto getTombstoneKey() -> Inst {
-    return Inst(-2, Carbon::SemIR::TypeId::Invalid, 0, 0);
-  }
-  static auto getHashValue(const Inst& val) -> unsigned {
-    return static_cast<uint64_t>(Carbon::HashValue(val));
-  }
-  static auto isEqual(const Inst& lhs, const Inst& rhs) -> bool {
-    return std::memcmp(&lhs, &rhs, sizeof(Inst)) == 0;
-  }
-};
 
 #endif  // CARBON_TOOLCHAIN_SEM_IR_INST_H_

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -48,16 +48,14 @@ struct NameScope : Printable<NameScope> {
 
   // Adds a name to the scope that must not already exist.
   auto AddRequired(Entry name_entry) -> void {
-    bool success = name_map
-                       .Insert(name_entry.name_id,
-                               [&] {
-                                 int index = names.size();
-                                 names.push_back(name_entry);
-                                 return index;
-                               })
-                       .is_inserted();
-    CARBON_CHECK(success) << "Failed to add required name: "
-                          << name_entry.name_id;
+    auto add_name = [&] {
+      int index = names.size();
+      names.push_back(name_entry);
+      return index;
+    };
+    auto result = name_map.Insert(name_entry.name_id, add_name);
+    CARBON_CHECK(result.is_inserted())
+        << "Failed to add required name: " << name_entry.name_id;
   }
 
   // Names in the scope. We store both an insertion-ordered vector for iterating


### PR DESCRIPTION
This works to leverage the capabilities of the hashtable as much as
possible, for example using the key context in the value stores.
However, there may still be opportunities to refactor more deeply and
use the functionality even better. Hopefully this is at least
a reasonable start and gets us a clean baseline.

On an Arm M1, this is a 15% improvement on my large lexing stress test,
but ends up a wash on my x86-64 server. This is a smaller benefit than
I expected, and it's because we're using a set-of-IDs and looking up
values with a key context for things like identifiers. This pattern has
a surprising tradeoff. The new hashtable uses significantly less memory,
a 10% peak RSS reduction just from the hashtable change. But indirecting
through the vector of values makes growing the hashtable dramatically
less cache-friendly: it causes growth to randomly access every key when
rehashing. On x86, everything gained by the faster hashtable is lost in
even slower growth. And even on Arm, this eats into the benefits.

But I have a plan to tweak how identifiers specifically work to avoid
most of the growth, and so I suspect this is the right tradeoff on the
whole. It gives us significant working set size reduction and we can
likely avoid the regressed operation (growth with rehash) in most cases
by clever reserving and if necessary by adding a hash caching layer to
the table infrastructure.