### PR TITLE
Fix parse to use the error tracking consumer for has_errors_.

### DIFF
--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -69,17 +69,11 @@ Context::Context(Tree& tree, Lex::TokenizedBuffer& tokens,
 auto Context::AddLeafNode(NodeKind kind, Lex::TokenIndex token, bool has_error)
     -> void {
   tree_->node_impls_.push_back(Tree::NodeImpl(kind, has_error, token));
-  if (has_error) {
-    tree_->has_errors_ = true;
-  }
 }
 
 auto Context::AddNode(NodeKind kind, Lex::TokenIndex token, bool has_error)
     -> void {
   tree_->node_impls_.push_back(Tree::NodeImpl(kind, has_error, token));
-  if (has_error) {
-    tree_->has_errors_ = true;
-  }
 }
 
 auto Context::ReplacePlaceholderNode(int32_t position, NodeKind kind,
@@ -92,9 +86,6 @@ auto Context::ReplacePlaceholderNode(int32_t position, NodeKind kind,
   node_impl->kind = kind;
   node_impl->has_error = has_error;
   node_impl->token = token;
-  if (has_error) {
-    tree_->has_errors_ = true;
-  }
 }
 
 auto Context::ConsumeAndAddOpenParen(Lex::TokenIndex default_token,

--- a/toolchain/parse/testdata/operators/fail_infix_uneven_space_before.carbon
+++ b/toolchain/parse/testdata/operators/fail_infix_uneven_space_before.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_infix_uneven_space_before.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_infix_uneven_space_before.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_infix_uneven_space_before.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_infix_uneven_space_before.carbon
 
-// CHECK:STDERR: recover_infix_uneven_space_before.carbon:[[@LINE+3]]:15: ERROR: Whitespace missing after binary operator.
+// CHECK:STDERR: fail_infix_uneven_space_before.carbon:[[@LINE+3]]:15: ERROR: Whitespace missing after binary operator.
 // CHECK:STDERR: var n: i8 = n *n;
 // CHECK:STDERR:               ^
 var n: i8 = n *n;
 
-// CHECK:STDOUT: - filename: recover_infix_uneven_space_before.carbon
+// CHECK:STDOUT: - filename: fail_infix_uneven_space_before.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_postfix_space.carbon
+++ b/toolchain/parse/testdata/operators/fail_postfix_space.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_postfix_space_surrounding.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_postfix_space.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_postfix_space_surrounding.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_postfix_space.carbon
 
-// CHECK:STDERR: recover_postfix_space_surrounding.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
-// CHECK:STDERR: var v: type = i8 * ;
+// CHECK:STDERR: fail_postfix_space.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: var v: type = i8 *;
 // CHECK:STDERR:                  ^
-var v: type = i8 * ;
+var v: type = i8 *;
 
-// CHECK:STDOUT: - filename: recover_postfix_space_surrounding.carbon
+// CHECK:STDOUT: - filename: fail_postfix_space.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_postfix_space_before_comma.carbon
+++ b/toolchain/parse/testdata/operators/fail_postfix_space_before_comma.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_postfix_space_before_comma.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_postfix_space_before_comma.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_postfix_space_before_comma.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_postfix_space_before_comma.carbon
 
-// CHECK:STDERR: recover_postfix_space_before_comma.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: fail_postfix_space_before_comma.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
 // CHECK:STDERR: var n: i8 = F(i8 *, 0);
 // CHECK:STDERR:                  ^
 var n: i8 = F(i8 *, 0);
 
-// CHECK:STDOUT: - filename: recover_postfix_space_before_comma.carbon
+// CHECK:STDOUT: - filename: fail_postfix_space_before_comma.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_postfix_space_in_call.carbon
+++ b/toolchain/parse/testdata/operators/fail_postfix_space_in_call.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_postfix_space_in_call.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_postfix_space_in_call.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_postfix_space_in_call.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_postfix_space_in_call.carbon
 
-// CHECK:STDERR: recover_postfix_space_in_call.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: fail_postfix_space_in_call.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
 // CHECK:STDERR: var n: i8 = F(i8 *);
 // CHECK:STDERR:                  ^
 var n: i8 = F(i8 *);
 
-// CHECK:STDOUT: - filename: recover_postfix_space_in_call.carbon
+// CHECK:STDOUT: - filename: fail_postfix_space_in_call.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_postfix_space_surrounding.carbon
+++ b/toolchain/parse/testdata/operators/fail_postfix_space_surrounding.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_postfix_space.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_postfix_space_surrounding.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_postfix_space.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_postfix_space_surrounding.carbon
 
-// CHECK:STDERR: recover_postfix_space.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
-// CHECK:STDERR: var v: type = i8 *;
+// CHECK:STDERR: fail_postfix_space_surrounding.carbon:[[@LINE+3]]:18: ERROR: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: var v: type = i8 * ;
 // CHECK:STDERR:                  ^
-var v: type = i8 *;
+var v: type = i8 * ;
 
-// CHECK:STDOUT: - filename: recover_postfix_space.carbon
+// CHECK:STDOUT: - filename: fail_postfix_space_surrounding.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_prefix_repeat.carbon
+++ b/toolchain/parse/testdata/operators/fail_prefix_repeat.carbon
@@ -4,17 +4,17 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_prefix_repeat.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_prefix_repeat.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_prefix_repeat.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_prefix_repeat.carbon
 
-// CHECK:STDERR: recover_prefix_repeat.carbon:[[@LINE+3]]:17: ERROR: Parentheses are required around this unary `const` operator.
+// CHECK:STDERR: fail_prefix_repeat.carbon:[[@LINE+3]]:17: ERROR: Parentheses are required around this unary `const` operator.
 // CHECK:STDERR: fn F() -> const const i32* {
 // CHECK:STDERR:                 ^~~~~
 fn F() -> const const i32* {
 }
 
-// CHECK:STDOUT: - filename: recover_prefix_repeat.carbon
+// CHECK:STDOUT: - filename: fail_prefix_repeat.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:         {kind: 'FunctionIntroducer', text: 'fn'},

--- a/toolchain/parse/testdata/operators/fail_prefix_space.carbon
+++ b/toolchain/parse/testdata/operators/fail_prefix_space.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_prefix_uneven_space_with_assign.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_prefix_space.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_prefix_uneven_space_with_assign.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_prefix_space.carbon
 
-// CHECK:STDERR: recover_prefix_uneven_space_with_assign.carbon:[[@LINE+3]]:12: ERROR: Whitespace is not allowed after this unary operator.
-// CHECK:STDERR: var n: i8 =- n;
-// CHECK:STDERR:            ^
-var n: i8 =- n;
+// CHECK:STDERR: fail_prefix_space.carbon:[[@LINE+3]]:13: ERROR: Whitespace is not allowed after this unary operator.
+// CHECK:STDERR: var n: i8 = - n;
+// CHECK:STDERR:             ^
+var n: i8 = - n;
 
-// CHECK:STDOUT: - filename: recover_prefix_uneven_space_with_assign.carbon
+// CHECK:STDOUT: - filename: fail_prefix_space.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_prefix_uneven_space_with_assign.carbon
+++ b/toolchain/parse/testdata/operators/fail_prefix_uneven_space_with_assign.carbon
@@ -4,16 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_prefix_space.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_prefix_uneven_space_with_assign.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_prefix_space.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_prefix_uneven_space_with_assign.carbon
 
-// CHECK:STDERR: recover_prefix_space.carbon:[[@LINE+3]]:13: ERROR: Whitespace is not allowed after this unary operator.
-// CHECK:STDERR: var n: i8 = - n;
-// CHECK:STDERR:             ^
-var n: i8 = - n;
+// CHECK:STDERR: fail_prefix_uneven_space_with_assign.carbon:[[@LINE+3]]:12: ERROR: Whitespace is not allowed after this unary operator.
+// CHECK:STDERR: var n: i8 =- n;
+// CHECK:STDERR:            ^
+var n: i8 =- n;
 
-// CHECK:STDOUT: - filename: recover_prefix_space.carbon
+// CHECK:STDOUT: - filename: fail_prefix_uneven_space_with_assign.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},

--- a/toolchain/parse/testdata/operators/fail_star_minus.carbon
+++ b/toolchain/parse/testdata/operators/fail_star_minus.carbon
@@ -4,16 +4,21 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_star_star.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_star_minus.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_star_star.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_star_minus.carbon
 
-// CHECK:STDERR: recover_star_star.carbon:[[@LINE+3]]:16: ERROR: Whitespace missing after binary operator.
-// CHECK:STDERR: var n: i8 = n* *p;
+// TODO: There are two possible fixes that would make this expression legal:
+// `n * -n` and `n* - n`. The parser doesn't realize that the first fix is
+// available because it has already accepted that first part of the expression,
+// so it is recovering by using the second option, but the diagnostic should
+// ideally offer (or consider) both fixes as alternatives.
+// CHECK:STDERR: fail_star_minus.carbon:[[@LINE+3]]:16: ERROR: Whitespace missing after binary operator.
+// CHECK:STDERR: var n: i8 = n* -n;
 // CHECK:STDERR:                ^
-var n: i8 = n* *p;
+var n: i8 = n* -n;
 
-// CHECK:STDOUT: - filename: recover_star_star.carbon
+// CHECK:STDOUT: - filename: fail_star_minus.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},
@@ -23,8 +28,8 @@ var n: i8 = n* *p;
 // CHECK:STDOUT:       {kind: 'VariableInitializer', text: '='},
 // CHECK:STDOUT:           {kind: 'IdentifierNameExpr', text: 'n'},
 // CHECK:STDOUT:         {kind: 'PostfixOperatorStar', text: '*', subtree_size: 2},
-// CHECK:STDOUT:         {kind: 'IdentifierNameExpr', text: 'p'},
-// CHECK:STDOUT:       {kind: 'InfixOperatorStar', text: '*', subtree_size: 4},
+// CHECK:STDOUT:         {kind: 'IdentifierNameExpr', text: 'n'},
+// CHECK:STDOUT:       {kind: 'InfixOperatorMinus', text: '-', subtree_size: 4},
 // CHECK:STDOUT:     {kind: 'VariableDecl', text: ';', subtree_size: 10},
 // CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT:   ]

--- a/toolchain/parse/testdata/operators/fail_star_star.carbon
+++ b/toolchain/parse/testdata/operators/fail_star_star.carbon
@@ -4,21 +4,16 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/recover_star_minus.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/parse/testdata/operators/fail_star_star.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/recover_star_minus.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/parse/testdata/operators/fail_star_star.carbon
 
-// TODO: There are two possible fixes that would make this expression legal:
-// `n * -n` and `n* - n`. The parser doesn't realize that the first fix is
-// available because it has already accepted that first part of the expression,
-// so it is recovering by using the second option, but the diagnostic should
-// ideally offer (or consider) both fixes as alternatives.
-// CHECK:STDERR: recover_star_minus.carbon:[[@LINE+3]]:16: ERROR: Whitespace missing after binary operator.
-// CHECK:STDERR: var n: i8 = n* -n;
+// CHECK:STDERR: fail_star_star.carbon:[[@LINE+3]]:16: ERROR: Whitespace missing after binary operator.
+// CHECK:STDERR: var n: i8 = n* *p;
 // CHECK:STDERR:                ^
-var n: i8 = n* -n;
+var n: i8 = n* *p;
 
-// CHECK:STDOUT: - filename: recover_star_minus.carbon
+// CHECK:STDOUT: - filename: fail_star_star.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},
@@ -28,8 +23,8 @@ var n: i8 = n* -n;
 // CHECK:STDOUT:       {kind: 'VariableInitializer', text: '='},
 // CHECK:STDOUT:           {kind: 'IdentifierNameExpr', text: 'n'},
 // CHECK:STDOUT:         {kind: 'PostfixOperatorStar', text: '*', subtree_size: 2},
-// CHECK:STDOUT:         {kind: 'IdentifierNameExpr', text: 'n'},
-// CHECK:STDOUT:       {kind: 'InfixOperatorMinus', text: '-', subtree_size: 4},
+// CHECK:STDOUT:         {kind: 'IdentifierNameExpr', text: 'p'},
+// CHECK:STDOUT:       {kind: 'InfixOperatorStar', text: '*', subtree_size: 4},
 // CHECK:STDOUT:     {kind: 'VariableDecl', text: ';', subtree_size: 10},
 // CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT:   ]

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -103,7 +103,6 @@ class Tree : public Printable<Tree> {
     node_impls_.reserve(tokens_->expected_parse_tree_size());
   }
 
-  // Tests whether there are any errors in the parse tree.
   auto has_errors() const -> bool { return has_errors_; }
 
   auto set_has_errors(bool has_errors) -> void { has_errors_ = has_errors; }
@@ -244,14 +243,15 @@ class Tree : public Printable<Tree> {
 
   Lex::TokenizedBuffer* tokens_;
 
-  // Indicates if any errors were encountered while parsing.
+  // True if any lowering-blocking issues were encountered while parsing. Trees
+  // are expected to still be structurally valid for checking.
   //
   // This doesn't indicate how much of the tree is structurally accurate with
-  // respect to the grammar. That can be identified by looking at the `HasError`
-  // flag for a given node (see above for details). This simply indicates that
-  // some errors were encountered somewhere. A key implication is that when this
-  // is true we do *not* have the expected 1:1 mapping between tokens and parsed
-  // nodes as some tokens may have been skipped.
+  // respect to the grammar. That can be identified by looking at
+  // `node_has_error` (see above for details). This simply indicates that some
+  // errors were encountered somewhere. A key implication is that when this is
+  // true we do *not* enforce the expected 1:1 mapping between tokens and parsed
+  // nodes, because some tokens may have been skipped.
   bool has_errors_ = false;
 
   std::optional<PackagingDecl> packaging_decl_;

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -106,6 +106,8 @@ class Tree : public Printable<Tree> {
   // Tests whether there are any errors in the parse tree.
   auto has_errors() const -> bool { return has_errors_; }
 
+  auto set_has_errors(bool has_errors) -> void { has_errors_ = has_errors; }
+
   // Returns the number of nodes in this parse tree.
   auto size() const -> int { return node_impls_.size(); }
 


### PR DESCRIPTION
This is how we are setting has_errors_ in other stages; this should only make parse consistent.

Fixes #4259 