### PR TITLE
Compute specific constant values.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -68,7 +68,7 @@ struct EvalContext {
 
   // Gets the instruction describing the constant value of the specified type in
   // this context.
-  template<typename IdT>
+  template <typename IdT>
   auto GetConstantValueAsInst(IdT id) -> SemIR::Inst {
     return insts().Get(
         context.constant_values().GetInstId(GetConstantValue(id)));
@@ -76,9 +76,7 @@ struct EvalContext {
 
   auto ints() -> CanonicalValueStore<IntId>& { return sem_ir().ints(); }
   auto floats() -> FloatValueStore& { return sem_ir().floats(); }
-  auto bind_names() -> SemIR::BindNameStore& {
-    return sem_ir().bind_names();
-  }
+  auto bind_names() -> SemIR::BindNameStore& { return sem_ir().bind_names(); }
   auto functions() -> const ValueStore<SemIR::FunctionId>& {
     return sem_ir().functions();
   }
@@ -156,8 +154,8 @@ static auto GetPhase(SemIR::ConstantId constant_id) -> Phase {
 // type of a constant is effectively treated as an operand of that constant when
 // determining its phase. For example, an empty struct with a symbolic type is a
 // symbolic constant, not a template constant.
-static auto GetTypePhase(EvalContext& eval_context,
-                         SemIR::TypeId type_id) -> Phase {
+static auto GetTypePhase(EvalContext& eval_context, SemIR::TypeId type_id)
+    -> Phase {
   CARBON_CHECK(type_id.is_valid());
   return GetPhase(eval_context.GetConstantValue(type_id));
 }
@@ -240,8 +238,8 @@ static auto GetConstantValue(EvalContext& eval_context, SemIR::TypeId type_id,
 // If the given instruction block contains only constants, returns a
 // corresponding block of those values.
 static auto GetConstantValue(EvalContext& eval_context,
-                             SemIR::InstBlockId inst_block_id,
-                             Phase* phase) -> SemIR::InstBlockId {
+                             SemIR::InstBlockId inst_block_id, Phase* phase)
+    -> SemIR::InstBlockId {
   if (!inst_block_id.is_valid()) {
     return SemIR::InstBlockId::Invalid;
   }
@@ -270,8 +268,8 @@ static auto GetConstantValue(EvalContext& eval_context,
 // The constant value of a type block is that type block, but we still need to
 // extract its phase.
 static auto GetConstantValue(EvalContext& eval_context,
-                             SemIR::TypeBlockId type_block_id,
-                             Phase* phase) -> SemIR::TypeBlockId {
+                             SemIR::TypeBlockId type_block_id, Phase* phase)
+    -> SemIR::TypeBlockId {
   if (!type_block_id.is_valid()) {
     return SemIR::TypeBlockId::Invalid;
   }
@@ -308,9 +306,9 @@ static auto GetConstantValue(EvalContext& eval_context,
 // value, if it has constant phase. Returns true on success, false if the value
 // has runtime phase.
 template <typename InstT, typename FieldIdT>
-static auto ReplaceFieldWithConstantValue(EvalContext& eval_context, InstT* inst,
-                                          FieldIdT InstT::*field, Phase* phase)
-    -> bool {
+static auto ReplaceFieldWithConstantValue(EvalContext& eval_context,
+                                          InstT* inst, FieldIdT InstT::*field,
+                                          Phase* phase) -> bool {
   auto unwrapped = GetConstantValue(eval_context, inst->*field, phase);
   if (!unwrapped.is_valid() && (inst->*field).is_valid()) {
     return false;
@@ -354,9 +352,10 @@ static auto RebuildAndValidateIfFieldsAreConstant(
 
 // Same as above but with no validation step.
 template <typename InstT, typename... EachFieldIdT>
-static auto RebuildIfFieldsAreConstant(
-    EvalContext& eval_context, SemIR::Inst inst,
-    EachFieldIdT InstT::*... each_field_id) -> SemIR::ConstantId {
+static auto RebuildIfFieldsAreConstant(EvalContext& eval_context,
+                                       SemIR::Inst inst,
+                                       EachFieldIdT InstT::*... each_field_id)
+    -> SemIR::ConstantId {
   return RebuildAndValidateIfFieldsAreConstant(
       eval_context, inst, [](...) { return true; }, each_field_id...);
 }
@@ -379,8 +378,8 @@ static auto RebuildInitAsValue(EvalContext& eval_context, SemIR::Inst inst,
 }
 
 // Performs an access into an aggregate, retrieving the specified element.
-static auto PerformAggregateAccess(EvalContext& eval_context,
-                                   SemIR::Inst inst) -> SemIR::ConstantId {
+static auto PerformAggregateAccess(EvalContext& eval_context, SemIR::Inst inst)
+    -> SemIR::ConstantId {
   auto access_inst = inst.As<SemIR::AnyAggregateAccess>();
   Phase phase = Phase::Template;
   if (auto aggregate_id =
@@ -389,8 +388,7 @@ static auto PerformAggregateAccess(EvalContext& eval_context,
     if (auto aggregate =
             eval_context.insts().TryGetAs<SemIR::AnyAggregateValue>(
                 aggregate_id)) {
-      auto elements =
-          eval_context.inst_blocks().Get(aggregate->elements_id);
+      auto elements = eval_context.inst_blocks().Get(aggregate->elements_id);
       auto index = static_cast<size_t>(access_inst.index.index);
       CARBON_CHECK(index < elements.size()) << "Access out of bounds.";
       // `Phase` is not used here. If this element is a template constant, then
@@ -407,8 +405,8 @@ static auto PerformAggregateAccess(EvalContext& eval_context,
 
 // Performs an index into a homogeneous aggregate, retrieving the specified
 // element.
-static auto PerformAggregateIndex(EvalContext& eval_context,
-                                  SemIR::Inst inst) -> SemIR::ConstantId {
+static auto PerformAggregateIndex(EvalContext& eval_context, SemIR::Inst inst)
+    -> SemIR::ConstantId {
   auto index_inst = inst.As<SemIR::AnyAggregateIndex>();
   Phase phase = Phase::Template;
   auto aggregate_id =
@@ -431,8 +429,8 @@ static auto PerformAggregateIndex(EvalContext& eval_context,
   const auto& index_val = eval_context.ints().Get(index->int_id);
   if (auto array_type =
           eval_context.types().TryGetAs<SemIR::ArrayType>(aggregate_type_id)) {
-    if (auto bound =
-            eval_context.insts().TryGetAs<SemIR::IntLiteral>(array_type->bound_id)) {
+    if (auto bound = eval_context.insts().TryGetAs<SemIR::IntLiteral>(
+            array_type->bound_id)) {
       // This awkward call to `getZExtValue` is a workaround for APInt not
       // supporting comparisons between integers of different bit widths.
       if (index_val.getActiveBits() > 64 ||
@@ -1046,10 +1044,12 @@ static auto MakeConstantForCall(EvalContext& eval_context, SemIRLoc loc,
           phase);
     }
     case CARBON_KIND(SemIR::GenericInterfaceType generic_interface): {
-      auto instance_id = MakeGenericInstance(
-          eval_context.context,
-          eval_context.interfaces().Get(generic_interface.interface_id).generic_id,
-          call.args_id);
+      auto instance_id =
+          MakeGenericInstance(eval_context.context,
+                              eval_context.interfaces()
+                                  .Get(generic_interface.interface_id)
+                                  .generic_id,
+                              call.args_id);
       return MakeConstantResult(
           eval_context.context,
           SemIR::InterfaceType{.type_id = call.type_id,
@@ -1077,8 +1077,8 @@ auto TryEvalInstInContext(EvalContext& eval_context, SemIR::InstId inst_id,
           eval_context, inst,
           [&](SemIR::ArrayType result) {
             auto bound_id = array_type.bound_id;
-            auto int_bound =
-                eval_context.insts().TryGetAs<SemIR::IntLiteral>(result.bound_id);
+            auto int_bound = eval_context.insts().TryGetAs<SemIR::IntLiteral>(
+                result.bound_id);
             if (!int_bound) {
               // TODO: Permit symbolic array bounds. This will require fixing
               // callers of `GetArrayBoundValue`.
@@ -1218,7 +1218,9 @@ auto TryEvalInstInContext(EvalContext& eval_context, SemIR::InstId inst_id,
     case CARBON_KIND(SemIR::InterfaceDecl interface_decl): {
       // If the interface has generic parameters, we don't produce an interface
       // type, but a callable whose return value is an interface type.
-      if (eval_context.interfaces().Get(interface_decl.interface_id).is_generic()) {
+      if (eval_context.interfaces()
+              .Get(interface_decl.interface_id)
+              .is_generic()) {
         return MakeConstantResult(
             eval_context.context,
             SemIR::StructValue{.type_id = interface_decl.type_id,
@@ -1399,8 +1401,8 @@ auto TryEvalInstInContext(EvalContext& eval_context, SemIR::InstId inst_id,
   return SemIR::ConstantId::NotConstant;
 }
 
-auto TryEvalInst(Context& context, SemIR::InstId inst_id,
-                 SemIR::Inst inst) -> SemIR::ConstantId {
+auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
+    -> SemIR::ConstantId {
   EvalContext eval_context = {
       .context = context,
       .specific_id = SemIR::GenericInstanceId::Invalid,
@@ -1409,9 +1411,10 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id,
   return TryEvalInstInContext(eval_context, inst_id, inst);
 }
 
-auto TryEvalBlockForSpecific(
-    Context& context, SemIR::GenericInstanceId specific_id,
-    SemIR::GenericInstIndex::Region region) -> SemIR::InstBlockId {
+auto TryEvalBlockForSpecific(Context& context,
+                             SemIR::GenericInstanceId specific_id,
+                             SemIR::GenericInstIndex::Region region)
+    -> SemIR::InstBlockId {
   auto generic_id = context.generic_instances().Get(specific_id).generic_id;
   auto eval_block_id = context.generics().Get(generic_id).GetEvalBlock(region);
   auto eval_block = context.inst_blocks().Get(eval_block_id);

--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -17,10 +17,11 @@ namespace Carbon::Check {
 auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     -> SemIR::ConstantId;
 
-// Evaluates each instruction in the specified block in turn. Produces a block
-// containing the evaluated constant values of the instructions.
-auto TryEvalBlockForGenericInstance(
-    Context& context, SemIR::GenericInstanceId instance_id,
+// Evaluates the eval block for a region of a specific. Produces a block
+// containing the evaluated constant values of the instructions in the eval
+// block.
+auto TryEvalBlockForSpecific(
+    Context& context, SemIR::GenericInstanceId specific_id,
     SemIR::GenericInstIndex::Region region) -> SemIR::InstBlockId;
 
 }  // namespace Carbon::Check

--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -14,10 +14,14 @@ namespace Carbon::Check {
 // Determines the phase of the instruction `inst`, and returns its constant
 // value if it has constant phase. If it has runtime phase, returns
 // `SemIR::ConstantId::NotConstant`.
-//
-// TODO: Support symbolic phase.
 auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     -> SemIR::ConstantId;
+
+// Evaluates each instruction in the specified block in turn. Produces a block
+// containing the evaluated constant values of the instructions.
+auto TryEvalBlockForGenericInstance(
+    Context& context, SemIR::GenericInstanceId instance_id,
+    SemIR::GenericInstIndex::Region region) -> SemIR::InstBlockId;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -20,9 +20,10 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
 // Evaluates the eval block for a region of a specific. Produces a block
 // containing the evaluated constant values of the instructions in the eval
 // block.
-auto TryEvalBlockForSpecific(
-    Context& context, SemIR::GenericInstanceId specific_id,
-    SemIR::GenericInstIndex::Region region) -> SemIR::InstBlockId;
+auto TryEvalBlockForSpecific(Context& context,
+                             SemIR::GenericInstanceId specific_id,
+                             SemIR::GenericInstIndex::Region region)
+    -> SemIR::InstBlockId;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -248,7 +248,7 @@ auto MakeGenericInstance(Context& context, SemIR::GenericId generic_id,
   // If this is the first time we've formed this instance, evaluate its decl
   // block to form information about the instance.
   if (!context.generic_instances().Get(instance_id).decl_block_id.is_valid()) {
-    auto decl_block_id = TryEvalBlockForGenericInstance(
+    auto decl_block_id = TryEvalBlockForSpecific(
         context, instance_id, SemIR::GenericInstIndex::Region::Declaration);
     // Note that TryEvalBlockForGenericInstance may reallocate the list of
     // generic instances, so re-lookup the instance here.

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -250,8 +250,8 @@ auto MakeGenericInstance(Context& context, SemIR::GenericId generic_id,
   if (!context.generic_instances().Get(instance_id).decl_block_id.is_valid()) {
     auto decl_block_id = TryEvalBlockForSpecific(
         context, instance_id, SemIR::GenericInstIndex::Region::Declaration);
-    // Note that TryEvalBlockForGenericInstance may reallocate the list of
-    // generic instances, so re-lookup the instance here.
+    // Note that TryEvalBlockForSpecific may reallocate the list of generic
+    // instances, so re-lookup the instance here.
     context.generic_instances().Get(instance_id).decl_block_id = decl_block_id;
   }
 

--- a/toolchain/check/testdata/array/generic_empty.carbon
+++ b/toolchain/check/testdata/array/generic_empty.carbon
@@ -54,3 +54,8 @@ fn G(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%G.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @G.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/array/generic_empty.carbon
+++ b/toolchain/check/testdata/array/generic_empty.carbon
@@ -54,7 +54,7 @@ fn G(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%G.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%G.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @G.%T => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
@@ -28,7 +28,7 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     bind_name0:      {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind0}
 // CHECK:STDOUT:     bind_name1:      {name: name2, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block5, return_storage: inst+15, return_slot: present, body: [block11]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, param_refs: block5, return_storage: inst+15, return_slot: present, body: [block12]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:
 // CHECK:STDOUT:     generic0:        {decl: inst+16, bindings: block8}
@@ -75,14 +75,14 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     'inst+19':         {kind: PointerType, arg0: type4, type: typeTypeType}
 // CHECK:STDOUT:     'inst+20':         {kind: NameRef, arg0: name2, arg1: inst+6, type: type1}
 // CHECK:STDOUT:     'inst+21':         {kind: TupleLiteral, arg0: empty, type: type2}
-// CHECK:STDOUT:     'inst+22':         {kind: TupleLiteral, arg0: block12, type: type4}
+// CHECK:STDOUT:     'inst+22':         {kind: TupleLiteral, arg0: block13, type: type4}
 // CHECK:STDOUT:     'inst+23':         {kind: TupleAccess, arg0: inst+15, arg1: element0, type: type1}
 // CHECK:STDOUT:     'inst+24':         {kind: InitializeFrom, arg0: inst+20, arg1: inst+23, type: type1}
 // CHECK:STDOUT:     'inst+25':         {kind: TupleAccess, arg0: inst+15, arg1: element1, type: type2}
 // CHECK:STDOUT:     'inst+26':         {kind: TupleInit, arg0: empty, arg1: inst+25, type: type2}
-// CHECK:STDOUT:     'inst+27':         {kind: TupleValue, arg0: block14, type: type2}
+// CHECK:STDOUT:     'inst+27':         {kind: TupleValue, arg0: block15, type: type2}
 // CHECK:STDOUT:     'inst+28':         {kind: Converted, arg0: inst+21, arg1: inst+26, type: type2}
-// CHECK:STDOUT:     'inst+29':         {kind: TupleInit, arg0: block13, arg1: inst+15, type: type4}
+// CHECK:STDOUT:     'inst+29':         {kind: TupleInit, arg0: block14, arg1: inst+15, type: type4}
 // CHECK:STDOUT:     'inst+30':         {kind: Converted, arg0: inst+22, arg1: inst+29, type: type4}
 // CHECK:STDOUT:     'inst+31':         {kind: ReturnExpr, arg0: inst+30, arg1: inst+15}
 // CHECK:STDOUT:   constant_values:
@@ -136,6 +136,9 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     block10:
 // CHECK:STDOUT:       0:               inst+3
 // CHECK:STDOUT:     block11:
+// CHECK:STDOUT:       0:               inst+3
+// CHECK:STDOUT:       1:               inst+13
+// CHECK:STDOUT:     block12:
 // CHECK:STDOUT:       0:               inst+20
 // CHECK:STDOUT:       1:               inst+21
 // CHECK:STDOUT:       2:               inst+22
@@ -147,14 +150,14 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:       8:               inst+29
 // CHECK:STDOUT:       9:               inst+30
 // CHECK:STDOUT:       10:              inst+31
-// CHECK:STDOUT:     block12:
+// CHECK:STDOUT:     block13:
 // CHECK:STDOUT:       0:               inst+20
 // CHECK:STDOUT:       1:               inst+21
-// CHECK:STDOUT:     block13:
+// CHECK:STDOUT:     block14:
 // CHECK:STDOUT:       0:               inst+24
 // CHECK:STDOUT:       1:               inst+28
-// CHECK:STDOUT:     block14:         {}
-// CHECK:STDOUT:     block15:
+// CHECK:STDOUT:     block15:         {}
+// CHECK:STDOUT:     block16:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+16
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -217,6 +217,12 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   return %x.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Symbolic.decl(constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Symbolic.%N => constants.%N
+// CHECK:STDOUT:   file.%int.make_type_signed.loc14_28 => constants.%.6
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_zero_size.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -217,7 +217,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   return %x.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Symbolic.decl(constants.%N) {
+// CHECK:STDOUT: specific file.%Symbolic.decl(constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Symbolic.%N => constants.%N
 // CHECK:STDOUT:   file.%int.make_type_signed.loc14_28 => constants.%.6

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -217,6 +217,12 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   return %x.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Symbolic.decl(constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Symbolic.%N => constants.%N
+// CHECK:STDOUT:   file.%int.make_type_unsigned.loc14_29 => constants.%.6
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_zero_size.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -217,7 +217,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   return %x.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Symbolic.decl(constants.%N) {
+// CHECK:STDOUT: specific file.%Symbolic.decl(constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Symbolic.%N => constants.%N
 // CHECK:STDOUT:   file.%int.make_type_unsigned.loc14_29 => constants.%.6

--- a/toolchain/check/testdata/class/fail_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_generic_method.carbon
@@ -111,18 +111,18 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%.loc13 => constants.%Class.2
 // CHECK:STDOUT:   @Class.%T.ref.loc13 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%N) {
+// CHECK:STDOUT: specific file.%.decl(constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%N.loc32_10.2 => constants.%N
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_generic_method.carbon
@@ -38,7 +38,7 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = unbound_element_type %Class.2, %T [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -85,7 +85,7 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %T.ref.loc12: type = name_ref T, file.%T.loc11_13.2 [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc12: %.2 = field_decl a, element0 [template]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
-// CHECK:STDOUT:     %.loc13: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = %.loc13 (constants.%Class.2)]
+// CHECK:STDOUT:     %.loc13: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = %.loc13 (constants.%Class.2)]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc13 [symbolic = %.loc13 (constants.%Class.2)]
 // CHECK:STDOUT:     %self.loc13_8.1: @Class.%.loc13 (%Class.2) = param self
 // CHECK:STDOUT:     %self.loc13_8.2: @Class.%.loc13 (%Class.2) = bind_name self, %self.loc13_8.1
@@ -109,5 +109,21 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:     generic [file.%N.loc32_10.2: i32] {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%.loc13 => constants.%Class.2
+// CHECK:STDOUT:   @Class.%T.ref.loc13 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%N.loc32_10.2 => constants.%N
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/basic.carbon
+++ b/toolchain/check/testdata/class/generic/basic.carbon
@@ -106,12 +106,12 @@ class Class(T:! type) {
 // CHECK:STDOUT:   return %.loc18_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%GetAddr.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%GetAddr.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%.loc12_25 => constants.%Class.2
 // CHECK:STDOUT:   @Class.%.loc12_29 => constants.%.2
@@ -119,7 +119,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   @Class.%.loc12_38 => constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%GetValue.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%GetValue.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%.loc17 => constants.%Class.2
 // CHECK:STDOUT:   @Class.%T.ref.loc17 => constants.%T

--- a/toolchain/check/testdata/class/generic/basic.carbon
+++ b/toolchain/check/testdata/class/generic/basic.carbon
@@ -29,7 +29,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type %Class.2 [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type %T [symbolic]
 // CHECK:STDOUT:   %GetAddr.type: type = fn_type @GetAddr [template]
@@ -57,7 +57,7 @@ class Class(T:! type) {
 // CHECK:STDOUT: class @Class
 // CHECK:STDOUT:     generic [file.%T.loc11_13.2: type] {
 // CHECK:STDOUT:   %GetAddr.decl: %GetAddr.type = fn_decl @GetAddr [template = constants.%GetAddr] {
-// CHECK:STDOUT:     %.loc12_25: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = %.loc12_25 (constants.%Class.2)]
+// CHECK:STDOUT:     %.loc12_25: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = %.loc12_25 (constants.%Class.2)]
 // CHECK:STDOUT:     %Self.ref.loc12: type = name_ref Self, %.loc12_25 [symbolic = %.loc12_25 (constants.%Class.2)]
 // CHECK:STDOUT:     %.loc12_29: type = ptr_type %Class.2 [symbolic = %.loc12_29 (constants.%.2)]
 // CHECK:STDOUT:     %self.loc12_19.1: @Class.%.loc12_29 (%.2) = param self
@@ -68,7 +68,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:     %return.var.loc12: ref %.3 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %GetValue.decl: %GetValue.type = fn_decl @GetValue [template = constants.%GetValue] {
-// CHECK:STDOUT:     %.loc17: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = %.loc17 (constants.%Class.2)]
+// CHECK:STDOUT:     %.loc17: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = %.loc17 (constants.%Class.2)]
 // CHECK:STDOUT:     %Self.ref.loc17: type = name_ref Self, %.loc17 [symbolic = %.loc17 (constants.%Class.2)]
 // CHECK:STDOUT:     %self.loc17_15.1: @Class.%.loc17 (%Class.2) = param self
 // CHECK:STDOUT:     %self.loc17_15.2: @Class.%.loc17 (%Class.2) = bind_name self, %self.loc17_15.1
@@ -104,5 +104,24 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %.loc18_16.1: ref %T = class_element_access %self.ref, element0
 // CHECK:STDOUT:   %.loc18_16.2: %T = bind_value %.loc18_16.1
 // CHECK:STDOUT:   return %.loc18_16.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%GetAddr.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%.loc12_25 => constants.%Class.2
+// CHECK:STDOUT:   @Class.%.loc12_29 => constants.%.2
+// CHECK:STDOUT:   @Class.%T.ref.loc12 => constants.%T
+// CHECK:STDOUT:   @Class.%.loc12_38 => constants.%.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%GetValue.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%.loc17 => constants.%Class.2
+// CHECK:STDOUT:   @Class.%T.ref.loc17 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/call.carbon
+++ b/toolchain/check/testdata/class/generic/call.carbon
@@ -136,19 +136,19 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
 // CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%.3, constants.%.4) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%.3, constants.%.4) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%.3
 // CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%.1, constants.%.6) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%.1, constants.%.6) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%.1
 // CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%.6
@@ -211,7 +211,7 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
 // CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
@@ -278,7 +278,7 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
 // CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
@@ -343,7 +343,7 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
 // CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N

--- a/toolchain/check/testdata/class/generic/call.carbon
+++ b/toolchain/check/testdata/class/generic/call.carbon
@@ -73,14 +73,14 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 1 [symbolic]
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T, %N) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T, %N) [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %Class.3: type = class_type @Class, (%.3, %.4) [template]
+// CHECK:STDOUT:   %Class.3: type = class_type @Class, file.%Class.decl(%.3, %.4) [template]
 // CHECK:STDOUT:   %.5: type = ptr_type %.2 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %Class.4: type = class_type @Class, (%.1, %.6) [template]
+// CHECK:STDOUT:   %Class.4: type = class_type @Class, file.%Class.decl(%.1, %.6) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -136,6 +136,24 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
+// CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%.3, constants.%.4) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%.3
+// CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%.4
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%.1, constants.%.6) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%.1
+// CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%.6
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_too_few.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -146,7 +164,7 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 1 [symbolic]
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T, %N) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T, %N) [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = ptr_type i32 [template]
 // CHECK:STDOUT: }
@@ -193,6 +211,12 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
+// CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_too_many.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -203,7 +227,7 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 1 [symbolic]
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T, %N) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T, %N) [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
@@ -254,6 +278,12 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
+// CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_no_conversion.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -264,7 +294,7 @@ var a: Class(5, i32*);
 // CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 1 [symbolic]
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T, %N) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T, %N) [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 5 [template]
 // CHECK:STDOUT:   %.4: type = ptr_type i32 [template]
@@ -312,4 +342,10 @@ var a: Class(5, i32*);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
+// CHECK:STDOUT:   file.%N.loc4_23.2 => constants.%N
+// CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/fail_todo_use.carbon
+++ b/toolchain/check/testdata/class/generic/fail_todo_use.carbon
@@ -143,12 +143,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%Get.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%Get.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%.loc12_21 => constants.%Class.2
 // CHECK:STDOUT:   @Class.%.loc12_25 => constants.%.2
@@ -156,7 +156,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   @Class.%.loc12_34 => constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(i32) {
+// CHECK:STDOUT: specific file.%Class.decl(i32) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => i32
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/fail_todo_use.carbon
+++ b/toolchain/check/testdata/class/generic/fail_todo_use.carbon
@@ -43,7 +43,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type %Class.2 [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type %T [symbolic]
 // CHECK:STDOUT:   %Get.type: type = fn_type @Get [template]
@@ -55,7 +55,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
 // CHECK:STDOUT:   %Run.type: type = fn_type @Run [template]
 // CHECK:STDOUT:   %Run: %Run.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.3: type = class_type @Class, (i32) [template]
+// CHECK:STDOUT:   %Class.3: type = class_type @Class, file.%Class.decl(i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
 // CHECK:STDOUT:   %.8: type = struct_type {.k: i32} [template]
 // CHECK:STDOUT:   %.9: type = ptr_type %Class.3 [template]
@@ -89,7 +89,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: class @Class
 // CHECK:STDOUT:     generic [file.%T.loc11_13.2: type] {
 // CHECK:STDOUT:   %Get.decl: %Get.type = fn_decl @Get [template = constants.%Get] {
-// CHECK:STDOUT:     %.loc12_21: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = %.loc12_21 (constants.%Class.2)]
+// CHECK:STDOUT:     %.loc12_21: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = %.loc12_21 (constants.%Class.2)]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc12_21 [symbolic = %.loc12_21 (constants.%Class.2)]
 // CHECK:STDOUT:     %.loc12_25: type = ptr_type %Class.2 [symbolic = %.loc12_25 (constants.%.2)]
 // CHECK:STDOUT:     %self.loc12_15.1: @Class.%.loc12_25 (%.2) = param self
@@ -141,5 +141,23 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %.loc36_10: %.9 = addr_of %v.ref
 // CHECK:STDOUT:   %Get.call: init %.3 = call %.loc36_11(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%Get.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%.loc12_21 => constants.%Class.2
+// CHECK:STDOUT:   @Class.%.loc12_25 => constants.%.2
+// CHECK:STDOUT:   @Class.%T.ref.loc12 => constants.%T
+// CHECK:STDOUT:   @Class.%.loc12_34 => constants.%.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(i32) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => i32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/field.carbon
+++ b/toolchain/check/testdata/class/generic/field.carbon
@@ -113,12 +113,12 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   return %.loc9_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc2_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%G.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%G.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @G.%T => constants.%T
 // CHECK:STDOUT:   file.%.loc8_24 => constants.%Class.2
@@ -223,22 +223,22 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc2_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(i32) {
+// CHECK:STDOUT: specific file.%Class.decl(i32) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc2_13.2 => i32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%U) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc2_13.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%H.decl(constants.%U) {
+// CHECK:STDOUT: specific file.%H.decl(constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @H.%U => constants.%U
 // CHECK:STDOUT:   file.%.loc18_24 => constants.%Class.4

--- a/toolchain/check/testdata/class/generic/field.carbon
+++ b/toolchain/check/testdata/class/generic/field.carbon
@@ -58,7 +58,7 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = unbound_element_type %Class.2, %T [symbolic]
 // CHECK:STDOUT:   %.3: type = struct_type {.x: %T} [symbolic]
 // CHECK:STDOUT:   %G.type: type = fn_type @G [template]
@@ -113,6 +113,17 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   return %.loc9_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc2_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%G.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @G.%T => constants.%T
+// CHECK:STDOUT:   file.%.loc8_24 => constants.%Class.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_field.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -120,17 +131,17 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = unbound_element_type %Class.2, %T [symbolic]
 // CHECK:STDOUT:   %.3: type = struct_type {.x: %T} [symbolic]
 // CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.3: type = class_type @Class, (i32) [template]
+// CHECK:STDOUT:   %Class.3: type = class_type @Class, file.%Class.decl(i32) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.4: type = ptr_type %.3 [symbolic]
 // CHECK:STDOUT:   %U: type = bind_symbolic_name U 0 [symbolic]
-// CHECK:STDOUT:   %Class.4: type = class_type @Class, (%U) [symbolic]
+// CHECK:STDOUT:   %Class.4: type = class_type @Class, file.%Class.decl(%U) [symbolic]
 // CHECK:STDOUT:   %H.type: type = fn_type @H [template]
 // CHECK:STDOUT:   %H: %H.type = struct_value () [template]
 // CHECK:STDOUT: }
@@ -210,5 +221,26 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %x.ref: %.2 = name_ref x, @Class.%.loc3 [template = @Class.%.loc3]
 // CHECK:STDOUT:   %.loc26: %T = class_element_access <error>, element0 [template = <error>]
 // CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc2_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(i32) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc2_13.2 => i32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc2_13.2 => constants.%U
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%H.decl(constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @H.%U => constants.%U
+// CHECK:STDOUT:   file.%.loc18_24 => constants.%Class.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -95,10 +95,10 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %CompleteClass.type: type = generic_class_type @CompleteClass [template]
 // CHECK:STDOUT:   %CompleteClass.1: %CompleteClass.type = struct_value () [template]
-// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, (%T) [symbolic]
+// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, file.%CompleteClass.decl(%T) [symbolic]
 // CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = unbound_element_type %CompleteClass.2, i32 [symbolic]
@@ -106,7 +106,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %F.1: %F.type.1 = struct_value () [template]
 // CHECK:STDOUT:   %.3: type = struct_type {.n: i32} [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, (i32) [template]
+// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, file.%CompleteClass.decl(i32) [template]
 // CHECK:STDOUT:   %F.type.2: type = fn_type @F.2 [template]
 // CHECK:STDOUT:   %F.2: %F.type.2 = struct_value () [template]
 // CHECK:STDOUT: }
@@ -179,6 +179,25 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> %CompleteClass.3;
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%CompleteClass.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc6_21.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @CompleteClass.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%CompleteClass.decl(i32) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc6_21.2 => i32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- foo.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -186,16 +205,16 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, <invalid>(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = unbound_element_type %Class.2, %T [symbolic]
 // CHECK:STDOUT:   %.3: type = struct_type {.x: %T} [symbolic]
 // CHECK:STDOUT:   %CompleteClass.type: type = generic_class_type @CompleteClass [template]
 // CHECK:STDOUT:   %CompleteClass.1: %CompleteClass.type = struct_value () [template]
 // CHECK:STDOUT:   %.4: type = struct_type {.n: i32} [template]
-// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, (%T) [symbolic]
+// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, <invalid>(%T) [symbolic]
 // CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
-// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, (i32) [template]
+// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, <invalid>(i32) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type %.4 [template]
@@ -269,6 +288,10 @@ class Class(U:! type) {
 // CHECK:STDOUT:   return %.loc9_18 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- use_foo.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -281,8 +304,8 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %CompleteClass.1: %CompleteClass.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.n: i32} [template]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, <unexpected instref inst+28> [symbolic]
-// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, (%T) [symbolic]
-// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, (i32) [template]
+// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, <invalid>(%T) [symbolic]
+// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, <invalid>(i32) [template]
 // CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
 // CHECK:STDOUT:   %F.type.1: type = fn_type @F.1 [template]
 // CHECK:STDOUT:   %F.1: %F.type.1 = struct_value () [template]
@@ -356,6 +379,10 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> i32;
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_use_foo.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -368,8 +395,8 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %CompleteClass.1: %CompleteClass.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.n: i32} [template]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, <unexpected instref inst+28> [symbolic]
-// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, (%T) [symbolic]
-// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, (i32) [template]
+// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, <invalid>(%T) [symbolic]
+// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, <invalid>(i32) [template]
 // CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -438,6 +465,10 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %CompleteClass.3;
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_generic_arg_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -448,13 +479,13 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %CompleteClass.1: %CompleteClass.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.n: i32} [template]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, <unexpected instref inst+19> [symbolic]
-// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, (%T) [symbolic]
+// CHECK:STDOUT:   %CompleteClass.2: type = class_type @CompleteClass, <invalid>(%T) [symbolic]
 // CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type i32 [template]
-// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, (%.3) [template]
+// CHECK:STDOUT:   %CompleteClass.3: type = class_type @CompleteClass, <invalid>(%.3) [template]
 // CHECK:STDOUT:   %.4: type = ptr_type %.2 [template]
-// CHECK:STDOUT:   %CompleteClass.4: type = class_type @CompleteClass, (i32) [template]
+// CHECK:STDOUT:   %CompleteClass.4: type = class_type @CompleteClass, <invalid>(i32) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT: }
@@ -513,6 +544,12 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %CompleteClass.4;
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%.3);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_foo.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -521,10 +558,10 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, <unexpected instref inst+17> [symbolic]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, <invalid>(%T) [symbolic]
 // CHECK:STDOUT:   %.type: type = generic_class_type @.1 [template]
 // CHECK:STDOUT:   %.2: %.type = struct_value () [template]
-// CHECK:STDOUT:   %.3: type = class_type @.1, (%U) [symbolic]
+// CHECK:STDOUT:   %.3: type = class_type @.1, file.%.decl(%U) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -560,5 +597,12 @@ class Class(U:! type) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%.3
 // CHECK:STDOUT:   .x = %.loc13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%U.loc9_13.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -179,21 +179,21 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> %CompleteClass.3;
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%CompleteClass.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%CompleteClass.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc6_21.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @CompleteClass.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @CompleteClass.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%CompleteClass.decl(i32) {
+// CHECK:STDOUT: specific file.%CompleteClass.decl(i32) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc6_21.2 => i32
 // CHECK:STDOUT: }
@@ -288,9 +288,9 @@ class Class(U:! type) {
 // CHECK:STDOUT:   return %.loc9_18 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT: specific <invalid>(i32);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- use_foo.carbon
 // CHECK:STDOUT:
@@ -379,9 +379,9 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> i32;
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT: specific <invalid>(i32);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_use_foo.carbon
 // CHECK:STDOUT:
@@ -465,9 +465,9 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %CompleteClass.3;
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT: specific <invalid>(i32);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_generic_arg_mismatch.carbon
 // CHECK:STDOUT:
@@ -544,11 +544,11 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %CompleteClass.4;
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%.3);
+// CHECK:STDOUT: specific <invalid>(constants.%.3);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(i32);
+// CHECK:STDOUT: specific <invalid>(i32);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_foo.impl.carbon
 // CHECK:STDOUT:
@@ -599,9 +599,9 @@ class Class(U:! type) {
 // CHECK:STDOUT:   .x = %.loc13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%U) {
+// CHECK:STDOUT: specific file.%.decl(constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%U.loc9_13.2 => constants.%U
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/member_inline.carbon
+++ b/toolchain/check/testdata/class/generic/member_inline.carbon
@@ -62,12 +62,12 @@ class Class(T:! type) {
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%T.ref.loc12_11 => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/member_inline.carbon
+++ b/toolchain/check/testdata/class/generic/member_inline.carbon
@@ -21,7 +21,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
@@ -60,5 +60,15 @@ class Class(T:! type) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: %T = name_ref n, @Class.%n.loc12_8.2
 // CHECK:STDOUT:   return %n.ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%T.ref.loc12_11 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/member_out_of_line.carbon
+++ b/toolchain/check/testdata/class/generic/member_out_of_line.carbon
@@ -106,7 +106,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
@@ -156,6 +156,16 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%T.ref.loc5_11 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -163,11 +173,11 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %A.type: type = generic_class_type @A [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %A.1: %A.type = struct_value () [template]
-// CHECK:STDOUT:   %A.2: type = class_type @A, (%T) [symbolic]
+// CHECK:STDOUT:   %A.2: type = class_type @A, file.%A.decl(%T) [symbolic]
 // CHECK:STDOUT:   %N: %T = bind_symbolic_name N 1 [symbolic]
 // CHECK:STDOUT:   %B.type: type = generic_class_type @B [template]
 // CHECK:STDOUT:   %B.1: %B.type = struct_value () [template]
-// CHECK:STDOUT:   %B.2: type = class_type @B, (%T, %N) [symbolic]
+// CHECK:STDOUT:   %B.2: type = class_type @B, @A.%B.decl(%T, %N) [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
@@ -191,7 +201,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     %T.ref.loc10_22: type = name_ref T, %T.loc10_6.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %N.loc10_18.1: %T = param N
 // CHECK:STDOUT:     %N.loc10_18.2: %T = bind_symbolic_name N 1, %N.loc10_18.1 [symbolic = constants.%N]
-// CHECK:STDOUT:     %.loc10: type = specific_constant constants.%B.2, (constants.%T, constants.%N) [symbolic = constants.%B.2]
+// CHECK:STDOUT:     %.loc10: type = specific_constant constants.%B.2, @A.%B.decl(constants.%T, constants.%N) [symbolic = constants.%B.2]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc10 [symbolic = constants.%B.2]
 // CHECK:STDOUT:     %self.loc10_27.1: %B.2 = param self
 // CHECK:STDOUT:     @F.%self: %B.2 = bind_name self, %self.loc10_27.1
@@ -217,7 +227,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT: class @B
 // CHECK:STDOUT:     generic [file.%T.loc4_9.2: type, @A.%N.loc5_11.2: @A.%T.ref (%T)] {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
-// CHECK:STDOUT:     %.loc6: type = specific_constant constants.%B.2, (constants.%T, constants.%N) [symbolic = %.loc6 (constants.%B.2)]
+// CHECK:STDOUT:     %.loc6: type = specific_constant constants.%B.2, @A.%B.decl(constants.%T, constants.%N) [symbolic = %.loc6 (constants.%B.2)]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc6 [symbolic = %.loc6 (constants.%B.2)]
 // CHECK:STDOUT:     %self.loc6_10.1: @B.%.loc6 (%B.2) = param self
 // CHECK:STDOUT:     %self.loc6_10.2: @B.%.loc6 (%B.2) = bind_name self, %self.loc6_10.1
@@ -235,6 +245,23 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     generic [file.%T.loc4_9.2: type, @A.%N.loc5_11.2: @A.%T.ref (%T)] {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%A.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @A.%B.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @A.%T.ref => constants.%T
+// CHECK:STDOUT:   @A.%N.loc5_11.2 => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @B.%F.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @B.%.loc6 => constants.%B.2
+// CHECK:STDOUT:   @B.%T.ref => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_not_generic_vs_generic.carbon
@@ -280,6 +307,11 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc15_15.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_too_few_args.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -287,7 +319,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Generic.type: type = generic_class_type @Generic [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Generic.1: %Generic.type = struct_value () [template]
-// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, (%T) [symbolic]
+// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, file.%Generic.decl(%T) [symbolic]
 // CHECK:STDOUT:   %TooFew.type: type = fn_type @TooFew [template]
 // CHECK:STDOUT:   %TooFew: %TooFew.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
@@ -326,6 +358,15 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Generic.%TooFew.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_too_many_args.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -333,7 +374,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Generic.type: type = generic_class_type @Generic [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Generic.1: %Generic.type = struct_value () [template]
-// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, (%T) [symbolic]
+// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, file.%Generic.decl(%T) [symbolic]
 // CHECK:STDOUT:   %TooMany.type: type = fn_type @TooMany [template]
 // CHECK:STDOUT:   %TooMany: %TooMany.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
@@ -379,6 +420,21 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Generic.%TooMany.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc15_12.2 => constants.%T
+// CHECK:STDOUT:   file.%U.loc15_22.2 => constants.%U
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_wrong_arg_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -386,7 +442,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Generic.type: type = generic_class_type @Generic [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Generic.1: %Generic.type = struct_value () [template]
-// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, (%T.1) [symbolic]
+// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, file.%Generic.decl(%T.1) [symbolic]
 // CHECK:STDOUT:   %WrongType.type: type = fn_type @WrongType [template]
 // CHECK:STDOUT:   %WrongType: %WrongType.type = struct_value () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
@@ -430,5 +486,19 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     generic [file.%T.loc14_12.2: %.1] {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Generic.%WrongType.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc14_12.2 => constants.%T.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/member_out_of_line.carbon
+++ b/toolchain/check/testdata/class/generic/member_out_of_line.carbon
@@ -156,12 +156,12 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%T.ref.loc5_11 => constants.%T
 // CHECK:STDOUT: }
@@ -247,18 +247,18 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%A.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%A.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @A.%B.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: specific @A.%B.decl(constants.%T, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @A.%T.ref => constants.%T
 // CHECK:STDOUT:   @A.%N.loc5_11.2 => constants.%N
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @B.%F.decl(constants.%T, constants.%N) {
+// CHECK:STDOUT: specific @B.%F.decl(constants.%T, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @B.%.loc6 => constants.%B.2
 // CHECK:STDOUT:   @B.%T.ref => constants.%T
@@ -307,7 +307,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc15_15.2 => constants.%T
 // CHECK:STDOUT: }
@@ -358,12 +358,12 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Generic.%TooFew.decl(constants.%T) {
+// CHECK:STDOUT: specific @Generic.%TooFew.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -420,16 +420,16 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Generic.%TooMany.decl(constants.%T) {
+// CHECK:STDOUT: specific @Generic.%TooMany.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T, constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc15_12.2 => constants.%T
 // CHECK:STDOUT:   file.%U.loc15_22.2 => constants.%U
@@ -488,16 +488,16 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Generic.%WrongType.decl(constants.%T.1) {
+// CHECK:STDOUT: specific @Generic.%WrongType.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T.2) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc14_12.2 => constants.%T.2
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/redeclare.carbon
+++ b/toolchain/check/testdata/class/generic/redeclare.carbon
@@ -120,7 +120,7 @@ class E(U:! type) {}
 // CHECK:STDOUT:   .Self = constants.%Generic.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl.loc4(constants.%T) {
+// CHECK:STDOUT: specific file.%Generic.decl.loc4(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T
 // CHECK:STDOUT: }
@@ -159,7 +159,7 @@ class E(U:! type) {}
 // CHECK:STDOUT:   .Self = constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T
 // CHECK:STDOUT: }
@@ -220,12 +220,12 @@ class E(U:! type) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%B.decl(constants.%N.1) {
+// CHECK:STDOUT: specific file.%B.decl(constants.%N.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%N.loc4_9.2 => constants.%N.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%N.2) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T, constants.%N.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T
 // CHECK:STDOUT:   file.%N.loc12_19.2 => constants.%N.2
@@ -285,12 +285,12 @@ class E(U:! type) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%C.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T, constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T
 // CHECK:STDOUT:   file.%U.loc12_19.2 => constants.%U
@@ -348,12 +348,12 @@ class E(U:! type) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%D.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%D.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T.2) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T.2
 // CHECK:STDOUT: }
@@ -399,12 +399,12 @@ class E(U:! type) {}
 // CHECK:STDOUT:   .Self = constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%E.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%E.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%U) {
+// CHECK:STDOUT: specific file.%.decl(constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%U.loc11_9.2 => constants.%U
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/redeclare.carbon
+++ b/toolchain/check/testdata/class/generic/redeclare.carbon
@@ -93,7 +93,7 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %Generic.type: type = generic_class_type @Generic [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Generic.1: %Generic.type = struct_value () [template]
-// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, (%T) [symbolic]
+// CHECK:STDOUT:   %Generic.2: type = class_type @Generic, file.%Generic.decl.loc4(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -120,6 +120,11 @@ class E(U:! type) {}
 // CHECK:STDOUT:   .Self = constants.%Generic.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl.loc4(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_15.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatch_param_list.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -128,7 +133,7 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %.type: type = generic_class_type @.1 [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: %.type = struct_value () [template]
-// CHECK:STDOUT:   %.3: type = class_type @.1, (%T) [symbolic]
+// CHECK:STDOUT:   %.3: type = class_type @.1, file.%.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.4: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -154,6 +159,11 @@ class E(U:! type) {}
 // CHECK:STDOUT:   .Self = constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatch_implicit_param_list.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -163,12 +173,12 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %N.1: i32 = bind_symbolic_name N 0 [symbolic]
 // CHECK:STDOUT:   %B.type: type = generic_class_type @B [template]
 // CHECK:STDOUT:   %B.1: %B.type = struct_value () [template]
-// CHECK:STDOUT:   %B.2: type = class_type @B, (%N.1) [symbolic]
+// CHECK:STDOUT:   %B.2: type = class_type @B, file.%B.decl(%N.1) [symbolic]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %N.2: %T = bind_symbolic_name N 1 [symbolic]
 // CHECK:STDOUT:   %.type: type = generic_class_type @.1 [template]
 // CHECK:STDOUT:   %.2: %.type = struct_value () [template]
-// CHECK:STDOUT:   %.3: type = class_type @.1, (%T, %N.2) [symbolic]
+// CHECK:STDOUT:   %.3: type = class_type @.1, file.%.decl(%T, %N.2) [symbolic]
 // CHECK:STDOUT:   %.4: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -210,6 +220,17 @@ class E(U:! type) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%B.decl(constants.%N.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%N.loc4_9.2 => constants.%N.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%N.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T
+// CHECK:STDOUT:   file.%N.loc12_19.2 => constants.%N.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatch_param_count.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -217,13 +238,13 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %C.type: type = generic_class_type @C [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %C.1: %C.type = struct_value () [template]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%T) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, file.%C.decl(%T) [symbolic]
 // CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
 // CHECK:STDOUT:   %U: i32 = bind_symbolic_name U 1 [symbolic]
 // CHECK:STDOUT:   %.type: type = generic_class_type @.1 [template]
 // CHECK:STDOUT:   %.2: %.type = struct_value () [template]
-// CHECK:STDOUT:   %.3: type = class_type @.1, (%T, %U) [symbolic]
+// CHECK:STDOUT:   %.3: type = class_type @.1, file.%.decl(%T, %U) [symbolic]
 // CHECK:STDOUT:   %.4: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -264,6 +285,17 @@ class E(U:! type) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T
+// CHECK:STDOUT:   file.%U.loc12_19.2 => constants.%U
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatch_param_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -271,13 +303,13 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %D.type: type = generic_class_type @D [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %D.1: %D.type = struct_value () [template]
-// CHECK:STDOUT:   %D.2: type = class_type @D, (%T.1) [symbolic]
+// CHECK:STDOUT:   %D.2: type = class_type @D, file.%D.decl(%T.1) [symbolic]
 // CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
 // CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
 // CHECK:STDOUT:   %T.2: i32 = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.type: type = generic_class_type @.1 [template]
 // CHECK:STDOUT:   %.2: %.type = struct_value () [template]
-// CHECK:STDOUT:   %.3: type = class_type @.1, (%T.2) [symbolic]
+// CHECK:STDOUT:   %.3: type = class_type @.1, file.%.decl(%T.2) [symbolic]
 // CHECK:STDOUT:   %.4: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -316,6 +348,16 @@ class E(U:! type) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%D.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc12_9.2 => constants.%T.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatch_param_name.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -323,11 +365,11 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %E.type: type = generic_class_type @E [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %E.1: %E.type = struct_value () [template]
-// CHECK:STDOUT:   %E.2: type = class_type @E, (%T) [symbolic]
+// CHECK:STDOUT:   %E.2: type = class_type @E, file.%E.decl(%T) [symbolic]
 // CHECK:STDOUT:   %U: type = bind_symbolic_name U 0 [symbolic]
 // CHECK:STDOUT:   %.type: type = generic_class_type @.1 [template]
 // CHECK:STDOUT:   %.2: %.type = struct_value () [template]
-// CHECK:STDOUT:   %.3: type = class_type @.1, (%U) [symbolic]
+// CHECK:STDOUT:   %.3: type = class_type @.1, file.%.decl(%U) [symbolic]
 // CHECK:STDOUT:   %.4: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -355,5 +397,15 @@ class E(U:! type) {}
 // CHECK:STDOUT:     generic [file.%U.loc11_9.2: type] {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%E.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_9.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%U.loc11_9.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/self.carbon
+++ b/toolchain/check/testdata/class/generic/self.carbon
@@ -105,23 +105,23 @@ class Class(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%MakeSelf.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%MakeSelf.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%.loc14 => constants.%Class.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%MakeClass.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%MakeClass.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%T.ref => constants.%T
 // CHECK:STDOUT:   @Class.%.loc15_26 => constants.%Class.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/self.carbon
+++ b/toolchain/check/testdata/class/generic/self.carbon
@@ -26,7 +26,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %MakeSelf.type: type = fn_type @MakeSelf [template]
 // CHECK:STDOUT:   %MakeSelf: %MakeSelf.type = struct_value () [template]
 // CHECK:STDOUT:   %MakeClass.type: type = fn_type @MakeClass [template]
@@ -53,7 +53,7 @@ class Class(T:! type) {
 // CHECK:STDOUT: class @Class
 // CHECK:STDOUT:     generic [file.%T.loc11_13.2: type] {
 // CHECK:STDOUT:   %MakeSelf.decl: %MakeSelf.type = fn_decl @MakeSelf [template = constants.%MakeSelf] {
-// CHECK:STDOUT:     %.loc14: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = %.loc14 (constants.%Class.2)]
+// CHECK:STDOUT:     %.loc14: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = %.loc14 (constants.%Class.2)]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc14 [symbolic = %.loc14 (constants.%Class.2)]
 // CHECK:STDOUT:     %return.var.loc14: ref %Class.2 = var <return slot>
 // CHECK:STDOUT:   }
@@ -94,7 +94,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %.loc17_9: ref %Class.2 = splice_block %c.var {}
 // CHECK:STDOUT:   %MakeSelf.call: init %Class.2 = call %MakeSelf.ref() to %.loc17_9
 // CHECK:STDOUT:   assign %c.var, %MakeSelf.call
-// CHECK:STDOUT:   %.loc18_12: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = constants.%Class.2]
+// CHECK:STDOUT:   %.loc18_12: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = constants.%Class.2]
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, %.loc18_12 [symbolic = constants.%Class.2]
 // CHECK:STDOUT:   %s.var: ref %Class.2 = var s
 // CHECK:STDOUT:   %s: ref %Class.2 = bind_name s, %s.var
@@ -103,5 +103,25 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %MakeClass.call: init %Class.2 = call %MakeClass.ref() to %.loc18_9
 // CHECK:STDOUT:   assign %s.var, %MakeClass.call
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%MakeSelf.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%.loc14 => constants.%Class.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%MakeClass.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%T.ref => constants.%T
+// CHECK:STDOUT:   @Class.%.loc15_26 => constants.%Class.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic_method.carbon
+++ b/toolchain/check/testdata/class/generic_method.carbon
@@ -22,7 +22,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Class.type: type = generic_class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Class.1: %Class.type = struct_value () [template]
-// CHECK:STDOUT:   %Class.2: type = class_type @Class, (%T) [symbolic]
+// CHECK:STDOUT:   %Class.2: type = class_type @Class, file.%Class.decl(%T) [symbolic]
 // CHECK:STDOUT:   %.2: type = unbound_element_type %Class.2, %T [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -44,7 +44,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.loc16_10.1: type = param T
 // CHECK:STDOUT:     %T.loc16_10.2: type = bind_symbolic_name T 0, %T.loc16_10.1 [symbolic = constants.%T]
-// CHECK:STDOUT:     %.loc16: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = constants.%Class.2]
+// CHECK:STDOUT:     %.loc16: type = specific_constant constants.%Class.2, %Class.decl(constants.%T) [symbolic = constants.%Class.2]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc16 [symbolic = constants.%Class.2]
 // CHECK:STDOUT:     %self.loc16_22.1: %Class.2 = param self
 // CHECK:STDOUT:     @F.%self: %Class.2 = bind_name self, %self.loc16_22.1
@@ -59,7 +59,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %T.ref.loc12: type = name_ref T, file.%T.loc11_13.2 [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc12: %.2 = field_decl a, element0 [template]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
-// CHECK:STDOUT:     %.loc13: type = specific_constant constants.%Class.2, (constants.%T) [symbolic = %.loc13 (constants.%Class.2)]
+// CHECK:STDOUT:     %.loc13: type = specific_constant constants.%Class.2, file.%Class.decl(constants.%T) [symbolic = %.loc13 (constants.%Class.2)]
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, %.loc13 [symbolic = %.loc13 (constants.%Class.2)]
 // CHECK:STDOUT:     %self.loc13_8.1: @Class.%.loc13 (%Class.2) = param self
 // CHECK:STDOUT:     %self.loc13_8.2: @Class.%.loc13 (%Class.2) = bind_name self, %self.loc13_8.1
@@ -78,5 +78,16 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:     generic [file.%T.loc11_13.2: type] {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Class.%.loc13 => constants.%Class.2
+// CHECK:STDOUT:   @Class.%T.ref.loc13 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic_method.carbon
+++ b/toolchain/check/testdata/class/generic_method.carbon
@@ -80,12 +80,12 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Class.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%Class.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Class.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @Class.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Class.%.loc13 => constants.%Class.2
 // CHECK:STDOUT:   @Class.%T.ref.loc13 => constants.%T

--- a/toolchain/check/testdata/eval/fail_symbolic.carbon
+++ b/toolchain/check/testdata/eval/fail_symbolic.carbon
@@ -63,7 +63,7 @@ fn G(N:! i32) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%G.decl(constants.%N) {
+// CHECK:STDOUT: specific file.%G.decl(constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @G.%N => constants.%N
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/eval/fail_symbolic.carbon
+++ b/toolchain/check/testdata/eval/fail_symbolic.carbon
@@ -63,3 +63,8 @@ fn G(N:! i32) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%G.decl(constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @G.%N => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/symbolic.carbon
+++ b/toolchain/check/testdata/eval/symbolic.carbon
@@ -70,7 +70,7 @@ fn F(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/eval/symbolic.carbon
+++ b/toolchain/check/testdata/eval/symbolic.carbon
@@ -70,3 +70,8 @@ fn F(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/builtin/method.carbon
+++ b/toolchain/check/testdata/function/builtin/method.carbon
@@ -136,7 +136,7 @@ var arr: [i32; 1.(I.F)(2)];
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2[@impl.%self.loc16_8.2: i32](@impl.%other.loc16_19.2: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @I.%Self.ref.loc12_14 => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/builtin/method.carbon
+++ b/toolchain/check/testdata/function/builtin/method.carbon
@@ -136,3 +136,8 @@ var arr: [i32; 1.(I.F)(2)];
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2[@impl.%self.loc16_8.2: i32](@impl.%other.loc16_19.2: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @I.%Self.ref.loc12_14 => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
@@ -86,7 +86,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT: fn @Op[@Add.%self.loc7_9.2: @Add.%Self.ref.loc7_15 (%Self)](@Add.%other.loc7_21.2: @Add.%Self.ref.loc7_15 (%Self)) -> %Self
 // CHECK:STDOUT:     generic [@Add.%Self: %.2];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Add.%Op.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Add.%Op.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Add.%Self.ref.loc7_15 => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
@@ -86,6 +86,11 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT: fn @Op[@Add.%self.loc7_9.2: @Add.%Self.ref.loc7_15 (%Self)](@Add.%other.loc7_21.2: @Add.%Self.ref.loc7_15 (%Self)) -> %Self
 // CHECK:STDOUT:     generic [@Add.%Self: %.2];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Add.%Op.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Add.%Self.ref.loc7_15 => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- user.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
+++ b/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
@@ -58,3 +58,8 @@ fn F(N:! i32, a: [i32; N]*);
 // CHECK:STDOUT: fn @F(%N: i32, %a: <error>)
 // CHECK:STDOUT:     generic [%N: i32];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%N => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
+++ b/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
@@ -58,7 +58,7 @@ fn F(N:! i32, a: [i32; N]*);
 // CHECK:STDOUT: fn @F(%N: i32, %a: <error>)
 // CHECK:STDOUT:     generic [%N: i32];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%N) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%N => constants.%N
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
@@ -54,3 +54,9 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT:   @F.%U => constants.%U
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
@@ -54,7 +54,7 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T, constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT:   @F.%U => constants.%U

--- a/toolchain/check/testdata/function/generic/no_prelude/indirect_generic_type.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/indirect_generic_type.carbon
@@ -50,3 +50,10 @@ fn F(T:! type, p: T**) -> T* {
 // CHECK:STDOUT:   return %.loc12_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT:   file.%.loc11_20 => constants.%.1
+// CHECK:STDOUT:   file.%.loc11_21 => constants.%.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/no_prelude/indirect_generic_type.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/indirect_generic_type.carbon
@@ -50,7 +50,7 @@ fn F(T:! type, p: T**) -> T* {
 // CHECK:STDOUT:   return %.loc12_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT:   file.%.loc11_20 => constants.%.1

--- a/toolchain/check/testdata/function/generic/no_prelude/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/type_param.carbon
@@ -49,3 +49,8 @@ fn F(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/no_prelude/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/type_param.carbon
@@ -49,7 +49,7 @@ fn F(T:! type) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/type_param_scope.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/type_param_scope.carbon
@@ -47,7 +47,7 @@ fn F(T:! type, n: T) -> T {
 // CHECK:STDOUT:   return %m.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/type_param_scope.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/type_param_scope.carbon
@@ -47,3 +47,8 @@ fn F(T:! type, n: T) -> T {
 // CHECK:STDOUT:   return %m.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -145,6 +145,12 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   return %.loc7_14.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl.loc4(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_6.2 => constants.%T
+// CHECK:STDOUT:   file.%.loc4 => constants.%.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_different_return_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -196,6 +202,20 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %F.call: init %.1 = call %F.ref(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT:   @F.%U => constants.%U
+// CHECK:STDOUT:   file.%.loc4 => constants.%.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @.1.%T => constants.%T
+// CHECK:STDOUT:   @.1.%U => constants.%U
+// CHECK:STDOUT:   file.%.loc13 => constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_reorder.carbon
@@ -253,6 +273,20 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T.1, constants.%U.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T.1
+// CHECK:STDOUT:   @F.%U => constants.%U.1
+// CHECK:STDOUT:   file.%.loc4 => constants.%.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%U.2, constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @.1.%U => constants.%U.2
+// CHECK:STDOUT:   @.1.%T => constants.%T.2
+// CHECK:STDOUT:   file.%.loc13 => constants.%.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_rename.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -306,5 +340,19 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T.2]
 // CHECK:STDOUT:   %F.call: init %.1 = call %F.ref(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T.1, constants.%U.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T.1
+// CHECK:STDOUT:   @F.%U => constants.%U.1
+// CHECK:STDOUT:   file.%.loc4 => constants.%.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%U.2, constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @.1.%U => constants.%U.2
+// CHECK:STDOUT:   @.1.%T => constants.%T.2
+// CHECK:STDOUT:   file.%.loc13 => constants.%.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -145,7 +145,7 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   return %.loc7_14.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl.loc4(constants.%T) {
+// CHECK:STDOUT: specific file.%F.decl.loc4(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_6.2 => constants.%T
 // CHECK:STDOUT:   file.%.loc4 => constants.%.1
@@ -204,14 +204,14 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T, constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT:   @F.%U => constants.%U
 // CHECK:STDOUT:   file.%.loc4 => constants.%.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T, constants.%U) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T, constants.%U) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @.1.%T => constants.%T
 // CHECK:STDOUT:   @.1.%U => constants.%U
@@ -273,14 +273,14 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T.1, constants.%U.1) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T.1, constants.%U.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T.1
 // CHECK:STDOUT:   @F.%U => constants.%U.1
 // CHECK:STDOUT:   file.%.loc4 => constants.%.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%U.2, constants.%T.2) {
+// CHECK:STDOUT: specific file.%.decl(constants.%U.2, constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @.1.%U => constants.%U.2
 // CHECK:STDOUT:   @.1.%T => constants.%T.2
@@ -342,14 +342,14 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T.1, constants.%U.1) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T.1, constants.%U.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T.1
 // CHECK:STDOUT:   @F.%U => constants.%U.1
 // CHECK:STDOUT:   file.%.loc4 => constants.%.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%U.2, constants.%T.2) {
+// CHECK:STDOUT: specific file.%.decl(constants.%U.2, constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @.1.%U => constants.%U.2
 // CHECK:STDOUT:   @.1.%T => constants.%T.2

--- a/toolchain/check/testdata/impl/compound.carbon
+++ b/toolchain/check/testdata/impl/compound.carbon
@@ -219,11 +219,11 @@ fn InstanceCallIndirect(p: i32*) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%G.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%G.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Simple.%Self.ref => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/compound.carbon
+++ b/toolchain/check/testdata/impl/compound.carbon
@@ -219,3 +219,12 @@ fn InstanceCallIndirect(p: i32*) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%G.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Simple.%Self.ref => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/extend_impl.carbon
+++ b/toolchain/check/testdata/impl/extend_impl.carbon
@@ -112,7 +112,7 @@ fn G(c: C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @HasF.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/extend_impl.carbon
+++ b/toolchain/check/testdata/impl/extend_impl.carbon
@@ -112,3 +112,7 @@ fn G(c: C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_call_invalid.carbon
+++ b/toolchain/check/testdata/impl/fail_call_invalid.carbon
@@ -117,7 +117,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%G.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%G.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Simple.%Self.ref => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/fail_call_invalid.carbon
+++ b/toolchain/check/testdata/impl/fail_call_invalid.carbon
@@ -117,3 +117,8 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%G.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Simple.%Self.ref => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -110,17 +110,17 @@ class C {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%GenericInterface.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%GenericInterface.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_28.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @GenericInterface.%F.decl(constants.%T, constants.%Self) {
+// CHECK:STDOUT: specific @GenericInterface.%F.decl(constants.%T, constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @GenericInterface.%T.ref => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @impl.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @impl.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @impl.%T.ref => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -28,7 +28,7 @@ class C {
 // CHECK:STDOUT:   %GenericInterface.type: type = generic_interface_type @GenericInterface [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %GenericInterface: %GenericInterface.type = struct_value () [template]
-// CHECK:STDOUT:   %.2: type = interface_type @GenericInterface, (%T) [symbolic]
+// CHECK:STDOUT:   %.2: type = interface_type @GenericInterface, file.%GenericInterface.decl(%T) [symbolic]
 // CHECK:STDOUT:   %Self: %.2 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %F.type.1: type = fn_type @F.1 [template]
 // CHECK:STDOUT:   %F.1: %F.type.1 = struct_value () [template]
@@ -108,5 +108,20 @@ class C {
 // CHECK:STDOUT:     generic [@C.%T.loc19_23.2: type] {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%GenericInterface.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_28.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @GenericInterface.%F.decl(constants.%T, constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @GenericInterface.%T.ref => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @impl.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @impl.%T.ref => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -62,3 +62,7 @@ interface I {
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%C.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -62,7 +62,7 @@ interface I {
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%C.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%C.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
@@ -75,3 +75,7 @@ impl as Simple {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
@@ -75,7 +75,7 @@ impl as Simple {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -887,3 +887,21 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.15(@impl.15.%x.loc212_10.2: %.26) -> %.21;
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @J.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @SelfNested.%F.decl(constants.%Self.3) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @SelfNested.%Self.ref.loc188_12 => constants.%Self.3
+// CHECK:STDOUT:   @SelfNested.%.loc188_16.3 => constants.%.10
+// CHECK:STDOUT:   <unexpected instref inst+267> => <unexpected instref inst+268>
+// CHECK:STDOUT:   @SelfNested.%.loc188_37 => constants.%.11
+// CHECK:STDOUT:   @SelfNested.%.loc188_38.2 => constants.%.13
+// CHECK:STDOUT:   @SelfNested.%.loc188_52 => constants.%.15
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -887,15 +887,15 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.15(@impl.15.%x.loc212_10.2: %.26) -> %.21;
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self.1) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @J.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: specific @J.%F.decl(constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @SelfNested.%F.decl(constants.%Self.3) {
+// CHECK:STDOUT: specific @SelfNested.%F.decl(constants.%Self.3) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @SelfNested.%Self.ref.loc188_12 => constants.%Self.3
 // CHECK:STDOUT:   @SelfNested.%.loc188_16.3 => constants.%.10

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -96,7 +96,7 @@ class C {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -96,3 +96,7 @@ class C {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -77,11 +77,11 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @impl.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific @impl.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -77,3 +77,11 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @impl.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/alias.carbon
+++ b/toolchain/check/testdata/impl/lookup/alias.carbon
@@ -118,3 +118,7 @@ fn G(c: C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/alias.carbon
+++ b/toolchain/check/testdata/impl/lookup/alias.carbon
@@ -118,7 +118,7 @@ fn G(c: C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @HasF.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -96,7 +96,7 @@ fn F(c: C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -96,3 +96,7 @@ fn F(c: C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
@@ -124,7 +124,7 @@ impl C as I {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
@@ -124,3 +124,7 @@ impl C as I {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -96,6 +96,10 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- use.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -96,7 +96,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @HasF.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -142,3 +142,8 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   return %.loc24_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @I.%Self.ref => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -142,7 +142,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   return %.loc24_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @I.%Self.ref => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -93,6 +93,10 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- use.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -93,7 +93,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @HasF.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @HasF.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/basic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/basic.carbon
@@ -81,7 +81,7 @@ impl C as Simple {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Simple.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/basic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/basic.carbon
@@ -81,3 +81,7 @@ impl C as Simple {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Simple.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_self.carbon
@@ -78,7 +78,7 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT: fn @Op[@Add.%self.loc5_9.2: @Add.%Self.ref.loc5_15 (%Self)](@Add.%other.loc5_21.2: @Add.%Self.ref.loc5_15 (%Self)) -> %Self
 // CHECK:STDOUT:     generic [@Add.%Self: %.1];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Add.%Op.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Add.%Op.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Add.%Self.ref.loc5_15 => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_self.carbon
@@ -78,6 +78,11 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT: fn @Op[@Add.%self.loc5_9.2: @Add.%Self.ref.loc5_15 (%Self)](@Add.%other.loc5_21.2: @Add.%Self.ref.loc5_15 (%Self)) -> %Self
 // CHECK:STDOUT:     generic [@Add.%Self: %.1];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Add.%Op.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Add.%Self.ref.loc5_15 => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
@@ -107,3 +107,8 @@ class A {
 // CHECK:STDOUT:   return %.loc21_34 to @impl.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @DefaultConstructible.%Make.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @DefaultConstructible.%Self.ref => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
@@ -107,7 +107,7 @@ class A {
 // CHECK:STDOUT:   return %.loc21_34 to @impl.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @DefaultConstructible.%Make.decl(constants.%Self) {
+// CHECK:STDOUT: specific @DefaultConstructible.%Make.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @DefaultConstructible.%Self.ref => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -275,12 +275,12 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.6(@impl.4.%x.loc36_8.2: %.22);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @UseSelf.%F.decl(constants.%Self.1) {
+// CHECK:STDOUT: specific @UseSelf.%F.decl(constants.%Self.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @UseSelf.%Self.ref.loc12_14 => constants.%Self.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @SelfNested.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: specific @SelfNested.%F.decl(constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @SelfNested.%Self.ref.loc28_12 => constants.%Self.2
 // CHECK:STDOUT:   @SelfNested.%.loc28_16.3 => constants.%.10

--- a/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -275,3 +275,17 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.6(@impl.4.%x.loc36_8.2: %.22);
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @UseSelf.%F.decl(constants.%Self.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @UseSelf.%Self.ref.loc12_14 => constants.%Self.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @SelfNested.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @SelfNested.%Self.ref.loc28_12 => constants.%Self.2
+// CHECK:STDOUT:   @SelfNested.%.loc28_16.3 => constants.%.10
+// CHECK:STDOUT:   <unexpected instref inst+86> => <unexpected instref inst+87>
+// CHECK:STDOUT:   @SelfNested.%.loc28_36 => constants.%.11
+// CHECK:STDOUT:   @SelfNested.%.loc28_37.2 => constants.%.13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
@@ -95,3 +95,11 @@ interface Interface {
 // CHECK:STDOUT: fn @G(@Interface.%a.loc21_16.2: i32, @Interface.%b.loc21_24.2: i32) -> i32 = "int.sadd"
 // CHECK:STDOUT:     generic [@Interface.%Self: %.1];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%G.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
@@ -95,11 +95,11 @@ interface Interface {
 // CHECK:STDOUT: fn @G(@Interface.%a.loc21_16.2: i32, @Interface.%b.loc21_24.2: i32) -> i32 = "int.sadd"
 // CHECK:STDOUT:     generic [@Interface.%Self: %.1];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%G.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%G.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
@@ -141,11 +141,11 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.2(%a: i32, %b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%G.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%G.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
@@ -141,3 +141,11 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.2(%a: i32, %b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%G.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/as_type_of_type.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/as_type_of_type.carbon
@@ -57,7 +57,7 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/no_prelude/as_type_of_type.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/as_type_of_type.carbon
@@ -57,3 +57,8 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/basic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/basic.carbon
@@ -63,3 +63,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: fn @F()
 // CHECK:STDOUT:     generic [@ForwardDeclared.%Self: %.2];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @ForwardDeclared.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/basic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/basic.carbon
@@ -63,7 +63,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: fn @F()
 // CHECK:STDOUT:     generic [@ForwardDeclared.%Self: %.2];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @ForwardDeclared.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: specific @ForwardDeclared.%F.decl(constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/default_fn.carbon
@@ -104,7 +104,7 @@ class C {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/default_fn.carbon
@@ -104,3 +104,7 @@ class C {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_add_member_outside_definition.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_add_member_outside_definition.carbon
@@ -101,15 +101,15 @@ interface Outer {
 // CHECK:STDOUT: fn @F.2()
 // CHECK:STDOUT:     generic [@Outer.%Self: %.3];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Outer.%Inner.decl(constants.%Self.2) {
+// CHECK:STDOUT: specific @Outer.%Inner.decl(constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Inner.%.decl(constants.%Self.2, constants.%Self.3) {
+// CHECK:STDOUT: specific @Inner.%.decl(constants.%Self.2, constants.%Self.3) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Outer.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: specific @Outer.%F.decl(constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_add_member_outside_definition.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_add_member_outside_definition.carbon
@@ -101,3 +101,15 @@ interface Outer {
 // CHECK:STDOUT: fn @F.2()
 // CHECK:STDOUT:     generic [@Outer.%Self: %.3];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Outer.%Inner.decl(constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Inner.%.decl(constants.%Self.2, constants.%Self.3) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Outer.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
@@ -45,7 +45,7 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT:   %.type.1: type = generic_interface_type @.1 [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: %.type.1 = struct_value () [template]
-// CHECK:STDOUT:   %.4: type = interface_type @.1, (%T.1) [symbolic]
+// CHECK:STDOUT:   %.4: type = interface_type @.1, file.%.decl.loc19(%T.1) [symbolic]
 // CHECK:STDOUT:   %Self.1: %.4 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %Generic.type: type = generic_interface_type @Generic [template]
 // CHECK:STDOUT:   %Generic: %Generic.type = struct_value () [template]
@@ -56,7 +56,7 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT:   %T.2: %.2 = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.type.2: type = generic_interface_type @.3 [template]
 // CHECK:STDOUT:   %.6: %.type.2 = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @.3, (%T.2) [symbolic]
+// CHECK:STDOUT:   %.7: type = interface_type @.3, file.%.decl.loc38(%T.2) [symbolic]
 // CHECK:STDOUT:   %Self.3: %.7 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -120,5 +120,25 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl.loc19(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc19_22.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc21_19.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%DifferentParams.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc31_27.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl.loc38(constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc38_27.2 => constants.%T.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
@@ -122,22 +122,22 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl.loc19(constants.%T.1) {
+// CHECK:STDOUT: specific file.%.decl.loc19(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc19_22.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc21_19.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%DifferentParams.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%DifferentParams.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc31_27.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl.loc38(constants.%T.2) {
+// CHECK:STDOUT: specific file.%.decl.loc38(constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc38_27.2 => constants.%T.2
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/no_prelude/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_lookup_undefined.carbon
@@ -113,3 +113,11 @@ interface BeingDefined {
 // CHECK:STDOUT: fn @.2()
 // CHECK:STDOUT:     generic [@BeingDefined.%Self: %.4];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @BeingDefined.%H.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @BeingDefined.%.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_lookup_undefined.carbon
@@ -113,11 +113,11 @@ interface BeingDefined {
 // CHECK:STDOUT: fn @.2()
 // CHECK:STDOUT:     generic [@BeingDefined.%Self: %.4];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @BeingDefined.%H.decl(constants.%Self) {
+// CHECK:STDOUT: specific @BeingDefined.%H.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @BeingDefined.%.decl(constants.%Self) {
+// CHECK:STDOUT: specific @BeingDefined.%.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
@@ -80,7 +80,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
@@ -80,3 +80,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_redeclare_member.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_redeclare_member.carbon
@@ -58,3 +58,11 @@ interface Interface {
 // CHECK:STDOUT: fn @.1()
 // CHECK:STDOUT:     generic [@Interface.%Self: %.1];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_redeclare_member.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_redeclare_member.carbon
@@ -58,11 +58,11 @@ interface Interface {
 // CHECK:STDOUT: fn @.1()
 // CHECK:STDOUT:     generic [@Interface.%Self: %.1];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_facet_lookup.carbon
@@ -95,16 +95,16 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Interface.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%CallStatic.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%CallStatic.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @CallStatic.%T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%CallFacet.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%CallFacet.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @CallFacet.%T => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_facet_lookup.carbon
@@ -95,3 +95,17 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Interface.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%CallStatic.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @CallStatic.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%CallFacet.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @CallFacet.%T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
@@ -97,22 +97,22 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:   return %self.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%I.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%I.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%T, constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%T, constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @I.%.loc13_14.1 => constants.%Self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%I.decl(file.%T.loc22_6.2) {
+// CHECK:STDOUT: specific file.%I.decl(file.%T.loc22_6.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc22_6.2 => constants.%T
 // CHECK:STDOUT:   <unexpected instref inst+42> => constants.%.2

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
@@ -28,7 +28,7 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:   %I.type: type = generic_interface_type @I [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %I: %I.type = struct_value () [template]
-// CHECK:STDOUT:   %.2: type = interface_type @I, (%T) [symbolic]
+// CHECK:STDOUT:   %.2: type = interface_type @I, file.%I.decl(%T) [symbolic]
 // CHECK:STDOUT:   %Self: %.2 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -49,13 +49,13 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.5] {
 // CHECK:STDOUT:     %T.loc22_6.1: type = param T
 // CHECK:STDOUT:     %T.loc22_6.2: type = bind_symbolic_name T 0, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc22_24.1: <unexpected instref inst+42> (%.2) = specific_constant @I.%Self, (constants.%T) [symbolic = %.loc22_24.1 (constants.%Self)]
+// CHECK:STDOUT:     %.loc22_24.1: <unexpected instref inst+42> (%.2) = specific_constant @I.%Self, %I.decl(constants.%T) [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %Self.ref.loc22_24: <unexpected instref inst+42> (%.2) = name_ref Self, %.loc22_24.1 [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc22_24.2: type = facet_type_access %Self.ref.loc22_24 [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc22_24.3: type = converted %Self.ref.loc22_24, %.loc22_24.2 [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %self.loc22_18.1: file.%.loc22_24.1 (%Self) = param self
 // CHECK:STDOUT:     @.1.%self: file.%.loc22_24.1 (%Self) = bind_name self, %self.loc22_18.1
-// CHECK:STDOUT:     %.loc22_35.1: <unexpected instref inst+42> (%.2) = specific_constant @I.%Self, (constants.%T) [symbolic = %.loc22_24.1 (constants.%Self)]
+// CHECK:STDOUT:     %.loc22_35.1: <unexpected instref inst+42> (%.2) = specific_constant @I.%Self, %I.decl(constants.%T) [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %Self.ref.loc22_35: <unexpected instref inst+42> (%.2) = name_ref Self, %.loc22_35.1 [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc22_35.2: type = facet_type_access %Self.ref.loc22_35 [symbolic = %.loc22_24.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc22_35.3: type = converted %Self.ref.loc22_35, %.loc22_35.2 [symbolic = %.loc22_24.1 (constants.%Self)]
@@ -67,13 +67,13 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:     generic [file.%T.loc11_13.2: type] {
 // CHECK:STDOUT:   %Self: %.2 = bind_symbolic_name Self 1 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
-// CHECK:STDOUT:     %.loc13_14.1: %.2 = specific_constant %Self, (constants.%T) [symbolic = %.loc13_14.1 (constants.%Self)]
+// CHECK:STDOUT:     %.loc13_14.1: %.2 = specific_constant %Self, file.%I.decl(constants.%T) [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %Self.ref.loc13_14: %.2 = name_ref Self, %.loc13_14.1 [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc13_14.2: type = facet_type_access %Self.ref.loc13_14 [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc13_14.3: type = converted %Self.ref.loc13_14, %.loc13_14.2 [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %self.loc13_8.1: @I.%.loc13_14.1 (%Self) = param self
 // CHECK:STDOUT:     %self.loc13_8.2: @I.%.loc13_14.1 (%Self) = bind_name self, %self.loc13_8.1
-// CHECK:STDOUT:     %.loc13_25.1: %.2 = specific_constant %Self, (constants.%T) [symbolic = %.loc13_14.1 (constants.%Self)]
+// CHECK:STDOUT:     %.loc13_25.1: %.2 = specific_constant %Self, file.%I.decl(constants.%T) [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %Self.ref.loc13_25: %.2 = name_ref Self, %.loc13_25.1 [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc13_25.2: type = facet_type_access %Self.ref.loc13_25 [symbolic = %.loc13_14.1 (constants.%Self)]
 // CHECK:STDOUT:     %.loc13_25.3: type = converted %Self.ref.loc13_25, %.loc13_25.2 [symbolic = %.loc13_14.1 (constants.%Self)]
@@ -95,5 +95,27 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: %Self = name_ref self, %self
 // CHECK:STDOUT:   return %self.ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%I.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%T, constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @I.%.loc13_14.1 => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%I.decl(file.%T.loc22_6.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc11_13.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc22_6.2 => constants.%T
+// CHECK:STDOUT:   <unexpected instref inst+42> => constants.%.2
+// CHECK:STDOUT:   file.%.loc22_24.1 => constants.%Self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_modifiers.carbon
@@ -69,3 +69,11 @@ interface Modifiers {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Modifiers.%Final.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @Modifiers.%Default.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_modifiers.carbon
@@ -69,11 +69,11 @@ interface Modifiers {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Modifiers.%Final.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Modifiers.%Final.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Modifiers.%Default.decl(constants.%Self) {
+// CHECK:STDOUT: specific @Modifiers.%Default.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic.carbon
@@ -65,22 +65,22 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   %Simple.type: type = generic_interface_type @Simple [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Simple: %Simple.type = struct_value () [template]
-// CHECK:STDOUT:   %.2: type = interface_type @Simple, (%T.1) [symbolic]
+// CHECK:STDOUT:   %.2: type = interface_type @Simple, file.%Simple.decl(%T.1) [symbolic]
 // CHECK:STDOUT:   %Self.1: %.2 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %X: type = class_type @X [template]
 // CHECK:STDOUT:   %.3: type = struct_type {} [template]
 // CHECK:STDOUT:   %WithAssocFn.type: type = generic_interface_type @WithAssocFn [template]
 // CHECK:STDOUT:   %WithAssocFn: %WithAssocFn.type = struct_value () [template]
-// CHECK:STDOUT:   %.4: type = interface_type @WithAssocFn, (%T.1) [symbolic]
+// CHECK:STDOUT:   %.4: type = interface_type @WithAssocFn, file.%WithAssocFn.decl(%T.1) [symbolic]
 // CHECK:STDOUT:   %Self.2: %.4 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %F.type.1: type = fn_type @F.1 [template]
 // CHECK:STDOUT:   %F.1: %F.type.1 = struct_value () [template]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @WithAssocFn, %F.type.1 [template]
 // CHECK:STDOUT:   %.6: %.5 = assoc_entity element0, @WithAssocFn.%F.decl [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
-// CHECK:STDOUT:   %.7: type = interface_type @Simple, (%C) [template]
+// CHECK:STDOUT:   %.7: type = interface_type @Simple, file.%Simple.decl(%C) [template]
 // CHECK:STDOUT:   %.8: <witness> = interface_witness () [template]
-// CHECK:STDOUT:   %.9: type = interface_type @WithAssocFn, (%C) [template]
+// CHECK:STDOUT:   %.9: type = interface_type @WithAssocFn, file.%WithAssocFn.decl(%C) [template]
 // CHECK:STDOUT:   %F.type.2: type = fn_type @F.2 [template]
 // CHECK:STDOUT:   %F.2: %F.type.2 = struct_value () [template]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (%F.2) [template]
@@ -237,6 +237,46 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Simple.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_18.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%WithAssocFn.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc8_23.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @WithAssocFn.%F.decl(constants.%T.1, constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Simple.decl(constants.%C) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_18.2 => constants.%C
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%WithAssocFn.decl(constants.%C) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc8_23.2 => constants.%C
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%WithImplicitArgs.decl(constants.%T.1, constants.%N) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc22_28.2 => constants.%T.1
+// CHECK:STDOUT:   file.%N.loc22_38.2 => constants.%N
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Receive.decl(constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Receive.%T => constants.%T.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Pass.decl(constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @Pass.%T => constants.%T.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_args.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -244,16 +284,16 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   %Generic.type: type = generic_interface_type @Generic [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %Generic: %Generic.type = struct_value () [template]
-// CHECK:STDOUT:   %.2: type = interface_type @Generic, (%T.1) [symbolic]
+// CHECK:STDOUT:   %.2: type = interface_type @Generic, file.%Generic.decl(%T.1) [symbolic]
 // CHECK:STDOUT:   %Self: %.2 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %A: type = class_type @A [template]
 // CHECK:STDOUT:   %.3: type = struct_type {} [template]
 // CHECK:STDOUT:   %B: type = class_type @B [template]
-// CHECK:STDOUT:   %.4: type = interface_type @Generic, (%A) [template]
+// CHECK:STDOUT:   %.4: type = interface_type @Generic, file.%Generic.decl(%A) [template]
 // CHECK:STDOUT:   %T.2: %.4 = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
-// CHECK:STDOUT:   %.5: type = interface_type @Generic, (%B) [template]
+// CHECK:STDOUT:   %.5: type = interface_type @Generic, file.%Generic.decl(%B) [template]
 // CHECK:STDOUT:   %T.3: %.5 = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %G.type: type = fn_type @G [template]
 // CHECK:STDOUT:   %G: %G.type = struct_value () [template]
@@ -322,5 +362,30 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   %T.ref: %.5 = name_ref T, %T [symbolic = constants.%T.3]
 // CHECK:STDOUT:   %F.call: init %.1 = call %F.ref(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%T.1) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%T.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%A) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%A
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%F.decl(constants.%T.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @F.%T => constants.%T.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%Generic.decl(constants.%B) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%B
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%G.decl(constants.%T.3) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @G.%T => constants.%T.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic.carbon
@@ -237,42 +237,42 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Simple.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%Simple.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_18.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%WithAssocFn.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%WithAssocFn.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc8_23.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @WithAssocFn.%F.decl(constants.%T.1, constants.%Self.2) {
+// CHECK:STDOUT: specific @WithAssocFn.%F.decl(constants.%T.1, constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Simple.decl(constants.%C) {
+// CHECK:STDOUT: specific file.%Simple.decl(constants.%C) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_18.2 => constants.%C
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%WithAssocFn.decl(constants.%C) {
+// CHECK:STDOUT: specific file.%WithAssocFn.decl(constants.%C) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc8_23.2 => constants.%C
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%WithImplicitArgs.decl(constants.%T.1, constants.%N) {
+// CHECK:STDOUT: specific file.%WithImplicitArgs.decl(constants.%T.1, constants.%N) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc22_28.2 => constants.%T.1
 // CHECK:STDOUT:   file.%N.loc22_38.2 => constants.%N
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Receive.decl(constants.%T.2) {
+// CHECK:STDOUT: specific file.%Receive.decl(constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Receive.%T => constants.%T.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Pass.decl(constants.%T.2) {
+// CHECK:STDOUT: specific file.%Pass.decl(constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @Pass.%T => constants.%T.2
 // CHECK:STDOUT: }
@@ -364,27 +364,27 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%T.1) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%T.1) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%A) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%A) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%F.decl(constants.%T.2) {
+// CHECK:STDOUT: specific file.%F.decl(constants.%T.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @F.%T => constants.%T.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%Generic.decl(constants.%B) {
+// CHECK:STDOUT: specific file.%Generic.decl(constants.%B) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%G.decl(constants.%T.3) {
+// CHECK:STDOUT: specific file.%G.decl(constants.%T.3) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @G.%T => constants.%T.3
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/no_prelude/generic_binding_after_assoc_const.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_binding_after_assoc_const.carbon
@@ -71,12 +71,12 @@ interface I {
 // CHECK:STDOUT: fn @G(@I.%T.loc16_8.2: type)
 // CHECK:STDOUT:     generic [@I.%Self: %.1, @I.%T.loc16_8.2: type];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self, constants.%T) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self, constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @I.%T.loc12_8.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%G.decl(constants.%Self, constants.%T) {
+// CHECK:STDOUT: specific @I.%G.decl(constants.%Self, constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @I.%T.loc16_8.2 => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/no_prelude/generic_binding_after_assoc_const.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_binding_after_assoc_const.carbon
@@ -71,3 +71,13 @@ interface I {
 // CHECK:STDOUT: fn @G(@I.%T.loc16_8.2: type)
 // CHECK:STDOUT:     generic [@I.%Self: %.1, @I.%T.loc16_8.2: type];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self, constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @I.%T.loc12_8.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%G.decl(constants.%Self, constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @I.%T.loc16_8.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
@@ -34,7 +34,7 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:   %AddWith.type: type = generic_interface_type @AddWith [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %AddWith: %AddWith.type = struct_value () [template]
-// CHECK:STDOUT:   %.2: type = interface_type @AddWith, (%T) [symbolic]
+// CHECK:STDOUT:   %.2: type = interface_type @AddWith, file.%AddWith.decl(%T) [symbolic]
 // CHECK:STDOUT:   %Self: %.2 = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -67,6 +67,15 @@ impl C as AddWith(C) {
 // CHECK:STDOUT: fn @F()
 // CHECK:STDOUT:     generic [file.%T.loc4_19.2: type, @AddWith.%Self: %.2];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%AddWith.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @AddWith.%F.decl(constants.%T, constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -76,9 +85,9 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %AddWith: %AddWith.type = struct_value () [template]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, <unexpected instref inst+14> [symbolic]
-// CHECK:STDOUT:   %.3: type = interface_type @AddWith, (%T) [symbolic]
+// CHECK:STDOUT:   %.3: type = interface_type @AddWith, <invalid>(%T) [symbolic]
 // CHECK:STDOUT:   %Self: %.3 = bind_symbolic_name Self 1 [symbolic]
-// CHECK:STDOUT:   %.4: type = interface_type @AddWith, (%C) [template]
+// CHECK:STDOUT:   %.4: type = interface_type @AddWith, <invalid>(%C) [template]
 // CHECK:STDOUT:   %F.type.1: type = fn_type @F.1 [template]
 // CHECK:STDOUT:   %F.1: %F.type.1 = struct_value () [template]
 // CHECK:STDOUT:   %F.type.2: type = fn_type @F.2 [template]
@@ -137,4 +146,8 @@ impl C as AddWith(C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2();
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%C);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
@@ -67,12 +67,12 @@ impl C as AddWith(C) {
 // CHECK:STDOUT: fn @F()
 // CHECK:STDOUT:     generic [file.%T.loc4_19.2: type, @AddWith.%Self: %.2];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%AddWith.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%AddWith.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_19.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @AddWith.%F.decl(constants.%T, constants.%Self) {
+// CHECK:STDOUT: specific @AddWith.%F.decl(constants.%T, constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -147,7 +147,7 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2();
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%C);
+// CHECK:STDOUT: specific <invalid>(constants.%C);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import.carbon
@@ -132,11 +132,11 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: fn @F.2()
 // CHECK:STDOUT:     generic [@ForwardDeclared.%Self: %.8];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @Basic.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: specific @Basic.%F.decl(constants.%Self.2) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @ForwardDeclared.%F.decl(constants.%Self.3) {
+// CHECK:STDOUT: specific @ForwardDeclared.%F.decl(constants.%Self.3) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import.carbon
@@ -132,6 +132,14 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: fn @F.2()
 // CHECK:STDOUT:     generic [@ForwardDeclared.%Self: %.8];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @Basic.%F.decl(constants.%Self.2) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @ForwardDeclared.%F.decl(constants.%Self.3) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/interface/no_prelude/self.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/self.carbon
@@ -55,3 +55,8 @@ interface UseSelf {
 // CHECK:STDOUT: fn @F[@UseSelf.%self.loc12_8.2: @UseSelf.%Self.ref.loc12_14 (%Self)]() -> %Self
 // CHECK:STDOUT:     generic [@UseSelf.%Self: %.1];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @UseSelf.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   @UseSelf.%Self.ref.loc12_14 => constants.%Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/self.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/self.carbon
@@ -55,7 +55,7 @@ interface UseSelf {
 // CHECK:STDOUT: fn @F[@UseSelf.%self.loc12_8.2: @UseSelf.%Self.ref.loc12_14 (%Self)]() -> %Self
 // CHECK:STDOUT:     generic [@UseSelf.%Self: %.1];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @UseSelf.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @UseSelf.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   @UseSelf.%Self.ref.loc12_14 => constants.%Self
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/todo_define_not_default.carbon
+++ b/toolchain/check/testdata/interface/todo_define_not_default.carbon
@@ -121,11 +121,11 @@ interface I {
 // CHECK:STDOUT: fn @G(@I.%a.loc14_8.2: i32, @I.%b.loc14_16.2: i32) -> i32 = "int.sadd"
 // CHECK:STDOUT:     generic [@I.%Self: %.1];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%F.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance @I.%G.decl(constants.%Self) {
+// CHECK:STDOUT: specific @I.%G.decl(constants.%Self) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/todo_define_not_default.carbon
+++ b/toolchain/check/testdata/interface/todo_define_not_default.carbon
@@ -121,3 +121,11 @@ interface I {
 // CHECK:STDOUT: fn @G(@I.%a.loc14_8.2: i32, @I.%b.loc14_16.2: i32) -> i32 = "int.sadd"
 // CHECK:STDOUT:     generic [@I.%Self: %.1];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%F.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance @I.%G.decl(constants.%Self) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_params.carbon
+++ b/toolchain/check/testdata/namespace/fail_params.carbon
@@ -101,3 +101,8 @@ fn D(T:! type).F() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc39_6.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_params.carbon
+++ b/toolchain/check/testdata/namespace/fail_params.carbon
@@ -101,7 +101,7 @@ fn D(T:! type).F() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc39_6.2 => constants.%T
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
@@ -62,12 +62,12 @@ export C2(T:! type);
 // CHECK:STDOUT: class @C2
 // CHECK:STDOUT:     generic [file.%T.loc5_10.2: type];
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C1.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%C1.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc4_10.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C2.decl(constants.%T) {
+// CHECK:STDOUT: specific file.%C2.decl(constants.%T) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%T.loc5_10.2 => constants.%T
 // CHECK:STDOUT: }
@@ -106,5 +106,5 @@ export C2(T:! type);
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C2;
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%T);
+// CHECK:STDOUT: specific <invalid>(constants.%T);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
@@ -35,10 +35,10 @@ export C2(T:! type);
 // CHECK:STDOUT:   %C1.type: type = generic_class_type @C1 [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %C1.1: %C1.type = struct_value () [template]
-// CHECK:STDOUT:   %C1.2: type = class_type @C1, (%T) [symbolic]
+// CHECK:STDOUT:   %C1.2: type = class_type @C1, file.%C1.decl(%T) [symbolic]
 // CHECK:STDOUT:   %C2.type: type = generic_class_type @C2 [template]
 // CHECK:STDOUT:   %C2.1: %C2.type = struct_value () [template]
-// CHECK:STDOUT:   %C2.2: type = class_type @C2, (%T) [symbolic]
+// CHECK:STDOUT:   %C2.2: type = class_type @C2, file.%C2.decl(%T) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -62,6 +62,16 @@ export C2(T:! type);
 // CHECK:STDOUT: class @C2
 // CHECK:STDOUT:     generic [file.%T.loc5_10.2: type];
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C1.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc4_10.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C2.decl(constants.%T) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%T.loc5_10.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -69,10 +79,10 @@ export C2(T:! type);
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %C1.1: %C1.type = struct_value () [template]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, <unexpected instref inst+18> [symbolic]
-// CHECK:STDOUT:   %C1.2: type = class_type @C1, (%T) [symbolic]
+// CHECK:STDOUT:   %C1.2: type = class_type @C1, <invalid>(%T) [symbolic]
 // CHECK:STDOUT:   %C2.type: type = generic_class_type @C2 [template]
 // CHECK:STDOUT:   %C2.1: %C2.type = struct_value () [template]
-// CHECK:STDOUT:   %C2.2: type = class_type @C2, (%T) [symbolic]
+// CHECK:STDOUT:   %C2.2: type = class_type @C2, <invalid>(%T) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -95,4 +105,6 @@ export C2(T:! type);
 // CHECK:STDOUT: class @C1;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%T);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -61,3 +61,8 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <unexpected instref inst+29>(constants.%y) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   <unexpected instref inst+27> => constants.%y
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -61,7 +61,7 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <unexpected instref inst+29>(constants.%y) {
+// CHECK:STDOUT: specific <unexpected instref inst+29>(constants.%y) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   <unexpected instref inst+27> => constants.%y
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -189,12 +189,12 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C.decl(constants.%S) {
+// CHECK:STDOUT: specific file.%C.decl(constants.%S) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%S.loc8_9.2 => constants.%S
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C.decl(constants.%struct.4) {
+// CHECK:STDOUT: specific file.%C.decl(constants.%struct.4) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%S.loc8_9.2 => constants.%struct.4
 // CHECK:STDOUT: }
@@ -337,9 +337,9 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%S);
+// CHECK:STDOUT: specific <invalid>(constants.%S);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%struct);
+// CHECK:STDOUT: specific <invalid>(constants.%struct);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_type.impl.carbon
 // CHECK:STDOUT:
@@ -410,9 +410,9 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%S);
+// CHECK:STDOUT: specific <invalid>(constants.%S);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%struct);
+// CHECK:STDOUT: specific <invalid>(constants.%struct);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_value.impl.carbon
 // CHECK:STDOUT:
@@ -488,9 +488,9 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%S);
+// CHECK:STDOUT: specific <invalid>(constants.%S);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%struct.1);
+// CHECK:STDOUT: specific <invalid>(constants.%struct.1);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%struct.2);
+// CHECK:STDOUT: specific <invalid>(constants.%struct.2);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -73,13 +73,13 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %S: %.11 = bind_symbolic_name S 0 [symbolic]
 // CHECK:STDOUT:   %C.type: type = generic_class_type @C [template]
 // CHECK:STDOUT:   %C.1: %C.type = struct_value () [template]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%S) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, file.%C.decl(%S) [symbolic]
 // CHECK:STDOUT:   %.12: type = struct_type {} [template]
 // CHECK:STDOUT:   %.13: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.14: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.15: type = ptr_type %.11 [template]
 // CHECK:STDOUT:   %struct.4: %.11 = struct_value (%.13, %.14) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%struct.4) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, file.%C.decl(%struct.4) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT: }
@@ -189,6 +189,16 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C.decl(constants.%S) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%S.loc8_9.2 => constants.%S
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C.decl(constants.%struct.4) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%S.loc8_9.2 => constants.%struct.4
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -208,12 +218,12 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %.10: type = struct_type {} [template]
 // CHECK:STDOUT:   %.11: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %S: %.11 = bind_symbolic_name S 0, <unexpected instref inst+103> [symbolic]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%S) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, <invalid>(%S) [symbolic]
 // CHECK:STDOUT:   %.12: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.13: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.14: type = ptr_type %.11 [template]
 // CHECK:STDOUT:   %struct: %.11 = struct_value (%.12, %.13) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%struct) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, <invalid>(%struct) [template]
 // CHECK:STDOUT:   %.15: type = ptr_type %.10 [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -327,6 +337,10 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%S);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%struct);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_type.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -336,13 +350,13 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %S: %.3 = bind_symbolic_name S 0, <unexpected instref inst+21> [symbolic]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%S) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, <invalid>(%S) [symbolic]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: type = struct_type {.c: i32, .d: i32} [template]
 // CHECK:STDOUT:   %.7: type = ptr_type %.3 [template]
 // CHECK:STDOUT:   %struct: %.3 = struct_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%struct) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, <invalid>(%struct) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.8: type = ptr_type %.2 [template]
@@ -396,6 +410,10 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%S);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%struct);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_value.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -405,17 +423,17 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %S: %.3 = bind_symbolic_name S 0, <unexpected instref inst+21> [symbolic]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%S) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, <invalid>(%S) [symbolic]
 // CHECK:STDOUT:   %.4: i32 = int_literal 3 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 4 [template]
 // CHECK:STDOUT:   %.6: type = ptr_type %.3 [template]
 // CHECK:STDOUT:   %struct.1: %.3 = struct_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%struct.1) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, <invalid>(%struct.1) [template]
 // CHECK:STDOUT:   %.7: type = ptr_type %.2 [template]
 // CHECK:STDOUT:   %.8: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.9: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %struct.2: %.3 = struct_value (%.9, %.8) [template]
-// CHECK:STDOUT:   %C.4: type = class_type @C, (%struct.2) [template]
+// CHECK:STDOUT:   %C.4: type = class_type @C, <invalid>(%struct.2) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT: }
@@ -469,4 +487,10 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   assign file.%c_bad.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%S);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%struct.1);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%struct.2);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/import.carbon
+++ b/toolchain/check/testdata/tuples/import.carbon
@@ -81,10 +81,10 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %X: %.9 = bind_symbolic_name X 0 [symbolic]
 // CHECK:STDOUT:   %C.type: type = generic_class_type @C [template]
 // CHECK:STDOUT:   %C.1: %C.type = struct_value () [template]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%X) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, file.%C.decl(%X) [symbolic]
 // CHECK:STDOUT:   %.18: type = struct_type {} [template]
 // CHECK:STDOUT:   %tuple.5: %.9 = tuple_value (%.15, %.16) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%tuple.5) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, file.%C.decl(%tuple.5) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT: }
@@ -211,6 +211,16 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C.decl(constants.%X) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%X.loc7_9.2 => constants.%X
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance file.%C.decl(constants.%tuple.5) {
+// CHECK:STDOUT: declaration:
+// CHECK:STDOUT:   file.%X.loc7_9.2 => constants.%tuple.5
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -233,11 +243,11 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %C.1: %C.type = struct_value () [template]
 // CHECK:STDOUT:   %.14: type = struct_type {} [template]
 // CHECK:STDOUT:   %X: %.8 = bind_symbolic_name X 0, <unexpected instref inst+105> [symbolic]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%X) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, <invalid>(%X) [symbolic]
 // CHECK:STDOUT:   %.15: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.16: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %tuple: %.8 = tuple_value (%.15, %.16) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%tuple) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, <invalid>(%tuple) [template]
 // CHECK:STDOUT:   %.17: type = ptr_type %.14 [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
@@ -368,6 +378,10 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%X);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%tuple);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_type.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -377,14 +391,14 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT:   %X: %.3 = bind_symbolic_name X 0, <unexpected instref inst+17> [symbolic]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%X) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, <invalid>(%X) [symbolic]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
 // CHECK:STDOUT:   %.7: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.8: type = ptr_type %.3 [template]
 // CHECK:STDOUT:   %tuple: %.3 = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%tuple) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, <invalid>(%tuple) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %.9: type = ptr_type %.2 [template]
@@ -439,6 +453,10 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%X);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%tuple);
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_value.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -448,17 +466,17 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT:   %X: %.3 = bind_symbolic_name X 0, <unexpected instref inst+17> [symbolic]
-// CHECK:STDOUT:   %C.2: type = class_type @C, (%X) [symbolic]
+// CHECK:STDOUT:   %C.2: type = class_type @C, <invalid>(%X) [symbolic]
 // CHECK:STDOUT:   %.4: i32 = int_literal 3 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 4 [template]
 // CHECK:STDOUT:   %.6: type = ptr_type %.3 [template]
 // CHECK:STDOUT:   %tuple.1: %.3 = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %C.3: type = class_type @C, (%tuple.1) [template]
+// CHECK:STDOUT:   %C.3: type = class_type @C, <invalid>(%tuple.1) [template]
 // CHECK:STDOUT:   %.7: type = ptr_type %.2 [template]
 // CHECK:STDOUT:   %.8: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.9: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %tuple.2: %.3 = tuple_value (%.9, %.8) [template]
-// CHECK:STDOUT:   %C.4: type = class_type @C, (%tuple.2) [template]
+// CHECK:STDOUT:   %C.4: type = class_type @C, <invalid>(%tuple.2) [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT: }
@@ -512,4 +530,10 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   assign file.%c_bad.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%X);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%tuple.1);
+// CHECK:STDOUT:
+// CHECK:STDOUT: instance <invalid>(constants.%tuple.2);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/import.carbon
+++ b/toolchain/check/testdata/tuples/import.carbon
@@ -211,12 +211,12 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C.decl(constants.%X) {
+// CHECK:STDOUT: specific file.%C.decl(constants.%X) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%X.loc7_9.2 => constants.%X
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance file.%C.decl(constants.%tuple.5) {
+// CHECK:STDOUT: specific file.%C.decl(constants.%tuple.5) {
 // CHECK:STDOUT: declaration:
 // CHECK:STDOUT:   file.%X.loc7_9.2 => constants.%tuple.5
 // CHECK:STDOUT: }
@@ -378,9 +378,9 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%X);
+// CHECK:STDOUT: specific <invalid>(constants.%X);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%tuple);
+// CHECK:STDOUT: specific <invalid>(constants.%tuple);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_type.impl.carbon
 // CHECK:STDOUT:
@@ -453,9 +453,9 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%X);
+// CHECK:STDOUT: specific <invalid>(constants.%X);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%tuple);
+// CHECK:STDOUT: specific <invalid>(constants.%tuple);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_value.impl.carbon
 // CHECK:STDOUT:
@@ -531,9 +531,9 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%X);
+// CHECK:STDOUT: specific <invalid>(constants.%X);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%tuple.1);
+// CHECK:STDOUT: specific <invalid>(constants.%tuple.1);
 // CHECK:STDOUT:
-// CHECK:STDOUT: instance <invalid>(constants.%tuple.2);
+// CHECK:STDOUT: specific <invalid>(constants.%tuple.2);
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -869,9 +869,7 @@ class Formatter {
     out_ << ')';
   }
 
-  auto FormatArg(GenericInstanceId id) -> void {
-    FormatSpecificName(id);
-  }
+  auto FormatArg(GenericInstanceId id) -> void { FormatSpecificName(id); }
 
   auto FormatArg(RealId id) -> void {
     // TODO: Format with a `.` when the exponent is near zero.

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -366,7 +366,7 @@ class Formatter {
       out_ << ";\n";
       return;
     }
-    out_ << ' ';
+    out_ << " ";
 
     const auto& generic = sem_ir_.generics().Get(specific.generic_id);
 
@@ -377,7 +377,7 @@ class Formatter {
                          GenericInstIndex::Region::Definition, "definition");
     CloseBrace();
 
-    out_ << '\n';
+    out_ << "\n";
   }
 
   auto FormatParamList(InstBlockId param_refs_id) -> void {

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -71,12 +71,11 @@ struct GenericInstance : Printable<GenericInstance> {
     out << "{generic: " << generic_id << ", args: " << args_id << "}";
   }
 
-  // Returns the value block for this instance of the specified region of the
-  // generic. This is a block containing values and instructions produced by
-  // evaluating the corresponding eval block of the generic within the context
-  // of this instance. These are the constant values and types and the
-  // instantiated template-dependent instructions that are used in this region
-  // of the instance.
+  // Returns the value block for this region of the specific. This is a block
+  // containing values and instructions produced by evaluating the corresponding
+  // eval block of the generic within the context of this specific. These are
+  // the constant values and types and the instantiated template-dependent
+  // instructions that are used in this region of the specific.
   auto GetValueBlock(GenericInstIndex::Region region) const -> InstBlockId {
     return region == GenericInstIndex::Region::Declaration
                ? decl_block_id
@@ -88,12 +87,12 @@ struct GenericInstance : Printable<GenericInstance> {
   // Argument values, corresponding to the bindings in `Generic::bindings_id`.
   InstBlockId args_id;
 
-  // The following members are set when the corresponding region of the generic
-  // instance is resolved.
+  // The following members are set when the corresponding region of the specific
+  // is resolved.
 
-  // The value block for the declaration region of the generic.
+  // The value block for the declaration region of the specific.
   InstBlockId decl_block_id = InstBlockId::Invalid;
-  // The value block for the definition region of the generic.
+  // The value block for the definition region of the specific.
   InstBlockId definition_block_id = InstBlockId::Invalid;
 };
 

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -19,6 +19,15 @@ struct Generic : public Printable<Generic> {
     out << "{decl: " << decl_id << ", bindings: " << bindings_id << "}";
   }
 
+  // Returns the eval block for the specified region of the generic. This is a
+  // block of instructions that should be evaluated to compute the values and
+  // instructions needed by that region of the generic.
+  auto GetEvalBlock(GenericInstIndex::Region region) const -> InstBlockId {
+    return region == GenericInstIndex::Region::Declaration
+               ? decl_block_id
+               : definition_block_id;
+  }
+
   // The following members always have values, and do not change throughout the
   // lifetime of the generic.
 
@@ -36,9 +45,10 @@ struct Generic : public Printable<Generic> {
   // The following members are set at the end of the corresponding region of the
   // generic.
 
-  // A block of instructions that should be evaluated to compute the values and
-  // instructions needed by the declaration of the generic.
+  // The eval block for the declaration region of the generic.
   InstBlockId decl_block_id = InstBlockId::Invalid;
+  // The eval block for the definition region of the generic.
+  InstBlockId definition_block_id = InstBlockId::Invalid;
 };
 
 // Provides storage for generics.
@@ -61,6 +71,18 @@ struct GenericInstance : Printable<GenericInstance> {
     out << "{generic: " << generic_id << ", args: " << args_id << "}";
   }
 
+  // Returns the value block for this instance of the specified region of the
+  // generic. This is a block containing values and instructions produced by
+  // evaluating the corresponding eval block of the generic within the context
+  // of this instance. These are the constant values and types and the
+  // instantiated template-dependent instructions that are used in this region
+  // of the instance.
+  auto GetValueBlock(GenericInstIndex::Region region) const -> InstBlockId {
+    return region == GenericInstIndex::Region::Declaration
+               ? decl_block_id
+               : definition_block_id;
+  }
+
   // The generic that this is an instance of.
   GenericId generic_id;
   // Argument values, corresponding to the bindings in `Generic::bindings_id`.
@@ -69,10 +91,10 @@ struct GenericInstance : Printable<GenericInstance> {
   // The following members are set when the corresponding region of the generic
   // instance is resolved.
 
-  // The values and instructions produced by evaluating the decl block of the
-  // generic. These are the constant values and types and the instantiated
-  // template-dependent instructions needed by the declaration of this instance.
+  // The value block for the declaration region of the generic.
   InstBlockId decl_block_id = InstBlockId::Invalid;
+  // The value block for the definition region of the generic.
+  InstBlockId definition_block_id = InstBlockId::Invalid;
 };
 
 // Provides storage for deduplicated instances of generics.
@@ -98,6 +120,11 @@ class GenericInstanceStore : public Yaml::Printable<GenericInstanceStore> {
   auto OutputYaml() const -> Yaml::OutputMapping {
     return generic_instances_.OutputYaml();
   }
+
+  auto array_ref() const -> llvm::ArrayRef<GenericInstance> {
+    return generic_instances_.array_ref();
+  }
+  auto size() const -> size_t { return generic_instances_.size(); }
 
  private:
   // Context for hashing keys.


### PR DESCRIPTION
When forming a specific (previously called a generic instance), evaluate the eval block of the generic to determine the values of any constants used in that specific. The majority of the work here is updating eval.cpp so that it can use the results of prior evaluations in the same block when computing later values.

Include the computed results in the formatted SemIR output.