### PR TITLE
Add function debug info descriptions

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -289,7 +289,7 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
     return;
   }
 
-  llvm_function->setSubprogram(BuildSubprogram(function, llvm_function));
+  llvm_function->setSubprogram(BuildDISubprogram(function, llvm_function));
 
   FunctionContext function_lowering(*this, llvm_function, vlog_stream_);
 
@@ -362,7 +362,7 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   }
 }
 
-auto FileContext::BuildSubprogram(
+auto FileContext::BuildDISubprogram(
     const Carbon::SemIR::Function& /*semir_function*/,
     const llvm::Function* llvm_function) -> llvm::DISubprogram* {
   if (!di_compile_unit_) {

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -379,6 +379,7 @@ auto FileContext::BuildDISubprogram(const Carbon::SemIR::Function& /*function*/,
       /*ScopeLine=*/0, llvm::DINode::FlagZero,
       llvm::DISubprogram::SPFlagDefinition);
 }
+
 static auto BuildTypeForInst(FileContext& context, SemIR::ArrayType inst)
     -> llvm::Type* {
   return llvm::ArrayType::get(

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -362,17 +362,22 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   }
 }
 
-auto FileContext::BuildDISubprogram(
-    const Carbon::SemIR::Function& /*semir_function*/,
-    const llvm::Function* llvm_function) -> llvm::DISubprogram* {
+auto FileContext::BuildDISubprogram(const Carbon::SemIR::Function& /*function*/,
+                                    const llvm::Function* llvm_function)
+    -> llvm::DISubprogram* {
   if (!di_compile_unit_) {
     return nullptr;
   }
+  // FIXME: Add more details here, including mangled name, real subroutine type
+  // (once type information is built), etc.
   return di_builder_.createFunction(
-      di_compile_unit_, llvm_function->getName(), "", nullptr, 0,
+      di_compile_unit_, llvm_function->getName(), /*LinkageName=*/"",
+      /*File=*/nullptr,
+      /*LineNo=*/0,
       di_builder_.createSubroutineType(
           di_builder_.getOrCreateTypeArray(std::nullopt)),
-      0, llvm::DINode::FlagZero, llvm::DISubprogram::SPFlagDefinition);
+      /*ScopeLine=*/0, llvm::DINode::FlagZero,
+      llvm::DISubprogram::SPFlagDefinition);
 }
 static auto BuildTypeForInst(FileContext& context, SemIR::ArrayType inst)
     -> llvm::Type* {

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -362,7 +362,7 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   }
 }
 
-auto FileContext::BuildDISubprogram(const Carbon::SemIR::Function& /*function*/,
+auto FileContext::BuildDISubprogram(const SemIR::Function& /*function*/,
                                     const llvm::Function* llvm_function)
     -> llvm::DISubprogram* {
   if (!di_compile_unit_) {

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -289,6 +289,8 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
     return;
   }
 
+  llvm_function->setSubprogram(BuildSubprogram(function, llvm_function));
+
   FunctionContext function_lowering(*this, llvm_function, vlog_stream_);
 
   // TODO: Pass in a specific ID for generic functions.
@@ -360,6 +362,18 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   }
 }
 
+auto FileContext::BuildSubprogram(
+    const Carbon::SemIR::Function& /*semir_function*/,
+    const llvm::Function* llvm_function) -> llvm::DISubprogram* {
+  if (!di_compile_unit_) {
+    return nullptr;
+  }
+  return di_builder_.createFunction(
+      di_compile_unit_, llvm_function->getName(), "", nullptr, 0,
+      di_builder_.createSubroutineType(
+          di_builder_.getOrCreateTypeArray(std::nullopt)),
+      0, llvm::DINode::FlagZero, llvm::DISubprogram::SPFlagDefinition);
+}
 static auto BuildTypeForInst(FileContext& context, SemIR::ArrayType inst)
     -> llvm::Type* {
   return llvm::ArrayType::get(

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -78,6 +78,7 @@ class FileContext {
   // declaration with no definition, does nothing.
   auto BuildFunctionDefinition(SemIR::FunctionId function_id) -> void;
 
+  // Build the DISubprogram metadata for the given function.
   auto BuildSubprogram(const Carbon::SemIR::Function& function,
                        const llvm::Function* llvm_function)
       -> llvm::DISubprogram*;

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -79,7 +79,7 @@ class FileContext {
   auto BuildFunctionDefinition(SemIR::FunctionId function_id) -> void;
 
   // Build the DISubprogram metadata for the given function.
-  auto BuildDISubprogram(const Carbon::SemIR::Function& function,
+  auto BuildDISubprogram(const SemIR::Function& function,
                          const llvm::Function* llvm_function)
       -> llvm::DISubprogram*;
 

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -78,6 +78,10 @@ class FileContext {
   // declaration with no definition, does nothing.
   auto BuildFunctionDefinition(SemIR::FunctionId function_id) -> void;
 
+  auto BuildSubprogram(const Carbon::SemIR::Function& function,
+                       const llvm::Function* llvm_function)
+      -> llvm::DISubprogram*;
+
   // Builds the type for the given instruction, which should then be cached by
   // the caller.
   auto BuildType(SemIR::InstId inst_id) -> llvm::Type*;

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -79,8 +79,8 @@ class FileContext {
   auto BuildFunctionDefinition(SemIR::FunctionId function_id) -> void;
 
   // Build the DISubprogram metadata for the given function.
-  auto BuildSubprogram(const Carbon::SemIR::Function& function,
-                       const llvm::Function* llvm_function)
+  auto BuildDISubprogram(const Carbon::SemIR::Function& function,
+                         const llvm::Function* llvm_function)
       -> llvm::DISubprogram*;
 
   // Builds the type for the given instruction, which should then be cached by

--- a/toolchain/lower/testdata/alias/local.carbon
+++ b/toolchain/lower/testdata/alias/local.carbon
@@ -17,7 +17,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'local.carbon'
 // CHECK:STDOUT: source_filename = "local.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F() {
+// CHECK:STDOUT: define i32 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %a.var, align 4
@@ -32,3 +32,6 @@ fn F() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "local.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/array/array_in_place.carbon
+++ b/toolchain/lower/testdata/array/array_in_place.carbon
@@ -19,7 +19,7 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @F(ptr sret({ i32, i32, i32 }))
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %v.var = alloca [2 x { i32, i32, i32 }], align 8
 // CHECK:STDOUT:   %.loc14_42.2.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, i32 0
@@ -36,3 +36,6 @@ fn G() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "array_in_place.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -19,7 +19,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.loc11_39 = internal constant { i32, i32 } { i32 12, i32 24 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F(ptr sret({ i32, i32 }) %return) {
+// CHECK:STDOUT: define void @F(ptr sret({ i32, i32 }) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc11_38.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc11_38.4.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 1
@@ -27,7 +27,7 @@ fn Run() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @main() {
+// CHECK:STDOUT: define void @main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %t.var = alloca [2 x i32], align 4
 // CHECK:STDOUT:   %.loc14_22.1.temp = alloca { i32, i32 }, align 8
@@ -55,3 +55,7 @@ fn Run() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "assign_return_value.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -24,7 +24,7 @@ fn Run() {
 // CHECK:STDOUT: @array.3.loc14_41 = internal constant [5 x {}] zeroinitializer
 // CHECK:STDOUT: @tuple.2.loc15_37 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @main() {
+// CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [1 x i32], align 4
 // CHECK:STDOUT:   %.loc12_24.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, i32 0
@@ -76,3 +76,6 @@ fn Run() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "base.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/array/function_param.carbon
+++ b/toolchain/lower/testdata/array/function_param.carbon
@@ -21,14 +21,14 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @array.loc16_11.1 = internal constant [3 x i32] [i32 1, i32 2, i32 3]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F(ptr %arr, i32 %i) {
+// CHECK:STDOUT: define i32 @F(ptr %arr, i32 %i) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12_15.2.array.index = getelementptr inbounds [3 x i32], ptr %arr, i32 0, i32 %i
 // CHECK:STDOUT:   %.loc12_15.3 = load i32, ptr %.loc12_15.2.array.index, align 4
 // CHECK:STDOUT:   ret i32 %.loc12_15.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @G() {
+// CHECK:STDOUT: define i32 @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc16_20.2.temp = alloca [3 x i32], align 4
 // CHECK:STDOUT:   %.loc16_20.4.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.2.temp, i32 0, i32 0
@@ -51,3 +51,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "function_param.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/basics/false_true.carbon
+++ b/toolchain/lower/testdata/basics/false_true.carbon
@@ -19,12 +19,12 @@ fn T() -> bool {
 // CHECK:STDOUT: ; ModuleID = 'false_true.carbon'
 // CHECK:STDOUT: source_filename = "false_true.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @F() {
+// CHECK:STDOUT: define i1 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i1 false
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @T() {
+// CHECK:STDOUT: define i1 @T() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i1 true
 // CHECK:STDOUT: }
@@ -36,3 +36,7 @@ fn T() -> bool {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "false_true.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "T", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/basics/int_types.carbon
+++ b/toolchain/lower/testdata/basics/int_types.carbon
@@ -16,22 +16,22 @@ fn F_u65536(a: u65536) -> u65536 { return a; }
 // CHECK:STDOUT: ; ModuleID = 'int_types.carbon'
 // CHECK:STDOUT: source_filename = "int_types.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i8 @F_i8(i8 %a) {
+// CHECK:STDOUT: define i8 @F_i8(i8 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i8 %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i16 @F_u16(i16 %a) {
+// CHECK:STDOUT: define i16 @F_u16(i16 %a) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i16 %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @F_i64(i64 %a) {
+// CHECK:STDOUT: define i64 @F_i64(i64 %a) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i64 %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i65536 @F_u65536(i65536 %a) {
+// CHECK:STDOUT: define i65536 @F_u65536(i65536 %a) !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i65536 %a
 // CHECK:STDOUT: }
@@ -43,3 +43,9 @@ fn F_u65536(a: u65536) -> u65536 { return a; }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "int_types.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F_i8", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "F_u16", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "F_i64", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "F_u65536", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/basics/numeric_literals.carbon
+++ b/toolchain/lower/testdata/basics/numeric_literals.carbon
@@ -33,7 +33,7 @@ fn F() {
 // CHECK:STDOUT: @array.1.loc19_4 = internal constant [4 x i32] [i32 8, i32 9, i32 8, i32 8]
 // CHECK:STDOUT: @array.2.loc27_4 = internal constant [6 x double] [double 9.000000e-01, double 8.000000e+00, double 8.000000e+01, double 1.000000e+07, double 1.000000e+08, double 1.000000e-08]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %ints.var = alloca [4 x i32], align 4
 // CHECK:STDOUT:   %.loc19_3.3.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i32 0
@@ -67,3 +67,6 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "numeric_literals.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/basics/type_values.carbon
+++ b/toolchain/lower/testdata/basics/type_values.carbon
@@ -28,17 +28,17 @@ fn F64() -> type {
 // CHECK:STDOUT:
 // CHECK:STDOUT: %type = type {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @I32() {
+// CHECK:STDOUT: define %type @I32() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret %type zeroinitializer
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @I48() {
+// CHECK:STDOUT: define %type @I48() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret %type zeroinitializer
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @F64() {
+// CHECK:STDOUT: define %type @F64() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret %type zeroinitializer
 // CHECK:STDOUT: }
@@ -50,3 +50,8 @@ fn F64() -> type {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "type_values.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "I32", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "I48", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "F64", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/basics/zero.carbon
+++ b/toolchain/lower/testdata/basics/zero.carbon
@@ -15,7 +15,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'zero.carbon'
 // CHECK:STDOUT: source_filename = "zero.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Main() {
+// CHECK:STDOUT: define i32 @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
@@ -27,3 +27,6 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "zero.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/builtins/float.carbon
+++ b/toolchain/lower/testdata/builtins/float.carbon
@@ -44,67 +44,67 @@ fn TestGreaterEq(a: f64, b: f64) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: ; ModuleID = 'float.carbon'
 // CHECK:STDOUT: source_filename = "float.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @TestNegate(double %a) {
+// CHECK:STDOUT: define double @TestNegate(double %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.negate = fneg double %a
 // CHECK:STDOUT:   ret double %float.negate
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @TestAdd(double %a, double %b) {
+// CHECK:STDOUT: define double @TestAdd(double %a, double %b) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.add = fadd double %a, %b
 // CHECK:STDOUT:   ret double %float.add
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @TestSub(double %a, double %b) {
+// CHECK:STDOUT: define double @TestSub(double %a, double %b) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.sub = fsub double %a, %b
 // CHECK:STDOUT:   ret double %float.sub
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @TestMul(double %a, double %b) {
+// CHECK:STDOUT: define double @TestMul(double %a, double %b) !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.mul = fmul double %a, %b
 // CHECK:STDOUT:   ret double %float.mul
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @TestDiv(double %a, double %b) {
+// CHECK:STDOUT: define double @TestDiv(double %a, double %b) !dbg !10 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.div = fdiv double %a, %b
 // CHECK:STDOUT:   ret double %float.div
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestEq(double %a, double %b) {
+// CHECK:STDOUT: define i1 @TestEq(double %a, double %b) !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.eq = fcmp oeq double %a, %b
 // CHECK:STDOUT:   ret i1 %float.eq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestNeq(double %a, double %b) {
+// CHECK:STDOUT: define i1 @TestNeq(double %a, double %b) !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.neq = fcmp one double %a, %b
 // CHECK:STDOUT:   ret i1 %float.neq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestLess(double %a, double %b) {
+// CHECK:STDOUT: define i1 @TestLess(double %a, double %b) !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.less = fcmp olt double %a, %b
 // CHECK:STDOUT:   ret i1 %float.less
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestLessEq(double %a, double %b) {
+// CHECK:STDOUT: define i1 @TestLessEq(double %a, double %b) !dbg !14 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.less_eq = fcmp ole double %a, %b
 // CHECK:STDOUT:   ret i1 %float.less_eq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestGreater(double %a, double %b) {
+// CHECK:STDOUT: define i1 @TestGreater(double %a, double %b) !dbg !15 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.greater = fcmp ogt double %a, %b
 // CHECK:STDOUT:   ret i1 %float.greater
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestGreaterEq(double %a, double %b) {
+// CHECK:STDOUT: define i1 @TestGreaterEq(double %a, double %b) !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %float.greater_eq = fcmp oge double %a, %b
 // CHECK:STDOUT:   ret i1 %float.greater_eq
@@ -117,3 +117,16 @@ fn TestGreaterEq(a: f64, b: f64) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "float.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestNegate", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "TestAdd", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "TestSub", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "TestMul", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "TestDiv", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "TestEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "TestNeq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = distinct !DISubprogram(name: "TestLess", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "TestLessEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "TestGreater", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "TestGreaterEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/builtins/int.carbon
+++ b/toolchain/lower/testdata/builtins/int.carbon
@@ -65,109 +65,109 @@ fn TestGreaterEq(a: i32, b: i32) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: ; ModuleID = 'int.carbon'
 // CHECK:STDOUT: source_filename = "int.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestNegate(i32 %a) {
+// CHECK:STDOUT: define i32 @TestNegate(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.snegate = sub i32 0, %a
 // CHECK:STDOUT:   ret i32 %int.snegate
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestAdd(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestAdd(i32 %a, i32 %b) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.sadd
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestSub(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestSub(i32 %a, i32 %b) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.ssub = sub i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.ssub
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestMul(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestMul(i32 %a, i32 %b) !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.smul = mul i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.smul
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestDiv(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestDiv(i32 %a, i32 %b) !dbg !10 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sdiv = sdiv i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.sdiv
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestMod(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestMod(i32 %a, i32 %b) !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.smod = srem i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.smod
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestComplement(i32 %a) {
+// CHECK:STDOUT: define i32 @TestComplement(i32 %a) !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.complement = xor i32 -1, %a
 // CHECK:STDOUT:   ret i32 %int.complement
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestAnd(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestAnd(i32 %a, i32 %b) !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.and = and i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.and
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestOr(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestOr(i32 %a, i32 %b) !dbg !14 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.or = or i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.or
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestXor(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestXor(i32 %a, i32 %b) !dbg !15 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.xor = xor i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.xor
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestLeftShift(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestLeftShift(i32 %a, i32 %b) !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.left_shift = shl i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.left_shift
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestRightShift(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestRightShift(i32 %a, i32 %b) !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.right_shift = ashr i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.right_shift
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestEq(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i1 @TestEq(i32 %a, i32 %b) !dbg !18 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.eq = icmp eq i32 %a, %b
 // CHECK:STDOUT:   ret i1 %int.eq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestNeq(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i1 @TestNeq(i32 %a, i32 %b) !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.neq = icmp ne i32 %a, %b
 // CHECK:STDOUT:   ret i1 %int.neq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestLess(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i1 @TestLess(i32 %a, i32 %b) !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less = icmp slt i32 %a, %b
 // CHECK:STDOUT:   ret i1 %int.less
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestLessEq(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i1 @TestLessEq(i32 %a, i32 %b) !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less_eq = icmp sle i32 %a, %b
 // CHECK:STDOUT:   ret i1 %int.less_eq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestGreater(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i1 @TestGreater(i32 %a, i32 %b) !dbg !22 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %a, %b
 // CHECK:STDOUT:   ret i1 %int.greater
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestGreaterEq(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i1 @TestGreaterEq(i32 %a, i32 %b) !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater_eq = icmp sge i32 %a, %b
 // CHECK:STDOUT:   ret i1 %int.greater_eq
@@ -180,3 +180,23 @@ fn TestGreaterEq(a: i32, b: i32) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "int.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestNegate", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "TestAdd", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "TestSub", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "TestMul", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "TestDiv", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "TestMod", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "TestComplement", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = distinct !DISubprogram(name: "TestAnd", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "TestOr", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "TestXor", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "TestLeftShift", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "TestRightShift", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "TestEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "TestNeq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "TestLess", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "TestLessEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "TestGreater", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = distinct !DISubprogram(name: "TestGreaterEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/builtins/method_vs_nonmethod.carbon
+++ b/toolchain/lower/testdata/builtins/method_vs_nonmethod.carbon
@@ -17,13 +17,13 @@ fn TestAddMethod(a: i32, b: i32) -> i32 { return a.(AddMethod)(b); }
 // CHECK:STDOUT: ; ModuleID = 'method_vs_nonmethod.carbon'
 // CHECK:STDOUT: source_filename = "method_vs_nonmethod.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestAddNonmethod(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestAddNonmethod(i32 %a, i32 %b) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.sadd
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TestAddMethod(i32 %a, i32 %b) {
+// CHECK:STDOUT: define i32 @TestAddMethod(i32 %a, i32 %b) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %a, %b
 // CHECK:STDOUT:   ret i32 %int.sadd
@@ -36,3 +36,7 @@ fn TestAddMethod(a: i32, b: i32) -> i32 { return a.(AddMethod)(b); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "method_vs_nonmethod.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestAddNonmethod", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "TestAddMethod", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/builtins/overloaded_operator.carbon
+++ b/toolchain/lower/testdata/builtins/overloaded_operator.carbon
@@ -21,7 +21,7 @@ fn AddThreeIntegers(a: i32, b: i32, c: i32) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'overloaded_operator.carbon'
 // CHECK:STDOUT: source_filename = "overloaded_operator.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @AddThreeIntegers(i32 %a, i32 %b, i32 %c) {
+// CHECK:STDOUT: define i32 @AddThreeIntegers(i32 %a, i32 %b, i32 %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd.loc18_12 = add i32 %a, %b
 // CHECK:STDOUT:   %.loc18_12.2.temp = alloca i32, align 4
@@ -38,3 +38,6 @@ fn AddThreeIntegers(a: i32, b: i32, c: i32) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "overloaded_operator.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "AddThreeIntegers", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/builtins/print.carbon
+++ b/toolchain/lower/testdata/builtins/print.carbon
@@ -17,7 +17,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @printf.int.format = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int.printf = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1)
 // CHECK:STDOUT:   ret void
@@ -32,3 +32,6 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "print.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/builtins/types.carbon
+++ b/toolchain/lower/testdata/builtins/types.carbon
@@ -21,7 +21,7 @@ fn F() {
 // CHECK:STDOUT: ; ModuleID = 'types.carbon'
 // CHECK:STDOUT: source_filename = "types.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %i.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %i.var, align 4
@@ -39,3 +39,6 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "types.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/builtins/uint.carbon
+++ b/toolchain/lower/testdata/builtins/uint.carbon
@@ -65,109 +65,109 @@ fn TestGreaterEq(a: u64, b: u64) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: ; ModuleID = 'uint.carbon'
 // CHECK:STDOUT: source_filename = "uint.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestNegate(i64 %a) {
+// CHECK:STDOUT: define i64 @TestNegate(i64 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.unegate = sub i64 0, %a
 // CHECK:STDOUT:   ret i64 %int.unegate
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestAdd(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestAdd(i64 %a, i64 %b) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.uadd = add i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.uadd
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestSub(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestSub(i64 %a, i64 %b) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.usub = sub i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.usub
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestMul(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestMul(i64 %a, i64 %b) !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.umul = mul i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.umul
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestDiv(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestDiv(i64 %a, i64 %b) !dbg !10 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.udiv = udiv i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.udiv
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestMod(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestMod(i64 %a, i64 %b) !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.umod = urem i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.umod
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestComplement(i64 %a) {
+// CHECK:STDOUT: define i64 @TestComplement(i64 %a) !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.complement = xor i64 -1, %a
 // CHECK:STDOUT:   ret i64 %int.complement
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestAnd(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestAnd(i64 %a, i64 %b) !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.and = and i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.and
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestOr(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestOr(i64 %a, i64 %b) !dbg !14 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.or = or i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.or
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestXor(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestXor(i64 %a, i64 %b) !dbg !15 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.xor = xor i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.xor
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestLeftShift(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestLeftShift(i64 %a, i64 %b) !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.left_shift = shl i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.left_shift
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i64 @TestRightShift(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i64 @TestRightShift(i64 %a, i64 %b) !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.right_shift = lshr i64 %a, %b
 // CHECK:STDOUT:   ret i64 %int.right_shift
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestEq(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i1 @TestEq(i64 %a, i64 %b) !dbg !18 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.eq = icmp eq i64 %a, %b
 // CHECK:STDOUT:   ret i1 %int.eq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestNeq(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i1 @TestNeq(i64 %a, i64 %b) !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.neq = icmp ne i64 %a, %b
 // CHECK:STDOUT:   ret i1 %int.neq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestLess(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i1 @TestLess(i64 %a, i64 %b) !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less = icmp ult i64 %a, %b
 // CHECK:STDOUT:   ret i1 %int.less
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestLessEq(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i1 @TestLessEq(i64 %a, i64 %b) !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less_eq = icmp ule i64 %a, %b
 // CHECK:STDOUT:   ret i1 %int.less_eq
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestGreater(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i1 @TestGreater(i64 %a, i64 %b) !dbg !22 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp ugt i64 %a, %b
 // CHECK:STDOUT:   ret i1 %int.greater
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @TestGreaterEq(i64 %a, i64 %b) {
+// CHECK:STDOUT: define i1 @TestGreaterEq(i64 %a, i64 %b) !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater_eq = icmp uge i64 %a, %b
 // CHECK:STDOUT:   ret i1 %int.greater_eq
@@ -180,3 +180,23 @@ fn TestGreaterEq(a: u64, b: u64) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "uint.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestNegate", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "TestAdd", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "TestSub", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "TestMul", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "TestDiv", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "TestMod", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "TestComplement", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = distinct !DISubprogram(name: "TestAnd", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "TestOr", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "TestXor", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "TestLeftShift", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "TestRightShift", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "TestEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "TestNeq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "TestLess", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "TestLessEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "TestGreater", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = distinct !DISubprogram(name: "TestGreaterEq", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/class/adapt.carbon
+++ b/toolchain/lower/testdata/class/adapt.carbon
@@ -56,7 +56,7 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @struct.loc9_28 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Make(ptr sret({ i32, i32 }) %return) {
+// CHECK:STDOUT: define void @Make(ptr sret({ i32, i32 }) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc9_27.2.a = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_27.4.b = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 1
@@ -64,20 +64,20 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Make.1(ptr sret({ i32, i32 }) %return) {
+// CHECK:STDOUT: define void @Make.1(ptr sret({ i32, i32 }) %return) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Make(ptr %return)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @GetB(ptr %self) {
+// CHECK:STDOUT: define i32 @GetB(ptr %self) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc22_14.1.b = getelementptr inbounds nuw { i32, i32 }, ptr %self, i32 0, i32 1
 // CHECK:STDOUT:   %.loc22_14.2 = load i32, ptr %.loc22_14.1.b, align 4
 // CHECK:STDOUT:   ret i32 %.loc22_14.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Use() {
+// CHECK:STDOUT: define i32 @Use() !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %pa.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   call void @Make.1(ptr %pa.var)
@@ -97,10 +97,16 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "adapt_class.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Make", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Make.1", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "GetB", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "Use", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: ; ModuleID = 'adapt_int.carbon'
 // CHECK:STDOUT: source_filename = "adapt_int.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @DoStuff(i32 %a) {
+// CHECK:STDOUT: define i32 @DoStuff(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %a
 // CHECK:STDOUT: }
@@ -112,3 +118,6 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "adapt_int.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "DoStuff", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/class/base.carbon
+++ b/toolchain/lower/testdata/class/base.carbon
@@ -35,7 +35,7 @@ fn Convert(p: Derived*) -> Base* {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @struct.2.loc22_36 = internal constant { { i32 }, i32 } { { i32 } { i32 4 }, i32 7 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Make(ptr sret({ { i32 }, i32 }) %return) {
+// CHECK:STDOUT: define void @Make(ptr sret({ { i32 }, i32 }) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc22_35.2.base = getelementptr inbounds nuw { { i32 }, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc22_26.2.b = getelementptr inbounds nuw { i32 }, ptr %.loc22_35.2.base, i32 0, i32 0
@@ -44,7 +44,7 @@ fn Convert(p: Derived*) -> Base* {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Access(ptr sret({ i32, i32 }) %return, ptr %d) {
+// CHECK:STDOUT: define void @Access(ptr sret({ i32, i32 }) %return, ptr %d) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc26_12.1.d = getelementptr inbounds nuw { { i32 }, i32 }, ptr %d, i32 0, i32 1
 // CHECK:STDOUT:   %.loc26_12.2 = load i32, ptr %.loc26_12.1.d, align 4
@@ -58,7 +58,7 @@ fn Convert(p: Derived*) -> Base* {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @Convert(ptr %p) {
+// CHECK:STDOUT: define ptr @Convert(ptr %p) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc30_11.2.base = getelementptr inbounds nuw { { i32 }, i32 }, ptr %p, i32 0, i32 0
 // CHECK:STDOUT:   ret ptr %.loc30_11.2.base
@@ -76,3 +76,8 @@ fn Convert(p: Derived*) -> Base* {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "base.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Make", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Access", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Convert", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/class/basic.carbon
+++ b/toolchain/lower/testdata/class/basic.carbon
@@ -25,7 +25,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @F(ptr sret({ i32, ptr }), ptr)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @main() {
+// CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca { i32, ptr }, align 8
 // CHECK:STDOUT:   %d.var = alloca { i32, ptr }, align 8
@@ -40,3 +40,6 @@ fn Run() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "basic.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/class/field.carbon
+++ b/toolchain/lower/testdata/class/field.carbon
@@ -27,7 +27,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'field.carbon'
 // CHECK:STDOUT: source_filename = "field.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F(ptr %c) {
+// CHECK:STDOUT: define i32 @F(ptr %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc17_13.1.b = getelementptr inbounds nuw { i32, ptr }, ptr %c, i32 0, i32 1
 // CHECK:STDOUT:   %.loc17_13.2 = load ptr, ptr %.loc17_13.1.b, align 8
@@ -36,7 +36,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   ret i32 %.loc17_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca { i32, ptr }, align 8
 // CHECK:STDOUT:   %.loc22_4.a = getelementptr inbounds nuw { i32, ptr }, ptr %c.var, i32 0, i32 0
@@ -54,3 +54,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "field.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/class/method.carbon
+++ b/toolchain/lower/testdata/class/method.carbon
@@ -27,7 +27,7 @@ fn F(p: C*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @Set(ptr, i32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F(ptr %p) {
+// CHECK:STDOUT: define void @F(ptr %p) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %Get.call = call i32 @Get(ptr %p)
 // CHECK:STDOUT:   call void @Set(ptr %p, i32 %Get.call)
@@ -41,3 +41,6 @@ fn F(p: C*) {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "method.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/class/self.carbon
+++ b/toolchain/lower/testdata/class/self.carbon
@@ -26,14 +26,14 @@ fn C.Set[addr self: C*]() {
 // CHECK:STDOUT: ; ModuleID = 'self.carbon'
 // CHECK:STDOUT: source_filename = "self.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Get(ptr %self) {
+// CHECK:STDOUT: define i32 @Get(ptr %self) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc19_14.1.a = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   %.loc19_14.2 = load i32, ptr %.loc19_14.1.a, align 4
 // CHECK:STDOUT:   ret i32 %.loc19_14.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Set(ptr %self) {
+// CHECK:STDOUT: define void @Set(ptr %self) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc23_10.a = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   store i32 1, ptr %.loc23_10.a, align 4
@@ -47,3 +47,7 @@ fn C.Set[addr self: C*]() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "self.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Get", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Set", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/class/value_access.carbon
+++ b/toolchain/lower/testdata/class/value_access.carbon
@@ -22,7 +22,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'value_access.carbon'
 // CHECK:STDOUT: source_filename = "value_access.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F(ptr %c) {
+// CHECK:STDOUT: define i32 @F(ptr %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc19_11.1.a = getelementptr inbounds nuw { { i32, i32, i32 } }, ptr %c, i32 0, i32 0
 // CHECK:STDOUT:   %.loc19_11.2.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %.loc19_11.1.a, i32 0, i32 0
@@ -50,3 +50,6 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "value_access.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/function/call/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/call/empty_struct.carbon
@@ -19,12 +19,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
 // CHECK:STDOUT: source_filename = "empty_struct.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Echo() {
+// CHECK:STDOUT: define void @Echo() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca {}, align 8
 // CHECK:STDOUT:   call void @Echo()
@@ -38,3 +38,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "empty_struct.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Echo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lower/testdata/function/call/empty_tuple.carbon
@@ -19,12 +19,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'empty_tuple.carbon'
 // CHECK:STDOUT: source_filename = "empty_tuple.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Echo() {
+// CHECK:STDOUT: define void @Echo() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca {}, align 8
 // CHECK:STDOUT:   call void @Echo()
@@ -38,3 +38,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "empty_tuple.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Echo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/i32.carbon
+++ b/toolchain/lower/testdata/function/call/i32.carbon
@@ -19,12 +19,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'i32.carbon'
 // CHECK:STDOUT: source_filename = "i32.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Echo(i32 %a) {
+// CHECK:STDOUT: define i32 @Echo(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca i32, align 4
 // CHECK:STDOUT:   %Echo.call = call i32 @Echo(i32 1)
@@ -39,3 +39,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "i32.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Echo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
+++ b/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
@@ -20,17 +20,17 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'implicit_empty_tuple_as_arg.carbon'
 // CHECK:STDOUT: source_filename = "implicit_empty_tuple_as_arg.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo() {
+// CHECK:STDOUT: define void @Foo() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Bar() {
+// CHECK:STDOUT: define void @Bar() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8
 // CHECK:STDOUT:   call void @Foo()
@@ -46,3 +46,8 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "implicit_empty_tuple_as_arg.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Bar", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/params_one.carbon
+++ b/toolchain/lower/testdata/function/call/params_one.carbon
@@ -17,12 +17,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
 // CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo(i32 %a) {
+// CHECK:STDOUT: define void @Foo(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Foo(i32 1)
 // CHECK:STDOUT:   ret void
@@ -35,3 +35,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_one.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/lower/testdata/function/call/params_one_comma.carbon
@@ -18,12 +18,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'params_one_comma.carbon'
 // CHECK:STDOUT: source_filename = "params_one_comma.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo(i32 %a) {
+// CHECK:STDOUT: define void @Foo(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Foo(i32 1)
 // CHECK:STDOUT:   call void @Foo(i32 1)
@@ -37,3 +37,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_one_comma.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/params_two.carbon
+++ b/toolchain/lower/testdata/function/call/params_two.carbon
@@ -17,12 +17,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
 // CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo(i32 %a, i32 %b) {
+// CHECK:STDOUT: define void @Foo(i32 %a, i32 %b) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Foo(i32 1, i32 2)
 // CHECK:STDOUT:   ret void
@@ -35,3 +35,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_two.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/lower/testdata/function/call/params_two_comma.carbon
@@ -18,12 +18,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'params_two_comma.carbon'
 // CHECK:STDOUT: source_filename = "params_two_comma.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo(i32 %a, i32 %b) {
+// CHECK:STDOUT: define void @Foo(i32 %a, i32 %b) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Foo(i32 1, i32 2)
 // CHECK:STDOUT:   call void @Foo(i32 1, i32 2)
@@ -37,3 +37,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_two_comma.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/params_zero.carbon
+++ b/toolchain/lower/testdata/function/call/params_zero.carbon
@@ -17,12 +17,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'params_zero.carbon'
 // CHECK:STDOUT: source_filename = "params_zero.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo() {
+// CHECK:STDOUT: define void @Foo() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Foo()
 // CHECK:STDOUT:   ret void
@@ -35,3 +35,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_zero.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/return_implicit.carbon
+++ b/toolchain/lower/testdata/function/call/return_implicit.carbon
@@ -19,12 +19,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'return_implicit.carbon'
 // CHECK:STDOUT: source_filename = "return_implicit.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @MakeImplicitEmptyTuple() {
+// CHECK:STDOUT: define void @MakeImplicitEmptyTuple() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca {}, align 8
 // CHECK:STDOUT:   call void @MakeImplicitEmptyTuple()
@@ -38,3 +38,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "return_implicit.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "MakeImplicitEmptyTuple", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/struct_param.carbon
+++ b/toolchain/lower/testdata/function/call/struct_param.carbon
@@ -19,12 +19,12 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @struct.3.loc14_4.3 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) {
+// CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @F({ i32 } { i32 1 }, ptr @struct.3.loc14_4.3)
 // CHECK:STDOUT:   ret void
@@ -37,3 +37,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "struct_param.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/tuple_param.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param.carbon
@@ -19,12 +19,12 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.3.loc14_4.3 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) {
+// CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @F({ i32 } { i32 1 }, ptr @tuple.3.loc14_4.3)
 // CHECK:STDOUT:   ret void
@@ -37,3 +37,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "tuple_param.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
@@ -21,7 +21,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.3.loc16_4.4 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F(ptr sret({ i32, i32, i32 }) %return, { i32 } %b, ptr %c) {
+// CHECK:STDOUT: define void @F(ptr sret({ i32, i32, i32 }) %return, { i32 } %b, ptr %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12_12.tuple.index = extractvalue { i32 } %b, 0
 // CHECK:STDOUT:   %.loc12_17.tuple.index = getelementptr inbounds nuw { i32, i32 }, ptr %c, i32 0, i32 0
@@ -37,7 +37,7 @@ fn Main() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc16_4.1.temp = alloca { i32, i32, i32 }, align 8
 // CHECK:STDOUT:   call void @F(ptr %.loc16_4.1.temp, { i32 } { i32 1 }, ptr @tuple.3.loc16_4.4)
@@ -54,3 +54,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "tuple_param_with_return_slot.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/call/var_param.carbon
+++ b/toolchain/lower/testdata/function/call/var_param.carbon
@@ -18,12 +18,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'var_param.carbon'
 // CHECK:STDOUT: source_filename = "var_param.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @DoNothing(i32 %a) {
+// CHECK:STDOUT: define void @DoNothing(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %a.var, align 4
@@ -39,3 +39,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "var_param.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "DoNothing", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/function/declaration/simple.carbon
+++ b/toolchain/lower/testdata/function/declaration/simple.carbon
@@ -17,7 +17,7 @@ fn G(n: i32) { F(n); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @F(i32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G(i32 %n) {
+// CHECK:STDOUT: define void @G(i32 %n) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @F(i32 %n)
 // CHECK:STDOUT:   ret void
@@ -30,3 +30,6 @@ fn G(n: i32) { F(n); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "simple.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/function/definition/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/definition/empty_struct.carbon
@@ -14,7 +14,7 @@ fn Echo(a: {}) {
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
 // CHECK:STDOUT: source_filename = "empty_struct.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Echo() {
+// CHECK:STDOUT: define void @Echo() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -26,3 +26,6 @@ fn Echo(a: {}) {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "empty_struct.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Echo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/function/definition/params_one.carbon
+++ b/toolchain/lower/testdata/function/definition/params_one.carbon
@@ -13,7 +13,7 @@ fn Foo(a: i32) {}
 // CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
 // CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo(i32 %a) {
+// CHECK:STDOUT: define void @Foo(i32 %a) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -25,3 +25,6 @@ fn Foo(a: i32) {}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_one.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/function/definition/params_two.carbon
+++ b/toolchain/lower/testdata/function/definition/params_two.carbon
@@ -13,7 +13,7 @@ fn Foo(a: i32, b: i32) {}
 // CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
 // CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo(i32 %a, i32 %b) {
+// CHECK:STDOUT: define void @Foo(i32 %a, i32 %b) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -25,3 +25,6 @@ fn Foo(a: i32, b: i32) {}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_two.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/function/definition/params_zero.carbon
+++ b/toolchain/lower/testdata/function/definition/params_zero.carbon
@@ -13,7 +13,7 @@ fn Foo() {}
 // CHECK:STDOUT: ; ModuleID = 'params_zero.carbon'
 // CHECK:STDOUT: source_filename = "params_zero.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Foo() {
+// CHECK:STDOUT: define void @Foo() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -25,3 +25,6 @@ fn Foo() {}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "params_zero.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Foo", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/global/class_obj.carbon
+++ b/toolchain/lower/testdata/global/class_obj.carbon
@@ -18,7 +18,7 @@ var a: A = {};
 // CHECK:STDOUT: @struct.loc12_14 = internal constant {} zeroinitializer
 // CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @__global_init, ptr null }]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @__global_init() {
+// CHECK:STDOUT: define void @__global_init() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 @a, ptr align 1 @struct.loc12_14, i64 0, i1 false)
 // CHECK:STDOUT:   ret void
@@ -36,3 +36,6 @@ var a: A = {};
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "class_obj.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "__global_init", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/global/class_with_fun.carbon
+++ b/toolchain/lower/testdata/global/class_with_fun.carbon
@@ -23,13 +23,13 @@ var a: A = {};
 // CHECK:STDOUT: @struct.loc16_14 = internal constant {} zeroinitializer
 // CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @__global_init, ptr null }]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @ret_a(ptr sret({}) %return) {
+// CHECK:STDOUT: define void @ret_a(ptr sret({}) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %return, ptr align 1 @struct.loc13_12, i64 0, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @__global_init() {
+// CHECK:STDOUT: define void @__global_init() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 @a, ptr align 1 @struct.loc16_14, i64 0, i1 false)
 // CHECK:STDOUT:   ret void
@@ -50,3 +50,7 @@ var a: A = {};
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "class_with_fun.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "ret_a", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "__global_init", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/global/simple_init.carbon
+++ b/toolchain/lower/testdata/global/simple_init.carbon
@@ -15,7 +15,7 @@ var a: i32 = 0;
 // CHECK:STDOUT: @a = internal global i32
 // CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @__global_init, ptr null }]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @__global_init() {
+// CHECK:STDOUT: define void @__global_init() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   store i32 0, ptr @a, align 4
 // CHECK:STDOUT:   ret void
@@ -31,3 +31,6 @@ var a: i32 = 0;
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "simple_init.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "__global_init", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/global/simple_with_fun.carbon
+++ b/toolchain/lower/testdata/global/simple_with_fun.carbon
@@ -20,12 +20,12 @@ var a: i32 = test_a();
 // CHECK:STDOUT: @a = internal global i32
 // CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @__global_init, ptr null }]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @test_a() {
+// CHECK:STDOUT: define i32 @test_a() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @__global_init() {
+// CHECK:STDOUT: define void @__global_init() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %test_a.call = call i32 @test_a()
 // CHECK:STDOUT:   store i32 %test_a.call, ptr @a, align 4
@@ -42,3 +42,7 @@ var a: i32 = test_a();
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "simple_with_fun.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "test_a", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "__global_init", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/if/else.carbon
+++ b/toolchain/lower/testdata/if/else.carbon
@@ -24,22 +24,22 @@ fn If(b: bool) {
 // CHECK:STDOUT: ; ModuleID = 'else.carbon'
 // CHECK:STDOUT: source_filename = "else.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @H() {
+// CHECK:STDOUT: define void @H() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @If(i1 %b) {
+// CHECK:STDOUT: define void @If(i1 %b) !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br i1 %b, label %if.then, label %if.else
 // CHECK:STDOUT:
@@ -63,3 +63,9 @@ fn If(b: bool) {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "else.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "H", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "If", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/if/no_else.carbon
+++ b/toolchain/lower/testdata/if/no_else.carbon
@@ -21,17 +21,17 @@ fn If(b: bool) {
 // CHECK:STDOUT: ; ModuleID = 'no_else.carbon'
 // CHECK:STDOUT: source_filename = "no_else.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @If(i1 %b) {
+// CHECK:STDOUT: define void @If(i1 %b) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br i1 %b, label %if.then, label %if.else
 // CHECK:STDOUT:
@@ -51,3 +51,8 @@ fn If(b: bool) {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "no_else.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "If", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/if_expr/basic.carbon
+++ b/toolchain/lower/testdata/if_expr/basic.carbon
@@ -18,17 +18,17 @@ fn Select(b: bool) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F() {
+// CHECK:STDOUT: define i32 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @G() {
+// CHECK:STDOUT: define i32 @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Select(i1 %b) {
+// CHECK:STDOUT: define i32 @Select(i1 %b) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br i1 %b, label %if.expr.then, label %if.expr.else
 // CHECK:STDOUT:
@@ -52,3 +52,8 @@ fn Select(b: bool) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "basic.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Select", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/if_expr/empty_block.carbon
+++ b/toolchain/lower/testdata/if_expr/empty_block.carbon
@@ -15,7 +15,7 @@ fn Select(b: bool, c: bool, d: bool) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'empty_block.carbon'
 // CHECK:STDOUT: source_filename = "empty_block.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Select(i1 %b, i1 %c, i1 %d) {
+// CHECK:STDOUT: define i32 @Select(i1 %b, i1 %c, i1 %d) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br i1 %b, label %if.expr.then.loc12_10, label %if.expr.else.loc12_10
 // CHECK:STDOUT:
@@ -57,3 +57,6 @@ fn Select(b: bool, c: bool, d: bool) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "empty_block.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Select", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/impl/assoc_fn_alias.carbon
+++ b/toolchain/lower/testdata/impl/assoc_fn_alias.carbon
@@ -30,14 +30,14 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'assoc_fn_alias.carbon'
 // CHECK:STDOUT: source_filename = "assoc_fn_alias.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F(ptr %self) {
+// CHECK:STDOUT: define i32 @F(ptr %self) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc22_16.1.n = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   %.loc22_16.2 = load i32, ptr %.loc22_16.1.n, align 4
 // CHECK:STDOUT:   ret i32 %.loc22_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Call(ptr %a) {
+// CHECK:STDOUT: define i32 @Call(ptr %a) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %F.call = call i32 @F(ptr %a)
 // CHECK:STDOUT:   ret i32 %F.call
@@ -50,3 +50,7 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "assoc_fn_alias.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Call", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/impl/extend_impl.carbon
+++ b/toolchain/lower/testdata/impl/extend_impl.carbon
@@ -31,18 +31,18 @@ fn InstanceAccess(a: A) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'extend_impl.carbon'
 // CHECK:STDOUT: source_filename = "extend_impl.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F() {
+// CHECK:STDOUT: define i32 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @TypeAccess() {
+// CHECK:STDOUT: define i32 @TypeAccess() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %F.call = call i32 @F()
 // CHECK:STDOUT:   ret i32 %F.call
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @InstanceAccess(ptr %a) {
+// CHECK:STDOUT: define i32 @InstanceAccess(ptr %a) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %F.call = call i32 @F()
 // CHECK:STDOUT:   ret i32 %F.call
@@ -55,3 +55,8 @@ fn InstanceAccess(a: A) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "extend_impl.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "TypeAccess", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "InstanceAccess", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/impl/impl.carbon
+++ b/toolchain/lower/testdata/impl/impl.carbon
@@ -29,14 +29,14 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'impl.carbon'
 // CHECK:STDOUT: source_filename = "impl.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F(ptr %self) {
+// CHECK:STDOUT: define i32 @F(ptr %self) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc21_16.1.n = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   %.loc21_16.2 = load i32, ptr %.loc21_16.1.n, align 4
 // CHECK:STDOUT:   ret i32 %.loc21_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Call(ptr %a) {
+// CHECK:STDOUT: define i32 @Call(ptr %a) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %F.call = call i32 @F(ptr %a)
 // CHECK:STDOUT:   ret i32 %F.call
@@ -49,3 +49,7 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "impl.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Call", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/impl/instance_method.carbon
+++ b/toolchain/lower/testdata/impl/instance_method.carbon
@@ -29,12 +29,12 @@ fn Call(a: A*) -> A* {
 // CHECK:STDOUT: ; ModuleID = 'instance_method.carbon'
 // CHECK:STDOUT: source_filename = "instance_method.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @Get(ptr %self) {
+// CHECK:STDOUT: define ptr @Get(ptr %self) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @Call(ptr %a) {
+// CHECK:STDOUT: define ptr @Call(ptr %a) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %Get.call = call ptr @Get(ptr %a)
 // CHECK:STDOUT:   ret ptr %Get.call
@@ -47,3 +47,7 @@ fn Call(a: A*) -> A* {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "instance_method.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Get", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Call", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -24,7 +24,7 @@ fn Run() {
 // CHECK:STDOUT: @tuple.loc10_37 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT: @array.loc12_35 = internal constant [2 x i32] [i32 1, i32 2]
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @A(ptr sret({ i32, i32 }) %return) {
+// CHECK:STDOUT: define void @A(ptr sret({ i32, i32 }) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc10_36.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc10_36.4.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 1
@@ -32,7 +32,7 @@ fn Run() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @B(ptr sret([2 x i32]) %return) {
+// CHECK:STDOUT: define void @B(ptr sret([2 x i32]) %return) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12_34.3.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc12_34.6.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, i32 1
@@ -40,7 +40,7 @@ fn Run() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @main() {
+// CHECK:STDOUT: define void @main() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [2 x i32], align 4
 // CHECK:STDOUT:   %.loc15_22.1.temp = alloca { i32, i32 }, align 8
@@ -84,3 +84,8 @@ fn Run() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "array_element_access.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "A", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "B", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/interface/assoc.carbon
+++ b/toolchain/lower/testdata/interface/assoc.carbon
@@ -17,7 +17,7 @@ fn F() { I.Assoc; }
 // CHECK:STDOUT: ; ModuleID = 'assoc.carbon'
 // CHECK:STDOUT: source_filename = "assoc.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -29,3 +29,6 @@ fn F() { I.Assoc; }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "assoc.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/interface/basic.carbon
+++ b/toolchain/lower/testdata/interface/basic.carbon
@@ -24,12 +24,12 @@ fn G(T: J) {}
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -41,3 +41,7 @@ fn G(T: J) {}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "basic.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/let/local.carbon
+++ b/toolchain/lower/testdata/let/local.carbon
@@ -17,7 +17,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'local.carbon'
 // CHECK:STDOUT: source_filename = "local.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 1
 // CHECK:STDOUT: }
@@ -29,3 +29,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "local.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/let/tuple.carbon
+++ b/toolchain/lower/testdata/let/tuple.carbon
@@ -21,7 +21,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: @tuple.1.loc12_37 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
 // CHECK:STDOUT: @tuple.2.loc13_29 = internal constant { i32, i32 } { i32 4, i32 5 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F() {
+// CHECK:STDOUT: define i32 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc12_36.2.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0
@@ -81,3 +81,6 @@ fn F() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "tuple.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/namespace/function.carbon
+++ b/toolchain/lower/testdata/namespace/function.carbon
@@ -24,17 +24,17 @@ fn Bar() {
 // CHECK:STDOUT: ; ModuleID = 'function.carbon'
 // CHECK:STDOUT: source_filename = "function.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Baz() {
+// CHECK:STDOUT: define void @Baz() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Baz.1() {
+// CHECK:STDOUT: define void @Baz.1() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Bar() {
+// CHECK:STDOUT: define void @Bar() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Baz.1()
 // CHECK:STDOUT:   ret void
@@ -47,3 +47,8 @@ fn Bar() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "function.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Baz", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Baz.1", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Bar", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/namespace/nested.carbon
+++ b/toolchain/lower/testdata/namespace/nested.carbon
@@ -21,12 +21,12 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: ; ModuleID = 'nested.carbon'
 // CHECK:STDOUT: source_filename = "nested.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Wiz() {
+// CHECK:STDOUT: define void @Wiz() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Baz() {
+// CHECK:STDOUT: define void @Baz() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @Wiz()
 // CHECK:STDOUT:   ret void
@@ -39,3 +39,7 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "nested.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Wiz", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Baz", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/operators/and.carbon
+++ b/toolchain/lower/testdata/operators/and.carbon
@@ -18,17 +18,17 @@ fn And() -> bool {
 // CHECK:STDOUT: ; ModuleID = 'and.carbon'
 // CHECK:STDOUT: source_filename = "and.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @F() {
+// CHECK:STDOUT: define i1 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i1 true
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @G() {
+// CHECK:STDOUT: define i1 @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i1 true
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @And() {
+// CHECK:STDOUT: define i1 @And() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %F.call = call i1 @F()
 // CHECK:STDOUT:   br i1 %F.call, label %and.rhs, label %and.result
@@ -49,3 +49,8 @@ fn And() -> bool {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "and.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "And", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/operators/and_empty_block.carbon
+++ b/toolchain/lower/testdata/operators/and_empty_block.carbon
@@ -17,7 +17,7 @@ fn And(b: bool, c: bool) -> bool {
 // CHECK:STDOUT: ; ModuleID = 'and_empty_block.carbon'
 // CHECK:STDOUT: source_filename = "and_empty_block.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @And(i1 %b, i1 %c) {
+// CHECK:STDOUT: define i1 @And(i1 %b, i1 %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br i1 %b, label %and.rhs, label %and.result
 // CHECK:STDOUT:
@@ -36,3 +36,6 @@ fn And(b: bool, c: bool) -> bool {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "and_empty_block.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "And", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -20,7 +20,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.loc15_5 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 12, ptr %a.var, align 4
@@ -44,3 +44,6 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "assignment.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/operators/not.carbon
+++ b/toolchain/lower/testdata/operators/not.carbon
@@ -15,7 +15,7 @@ fn Not(b: bool) -> bool {
 // CHECK:STDOUT: ; ModuleID = 'not.carbon'
 // CHECK:STDOUT: source_filename = "not.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @Not(i1 %b) {
+// CHECK:STDOUT: define i1 @Not(i1 %b) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12 = xor i1 %b, true
 // CHECK:STDOUT:   ret i1 %.loc12
@@ -28,3 +28,6 @@ fn Not(b: bool) -> bool {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "not.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Not", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/operators/or.carbon
+++ b/toolchain/lower/testdata/operators/or.carbon
@@ -18,17 +18,17 @@ fn Or() -> bool {
 // CHECK:STDOUT: ; ModuleID = 'or.carbon'
 // CHECK:STDOUT: source_filename = "or.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @F() {
+// CHECK:STDOUT: define i1 @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i1 true
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @G() {
+// CHECK:STDOUT: define i1 @G() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i1 true
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @Or() {
+// CHECK:STDOUT: define i1 @Or() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %F.call = call i1 @F()
 // CHECK:STDOUT:   %.loc15_14.3 = xor i1 %F.call, true
@@ -50,3 +50,8 @@ fn Or() -> bool {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "or.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Or", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/operators/or_empty_block.carbon
+++ b/toolchain/lower/testdata/operators/or_empty_block.carbon
@@ -17,7 +17,7 @@ fn Or(b: bool, c: bool) -> bool {
 // CHECK:STDOUT: ; ModuleID = 'or_empty_block.carbon'
 // CHECK:STDOUT: source_filename = "or_empty_block.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i1 @Or(i1 %b, i1 %c) {
+// CHECK:STDOUT: define i1 @Or(i1 %b, i1 %c) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc14_12.1 = xor i1 %b, true
 // CHECK:STDOUT:   br i1 %.loc14_12.1, label %or.rhs, label %or.result
@@ -37,3 +37,6 @@ fn Or(b: bool, c: bool) -> bool {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "or_empty_block.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Or", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/operators/overloaded.carbon
+++ b/toolchain/lower/testdata/operators/overloaded.carbon
@@ -31,7 +31,7 @@ fn Calculate(a: Number, b: Number) -> Number {
 // CHECK:STDOUT: ; ModuleID = 'overloaded.carbon'
 // CHECK:STDOUT: source_filename = "overloaded.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Op(ptr sret({ i1 }) %return, ptr %self) {
+// CHECK:STDOUT: define void @Op(ptr sret({ i1 }) %return, ptr %self) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc17_36.1.is_positive = getelementptr inbounds nuw { i1 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   %.loc17_36.2 = load i1, ptr %.loc17_36.1.is_positive, align 1
@@ -41,7 +41,7 @@ fn Calculate(a: Number, b: Number) -> Number {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Op.1(ptr sret({ i1 }) %return, ptr %self, ptr %other) {
+// CHECK:STDOUT: define void @Op.1(ptr sret({ i1 }) %return, ptr %self, ptr %other) !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc22_33.1.is_positive = getelementptr inbounds nuw { i1 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   %.loc22_33.2 = load i1, ptr %.loc22_33.1.is_positive, align 1
@@ -80,7 +80,7 @@ fn Calculate(a: Number, b: Number) -> Number {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Calculate(ptr sret({ i1 }) %return, ptr %a, ptr %b) {
+// CHECK:STDOUT: define void @Calculate(ptr sret({ i1 }) %return, ptr %a, ptr %b) !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc28_10.2.temp = alloca { i1 }, align 8
 // CHECK:STDOUT:   call void @Op(ptr %.loc28_10.2.temp, ptr %a)
@@ -98,3 +98,8 @@ fn Calculate(a: Number, b: Number) -> Number {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "overloaded.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Op", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Op.1", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Calculate", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/packages/cross_package_call.carbon
+++ b/toolchain/lower/testdata/packages/cross_package_call.carbon
@@ -23,7 +23,7 @@ fn G() { A.F(); }
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -35,10 +35,13 @@ fn G() { A.F(); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "a.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @F()
 // CHECK:STDOUT:   ret void
@@ -53,3 +56,6 @@ fn G() { A.F(); }
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "b.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/pointer/address_of_field.carbon
+++ b/toolchain/lower/testdata/pointer/address_of_field.carbon
@@ -22,7 +22,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @G(ptr)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %s.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc14_46.2.a = getelementptr inbounds nuw { i32, i32 }, ptr %s.var, i32 0, i32 0
@@ -45,3 +45,6 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "address_of_field.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/pointer/address_of_unused.carbon
+++ b/toolchain/lower/testdata/pointer/address_of_unused.carbon
@@ -16,7 +16,7 @@ fn F() {
 // CHECK:STDOUT: ; ModuleID = 'address_of_unused.carbon'
 // CHECK:STDOUT: source_filename = "address_of_unused.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4
@@ -30,3 +30,6 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "address_of_unused.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/pointer/basic.carbon
+++ b/toolchain/lower/testdata/pointer/basic.carbon
@@ -20,13 +20,13 @@ fn F() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @G(ptr %p) {
+// CHECK:STDOUT: define i32 @G(ptr %p) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12_10.2 = load i32, ptr %p, align 4
 // CHECK:STDOUT:   ret i32 %.loc12_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F() {
+// CHECK:STDOUT: define i32 @F() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4
@@ -41,3 +41,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "basic.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
+++ b/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
@@ -18,7 +18,7 @@ fn F(p: i32**) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'pointer_to_pointer.carbon'
 // CHECK:STDOUT: source_filename = "pointer_to_pointer.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F(ptr %p) {
+// CHECK:STDOUT: define i32 @F(ptr %p) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca ptr, align 8
 // CHECK:STDOUT:   store ptr %p, ptr %a.var, align 8
@@ -40,3 +40,6 @@ fn F(p: i32**) -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "pointer_to_pointer.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/return/code_after_return.carbon
+++ b/toolchain/lower/testdata/return/code_after_return.carbon
@@ -18,12 +18,12 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'code_after_return.carbon'
 // CHECK:STDOUT: source_filename = "code_after_return.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -35,3 +35,7 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "code_after_return.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/return/no_value.carbon
+++ b/toolchain/lower/testdata/return/no_value.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'no_value.carbon'
 // CHECK:STDOUT: source_filename = "no_value.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT: define void @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -27,3 +27,6 @@ fn Main() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "no_value.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/return/return_var.carbon
+++ b/toolchain/lower/testdata/return/return_var.carbon
@@ -22,7 +22,7 @@ fn Make() -> C {
 // CHECK:STDOUT: ; ModuleID = 'return_var.carbon'
 // CHECK:STDOUT: source_filename = "return_var.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Make(ptr sret({ i32, ptr }) %return) {
+// CHECK:STDOUT: define void @Make(ptr sret({ i32, ptr }) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc18_30.2.data = getelementptr inbounds nuw { i32, ptr }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc18_30.4.next = getelementptr inbounds nuw { i32, ptr }, ptr %return, i32 0, i32 1
@@ -37,3 +37,6 @@ fn Make() -> C {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "return_var.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Make", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/return/return_var_byval.carbon
+++ b/toolchain/lower/testdata/return/return_var_byval.carbon
@@ -16,7 +16,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'return_var_byval.carbon'
 // CHECK:STDOUT: source_filename = "return_var_byval.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Main() {
+// CHECK:STDOUT: define i32 @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %x.var, align 4
@@ -31,3 +31,6 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "return_var_byval.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/return/value.carbon
+++ b/toolchain/lower/testdata/return/value.carbon
@@ -15,7 +15,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'value.carbon'
 // CHECK:STDOUT: source_filename = "value.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Main() {
+// CHECK:STDOUT: define i32 @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
@@ -27,3 +27,6 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "value.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/return/var.carbon
+++ b/toolchain/lower/testdata/return/var.carbon
@@ -16,7 +16,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'var.carbon'
 // CHECK:STDOUT: source_filename = "var.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @Main() {
+// CHECK:STDOUT: define i32 @Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 0, ptr %x.var, align 4
@@ -31,3 +31,6 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "var.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/struct/empty.carbon
+++ b/toolchain/lower/testdata/struct/empty.carbon
@@ -17,7 +17,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'empty.carbon'
 // CHECK:STDOUT: source_filename = "empty.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8
 // CHECK:STDOUT:   %y.var = alloca {}, align 8
@@ -31,3 +31,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "empty.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/struct/member_access.carbon
+++ b/toolchain/lower/testdata/struct/member_access.carbon
@@ -20,7 +20,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @struct.loc12_49 = internal constant { double, i32 } { double 0.000000e+00, i32 1 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { double, i32 }, align 8
 // CHECK:STDOUT:   %.loc12_48.2.a = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 0
@@ -48,3 +48,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "member_access.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/struct/nested_struct.carbon
+++ b/toolchain/lower/testdata/struct/nested_struct.carbon
@@ -16,7 +16,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'nested_struct.carbon'
 // CHECK:STDOUT: source_filename = "nested_struct.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
@@ -28,3 +28,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "nested_struct.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
@@ -19,7 +19,7 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @F(ptr sret({ i32, i32, i32 }))
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %v.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8
 // CHECK:STDOUT:   %.loc14_74.1.a = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %v.var, i32 0, i32 0
@@ -36,3 +36,6 @@ fn G() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "nested_struct_in_place.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/struct/one_entry.carbon
+++ b/toolchain/lower/testdata/struct/one_entry.carbon
@@ -17,7 +17,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'one_entry.carbon'
 // CHECK:STDOUT: source_filename = "one_entry.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32 }, align 8
 // CHECK:STDOUT:   store { i32 } { i32 4 }, ptr %x.var, align 4
@@ -36,3 +36,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "one_entry.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/struct/two_entries.carbon
+++ b/toolchain/lower/testdata/struct/two_entries.carbon
@@ -19,7 +19,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @struct.loc12_47 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc12_46.2.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0
@@ -49,3 +49,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "two_entries.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/access/element_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/element_access.carbon
@@ -20,7 +20,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.loc12_37 = internal constant { i32, i32, i32 } { i32 0, i32 1, i32 2 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc12_36.2.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0
@@ -50,3 +50,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "element_access.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/access/return_value_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/return_value_access.carbon
@@ -19,7 +19,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.loc11_39 = internal constant { i32, i32 } { i32 12, i32 24 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F(ptr sret({ i32, i32 }) %return) {
+// CHECK:STDOUT: define void @F(ptr sret({ i32, i32 }) %return) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc11_38.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc11_38.4.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 1
@@ -27,7 +27,7 @@ fn Run() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @main() {
+// CHECK:STDOUT: define void @main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %t.var = alloca i32, align 4
 // CHECK:STDOUT:   %.loc14_17.1.temp = alloca { i32, i32 }, align 8
@@ -50,3 +50,7 @@ fn Run() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "return_value_access.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)

--- a/toolchain/lower/testdata/tuple/empty.carbon
+++ b/toolchain/lower/testdata/tuple/empty.carbon
@@ -17,7 +17,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'empty.carbon'
 // CHECK:STDOUT: source_filename = "empty.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8
 // CHECK:STDOUT:   %y.var = alloca {}, align 8
@@ -31,3 +31,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "empty.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/nested_tuple.carbon
+++ b/toolchain/lower/testdata/tuple/nested_tuple.carbon
@@ -16,7 +16,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'nested_tuple.carbon'
 // CHECK:STDOUT: source_filename = "nested_tuple.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
@@ -28,3 +28,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "nested_tuple.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
+++ b/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
@@ -19,7 +19,7 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @F(ptr sret({ i32, i32, i32 }))
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @G() {
+// CHECK:STDOUT: define void @G() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %v.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8
 // CHECK:STDOUT:   %.loc14_56.1.tuple.elem = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %v.var, i32 0, i32 0
@@ -36,3 +36,6 @@ fn G() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "nested_tuple_in_place.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/one_entry.carbon
+++ b/toolchain/lower/testdata/tuple/one_entry.carbon
@@ -17,7 +17,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'one_entry.carbon'
 // CHECK:STDOUT: source_filename = "one_entry.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32 }, align 8
 // CHECK:STDOUT:   store { i32 } { i32 1 }, ptr %x.var, align 4
@@ -39,3 +39,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "one_entry.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/two_entries.carbon
+++ b/toolchain/lower/testdata/tuple/two_entries.carbon
@@ -19,7 +19,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @tuple.loc12_30 = internal constant { i32, i32 } { i32 12, i32 7 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc12_29.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0
@@ -49,3 +49,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "two_entries.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/value_formation.carbon
+++ b/toolchain/lower/testdata/tuple/value_formation.carbon
@@ -21,7 +21,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @G(ptr)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: define void @F() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8
 // CHECK:STDOUT:   %b.var = alloca { i32, i32, i32 }, align 8
@@ -67,3 +67,6 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "value_formation.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/tuple/value_forwarding.carbon
+++ b/toolchain/lower/testdata/tuple/value_forwarding.carbon
@@ -19,7 +19,7 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @G(ptr)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @F(ptr %a, ptr %b) {
+// CHECK:STDOUT: define void @F(ptr %a, ptr %b) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %tuple = alloca { ptr, ptr }, align 8
 // CHECK:STDOUT:   %tuple1 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple, i32 0, i32 0
@@ -37,3 +37,6 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "value_forwarding.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/var/local.carbon
+++ b/toolchain/lower/testdata/var/local.carbon
@@ -16,7 +16,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'local.carbon'
 // CHECK:STDOUT: source_filename = "local.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @main() {
+// CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca i32, align 4
 // CHECK:STDOUT:   store i32 1, ptr %x.var, align 4
@@ -31,3 +31,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "local.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "main", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/while/break_continue.carbon
+++ b/toolchain/lower/testdata/while/break_continue.carbon
@@ -28,7 +28,7 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i1 @C()
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @While() {
+// CHECK:STDOUT: define void @While() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br label %while.cond
 // CHECK:STDOUT:
@@ -67,3 +67,6 @@ fn While() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "break_continue.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "While", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/while/preheader.carbon
+++ b/toolchain/lower/testdata/while/preheader.carbon
@@ -37,7 +37,7 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @G()
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @While() {
+// CHECK:STDOUT: define void @While() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   br label %while.cond.loc20
 // CHECK:STDOUT:
@@ -78,3 +78,6 @@ fn While() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "preheader.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "While", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/while/unreachable_end.carbon
+++ b/toolchain/lower/testdata/while/unreachable_end.carbon
@@ -34,7 +34,7 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @H()
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @While() {
+// CHECK:STDOUT: define void @While() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @F()
 // CHECK:STDOUT:   br label %while.cond
@@ -59,3 +59,6 @@ fn While() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "unreachable_end.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "While", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}

--- a/toolchain/lower/testdata/while/while.carbon
+++ b/toolchain/lower/testdata/while/while.carbon
@@ -33,7 +33,7 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @H()
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @While() {
+// CHECK:STDOUT: define void @While() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @F()
 // CHECK:STDOUT:   br label %while.cond
@@ -58,3 +58,6 @@ fn While() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "while.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "While", scope: null, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}


### PR DESCRIPTION
Still doesn't have line tables, so of limited value (at least now this'll be enough that LLVM really generates debug info into the resulting object file (whereas with only the compilation unit metadata, LLVM will consider it empty and avoid emitting any of it)) - but another step along the path.

This also doesn't attach the right source location to the functions - I'll do that in a follow-up change because I think it'll require the majority of the refactoring between driver and check to extract the essential functionality sem_ir_diagnostic_converter, I think, to allow retrieving source locations during lowering.