### PR TITLE
Refactor whether a function is lowered into InstKind::Define

### DIFF
--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -18,20 +18,6 @@
 
 namespace Carbon::Lower {
 
-template <typename InstT>
-static auto FatalErrorIfEncountered(InstT inst) -> void {
-  CARBON_FATAL()
-      << "Encountered an instruction that isn't expected to lower. It's "
-         "possible that logic needs to be changed in order to stop "
-         "showing this instruction in lowered contexts. Instruction: "
-      << inst;
-}
-
-auto HandleAdaptDecl(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
-                     SemIR::AdaptDecl inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
 auto HandleAddrOf(FunctionContext& context, SemIR::InstId inst_id,
                   SemIR::AddrOf inst) -> void {
   context.SetLocal(inst_id, context.GetValue(inst.lvalue_id));
@@ -70,12 +56,6 @@ auto HandleAssign(FunctionContext& context, SemIR::InstId /*inst_id*/,
                   SemIR::Assign inst) -> void {
   auto storage_type_id = context.sem_ir().insts().Get(inst.lhs_id).type_id();
   context.FinishInit(storage_type_id, inst.lhs_id, inst.rhs_id);
-}
-
-auto HandleAssociatedConstantDecl(FunctionContext& /*context*/,
-                                  SemIR::InstId /*inst_id*/,
-                                  SemIR::AssociatedConstantDecl inst) -> void {
-  FatalErrorIfEncountered(inst);
 }
 
 auto HandleBindAlias(FunctionContext& context, SemIR::InstId inst_id,
@@ -180,55 +160,10 @@ auto HandleDeref(FunctionContext& context, SemIR::InstId inst_id,
   context.SetLocal(inst_id, context.GetValue(inst.pointer_id));
 }
 
-auto HandleFunctionDecl(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
-                        SemIR::FunctionDecl inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
-auto HandleImplDecl(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
-                    SemIR::ImplDecl inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
-auto HandleImportDecl(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
-                      SemIR::ImportDecl inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
-auto HandleImportRefUnloaded(FunctionContext& /*context*/,
-                             SemIR::InstId /*inst_id*/,
-                             SemIR::ImportRefUnloaded inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
-auto HandleImportRefLoaded(FunctionContext& /*context*/,
-                           SemIR::InstId /*inst_id*/,
-                           SemIR::ImportRefLoaded inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
 auto HandleInitializeFrom(FunctionContext& context, SemIR::InstId /*inst_id*/,
                           SemIR::InitializeFrom inst) -> void {
   auto storage_type_id = context.sem_ir().insts().Get(inst.dest_id).type_id();
   context.FinishInit(storage_type_id, inst.dest_id, inst.src_id);
-}
-
-auto HandleInterfaceDecl(FunctionContext& /*context*/,
-                         SemIR::InstId /*inst_id*/, SemIR::InterfaceDecl inst)
-    -> void {
-  FatalErrorIfEncountered(inst);
-}
-
-auto HandleInterfaceWitness(FunctionContext& /*context*/,
-                            SemIR::InstId /*inst_id*/,
-                            SemIR::InterfaceWitness inst) -> void {
-  FatalErrorIfEncountered(inst);
-}
-
-auto HandleInterfaceWitnessAccess(FunctionContext& /*context*/,
-                                  SemIR::InstId /*inst_id*/,
-                                  SemIR::InterfaceWitnessAccess inst) -> void {
-  FatalErrorIfEncountered(inst);
 }
 
 auto HandleNameRef(FunctionContext& context, SemIR::InstId inst_id,

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -52,6 +52,7 @@ cc_library(
     ],
     textual_hdrs = ["inst_kind.def"],
     deps = [
+        "//common:check",
         "//common:enum_base",
         "//toolchain/parse:node_kind",
         "//toolchain/sem_ir:builtin_inst_kind",

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -46,8 +46,8 @@ namespace Carbon::SemIR {
 
 // An adapted type declaration in a class, of the form `adapt T;`.
 struct AdaptDecl {
-  static constexpr auto Kind =
-      InstKind::AdaptDecl.Define<Parse::AdaptDeclId>("adapt_decl");
+  static constexpr auto Kind = InstKind::AdaptDecl.Define<Parse::AdaptDeclId>(
+      "adapt_decl", /*is_lowered=*/false);
 
   // No type_id; this is not a value.
   TypeId adapted_type_id;
@@ -181,7 +181,7 @@ struct Assign {
 struct AssociatedConstantDecl {
   static constexpr auto Kind =
       InstKind::AssociatedConstantDecl.Define<Parse::NodeId>(
-          "assoc_const_decl");
+          "assoc_const_decl", /*is_lowered=*/false);
 
   TypeId type_id;
   NameId name_id;
@@ -532,7 +532,8 @@ struct FloatType {
 // A function declaration.
 struct FunctionDecl {
   static constexpr auto Kind =
-      InstKind::FunctionDecl.Define<Parse::AnyFunctionDeclId>("fn_decl");
+      InstKind::FunctionDecl.Define<Parse::AnyFunctionDeclId>(
+          "fn_decl", /*is_lowered=*/false);
 
   TypeId type_id;
   FunctionId function_id;
@@ -576,8 +577,8 @@ struct GenericInterfaceType {
 
 // An `impl` declaration.
 struct ImplDecl {
-  static constexpr auto Kind =
-      InstKind::ImplDecl.Define<Parse::AnyImplDeclId>("impl_decl");
+  static constexpr auto Kind = InstKind::ImplDecl.Define<Parse::AnyImplDeclId>(
+      "impl_decl", /*is_lowered=*/false);
 
   // No type: an impl declaration is not a value.
   ImplId impl_id;
@@ -589,8 +590,8 @@ struct ImplDecl {
 // An `import` declaration. This is mainly for `import` diagnostics, and a 1:1
 // correspondence with actual `import`s isn't guaranteed.
 struct ImportDecl {
-  static constexpr auto Kind =
-      InstKind::ImportDecl.Define<Parse::ImportDeclId>("import");
+  static constexpr auto Kind = InstKind::ImportDecl.Define<Parse::ImportDeclId>(
+      "import", /*is_lowered=*/false);
 
   NameId package_id;
 };
@@ -611,7 +612,8 @@ struct AnyImportRef {
 struct ImportRefUnloaded {
   // No parse node: any parse node logic must use the referenced IR.
   static constexpr auto Kind =
-      InstKind::ImportRefUnloaded.Define<Parse::InvalidNodeId>("import_ref");
+      InstKind::ImportRefUnloaded.Define<Parse::InvalidNodeId>(
+          "import_ref", /*is_lowered=*/false);
 
   ImportIRInstId import_ir_inst_id;
   BindNameId bind_name_id;
@@ -621,7 +623,8 @@ struct ImportRefUnloaded {
 struct ImportRefLoaded {
   // No parse node: any parse node logic must use the referenced IR.
   static constexpr auto Kind =
-      InstKind::ImportRefLoaded.Define<Parse::InvalidNodeId>("import_ref");
+      InstKind::ImportRefLoaded.Define<Parse::InvalidNodeId>(
+          "import_ref", /*is_lowered=*/false);
 
   TypeId type_id;
   ImportIRInstId import_ir_inst_id;
@@ -645,7 +648,7 @@ struct InitializeFrom {
 struct InterfaceDecl {
   static constexpr auto Kind =
       InstKind::InterfaceDecl.Define<Parse::AnyInterfaceDeclId>(
-          "interface_decl");
+          "interface_decl", /*is_lowered=*/false);
 
   TypeId type_id;
   // TODO: For a generic interface declaration, the name of the interface
@@ -671,7 +674,7 @@ struct InterfaceType {
 struct InterfaceWitness {
   static constexpr auto Kind =
       InstKind::InterfaceWitness.Define<Parse::InvalidNodeId>(
-          "interface_witness");
+          "interface_witness", /*is_lowered=*/false);
 
   TypeId type_id;
   InstBlockId elements_id;
@@ -681,7 +684,7 @@ struct InterfaceWitness {
 struct InterfaceWitnessAccess {
   static constexpr auto Kind =
       InstKind::InterfaceWitnessAccess.Define<Parse::InvalidNodeId>(
-          "interface_witness_access");
+          "interface_witness_access", /*is_lowered=*/false);
 
   TypeId type_id;
   InstId witness_id;


### PR DESCRIPTION
This is to remove all the FatalIfEncountered handlers in handle.cpp. They just feel like noise when reading the file. Plus it's one less bit of boilerplate to add for instructions that don't lower.

Note that I left HandleParam/HandleAddrPattern. I'd be happy to change those to just set lowered=false too, but was hesitant to given the separate logic.

Also, I'm separately considering migrating the macro logic into similar constexpr things. If I do, I might switch Define to take in a struct. But for how this particular parameter works, the overload felt reasonable, particularly since is_lowered is not used in combination with TerminatorKind.