### PR TITLE
Add a mention of our nightly builds to our `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,15 @@ semantics onto C++ such as Rust-inspired
 
 ## Getting started
 
-To try out Carbon, you can use the Carbon explorer to interpret Carbon code and
-print its output. You can try it out immediately at
+To try out Carbon immediately in your browser, you can use the Carbon explorer
+to interpret Carbon code and print its output on:
 [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
-Carbon is an early, experimental project, and so we only have very experimental
-nightly releases of the Carbon toolchain available to download, and only on
-limited platforms. If you are using a recent Ubuntu Linux or similar (Debian,
-WSL, etc.), you can try these out by going to our
+We are developing a traditional toolchain for Carbon that can compile and link
+programs. However, Carbon is still an early, experimental project, and so we
+only have very experimental nightly releases of the Carbon toolchain available
+to download, and only on limited platforms. If you are using a recent Ubuntu
+Linux or similar (Debian, WSL, etc.), you can try these out by going to our
 [releases](https://github.com/carbon-language/carbon-lang/releases) page and
 download the latest nightly toolchain tar file:
 `carbon_toolchain-0.0.0-0.nightly.YYYY.MM.DD.tar.gz`. Then you can try it out:
@@ -301,17 +302,17 @@ echo "fn Run() { Core.Print(42); }" > forty_two.carbon
 ./forty_two
 ```
 
