### PR TITLE
Make the 'library' lines in tests use a substitution.

### DIFF
--- a/testing/file_test/README.md
+++ b/testing/file_test/README.md
@@ -80,6 +80,21 @@ The main test file and any split-files must have a `fail_` prefix if and only if
 they have an associated error. An exception is that the main test file may omit
 `fail_` when it contains split-files that have a `fail_` prefix.
 
+## Content replacement
+
+Some keywords can be inserted for content:
+
+-   ```
+    [[@TEST_NAME]]
+    ```
+
+    Replaces with the test name, which is the filename with the extension and
+    any `fail_` or `todo_` prefixes removed. For split files, this is based on
+    the split filename.
+
+The `[[@` string is reserved for future replacements, but `[[` is allowed in
+content (comment markers don't allow `[[`).
+
 ## Comment markers
 
 Settings in files are provided in comments, similar to `FileCheck` syntax.
@@ -106,7 +121,9 @@ Supported comment markers are:
     check line refers to any line in the test, all STDOUT check lines are placed
     at the end of the file instead of immediately after AUTOUPDATE.
 
--   `// ARGS: <arguments>`
+-   ```
+    // ARGS: <arguments>
+    ```
 
     Provides a space-separated list of arguments, which will be passed to
     RunWithFiles as test_args. These are intended for use by the command as
@@ -131,7 +148,9 @@ Supported comment markers are:
     ARGS can be specified at most once. If not provided, the FileTestBase child
     is responsible for providing default arguments.
 
--   `// SET-CHECK-SUBSET`
+-   ```
+    // SET-CHECK-SUBSET
+    ```
 
     By default, all lines of output must have a CHECK match. Adding this as a
     option sets it so that non-matching lines are ignored. All provided
@@ -139,7 +158,9 @@ Supported comment markers are:
 
     SET-CHECK-SUBSET can be specified at most once.
 
--   `// --- <filename>`
+-   ```
+    // --- <filename>
+    ```
 
     By default, all file content is provided to the test as a single file in
     test_files. Using this marker allows the file to be split into multiple

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -443,7 +443,7 @@ struct SplitState {
   auto has_splits() const -> bool { return file_index > 0; }
 
   auto add_content(llvm::StringRef line) -> void {
-    content.append(line);
+    content.append(line.str());
     content.append("\n");
   }
 
@@ -462,13 +462,62 @@ struct SplitState {
   int file_index = 0;
 };
 
+// Replaces the content keywords.
+//
+// TEST_NAME is the only content keyword at present, but we do validate that
+// other names
+static auto ReplaceContentKeywords(llvm::StringRef filename,
+                                   std::string* content) -> ErrorOr<Success> {
+  static constexpr llvm::StringLiteral Prefix = "[[@";
+
+  auto keyword_pos = content->find(Prefix);
+  // Return early if not finding anything.
+  if (keyword_pos == std::string::npos) {
+    return Success();
+  }
+
+  // Construct the test name by getting the base name without the extension,
+  // then removing any "fail_" or "todo_" prefixes.
+  llvm::StringRef test_name = filename;
+  if (auto last_slash = test_name.rfind("/");
+      last_slash != llvm::StringRef::npos) {
+    test_name = test_name.substr(last_slash + 1);
+  }
+  if (auto ext_dot = test_name.find("."); ext_dot != llvm::StringRef::npos) {
+    test_name = test_name.substr(0, ext_dot);
+  }
+  while (test_name.consume_front("fail_") || test_name.consume_front("todo_")) {
+  }
+
+  while (keyword_pos != std::string::npos) {
+    static constexpr llvm::StringLiteral TestName = "[[@TEST_NAME]]";
+    auto keyword = llvm::StringRef(*content).substr(keyword_pos);
+    if (keyword.starts_with(TestName)) {
+      keyword = TestName;
+      content->replace(keyword_pos, TestName.size(), test_name);
+      keyword_pos += test_name.size();
+    } else if (keyword.starts_with("[[@LINE")) {
+      // Just move past the prefix to find the next one.
+      keyword_pos += Prefix.size();
+    } else {
+      return ErrorBuilder()
+             << "Unexpected use of `[[@` at `" << keyword.substr(0, 5) << "`";
+    }
+    keyword_pos = content->find(Prefix, keyword_pos);
+  }
+  return Success();
+}
+
 // Adds a file. Used for both split and unsplit test files.
 static auto AddTestFile(llvm::StringRef filename, std::string* content,
                         llvm::SmallVector<FileTestBase::TestFile>* test_files)
-    -> void {
+    -> ErrorOr<Success> {
+  CARBON_RETURN_IF_ERROR(ReplaceContentKeywords(filename, content));
+
   test_files->push_back(
       {.filename = filename.str(), .content = std::move(*content)});
   content->clear();
+  return Success();
 }
 
 // Process file split ("---") lines when found. Returns true if the line is
@@ -500,7 +549,8 @@ static auto TryConsumeSplit(
 
   // On a file split, add the previous file, then start a new one.
   if (split->has_splits()) {
-    AddTestFile(split->filename, &split->content, test_files);
+    CARBON_RETURN_IF_ERROR(
+        AddTestFile(split->filename, &split->content, test_files));
   } else {
     split->content.clear();
     if (split->found_code_pre_split) {
@@ -646,14 +696,14 @@ static auto TransformExpectation(int line_index, llvm::StringRef in)
 // Once all content is processed, do any remaining split processing.
 static auto FinishSplit(llvm::StringRef test_name, SplitState* split,
                         llvm::SmallVector<FileTestBase::TestFile>* test_files)
-    -> void {
+    -> ErrorOr<Success> {
   if (split->has_splits()) {
-    AddTestFile(split->filename, &split->content, test_files);
+    return AddTestFile(split->filename, &split->content, test_files);
   } else {
     // If no file splitting happened, use the main file as the test file.
     // There will always be a `/` unless tests are in the repo root.
-    AddTestFile(test_name.drop_front(test_name.rfind("/") + 1), &split->content,
-                test_files);
+    return AddTestFile(test_name.drop_front(test_name.rfind("/") + 1),
+                       &split->content, test_files);
   }
 }
 
@@ -826,7 +876,7 @@ auto FileTestBase::ProcessTestFile(TestContext& context) -> ErrorOr<Success> {
   }
 
   context.has_splits = split.has_splits();
-  FinishSplit(test_name_, &split, &context.test_files);
+  CARBON_RETURN_IF_ERROR(FinishSplit(test_name_, &split, &context.test_files));
 
   // Assume there is always a suffix `\n` in output.
   if (!context.expected_stdout.empty()) {

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -486,8 +486,10 @@ static auto ReplaceContentKeywords(llvm::StringRef filename,
   if (auto ext_dot = test_name.find("."); ext_dot != llvm::StringRef::npos) {
     test_name = test_name.substr(0, ext_dot);
   }
-  while (test_name.consume_front("fail_") || test_name.consume_front("todo_")) {
-  }
+  // Note this also handles `fail_todo_` and `todo_fail_`.
+  test_name.consume_front("todo_");
+  test_name.consume_front("fail_");
+  test_name.consume_front("todo_");
 
   while (keyword_pos != std::string::npos) {
     static constexpr llvm::StringLiteral TestName = "[[@TEST_NAME]]";

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -465,7 +465,7 @@ struct SplitState {
 // Replaces the content keywords.
 //
 // TEST_NAME is the only content keyword at present, but we do validate that
-// other names
+// other names are reserved.
 static auto ReplaceContentKeywords(llvm::StringRef filename,
                                    std::string* content) -> ErrorOr<Success> {
   static constexpr llvm::StringLiteral Prefix = "[[@";
@@ -493,7 +493,6 @@ static auto ReplaceContentKeywords(llvm::StringRef filename,
     static constexpr llvm::StringLiteral TestName = "[[@TEST_NAME]]";
     auto keyword = llvm::StringRef(*content).substr(keyword_pos);
     if (keyword.starts_with(TestName)) {
-      keyword = TestName;
       content->replace(keyword_pos, TestName.size(), test_name);
       keyword_pos += test_name.size();
     } else if (keyword.starts_with("[[@LINE")) {

--- a/testing/file_test/testdata/not_split.carbon
+++ b/testing/file_test/testdata/not_split.carbon
@@ -8,4 +8,6 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/not_split.carbon
 // CHECK:STDOUT: 2 args: `default_args`, `not_split.carbon`
-// CHECK:STDOUT: not_split.carbon:[[@LINE-10]]: starts with "// Part of the Carbon Language project, ", length 11 lines
+
+not split
+// CHECK:STDOUT: not_split.carbon:[[@LINE-1]]: not split

--- a/testing/file_test/testdata/replace_content.carbon
+++ b/testing/file_test/testdata/replace_content.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //testing/file_test:file_test_base_test --test_arg=--file_tests=testing/file_test/testdata/replace_content.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/replace_content.carbon
+// CHECK:STDOUT: 2 args: `default_args`, `replace_content.carbon`
+
+library "[[@TEST_NAME]]";
+// CHECK:STDOUT: replace_content.carbon:[[@LINE-1]]: library "replace_content";

--- a/testing/file_test/testdata/replace_split_content.carbon
+++ b/testing/file_test/testdata/replace_split_content.carbon
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //testing/file_test:file_test_base_test --test_arg=--file_tests=testing/file_test/testdata/replace_split_content.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/replace_split_content.carbon
+// CHECK:STDOUT: 6 args: `default_args`, `a.carbon`, `b.impl.carbon`, `todo_c.carbon`, `todo_fail_d.carbon`, `triplicate.carbon`
+
+// --- a.carbon
+
+library "[[@TEST_NAME]]";
+// CHECK:STDOUT: a.carbon:[[@LINE-1]]: library "a";
+
+// --- b.impl.carbon
+
+library "[[@TEST_NAME]]";
+// CHECK:STDOUT: b.impl.carbon:[[@LINE-1]]: library "b";
+
+// --- todo_c.carbon
+
+library "[[@TEST_NAME]]";
+// CHECK:STDOUT: todo_c.carbon:[[@LINE-1]]: library "c";
+
+// --- todo_fail_d.carbon
+
+library "[[@TEST_NAME]]";
+// CHECK:STDOUT: todo_fail_d.carbon:[[@LINE-1]]: library "d";
+
+// --- triplicate.carbon
+
+[[@TEST_NAME]][[@TEST_NAME]][[@TEST_NAME]]
+// CHECK:STDOUT: triplicate.carbon:[[@LINE-1]]: triplicatetriplicatetriplicate

--- a/testing/file_test/testdata/two_files.carbon
+++ b/testing/file_test/testdata/two_files.carbon
@@ -11,8 +11,9 @@
 
 // --- a.carbon
 aaa
-// CHECK:STDOUT: a.carbon:[[@LINE-1]]: starts with "aaa\n// CHECK:STDOUT: a.carbon:{{\[\[}}@LINE-1]", length 3 lines
+// CHECK:STDOUT: a.carbon:[[@LINE-1]]: aaa
+
 
 // --- b.carbon
 bbb
-// CHECK:STDOUT: b.carbon:[[@LINE-1]]: starts with "bbb\n// CHECK:STDOUT: b.carbon:{{\[\[}}@LINE-1]", length 2 lines
+// CHECK:STDOUT: b.carbon:[[@LINE-1]]: bbb


### PR DESCRIPTION
This opens the door for replacing all `library ...` lines in toolchain test files with `library "[[@TEST_NAME]]";`. That's technically more typing in a lot of cases, but OTOH means we can just do some copy-paste boilerplate and stop carefully writing library names.

Also cleans up the test setup, because it's getting messy. I'm trying to make it easier to see the divisions of tests and the output associated with them. StringSwitch looked like a way to do this, with a few edits to make it work nicely.