### PR TITLE
Do some HTML cleanup in the md files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Edit snippet in docs/images/snippets.md and:
 https://drive.google.com/drive/folders/1QrBXiy_X74YsOueeC0IYlgyolWIhvusB
 -->
 <img src="docs/images/quicksort_snippet.svg" align="right" width="575"
-     alt="Quicksort code in Carbon. Follow the link to read more.">
+     alt="Quicksort code in Carbon. Follow the link to read more."/>
 </a>
 
 <!--
@@ -32,7 +32,7 @@ Don't let the text wrap too narrowly to the left of the above image.
 The `div` reduces the vertical height.
 GitHub will autolink `img`, but won't produce a link when `href="#"`.
 -->
-<div><a href="#"><img src="docs/images/bumper.png"></a></div>
+<div><a href="#"><img src="docs/images/bumper.png"/></a></div>
 
 **Fast and works with C++**
 
@@ -177,7 +177,7 @@ Edit snippet in docs/images/snippets.md and:
 https://drive.google.com/drive/folders/1QrBXiy_X74YsOueeC0IYlgyolWIhvusB
 -->
 <img src="docs/images/cpp_snippet.svg" width="600"
-     alt="A snippet of C++ code. Follow the link to read it.">
+     alt="A snippet of C++ code. Follow the link to read it."/>
 </a>
 
 corresponds to this Carbon code:
@@ -188,7 +188,7 @@ Edit snippet in docs/images/snippets.md and:
 https://drive.google.com/drive/folders/1QrBXiy_X74YsOueeC0IYlgyolWIhvusB
 -->
 <img src="docs/images/carbon_snippet.svg" width="600"
-     alt="A snippet of converted Carbon code. Follow the link to read it.">
+     alt="A snippet of converted Carbon code. Follow the link to read it."/>
 </a>
 
 You can call Carbon from C++ without overhead and the other way around. This
@@ -201,7 +201,7 @@ Edit snippet in docs/images/snippets.md and:
 https://drive.google.com/drive/folders/1QrBXiy_X74YsOueeC0IYlgyolWIhvusB
 -->
 <img src="docs/images/mixed_snippet.svg" width="600"
