### PR TITLE
Fix use-after-free bug in call argument conversion.

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -23,7 +23,7 @@ static auto PerformCallToGenericClass(Context& context, Parse::NodeId node_id,
                                       SemIR::ClassId class_id,
                                       llvm::ArrayRef<SemIR::InstId> arg_ids)
     -> SemIR::InstId {
-  auto& class_info = context.classes().Get(class_id);
+  CalleeParamsInfo class_info(context.classes().Get(class_id));
 
   // TODO: Pass in information about the specific in which the generic class
   // name was found.
@@ -49,7 +49,7 @@ static auto PerformCallToGenericInterface(Context& context,
                                           SemIR::InterfaceId interface_id,
                                           llvm::ArrayRef<SemIR::InstId> arg_ids)
     -> SemIR::InstId {
-  auto& interface_info = context.interfaces().Get(interface_id);
+  CalleeParamsInfo interface_info(context.interfaces().Get(interface_id));
 
   // TODO: Pass in information about the specific in which the generic interface
   // name was found.
@@ -147,9 +147,9 @@ auto PerformCall(Context& context, Parse::NodeId node_id,
   }
 
   // Convert the arguments to match the parameters.
-  auto converted_args_id =
-      ConvertCallArgs(context, node_id, callee_function.self_id, arg_ids,
-                      return_storage_id, callable, specific_id);
+  auto converted_args_id = ConvertCallArgs(
+      context, node_id, callee_function.self_id, arg_ids, return_storage_id,
+      CalleeParamsInfo(callable), specific_id);
   auto call_inst_id =
       context.AddInst<SemIR::Call>(node_id, {.type_id = return_info.type_id,
                                              .callee_id = callee_id,

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -1119,7 +1119,7 @@ CARBON_DIAGNOSTIC(InCallToFunction, Note, "Calling function declared here.");
 
 // Convert the object argument in a method call to match the `self` parameter.
 static auto ConvertSelf(Context& context, SemIR::LocId call_loc_id,
-                        SemIR::InstId callee_id,
+                        SemIRLoc callee_loc,
                         SemIR::SpecificId callee_specific_id,
                         std::optional<SemIR::AddrPattern> addr_pattern,
                         SemIR::InstId self_param_id, SemIR::Param self_param,
@@ -1129,7 +1129,7 @@ static auto ConvertSelf(Context& context, SemIR::LocId call_loc_id,
                       "Missing object argument in method call.");
     context.emitter()
         .Build(call_loc_id, MissingObjectInMethodCall)
-        .Note(callee_id, InCallToFunction)
+        .Note(callee_loc, InCallToFunction)
         .Emit();
     return SemIR::InstId::BuiltinError;
   }
@@ -1177,7 +1177,7 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
                      SemIR::InstId self_id,
                      llvm::ArrayRef<SemIR::InstId> arg_refs,
                      SemIR::InstId return_storage_id,
-                     const SemIR::EntityWithParamsBase& callee,
+                     const CalleeParamsInfo& callee,
                      SemIR::SpecificId callee_specific_id)
     -> SemIR::InstBlockId {
   auto implicit_param_refs =
@@ -1193,7 +1193,7 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
     context.emitter()
         .Build(call_loc_id, CallArgCountMismatch, arg_refs.size(),
                param_refs.size())
-        .Note(callee.latest_decl_id(), InCallToFunction)
+        .Note(callee.callee_loc, InCallToFunction)
         .Emit();
     return SemIR::InstBlockId::Invalid;
   }
@@ -1211,7 +1211,7 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
         context.sem_ir(), implicit_param_id);
     if (param.name_id == SemIR::NameId::SelfValue) {
       auto converted_self_id = ConvertSelf(
-          context, call_loc_id, callee.latest_decl_id(), callee_specific_id,
+          context, call_loc_id, callee.callee_loc, callee_specific_id,
           addr_pattern, param_id, param, self_id);
       if (converted_self_id == SemIR::InstId::BuiltinError) {
         return SemIR::InstBlockId::Invalid;
@@ -1230,7 +1230,7 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
         CARBON_DIAGNOSTIC(
             InCallToFunctionParam, Note,
             "Initializing parameter {0} of function declared here.", int);
-        builder.Note(callee.latest_decl_id(), InCallToFunctionParam,
+        builder.Note(callee.callee_loc, InCallToFunctionParam,
                      diag_param_index + 1);
       });
 


### PR DESCRIPTION
Conversion can trigger new entities to be imported, which can invalidate the reference it holds to an EntityWithParamBase. Instead of holding such a reference, pull the information we need out of the entity early and only pass that into ConvertCallArgs.

I couldn't find a good standalone way to test this, but this fixes the test failure we otherwise see on MacOS after #4209, so it will be tested once that PR lands.