### PR TITLE
Manually free up disk space on macOS

### DIFF
--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -18,9 +18,6 @@ runs:
         xcrun simctl delete all
         sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
-        echo '*** Remove older Xcode versions'
-        sudo rm -rf /Applications/Xcode_14.3.1.app
-
     # Install and cache LLVM 16 from Homebrew.
     # TODO: We can potentially remove this and simplify things when the
     # Homebrew version of LLVM updates to 16 here:

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -9,6 +9,22 @@ inputs:
 runs:
   using: composite
   steps:
+    # Free up disk space as the macOS runners end up using most for Xcode
+    # versions we don't need and iOS simulators.
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo '*** Delete iOS simulators'
+        xcrun simctl delete all
+        sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
+
+        echo '*** Remove older Xcode versions'
+        sudo rm -rf /Applications/Xcode_14.3.1.app
+        sudo rm -rf /Applications/Xcode_15.0.1.app
+        sudo rm -rf /Applications/Xcode_15.1.app
+        sudo rm -rf /Applications/Xcode_15.2.app
+        sudo rm -rf /Applications/Xcode_15.3.app
+
     # Install and cache LLVM 16 from Homebrew.
     # TODO: We can potentially remove this and simplify things when the
     # Homebrew version of LLVM updates to 16 here:

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -20,10 +20,6 @@ runs:
 
         echo '*** Remove older Xcode versions'
         sudo rm -rf /Applications/Xcode_14.3.1.app
-        sudo rm -rf /Applications/Xcode_15.0.1.app
-        sudo rm -rf /Applications/Xcode_15.1.app
-        sudo rm -rf /Applications/Xcode_15.2.app
-        sudo rm -rf /Applications/Xcode_15.3.app
 
     # Install and cache LLVM 16 from Homebrew.
     # TODO: We can potentially remove this and simplify things when the


### PR DESCRIPTION
This should mitigate the effects of a GitHub regression that reduced space on these runners:
https://github.com/actions/runner-images/issues/10511

After this, we're mostly fine, but builds that happen to compile enough of the codebase can bump past it. With this PR we have over 50 GiB of space which is more than we need.

See a test run here: https://github.com/carbon-language/carbon-lang/actions/runs/10780743574