### PR TITLE
Remove support for `beta` and `alpha` versions.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,8 +14,6 @@ build --stamp
 build --flag_alias=release=//bazel/version:release
 build --flag_alias=pre_release=//bazel/version:pre_release
 build --flag_alias=rc_number=//bazel/version:rc_number
-build --flag_alias=beta_number=//bazel/version:beta_number
-build --flag_alias=alpha_number=//bazel/version:alpha_number
 build --flag_alias=nightly_date=//bazel/version:nightly_date
 
 # Support running clang-tidy with:

--- a/bazel/version/BUILD
+++ b/bazel/version/BUILD
@@ -34,10 +34,6 @@ bool_flag(
 # A `--pre_release=KIND` flag where `KIND` must be one of:
 # - `rc` -- a release candidate version.
 #    Example: `--pre_release=rc --rc_number=2`
-# - `beta` -- a beta version.
-#    Example: `--pre_release=beta --beta_number=2`
-# - `alpha` -- an alpha version.
-#    Example: `--pre_release=alpha --alpha_number=2`
 # - `nightly -- a nightly version.
 #    Example: `--pre_release=nightly --nightly_date=2024.06.17`
 # - `dev` -- the default, a development build.
@@ -51,8 +47,6 @@ string_flag(
     build_setting_default = "dev",
     values = [
         "rc",
-        "beta",
-        "alpha",
         "nightly",
         "dev",
     ],
@@ -62,20 +56,6 @@ string_flag(
 # `--pre_release=rc`.
 int_flag(
     name = "rc_number",
-    build_setting_default = -1,
-)
-
-# `--beta_number=N` sets the beta pre-release number to `N`. Requires
-# `--pre_release=beta`.
-int_flag(
-    name = "beta_number",
-    build_setting_default = -1,
-)
-
-# `--alpha_number=N` sets the alpha pre-release number to `N`. Requires
-# `--pre_release=alpha`.
-int_flag(
-    name = "alpha_number",
     build_setting_default = -1,
 )
 

--- a/bazel/version/compute_version.bzl
+++ b/bazel/version/compute_version.bzl
@@ -39,8 +39,6 @@ def compute_version(ctx):
     if not ctx.attr._release_flag[BuildSettingInfo].value:
         pre_release = ctx.attr._pre_release_flag[BuildSettingInfo].value
         pre_release_numbers = {
-            "alpha": ctx.attr._alpha_number_flag[BuildSettingInfo].value,
-            "beta": ctx.attr._beta_number_flag[BuildSettingInfo].value,
             "rc": ctx.attr._rc_number_flag[BuildSettingInfo].value,
         }
         if pre_release in pre_release_numbers:
@@ -60,8 +58,6 @@ def compute_version(ctx):
     return version
 
 VERSION_ATTRS = {
-    "_alpha_number_flag": attr.label(default = ":alpha_number"),
-    "_beta_number_flag": attr.label(default = ":beta_number"),
     "_nightly_date_flag": attr.label(default = ":nightly_date"),
     "_pre_release_flag": attr.label(default = ":pre_release"),
     "_rc_number_flag": attr.label(default = ":rc_number"),

--- a/bazel/version/rules.bzl
+++ b/bazel/version/rules.bzl
@@ -116,8 +116,6 @@ expand_version_build_info_internal = rule(
         "template": attr.label(
             allow_single_file = True,
         ),
-        "_alpha_number_flag": attr.label(default = ":alpha_number"),
-        "_beta_number_flag": attr.label(default = ":beta_number"),
         "_gen_tmpl_tool": attr.label(
             default = Label("//bazel/version:gen_tmpl"),
             allow_files = True,


### PR DESCRIPTION
With this our infrastructure should match the final form of proposal #4105 that established our versioning scheme.