### PR TITLE
Fix crash when disabling debug info

### DIFF
--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -97,10 +97,12 @@ auto FunctionContext::LowerInst(SemIR::InstId inst_id) -> void {
   auto inst = sem_ir().insts().Get(inst_id);
   CARBON_VLOG() << "Lowering " << inst_id << ": " << inst << "\n";
   builder_.getInserter().SetCurrentInstId(inst_id);
-  auto loc = file_context_->GetDiagnosticLoc(inst_id);
-  builder_.SetCurrentDebugLocation(
-      llvm::DILocation::get(builder_.getContext(), loc.line_number,
-                            loc.column_number, di_subprogram_));
+  if (di_subprogram_) {
+    auto loc = file_context_->GetDiagnosticLoc(inst_id);
+    builder_.SetCurrentDebugLocation(
+        llvm::DILocation::get(builder_.getContext(), loc.line_number,
+                              loc.column_number, di_subprogram_));
+  }
 
   CARBON_KIND_SWITCH(inst) {
 #define CARBON_SEM_IR_INST_KIND(Name)            \
@@ -112,7 +114,9 @@ auto FunctionContext::LowerInst(SemIR::InstId inst_id) -> void {
   }
 
   builder_.getInserter().SetCurrentInstId(SemIR::InstId::Invalid);
-  builder_.SetCurrentDebugLocation(llvm::DebugLoc());
+  if (di_subprogram_) {
+    builder_.SetCurrentDebugLocation(llvm::DebugLoc());
+  }
 }
 
 auto FunctionContext::GetBlockArg(SemIR::InstBlockId block_id,

--- a/toolchain/lower/testdata/debug/nodebug.carbon
+++ b/toolchain/lower/testdata/debug/nodebug.carbon
@@ -10,5 +10,13 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/debug/nodebug.carbon
 
+fn F() {
+}
+
 // CHECK:STDOUT: ; ModuleID = 'nodebug.carbon'
 // CHECK:STDOUT: source_filename = "nodebug.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @F() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }


### PR DESCRIPTION
The source line debug info generation assumed that the function would have debug info. Check for a non-null di_subprogram_ to ensure we are emitting debug info for the function.

Rather than checking the di_builder_ - this way if we implement `nodebug` function attributes, it'll fall out naturally (by creating a null di_subprogram_) rather than having to come back and change this from "is debug info enabled" to "is debug info enabled for this function" later on.
