### PR TITLE
Remove supurfluous/confusing {} around a temporary

### DIFF
--- a/migrate_cpp/rewriter.cpp
+++ b/migrate_cpp/rewriter.cpp
@@ -222,7 +222,7 @@ auto RewriteBuilder::VisitIntegerLiteral(clang::IntegerLiteral* expr) -> bool {
       c = '_';
     }
   }
-  SetReplacement(expr, {OutputSegment(std::move(text))});
+  SetReplacement(expr, OutputSegment(std::move(text)));
   return true;
 }
 


### PR DESCRIPTION
This was failing to build for me locally with some arbitrary Clang HEAD host compiler:
```
migrate_cpp/rewriter.cpp:225:3: error: call to member function 'SetReplacement' is ambiguous
  225 |   SetReplacement(expr, {OutputSegment(std::move(text))});
      |   ^~~~~~~~~~~~~~
./migrate_cpp/rewriter.h:141:8: note: candidate function [with T = clang::IntegerLiteral]
  141 |   auto SetReplacement(const T* node, std::vector<OutputSegment> output_segments)
      |        ^
./migrate_cpp/rewriter.h:150:8: note: candidate function [with T = clang::IntegerLiteral]
  150 |   auto SetReplacement(const T* node, OutputSegment segment) -> void {
      |        ^
```
No idea if that's a bug in clang HEAD, but it seemed like removing the {} simplified the code anyway - so here's that.
