### PR TITLE
Add KeywordModifierSet helper for conversion to (likely SemIR) enums

### DIFF
--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -200,12 +200,10 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
   if (introducer.extern_library.is_valid()) {
     context.TODO(node_id, "extern library");
   }
-  auto inheritance_kind =
-      introducer.modifier_set.HasAnyOf(KeywordModifierSet::Abstract)
-          ? SemIR::Class::Abstract
-      : introducer.modifier_set.HasAnyOf(KeywordModifierSet::Base)
-          ? SemIR::Class::Base
-          : SemIR::Class::Final;
+  SemIR::ClassFields::InheritanceKind inheritance_kind =
+      introducer.modifier_set.ToEnumerator(SemIR::Class::Final)
+          .Case(KeywordModifierSet::Abstract, SemIR::Class::Abstract)
+          .Case(KeywordModifierSet::Base, SemIR::Class::Base);
 
   auto decl_block_id = context.inst_block_stack().Pop();
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -200,10 +200,11 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
   if (introducer.extern_library.is_valid()) {
     context.TODO(node_id, "extern library");
   }
-  SemIR::Class::InheritanceKind inheritance_kind =
-      introducer.modifier_set.ToEnum(SemIR::Class::Final)
+  auto inheritance_kind =
+      introducer.modifier_set.ToEnum<SemIR::Class::InheritanceKind>()
           .Case(KeywordModifierSet::Abstract, SemIR::Class::Abstract)
-          .Case(KeywordModifierSet::Base, SemIR::Class::Base);
+          .Case(KeywordModifierSet::Base, SemIR::Class::Base)
+          .Default(SemIR::Class::Final);
 
   auto decl_block_id = context.inst_block_stack().Pop();
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -201,7 +201,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
     context.TODO(node_id, "extern library");
   }
   SemIR::Class::InheritanceKind inheritance_kind =
-      introducer.modifier_set.ToEnumerator(SemIR::Class::Final)
+      introducer.modifier_set.ToEnum(SemIR::Class::Final)
           .Case(KeywordModifierSet::Abstract, SemIR::Class::Abstract)
           .Case(KeywordModifierSet::Base, SemIR::Class::Base);
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -200,7 +200,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
   if (introducer.extern_library.is_valid()) {
     context.TODO(node_id, "extern library");
   }
-  SemIR::ClassFields::InheritanceKind inheritance_kind =
+  SemIR::Class::InheritanceKind inheritance_kind =
       introducer.modifier_set.ToEnumerator(SemIR::Class::Final)
           .Case(KeywordModifierSet::Abstract, SemIR::Class::Abstract)
           .Case(KeywordModifierSet::Base, SemIR::Class::Base);

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -195,17 +195,14 @@ static auto BuildFunctionDecl(Context& context,
                     parent_scope_inst);
   bool is_extern = introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
   SemIR::FunctionFields::VirtualModifier virtual_modifier =
