### PR TITLE
Factor library names into their own ID structure.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -883,7 +883,8 @@ static auto CheckParseTree(
     library_id = packaging->names.library_id;
   }
   unit_info.unit->sem_ir->emplace(
-      unit_info.check_ir_id, package_id, library_id,
+      unit_info.check_ir_id, package_id,
+      SemIR::LibraryNameId::ForStringLiteralValueId(library_id),
       *unit_info.unit->value_stores,
       unit_info.unit->tokens->source().filename().str());
 

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -20,7 +20,7 @@
 namespace Carbon::SemIR {
 
 File::File(CheckIRId check_ir_id, IdentifierId package_id,
-           StringLiteralValueId library_id, SharedValueStores& value_stores,
+           LibraryNameId library_id, SharedValueStores& value_stores,
            std::string filename)
     : check_ir_id_(check_ir_id),
       package_id_(package_id),

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -34,8 +34,8 @@ class File : public Printable<File> {
  public:
   // Starts a new file for Check::CheckParseTree.
   explicit File(CheckIRId check_ir_id, IdentifierId package_id,
-                StringLiteralValueId library_id,
-                SharedValueStores& value_stores, std::string filename);
+                LibraryNameId library_id, SharedValueStores& value_stores,
+                std::string filename);
 
   File(const File&) = delete;
   auto operator=(const File&) -> File& = delete;
@@ -82,7 +82,7 @@ class File : public Printable<File> {
 
   auto check_ir_id() const -> CheckIRId { return check_ir_id_; }
   auto package_id() const -> IdentifierId { return package_id_; }
-  auto library_id() const -> StringLiteralValueId { return library_id_; }
+  auto library_id() const -> SemIR::LibraryNameId { return library_id_; }
 
   // Directly expose SharedValueStores members.
   auto identifiers() -> CanonicalValueStore<IdentifierId>& {
@@ -181,7 +181,7 @@ class File : public Printable<File> {
   IdentifierId package_id_ = IdentifierId::Invalid;
 
   // The file's library.
-  StringLiteralValueId library_id_ = StringLiteralValueId::Invalid;
+  LibraryNameId library_id_ = LibraryNameId::Invalid;
 
   // Shared, compile-scoped values.
   SharedValueStores* value_stores_;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -900,10 +900,12 @@ class FormatterImpl {
       out_ << "Main";
     }
     out_ << "//";
-    if (import_ir.library_id().is_valid()) {
-      out_ << import_ir.string_literal_values().Get(import_ir.library_id());
-    } else {
+    CARBON_CHECK(import_ir.library_id().is_valid());
+    if (import_ir.library_id() == LibraryNameId::Default) {
       out_ << "default";
+    } else {
+      out_ << import_ir.string_literal_values().Get(
+          import_ir.library_id().AsStringLiteralValueId());
     }
   }
 

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -123,7 +123,7 @@ using IdKind = TypeEnum<
     InstId, ConstantId, EntityNameId, CompileTimeBindIndex, FunctionId, ClassId,
     InterfaceId, ImplId, GenericId, SpecificId, ImportIRId, ImportIRInstId,
     LocId, BoolValue, IntKind, NameId, NameScopeId, InstBlockId, TypeId,
-    TypeBlockId, ElementIndex, FloatKind>;
+    TypeBlockId, ElementIndex, LibraryNameId, FloatKind>;
 
 }  // namespace Carbon::SemIR
 


### PR DESCRIPTION
This supports distinguishing between unset, Default, and "incorrect but already diagnosed, do not use" for `extern library` logic.