### PR TITLE
Update workflows for security hardening.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,10 +1,33 @@
-# Testing workflows
+# Workflows
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
+
+## Hardening
+
+Workflows are hardened using
+[Step Security tool](https://app.stepsecurity.io/secureworkflow). Findings for
+the "Harden Runner" steps are
+[available online](https://app.stepsecurity.io/github/carbon-language/carbon-lang/actions/runs).
+
+### Allowed endpoints
+
+Most jobs only have a few endpoints, but due to tools which do downloads, a few
+have significantly more. These are:
+
+-   pre_commit.yaml (Bazel, pre-commit)
+-   nightly_release.yaml (Bazel)
+-   tests.yaml (Bazel)
+
+When updating one of these, consider updating all of them.
+
+We try to keep `allowed-endpoints` with one per line. Prettier wants to wrap
+them, which we fix this with `prettier-ignore`.
+
+## Testing
 
 We keep around an `action-test` branch in carbon-lang, which can be used to test
 triggers with `push:` configurations. For example:

--- a/.github/workflows/auto_assign_prs.yaml
+++ b/.github/workflows/auto_assign_prs.yaml
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: 'Auto Assign'
+name: 'Auto assign PRs'
 on:
   pull_request_target:
     types: [opened, ready_for_review]
@@ -15,9 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
 
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -15,9 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
 
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/discord_wiki.yaml
+++ b/.github/workflows/discord_wiki.yaml
@@ -2,18 +2,20 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: Wiki Changed Discord Notification
+name: Discord Wiki Change Notifications
 
 on: gollum
 
-permissions: none
+# Minimum permissions.
+permissions:
+  contents: read
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -37,9 +37,30 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # When adding endpoints, see README.md.
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
+            bcr.bazel.build:443
+            cfhcable.dl.sourceforge.net:443
+            cytranet-dal.dl.sourceforge.net:443
+            downloads.sourceforge.net:443
+            gigenet.dl.sourceforge.net:443
+            github.com:443
+            netactuate.dl.sourceforge.net:443
+            oauth2.googleapis.com:443
+            objects.githubusercontent.com:443
+            phoenixnap.dl.sourceforge.net:443
+            pilotfiber.dl.sourceforge.net:443
+            psychz.dl.sourceforge.net:443
+            releases.bazel.build:443
+            sourceforge.net:443
+            storage.googleapis.com:443
+            uploads.github.com:443
+            versaweb.dl.sourceforge.net:443
 
       - name: Checkout branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -43,24 +43,17 @@ jobs:
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
+            *.dl.sourceforge.net:443
             api.github.com:443
             bcr.bazel.build:443
-            cfhcable.dl.sourceforge.net:443
-            cytranet-dal.dl.sourceforge.net:443
             downloads.sourceforge.net:443
-            gigenet.dl.sourceforge.net:443
             github.com:443
-            netactuate.dl.sourceforge.net:443
             oauth2.googleapis.com:443
             objects.githubusercontent.com:443
-            phoenixnap.dl.sourceforge.net:443
-            pilotfiber.dl.sourceforge.net:443
-            psychz.dl.sourceforge.net:443
             releases.bazel.build:443
             sourceforge.net:443
             storage.googleapis.com:443
             uploads.github.com:443
-            versaweb.dl.sourceforge.net:443
 
       - name: Checkout branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -18,9 +18,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # When adding endpoints, see README.md.
+          # prettier-ignore
+          allowed-endpoints: >
+            bcr.bazel.build:443
+            cfhcable.dl.sourceforge.net:443
+            cytranet-dal.dl.sourceforge.net:443
+            cytranet.dl.sourceforge.net:443
+            downloads.sourceforge.net:443
+            files.pythonhosted.org:443
+            gigenet.dl.sourceforge.net:443
+            github.com:443
+            mirror.bazel.build:443
+            netactuate.dl.sourceforge.net:443
+            newcontinuum.dl.sourceforge.net:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            phoenixnap.dl.sourceforge.net:443
+            pilotfiber.dl.sourceforge.net:443
+            psychz.dl.sourceforge.net:443
+            pypi.org:443
+            registry.npmjs.org:443
+            releases.bazel.build:443
+            sfcdn.dl.sourceforge.net:443
+            sourceforge.net:443
+            versaweb.dl.sourceforge.net:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -25,28 +25,18 @@ jobs:
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
+            *.dl.sourceforge.net:443
             bcr.bazel.build:443
-            cfhcable.dl.sourceforge.net:443
-            cytranet-dal.dl.sourceforge.net:443
-            cytranet.dl.sourceforge.net:443
             downloads.sourceforge.net:443
             files.pythonhosted.org:443
-            gigenet.dl.sourceforge.net:443
             github.com:443
             mirror.bazel.build:443
-            netactuate.dl.sourceforge.net:443
-            newcontinuum.dl.sourceforge.net:443
             nodejs.org:443
             objects.githubusercontent.com:443
-            phoenixnap.dl.sourceforge.net:443
-            pilotfiber.dl.sourceforge.net:443
-            psychz.dl.sourceforge.net:443
             pypi.org:443
             registry.npmjs.org:443
             releases.bazel.build:443
-            sfcdn.dl.sourceforge.net:443
             sourceforge.net:443
-            versaweb.dl.sourceforge.net:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0

--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -33,9 +33,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
 
       - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
         with:

--- a/.github/workflows/proposal_labeled.yaml
+++ b/.github/workflows/proposal_labeled.yaml
@@ -27,9 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: draft
         if: |

--- a/.github/workflows/proposal_ready.yaml
+++ b/.github/workflows/proposal_ready.yaml
@@ -19,9 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: rfc
         run: |

--- a/.github/workflows/sync_repos.yaml
+++ b/.github/workflows/sync_repos.yaml
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: sync-repos
+name: Sync repos
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: test
+name: Tests
 
 on:
   push:
@@ -39,9 +39,35 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # When adding endpoints, see README.md.
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
+            bcr.bazel.build:443
+            cfhcable.dl.sourceforge.net:443
+            cytranet-dal.dl.sourceforge.net:443
+            cytranet.dl.sourceforge.net:443
+            downloads.sourceforge.net:443
+            gigenet.dl.sourceforge.net:443
+            github.com:443
+            mirrors.kernel.org:443
+            netactuate.dl.sourceforge.net:443
+            newcontinuum.dl.sourceforge.net:443
+            nodejs.org:443
+            oauth2.googleapis.com:443
+            objects.githubusercontent.com:443
+            phoenixnap.dl.sourceforge.net:443
+            pilotfiber.dl.sourceforge.net:443
+            psychz.dl.sourceforge.net:443
+            pypi.org:443
+            releases.bazel.build:443
+            sfcdn.dl.sourceforge.net:443
+            sourceforge.net:443
+            storage.googleapis.com:443
+            versaweb.dl.sourceforge.net:443
 
       # Checkout the pull request head or the branch.
       - name: Checkout pull request

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,29 +45,19 @@ jobs:
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
+            *.dl.sourceforge.net:443
             api.github.com:443
             bcr.bazel.build:443
-            cfhcable.dl.sourceforge.net:443
-            cytranet-dal.dl.sourceforge.net:443
-            cytranet.dl.sourceforge.net:443
             downloads.sourceforge.net:443
-            gigenet.dl.sourceforge.net:443
             github.com:443
             mirrors.kernel.org:443
-            netactuate.dl.sourceforge.net:443
-            newcontinuum.dl.sourceforge.net:443
             nodejs.org:443
             oauth2.googleapis.com:443
             objects.githubusercontent.com:443
-            phoenixnap.dl.sourceforge.net:443
-            pilotfiber.dl.sourceforge.net:443
-            psychz.dl.sourceforge.net:443
             pypi.org:443
             releases.bazel.build:443
-            sfcdn.dl.sourceforge.net:443
             sourceforge.net:443
             storage.googleapis.com:443
-            versaweb.dl.sourceforge.net:443
 
       # Checkout the pull request head or the branch.
       - name: Checkout pull request

--- a/.github/workflows/triage_inactive.yaml
+++ b/.github/workflows/triage_inactive.yaml
@@ -16,9 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
 
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:

--- a/docs/project/code_review.md
+++ b/docs/project/code_review.md
@@ -85,11 +85,11 @@ In Carbon, developers will focus on particular areas, loosely broken down as:
     -   We split out auto-assignment by explorer, toolchain, and other files
         (including documentation).
 
-[Auto-assignment](/.github/workflows/assign_prs.yaml) will help find owners, but
-won't always be perfect -- developers may take a PR they weren't auto-assigned
-in order to help review go quickly. Contributors can also request multiple
-reviewers, but it can be daunting to get feedback from a large number of
-reviewers, so we suggest keeping the number of reviewers reasonably small.
+[Auto-assignment](/.github/workflows/auto_assign_prs.yaml) will help find
+owners, but won't always be perfect -- developers may take a PR they weren't
+auto-assigned in order to help review go quickly. Contributors can also request
+multiple reviewers, but it can be daunting to get feedback from a large number
+of reviewers, so we suggest keeping the number of reviewers reasonably small.
 
 Any reviews that explicitly request changes should be addressed, either with the
 changes or an explanation of why not, before a pull request is merged. Further,

--- a/proposals/p1367.md
+++ b/proposals/p1367.md
@@ -110,7 +110,7 @@ group access controls are the last word on who can commit PRs.
 
 ### Auto-assignment
 
-This PR [introduces auto-assignment](/.github/workflows/assign_prs.yaml) in
+This PR [introduces auto-assignment](/.github/workflows/auto_assign_prs.yaml) in
 order to ensure PRs aren't lost. It provides categories of assignment, and a
 fallback for other PRs that don't have explicit assignment.
 


### PR DESCRIPTION
Also a small pass on workflow names.

Note, I'm a little concerned that the test/nightly release/pre-commit endpoints may be fragile. At the same time, it's also where it may be most useful, to prevent network access by arbitrary test code. I think this is imperfect, but maybe we can try it out and see if it's much of an issue.

Note, the discord wiki action is currently broken, this should fix it.