### PR TITLE
Move `GetTypeInInstance` from `Check` to `SemIR`.

### DIFF
--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -329,16 +329,4 @@ auto ResolveSpecificDefinition(Context& context,
   return true;
 }
 
-auto GetTypeInInstance(Context& context, SemIR::GenericInstanceId instance_id,
-                       SemIR::TypeId type_id) -> SemIR::TypeId {
-  auto const_id = context.types().GetConstantId(type_id);
-  auto inst_const_id =
-      GetConstantInInstance(context.sem_ir(), instance_id, const_id);
-  if (inst_const_id == const_id) {
-    // Common case: not an instance constant.
-    return type_id;
-  }
-  return context.GetTypeIdForTypeConstant(inst_const_id);
-}
-
 }  // namespace Carbon::Check

--- a/toolchain/check/generic.h
+++ b/toolchain/check/generic.h
@@ -52,14 +52,6 @@ auto MakeGenericSelfInstance(Context& context, SemIR::GenericId generic_id)
 auto ResolveSpecificDefinition(Context& context,
                                SemIR::GenericInstanceId specific_id) -> bool;
 
-// Gets the substituted value of a type within a specified instance of a
-// generic. Note that this does not perform substitution, and will return
-// `Invalid` if the substituted type is not yet known.
-//
-// TODO: Move this to sem_ir so that lowering can use it.
-auto GetTypeInInstance(Context& context, SemIR::GenericInstanceId instance_id,
-                       SemIR::TypeId type_id) -> SemIR::TypeId;
-
 }  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_CHECK_GENERIC_H_

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -279,8 +279,9 @@ static auto BuildFunctionDecl(Context& context,
   // substitution is ready.
   if (return_storage_id.is_valid()) {
     auto return_storage = context.insts().Get(return_storage_id);
-    return_storage.SetType(GetTypeInInstance(
-        context, SemIR::GenericInstanceId::Invalid, return_storage.type_id()));
+    return_storage.SetType(SemIR::GetTypeInInstance(
+        context.sem_ir(), SemIR::GenericInstanceId::Invalid,
+        return_storage.type_id()));
     context.sem_ir().insts().Set(return_storage_id, return_storage);
   }
 

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -81,8 +81,8 @@ static auto HandleNameAsExpr(Context& context, Parse::NodeId node_id,
                              SemIR::NameId name_id) -> bool {
   auto result = context.LookupUnqualifiedName(node_id, name_id);
   auto value = context.insts().Get(result.inst_id);
-  auto type_id =
-      GetTypeInInstance(context, result.instance_id, value.type_id());
+  auto type_id = SemIR::GetTypeInInstance(context.sem_ir(), result.instance_id,
+                                          value.type_id());
   CARBON_CHECK(type_id.is_valid()) << "Missing type for " << value;
 
   // If the named entity has a constant value that depends on its generic

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -225,7 +225,8 @@ static auto LookupMemberNameInScope(Context& context, Parse::NodeId node_id,
 
   // TODO: This duplicates the work that HandleNameAsExpr does. Factor this out.
   auto inst = context.insts().Get(result.inst_id);
-  auto type_id = GetTypeInInstance(context, result.instance_id, inst.type_id());
+  auto type_id = SemIR::GetTypeInInstance(context.sem_ir(), result.instance_id,
+                                          inst.type_id());
   CARBON_CHECK(type_id.is_valid()) << "Missing type for member " << inst;
 
   // If the named entity has a constant value that depends on its generic

--- a/toolchain/sem_ir/generic.cpp
+++ b/toolchain/sem_ir/generic.cpp
@@ -95,4 +95,10 @@ auto GetConstantValueInInstance(const File& sem_ir,
                                sem_ir.constant_values().Get(inst_id));
 }
 
+auto GetTypeInInstance(const File& sem_ir, GenericInstanceId instance_id,
+                       TypeId type_id) -> TypeId {
+  return TypeId::ForTypeConstant(GetConstantInInstance(
+      sem_ir, instance_id, sem_ir.types().GetConstantId(type_id)));
+}
+
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -150,6 +150,12 @@ auto GetConstantValueInInstance(const File& sem_ir,
                                 GenericInstanceId instance_id, InstId inst_id)
     -> ConstantId;
 
+// Gets the substituted value of a type within a specified instance of a
+// generic. Note that this does not perform substitution, and will return
+// `Invalid` if the substituted type is not yet known.
+auto GetTypeInInstance(const File& sem_ir, GenericInstanceId instance_id,
+                       TypeId type_id) -> TypeId;
+
 }  // namespace Carbon::SemIR
 
 #endif  // CARBON_TOOLCHAIN_SEM_IR_GENERIC_H_


### PR DESCRIPTION
In preparation for this function being used by other parts of `SemIR` and by lowering.