### PR TITLE
Enforce `private` and `protected` access modifiers for class member access

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -371,7 +371,7 @@ static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
   // TODO: Support passing AccessKind to diagnostics.
   CARBON_DIAGNOSTIC(ClassInvalidMemberAccess, Error,
                     "Cannot access {0} member `{1}` of type `{2}`.",
-                    std::string_view, SemIR::NameId, SemIR::TypeId);
+                    llvm::StringLiteral, SemIR::NameId, SemIR::TypeId);
   CARBON_DIAGNOSTIC(ClassMemberDefinition, Note,
                     "The {0} member `{1}` is defined here.",
                     llvm::StringLiteral, SemIR::NameId);

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/context.h"
 
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -292,7 +293,8 @@ auto Context::LookupNameInDecl(SemIR::LocId loc_id, SemIR::NameId name_id,
     //    // Error, no `F` in `B`.
     //    fn B.F() {}
     return LookupNameInExactScope(loc_id, name_id, scope_id,
-                                  name_scopes().Get(scope_id));
+                                  name_scopes().Get(scope_id))
+        .first;
   }
 }
 
@@ -334,26 +336,115 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
 auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
                                      SemIR::NameScopeId scope_id,
                                      const SemIR::NameScope& scope)
-    -> SemIR::InstId {
+    -> std::pair<SemIR::InstId, SemIR::AccessKind> {
   if (auto lookup = scope.name_map.Lookup(name_id)) {
-    auto inst_id = scope.names[lookup.value()].inst_id;
-    LoadImportRef(*this, inst_id);
-    return inst_id;
+    auto entry = scope.names[lookup.value()];
+    LoadImportRef(*this, entry.inst_id);
+    return {entry.inst_id, entry.access_kind};
   }
+
   if (!scope.import_ir_scopes.empty()) {
-    return ImportNameFromOtherPackage(*this, loc, scope_id,
-                                      scope.import_ir_scopes, name_id);
+    // TODO: Enforce other access modifiers for imports.
+    return {ImportNameFromOtherPackage(*this, loc, scope_id,
+                                       scope.import_ir_scopes, name_id),
+            SemIR::AccessKind::Public};
   }
-  return SemIR::InstId::Invalid;
+  return {SemIR::InstId::Invalid, SemIR::AccessKind::Public};
 }
 
+// Prints diagnostics on invalid qualified name access.
+static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
+                                               SemIR::InstId scope_result_id,
+                                               SemIR::NameId name_id,
+                                               SemIR::AccessKind access_kind,
+                                               bool is_parent_access,
+                                               AccessInfo access_info) -> void {
+  auto class_type = context.insts().TryGetAs<SemIR::ClassType>(
+      context.constant_values().GetInstId(access_info.constant_id));
+  if (!class_type) {
+    return;
+  }
+
+  // TODO: Support scoped entities other than just classes.
+  auto class_info = context.classes().Get(class_type->class_id);
+
+  // TODO: Support passing AccessKind to diagnostics.
+  CARBON_DIAGNOSTIC(ClassInvalidMemberAccess, Error,
+                    "Cannot access {0} member `{1}` of type `{2}`.",
+                    std::string_view, SemIR::NameId, SemIR::TypeId);
+  CARBON_DIAGNOSTIC(ClassMemberDefinition, Note,
+                    "The {0} member `{1}` is defined here.",
+                    llvm::StringLiteral, SemIR::NameId);
+
+  auto parent_type_id = class_info.self_type_id;
+  auto access_desc = access_kind == SemIR::AccessKind::Private
+                         ? llvm::StringLiteral("private")
+                         : llvm::StringLiteral("protected");
+
+  if (access_kind == SemIR::AccessKind::Private && is_parent_access) {
+    if (auto base_decl = context.insts().TryGetAsIfValid<SemIR::BaseDecl>(
+            class_info.base_id)) {
+      parent_type_id = base_decl->base_type_id;
+    } else if (auto adapt_decl =
+                   context.insts().TryGetAsIfValid<SemIR::AdaptDecl>(
+                       class_info.adapt_id)) {
+      parent_type_id = adapt_decl->adapted_type_id;
+    } else {
+      CARBON_FATAL() << "Expected parent for parent access";
+    }
+  }
+
+  context.emitter()
+      .Build(loc, ClassInvalidMemberAccess, access_desc, name_id,
+             parent_type_id)
+      .Note(scope_result_id, ClassMemberDefinition, access_desc, name_id)
+      .Emit();
+}
+
+// Returns whether the access is prohibited by the access modifiers.
+static auto IsAccessProhibited(std::optional<AccessInfo> access_info,
+                               SemIR::AccessKind access_kind,
+                               bool is_parent_access) -> bool {
+  if (!access_info) {
+    return false;
+  }
+
+  switch (access_kind) {
+    case SemIR::AccessKind::Public:
+      return false;
+    case SemIR::AccessKind::Protected:
+      return access_info->highest_allowed_access == SemIR::AccessKind::Public;
+    case SemIR::AccessKind::Private:
+      return access_info->highest_allowed_access !=
+                 SemIR::AccessKind::Private ||
+             is_parent_access;
+  }
+}
+
+// Information regarding a prohibited access.
+struct ProhibitedAccessInfo {
+  // The resulting inst of the lookup.
+  SemIR::InstId scope_result_id;
+  // The access kind of the lookup.
+  SemIR::AccessKind access_kind;
+  // If the lookup is from an extended scope. For example, if this is a base
+  // class member access from a class that extends it.
+  bool is_parent_access;
+};
+
 auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
