### PR TITLE
Enable the more effective version of `-Wnon-virtual-dtor`.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -144,6 +144,7 @@ def _impl(ctx):
                             "-Wextra-semi",
                             "-Wmissing-prototypes",
                             "-Wzero-as-null-pointer-constant",
+                            "-Wdelete-non-virtual-dtor",
                             # Don't warn on external code as we can't
                             # necessarily patch it easily. Note that these have
                             # to be initial directories in the `#include` line.


### PR DESCRIPTION
Most of this is enabled by default, but there is some that needs an explicit flag.

Avoiding `-Wnon-virtual-dtor` itself for now because that warning can require changes that carry overhead such as having an extra, unused destructor entry in the vtable. Hopefully we don't have too many folks who need our code to be `-Wnon-virtual-dtor` clean.