-     alt="A snippet of mixed Carbon and C++ code. Follow the link to read it.">
+     alt="A snippet of mixed Carbon and C++ code. Follow the link to read it."/>
 </a>
 
 Read more about

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -3658,7 +3658,7 @@ and [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
 will be migrated using a combination of Carbon features. Carbon mixins support
 implementation reuse and Carbon interfaces allow a type to implement multiple
 APIs. However, there may be limits on the degree of interop available with
-multiple inheritance across the C++ <-> Carbon boundaries.
+multiple inheritance across the C++ \<-> Carbon boundaries.
 
 Carbon dyn-safe interfaces may be exported to C++ as an
 [abstract base class](<https://en.wikipedia.org/wiki/Class_(computer_programming)#Abstract_and_concrete>).

--- a/docs/design/expressions/comparison_operators.md
+++ b/docs/design/expressions/comparison_operators.md
@@ -36,12 +36,12 @@ standard mathematical meaning:
 
 | Category   | Operator | Example  | Mathematical meaning | Description                |
 | ---------- | -------- | -------- | -------------------- | -------------------------- |
-| Equality   | `==`     | `x == y` | =                    | Equality or equal to       |
-| Equality   | `!=`     | `x != y` | ≠                    | Inequality or not equal to |
-| Relational | `<`      | `x < y`  | <                    | Less than                  |
-| Relational | `<=`     | `x <= y` | ≤                    | Less than or equal to      |
-| Relational | `>`      | `x > y`  | >                    | Greater than               |
-| Relational | `>=`     | `x >= y` | ≥                    | Greater than or equal to   |
+| Equality   | `==`     | `x == y` | `=`                  | Equality or equal to       |
+| Equality   | `!=`     | `x != y` | `≠`                  | Inequality or not equal to |
+| Relational | `<`      | `x < y`  | `<`                  | Less than                  |
+| Relational | `<=`     | `x <= y` | `≤`                  | Less than or equal to      |
+| Relational | `>`      | `x > y`  | `>`                  | Greater than               |
+| Relational | `>=`     | `x >= y` | `≥`                  | Greater than or equal to   |
 
 Comparison operators all return a `bool`; they evaluate to `true` when the
 indicated comparison is true. All comparison operators are infix binary

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -4034,8 +4034,8 @@ The syntax for an out-of-line parameterized `impl` declaration is:
 
 <!-- The following triggers a bug in prettier where it adds an `>` -->
 
-> `impl forall [`_<parameter-bindings>_`]` _<type-expression>_ `as`
-> _<facet-type-expression> [_ `where` _<optional-rewrite-constraints> ]_ `;`
+> `impl forall [`_\<parameter-bindings>_`]` _\<type-expression>_ `as`
+> _\<facet-type-expression> [_ `where` _\<optional-rewrite-constraints> ]_ `;`
 
 <!-- prettier-ignore-end -->
 

--- a/docs/design/generics/terminology.md
+++ b/docs/design/generics/terminology.md
@@ -100,51 +100,67 @@ Expected difference between checked and template parameters:
 
 <table>
   <tr>
-   <td><strong>Checked</strong>
+   <td>
+    <strong>Checked</strong>
    </td>
-   <td><strong>Template</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>bounded parametric polymorphism
-   </td>
-   <td>compile-time duck typing and ad-hoc polymorphism
+   <td>
+    <strong>Template</strong>
    </td>
   </tr>
   <tr>
-   <td>constrained genericity
+   <td>
+    bounded parametric polymorphism
    </td>
-   <td>optional constraints
-   </td>
-  </tr>
-  <tr>
-   <td>name lookup resolved for definitions in isolation ("early")
-   </td>
-   <td>name lookup can use information from arguments (name lookup may be "late")
+   <td>
+    compile-time duck typing and ad-hoc polymorphism
    </td>
   </tr>
   <tr>
-   <td>sound to typecheck definitions in isolation ("early")
+   <td>
+    constrained genericity
    </td>
-   <td>complete type checking may require information from calls (may be "late")
-   </td>
-  </tr>
-  <tr>
-   <td>supports separate type checking; may also support separate compilation
-   </td>
-   <td>separate compilation only to the extent that C++ supports it
+   <td>
+    optional constraints
    </td>
   </tr>
   <tr>
-   <td>allowed but not required to be implemented using dynamic dispatch
+   <td>
+    name lookup resolved for definitions in isolation ("early")
    </td>
-   <td>does not support implementation by way of dynamic dispatch, just static by way of <a href="#instantiation">instantiation</a>
+   <td>
+    name lookup can use information from arguments (name lookup may be "late")
    </td>
   </tr>
   <tr>
-   <td>monomorphization is an optional optimization that cannot render the program invalid
+   <td>
+    sound to typecheck definitions in isolation ("early")
    </td>
-   <td>monomorphization is mandatory and can fail, resulting in the program being invalid
+   <td>
+    complete type checking may require information from calls (may be "late")
+   </td>
+  </tr>
+  <tr>
+   <td>
+    supports separate type checking; may also support separate compilation
+   </td>
+   <td>
+    separate compilation only to the extent that C++ supports it
+   </td>
+  </tr>
+  <tr>
+   <td>
+    allowed but not required to be implemented using dynamic dispatch
+   </td>
+   <td>
+    does not support implementation by way of dynamic dispatch, just static by way of <a href="#instantiation">instantiation</a>
+   </td>
+  </tr>
+  <tr>
+   <td>
+    monomorphization is an optional optimization that cannot render the program invalid
+   </td>
+   <td>
+    monomorphization is mandatory and can fail, resulting in the program being invalid
    </td>
   </tr>
 </table>

--- a/docs/project/faq.md
+++ b/docs/project/faq.md
@@ -182,7 +182,7 @@ Edit snippet in /docs/images/snippets.md and:
 https://drive.google.com/drive/folders/1QrBXiy_X74YsOueeC0IYlgyolWIhvusB
 -->
 <img src="/docs/images/cpp_snippet.svg" width="600"
-     alt="A snippet of C++ code. Follow the link to read it.">
+     alt="A snippet of C++ code. Follow the link to read it."/>
 </a>
 
 It's possible to migrate a single function to Carbon:
@@ -193,7 +193,7 @@ Edit snippet in /docs/images/snippets.md and:
 https://drive.google.com/drive/folders/1QrBXiy_X74YsOueeC0IYlgyolWIhvusB
 -->
 <img src="/docs/images/mixed_snippet.svg" width="600"
-     alt="A snippet of mixed Carbon and C++ code. Follow the link to read it.">
+     alt="A snippet of mixed Carbon and C++ code. Follow the link to read it."/>
 </a>
 
 References:


### PR DESCRIPTION
This is really minor cleanup as I look at adopting docusaurus, just fixing a few misc things it's flagging. Nothing here should affect rendering, except for the comparison operators change (using backtics to escape a `<`, and treating all other operators the same)