-                                  LookupScope scope, bool required)
+                                  LookupScope scope, bool required,
+                                  std::optional<AccessInfo> access_info)
     -> LookupResult {
   llvm::SmallVector<LookupScope> scopes = {scope};
+
+  // TODO: Support reporting of multiple prohibited access.
+  llvm::SmallVector<ProhibitedAccessInfo> prohibited_accesses;
+
   LookupResult result = {.specific_id = SemIR::SpecificId::Invalid,
                          .inst_id = SemIR::InstId::Invalid};
   bool has_error = false;
+  bool is_parent_access = false;
 
   // Walk this scope and, if nothing is found here, the scopes it extends.
   while (!scopes.empty()) {
@@ -361,10 +452,25 @@ auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
     const auto& name_scope = name_scopes().Get(scope_id);
     has_error |= name_scope.has_error;
 
-    auto scope_result_id =
+    auto [scope_result_id, access_kind] =
         LookupNameInExactScope(loc, name_id, scope_id, name_scope);
-    if (!scope_result_id.is_valid()) {
-      // Nothing found in this scope: also look in its extended scopes.
+
+    auto is_access_prohibited =
+        IsAccessProhibited(access_info, access_kind, is_parent_access);
+
+    // Keep track of prohibited accesses, this will be useful for reporting
+    // multiple prohibited accesses if we can't find a suitable lookup.
+    if (is_access_prohibited) {
+      prohibited_accesses.push_back({
+          .scope_result_id = scope_result_id,
+          .access_kind = access_kind,
+          .is_parent_access = is_parent_access,
+      });
+    }
+
+    if (!scope_result_id.is_valid() || is_access_prohibited) {
+      // If nothing is found in this scope or if we encountered an invalid
+      // access, look in its extended scopes.
       auto extended = name_scope.extended_scopes;
       scopes.reserve(scopes.size() + extended.size());
       for (auto extended_id : llvm::reverse(extended)) {
@@ -373,6 +479,7 @@ auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
         scopes.push_back({.name_scope_id = extended_id,
                           .specific_id = SemIR::SpecificId::Invalid});
       }
+      is_parent_access |= !extended.empty();
       continue;
     }
 
@@ -397,8 +504,22 @@ auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
 
   if (required && !result.inst_id.is_valid()) {
     if (!has_error) {
-      DiagnoseNameNotFound(loc, name_id);
+      if (prohibited_accesses.empty()) {
+        DiagnoseNameNotFound(loc, name_id);
+      } else {
+        //  TODO: We should report multiple prohibited accesses in case we don't
+        //  find a valid lookup. Reporting the last one should suffice for now.
+        auto [scope_result_id, access_kind, is_parent_access] =
+            prohibited_accesses.back();
+
+        // Note, `access_info` is guaranteed to have a value here, since
+        // `prohibited_accesses` is non-empty.
+        DiagnoseInvalidQualifiedNameAccess(*this, loc, scope_result_id, name_id,
+                                           access_kind, is_parent_access,
+                                           *access_info);
+      }
     }
+
     return {.specific_id = SemIR::SpecificId::Invalid,
             .inst_id = SemIR::InstId::BuiltinError};
   }
@@ -420,7 +541,7 @@ static auto GetCorePackage(Context& context, SemIRLoc loc)
   auto core_name_id = SemIR::NameId::ForIdentifier(core_ident_id);
 
   // Look up `package.Core`.
-  auto core_inst_id = context.LookupNameInExactScope(
+  auto [core_inst_id, _] = context.LookupNameInExactScope(
       loc, core_name_id, SemIR::NameScopeId::Package,
       context.name_scopes().Get(SemIR::NameScopeId::Package));
   if (core_inst_id.is_valid()) {
@@ -447,8 +568,8 @@ auto Context::LookupNameInCore(SemIRLoc loc, llvm::StringRef name)
   }
 
   auto name_id = SemIR::NameId::ForIdentifier(identifiers().Add(name));
-  auto inst_id = LookupNameInExactScope(loc, name_id, core_package_id,
-                                        name_scopes().Get(core_package_id));
+  auto [inst_id, _] = LookupNameInExactScope(
+      loc, name_id, core_package_id, name_scopes().Get(core_package_id));
   if (!inst_id.is_valid()) {
     CARBON_DIAGNOSTIC(
         CoreNameNotFound, Error,

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -163,7 +163,7 @@ static auto BuildInterfaceWitness(
           CARBON_FATAL() << "Unexpected type: " << type_inst;
         }
         auto& fn = context.functions().Get(fn_type->function_id);
-        auto impl_decl_id = context.LookupNameInExactScope(
+        auto [impl_decl_id, _] = context.LookupNameInExactScope(
             decl_id, fn.name_id, impl.scope_id, impl_scope);
         if (impl_decl_id.is_valid()) {
           used_decl_ids.push_back(impl_decl_id);

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/member_access.h"
 
+#include <optional>
+
 #include "llvm/ADT/STLExtras.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
@@ -13,6 +15,7 @@
 #include "toolchain/sem_ir/generic.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/name_scope.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -96,6 +99,82 @@ static auto IsInstanceMethod(const SemIR::File& sem_ir,
   }
 
   return false;
+}
+
+// Returns the FunctionId of the current function if it exists.
+static auto GetCurrentFunction(Context& context)
+    -> std::optional<SemIR::FunctionId> {
+  if (context.return_scope_stack().empty()) {
+    return std::nullopt;
+  }
+
+  return context.insts()
+      .GetAs<SemIR::FunctionDecl>(context.return_scope_stack().back().decl_id)
+      .function_id;
+}
+
+// Returns the highest allowed access. For example, if this returns `Protected`
+// then only `Public` and `Protected` accesses are allowed--not `Private`.
+static auto GetHighestAllowedAccess(Context& context, SemIRLoc loc,
+                                    SemIR::ConstantId name_scope_const_id)
+    -> SemIR::AccessKind {
+  // TODO: Maybe use LookupUnqualifiedName for `Self` to support things like
+  // `var x: Self.ParentProtectedType`?
+  auto current_function = GetCurrentFunction(context);
+  // If `current_function` is a `nullopt` then we're accessing from a global
+  // variable.
+  if (!current_function) {
+    return SemIR::AccessKind::Public;
+  }
+
+  auto scope_id = context.functions().Get(*current_function).parent_scope_id;
+  if (!scope_id.is_valid()) {
+    return SemIR::AccessKind::Public;
+  }
+  auto scope = context.name_scopes().Get(scope_id);
+
+  // Lookup the inst for `Self` in the parent scope of the current function.
+  auto [self_type_inst_id, _] = context.LookupNameInExactScope(
+      loc, SemIR::NameId::SelfType, scope_id, scope);
+  if (!self_type_inst_id.is_valid()) {
+    return SemIR::AccessKind::Public;
+  }
+
+  // TODO: Support other types for `Self`.
+  auto self_class_type =
+      context.insts().TryGetAs<SemIR::ClassType>(self_type_inst_id);
+  if (!self_class_type) {
+    return SemIR::AccessKind::Public;
+  }
+
+  auto self_class_info = context.classes().Get(self_class_type->class_id);
+
+  // TODO: Support other types.
+  if (auto class_type = context.insts().TryGetAs<SemIR::ClassType>(
+          context.constant_values().GetInstId(name_scope_const_id))) {
+    auto class_info = context.classes().Get(class_type->class_id);
+
+    if (self_class_info.self_type_id == class_info.self_type_id) {
+      return SemIR::AccessKind::Private;
+    }
+
+    // If the type_id of `Self` does not match with the one we're currently
+    // accessing. Try checking if this class is of the parent type of `Self`.
+    if (auto base_decl = context.insts().TryGetAsIfValid<SemIR::BaseDecl>(
+            self_class_info.base_id)) {
+      if (base_decl->base_type_id == class_info.self_type_id) {
+        return SemIR::AccessKind::Protected;
+      }
+    } else if (auto adapt_decl =
+                   context.insts().TryGetAsIfValid<SemIR::AdaptDecl>(
+                       self_class_info.adapt_id)) {
+      if (adapt_decl->adapted_type_id == class_info.self_type_id) {
+        return SemIR::AccessKind::Protected;
+      }
+    }
+  }
+
+  return SemIR::AccessKind::Public;
 }
 
 // Returns whether `scope` is a scope for which impl lookup should be performed
@@ -224,7 +303,18 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
   LookupResult result = {.specific_id = SemIR::SpecificId::Invalid,
                          .inst_id = SemIR::InstId::BuiltinError};
   if (lookup_scope.name_scope_id.is_valid()) {
-    result = context.LookupQualifiedName(loc_id, name_id, lookup_scope);
+    AccessInfo access_info = {
+        .constant_id = name_scope_const_id,
+        .highest_allowed_access =
+            GetHighestAllowedAccess(context, loc_id, name_scope_const_id),
+    };
+
+    result = context.LookupQualifiedName(loc_id, name_id, lookup_scope,
+                                         /*required=*/true, access_info);
+
+    if (!result.inst_id.is_valid()) {
+      return SemIR::InstId::BuiltinError;
+    }
   }
 
   // TODO: This duplicates the work that HandleNameAsExpr does. Factor this out.

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -158,8 +158,8 @@ static auto GetHighestAllowedAccess(Context& context, SemIRLoc loc,
       return SemIR::AccessKind::Private;
     }
 
-    // If the type_id of `Self` does not match with the one we're currently
-    // accessing. Try checking if this class is of the parent type of `Self`.
+    // If the `type_id` of `Self` does not match with the one we're currently
+    // accessing, try checking if this class is of the parent type of `Self`.
     if (auto base_decl = context.insts().TryGetAsIfValid<SemIR::BaseDecl>(
             self_class_info.base_id)) {
       if (base_decl->base_type_id == class_info.self_type_id) {

--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -1,0 +1,648 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/access_modifers.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/class/access_modifers.carbon
+
+// --- fail_private_field_access.carbon
+
+library "private_field_access";
+
+class Circle {
+  private var radius: i32;
+  private let SOME_INTERNAL_CONSTANT: i32 = 5;
+
+  private fn SomeInternalFunction() -> i32 {
+    return 0;
+  }
+
+  fn Make() -> Self {
+    return {.radius = 5};
+  }
+}
+
+fn Run() {
+  let circle: Circle = Circle.Make();
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE+7]]:21: ERROR: Cannot access private member `radius` of type `Circle`.
+  // CHECK:STDERR:   let radius: i32 = circle.radius;
+  // CHECK:STDERR:                     ^~~~~~~~~~~~~
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE-17]]:15: The private member `radius` is defined here.
+  // CHECK:STDERR:   private var radius: i32;
+  // CHECK:STDERR:               ^~~~~~~~~~~
+  // CHECK:STDERR:
+  let radius: i32 = circle.radius;
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE+7]]:3: ERROR: Cannot access private member `radius` of type `Circle`.
+  // CHECK:STDERR:   circle.radius = 5;
+  // CHECK:STDERR:   ^~~~~~~~~~~~~
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE-25]]:15: The private member `radius` is defined here.
+  // CHECK:STDERR:   private var radius: i32;
+  // CHECK:STDERR:               ^~~~~~~~~~~
+  // CHECK:STDERR:
+  circle.radius = 5;
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE+7]]:3: ERROR: Cannot access private member `SOME_INTERNAL_CONSTANT` of type `Circle`.
+  // CHECK:STDERR:   circle.SOME_INTERNAL_CONSTANT;
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE-32]]:15: The private member `SOME_INTERNAL_CONSTANT` is defined here.
+  // CHECK:STDERR:   private let SOME_INTERNAL_CONSTANT: i32 = 5;
+  // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  circle.SOME_INTERNAL_CONSTANT;
+
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE+7]]:3: ERROR: Cannot access private member `SomeInternalFunction` of type `Circle`.
+  // CHECK:STDERR:   circle.SomeInternalFunction();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_private_field_access.carbon:[[@LINE-39]]:3: The private member `SomeInternalFunction` is defined here.
+  // CHECK:STDERR:   private fn SomeInternalFunction() -> i32 {
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  circle.SomeInternalFunction();
+}
+
+// --- fail_protected_field_access.carbon
+
+library "protected_field_access";
+
+class A {
+  protected var x: i32;
+}
+
+fn Run() {
+  // CHECK:STDERR: fail_protected_field_access.carbon:[[@LINE+7]]:16: ERROR: Cannot access protected member `x` of type `A`.
+  // CHECK:STDERR:   let x: i32 = A.x;
+  // CHECK:STDERR:                ^~~
+  // CHECK:STDERR: fail_protected_field_access.carbon:[[@LINE-7]]:17: The protected member `x` is defined here.
+  // CHECK:STDERR:   protected var x: i32;
+  // CHECK:STDERR:                 ^~~~~~
+  // CHECK:STDERR:
+  let x: i32 = A.x;
+}
+
+// --- instance_private_field_access_on_self.carbon
+
+library "instance_private_field_access_on_self";
+
+class Circle {
+  private var radius: i32;
+
+  fn GetRadius[self: Self]() -> i32 {
+    return self.radius;
+  }
+
+  private fn SomeInternalFunction() -> i32 {
+    return 0;
+  }
+
+  fn Compute[self: Self]() -> i32 {
+    return self.SomeInternalFunction();
+  }
+}
+
+// --- public_global_access.carbon
+
+library "public_global_access";
+
+class A {
+  let x: i32 = 5;
+}
+
+let x: i32 = A.x;
+
+// --- fail_global_access.carbon
+
+library "global_access";
+
+class A {
+  protected let x: i32 = 5;
+  private let y: i32 = 5;
+}
+
+// CHECK:STDERR: fail_global_access.carbon:[[@LINE+7]]:14: ERROR: Cannot access protected member `x` of type `A`.
+// CHECK:STDERR: let x: i32 = A.x;
+// CHECK:STDERR:              ^~~
+// CHECK:STDERR: fail_global_access.carbon:[[@LINE-7]]:17: The protected member `x` is defined here.
+// CHECK:STDERR:   protected let x: i32 = 5;
+// CHECK:STDERR:                 ^
+// CHECK:STDERR:
+let x: i32 = A.x;
+// CHECK:STDERR: fail_global_access.carbon:[[@LINE+7]]:14: ERROR: Cannot access private member `y` of type `A`.
+// CHECK:STDERR: let y: i32 = A.y;
+// CHECK:STDERR:              ^~~
+// CHECK:STDERR: fail_global_access.carbon:[[@LINE-14]]:15: The private member `y` is defined here.
+// CHECK:STDERR:   private let y: i32 = 5;
+// CHECK:STDERR:               ^
+// CHECK:STDERR:
+let y: i32 = A.y;
+
+// --- fail_todo_global_self_access.carbon
+
+library "global_self_access";
+
+class A {
+  private let internal: i32 = 10;
+  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE+13]]:16: ERROR: Member access into incomplete class `A`.
+  // CHECK:STDERR:   let y: i32 = Self.internal;
+  // CHECK:STDERR:                ^~~~~~~~~~~~~
+  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
+  // CHECK:STDERR: class A {
+  // CHECK:STDERR: ^~~~~~~~~
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE+6]]:16: ERROR: Cannot access private member `internal` of type `A`.
+  // CHECK:STDERR:   let y: i32 = Self.internal;
+  // CHECK:STDERR:                ^~~~~~~~~~~~~
+  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE-11]]:15: The private member `internal` is defined here.
+  // CHECK:STDERR:   private let internal: i32 = 10;
+  // CHECK:STDERR:               ^~~~~~~~
+  let y: i32 = Self.internal;
+}
+
+// CHECK:STDOUT: --- fail_private_field_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Circle: type = class_type @Circle [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = unbound_element_type %Circle, i32 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %SomeInternalFunction.type: type = fn_type @SomeInternalFunction [template]
+// CHECK:STDOUT:   %SomeInternalFunction: %SomeInternalFunction.type = struct_value () [template]
+// CHECK:STDOUT:   %Make.type: type = fn_type @Make [template]
+// CHECK:STDOUT:   %Make: %Make.type = struct_value () [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.radius: i32} [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.6: type = ptr_type %.4 [template]
+// CHECK:STDOUT:   %struct: %Circle = struct_value (%.3) [template]
+// CHECK:STDOUT:   %Run.type: type = fn_type @Run [template]
+// CHECK:STDOUT:   %Run: %Run.type = struct_value () [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Circle = %Circle.decl
+// CHECK:STDOUT:     .Run = %Run.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Circle.decl: type = class_decl @Circle [template = constants.%Circle] {}
+// CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Circle {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_23.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_23.2: type = converted %int.make_type_32.loc5, %.loc5_23.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_21: %.2 = field_decl radius, element0 [template]
+// CHECK:STDOUT:   %int.make_type_32.loc6: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc6_39.1: type = value_of_initializer %int.make_type_32.loc6 [template = i32]
+// CHECK:STDOUT:   %.loc6_39.2: type = converted %int.make_type_32.loc6, %.loc6_39.1 [template = i32]
+// CHECK:STDOUT:   %.loc6_45: i32 = int_literal 5 [template = constants.%.3]
+// CHECK:STDOUT:   %SOME_INTERNAL_CONSTANT: i32 = bind_name SOME_INTERNAL_CONSTANT, %.loc6_45
+// CHECK:STDOUT:   %SomeInternalFunction.decl: %SomeInternalFunction.type = fn_decl @SomeInternalFunction [template = constants.%SomeInternalFunction] {
+// CHECK:STDOUT:     %int.make_type_32.loc8: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc8_40.1: type = value_of_initializer %int.make_type_32.loc8 [template = i32]
+// CHECK:STDOUT:     %.loc8_40.2: type = converted %int.make_type_32.loc8, %.loc8_40.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc8: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Make.decl: %Make.type = fn_decl @Make [template = constants.%Make] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%Circle [template = constants.%Circle]
+// CHECK:STDOUT:     %return.var.loc12: ref %Circle = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Circle
+// CHECK:STDOUT:   .radius [private] = %.loc5_21
+// CHECK:STDOUT:   .SOME_INTERNAL_CONSTANT [private] = %SOME_INTERNAL_CONSTANT
+// CHECK:STDOUT:   .SomeInternalFunction [private] = %SomeInternalFunction.decl
+// CHECK:STDOUT:   .Make = %Make.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @SomeInternalFunction() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   return %.loc9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Make() -> @Circle.%return.var.loc12: %Circle {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc13_23: i32 = int_literal 5 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc13_24.1: %.4 = struct_literal (%.loc13_23)
+// CHECK:STDOUT:   %.loc13_24.2: ref i32 = class_element_access @Circle.%return.var.loc12, element0
+// CHECK:STDOUT:   %.loc13_24.3: init i32 = initialize_from %.loc13_23 to %.loc13_24.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc13_24.4: init %Circle = class_init (%.loc13_24.3), @Circle.%return.var.loc12 [template = constants.%struct]
+// CHECK:STDOUT:   %.loc13_25: init %Circle = converted %.loc13_24.1, %.loc13_24.4 [template = constants.%struct]
+// CHECK:STDOUT:   return %.loc13_25 to @Circle.%return.var.loc12
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Run() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Circle.ref.loc18_15: type = name_ref Circle, file.%Circle.decl [template = constants.%Circle]
+// CHECK:STDOUT:   %Circle.ref.loc18_24: type = name_ref Circle, file.%Circle.decl [template = constants.%Circle]
+// CHECK:STDOUT:   %Make.ref: %Make.type = name_ref Make, @Circle.%Make.decl [template = constants.%Make]
+// CHECK:STDOUT:   %.loc18_35.1: ref %Circle = temporary_storage
+// CHECK:STDOUT:   %Make.call: init %Circle = call %Make.ref() to %.loc18_35.1
+// CHECK:STDOUT:   %.loc18_35.2: ref %Circle = temporary %.loc18_35.1, %Make.call
+// CHECK:STDOUT:   %.loc18_35.3: %Circle = bind_value %.loc18_35.2
+// CHECK:STDOUT:   %circle: %Circle = bind_name circle, %.loc18_35.3
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc26_15.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc26_15.2: type = converted %int.make_type_32, %.loc26_15.1 [template = i32]
+// CHECK:STDOUT:   %circle.ref.loc26: %Circle = name_ref circle, %circle
+// CHECK:STDOUT:   %radius.ref.loc26: <error> = name_ref radius, <error> [template = <error>]
+// CHECK:STDOUT:   %radius: i32 = bind_name radius, <error>
+// CHECK:STDOUT:   %circle.ref.loc34: %Circle = name_ref circle, %circle
+// CHECK:STDOUT:   %radius.ref.loc34: <error> = name_ref radius, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc34: i32 = int_literal 5 [template = constants.%.3]
+// CHECK:STDOUT:   assign %radius.ref.loc34, <error>
+// CHECK:STDOUT:   %circle.ref.loc42: %Circle = name_ref circle, %circle
+// CHECK:STDOUT:   %SOME_INTERNAL_CONSTANT.ref: <error> = name_ref SOME_INTERNAL_CONSTANT, <error> [template = <error>]
+// CHECK:STDOUT:   %circle.ref.loc51: %Circle = name_ref circle, %circle
+// CHECK:STDOUT:   %SomeInternalFunction.ref: <error> = name_ref SomeInternalFunction, <error> [template = <error>]
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_protected_field_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = unbound_element_type %A, i32 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.x: i32} [template]
+// CHECK:STDOUT:   %Run.type: type = fn_type @Run [template]
+// CHECK:STDOUT:   %Run: %Run.type = struct_value () [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .Run = %Run.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_20.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc5_20.2: type = converted %int.make_type_32, %.loc5_20.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_18: %.2 = field_decl x, element0 [template]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .x [protected] = %.loc5_18
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Run() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc16_10.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc16_10.2: type = converted %int.make_type_32, %.loc16_10.1 [template = i32]
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %x.ref: <error> = name_ref x, <error> [template = <error>]
+// CHECK:STDOUT:   %x: i32 = bind_name x, <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- instance_private_field_access_on_self.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Circle: type = class_type @Circle [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = unbound_element_type %Circle, i32 [template]
+// CHECK:STDOUT:   %GetRadius.type: type = fn_type @GetRadius [template]
+// CHECK:STDOUT:   %GetRadius: %GetRadius.type = struct_value () [template]
+// CHECK:STDOUT:   %SomeInternalFunction.type: type = fn_type @SomeInternalFunction [template]
+// CHECK:STDOUT:   %SomeInternalFunction: %SomeInternalFunction.type = struct_value () [template]
+// CHECK:STDOUT:   %Compute.type: type = fn_type @Compute [template]
+// CHECK:STDOUT:   %Compute: %Compute.type = struct_value () [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.radius: i32} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Circle = %Circle.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Circle.decl: type = class_decl @Circle [template = constants.%Circle] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Circle {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_23.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_23.2: type = converted %int.make_type_32.loc5, %.loc5_23.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_21: %.2 = field_decl radius, element0 [template]
+// CHECK:STDOUT:   %GetRadius.decl: %GetRadius.type = fn_decl @GetRadius [template = constants.%GetRadius] {
+// CHECK:STDOUT:     %Self.ref.loc7: type = name_ref Self, constants.%Circle [template = constants.%Circle]
+// CHECK:STDOUT:     %self.loc7_16.1: %Circle = param self
+// CHECK:STDOUT:     %self.loc7_16.2: %Circle = bind_name self, %self.loc7_16.1
+// CHECK:STDOUT:     %int.make_type_32.loc7: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc7_33.1: type = value_of_initializer %int.make_type_32.loc7 [template = i32]
+// CHECK:STDOUT:     %.loc7_33.2: type = converted %int.make_type_32.loc7, %.loc7_33.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc7: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %SomeInternalFunction.decl: %SomeInternalFunction.type = fn_decl @SomeInternalFunction [template = constants.%SomeInternalFunction] {
+// CHECK:STDOUT:     %int.make_type_32.loc11: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc11_40.1: type = value_of_initializer %int.make_type_32.loc11 [template = i32]
+// CHECK:STDOUT:     %.loc11_40.2: type = converted %int.make_type_32.loc11, %.loc11_40.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc11: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Compute.decl: %Compute.type = fn_decl @Compute [template = constants.%Compute] {
+// CHECK:STDOUT:     %Self.ref.loc15: type = name_ref Self, constants.%Circle [template = constants.%Circle]
+// CHECK:STDOUT:     %self.loc15_14.1: %Circle = param self
+// CHECK:STDOUT:     %self.loc15_14.2: %Circle = bind_name self, %self.loc15_14.1
+// CHECK:STDOUT:     %int.make_type_32.loc15: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc15_31.1: type = value_of_initializer %int.make_type_32.loc15 [template = i32]
+// CHECK:STDOUT:     %.loc15_31.2: type = converted %int.make_type_32.loc15, %.loc15_31.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc15: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Circle
+// CHECK:STDOUT:   .radius [private] = %.loc5_21
+// CHECK:STDOUT:   .GetRadius = %GetRadius.decl
+// CHECK:STDOUT:   .SomeInternalFunction [private] = %SomeInternalFunction.decl
+// CHECK:STDOUT:   .Compute = %Compute.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @GetRadius[@Circle.%self.loc7_16.2: %Circle]() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %self.ref: %Circle = name_ref self, @Circle.%self.loc7_16.2
+// CHECK:STDOUT:   %radius.ref: %.2 = name_ref radius, @Circle.%.loc5_21 [template = @Circle.%.loc5_21]
+// CHECK:STDOUT:   %.loc8_16.1: ref i32 = class_element_access %self.ref, element0
+// CHECK:STDOUT:   %.loc8_16.2: i32 = bind_value %.loc8_16.1
+// CHECK:STDOUT:   return %.loc8_16.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @SomeInternalFunction() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   return %.loc12
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Compute[@Circle.%self.loc15_14.2: %Circle]() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %self.ref: %Circle = name_ref self, @Circle.%self.loc15_14.2
+// CHECK:STDOUT:   %SomeInternalFunction.ref: %SomeInternalFunction.type = name_ref SomeInternalFunction, @Circle.%SomeInternalFunction.decl [template = constants.%SomeInternalFunction]
+// CHECK:STDOUT:   %SomeInternalFunction.call: init i32 = call %SomeInternalFunction.ref()
+// CHECK:STDOUT:   %.loc16_39.1: i32 = value_of_initializer %SomeInternalFunction.call
+// CHECK:STDOUT:   %.loc16_39.2: i32 = converted %SomeInternalFunction.call, %.loc16_39.1
+// CHECK:STDOUT:   return %.loc16_39.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- public_global_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .x = @__global_init.%x
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc8_8.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc8_8.2: type = converted %int.make_type_32, %.loc8_8.1 [template = i32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_10.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc5_10.2: type = converted %int.make_type_32, %.loc5_10.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_16: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %x: i32 = bind_name x, %.loc5_16
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .x = %x
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %x.ref: i32 = name_ref x, @A.%x
+// CHECK:STDOUT:   %x: i32 = bind_name x, %x.ref
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_global_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .x = @__global_init.%x
+// CHECK:STDOUT:     .y = @__global_init.%y
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %int.make_type_32.loc16: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc16_8.1: type = value_of_initializer %int.make_type_32.loc16 [template = i32]
+// CHECK:STDOUT:   %.loc16_8.2: type = converted %int.make_type_32.loc16, %.loc16_8.1 [template = i32]
+// CHECK:STDOUT:   %int.make_type_32.loc24: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc24_8.1: type = value_of_initializer %int.make_type_32.loc24 [template = i32]
+// CHECK:STDOUT:   %.loc24_8.2: type = converted %int.make_type_32.loc24, %.loc24_8.1 [template = i32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_20.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_20.2: type = converted %int.make_type_32.loc5, %.loc5_20.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_26: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %x: i32 = bind_name x, %.loc5_26
+// CHECK:STDOUT:   %int.make_type_32.loc6: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc6_18.1: type = value_of_initializer %int.make_type_32.loc6 [template = i32]
+// CHECK:STDOUT:   %.loc6_18.2: type = converted %int.make_type_32.loc6, %.loc6_18.1 [template = i32]
+// CHECK:STDOUT:   %.loc6_24: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %y: i32 = bind_name y, %.loc6_24
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .x [protected] = %x
+// CHECK:STDOUT:   .y [private] = %y
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref.loc16: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %x.ref: <error> = name_ref x, <error> [template = <error>]
+// CHECK:STDOUT:   %x: i32 = bind_name x, <error>
+// CHECK:STDOUT:   %A.ref.loc24: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %y.ref: <error> = name_ref y, <error> [template = <error>]
+// CHECK:STDOUT:   %y: i32 = bind_name y, <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_todo_global_self_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_25.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_25.2: type = converted %int.make_type_32.loc5, %.loc5_25.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_31: i32 = int_literal 10 [template = constants.%.2]
+// CHECK:STDOUT:   %internal: i32 = bind_name internal, %.loc5_31
+// CHECK:STDOUT:   %int.make_type_32.loc19: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc19_10.1: type = value_of_initializer %int.make_type_32.loc19 [template = i32]
+// CHECK:STDOUT:   %.loc19_10.2: type = converted %int.make_type_32.loc19, %.loc19_10.1 [template = i32]
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%A [template = constants.%A]
+// CHECK:STDOUT:   %internal.ref: <error> = name_ref internal, <error> [template = <error>]
+// CHECK:STDOUT:   %y: i32 = bind_name y, <error>
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .internal [private] = %internal
+// CHECK:STDOUT:   .y = %y
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/class/inheritance_access.carbon
+++ b/toolchain/check/testdata/class/inheritance_access.carbon
@@ -1,0 +1,1015 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/inheritance_access.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/class/inheritance_access.carbon
+
+
+// --- instance_protected_field_access.carbon
+
+library "instance_protected_field_access";
+
+base class Shape {
+  protected var x: i32;
+  protected var y: i32;
+}
+
+class Circle {
+  extend base: Shape;
+
+  fn GetPosition[self: Self]() -> (i32, i32) {
+    return (self.x, self.y);
+  }
+}
+
+// --- shadowing_access.carbon
+
+library "shadowing_access";
+
+base class A {
+  fn F();
+}
+
+base class B {
+  extend base: A;
+  private fn F() -> i32;
+}
+
+base class C {
+  extend base: B;
+  fn G[self: Self]() -> () { return self.F(); }
+}
+
+// --- inherited_member_access.carbon
+
+library "inherited_member_access";
+
+base class A {
+  protected let SOME_CONSTANT: i32 = 5;
+  protected fn SomeProtectedFunction() -> i32 {
+    return 5;
+  }
+}
+
+class B {
+  extend base: A;
+
+  fn G() -> i32 {
+    return A.SOME_CONSTANT;
+  }
+
+  fn H() -> i32 {
+    return A.SomeProtectedFunction();
+  }
+}
+
+// --- fail_inherited_private_field_access.carbon
+
+library "inherited_private_field_access";
+
+base class Shape {
+  private var y: i32;
+}
+
+class Square {
+  extend base: Shape;
+
+  fn GetPosition[self: Self]() -> i32 {
+    // CHECK:STDERR: fail_inherited_private_field_access.carbon:[[@LINE+7]]:12: ERROR: Cannot access private member `y` of type `Shape`.
+    // CHECK:STDERR:     return self.y;
+    // CHECK:STDERR:            ^~~~~~
+    // CHECK:STDERR: fail_inherited_private_field_access.carbon:[[@LINE-10]]:15: The private member `y` is defined here.
+    // CHECK:STDERR:   private var y: i32;
+    // CHECK:STDERR:               ^~~~~~
+    // CHECK:STDERR:
+    return self.y;
+  }
+}
+
+// --- noninstance_private_on_self.carbon
+
+library "noninstance_private_on_self";
+
+class C {
+  private fn F() {}
+  fn G() { Self.F(); }
+}
+
+// --- noninstance_protected_on_self.carbon
+
+library "noninstance_protected_on_self";
+
+class C {
+  protected fn F() {}
+  fn G() { Self.F(); }
+}
+
+// --- fail_noninstance_private_on_parent.carbon
+
+library "noninstance_private_on_parent";
+
+base class B {
+  private fn F() {}
+}
+
+class C {
+  extend base: B;
+  // CHECK:STDERR: fail_noninstance_private_on_parent.carbon:[[@LINE+7]]:12: ERROR: Cannot access private member `F` of type `B`.
+  // CHECK:STDERR:   fn G() { Self.F(); }
+  // CHECK:STDERR:            ^~~~~~
+  // CHECK:STDERR: fail_noninstance_private_on_parent.carbon:[[@LINE-8]]:3: The private member `F` is defined here.
+  // CHECK:STDERR:   private fn F() {}
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  fn G() { Self.F(); }
+}
+
+// --- noninstance_protected_on_parent.carbon
+
+library "noninstance_protected_on_parent";
+
+base class B {
+  protected fn F() {}
+}
+
+class C {
+  extend base: B;
+  fn G() { Self.F(); }
+}
+
+// --- fail_non_inherited_access.carbon
+
+library "non_inherited_access";
+
+base class A {
+  protected let SOME_PROTECTED_CONSTANT: i32 = 5;
+  private let SOME_PRIVATE_CONSTANT: i32 = 5;
+}
+
+base class Internal {
+  protected let INTERNAL_CONSTANT: i32 = 5;
+}
+
+class B {
+  private var internal: Internal;
+
+  fn G() -> i32 {
+    // CHECK:STDERR: fail_non_inherited_access.carbon:[[@LINE+7]]:5: ERROR: Cannot access private member `SOME_PRIVATE_CONSTANT` of type `A`.
+    // CHECK:STDERR:     A.SOME_PRIVATE_CONSTANT;
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_non_inherited_access.carbon:[[@LINE-14]]:15: The private member `SOME_PRIVATE_CONSTANT` is defined here.
+    // CHECK:STDERR:   private let SOME_PRIVATE_CONSTANT: i32 = 5;
+    // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
+    A.SOME_PRIVATE_CONSTANT;
+
+    // CHECK:STDERR: fail_non_inherited_access.carbon:[[@LINE+7]]:12: ERROR: Cannot access protected member `SOME_PROTECTED_CONSTANT` of type `A`.
+    // CHECK:STDERR:     return A.SOME_PROTECTED_CONSTANT;
+    // CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_non_inherited_access.carbon:[[@LINE-24]]:17: The protected member `SOME_PROTECTED_CONSTANT` is defined here.
+    // CHECK:STDERR:   protected let SOME_PROTECTED_CONSTANT: i32 = 5;
+    // CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
+    return A.SOME_PROTECTED_CONSTANT;
+  }
+
+  fn SomeFunc[self: Self]() -> i32{
+    // CHECK:STDERR: fail_non_inherited_access.carbon:[[@LINE+6]]:12: ERROR: Cannot access protected member `INTERNAL_CONSTANT` of type `Internal`.
+    // CHECK:STDERR:     return self.internal.INTERNAL_CONSTANT;
+    // CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_non_inherited_access.carbon:[[@LINE-30]]:17: The protected member `INTERNAL_CONSTANT` is defined here.
+    // CHECK:STDERR:   protected let INTERNAL_CONSTANT: i32 = 5;
+    // CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~
+    return self.internal.INTERNAL_CONSTANT;
+  }
+}
+
+// CHECK:STDOUT: --- instance_protected_field_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Shape: type = class_type @Shape [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = unbound_element_type %Shape, i32 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %Circle: type = class_type @Circle [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT:   %.5: type = unbound_element_type %Circle, %Shape [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.7: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %GetPosition.type: type = fn_type @GetPosition [template]
+// CHECK:STDOUT:   %GetPosition: %GetPosition.type = struct_value () [template]
+// CHECK:STDOUT:   %.8: type = struct_type {.base: %Shape} [template]
+// CHECK:STDOUT:   %.9: type = ptr_type %.7 [template]
+// CHECK:STDOUT:   %.10: type = struct_type {.base: %.4} [template]
+// CHECK:STDOUT:   %.11: type = ptr_type %.8 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Shape = %Shape.decl
+// CHECK:STDOUT:     .Circle = %Circle.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Shape.decl: type = class_decl @Shape [template = constants.%Shape] {}
+// CHECK:STDOUT:   %Circle.decl: type = class_decl @Circle [template = constants.%Circle] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Shape {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_20.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_20.2: type = converted %int.make_type_32.loc5, %.loc5_20.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_18: %.2 = field_decl x, element0 [template]
+// CHECK:STDOUT:   %int.make_type_32.loc6: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc6_20.1: type = value_of_initializer %int.make_type_32.loc6 [template = i32]
+// CHECK:STDOUT:   %.loc6_20.2: type = converted %int.make_type_32.loc6, %.loc6_20.1 [template = i32]
+// CHECK:STDOUT:   %.loc6_18: %.2 = field_decl y, element1 [template]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Shape
+// CHECK:STDOUT:   .x [protected] = %.loc5_18
+// CHECK:STDOUT:   .y [protected] = %.loc6_18
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Circle {
+// CHECK:STDOUT:   %Shape.ref: type = name_ref Shape, file.%Shape.decl [template = constants.%Shape]
+// CHECK:STDOUT:   %.loc10: %.5 = base_decl %Shape, element0 [template]
+// CHECK:STDOUT:   %GetPosition.decl: %GetPosition.type = fn_decl @GetPosition [template = constants.%GetPosition] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%Circle [template = constants.%Circle]
+// CHECK:STDOUT:     %self.loc12_18.1: %Circle = param self
+// CHECK:STDOUT:     %self.loc12_18.2: %Circle = bind_name self, %self.loc12_18.1
+// CHECK:STDOUT:     %int.make_type_32.loc12_36: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %int.make_type_32.loc12_41: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc12_44.1: %.6 = tuple_literal (%int.make_type_32.loc12_36, %int.make_type_32.loc12_41)
+// CHECK:STDOUT:     %.loc12_44.2: type = value_of_initializer %int.make_type_32.loc12_36 [template = i32]
+// CHECK:STDOUT:     %.loc12_44.3: type = converted %int.make_type_32.loc12_36, %.loc12_44.2 [template = i32]
+// CHECK:STDOUT:     %.loc12_44.4: type = value_of_initializer %int.make_type_32.loc12_41 [template = i32]
+// CHECK:STDOUT:     %.loc12_44.5: type = converted %int.make_type_32.loc12_41, %.loc12_44.4 [template = i32]
+// CHECK:STDOUT:     %.loc12_44.6: type = converted %.loc12_44.1, constants.%.7 [template = constants.%.7]
+// CHECK:STDOUT:     %return.var: ref %.7 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Circle
+// CHECK:STDOUT:   .base = %.loc10
+// CHECK:STDOUT:   .GetPosition = %GetPosition.decl
+// CHECK:STDOUT:   extend name_scope2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @GetPosition[@Circle.%self.loc12_18.2: %Circle]() -> @Circle.%return.var: %.7 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %self.ref.loc13_13: %Circle = name_ref self, @Circle.%self.loc12_18.2
+// CHECK:STDOUT:   %x.ref: %.2 = name_ref x, @Shape.%.loc5_18 [template = @Shape.%.loc5_18]
+// CHECK:STDOUT:   %.loc13_17.1: ref %Shape = class_element_access %self.ref.loc13_13, element0
+// CHECK:STDOUT:   %.loc13_17.2: ref %Shape = converted %self.ref.loc13_13, %.loc13_17.1
+// CHECK:STDOUT:   %.loc13_17.3: ref i32 = class_element_access %.loc13_17.2, element0
+// CHECK:STDOUT:   %self.ref.loc13_21: %Circle = name_ref self, @Circle.%self.loc12_18.2
+// CHECK:STDOUT:   %y.ref: %.2 = name_ref y, @Shape.%.loc6_18 [template = @Shape.%.loc6_18]
+// CHECK:STDOUT:   %.loc13_25.1: ref %Shape = class_element_access %self.ref.loc13_21, element0
+// CHECK:STDOUT:   %.loc13_25.2: ref %Shape = converted %self.ref.loc13_21, %.loc13_25.1
+// CHECK:STDOUT:   %.loc13_25.3: ref i32 = class_element_access %.loc13_25.2, element1
+// CHECK:STDOUT:   %.loc13_27.1: %.7 = tuple_literal (%.loc13_17.3, %.loc13_25.3)
+// CHECK:STDOUT:   %.loc13_17.4: i32 = bind_value %.loc13_17.3
+// CHECK:STDOUT:   %.loc13_27.2: ref i32 = tuple_access @Circle.%return.var, element0
+// CHECK:STDOUT:   %.loc13_27.3: init i32 = initialize_from %.loc13_17.4 to %.loc13_27.2
+// CHECK:STDOUT:   %.loc13_25.4: i32 = bind_value %.loc13_25.3
+// CHECK:STDOUT:   %.loc13_27.4: ref i32 = tuple_access @Circle.%return.var, element1
+// CHECK:STDOUT:   %.loc13_27.5: init i32 = initialize_from %.loc13_25.4 to %.loc13_27.4
+// CHECK:STDOUT:   %.loc13_27.6: init %.7 = tuple_init (%.loc13_27.3, %.loc13_27.5) to @Circle.%return.var
+// CHECK:STDOUT:   %.loc13_28: init %.7 = converted %.loc13_27.1, %.loc13_27.6
+// CHECK:STDOUT:   return %.loc13_28 to @Circle.%return.var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- shadowing_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %F.type.1: type = fn_type @F.1 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %F.1: %F.type.1 = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %B: type = class_type @B [template]
+// CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
+// CHECK:STDOUT:   %.4: type = unbound_element_type %B, %A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %F.type.2: type = fn_type @F.2 [template]
+// CHECK:STDOUT:   %F.2: %F.type.2 = struct_value () [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: %A} [template]
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: %.3} [template]
+// CHECK:STDOUT:   %.7: type = ptr_type %.5 [template]
+// CHECK:STDOUT:   %.8: type = unbound_element_type %C, %B [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %.9: type = struct_type {.base: %B} [template]
+// CHECK:STDOUT:   %.10: type = struct_type {.base: %.7} [template]
+// CHECK:STDOUT:   %.11: type = ptr_type %.9 [template]
+// CHECK:STDOUT:   %tuple: %.1 = tuple_value () [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %F.decl: %F.type.1 = fn_decl @F.1 [template = constants.%F.1] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .F = %F.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B {
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %.loc9: %.4 = base_decl %A, element0 [template]
+// CHECK:STDOUT:   %F.decl: %F.type.2 = fn_decl @F.2 [template = constants.%F.2] {
+// CHECK:STDOUT:     %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc10_21.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:     %.loc10_21.2: type = converted %int.make_type_32, %.loc10_21.1 [template = i32]
+// CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B
+// CHECK:STDOUT:   .base = %.loc9
+// CHECK:STDOUT:   .F [private] = %F.decl
+// CHECK:STDOUT:   extend name_scope2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
+// CHECK:STDOUT:   %.loc14: %.8 = base_decl %B, element0 [template]
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
+// CHECK:STDOUT:     %self.loc15_8.1: %C = param self
+// CHECK:STDOUT:     %self.loc15_8.2: %C = bind_name self, %self.loc15_8.1
+// CHECK:STDOUT:     %.loc15_26.1: %.1 = tuple_literal ()
+// CHECK:STDOUT:     %.loc15_26.2: type = converted %.loc15_26.1, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %return.var: ref %.1 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .base = %.loc14
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT:   extend name_scope3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.1();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.2() -> i32;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G[@C.%self.loc15_8.2: %C]() -> %.1 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %self.ref: %C = name_ref self, @C.%self.loc15_8.2
+// CHECK:STDOUT:   %F.ref: %F.type.1 = name_ref F, @A.%F.decl [template = constants.%F.1]
+// CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
+// CHECK:STDOUT:   %.loc15_43.1: ref %.1 = temporary_storage
+// CHECK:STDOUT:   %.loc15_43.2: ref %.1 = temporary %.loc15_43.1, %F.call
+// CHECK:STDOUT:   %tuple: %.1 = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc15_45: %.1 = converted %F.call, %tuple [template = constants.%tuple]
+// CHECK:STDOUT:   return %.loc15_45
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- inherited_member_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %SomeProtectedFunction.type: type = fn_type @SomeProtectedFunction [template]
+// CHECK:STDOUT:   %SomeProtectedFunction: %SomeProtectedFunction.type = struct_value () [template]
+// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT:   %B: type = class_type @B [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT:   %.5: type = unbound_element_type %B, %A [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %H.type: type = fn_type @H [template]
+// CHECK:STDOUT:   %H: %H.type = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: %A} [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_32.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_32.2: type = converted %int.make_type_32.loc5, %.loc5_32.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_38: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %SOME_CONSTANT: i32 = bind_name SOME_CONSTANT, %.loc5_38
+// CHECK:STDOUT:   %SomeProtectedFunction.decl: %SomeProtectedFunction.type = fn_decl @SomeProtectedFunction [template = constants.%SomeProtectedFunction] {
+// CHECK:STDOUT:     %int.make_type_32.loc6: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc6_43.1: type = value_of_initializer %int.make_type_32.loc6 [template = i32]
+// CHECK:STDOUT:     %.loc6_43.2: type = converted %int.make_type_32.loc6, %.loc6_43.1 [template = i32]
+// CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .SOME_CONSTANT [protected] = %SOME_CONSTANT
+// CHECK:STDOUT:   .SomeProtectedFunction [protected] = %SomeProtectedFunction.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B {
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %.loc12: %.5 = base_decl %A, element0 [template]
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
+// CHECK:STDOUT:     %int.make_type_32.loc14: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc14_13.1: type = value_of_initializer %int.make_type_32.loc14 [template = i32]
+// CHECK:STDOUT:     %.loc14_13.2: type = converted %int.make_type_32.loc14, %.loc14_13.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc14: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {
+// CHECK:STDOUT:     %int.make_type_32.loc18: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc18_13.1: type = value_of_initializer %int.make_type_32.loc18 [template = i32]
+// CHECK:STDOUT:     %.loc18_13.2: type = converted %int.make_type_32.loc18, %.loc18_13.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc18: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B
+// CHECK:STDOUT:   .base = %.loc12
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT:   .H = %H.decl
+// CHECK:STDOUT:   extend name_scope2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @SomeProtectedFunction() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   return %.loc7
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %SOME_CONSTANT.ref: i32 = name_ref SOME_CONSTANT, @A.%SOME_CONSTANT
+// CHECK:STDOUT:   return %SOME_CONSTANT.ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @H() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %SomeProtectedFunction.ref: %SomeProtectedFunction.type = name_ref SomeProtectedFunction, @A.%SomeProtectedFunction.decl [template = constants.%SomeProtectedFunction]
+// CHECK:STDOUT:   %SomeProtectedFunction.call: init i32 = call %SomeProtectedFunction.ref()
+// CHECK:STDOUT:   %.loc19_37.1: i32 = value_of_initializer %SomeProtectedFunction.call
+// CHECK:STDOUT:   %.loc19_37.2: i32 = converted %SomeProtectedFunction.call, %.loc19_37.1
+// CHECK:STDOUT:   return %.loc19_37.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_inherited_private_field_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Shape: type = class_type @Shape [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = unbound_element_type %Shape, i32 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.y: i32} [template]
+// CHECK:STDOUT:   %Square: type = class_type @Square [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT:   %.5: type = unbound_element_type %Square, %Shape [template]
+// CHECK:STDOUT:   %GetPosition.type: type = fn_type @GetPosition [template]
+// CHECK:STDOUT:   %GetPosition: %GetPosition.type = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: %Shape} [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.base: %.4} [template]
+// CHECK:STDOUT:   %.8: type = ptr_type %.6 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Shape = %Shape.decl
+// CHECK:STDOUT:     .Square = %Square.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Shape.decl: type = class_decl @Shape [template = constants.%Shape] {}
+// CHECK:STDOUT:   %Square.decl: type = class_decl @Square [template = constants.%Square] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Shape {
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_18.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc5_18.2: type = converted %int.make_type_32, %.loc5_18.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_16: %.2 = field_decl y, element0 [template]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Shape
+// CHECK:STDOUT:   .y [private] = %.loc5_16
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Square {
+// CHECK:STDOUT:   %Shape.ref: type = name_ref Shape, file.%Shape.decl [template = constants.%Shape]
+// CHECK:STDOUT:   %.loc9: %.5 = base_decl %Shape, element0 [template]
+// CHECK:STDOUT:   %GetPosition.decl: %GetPosition.type = fn_decl @GetPosition [template = constants.%GetPosition] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%Square [template = constants.%Square]
+// CHECK:STDOUT:     %self.loc11_18.1: %Square = param self
+// CHECK:STDOUT:     %self.loc11_18.2: %Square = bind_name self, %self.loc11_18.1
+// CHECK:STDOUT:     %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc11_35.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:     %.loc11_35.2: type = converted %int.make_type_32, %.loc11_35.1 [template = i32]
+// CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Square
+// CHECK:STDOUT:   .base = %.loc9
+// CHECK:STDOUT:   .GetPosition = %GetPosition.decl
+// CHECK:STDOUT:   extend name_scope2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @GetPosition[@Square.%self.loc11_18.2: %Square]() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %self.ref: %Square = name_ref self, @Square.%self.loc11_18.2
+// CHECK:STDOUT:   %y.ref: <error> = name_ref y, <error> [template = <error>]
+// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- noninstance_private_on_self.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .F [private] = %F.decl
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @C.%F.decl [template = constants.%F]
+// CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- noninstance_protected_on_self.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .F [protected] = %F.decl
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @C.%F.decl [template = constants.%F]
+// CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_noninstance_private_on_parent.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %B: type = class_type @B [template]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
+// CHECK:STDOUT:   %.4: type = unbound_element_type %C, %B [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: %B} [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: %.3} [template]
+// CHECK:STDOUT:   %.7: type = ptr_type %.5 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B
+// CHECK:STDOUT:   .F [private] = %F.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
+// CHECK:STDOUT:   %.loc9: %.4 = base_decl %B, element0 [template]
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .base = %.loc9
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT:   extend name_scope2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
+// CHECK:STDOUT:   %F.ref: <error> = name_ref F, <error> [template = <error>]
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- noninstance_protected_on_parent.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %B: type = class_type @B [template]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
+// CHECK:STDOUT:   %.4: type = unbound_element_type %C, %B [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: %B} [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: %.3} [template]
+// CHECK:STDOUT:   %.7: type = ptr_type %.5 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B
+// CHECK:STDOUT:   .F [protected] = %F.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
+// CHECK:STDOUT:   %.loc9: %.4 = base_decl %B, element0 [template]
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .base = %.loc9
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT:   extend name_scope2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @B.%F.decl [template = constants.%F]
+// CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_non_inherited_access.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT:   %Internal: type = class_type @Internal [template]
+// CHECK:STDOUT:   %B: type = class_type @B [template]
+// CHECK:STDOUT:   %.4: type = ptr_type %.3 [template]
+// CHECK:STDOUT:   %.5: type = unbound_element_type %B, %Internal [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %SomeFunc.type: type = fn_type @SomeFunc [template]
+// CHECK:STDOUT:   %SomeFunc: %SomeFunc.type = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.internal: %Internal} [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.internal: %.4} [template]
+// CHECK:STDOUT:   %.8: type = ptr_type %.6 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .Int32 = %import_ref
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/operators
+// CHECK:STDOUT:     import Core//prelude/types
+// CHECK:STDOUT:     import Core//prelude/operators/arithmetic
+// CHECK:STDOUT:     import Core//prelude/operators/as
+// CHECK:STDOUT:     import Core//prelude/operators/bitwise
+// CHECK:STDOUT:     import Core//prelude/operators/comparison
+// CHECK:STDOUT:     import Core//prelude/types/bool
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     .Internal = %Internal.decl
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %Internal.decl: type = class_decl @Internal [template = constants.%Internal] {}
+// CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc5_42.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
+// CHECK:STDOUT:   %.loc5_42.2: type = converted %int.make_type_32.loc5, %.loc5_42.1 [template = i32]
+// CHECK:STDOUT:   %.loc5_48: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %SOME_PROTECTED_CONSTANT: i32 = bind_name SOME_PROTECTED_CONSTANT, %.loc5_48
+// CHECK:STDOUT:   %int.make_type_32.loc6: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc6_38.1: type = value_of_initializer %int.make_type_32.loc6 [template = i32]
+// CHECK:STDOUT:   %.loc6_38.2: type = converted %int.make_type_32.loc6, %.loc6_38.1 [template = i32]
+// CHECK:STDOUT:   %.loc6_44: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %SOME_PRIVATE_CONSTANT: i32 = bind_name SOME_PRIVATE_CONSTANT, %.loc6_44
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .SOME_PROTECTED_CONSTANT [protected] = %SOME_PROTECTED_CONSTANT
+// CHECK:STDOUT:   .SOME_PRIVATE_CONSTANT [private] = %SOME_PRIVATE_CONSTANT
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Internal {
+// CHECK:STDOUT:   %int.make_type_32: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc10_36.1: type = value_of_initializer %int.make_type_32 [template = i32]
+// CHECK:STDOUT:   %.loc10_36.2: type = converted %int.make_type_32, %.loc10_36.1 [template = i32]
+// CHECK:STDOUT:   %.loc10_42: i32 = int_literal 5 [template = constants.%.2]
+// CHECK:STDOUT:   %INTERNAL_CONSTANT: i32 = bind_name INTERNAL_CONSTANT, %.loc10_42
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Internal
+// CHECK:STDOUT:   .INTERNAL_CONSTANT [protected] = %INTERNAL_CONSTANT
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B {
+// CHECK:STDOUT:   %Internal.ref: type = name_ref Internal, file.%Internal.decl [template = constants.%Internal]
+// CHECK:STDOUT:   %.loc14: %.5 = field_decl internal, element0 [template]
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
+// CHECK:STDOUT:     %int.make_type_32.loc16: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc16_13.1: type = value_of_initializer %int.make_type_32.loc16 [template = i32]
+// CHECK:STDOUT:     %.loc16_13.2: type = converted %int.make_type_32.loc16, %.loc16_13.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc16: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %SomeFunc.decl: %SomeFunc.type = fn_decl @SomeFunc [template = constants.%SomeFunc] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%B [template = constants.%B]
+// CHECK:STDOUT:     %self.loc36_15.1: %B = param self
+// CHECK:STDOUT:     %self.loc36_15.2: %B = bind_name self, %self.loc36_15.1
+// CHECK:STDOUT:     %int.make_type_32.loc36: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:     %.loc36_32.1: type = value_of_initializer %int.make_type_32.loc36 [template = i32]
+// CHECK:STDOUT:     %.loc36_32.2: type = converted %int.make_type_32.loc36, %.loc36_32.1 [template = i32]
+// CHECK:STDOUT:     %return.var.loc36: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B
+// CHECK:STDOUT:   .internal [private] = %.loc14
+// CHECK:STDOUT:   .G = %G.decl
+// CHECK:STDOUT:   .SomeFunc = %SomeFunc.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref.loc24: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %SOME_PRIVATE_CONSTANT.ref: <error> = name_ref SOME_PRIVATE_CONSTANT, <error> [template = <error>]
+// CHECK:STDOUT:   %A.ref.loc33: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %SOME_PROTECTED_CONSTANT.ref: <error> = name_ref SOME_PROTECTED_CONSTANT, <error> [template = <error>]
+// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @SomeFunc[@B.%self.loc36_15.2: %B]() -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %self.ref: %B = name_ref self, @B.%self.loc36_15.2
+// CHECK:STDOUT:   %internal.ref: %.5 = name_ref internal, @B.%.loc14 [template = @B.%.loc14]
+// CHECK:STDOUT:   %.loc43_16.1: ref %Internal = class_element_access %self.ref, element0
+// CHECK:STDOUT:   %.loc43_16.2: %Internal = bind_value %.loc43_16.1
+// CHECK:STDOUT:   %INTERNAL_CONSTANT.ref: <error> = name_ref INTERNAL_CONSTANT, <error> [template = <error>]
+// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -348,6 +348,10 @@ CARBON_DIAGNOSTIC_KIND(ModifierPrevious)
 CARBON_DIAGNOSTIC_KIND(ExternLibraryOnDefinition)
 CARBON_DIAGNOSTIC_KIND(ExternLibraryIsCurrentLibrary)
 
+// Access modifiers.
+CARBON_DIAGNOSTIC_KIND(ClassMemberDefinition)
+CARBON_DIAGNOSTIC_KIND(ClassInvalidMemberAccess)
+
 // Alias diagnostics.
 CARBON_DIAGNOSTIC_KIND(AliasRequiresNameRef)
 


### PR DESCRIPTION
Print diagnostics for invalid class member access. This doesn't take into account compound member access.