### PR TITLE
Add a run_bazelisk wrapper script for linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ sudo apt update
 
 # Install tools.
 sudo apt install \
-  bazel \
   clang \
   libc++-dev \
   libc++abi-dev \
@@ -303,7 +302,7 @@ Then you can build and run the explorer:
 
 ```shell
 # Build and run the explorer.
-$ bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
+$ ./scripts/run_bazelisk.py run //explorer -- ./explorer/testdata/print/format_only.carbon
 ```
 
 And you can try out our toolchain which has a very early-stage compiler for
@@ -311,7 +310,7 @@ Carbon:
 
 ```shell
 # Build and run the toolchain's help to get documentation on the command line.
-$ bazel run //toolchain -- help
+$ ./scripts/run_bazelisk.py run //toolchain -- help
 ```
 
 For complete instructions, including installing dependencies on various

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -15,7 +15,7 @@ contributions.
 
 -   [Setup commands](#setup-commands)
     -   [Debian or Ubuntu](#debian-or-ubuntu)
-        -   [Bazelisk](#bazelisk)
+        -   [Installing Bazelisk](#installing-bazelisk)
         -   [Old `clang` versions](#old-clang-versions)
     -   [macOS](#macos)
 -   [Tools](#tools)

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -15,6 +15,8 @@ contributions.
 
 -   [Setup commands](#setup-commands)
     -   [Debian or Ubuntu](#debian-or-ubuntu)
+        -   [Bazelisk](#bazelisk)
+        -   [Old `clang` versions](#old-clang-versions)
     -   [macOS](#macos)
 -   [Tools](#tools)
     -   [Main tools](#main-tools)
@@ -48,7 +50,6 @@ apt-cache show clang | grep 'Version:'
 
 # Install tools.
 sudo apt install \
-  bazel \
   clang \
   gh \
   libc++-dev \
@@ -67,8 +68,18 @@ cd carbon-lang
 pre-commit install
 
 # Run tests.
-bazel test //...:all
+./scripts/run_bazelisk.py test //...:all
 ```
+
+#### Installing Bazelisk
+
+Although the `run_bazelisk` script can make it easy to get started, if you're
+frequently building Carbon, it can be a bit much to type. Consider either
+aliasing `bazel` to the `run_bazelisk.py` script, or
+[downloading a bazelisk release](https://github.com/bazelbuild/bazelisk) and
+adding it to your `$PATH`.
+
+#### Old `clang` versions
 
 If the version of `clang` is earlier than 16, you may still have version 16
 available. You can use the following install instead:
@@ -89,9 +100,6 @@ echo "build --repo_env=CC=$(readlink -f $(which clang-16))" >> user.bazelrc
 
 > NOTE: Most LLVM 16+ installs should build Carbon. If you're having issues, see
 > [troubleshooting build issues](#troubleshooting-build-issues).
-
-> NOTE: If you don't have a `bazel` package, see
-> [Bazel's install instructions](https://bazel.build/install) for help.
 
 ### macOS
 

--- a/scripts/run_bazelisk.py
+++ b/scripts/run_bazelisk.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""Runs bazelisk with arbitrary arguments."""
+
+__copyright__ = """
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+import os
+import sys
+
+import scripts_utils
+
+
+def main() -> None:
+    bazelisk = scripts_utils.get_release(scripts_utils.Release.BAZELISK)
+    os.execv(bazelisk, [bazelisk] + sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scripts_utils.py
+++ b/scripts/scripts_utils.py
@@ -21,6 +21,7 @@ import urllib.request
 
 # The tools we track releases for.
 class Release(Enum):
+    BAZELISK = "bazelisk"
     BUILDIFIER = "buildifier"
     BUILDOZER = "buildozer"
     TARGET_DETERMINATOR = "target-determinator"
@@ -39,6 +40,9 @@ _BAZEL_TOOLS_URL = (
 
 # Structured information per release tool.
 _RELEASES = {
+    Release.BAZELISK: ReleaseInfo(
+        "https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/", "-"
+    ),
     Release.BUILDIFIER: ReleaseInfo(_BAZEL_TOOLS_URL, "-"),
     Release.BUILDOZER: ReleaseInfo(_BAZEL_TOOLS_URL, "-"),
     Release.TARGET_DETERMINATOR: ReleaseInfo(
@@ -54,6 +58,13 @@ _RELEASES = {
 # `calculate_release_shas.py`. This is maintained separate from _RELEASES just
 # to make copy-paste updates simpler.
 _RELEASE_SHAS = {
+    Release.BAZELISK: {
+        "darwin-amd64": "51a6228d51704c656df9fceacad18d64f265b973905b3efdcf8a504b687545bf",  # noqa: E501
+        "darwin-arm64": "29753341c0ddc35931fb240e247fbba0b83ef81bccc2433dd075363ec02a67a6",  # noqa: E501
+        "linux-amd64": "d9af1fa808c0529753c3befda75123236a711d971d3485a390507122148773a3",  # noqa: E501
+        "linux-arm64": "467ec3821aca5e278c8570b7c25e0dfc1a061d2873be89e4a266aaf488148426",  # noqa: E501
+        "windows-amd64.exe": "4175ce7ef4b552fb17e93ce49a245679dc26a35cf2fbc7c3146daca6ffc7a81e",  # noqa: E501
+    },
     Release.BUILDIFIER: {
         "darwin-amd64": "687c49c318fb655970cf716eed3c7bfc9caeea4f2931a2fd36593c458de0c537",  # noqa: E501
         "darwin-arm64": "d0909b645496608fd6dfc67f95d9d3b01d90736d7b8c8ec41e802cb0b7ceae7c",  # noqa: E501
@@ -216,8 +227,11 @@ def calculate_release_shas() -> None:
 def locate_bazel() -> str:
     """Returns the bazel command.
 
-    We use the `BAZEL` environment variable if present. If not, then we try to
-    use `bazelisk` and then `bazel`.
+    In order, try:
+    1. The `BAZEL` environment variable.
+    2. `bazelisk`
+    3. `bazel`
+    4. `run_bazelisk.py`
     """
     bazel = os.environ.get("BAZEL")
     if bazel:
@@ -228,4 +242,4 @@ def locate_bazel() -> str:
         if target:
             return target
 
-    exit("Unable to run Bazel")
+    return str(Path(__file__).parent / "run_bazelisk.py")


### PR DESCRIPTION
I was considering making a "/bazel" alias for this, but I'm really on the fence about whether that's a good choice. However, I do think this is good to have to simplify installs.

Fixes #3071 and #3896