### PR TITLE
Adjust check's node formatting in crash output.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -844,9 +844,9 @@ static auto ProcessNodeIds(Context& context, llvm::raw_ostream* vlog_stream,
     auto loc = converter->ConvertLoc(
         node_id, [](DiagnosticLoc, const Internal::DiagnosticBase<>&) {});
     loc.FormatLocation(output);
-    output << ": Check::Handle" << context.parse_tree().node_kind(node_id)
-           << "\n";
-    loc.FormatSnippet(output);
+    output << ": checking " << context.parse_tree().node_kind(node_id) << "\n";
+    // Crash output has a tab indent; try to indent slightly past that.
+    loc.FormatSnippet(output, /*indent=*/10);
   });
 
   while (auto maybe_node_id = traversal.Next()) {

--- a/toolchain/diagnostics/diagnostic.cpp
+++ b/toolchain/diagnostics/diagnostic.cpp
@@ -19,7 +19,8 @@ auto DiagnosticLoc::FormatLocation(llvm::raw_ostream& out) const -> void {
   }
 }
 
-auto DiagnosticLoc::FormatSnippet(llvm::raw_ostream& out) const -> void {
+auto DiagnosticLoc::FormatSnippet(llvm::raw_ostream& out, int indent) const
+    -> void {
   if (column_number <= 0) {
     return;
   }
@@ -27,8 +28,9 @@ auto DiagnosticLoc::FormatSnippet(llvm::raw_ostream& out) const -> void {
   // column_number is 1-based.
   int32_t column = column_number - 1;
 
+  out.indent(indent);
   out << line << "\n";
-  out.indent(column);
+  out.indent(indent + column);
   out << "^";
   // We want to ensure that we don't underline past the end of the line in
   // case of a multiline token.

--- a/toolchain/diagnostics/diagnostic.h
+++ b/toolchain/diagnostics/diagnostic.h
@@ -52,7 +52,7 @@ struct DiagnosticLoc {
 
   // Write the source snippet corresponding to this location to the given
   // stream.
-  auto FormatSnippet(llvm::raw_ostream& out) const -> void;
+  auto FormatSnippet(llvm::raw_ostream& out, int indent = 0) const -> void;
 
   // Name of the file or buffer that this diagnostic refers to.
   llvm::StringRef filename;


### PR DESCRIPTION
I'm trying to make the line of code more clearly nested in crash output (the way it is, I sometimes forget about it). Also, `Check::HandleFunctionDecl` is the old naming scheme, it's now all `Check::HandleParseNode`, so I'm replacing that.

Before:

```
3.	extern_library_owner.carbon:6:1: Check::HandleFunctionDecl
extern fn F();
^~~~~~~~~~~~~~
 #0 0x0000564c0057ef1d llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) ...
```

After:

```
3.	extern_library_owner.carbon:6:1: checking FunctionDecl
          extern fn F();
          ^~~~~~~~~~~~~~
 #0 0x00005629029ffd9d llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) ...
```