### PR TITLE
Minor updates to support newer Clang versions.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -111,6 +111,8 @@ def _impl(ctx):
     # https://github.com/llvm/llvm-project/issues/70384
     if not clang_version or clang_version == 18:
         missing_field_init_flags = ["-Wno-missing-field-initializers"]
+    elif clang_version > 18:
+        missing_field_init_flags = ["-Wno-missing-designated-field-initializers"]
     else:
         missing_field_init_flags = []
 

--- a/explorer/interpreter/pattern_analysis.cpp
+++ b/explorer/interpreter/pattern_analysis.cpp
@@ -13,7 +13,7 @@ using llvm::isa;
 namespace Carbon {
 
 auto AbstractPattern::kind() const -> Kind {
-  if (const auto* pattern = value_.dyn_cast<const Pattern*>()) {
+  if (value_.is<const Pattern*>()) {
     return Compound;
   }
   if (const auto* value = value_.dyn_cast<const Value*>()) {
@@ -52,7 +52,7 @@ auto AbstractPattern::elements_size() const -> int {
   } else if (const auto* value = value_.dyn_cast<const Value*>()) {
     if (const auto* tuple = dyn_cast<TupleValue>(value)) {
       return tuple->elements().size();
-    } else if (const auto* alt = dyn_cast<AlternativeValue>(value)) {
+    } else if (isa<AlternativeValue>(value)) {
       return 1;
     }
   }


### PR DESCRIPTION
A flag was renamed after LLVM 18, and a warning caught a couple more trivially fixed issues.