### PR TITLE
Reserve memory for the identifiers hashtable. 

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -218,14 +218,7 @@ class CanonicalValueStore {
   auto Lookup(ValueType value) const -> IdT;
 
   // Reserves space.
-  auto Reserve(size_t size) -> void {
-    // Compute the resulting new insert count using the size of values -- the
-    // set doesn't have a fast to compute current size.
-    if (size > values_.size()) {
-      set_.GrowForInsertCount(size - values_.size(), KeyContext(values_));
-    }
-    values_.Reserve(size);
-  }
+  auto Reserve(size_t size) -> void;
 
   // These are to support printable structures, and are not guaranteed.
   auto OutputYaml() const -> Yaml::OutputMapping {
@@ -272,6 +265,17 @@ auto CanonicalValueStore<IdT>::Lookup(ValueType value) const -> IdT {
     return result.key();
   }
   return IdT::Invalid;
+}
+
+template <typename IdT>
+auto CanonicalValueStore<IdT>::Reserve(size_t size) -> void {
+  // Compute the resulting new insert count using the size of values -- the
+  // set doesn't have a fast to compute current size.
+  if (size > values_.size()) {
+    set_.GrowForInsertCount(size - values_.size(),
+                            KeyContext(values_.array_ref()));
+  }
+  values_.Reserve(size);
 }
 
 using FloatValueStore = CanonicalValueStore<FloatId>;

--- a/toolchain/base/value_store_test.cpp
+++ b/toolchain/base/value_store_test.cpp
@@ -82,6 +82,9 @@ TEST(ValueStore, Identifiers) {
   std::string b = "b";
   SharedValueStores value_stores;
 
+  // Make sure reserve works, we use it with identifiers.
+  value_stores.identifiers().Reserve(100);
+
   auto a_id = value_stores.identifiers().Add(a);
   auto b_id = value_stores.identifiers().Add(b);
 

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -633,7 +633,7 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
 // example, here is LLVM's distribution computed with `scripts/source_stats.py`
 // and rendered in an ASCII-art histogram:
 //
-//   # Unique IDs per 10 lines ## (median: 5)
+//   ## Unique IDs per 10 lines ## (median: 5, p90: 8, p95: 9, p99: 14)
 //   1 ids   [  29]  ▍
 //   2 ids   [ 282]  ███▊
 //   3 ids   [1492]  ███████████████████▉
@@ -645,7 +645,8 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
 //   9 ids   [ 301]  ████
 //   10 ids  [  98]  █▎
 //
-//   (Trimmed to only cover 1 - 10 unique IDs per 10 lines of code.)
+//   (Trimmed to only cover 1 - 10 unique IDs per 10 lines of code, 272 files
+//    with more unique IDs in the tail.)
 //
 // We have checked this distribution with several large codebases (currently
 // those at Google, happy to cross check with others) that use a similar coding


### PR DESCRIPTION
This uses a heuristic reserve to greatly reduce hashtable growth of the
identifiers hashtable. The design of the hashtable itself is optimized
around compact memory use and is especially slow to grow and so this has
an outsized impact.

The heuristic was computed using `scripts/source_stats.py` and looking
at C++ codebases. We may want to periodically re-evaluate it as Carbon
code emerges and we have better data on its distributions of tokens.

This also required fixing the `Reserve` method on `CanonicalValueStore`
that wasn't actually used anywhere and so didn't even compile correctly.
I added it to the relevant unit test so it is at least compiled locally
to its definition.