### PR TITLE
Remove some explicit (Mutable)ArrayRef constructions

### DIFF
--- a/common/hashing_test.cpp
+++ b/common/hashing_test.cpp
@@ -286,12 +286,11 @@ TEST(HashingTest, BasicStrings) {
 
 TEST(HashingTest, ArrayLike) {
   int c_array[] = {1, 2, 3, 4};
-  llvm::ArrayRef arr = c_array;
-  EXPECT_THAT(HashValue(c_array), Eq(HashValue(arr)));
-  EXPECT_THAT(HashValue(std::array{1, 2, 3, 4}), Eq(HashValue(arr)));
-  EXPECT_THAT(HashValue(std::vector{1, 2, 3, 4}), Eq(HashValue(arr)));
+  EXPECT_THAT(HashValue(c_array), Eq(HashValue(c_array)));
+  EXPECT_THAT(HashValue(std::array{1, 2, 3, 4}), Eq(HashValue(c_array)));
+  EXPECT_THAT(HashValue(std::vector{1, 2, 3, 4}), Eq(HashValue(c_array)));
   EXPECT_THAT(HashValue(llvm::SmallVector<int>{1, 2, 3, 4}),
-              Eq(HashValue(arr)));
+              Eq(HashValue(c_array)));
 }
 
 TEST(HashingTest, HashAPInt) {
@@ -700,7 +699,7 @@ auto ExpectNoHashCollisions(llvm::ArrayRef<HashedString> hashes) -> void {
 
 TEST(HashingTest, Collisions1ByteSized) {
   auto hashes_storage = AllByteStringsHashedAndSorted<1>();
-  auto hashes = llvm::ArrayRef(hashes_storage);
+  llvm::ArrayRef hashes = hashes_storage;
   ExpectNoHashCollisions(hashes);
 
   auto low_32bit_collisions = FindBitRangeCollisions<0, 32>(hashes);
@@ -725,7 +724,7 @@ TEST(HashingTest, Collisions1ByteSized) {
 
 TEST(HashingTest, Collisions2ByteSized) {
   auto hashes_storage = AllByteStringsHashedAndSorted<2>();
-  auto hashes = llvm::ArrayRef(hashes_storage);
+  llvm::ArrayRef hashes = hashes_storage;
   ExpectNoHashCollisions(hashes);
 
   auto low_32bit_collisions = FindBitRangeCollisions<0, 32>(hashes);
@@ -855,7 +854,7 @@ TYPED_TEST_SUITE(SparseHashTest, SparseHashTestParams);
 
 TYPED_TEST(SparseHashTest, Collisions) {
   auto hashes_storage = this->GetHashedByteStrings();
-  auto hashes = llvm::ArrayRef(hashes_storage);
+  llvm::ArrayRef hashes = hashes_storage;
   ExpectNoHashCollisions(hashes);
 
   int min_7bit_collisions = llvm::NextPowerOf2(hashes.size() - 1) / (1 << 7);

--- a/common/raw_hashtable_metadata_group_benchmark.cpp
+++ b/common/raw_hashtable_metadata_group_benchmark.cpp
@@ -122,7 +122,7 @@ static auto BuildBenchMetadata() -> llvm::ArrayRef<BenchMetadata> {
 
     for (ssize_t g_index : llvm::seq<ssize_t>(0, BenchSize)) {
       // Start by filling the group with random bytes.
-      auto group_bytes = llvm::MutableArrayRef(
+      llvm::MutableArrayRef group_bytes(
           &metadata_storage[bm_index][g_index * GroupSize], GroupSize);
       for (uint8_t& b : group_bytes) {
         b = absl::Uniform<uint8_t>(gen) | MetadataGroup::PresentMask;

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -945,8 +945,7 @@ auto Driver::Compile(const CompileOptions& options,
     }
   }
   CARBON_VLOG() << "*** Check::CheckParseTrees ***\n";
-  Check::CheckParseTrees(llvm::MutableArrayRef(check_units),
-                         options.prelude_import, vlog_stream_);
+  Check::CheckParseTrees(check_units, options.prelude_import, vlog_stream_);
   CARBON_VLOG() << "*** Check::CheckParseTrees done ***\n";
   for (auto& unit : units) {
     if (unit->has_source()) {


### PR DESCRIPTION
Rely on implicit conversion in call sites and initialization.

Removing the explicit conversions is only code simplication.
Moving from `auto x = Y(z)` to `Y x = z;` helps ensure that only implicit constructors/conversions are happening (whereas the prior syntax allows explicit conversions) which can help with readability since implicit conversions are generally "less complex"/risky/attention-requiring.