-      SemIR::FunctionFields::VirtualModifier::None;
-
-  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Virtual)) {
-    virtual_modifier = SemIR::FunctionFields::VirtualModifier::Virtual;
-  }
-  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Abstract)) {
-    virtual_modifier = SemIR::FunctionFields::VirtualModifier::Abstract;
-  }
-  if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Impl)) {
-    virtual_modifier = SemIR::FunctionFields::VirtualModifier::Impl;
-  }
+      introducer.modifier_set
+          .ToEnumerator(SemIR::FunctionFields::VirtualModifier::None)
+          .Case(KeywordModifierSet::Virtual,
+                SemIR::FunctionFields::VirtualModifier::Virtual)
+          .Case(KeywordModifierSet::Abstract,
+                SemIR::FunctionFields::VirtualModifier::Abstract)
+          .Case(KeywordModifierSet::Impl,
+                SemIR::FunctionFields::VirtualModifier::Impl);
   if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
     // TODO: Once we are saving the modifiers for a function, add check that
     // the function may only be defined if it is marked `default` or `final`.

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -194,14 +194,15 @@ static auto BuildFunctionDecl(Context& context,
   DiagnoseModifiers(context, introducer, is_definition, parent_scope_inst_id,
                     parent_scope_inst);
   bool is_extern = introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
-  SemIR::Function::VirtualModifier virtual_modifier =
-      introducer.modifier_set.ToEnum(SemIR::Function::VirtualModifier::None)
+  auto virtual_modifier =
+      introducer.modifier_set.ToEnum<SemIR::Function::VirtualModifier>()
           .Case(KeywordModifierSet::Virtual,
                 SemIR::Function::VirtualModifier::Virtual)
           .Case(KeywordModifierSet::Abstract,
                 SemIR::Function::VirtualModifier::Abstract)
           .Case(KeywordModifierSet::Impl,
-                SemIR::Function::VirtualModifier::Impl);
+                SemIR::Function::VirtualModifier::Impl)
+          .Default(SemIR::Function::VirtualModifier::None);
   if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
     // TODO: Once we are saving the modifiers for a function, add check that
     // the function may only be defined if it is marked `default` or `final`.

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -194,15 +194,14 @@ static auto BuildFunctionDecl(Context& context,
   DiagnoseModifiers(context, introducer, is_definition, parent_scope_inst_id,
                     parent_scope_inst);
   bool is_extern = introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
-  SemIR::FunctionFields::VirtualModifier virtual_modifier =
-      introducer.modifier_set
-          .ToEnum(SemIR::FunctionFields::VirtualModifier::None)
+  SemIR::Function::VirtualModifier virtual_modifier =
+      introducer.modifier_set.ToEnum(SemIR::Function::VirtualModifier::None)
           .Case(KeywordModifierSet::Virtual,
-                SemIR::FunctionFields::VirtualModifier::Virtual)
+                SemIR::Function::VirtualModifier::Virtual)
           .Case(KeywordModifierSet::Abstract,
-                SemIR::FunctionFields::VirtualModifier::Abstract)
+                SemIR::Function::VirtualModifier::Abstract)
           .Case(KeywordModifierSet::Impl,
-                SemIR::FunctionFields::VirtualModifier::Impl);
+                SemIR::Function::VirtualModifier::Impl);
   if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Interface)) {
     // TODO: Once we are saving the modifiers for a function, add check that
     // the function may only be defined if it is marked `default` or `final`.

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -196,7 +196,7 @@ static auto BuildFunctionDecl(Context& context,
   bool is_extern = introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
   SemIR::FunctionFields::VirtualModifier virtual_modifier =
       introducer.modifier_set
-          .ToEnumerator(SemIR::FunctionFields::VirtualModifier::None)
+          .ToEnum(SemIR::FunctionFields::VirtualModifier::None)
           .Case(KeywordModifierSet::Virtual,
                 SemIR::FunctionFields::VirtualModifier::Virtual)
           .Case(KeywordModifierSet::Abstract,

--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -82,7 +82,7 @@ class KeywordModifierSet {
   //                    .Case(KeywordModifierSet::B, SomeEnum::B);
   //   ```
   template <typename T>
-  auto ToEnumerator(T default_value) {
+  auto ToEnumerator(T default_value) -> auto {
     class Converter {
      public:
       Converter(const KeywordModifierSet& set, T default_value)

--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -77,12 +77,12 @@ class KeywordModifierSet {
   // Return a builder that implicitly converts to the specified enumeration type
   // mapping the cases passed to the `Case`s specified. For example:
   //   ```
-  //   SomeEnum e = set.ToEnumerator(SomeEnum::Default)
+  //   SomeEnum e = set.ToEnum(SomeEnum::Default)
   //                    .Case(KeywordModifierSet::A, SomeEnum::A)
   //                    .Case(KeywordModifierSet::B, SomeEnum::B);
   //   ```
   template <typename T>
-  auto ToEnumerator(T default_value) -> auto {
+  auto ToEnum(T default_value) -> auto {
     class Converter {
      public:
       Converter(const KeywordModifierSet& set, T default_value)

--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -87,12 +87,14 @@ class KeywordModifierSet {
      public:
       Converter(const KeywordModifierSet& set, T default_value)
           : set_(set), result_(default_value) {}
+
       auto Case(RawEnumType raw_enumerator, T result) -> Converter& {
         if (set_.HasAnyOf(raw_enumerator)) {
           result_ = result;
         }
         return *this;
       }
+
       operator T() { return result_; }
 
      private:

--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -77,7 +77,7 @@ class KeywordModifierSet {
   }
 
   // Return a builder that returns the new enumeration type once a series of
-  // mapping `Case`s and a final `Default` are provided:
+  // mapping `Case`s and a final `Default` are provided. For example:
   //   ```
   //   auto e = set.ToEnum<SomeEnum>()
   //                .Case(KeywordModifierSet::A, SomeEnum::A)


### PR DESCRIPTION
(based on https://github.com/carbon-language/carbon-lang/pull/4272#discussion_r1751001345)

Could haggle over the name "ToEnum" probably avoids the debate over "enumeration" (the type being returned) v "enumerator" (the value being returned)


