### PR TITLE
add syntax highlighting for `x-macro` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This tells Github to detect files having the extension `.def` as `C++` files, which
-# ensures that these files get syntax highlighted prpperly.
+# ensures that these files get syntax highlighted properly.
 *.def linguist-language=C++

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This tells Github to detect files having the extension `.def` as `C++` files, which
+# ensures that these files get syntax highlighted prpperly.
+*.def linguist-language=C++


### PR DESCRIPTION
This tells Github to detect files having the extension .def as C++ files, which ensures that these files get syntax highlighted prpperly.

I'm not sure whether more files like these are present throughout the repo. FWIW, it can also be configured to do other things, such as detect generated, vendored files and exclude these from the Github stats.

See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md.