### PR TITLE
Switch python syntax to use Path.parents

### DIFF
--- a/bazel/check_deps/update_roots.py
+++ b/bazel/check_deps/update_roots.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 # Change the working directory to the repository root so that the remaining
 # operations reliably operate relative to that root.
-os.chdir(Path(__file__).parent.parent.parent)
+os.chdir(Path(__file__).parents[2])
 
 print("Compute non-test C++ root targets...")
 non_test_cc_roots_query = subprocess.check_output(

--- a/scripts/run_clang_tidy.py
+++ b/scripts/run_clang_tidy.py
@@ -31,7 +31,7 @@ def main() -> None:
         files = ["^(?!.*/(bazel-|third_party)).*$"]
 
     # Set the repo root as the working directory.
-    os.chdir(Path(__file__).resolve().parent.parent)
+    os.chdir(Path(__file__).parents[1])
     # Ensure create_compdb has been run.
     subprocess.check_call(["./scripts/create_compdb.py"])
 

--- a/scripts/scripts_utils.py
+++ b/scripts/scripts_utils.py
@@ -94,7 +94,7 @@ def chdir_repo_root() -> None:
 
     This is done so that scripts run from a consistent directory.
     """
-    os.chdir(Path(__file__).parent.parent)
+    os.chdir(Path(__file__).parents[1])
 
 
 def _get_hash(file: Path) -> str:

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -51,7 +51,7 @@ def main() -> None:
     # Support specifying tests to update, such as:
     # ./autoupdate_testdata.py lex/**/*
     if len(sys.argv) > 1:
-        repo_root = Path(__file__).resolve().parent.parent
+        repo_root = Path(__file__).parents[1]
         file_tests = []
         # Filter down to just test files.
         for f in sys.argv[1:]:

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -107,7 +107,7 @@ def check_unused(decls: Set[str], uses: Dict[str, List[Loc]]) -> bool:
 
 def main() -> None:
     # Run from the repo root.
-    os.chdir(Path(__file__).parent.parent.parent)
+    os.chdir(Path(__file__).parents[2])
     decls = load_diagnostic_kind()
     uses = load_diagnostic_uses()
 

--- a/toolchain/install/toolchain_tar_test.py
+++ b/toolchain/install/toolchain_tar_test.py
@@ -31,7 +31,7 @@ def main() -> None:
     # Locate the prefix root from the install marker.
     if not args.install_marker.exists():
         sys.exit("ERROR: No install marker: " + args.install_marker)
-    prefix_root_path = args.install_marker.parent.parent.parent
+    prefix_root_path = args.install_marker.parents[2]
 
     # First check that every file and directory in the tar file exists in our
     # prefix root, and build a set of those paths.

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -144,7 +144,7 @@ def label_root_file(
 
 def main() -> None:
     # Ensure this runs from the repo root.
-    os.chdir(Path(__file__).parent.parent)
+    os.chdir(Path(__file__).parents[1])
 
     # bazel-execroot interferes with jekyll because it's a broken symlink.
     Path("bazel-execroot").unlink()


### PR DESCRIPTION
I think `paths.parents[2]` is easier to read than `path.parent.parent.parent`, just applying uniformly. I'd noticed this while looking at #4227

Also remove a couple `resolve()` calls that shouldn't be necessary since `__file__` is absolute (elsewhere in the same files, `resolve()` is used to resolve potentially relative paths)