### PR TITLE
Adjust driver references to use the install version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Carbon:
 
 ```shell
 # Build and run the toolchain's help to get documentation on the command line.
-$ bazel run //toolchain:carbon -- help
+$ bazel run //toolchain -- help
 ```
 
 For complete instructions, including installing dependencies on various

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Carbon:
 
 ```shell
 # Build and run the toolchain's help to get documentation on the command line.
-$ bazel run //toolchain/driver:carbon -- help
+$ bazel run //toolchain:carbon -- help
 ```
 
 For complete instructions, including installing dependencies on various

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -273,13 +273,13 @@ Pass `-c dbg` to `bazel build` in order to compile with debugging enabled. For
 example:
 
 ```shell
-bazel build -c dbg //toolchain/driver:carbon
+bazel build -c dbg //toolchain:carbon
 ```
 
 Then debugging works with GDB:
 
 ```shell
-gdb bazel-bin/toolchain/driver/carbon
+gdb bazel-bin/toolchain/install/prefix_root/bin/carbon
 ```
 
 Note that LLVM uses DWARF v5 debug symbols, which means that GDB version 10.1 or
@@ -301,7 +301,7 @@ for more information. To workaround, provide the `--spawn_strategy=local` option
 to Bazel for the debug build, like:
 
 ```shell
-bazel build --spawn_strategy=local -c dbg //toolchain/driver:carbon
+bazel build --spawn_strategy=local -c dbg //toolchain:carbon
 ```
 
 You should then be able to debug with `lldb`.

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -273,7 +273,7 @@ Pass `-c dbg` to `bazel build` in order to compile with debugging enabled. For
 example:
 
 ```shell
-bazel build -c dbg //toolchain:carbon
+bazel build -c dbg //toolchain
 ```
 
 Then debugging works with GDB:
@@ -301,7 +301,7 @@ for more information. To workaround, provide the `--spawn_strategy=local` option
 to Bazel for the debug build, like:
 
 ```shell
-bazel build --spawn_strategy=local -c dbg //toolchain:carbon
+bazel build --spawn_strategy=local -c dbg //toolchain
 ```
 
 You should then be able to debug with `lldb`.

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -1,0 +1,10 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A convenience target for running the toolchain with the full prelude
+# available.
+alias(
+    name = "carbon",
+    actual = "//toolchain/install:prefix_root/bin/carbon",
+)

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -5,6 +5,6 @@
 # A convenience target for running the toolchain with the full prelude
 # available.
 alias(
-    name = "carbon",
+    name = "toolchain",
     actual = "//toolchain/install:prefix_root/bin/carbon",
 )

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -119,7 +119,7 @@ cc_fuzz_test(
 )
 
 # This target doesn't include prelude libraries. To get a target that has the
-# prelude available, use //toolchain:carbon.
+# prelude available, use //toolchain.
 cc_binary(
     name = "carbon",
     srcs = ["driver_main.cpp"],

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -118,6 +118,8 @@ cc_fuzz_test(
     ],
 )
 
+# This target doesn't include prelude libraries. To get a target that has the
+# prelude available, use //toolchain:carbon.
 cc_binary(
     name = "carbon",
     srcs = ["driver_main.cpp"],


### PR DESCRIPTION
Also makes an alias so that this is easier to find. Verified that running the alias still finds prelude files.

Note the actual target is printed when building (although a symlink is also created, using that symlink confuses file-finding).

```
╚╡bazel build :carbon
...
Target //toolchain/install:prefix_root/bin/carbon up-to-date:
  bazel-bin/toolchain/install/prefix_root/bin/carbon
```