### PR TITLE
Rebuild the type of constants during evaluation.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -222,7 +222,7 @@ static auto GetConstantValue(EvalContext& eval_context, SemIR::InstId inst_id,
   return eval_context.context.constant_values().GetInstId(const_id);
 }
 
-// Gets the type corresponding to the specified type in this evaluation context.
+// Given a type which may refer to a generic parameter, returns the corresponding type in the evaluation context.
 static auto GetConstantValue(EvalContext& eval_context, SemIR::TypeId type_id,
                              Phase* phase) -> SemIR::TypeId {
   auto const_id = eval_context.GetConstantValue(type_id);

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -222,7 +222,8 @@ static auto GetConstantValue(EvalContext& eval_context, SemIR::InstId inst_id,
   return eval_context.context.constant_values().GetInstId(const_id);
 }
 
-// Given a type which may refer to a generic parameter, returns the corresponding type in the evaluation context.
+// Given a type which may refer to a generic parameter, returns the
+// corresponding type in the evaluation context.
 static auto GetConstantValue(EvalContext& eval_context, SemIR::TypeId type_id,
                              Phase* phase) -> SemIR::TypeId {
   auto const_id = eval_context.GetConstantValue(type_id);

--- a/toolchain/check/testdata/array/generic_empty.carbon
+++ b/toolchain/check/testdata/array/generic_empty.carbon
@@ -24,7 +24,6 @@ fn G(T:! type) {
 // CHECK:STDOUT:   %.3: type = array_type %.2, %T [symbolic]
 // CHECK:STDOUT:   %.4: type = ptr_type %.3 [symbolic]
 // CHECK:STDOUT:   %array: %.3 = tuple_value () [symbolic]
-// CHECK:STDOUT:   %.5: type = ptr_type @G.%.loc13_17 (%.3) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/eval/symbolic.carbon
+++ b/toolchain/check/testdata/eval/symbolic.carbon
@@ -32,7 +32,6 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %.9: i32 = int_literal 5 [template]
 // CHECK:STDOUT:   %.10: type = array_type %.9, %T [symbolic]
 // CHECK:STDOUT:   %.11: type = ptr_type %.10 [symbolic]
-// CHECK:STDOUT:   %.12: type = ptr_type @F.%.loc15_15 (%.10) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -71,7 +71,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   assign file.%a.var, %.loc11_24
 // CHECK:STDOUT:   %a.ref: ref %.3 = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc15_16: f64 = float_literal 2.6000000000000001 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc15_19.1: ref i32 = array_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc15_19.1: ref i32 = array_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   %.loc15_19.2: i32 = bind_value %.loc15_19.1
 // CHECK:STDOUT:   assign file.%b.var, %.loc15_19.2
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -52,7 +52,7 @@ fn Run() {
 // CHECK:STDOUT:   %.loc17_7: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc17_4.1: ref %.1 = temporary_storage
 // CHECK:STDOUT:   %.loc17_4.2: ref %.1 = temporary %.loc17_4.1, %F.call
-// CHECK:STDOUT:   %.loc17_8: ref <error> = tuple_index %.loc17_4.2, <error>
+// CHECK:STDOUT:   %.loc17_8: ref <error> = tuple_index %.loc17_4.2, <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -96,7 +96,7 @@ var b: i32 = a[-10];
 // CHECK:STDOUT:   assign file.%a.var, %.loc11_28
 // CHECK:STDOUT:   %a.ref: ref %.3 = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc15_17: i32 = int_literal 10 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc15_19: ref <error> = tuple_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc15_19: ref <error> = tuple_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -87,7 +87,7 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   %a.ref: ref %.3 = name_ref a, file.%a
 // CHECK:STDOUT:   %b.ref: ref i32 = name_ref b, file.%b
 // CHECK:STDOUT:   %.loc16_16: i32 = bind_value %b.ref
-// CHECK:STDOUT:   %.loc16_17: ref <error> = tuple_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc16_17: ref <error> = tuple_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_out_of_bound_not_literal.carbon
+++ b/toolchain/check/testdata/index/fail_out_of_bound_not_literal.carbon
@@ -82,7 +82,7 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %struct: %.8 = struct_value (%.loc15_26) [template = constants.%struct]
 // CHECK:STDOUT:   %.loc15_27.2: %.8 = converted %.loc15_27.1, %struct [template = constants.%struct]
 // CHECK:STDOUT:   %.loc15_28: i32 = struct_access %.loc15_27.2, element0 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc15_34: ref <error> = tuple_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc15_34: ref <error> = tuple_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -75,7 +75,7 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:   assign file.%a.var, %.loc11_28
 // CHECK:STDOUT:   %a.ref: ref %.3 = name_ref a, file.%a
 // CHECK:STDOUT:   %oops.ref: <error> = name_ref oops, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc15: ref <error> = tuple_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc15: ref <error> = tuple_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -94,11 +94,11 @@ var d: i32 = b[0x7FFF_FFFF];
 // CHECK:STDOUT:   assign file.%b.var, %.loc12_18
 // CHECK:STDOUT:   %b.ref.loc17: ref %.3 = name_ref b, file.%b
 // CHECK:STDOUT:   %.loc17_16: i32 = int_literal 1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc17_17: ref <error> = tuple_index %b.ref.loc17, <error>
+// CHECK:STDOUT:   %.loc17_17: ref <error> = tuple_index %b.ref.loc17, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   %b.ref.loc21: ref %.3 = name_ref b, file.%b
 // CHECK:STDOUT:   %.loc21_16: i32 = int_literal 2147483647 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc21_27: ref <error> = tuple_index %b.ref.loc21, <error>
+// CHECK:STDOUT:   %.loc21_27: ref <error> = tuple_index %b.ref.loc21, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%d.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -76,7 +76,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   assign file.%a.var, %.loc11_28
 // CHECK:STDOUT:   %a.ref: ref %.3 = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc15_16: f64 = float_literal 2.6000000000000001 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc15_19: ref <error> = tuple_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc15_19: ref <error> = tuple_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -76,7 +76,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   assign file.%a.var, %.loc11_28
 // CHECK:STDOUT:   %a.ref: ref %.3 = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc15_16: i32 = int_literal 2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc15_17: ref <error> = tuple_index %a.ref, <error>
+// CHECK:STDOUT:   %.loc15_17: ref <error> = tuple_index %a.ref, <error> [template = <error>]
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }


### PR DESCRIPTION
When evaluating in a generic context, a constant with a symbolic type might evaluate to a constant with a concrete type (or a more specific symbolic type). This can't actually happen yet given the current state of the toolchain, as far as I can determine, so this is more just a refactoring for now, but will be relied upon by future generics work.