### PR TITLE
Clean up: use across-decl comparison comparing interface.

### DIFF
--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -138,7 +138,8 @@ static auto LookupInterfaceWitness(Context& context,
             context.types().GetConstantId(impl.self_id), type_const_id)) {
       continue;
     }
-    if (impl.constraint_id != interface_type_id) {
+    if (!context.types().AreEqualAcrossDeclarations(impl.constraint_id,
+                                                    interface_type_id)) {
       // TODO: An impl of a constraint type should be treated as implementing
       // the constraint's interfaces.
       continue;


### PR DESCRIPTION
This doesn't seem to be observable because we don't support parameterized impls. But it's consistent with how we compare the type portion of the impl.