### PR TITLE
fix: `clangd: -32001: invalid AST`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 CompileFlags:
+  # Workaround for https://github.com/clangd/clangd/issues/1582
   Remove: [-march=*]

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+CompileFlags:
+  Remove: [-march=*]


### PR DESCRIPTION
Ignore the `-march=*` in `compile_commands.json` which causes issues in Neovim on Apple M2. This fix is from this [comment](https://github.com/clangd/clangd/issues/1582#issuecomment-1500031372)


