### PR TITLE
Fix drop_back call in scope_stack

### DIFF
--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -179,7 +179,7 @@ auto ScopeStack::Suspend() -> SuspendedScope {
 
   // Move any compile-time bindings into the suspended scope.
   for (auto inst_id : llvm::ArrayRef(compile_time_binding_stack_)
-                          .drop_back(remaining_compile_time_bindings)) {
+                          .drop_front(remaining_compile_time_bindings)) {
     result.suspended_items.push_back(
         {.index = SuspendedScope::ScopeItem::IndexForCompileTimeBinding,
          .inst_id = inst_id});


### PR DESCRIPTION
I found this through inspection, looking at an array stack data type. Tests pass either way, not sure what a good test would be for regressions (tests do fail if the size doesn't match, but either approach gets an appropriate size). But this is followed by `truncate(remaining_compile_time_bindings)`, so it seems like `drop_back` is a better match than `drop_front`.