### PR TITLE
Rename check handlers to HandleParseNode overloads.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -864,7 +864,7 @@ static auto ProcessNodeIds(Context& context, llvm::raw_ostream* vlog_stream,
     switch (parse_kind) {
 #define CARBON_PARSE_NODE_KIND(Name)                                         \
   case Parse::NodeKind::Name: {                                              \
-    if (!Check::Handle##Name(context, Parse::Name##Id(node_id))) {           \
+    if (!HandleParseNode(context, Parse::Name##Id(node_id))) {               \
       CARBON_CHECK(err_tracker.seen_error())                                 \
           << "Handle" #Name " returned false without printing a diagnostic"; \
       return false;                                                          \

--- a/toolchain/check/handle.h
+++ b/toolchain/check/handle.h
@@ -13,7 +13,7 @@ namespace Carbon::Check {
 
 // Parse node handlers. Returns false for unrecoverable errors.
 #define CARBON_PARSE_NODE_KIND(Name) \
-  auto Handle##Name(Context& context, Parse::Name##Id node_id) -> bool;
+  auto HandleParseNode(Context& context, Parse::Name##Id node_id) -> bool;
 #include "toolchain/parse/node_kind.def"
 
 // Handle suspending the definition of a function. This is used for inline

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -12,19 +12,19 @@
 
 namespace Carbon::Check {
 
-auto HandleAliasIntroducer(Context& context,
-                           Parse::AliasIntroducerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::AliasIntroducerId /*node_id*/)
+    -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Alias>();
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }
 
-auto HandleAliasInitializer(Context& /*context*/,
-                            Parse::AliasInitializerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/,
+                     Parse::AliasInitializerId /*node_id*/) -> bool {
   return true;
 }
 
-auto HandleAlias(Context& context, Parse::AliasId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::AliasId /*node_id*/) -> bool {
   auto [expr_node, expr_id] = context.node_stack().PopExprWithNodeId();
 
   auto name_context = context.decl_name_stack().FinishName(

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -9,18 +9,17 @@
 
 namespace Carbon::Check {
 
-auto HandleArrayExprStart(Context& /*context*/,
-                          Parse::ArrayExprStartId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/, Parse::ArrayExprStartId /*node_id*/)
+    -> bool {
   return true;
 }
 
-auto HandleArrayExprSemi(Context& context, Parse::ArrayExprSemiId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::ArrayExprSemiId node_id) -> bool {
   context.node_stack().Push(node_id);
   return true;
 }
 
-auto HandleArrayExpr(Context& context, Parse::ArrayExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ArrayExprId node_id) -> bool {
   // TODO: Handle array type with undefined bound.
   if (context.node_stack()
           .PopAndDiscardSoloNodeIdIf<Parse::NodeKind::ArrayExprSemi>()) {

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -191,18 +191,17 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   return true;
 }
 
-auto HandleBindingPattern(Context& context, Parse::BindingPatternId node_id)
+auto HandleParseNode(Context& context, Parse::BindingPatternId node_id)
     -> bool {
   return HandleAnyBindingPattern(context, node_id, /*is_generic=*/false);
 }
 
-auto HandleCompileTimeBindingPattern(Context& context,
-                                     Parse::CompileTimeBindingPatternId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::CompileTimeBindingPatternId node_id) -> bool {
   return HandleAnyBindingPattern(context, node_id, /*is_generic=*/true);
 }
 
-auto HandleAddr(Context& context, Parse::AddrId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::AddrId node_id) -> bool {
   auto self_param_id = context.node_stack().PopPattern();
   if (auto self_param =
           context.insts().TryGetAs<SemIR::AnyBindName>(self_param_id);
@@ -222,7 +221,7 @@ auto HandleAddr(Context& context, Parse::AddrId node_id) -> bool {
   return true;
 }
 
-auto HandleTemplate(Context& context, Parse::TemplateId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::TemplateId node_id) -> bool {
   return context.TODO(node_id, "HandleTemplate");
 }
 

--- a/toolchain/check/handle_call_expr.cpp
+++ b/toolchain/check/handle_call_expr.cpp
@@ -9,21 +9,20 @@
 
 namespace Carbon::Check {
 
-auto HandleCallExprStart(Context& context, Parse::CallExprStartId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::CallExprStartId node_id) -> bool {
   auto name_id = context.node_stack().PopExpr();
   context.node_stack().Push(node_id, name_id);
   context.param_and_arg_refs_stack().Push();
   return true;
 }
 
-auto HandleCallExprComma(Context& context, Parse::CallExprCommaId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::CallExprCommaId /*node_id*/)
     -> bool {
   context.param_and_arg_refs_stack().ApplyComma();
   return true;
 }
 
-auto HandleCallExpr(Context& context, Parse::CallExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::CallExprId node_id) -> bool {
   // Process the final explicit call argument now, but leave the arguments
   // block on the stack until the end of this function.
   context.param_and_arg_refs_stack().EndNoPop(Parse::NodeKind::CallExprStart);

--- a/toolchain/check/handle_choice.cpp
+++ b/toolchain/check/handle_choice.cpp
@@ -7,24 +7,23 @@
 
 namespace Carbon::Check {
 
-auto HandleChoiceDefinition(Context& context, Parse::ChoiceDefinitionId node_id)
+auto HandleParseNode(Context& context, Parse::ChoiceDefinitionId node_id)
     -> bool {
   return context.TODO(node_id, "HandleChoiceDefinition");
 }
 
-auto HandleChoiceIntroducer(Context& context, Parse::ChoiceIntroducerId node_id)
+auto HandleParseNode(Context& context, Parse::ChoiceIntroducerId node_id)
     -> bool {
   return context.TODO(node_id, "HandleChoiceIntroducer");
 }
 
-auto HandleChoiceDefinitionStart(Context& context,
-                                 Parse::ChoiceDefinitionStartId node_id)
+auto HandleParseNode(Context& context, Parse::ChoiceDefinitionStartId node_id)
     -> bool {
   return context.TODO(node_id, "HandleChoiceDefinitionStart");
 }
 
-auto HandleChoiceAlternativeListComma(
-    Context& context, Parse::ChoiceAlternativeListCommaId node_id) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::ChoiceAlternativeListCommaId node_id) -> bool {
   return context.TODO(node_id, "HandleChoiceAlternativeListComma");
 }
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -29,7 +29,7 @@ static auto TryGetAsClass(Context& context, SemIR::TypeId type_id)
   return &context.classes().Get(class_type->class_id);
 }
 
-auto HandleClassIntroducer(Context& context, Parse::ClassIntroducerId node_id)
+auto HandleParseNode(Context& context, Parse::ClassIntroducerId node_id)
     -> bool {
   // Create an instruction block to hold the instructions created as part of the
   // class signature, such as generic parameters.
@@ -279,14 +279,14 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
   return {class_decl.class_id, class_decl_id};
 }
 
-auto HandleClassDecl(Context& context, Parse::ClassDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ClassDeclId node_id) -> bool {
   BuildClassDecl(context, node_id, /*is_definition=*/false);
   context.decl_name_stack().PopScope();
   return true;
 }
 
-auto HandleClassDefinitionStart(Context& context,
-                                Parse::ClassDefinitionStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ClassDefinitionStartId node_id)
+    -> bool {
   auto [class_id, class_decl_id] =
       BuildClassDecl(context, node_id, /*is_definition=*/true);
   auto& class_info = context.classes().Get(class_id);
@@ -366,13 +366,13 @@ static auto DiagnoseClassSpecificDeclRepeated(Context& context,
       .Emit();
 }
 
-auto HandleAdaptIntroducer(Context& context,
-                           Parse::AdaptIntroducerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::AdaptIntroducerId /*node_id*/)
+    -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Adapt>();
   return true;
 }
 
-auto HandleAdaptDecl(Context& context, Parse::AdaptDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::AdaptDeclId node_id) -> bool {
   auto [adapted_type_node, adapted_type_expr_id] =
       context.node_stack().PopExprWithNodeId();
 
@@ -433,13 +433,13 @@ auto HandleAdaptDecl(Context& context, Parse::AdaptDeclId node_id) -> bool {
   return true;
 }
 
-auto HandleBaseIntroducer(Context& context, Parse::BaseIntroducerId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::BaseIntroducerId /*node_id*/)
     -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Base>();
   return true;
 }
 
-auto HandleBaseColon(Context& /*context*/, Parse::BaseColonId /*node_id*/)
+auto HandleParseNode(Context& /*context*/, Parse::BaseColonId /*node_id*/)
     -> bool {
   return true;
 }
@@ -502,7 +502,7 @@ static auto CheckBaseType(Context& context, Parse::NodeId node_id,
   return {.type_id = base_type_id, .scope_id = base_class_info->scope_id};
 }
 
-auto HandleBaseDecl(Context& context, Parse::BaseDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::BaseDeclId node_id) -> bool {
   auto [base_type_node_id, base_type_expr_id] =
       context.node_stack().PopExprWithNodeId();
 
@@ -568,8 +568,8 @@ auto HandleBaseDecl(Context& context, Parse::BaseDeclId node_id) -> bool {
   return true;
 }
 
-auto HandleClassDefinition(Context& context,
-                           Parse::ClassDefinitionId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::ClassDefinitionId /*node_id*/)
+    -> bool {
   auto fields_id = context.args_type_info_stack().Pop();
   auto class_id =
       context.node_stack().Pop<Parse::NodeKind::ClassDefinitionStart>();

--- a/toolchain/check/handle_codeblock.cpp
+++ b/toolchain/check/handle_codeblock.cpp
@@ -7,14 +7,14 @@
 
 namespace Carbon::Check {
 
-auto HandleCodeBlockStart(Context& context, Parse::CodeBlockStartId node_id)
+auto HandleParseNode(Context& context, Parse::CodeBlockStartId node_id)
     -> bool {
   context.node_stack().Push(node_id);
   context.scope_stack().Push();
   return true;
 }
 
-auto HandleCodeBlock(Context& context, Parse::CodeBlockId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::CodeBlockId /*node_id*/) -> bool {
   context.scope_stack().Pop();
   context.node_stack()
       .PopAndDiscardSoloNodeId<Parse::NodeKind::CodeBlockStart>();

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -13,15 +13,15 @@
 
 namespace Carbon::Check {
 
-auto HandleExportIntroducer(Context& context,
-                            Parse::ExportIntroducerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::ExportIntroducerId /*node_id*/)
+    -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Export>();
   // TODO: Probably need to update DeclNameStack to restrict to only namespaces.
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }
 
-auto HandleExportDecl(Context& context, Parse::ExportDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ExportDeclId node_id) -> bool {
   auto name_context = context.decl_name_stack().FinishName(
       PopNameComponentWithoutParams(context, Lex::TokenKind::Export));
   context.decl_name_stack().PopScope();

--- a/toolchain/check/handle_expr_statement.cpp
+++ b/toolchain/check/handle_expr_statement.cpp
@@ -22,7 +22,7 @@ static auto HandleDiscardedExpr(Context& context, SemIR::InstId expr_id)
   // TODO: This will eventually need to do some "do not discard" analysis.
 }
 
-auto HandleExprStatement(Context& context, Parse::ExprStatementId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::ExprStatementId /*node_id*/)
     -> bool {
   HandleDiscardedExpr(context, context.node_stack().PopExpr());
   return true;

--- a/toolchain/check/handle_file.cpp
+++ b/toolchain/check/handle_file.cpp
@@ -7,7 +7,7 @@
 
 namespace Carbon::Check {
 
-auto HandleFileStart(Context& /*context*/, Parse::FileStartId /*node_id*/)
+auto HandleParseNode(Context& /*context*/, Parse::FileStartId /*node_id*/)
     -> bool {
   // No action to perform.
   // TODO: We may want to push `FileStart` as a sentinel so that `Peek`s can't
@@ -15,7 +15,8 @@ auto HandleFileStart(Context& /*context*/, Parse::FileStartId /*node_id*/)
   return true;
 }
 
-auto HandleFileEnd(Context& /*context*/, Parse::FileEndId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/, Parse::FileEndId /*node_id*/)
+    -> bool {
   // No action to perform.
   return true;
 }

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -22,8 +22,8 @@
 
 namespace Carbon::Check {
 
-auto HandleFunctionIntroducer(Context& context,
-                              Parse::FunctionIntroducerId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::FunctionIntroducerId node_id)
+    -> bool {
   // Create an instruction block to hold the instructions created as part of the
   // function signature, such as parameter and return types.
   context.inst_block_stack().Push();
@@ -37,7 +37,7 @@ auto HandleFunctionIntroducer(Context& context,
   return true;
 }
 
-auto HandleReturnType(Context& context, Parse::ReturnTypeId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ReturnTypeId node_id) -> bool {
   // Propagate the type expression.
   auto [type_node_id, type_inst_id] = context.node_stack().PopExprWithNodeId();
   auto type_id = ExprAsType(context, type_node_id, type_inst_id);
@@ -329,8 +329,7 @@ static auto BuildFunctionDecl(Context& context,
   return {function_decl.function_id, decl_id};
 }
 
-auto HandleFunctionDecl(Context& context, Parse::FunctionDeclId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::FunctionDeclId node_id) -> bool {
   BuildFunctionDecl(context, node_id, /*is_definition=*/false);
   context.decl_name_stack().PopScope();
   return true;
@@ -400,8 +399,7 @@ auto HandleFunctionDefinitionResume(Context& context,
       context, node_id, suspended_fn.function_id, suspended_fn.decl_id);
 }
 
-auto HandleFunctionDefinitionStart(Context& context,
-                                   Parse::FunctionDefinitionStartId node_id)
+auto HandleParseNode(Context& context, Parse::FunctionDefinitionStartId node_id)
     -> bool {
   // Process the declaration portion of the function.
   auto [function_id, decl_id] =
@@ -411,8 +409,8 @@ auto HandleFunctionDefinitionStart(Context& context,
   return true;
 }
 
-auto HandleFunctionDefinition(Context& context,
-                              Parse::FunctionDefinitionId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::FunctionDefinitionId node_id)
+    -> bool {
   SemIR::FunctionId function_id =
       context.node_stack().Pop<Parse::NodeKind::FunctionDefinitionStart>();
 
@@ -441,8 +439,8 @@ auto HandleFunctionDefinition(Context& context,
   return true;
 }
 
-auto HandleBuiltinFunctionDefinitionStart(
-    Context& context, Parse::BuiltinFunctionDefinitionStartId node_id) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::BuiltinFunctionDefinitionStartId node_id) -> bool {
   // Process the declaration portion of the function.
   auto [function_id, _] =
       BuildFunctionDecl(context, node_id, /*is_definition=*/true);
@@ -450,7 +448,7 @@ auto HandleBuiltinFunctionDefinitionStart(
   return true;
 }
 
-auto HandleBuiltinName(Context& context, Parse::BuiltinNameId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::BuiltinNameId node_id) -> bool {
   context.node_stack().Push(node_id);
   return true;
 }
@@ -502,8 +500,8 @@ static auto IsValidBuiltinDeclaration(Context& context,
                                   return_type_id);
 }
 
-auto HandleBuiltinFunctionDefinition(
-    Context& context, Parse::BuiltinFunctionDefinitionId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::BuiltinFunctionDefinitionId /*node_id*/) -> bool {
   auto name_id =
       context.node_stack().PopForSoloNodeId<Parse::NodeKind::BuiltinName>();
   auto [fn_node_id, function_id] =

--- a/toolchain/check/handle_if_expr.cpp
+++ b/toolchain/check/handle_if_expr.cpp
@@ -8,7 +8,7 @@
 
 namespace Carbon::Check {
 
-auto HandleIfExprIf(Context& context, Parse::IfExprIfId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IfExprIfId node_id) -> bool {
   // Alias node_id for if/then/else consistency.
   auto& if_node = node_id;
 
@@ -30,7 +30,7 @@ auto HandleIfExprIf(Context& context, Parse::IfExprIfId node_id) -> bool {
   return true;
 }
 
-auto HandleIfExprThen(Context& context, Parse::IfExprThenId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IfExprThenId node_id) -> bool {
   auto then_value_id = context.node_stack().PopExpr();
   auto else_block_id = context.node_stack().Peek<Parse::NodeKind::IfExprIf>();
 
@@ -45,7 +45,7 @@ auto HandleIfExprThen(Context& context, Parse::IfExprThenId node_id) -> bool {
   return true;
 }
 
-auto HandleIfExprElse(Context& context, Parse::IfExprElseId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IfExprElseId node_id) -> bool {
   // Alias node_id for if/then/else consistency.
   auto& else_node = node_id;
 

--- a/toolchain/check/handle_if_statement.cpp
+++ b/toolchain/check/handle_if_statement.cpp
@@ -8,12 +8,12 @@
 
 namespace Carbon::Check {
 
-auto HandleIfConditionStart(Context& /*context*/,
-                            Parse::IfConditionStartId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/,
+                     Parse::IfConditionStartId /*node_id*/) -> bool {
   return true;
 }
 
-auto HandleIfCondition(Context& context, Parse::IfConditionId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IfConditionId node_id) -> bool {
   // Convert the condition to `bool`.
   auto cond_value_id = context.node_stack().PopExpr();
   cond_value_id = ConvertToBoolValue(context, node_id, cond_value_id);
@@ -34,7 +34,7 @@ auto HandleIfCondition(Context& context, Parse::IfConditionId node_id) -> bool {
   return true;
 }
 
-auto HandleIfStatementElse(Context& context, Parse::IfStatementElseId node_id)
+auto HandleParseNode(Context& context, Parse::IfStatementElseId node_id)
     -> bool {
   auto else_block_id = context.node_stack().Pop<Parse::NodeKind::IfCondition>();
 
@@ -46,7 +46,7 @@ auto HandleIfStatementElse(Context& context, Parse::IfStatementElseId node_id)
   return true;
 }
 
-auto HandleIfStatement(Context& context, Parse::IfStatementId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IfStatementId node_id) -> bool {
   switch (auto kind = context.node_stack().PeekNodeKind()) {
     case Parse::NodeKind::IfCondition: {
       // Branch from then block to else block, and start emitting the else

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -14,7 +14,7 @@
 
 namespace Carbon::Check {
 
-auto HandleImplIntroducer(Context& context, Parse::ImplIntroducerId node_id)
+auto HandleParseNode(Context& context, Parse::ImplIntroducerId node_id)
     -> bool {
   // Create an instruction block to hold the instructions created for the type
   // and interface.
@@ -33,14 +33,14 @@ auto HandleImplIntroducer(Context& context, Parse::ImplIntroducerId node_id)
   return true;
 }
 
-auto HandleImplForall(Context& context, Parse::ImplForallId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ImplForallId node_id) -> bool {
   auto params_id =
       context.node_stack().Pop<Parse::NodeKind::ImplicitParamList>();
   context.node_stack().Push(node_id, params_id);
   return true;
 }
 
-auto HandleTypeImplAs(Context& context, Parse::TypeImplAsId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::TypeImplAsId node_id) -> bool {
   auto [self_node, self_id] = context.node_stack().PopExprWithNodeId();
   auto self_type_id = ExprAsType(context, self_node, self_id);
   context.node_stack().Push(node_id, self_type_id);
@@ -81,8 +81,8 @@ static auto GetDefaultSelfType(Context& context) -> SemIR::TypeId {
   return SemIR::TypeId::Invalid;
 }
 
-auto HandleDefaultSelfImplAs(Context& context,
-                             Parse::DefaultSelfImplAsId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::DefaultSelfImplAsId node_id)
+    -> bool {
   auto self_type_id = GetDefaultSelfType(context);
   if (!self_type_id.is_valid()) {
     CARBON_DIAGNOSTIC(ImplAsOutsideClass, Error,
@@ -229,14 +229,14 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
   return {impl_decl.impl_id, impl_decl_id};
 }
 
-auto HandleImplDecl(Context& context, Parse::ImplDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ImplDeclId node_id) -> bool {
   BuildImplDecl(context, node_id, /*is_definition=*/false);
   context.decl_name_stack().PopScope();
   return true;
 }
 
-auto HandleImplDefinitionStart(Context& context,
-                               Parse::ImplDefinitionStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ImplDefinitionStartId node_id)
+    -> bool {
   auto [impl_id, impl_decl_id] =
       BuildImplDecl(context, node_id, /*is_definition=*/true);
   auto& impl_info = context.impls().Get(impl_id);
@@ -277,7 +277,7 @@ auto HandleImplDefinitionStart(Context& context,
   return true;
 }
 
-auto HandleImplDefinition(Context& context, Parse::ImplDefinitionId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::ImplDefinitionId /*node_id*/)
     -> bool {
   auto impl_id =
       context.node_stack().Pop<Parse::NodeKind::ImplDefinitionStart>();

--- a/toolchain/check/handle_import_and_package.cpp
+++ b/toolchain/check/handle_import_and_package.cpp
@@ -12,13 +12,13 @@ namespace Carbon::Check {
 // `import` and `package` are structured by parsing. As a consequence, no
 // checking logic is needed here.
 
-auto HandleImportIntroducer(Context& context,
-                            Parse::ImportIntroducerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::ImportIntroducerId /*node_id*/)
+    -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Import>();
   return true;
 }
 
-auto HandleImportDecl(Context& context, Parse::ImportDeclId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::ImportDeclId /*node_id*/)
     -> bool {
   auto introducer =
       context.decl_introducer_state_stack().Pop<Lex::TokenKind::Import>();
@@ -26,13 +26,13 @@ auto HandleImportDecl(Context& context, Parse::ImportDeclId /*node_id*/)
   return true;
 }
 
-auto HandleLibraryIntroducer(Context& context,
-                             Parse::LibraryIntroducerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::LibraryIntroducerId /*node_id*/)
+    -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Library>();
   return true;
 }
 
-auto HandleLibraryDecl(Context& context, Parse::LibraryDeclId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::LibraryDeclId /*node_id*/)
     -> bool {
   auto introducer =
       context.decl_introducer_state_stack().Pop<Lex::TokenKind::Library>();
@@ -40,13 +40,13 @@ auto HandleLibraryDecl(Context& context, Parse::LibraryDeclId /*node_id*/)
   return true;
 }
 
-auto HandlePackageIntroducer(Context& context,
-                             Parse::PackageIntroducerId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::PackageIntroducerId /*node_id*/)
+    -> bool {
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Package>();
   return true;
 }
 
-auto HandlePackageDecl(Context& context, Parse::PackageDeclId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::PackageDeclId /*node_id*/)
     -> bool {
   auto introducer =
       context.decl_introducer_state_stack().Pop<Lex::TokenKind::Package>();
@@ -54,23 +54,23 @@ auto HandlePackageDecl(Context& context, Parse::PackageDeclId /*node_id*/)
   return true;
 }
 
-auto HandleLibrarySpecifier(Context& /*context*/,
-                            Parse::LibrarySpecifierId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/,
+                     Parse::LibrarySpecifierId /*node_id*/) -> bool {
   return true;
 }
 
-auto HandlePackageName(Context& /*context*/, Parse::PackageNameId /*node_id*/)
+auto HandleParseNode(Context& /*context*/, Parse::PackageNameId /*node_id*/)
     -> bool {
   return true;
 }
 
-auto HandleLibraryName(Context& /*context*/, Parse::LibraryNameId /*node_id*/)
+auto HandleParseNode(Context& /*context*/, Parse::LibraryNameId /*node_id*/)
     -> bool {
   return true;
 }
 
-auto HandleDefaultLibrary(Context& /*context*/,
-                          Parse::DefaultLibraryId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/, Parse::DefaultLibraryId /*node_id*/)
+    -> bool {
   return true;
 }
 

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -10,8 +10,8 @@
 
 namespace Carbon::Check {
 
-auto HandleIndexExprStart(Context& /*context*/,
-                          Parse::IndexExprStartId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/, Parse::IndexExprStartId /*node_id*/)
+    -> bool {
   // Leave the expression on the stack for IndexExpr.
   return true;
 }
@@ -36,7 +36,7 @@ static auto ValidateTupleIndex(Context& context, Parse::NodeId node_id,
   return &index_val;
 }
 
-auto HandleIndexExpr(Context& context, Parse::IndexExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IndexExprId node_id) -> bool {
   auto index_inst_id = context.node_stack().PopExpr();
   auto operand_inst_id = context.node_stack().PopExpr();
   operand_inst_id = ConvertToValueOrRefExpr(context, operand_inst_id);

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -13,8 +13,8 @@
 
 namespace Carbon::Check {
 
-auto HandleInterfaceIntroducer(Context& context,
-                               Parse::InterfaceIntroducerId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InterfaceIntroducerId node_id)
+    -> bool {
   // Create an instruction block to hold the instructions created as part of the
   // interface signature, such as generic parameters.
   context.inst_block_stack().Push();
@@ -110,16 +110,14 @@ static auto BuildInterfaceDecl(Context& context,
   return {interface_decl.interface_id, interface_decl_id};
 }
 
-auto HandleInterfaceDecl(Context& context, Parse::InterfaceDeclId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::InterfaceDeclId node_id) -> bool {
   BuildInterfaceDecl(context, node_id);
   context.decl_name_stack().PopScope();
   return true;
 }
 
-auto HandleInterfaceDefinitionStart(Context& context,
-                                    Parse::InterfaceDefinitionStartId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InterfaceDefinitionStartId node_id) -> bool {
   auto [interface_id, interface_decl_id] = BuildInterfaceDecl(context, node_id);
   auto& interface_info = context.interfaces().Get(interface_id);
 
@@ -195,8 +193,7 @@ auto HandleInterfaceDefinitionStart(Context& context,
   return true;
 }
 
-auto HandleInterfaceDefinition(Context& context,
-                               Parse::InterfaceDefinitionId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::InterfaceDefinitionId /*node_id*/)
     -> bool {
   auto interface_id =
       context.node_stack().Pop<Parse::NodeKind::InterfaceDefinitionStart>();

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -24,17 +24,16 @@ static auto HandleIntroducer(Context& context, Parse::NodeId node_id) -> bool {
   return true;
 }
 
-auto HandleLetIntroducer(Context& context, Parse::LetIntroducerId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::LetIntroducerId node_id) -> bool {
   return HandleIntroducer<Lex::TokenKind::Let>(context, node_id);
 }
 
-auto HandleVariableIntroducer(Context& context,
-                              Parse::VariableIntroducerId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::VariableIntroducerId node_id)
+    -> bool {
   return HandleIntroducer<Lex::TokenKind::Var>(context, node_id);
 }
 
-auto HandleReturnedModifier(Context& context, Parse::ReturnedModifierId node_id)
+auto HandleParseNode(Context& context, Parse::ReturnedModifierId node_id)
     -> bool {
   // This is pushed to be seen by HandleBindingPattern.
   context.node_stack().Push(node_id);
@@ -49,13 +48,13 @@ static auto HandleInitializer(Context& context, Parse::NodeId node_id) -> bool {
   return true;
 }
 
-auto HandleLetInitializer(Context& context, Parse::LetInitializerId node_id)
+auto HandleParseNode(Context& context, Parse::LetInitializerId node_id)
     -> bool {
   return HandleInitializer(context, node_id);
 }
 
-auto HandleVariableInitializer(Context& context,
-                               Parse::VariableInitializerId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::VariableInitializerId node_id)
+    -> bool {
   return HandleInitializer(context, node_id);
 }
 
@@ -187,7 +186,7 @@ static auto HandleDecl(Context& context, NodeT node_id)
   return decl_info;
 }
 
-auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::LetDeclId node_id) -> bool {
   auto decl_info =
       HandleDecl<Lex::TokenKind::Let, Parse::NodeKind::LetIntroducer,
                  Parse::NodeKind::LetInitializer>(context, node_id);
@@ -256,8 +255,7 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   return true;
 }
 
-auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::VariableDeclId node_id) -> bool {
   auto decl_info =
       HandleDecl<Lex::TokenKind::Var, Parse::NodeKind::VariableIntroducer,
                  Parse::NodeKind::VariableInitializer>(context, node_id);

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -9,7 +9,7 @@
 
 namespace Carbon::Check {
 
-auto HandleBoolLiteralFalse(Context& context, Parse::BoolLiteralFalseId node_id)
+auto HandleParseNode(Context& context, Parse::BoolLiteralFalseId node_id)
     -> bool {
   context.AddInstAndPush<SemIR::BoolLiteral>(
       node_id, {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::BoolType),
@@ -17,7 +17,7 @@ auto HandleBoolLiteralFalse(Context& context, Parse::BoolLiteralFalseId node_id)
   return true;
 }
 
-auto HandleBoolLiteralTrue(Context& context, Parse::BoolLiteralTrueId node_id)
+auto HandleParseNode(Context& context, Parse::BoolLiteralTrueId node_id)
     -> bool {
   context.AddInstAndPush<SemIR::BoolLiteral>(
       node_id, {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::BoolType),
@@ -45,7 +45,7 @@ static auto MakeI32Literal(Context& context, Parse::NodeId node_id,
                 .int_id = context.ints().Add(i32_val)});
 }
 
-auto HandleIntLiteral(Context& context, Parse::IntLiteralId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IntLiteralId node_id) -> bool {
   // Convert the literal to i32.
   // TODO: Form an integer literal value and a corresponding type here instead.
   auto int_literal_id = MakeI32Literal(
@@ -55,7 +55,7 @@ auto HandleIntLiteral(Context& context, Parse::IntLiteralId node_id) -> bool {
   return true;
 }
 
-auto HandleRealLiteral(Context& context, Parse::RealLiteralId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::RealLiteralId node_id) -> bool {
   // Convert the real literal to an llvm::APFloat and add it to the floats
   // ValueStore. In the future this would use an arbitrary precision Rational
   // type.
@@ -99,8 +99,7 @@ auto HandleRealLiteral(Context& context, Parse::RealLiteralId node_id) -> bool {
   return true;
 }
 
-auto HandleStringLiteral(Context& context, Parse::StringLiteralId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::StringLiteralId node_id) -> bool {
   context.AddInstAndPush<SemIR::StringLiteral>(
       node_id,
       {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::StringType),
@@ -109,7 +108,7 @@ auto HandleStringLiteral(Context& context, Parse::StringLiteralId node_id)
   return true;
 }
 
-auto HandleBoolTypeLiteral(Context& context, Parse::BoolTypeLiteralId node_id)
+auto HandleParseNode(Context& context, Parse::BoolTypeLiteralId node_id)
     -> bool {
   auto fn_inst_id = context.LookupNameInCore(node_id, "Bool");
   auto type_inst_id = PerformCall(context, node_id, fn_inst_id, {});
@@ -139,7 +138,7 @@ static auto HandleIntOrUnsignedIntTypeLiteral(Context& context,
   return true;
 }
 
-auto HandleIntTypeLiteral(Context& context, Parse::IntTypeLiteralId node_id)
+auto HandleParseNode(Context& context, Parse::IntTypeLiteralId node_id)
     -> bool {
   auto tok_id = context.parse_tree().node_token(node_id);
   auto size_id = context.tokens().GetTypeLiteralSize(tok_id);
@@ -155,8 +154,7 @@ auto HandleIntTypeLiteral(Context& context, Parse::IntTypeLiteralId node_id)
                                            SemIR::IntKind::Signed, size_id);
 }
 
-auto HandleUnsignedIntTypeLiteral(Context& context,
-                                  Parse::UnsignedIntTypeLiteralId node_id)
+auto HandleParseNode(Context& context, Parse::UnsignedIntTypeLiteralId node_id)
     -> bool {
   auto tok_id = context.parse_tree().node_token(node_id);
   auto size_id = context.tokens().GetTypeLiteralSize(tok_id);
@@ -164,7 +162,7 @@ auto HandleUnsignedIntTypeLiteral(Context& context,
                                            SemIR::IntKind::Unsigned, size_id);
 }
 
-auto HandleFloatTypeLiteral(Context& context, Parse::FloatTypeLiteralId node_id)
+auto HandleParseNode(Context& context, Parse::FloatTypeLiteralId node_id)
     -> bool {
   auto text =
       context.tokens().GetTokenText(context.parse_tree().node_token(node_id));
@@ -180,19 +178,19 @@ auto HandleFloatTypeLiteral(Context& context, Parse::FloatTypeLiteralId node_id)
   return true;
 }
 
-auto HandleStringTypeLiteral(Context& context,
-                             Parse::StringTypeLiteralId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::StringTypeLiteralId node_id)
+    -> bool {
   context.node_stack().Push(node_id, SemIR::InstId::BuiltinStringType);
   return true;
 }
 
-auto HandleTypeTypeLiteral(Context& context, Parse::TypeTypeLiteralId node_id)
+auto HandleParseNode(Context& context, Parse::TypeTypeLiteralId node_id)
     -> bool {
   context.node_stack().Push(node_id, SemIR::InstId::BuiltinTypeType);
   return true;
 }
 
-auto HandleAutoTypeLiteral(Context& context, Parse::AutoTypeLiteralId node_id)
+auto HandleParseNode(Context& context, Parse::AutoTypeLiteralId node_id)
     -> bool {
   return context.TODO(node_id, "HandleAutoTypeLiteral");
 }

--- a/toolchain/check/handle_loop_statement.cpp
+++ b/toolchain/check/handle_loop_statement.cpp
@@ -11,8 +11,8 @@ namespace Carbon::Check {
 // `while`
 // -------
 
-auto HandleWhileConditionStart(Context& context,
-                               Parse::WhileConditionStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::WhileConditionStartId node_id)
+    -> bool {
   // Branch to the loop header block. Note that we create a new block here even
   // if the current block is empty; this ensures that the loop always has a
   // preheader block.
@@ -27,7 +27,7 @@ auto HandleWhileConditionStart(Context& context,
   return true;
 }
 
-auto HandleWhileCondition(Context& context, Parse::WhileConditionId node_id)
+auto HandleParseNode(Context& context, Parse::WhileConditionId node_id)
     -> bool {
   auto cond_value_id = context.node_stack().PopExpr();
   auto loop_header_id =
@@ -50,7 +50,7 @@ auto HandleWhileCondition(Context& context, Parse::WhileConditionId node_id)
   return true;
 }
 
-auto HandleWhileStatement(Context& context, Parse::WhileStatementId node_id)
+auto HandleParseNode(Context& context, Parse::WhileStatementId node_id)
     -> bool {
   auto loop_exit_id =
       context.node_stack().Pop<Parse::NodeKind::WhileCondition>();
@@ -71,30 +71,29 @@ auto HandleWhileStatement(Context& context, Parse::WhileStatementId node_id)
 // `for`
 // -----
 
-auto HandleForHeaderStart(Context& context, Parse::ForHeaderStartId node_id)
+auto HandleParseNode(Context& context, Parse::ForHeaderStartId node_id)
     -> bool {
   return context.TODO(node_id, "HandleForHeaderStart");
 }
 
-auto HandleForIn(Context& context, Parse::ForInId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ForInId node_id) -> bool {
   context.decl_introducer_state_stack().Pop<Lex::TokenKind::Var>();
   return context.TODO(node_id, "HandleForIn");
 }
 
-auto HandleForHeader(Context& context, Parse::ForHeaderId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ForHeaderId node_id) -> bool {
   return context.TODO(node_id, "HandleForHeader");
 }
 
-auto HandleForStatement(Context& context, Parse::ForStatementId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::ForStatementId node_id) -> bool {
   return context.TODO(node_id, "HandleForStatement");
 }
 
 // `break`
 // -------
 
-auto HandleBreakStatementStart(Context& context,
-                               Parse::BreakStatementStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::BreakStatementStartId node_id)
+    -> bool {
   auto& stack = context.break_continue_stack();
   if (stack.empty()) {
     CARBON_DIAGNOSTIC(BreakOutsideLoop, Error,
@@ -110,16 +109,15 @@ auto HandleBreakStatementStart(Context& context,
   return true;
 }
 
-auto HandleBreakStatement(Context& /*context*/,
-                          Parse::BreakStatementId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/, Parse::BreakStatementId /*node_id*/)
+    -> bool {
   return true;
 }
 
 // `continue`
 // ----------
 
-auto HandleContinueStatementStart(Context& context,
-                                  Parse::ContinueStatementStartId node_id)
+auto HandleParseNode(Context& context, Parse::ContinueStatementStartId node_id)
     -> bool {
   auto& stack = context.break_continue_stack();
   if (stack.empty()) {
@@ -136,8 +134,8 @@ auto HandleContinueStatementStart(Context& context,
   return true;
 }
 
-auto HandleContinueStatement(Context& /*context*/,
-                             Parse::ContinueStatementId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/,
+                     Parse::ContinueStatementId /*node_id*/) -> bool {
   return true;
 }
 

--- a/toolchain/check/handle_match.cpp
+++ b/toolchain/check/handle_match.cpp
@@ -8,85 +8,80 @@
 
 namespace Carbon::Check {
 
-auto HandleMatchConditionStart(Context& context,
-                               Parse::MatchConditionStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::MatchConditionStartId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleMatchConditionStart");
 }
 
-auto HandleMatchCondition(Context& context, Parse::MatchConditionId node_id)
+auto HandleParseNode(Context& context, Parse::MatchConditionId node_id)
     -> bool {
   return context.TODO(node_id, "HandleMatchCondition");
 }
 
-auto HandleMatchIntroducer(Context& context, Parse::MatchIntroducerId node_id)
+auto HandleParseNode(Context& context, Parse::MatchIntroducerId node_id)
     -> bool {
   return context.TODO(node_id, "HandleMatchIntroducer");
 }
 
-auto HandleMatchStatementStart(Context& context,
-                               Parse::MatchStatementStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::MatchStatementStartId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleMatchStatementStart");
 }
 
-auto HandleMatchCaseIntroducer(Context& context,
-                               Parse::MatchCaseIntroducerId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::MatchCaseIntroducerId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleMatchCaseIntroducer");
 }
 
-auto HandleMatchCaseGuardIntroducer(Context& context,
-                                    Parse::MatchCaseGuardIntroducerId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::MatchCaseGuardIntroducerId node_id) -> bool {
   return context.TODO(node_id, "HandleMatchCaseGuardIntroducer");
 }
 
-auto HandleMatchCaseGuardStart(Context& context,
-                               Parse::MatchCaseGuardStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::MatchCaseGuardStartId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleMatchCaseGuardStart");
 }
 
-auto HandleMatchCaseGuard(Context& context, Parse::MatchCaseGuardId node_id)
+auto HandleParseNode(Context& context, Parse::MatchCaseGuardId node_id)
     -> bool {
   return context.TODO(node_id, "HandleMatchCaseGuard");
 }
 
-auto HandleMatchCaseEqualGreater(Context& context,
-                                 Parse::MatchCaseEqualGreaterId node_id)
+auto HandleParseNode(Context& context, Parse::MatchCaseEqualGreaterId node_id)
     -> bool {
   return context.TODO(node_id, "HandleMatchCaseEqualGreater");
 }
 
-auto HandleMatchCaseStart(Context& context, Parse::MatchCaseStartId node_id)
+auto HandleParseNode(Context& context, Parse::MatchCaseStartId node_id)
     -> bool {
   return context.TODO(node_id, "HandleMatchCaseStart");
 }
 
-auto HandleMatchCase(Context& context, Parse::MatchCaseId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::MatchCaseId node_id) -> bool {
   return context.TODO(node_id, "HandleMatchCase");
 }
 
-auto HandleMatchDefaultIntroducer(Context& context,
-                                  Parse::MatchDefaultIntroducerId node_id)
+auto HandleParseNode(Context& context, Parse::MatchDefaultIntroducerId node_id)
     -> bool {
   return context.TODO(node_id, "MatchDefaultIntroducer");
 }
 
-auto HandleMatchDefaultEqualGreater(Context& context,
-                                    Parse::MatchDefaultEqualGreaterId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::MatchDefaultEqualGreaterId node_id) -> bool {
   return context.TODO(node_id, "MatchDefaultEqualGreater");
 }
 
-auto HandleMatchDefaultStart(Context& context,
-                             Parse::MatchDefaultStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::MatchDefaultStartId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleMatchDefaultStart");
 }
 
-auto HandleMatchDefault(Context& context, Parse::MatchDefaultId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::MatchDefaultId node_id) -> bool {
   return context.TODO(node_id, "HandleMatchDefault");
 }
 
-auto HandleMatchStatement(Context& context, Parse::MatchStatementId node_id)
+auto HandleParseNode(Context& context, Parse::MatchStatementId node_id)
     -> bool {
   return context.TODO(node_id, "HandleMatchStatement");
 }

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -87,10 +87,10 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
 }
 
 #define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...)                 \
-  auto Handle##Name##Modifier(Context& context,                          \
-                              Parse::Name##ModifierId node_id) -> bool { \
-    return HandleModifier(context, node_id, KeywordModifierSet::Name);   \
+#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...)                  \
+  auto HandleParseNode(Context& context, Parse::Name##ModifierId node_id) \
+      -> bool {                                                           \
+    return HandleModifier(context, node_id, KeywordModifierSet::Name);    \
   }
 #include "toolchain/parse/node_kind.def"
 

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -14,7 +14,7 @@
 
 namespace Carbon::Check {
 
-auto HandleMemberAccessExpr(Context& context, Parse::MemberAccessExprId node_id)
+auto HandleParseNode(Context& context, Parse::MemberAccessExprId node_id)
     -> bool {
   if (context.node_stack().PeekIs<Parse::NodeKind::ParenExpr>()) {
     auto member_expr_id = context.node_stack().PopExpr();
@@ -31,8 +31,7 @@ auto HandleMemberAccessExpr(Context& context, Parse::MemberAccessExprId node_id)
   return true;
 }
 
-auto HandlePointerMemberAccessExpr(Context& context,
-                                   Parse::PointerMemberAccessExprId node_id)
+auto HandleParseNode(Context& context, Parse::PointerMemberAccessExprId node_id)
     -> bool {
   auto diagnose_not_pointer = [&context,
                                &node_id](SemIR::TypeId not_pointer_type_id) {
@@ -92,7 +91,7 @@ static auto HandleNameAsExpr(Context& context, Parse::NodeId node_id,
   return true;
 }
 
-auto HandleIdentifierName(Context& context, Parse::IdentifierNameId node_id)
+auto HandleParseNode(Context& context, Parse::IdentifierNameId node_id)
     -> bool {
   // The parent is responsible for binding the name.
   auto name_id = GetIdentifierAsName(context, node_id);
@@ -103,8 +102,8 @@ auto HandleIdentifierName(Context& context, Parse::IdentifierNameId node_id)
   return true;
 }
 
-auto HandleIdentifierNameExpr(Context& context,
-                              Parse::IdentifierNameExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::IdentifierNameExprId node_id)
+    -> bool {
   auto name_id = GetIdentifierAsName(context, node_id);
   if (!name_id) {
     return context.TODO(node_id, "Error recovery from keyword name.");
@@ -112,34 +111,33 @@ auto HandleIdentifierNameExpr(Context& context,
   return HandleNameAsExpr(context, node_id, *name_id);
 }
 
-auto HandleBaseName(Context& context, Parse::BaseNameId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::BaseNameId node_id) -> bool {
   context.node_stack().Push(node_id, SemIR::NameId::Base);
   return true;
 }
 
-auto HandleSelfTypeNameExpr(Context& context, Parse::SelfTypeNameExprId node_id)
+auto HandleParseNode(Context& context, Parse::SelfTypeNameExprId node_id)
     -> bool {
   return HandleNameAsExpr(context, node_id, SemIR::NameId::SelfType);
 }
 
-auto HandleSelfValueName(Context& context, Parse::SelfValueNameId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::SelfValueNameId node_id) -> bool {
   context.node_stack().Push(node_id, SemIR::NameId::SelfValue);
   return true;
 }
 
-auto HandleSelfValueNameExpr(Context& context,
-                             Parse::SelfValueNameExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::SelfValueNameExprId node_id)
+    -> bool {
   return HandleNameAsExpr(context, node_id, SemIR::NameId::SelfValue);
 }
 
-auto HandleNameQualifier(Context& context, Parse::NameQualifierId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::NameQualifierId /*node_id*/)
     -> bool {
   context.decl_name_stack().ApplyNameQualifier(PopNameComponent(context));
   return true;
 }
 
-auto HandlePackageExpr(Context& context, Parse::PackageExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PackageExprId node_id) -> bool {
   context.AddInstAndPush<SemIR::NameRef>(
       node_id,
       {.type_id = context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),

--- a/toolchain/check/handle_named_constraint.cpp
+++ b/toolchain/check/handle_named_constraint.cpp
@@ -7,26 +7,24 @@
 
 namespace Carbon::Check {
 
-auto HandleNamedConstraintDecl(Context& context,
-                               Parse::NamedConstraintDeclId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::NamedConstraintDeclId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleNamedConstraintDecl");
 }
 
-auto HandleNamedConstraintDefinition(Context& context,
-                                     Parse::NamedConstraintDefinitionId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::NamedConstraintDefinitionId node_id) -> bool {
   // Note that the decl_name_stack will be popped by `ProcessNodeIds`.
   return context.TODO(node_id, "HandleNamedConstraintDefinition");
 }
 
-auto HandleNamedConstraintDefinitionStart(
-    Context& context, Parse::NamedConstraintDefinitionStartId node_id) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::NamedConstraintDefinitionStartId node_id) -> bool {
   return context.TODO(node_id, "HandleNamedConstraintDefinitionStart");
 }
 
-auto HandleNamedConstraintIntroducer(Context& context,
-                                     Parse::NamedConstraintIntroducerId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::NamedConstraintIntroducerId node_id) -> bool {
   return context.TODO(node_id, "HandleNamedConstraintIntroducer");
 }
 

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -13,7 +13,7 @@
 
 namespace Carbon::Check {
 
-auto HandleNamespaceStart(Context& context, Parse::NamespaceStartId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::NamespaceStartId /*node_id*/)
     -> bool {
   // Optional modifiers and the name follow.
   context.decl_introducer_state_stack().Push<Lex::TokenKind::Namespace>();
@@ -21,7 +21,7 @@ auto HandleNamespaceStart(Context& context, Parse::NamespaceStartId /*node_id*/)
   return true;
 }
 
-auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
   auto name_context = context.decl_name_stack().FinishName(
       PopNameComponentWithoutParams(context, Lex::TokenKind::Namespace));
 

--- a/toolchain/check/handle_noop.cpp
+++ b/toolchain/check/handle_noop.cpp
@@ -7,28 +7,27 @@
 
 namespace Carbon::Check {
 
-auto HandleEmptyDecl(Context& /*context*/, Parse::EmptyDeclId /*node_id*/)
+auto HandleParseNode(Context& /*context*/, Parse::EmptyDeclId /*node_id*/)
     -> bool {
   // Empty declarations have no actions associated.
   return true;
 }
 
-auto HandleInvalidParse(Context& context, Parse::InvalidParseId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::InvalidParseId node_id) -> bool {
   return context.TODO(node_id, "HandleInvalidParse");
 }
 
-auto HandleInvalidParseStart(Context& context,
-                             Parse::InvalidParseStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InvalidParseStartId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleInvalidParseStart");
 }
 
-auto HandleInvalidParseSubtree(Context& context,
-                               Parse::InvalidParseSubtreeId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InvalidParseSubtreeId node_id)
+    -> bool {
   return context.TODO(node_id, "HandleInvalidParseSubtree");
 }
 
-auto HandlePlaceholder(Context& /*context*/, Parse::PlaceholderId /*node_id*/)
+auto HandleParseNode(Context& /*context*/, Parse::PlaceholderId /*node_id*/)
     -> bool {
   CARBON_FATAL()
       << "Placeholder node should always be replaced before parse completes";

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -32,19 +32,18 @@ static auto HandleBinaryOperator(Context& context,
   return true;
 }
 
-auto HandleInfixOperatorAmp(Context& context, Parse::InfixOperatorAmpId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorAmpId node_id)
     -> bool {
   // TODO: Facet type intersection may need to be handled directly.
   return HandleBinaryOperator(context, node_id, {"BitAnd"});
 }
 
-auto HandleInfixOperatorAmpEqual(Context& context,
-                                 Parse::InfixOperatorAmpEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorAmpEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"BitAndAssign"});
 }
 
-auto HandleInfixOperatorAs(Context& context, Parse::InfixOperatorAsId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorAsId node_id)
     -> bool {
   auto [rhs_node, rhs_id] = context.node_stack().PopExprWithNodeId();
   auto [lhs_node, lhs_id] = context.node_stack().PopExprWithNodeId();
@@ -55,19 +54,18 @@ auto HandleInfixOperatorAs(Context& context, Parse::InfixOperatorAsId node_id)
   return true;
 }
 
-auto HandleInfixOperatorCaret(Context& context,
-                              Parse::InfixOperatorCaretId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorCaretId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"BitXor"});
 }
 
-auto HandleInfixOperatorCaretEqual(Context& context,
-                                   Parse::InfixOperatorCaretEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorCaretEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"BitXorAssign"});
 }
 
-auto HandleInfixOperatorEqual(Context& context,
-                              Parse::InfixOperatorEqualId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorEqualId node_id)
+    -> bool {
   // TODO: Switch to using assignment interface for most assignment. Some cases
   // may need to be handled directly.
   //
@@ -94,137 +92,126 @@ auto HandleInfixOperatorEqual(Context& context,
   return true;
 }
 
-auto HandleInfixOperatorEqualEqual(Context& context,
-                                   Parse::InfixOperatorEqualEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorEqualEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"Eq", "Equal"});
 }
 
-auto HandleInfixOperatorExclaimEqual(Context& context,
-                                     Parse::InfixOperatorExclaimEqualId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorExclaimEqualId node_id) -> bool {
   return HandleBinaryOperator(context, node_id, {"Eq", "NotEqual"});
 }
 
-auto HandleInfixOperatorGreater(Context& context,
-                                Parse::InfixOperatorGreaterId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorGreaterId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Ordered", "Greater"});
 }
 
-auto HandleInfixOperatorGreaterEqual(Context& context,
-                                     Parse::InfixOperatorGreaterEqualId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorGreaterEqualId node_id) -> bool {
   return HandleBinaryOperator(context, node_id,
                               {"Ordered", "GreaterOrEquivalent"});
 }
 
-auto HandleInfixOperatorGreaterGreater(
-    Context& context, Parse::InfixOperatorGreaterGreaterId node_id) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorGreaterGreaterId node_id) -> bool {
   return HandleBinaryOperator(context, node_id, {"RightShift"});
 }
 
-auto HandleInfixOperatorGreaterGreaterEqual(
-    Context& context, Parse::InfixOperatorGreaterGreaterEqualId node_id)
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorGreaterGreaterEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"RightShiftAssign"});
 }
 
-auto HandleInfixOperatorLess(Context& context,
-                             Parse::InfixOperatorLessId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorLessId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Ordered", "Less"});
 }
 
-auto HandleInfixOperatorLessEqual(Context& context,
-                                  Parse::InfixOperatorLessEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorLessEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id,
                               {"Ordered", "LessOrEquivalent"});
 }
 
-auto HandleInfixOperatorLessEqualGreater(
-    Context& context, Parse::InfixOperatorLessEqualGreaterId node_id) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorLessEqualGreaterId node_id) -> bool {
   return context.TODO(node_id, "remove <=> operator that is not in the design");
 }
 
-auto HandleInfixOperatorLessLess(Context& context,
-                                 Parse::InfixOperatorLessLessId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorLessLessId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"LeftShift"});
 }
 
-auto HandleInfixOperatorLessLessEqual(
-    Context& context, Parse::InfixOperatorLessLessEqualId node_id) -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorLessLessEqualId node_id) -> bool {
   return HandleBinaryOperator(context, node_id, {"LeftShiftAssign"});
 }
 
-auto HandleInfixOperatorMinus(Context& context,
-                              Parse::InfixOperatorMinusId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorMinusId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Sub"});
 }
 
-auto HandleInfixOperatorMinusEqual(Context& context,
-                                   Parse::InfixOperatorMinusEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorMinusEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"SubAssign"});
 }
 
-auto HandleInfixOperatorPercent(Context& context,
-                                Parse::InfixOperatorPercentId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorPercentId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Mod"});
 }
 
-auto HandleInfixOperatorPercentEqual(Context& context,
-                                     Parse::InfixOperatorPercentEqualId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::InfixOperatorPercentEqualId node_id) -> bool {
   return HandleBinaryOperator(context, node_id, {"ModAssign"});
 }
 
-auto HandleInfixOperatorPipe(Context& context,
-                             Parse::InfixOperatorPipeId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorPipeId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"BitOr"});
 }
 
-auto HandleInfixOperatorPipeEqual(Context& context,
-                                  Parse::InfixOperatorPipeEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorPipeEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"BitOrAssign"});
 }
 
-auto HandleInfixOperatorPlus(Context& context,
-                             Parse::InfixOperatorPlusId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorPlusId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Add"});
 }
 
-auto HandleInfixOperatorPlusEqual(Context& context,
-                                  Parse::InfixOperatorPlusEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorPlusEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"AddAssign"});
 }
 
-auto HandleInfixOperatorSlash(Context& context,
-                              Parse::InfixOperatorSlashId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorSlashId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Div"});
 }
 
-auto HandleInfixOperatorSlashEqual(Context& context,
-                                   Parse::InfixOperatorSlashEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorSlashEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"DivAssign"});
 }
 
-auto HandleInfixOperatorStar(Context& context,
-                             Parse::InfixOperatorStarId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::InfixOperatorStarId node_id)
+    -> bool {
   return HandleBinaryOperator(context, node_id, {"Mul"});
 }
 
-auto HandleInfixOperatorStarEqual(Context& context,
-                                  Parse::InfixOperatorStarEqualId node_id)
+auto HandleParseNode(Context& context, Parse::InfixOperatorStarEqualId node_id)
     -> bool {
   return HandleBinaryOperator(context, node_id, {"MulAssign"});
 }
 
-auto HandlePostfixOperatorStar(Context& context,
-                               Parse::PostfixOperatorStarId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PostfixOperatorStarId node_id)
+    -> bool {
   auto value_id = context.node_stack().PopExpr();
   auto inner_type_id = ExprAsType(context, node_id, value_id);
   context.AddInstAndPush<SemIR::PointerType>(
@@ -233,8 +220,8 @@ auto HandlePostfixOperatorStar(Context& context,
   return true;
 }
 
-auto HandlePrefixOperatorAmp(Context& context,
-                             Parse::PrefixOperatorAmpId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PrefixOperatorAmpId node_id)
+    -> bool {
   auto value_id = context.node_stack().PopExpr();
   auto type_id = context.insts().Get(value_id).type_id();
   // Only durable reference expressions can have their address taken.
@@ -261,13 +248,13 @@ auto HandlePrefixOperatorAmp(Context& context,
   return true;
 }
 
-auto HandlePrefixOperatorCaret(Context& context,
-                               Parse::PrefixOperatorCaretId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PrefixOperatorCaretId node_id)
+    -> bool {
   return HandleUnaryOperator(context, node_id, {"BitComplement"});
 }
 
-auto HandlePrefixOperatorConst(Context& context,
-                               Parse::PrefixOperatorConstId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PrefixOperatorConstId node_id)
+    -> bool {
   auto value_id = context.node_stack().PopExpr();
 
   // `const (const T)` is probably not what the developer intended.
@@ -285,19 +272,18 @@ auto HandlePrefixOperatorConst(Context& context,
   return true;
 }
 
-auto HandlePrefixOperatorMinus(Context& context,
-                               Parse::PrefixOperatorMinusId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PrefixOperatorMinusId node_id)
+    -> bool {
   return HandleUnaryOperator(context, node_id, {"Negate"});
 }
 
-auto HandlePrefixOperatorMinusMinus(Context& context,
-                                    Parse::PrefixOperatorMinusMinusId node_id)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::PrefixOperatorMinusMinusId node_id) -> bool {
   return HandleUnaryOperator(context, node_id, {"Dec"});
 }
 
-auto HandlePrefixOperatorNot(Context& context,
-                             Parse::PrefixOperatorNotId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PrefixOperatorNotId node_id)
+    -> bool {
   auto value_id = context.node_stack().PopExpr();
   value_id = ConvertToBoolValue(context, node_id, value_id);
   context.AddInstAndPush<SemIR::UnaryOperatorNot>(
@@ -306,14 +292,13 @@ auto HandlePrefixOperatorNot(Context& context,
   return true;
 }
 
-auto HandlePrefixOperatorPlusPlus(Context& context,
-                                  Parse::PrefixOperatorPlusPlusId node_id)
+auto HandleParseNode(Context& context, Parse::PrefixOperatorPlusPlusId node_id)
     -> bool {
   return HandleUnaryOperator(context, node_id, {"Inc"});
 }
 
-auto HandlePrefixOperatorStar(Context& context,
-                              Parse::PrefixOperatorStarId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::PrefixOperatorStarId node_id)
+    -> bool {
   auto base_id = context.node_stack().PopExpr();
 
   auto deref_base_id = PerformPointerDereference(
@@ -383,14 +368,12 @@ static auto HandleShortCircuitOperand(Context& context, Parse::NodeId node_id,
   return true;
 }
 
-auto HandleShortCircuitOperandAnd(Context& context,
-                                  Parse::ShortCircuitOperandAndId node_id)
+auto HandleParseNode(Context& context, Parse::ShortCircuitOperandAndId node_id)
     -> bool {
   return HandleShortCircuitOperand(context, node_id, /*is_or=*/false);
 }
 
-auto HandleShortCircuitOperandOr(Context& context,
-                                 Parse::ShortCircuitOperandOrId node_id)
+auto HandleParseNode(Context& context, Parse::ShortCircuitOperandOrId node_id)
     -> bool {
   return HandleShortCircuitOperand(context, node_id, /*is_or=*/true);
 }
@@ -426,14 +409,12 @@ static auto HandleShortCircuitOperator(Context& context, Parse::NodeId node_id)
   return true;
 }
 
-auto HandleShortCircuitOperatorAnd(Context& context,
-                                   Parse::ShortCircuitOperatorAndId node_id)
+auto HandleParseNode(Context& context, Parse::ShortCircuitOperatorAndId node_id)
     -> bool {
   return HandleShortCircuitOperator(context, node_id);
 }
 
-auto HandleShortCircuitOperatorOr(Context& context,
-                                  Parse::ShortCircuitOperatorOrId node_id)
+auto HandleParseNode(Context& context, Parse::ShortCircuitOperatorOrId node_id)
     -> bool {
   return HandleShortCircuitOperator(context, node_id);
 }

--- a/toolchain/check/handle_paren_expr.cpp
+++ b/toolchain/check/handle_paren_expr.cpp
@@ -7,13 +7,13 @@
 
 namespace Carbon::Check {
 
-auto HandleParenExprStart(Context& /*context*/,
-                          Parse::ParenExprStartId /*node_id*/) -> bool {
+auto HandleParseNode(Context& /*context*/, Parse::ParenExprStartId /*node_id*/)
+    -> bool {
   // The open paren is unused.
   return true;
 }
 
-auto HandleParenExpr(Context& context, Parse::ParenExprId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ParenExprId node_id) -> bool {
   // We re-push because the ParenExpr is valid for member expressions, whereas
   // the child expression might not be.
   context.node_stack().Push(node_id, context.node_stack().PopExpr());

--- a/toolchain/check/handle_pattern_list.cpp
+++ b/toolchain/check/handle_pattern_list.cpp
@@ -7,16 +7,15 @@
 
 namespace Carbon::Check {
 
-auto HandleImplicitParamListStart(Context& context,
-                                  Parse::ImplicitParamListStartId node_id)
+auto HandleParseNode(Context& context, Parse::ImplicitParamListStartId node_id)
     -> bool {
   context.node_stack().Push(node_id);
   context.param_and_arg_refs_stack().Push();
   return true;
 }
 
-auto HandleImplicitParamList(Context& context,
-                             Parse::ImplicitParamListId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ImplicitParamListId node_id)
+    -> bool {
   auto refs_id = context.param_and_arg_refs_stack().EndAndPop(
       Parse::NodeKind::ImplicitParamListStart);
   context.node_stack()
@@ -27,21 +26,20 @@ auto HandleImplicitParamList(Context& context,
   return true;
 }
 
-auto HandleTuplePatternStart(Context& context,
-                             Parse::TuplePatternStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::TuplePatternStartId node_id)
+    -> bool {
   context.node_stack().Push(node_id);
   context.param_and_arg_refs_stack().Push();
   return true;
 }
 
-auto HandlePatternListComma(Context& context,
-                            Parse::PatternListCommaId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::PatternListCommaId /*node_id*/)
+    -> bool {
   context.param_and_arg_refs_stack().ApplyComma();
   return true;
 }
 
-auto HandleTuplePattern(Context& context, Parse::TuplePatternId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::TuplePatternId node_id) -> bool {
   auto refs_id = context.param_and_arg_refs_stack().EndAndPop(
       Parse::NodeKind::TuplePatternStart);
   context.node_stack()

--- a/toolchain/check/handle_return_statement.cpp
+++ b/toolchain/check/handle_return_statement.cpp
@@ -8,21 +8,21 @@
 
 namespace Carbon::Check {
 
-auto HandleReturnStatementStart(Context& context,
-                                Parse::ReturnStatementStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ReturnStatementStartId node_id)
+    -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(node_id);
   return true;
 }
 
-auto HandleReturnVarModifier(Context& context,
-                             Parse::ReturnVarModifierId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::ReturnVarModifierId node_id)
+    -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(node_id);
   return true;
 }
 
-auto HandleReturnStatement(Context& context, Parse::ReturnStatementId node_id)
+auto HandleParseNode(Context& context, Parse::ReturnStatementId node_id)
     -> bool {
   switch (context.node_stack().PeekNodeKind()) {
     case Parse::NodeKind::ReturnStatementStart:

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -9,8 +9,7 @@
 
 namespace Carbon::Check {
 
-auto HandleStructTypeLiteralStart(Context& context,
-                                  Parse::StructTypeLiteralStartId node_id)
+auto HandleParseNode(Context& context, Parse::StructTypeLiteralStartId node_id)
     -> bool {
   context.scope_stack().Push();
   context.node_stack().Push(node_id);
@@ -18,8 +17,8 @@ auto HandleStructTypeLiteralStart(Context& context,
   return true;
 }
 
-auto HandleStructLiteralStart(Context& context,
-                              Parse::StructLiteralStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::StructLiteralStartId node_id)
+    -> bool {
   context.scope_stack().Push();
   context.node_stack().Push(node_id);
   context.args_type_info_stack().Push();
@@ -27,21 +26,20 @@ auto HandleStructLiteralStart(Context& context,
   return true;
 }
 
-auto HandleStructFieldDesignator(Context& context,
-                                 Parse::StructFieldDesignatorId /*node_id*/)
-    -> bool {
+auto HandleParseNode(Context& context,
+                     Parse::StructFieldDesignatorId /*node_id*/) -> bool {
   // This leaves the designated name on top because the `.` isn't interesting.
   CARBON_CHECK(context.node_stack().PeekIsName());
   return true;
 }
 
-auto HandleStructComma(Context& context, Parse::StructCommaId /*node_id*/)
+auto HandleParseNode(Context& context, Parse::StructCommaId /*node_id*/)
     -> bool {
   context.param_and_arg_refs_stack().ApplyComma();
   return true;
 }
 
-auto HandleStructField(Context& context, Parse::StructFieldId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::StructFieldId node_id) -> bool {
   auto value_inst_id = context.node_stack().PopExpr();
   auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
 
@@ -57,7 +55,7 @@ auto HandleStructField(Context& context, Parse::StructFieldId node_id) -> bool {
   return true;
 }
 
-auto HandleStructTypeField(Context& context, Parse::StructTypeFieldId node_id)
+auto HandleParseNode(Context& context, Parse::StructTypeFieldId node_id)
     -> bool {
   auto [type_node, type_id] = context.node_stack().PopExprWithNodeId();
   SemIR::TypeId cast_type_id = ExprAsType(context, type_node, type_id);
@@ -97,8 +95,7 @@ static auto DiagnoseDuplicateNames(Context& context,
   return false;
 }
 
-auto HandleStructLiteral(Context& context, Parse::StructLiteralId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::StructLiteralId node_id) -> bool {
   auto refs_id = context.param_and_arg_refs_stack().EndAndPop(
       Parse::NodeKind::StructLiteralStart);
 
@@ -119,8 +116,8 @@ auto HandleStructLiteral(Context& context, Parse::StructLiteralId node_id)
   return true;
 }
 
-auto HandleStructTypeLiteral(Context& context,
-                             Parse::StructTypeLiteralId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::StructTypeLiteralId node_id)
+    -> bool {
   auto refs_id = context.param_and_arg_refs_stack().EndAndPop(
       Parse::NodeKind::StructTypeLiteralStart);
 

--- a/toolchain/check/handle_tuple_literal.cpp
+++ b/toolchain/check/handle_tuple_literal.cpp
@@ -7,21 +7,20 @@
 
 namespace Carbon::Check {
 
-auto HandleTupleLiteralStart(Context& context,
-                             Parse::TupleLiteralStartId node_id) -> bool {
+auto HandleParseNode(Context& context, Parse::TupleLiteralStartId node_id)
+    -> bool {
   context.node_stack().Push(node_id);
   context.param_and_arg_refs_stack().Push();
   return true;
 }
 
-auto HandleTupleLiteralComma(Context& context,
-                             Parse::TupleLiteralCommaId /*node_id*/) -> bool {
+auto HandleParseNode(Context& context, Parse::TupleLiteralCommaId /*node_id*/)
+    -> bool {
   context.param_and_arg_refs_stack().ApplyComma();
   return true;
 }
 
-auto HandleTupleLiteral(Context& context, Parse::TupleLiteralId node_id)
-    -> bool {
+auto HandleParseNode(Context& context, Parse::TupleLiteralId node_id) -> bool {
   auto refs_id = context.param_and_arg_refs_stack().EndAndPop(
       Parse::NodeKind::TupleLiteralStart);
 


### PR DESCRIPTION
This is for consistency with #4120. Similar to that, we can use overloads on the typed NodeId rather than individually named handlers. There isn't the same caller benefit here though, since the calls from check.cpp are already boilerplate.