### PR TITLE
Fix formatting for imported `impl`s.

### DIFF
--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -179,7 +179,10 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   witness = (imports.%import_ref.4)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %C as %.2;
+// CHECK:STDOUT: impl @impl: %C as %.2 {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = imports.%import_ref.5
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -154,7 +154,10 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   witness = (imports.%import_ref.4)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %C as %.2;
+// CHECK:STDOUT: impl @impl: %C as %.2 {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = imports.%import_ref.5
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
@@ -262,7 +262,10 @@ impl A as Factory(B) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %A as %.6;
+// CHECK:STDOUT: impl @impl: %A as %.6 {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = imports.%import_ref.11
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
 // CHECK:STDOUT: !members:
@@ -397,7 +400,10 @@ impl A as Factory(B) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %A as %.6;
+// CHECK:STDOUT: impl @impl: %A as %.6 {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = imports.%import_ref.11
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
 // CHECK:STDOUT: !members:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -233,7 +233,7 @@ class FormatterImpl {
 
     llvm::SaveAndRestore impl_scope(scope_, inst_namer_->GetScopeFor(id));
 
-    if (impl_info.scope_id.is_valid()) {
+    if (impl_info.is_defined()) {
       out_ << ' ';
       OpenBrace();
       FormatCodeBlock(impl_info.body_block_id);
@@ -242,7 +242,9 @@ class FormatterImpl {
       // always list the witness in this section.
       IndentLabel();
       out_ << "!members:\n";
-      FormatNameScope(impl_info.scope_id);
+      if (impl_info.scope_id.is_valid()) {
+        FormatNameScope(impl_info.scope_id);
+      }
 
       Indent();
       out_ << "witness = ";


### PR DESCRIPTION
`impl`s may be defined even if they have no scope if they were imported.