### PR TITLE
Use separate value stores for identifiers and string literals

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -374,13 +374,13 @@ class Context {
 
   // Directly expose SemIR::File data accessors for brevity in calls.
 
-  auto identifiers() -> StringStoreWrapper<IdentifierId>& {
+  auto identifiers() -> CanonicalValueStore<IdentifierId>& {
     return sem_ir().identifiers();
   }
   auto ints() -> CanonicalValueStore<IntId>& { return sem_ir().ints(); }
   auto reals() -> ValueStore<RealId>& { return sem_ir().reals(); }
   auto floats() -> FloatValueStore& { return sem_ir().floats(); }
-  auto string_literal_values() -> StringStoreWrapper<StringLiteralValueId>& {
+  auto string_literal_values() -> CanonicalValueStore<StringLiteralValueId>& {
     return sem_ir().string_literal_values();
   }
   auto bind_names() -> SemIR::BindNameStore& { return sem_ir().bind_names(); }

--- a/toolchain/check/lexical_lookup.h
+++ b/toolchain/check/lexical_lookup.h
@@ -37,7 +37,7 @@ class LexicalLookup {
     SemIR::InstId inst_id;
   };
 
-  explicit LexicalLookup(const StringStoreWrapper<IdentifierId>& identifiers)
+  explicit LexicalLookup(const CanonicalValueStore<IdentifierId>& identifiers)
       : lookup_(identifiers.size() + SemIR::NameId::NonIndexValueCount) {}
 
   // Returns the lexical lookup results for a name.

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -18,7 +18,7 @@ namespace Carbon::Check {
 // checking within.
 class ScopeStack {
  public:
-  explicit ScopeStack(const StringStoreWrapper<IdentifierId>& identifiers)
+  explicit ScopeStack(const CanonicalValueStore<IdentifierId>& identifiers)
       : lexical_lookup_(identifiers) {}
 
   // A scope in which `break` and `continue` can be used.

--- a/toolchain/driver/testdata/dump_shared_values.carbon
+++ b/toolchain/driver/testdata/dump_shared_values.carbon
@@ -31,14 +31,15 @@ var str2: String = "ab'\"c";
 // CHECK:STDOUT:     real0:           10*10^-1
 // CHECK:STDOUT:     real1:           8*10^7
 // CHECK:STDOUT:     real2:           8*10^8
+// CHECK:STDOUT:   identifiers:
+// CHECK:STDOUT:     identifier0:     int1
+// CHECK:STDOUT:     identifier1:     int2
+// CHECK:STDOUT:     identifier2:     real1
+// CHECK:STDOUT:     identifier3:     real2
+// CHECK:STDOUT:     identifier4:     real3
+// CHECK:STDOUT:     identifier5:     str1
+// CHECK:STDOUT:     identifier6:     str2
 // CHECK:STDOUT:   strings:
-// CHECK:STDOUT:     str0:            int1
-// CHECK:STDOUT:     str1:            int2
-// CHECK:STDOUT:     str2:            real1
-// CHECK:STDOUT:     str3:            real2
-// CHECK:STDOUT:     str4:            real3
-// CHECK:STDOUT:     str5:            str1
-// CHECK:STDOUT:     str6:            abc
-// CHECK:STDOUT:     str7:            str2
-// CHECK:STDOUT:     str8:            'ab''"c'
+// CHECK:STDOUT:     string0:         abc
+// CHECK:STDOUT:     string1:         ab'"c
 // CHECK:STDOUT: ...

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -91,10 +91,10 @@ class File : public Printable<File> {
   auto check_ir_id() const -> CheckIRId { return check_ir_id_; }
 
   // Directly expose SharedValueStores members.
-  auto identifiers() -> StringStoreWrapper<IdentifierId>& {
+  auto identifiers() -> CanonicalValueStore<IdentifierId>& {
     return value_stores_->identifiers();
   }
-  auto identifiers() const -> const StringStoreWrapper<IdentifierId>& {
+  auto identifiers() const -> const CanonicalValueStore<IdentifierId>& {
     return value_stores_->identifiers();
   }
   auto ints() -> CanonicalValueStore<IntId>& { return value_stores_->ints(); }
@@ -109,11 +109,11 @@ class File : public Printable<File> {
   auto floats() const -> const FloatValueStore& {
     return value_stores_->floats();
   }
-  auto string_literal_values() -> StringStoreWrapper<StringLiteralValueId>& {
+  auto string_literal_values() -> CanonicalValueStore<StringLiteralValueId>& {
     return value_stores_->string_literal_values();
   }
   auto string_literal_values() const
-      -> const StringStoreWrapper<StringLiteralValueId>& {
+      -> const CanonicalValueStore<StringLiteralValueId>& {
     return value_stores_->string_literal_values();
   }
 

--- a/toolchain/sem_ir/name.h
+++ b/toolchain/sem_ir/name.h
@@ -23,7 +23,8 @@ namespace Carbon::SemIR {
 // currently a wrapper around an identifier store that has no state of its own.
 class NameStoreWrapper {
  public:
-  explicit NameStoreWrapper(const StringStoreWrapper<IdentifierId>* identifiers)
+  explicit NameStoreWrapper(
+      const CanonicalValueStore<IdentifierId>* identifiers)
       : identifiers_(identifiers) {}
 
   // Returns the requested name as a string, if it is an identifier name. This
@@ -48,7 +49,7 @@ class NameStoreWrapper {
   auto GetIRBaseName(NameId name_id) const -> llvm::StringRef;
 
  private:
-  const StringStoreWrapper<IdentifierId>* identifiers_;
+  const CanonicalValueStore<IdentifierId>* identifiers_;
 };
 
 }  // namespace Carbon::SemIR


### PR DESCRIPTION
This undoes a previous change to unify them, and I think at my advice. =[ Sorry about that, I think I was just wrong.

Specifically, I think I had suggested that it would be more efficient to have a single shared hashtable of strings. The more I look at profiles of the toolchain, the less likely that seems. Specifically for identifiers and string literals it seems especially problematic.

Using a single, joint hashtable is likely a good idea when all of the different querying code paths are equally likely, the strings follow the same distribution of sizes, and either there is no clustering of access to different sets of strings or none of the sets are meaningfully small enough to fit into a lower level of resident cache.

I think essentially none of these predicates actually hold for identifiers vs. string literals:
- Identifiers are *much* more hot
- They have wildly different size distributions.
- The access patterns are very clustered

Sorry for the misleading advice on that one.

While splitting them, I've worked to simplify the code a bit by building a way to have the `StringRef` holding canonical value stores not require specializations, and so we get a pretty large code cleanup in the process here.