### PR TITLE
debug-info: Add checks for instructions without source locations

### DIFF
--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -98,6 +98,11 @@ auto FunctionContext::LowerInst(SemIR::InstId inst_id) -> void {
   CARBON_VLOG() << "Lowering " << inst_id << ": " << inst << "\n";
   builder_.getInserter().SetCurrentInstId(inst_id);
   auto loc = file_context_->GetDiagnosticLoc(inst_id);
+  CARBON_CHECK(loc.filename == di_subprogram_->getFile()->getFilename())
+      << "Instructions located in a different file from their enclosing "
+         "function aren't handled yet";
+  CARBON_CHECK(loc.line_number >= 1 && loc.column_number >= 1)
+      << "Instructions without line locations aren't handled yet";
   builder_.SetCurrentDebugLocation(
       llvm::DILocation::get(builder_.getContext(), loc.line_number,
                             loc.column_number, di_subprogram_));


### PR DESCRIPTION
I think this is what you were looking for, @jonmeow? (I was trying to figure out how to tersely phrase the check to be "this isn't supported here yet, and not clear if it needs to be supported here - but if this assert is hit, then we should add support here?" - open to wording suggestions)

(this will fail testing due to #4249 - so shouldn't be submitted before that, though they aren't textually/patch-ually dependent on each other)