-However, the toolchain is still very early and many things don't yet work.
+As a reminder, the toolchain is still very early and many things don't yet work.
 Please hold off on filing lots of bugs: we know many parts of this don't work
 yet or may not work on all systems. We expect to have releases that are much
 more robust and reliable that you can try out when we reach our
 [0.1 milestone](/docs/project/milestones.md#milestone-01-a-minimum-viable-product-mvp-for-evaluation).
 
-If you do want to build Carbon's toolchain yourself and maybe contribute fixes
-or improvements to Carbon, you'll need to install our
-[build dependencies](/docs/project/contribution_tools.md#setup-commands) (Bazel,
-Clang, LLD, libc++) and check out the Carbon repository, for example on Debian
-or Ubuntu:
+If you want to build Carbon's toolchain yourself or are thinking about
+contributing fixes or improvements to Carbon, you'll need to install our
+[build dependencies](/docs/project/contribution_tools.md#setup-commands) (Clang,
+LLD, libc++) and check out the Carbon repository. For example, on Debian or
+Ubuntu:
 
 ```shell
 # Update apt.
@@ -329,14 +330,7 @@ $ git clone https://github.com/carbon-language/carbon-lang
 $ cd carbon-lang
 ```
 
-Then you can build and run the explorer:
-
-```shell
-# Build and run the explorer.
-$ ./scripts/run_bazelisk.py run //explorer -- ./explorer/testdata/print/format_only.carbon
-```
-
-And you can try out our toolchain which has a very early-stage compiler for
+Then you can try out our toolchain which has a very early-stage compiler for
 Carbon:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ semantics onto C++ such as Rust-inspired
 
 ## Getting started
 
-To try out Carbon immediately in your browser, you can use the Carbon explorer
-to interpret Carbon code and print its output on:
-[compiler-explorer.com](http://carbon.compiler-explorer.com/).
+To try out Carbon immediately in your browser, you can use the demo interpreter
+for Carbon on:
+[carbon.compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
 We are developing a traditional toolchain for Carbon that can compile and link
 programs. However, Carbon is still an early, experimental project, and so we
@@ -294,6 +294,11 @@ echo "fn Run() { Core.Print(42); }" > forty_two.carbon
 # Compile to an object file:
 ./carbon_toolchain-${VERSION}/bin/carbon compile \
   --output=forty_two.o forty_two.carbon
+
+# Install minimal system libraries used for linking, note that installing `gcc`
+# or `g++` for compiling C/C++ code with GCC will also be sufficient, this is
+# just the specific system libraries Carbon linking currently still uses.
+sudo apt install libgcc-11-dev
 
 # Link to an executable:
 ./carbon_toolchain-${VERSION}/bin/carbon link \

--- a/README.md
+++ b/README.md
@@ -277,17 +277,17 @@ limited platforms. If you are using a recent Ubuntu Linux or similar (Debian,
 WSL, etc.), you can try these out by going to our
 [releases](https://github.com/carbon-language/carbon-lang/releases) page and
 download the latest nightly toolchain tar file:
-`carbon_toolchain-v0.0.0-0.nightly.YYYY.MM.DD.tar.gz`. Then you can try it out:
+`carbon_toolchain-0.0.0-0.nightly.YYYY.MM.DD.tar.gz`. Then you can try it out:
 
 ```shell
 # A variable with the specific nightly version:
-VERSION="v0.0.0-0.nightly.YYYY.MM.DD"
+VERSION="0.0.0-0.nightly.YYYY.MM.DD"
 
 # Unpack the toolchain:
 tar -xvf carbon_toolchain-${VERSION}.tar.gz
 
 # Create a simple Carbon source file:
-echo "fn Run() { Print(42); }" > forty_two.carbon
+echo "fn Run() { Core.Print(42); }" > forty_two.carbon
 
 # Compile to an object file:
 ./carbon_toolchain-${VERSION}/bin/carbon compile \
@@ -302,7 +302,7 @@ echo "fn Run() { Print(42); }" > forty_two.carbon
 ```
 
 However, the toolchain is still very early and many things don't yet work.
-Please hold off on filing lots of bugs, we know many parts of this don't work
+Please hold off on filing lots of bugs: we know many parts of this don't work
 yet or may not work on all systems. We expect to have releases that are much
 more robust and reliable that you can try out when we reach our
 [0.1 milestone](/docs/project/milestones.md#milestone-01-a-minimum-viable-product-mvp-for-evaluation).

--- a/README.md
+++ b/README.md
@@ -271,13 +271,44 @@ To try out Carbon, you can use the Carbon explorer to interpret Carbon code and
 print its output. You can try it out immediately at
 [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
-Because Carbon is an early, experimental project we don't yet have releases you
-can download and try out locally, you'll instead need to build any tools
-yourself from source. We expect to have packaged releases you can try out when
-we reach our
+Carbon is an early, experimental project, and so we only have very experimental
+nightly releases of the Carbon toolchain available to download, and only on
+limited platforms. If you are using a recent Ubuntu Linux or similar (Debian,
+WSL, etc.), you can try these out by going to our
+[releases](https://github.com/carbon-language/carbon-lang/releases) page and
+download the latest nightly toolchain tar file:
+`carbon_toolchain-v0.0.0-0.nightly.YYYY.MM.DD.tar.gz`. Then you can try it out:
+
+```shell
+# A variable with the specific nightly version:
+VERSION="v0.0.0-0.nightly.YYYY.MM.DD"
+
+# Unpack the toolchain:
+tar -xvf carbon_toolchain-${VERSION}.tar.gz
+
+# Create a simple Carbon source file:
+echo "fn Run() { Print(42); }" > forty_two.carbon
+
+# Compile to an object file:
+./carbon_toolchain-${VERSION}/bin/carbon compile \
+  --output=forty_two.o forty_two.carbon
+
+# Link to an executable:
+./carbon_toolchain-${VERSION}/bin/carbon link \
+  --output=forty_two forty_two.o
+
+# Run it:
+./forty_two
+```
+
+However, the toolchain is still very early and many things don't yet work.
+Please hold off on filing lots of bugs, we know many parts of this don't work
+yet or may not work on all systems. We expect to have releases that are much
+more robust and reliable that you can try out when we reach our
 [0.1 milestone](/docs/project/milestones.md#milestone-01-a-minimum-viable-product-mvp-for-evaluation).
 
-If you do want to try out Carbon locally, you'll need to install our
+If you do want to build Carbon's toolchain yourself and maybe contribute fixes
+or improvements to Carbon, you'll need to install our
 [build dependencies](/docs/project/contribution_tools.md#setup-commands) (Bazel,
 Clang, LLD, libc++) and check out the Carbon repository, for example on Debian
 or Ubuntu:

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ and provides a deeper view into our goals for the Carbon project and language.
 
 ## Project status
 
-Carbon Language is currently an experimental project. There is no working
-compiler or toolchain. You can see the demo interpreter for Carbon on
-[compiler-explorer.com](http://carbon.compiler-explorer.com/).
+Carbon Language is currently an experimental project. You can see the demo
+interpreter for Carbon on
+[compiler-explorer.com](http://carbon.compiler-explorer.com/). We are also hard
+at work on a toolchain implementation with compiler and linker.
 
 We want to better understand whether we can build a language that meets our
 successor language criteria, and whether the resulting language can gather a

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ echo "fn Run() { Core.Print(42); }" > forty_two.carbon
 ./carbon_toolchain-${VERSION}/bin/carbon compile \
   --output=forty_two.o forty_two.carbon
 
-# Install minimal system libraries used for linking, note that installing `gcc`
-# or `g++` for compiling C/C++ code with GCC will also be sufficient, this is
-# just the specific system libraries Carbon linking currently still uses.
+# Install minimal system libraries used for linking. Note that installing `gcc`
+# or `g++` for compiling C/C++ code with GCC will also be sufficient, these are
+# just the specific system libraries Carbon linking still uses.
 sudo apt install libgcc-11-dev
 
 # Link to an executable:


### PR DESCRIPTION
This provides an example of downloading and using the nightly buildings of the toolchain. I've tried to provide appropriate caveats about the fact that this is very early and not something that's really reliable. But I wanted folks to know how they can play with the nightly releases if they're interested.

I've also focused the source build instructions on the toolchain where we'd be interested in contributions, and the first paragraph on trying out Carbon in the browser with CE.