### PR TITLE
Re-enable TCMalloc on Linux builds.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -109,9 +109,7 @@ build --enable_platform_specific_config
 build:linux --define=pfm=1
 
 # Enable TCMalloc on Linux as well.
-# TODO: tcmalloc needs to support compiler-explorer; see:
-# https://github.com/carbon-language/carbon-lang/issues/4176
-# build:linux --custom_malloc=@tcmalloc//tcmalloc
+build:linux --custom_malloc=@tcmalloc//tcmalloc
 
 # Allow users to override any of the flags desired by importing a user-specific
 # RC file here if present.


### PR DESCRIPTION
This tripped up the Compiler Explorer sandbox, but we think that is now fixed: https://github.com/compiler-explorer/compiler-explorer/issues/6734

Removing the workaround here, and once it's live and not crashing we can close #4176 as fixed (and without a temporary workaround).