### PR TITLE
Generate and use a manifest for prelude files.

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -2,9 +2,28 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# The prelude, and all of its dependencies.
+load("manifest.bzl", "manifest")
+
+# Raw prelude files.
+filegroup(
+    name = "prelude_files",
+    srcs = ["prelude.carbon"] + glob(["prelude/**/*.carbon"]),
+)
+
+# A list of prelude inputs.
+# This is consumed by //toolchain/install:install_paths.
+manifest(
+    name = "prelude_manifest",
+    srcs = [":prelude_files"],
+    out = "prelude_manifest.txt",
+)
+
+# All files for the toolchain install.
 filegroup(
     name = "prelude",
-    srcs = ["prelude.carbon"] + glob(["prelude/**/*.carbon"]),
+    srcs = [
+        ":prelude_files",
+        ":prelude_manifest.txt",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/core/manifest.bzl
+++ b/core/manifest.bzl
@@ -1,0 +1,25 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Rule for producing a manifest for a filegroup."""
+
+def _manifest(ctx):
+    dir = ctx.build_file_path.removesuffix("BUILD")
+    content = [f.path.removeprefix(dir) for f in ctx.files.srcs]
+    ctx.actions.write(ctx.outputs.out, "\n".join(content) + "\n")
+
+    return [
+        DefaultInfo(
+            files = depset(direct = [ctx.outputs.out]),
+            default_runfiles = ctx.runfiles(files = [ctx.outputs.out]),
+        ),
+    ]
+
+manifest = rule(
+    implementation = _manifest,
+    attrs = {
+        "out": attr.output(mandatory = True),
+        "srcs": attr.label_list(mandatory = True),
+    },
+)

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -829,7 +829,7 @@ auto Driver::Compile(const CompileOptions& options,
   // package-specific search path based on the library name.
   llvm::SmallVector<std::string> prelude;
   if (options.prelude_import && options.phase >= CompileOptions::Phase::Check) {
-    if (auto find = installation_->FindPreludeFiles(); find.ok()) {
+    if (auto find = installation_->ReadPreludeManifest(); find.ok()) {
       prelude = std::move(*find);
     } else {
       error_stream_ << "ERROR: " << find.error() << "\n";

--- a/toolchain/install/install_paths.h
+++ b/toolchain/install/install_paths.h
@@ -87,9 +87,9 @@ class InstallPaths {
   // using Carbon in an environment with an unusual path to the installed files.
   static auto Make(llvm::StringRef install_prefix) -> InstallPaths;
 
-  // Finds the source files that define the prelude and returns a list of their
-  // filenames. The list always includes at least one file.
-  auto FindPreludeFiles() const -> ErrorOr<llvm::SmallVector<std::string>>;
+  // Returns the contents of the prelude manifest file. This is the list of
+  // files that define the prelude, and will always be non-empty on success.
+  auto ReadPreludeManifest() const -> ErrorOr<llvm::SmallVector<std::string>>;
 
   // Check for an error detecting the install paths correctly.
   //

--- a/toolchain/install/install_paths_test_helpers.cpp
+++ b/toolchain/install/install_paths_test_helpers.cpp
@@ -14,7 +14,7 @@ auto AddPreludeFilesToVfs(InstallPaths install_paths,
                           llvm::vfs::InMemoryFileSystem* vfs) -> void {
   // Load the prelude into the test VFS.
   auto real_fs = llvm::vfs::getRealFileSystem();
-  auto prelude = install_paths.FindPreludeFiles();
+  auto prelude = install_paths.ReadPreludeManifest();
   CARBON_CHECK(prelude.ok()) << prelude.error();
 
   for (const auto& path : *prelude) {

--- a/toolchain/install/symlink_filegroup.bzl
+++ b/toolchain/install/symlink_filegroup.bzl
@@ -6,13 +6,10 @@
 
 def _symlink_filegroup_impl(ctx):
     prefix = ctx.attr.out_prefix
-    remove_prefix = ctx.attr.remove_prefix
 
     outputs = []
     for f in ctx.files.srcs:
-        out = ctx.actions.declare_file(
-            prefix + f.short_path.removeprefix(remove_prefix),
-        )
+        out = ctx.actions.declare_file(prefix + f.short_path)
         outputs.append(out)
         ctx.actions.symlink(output = out, target_file = f)
 
@@ -21,8 +18,8 @@ def _symlink_filegroup_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset(outputs),
-            runfiles = ctx.runfiles(files = outputs),
+            files = depset(direct = outputs),
+            default_runfiles = ctx.runfiles(files = outputs),
         ),
     ]
 
@@ -30,7 +27,6 @@ symlink_filegroup = rule(
     implementation = _symlink_filegroup_impl,
     attrs = {
         "out_prefix": attr.string(mandatory = True),
-        "remove_prefix": attr.string(default = ""),
         "srcs": attr.label_list(mandatory = True),
     },
 )

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -36,7 +36,7 @@ class ToolchainFileTest : public FileTestBase {
   auto Run(const llvm::SmallVector<llvm::StringRef>& test_args,
            llvm::vfs::InMemoryFileSystem& fs, llvm::raw_pwrite_stream& stdout,
            llvm::raw_pwrite_stream& stderr) -> ErrorOr<RunResult> override {
-    CARBON_ASSIGN_OR_RETURN(auto prelude, installation_.FindPreludeFiles());
+    CARBON_ASSIGN_OR_RETURN(auto prelude, installation_.ReadPreludeManifest());
     for (const auto& file : prelude) {
       CARBON_RETURN_IF_ERROR(AddFile(fs, file));
     }
@@ -136,10 +136,11 @@ class ToolchainFileTest : public FileTestBase {
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> file =
         llvm::MemoryBuffer::getFile(path);
     if (file.getError()) {
-      return ErrorBuilder() << file.getError().message();
+      return ErrorBuilder()
+             << "Getting `" << path << "`: " << file.getError().message();
     }
     if (!fs.addFile(path, /*ModificationTime=*/0, std::move(*file))) {
-      return ErrorBuilder() << "Duplicate file: " << path;
+      return ErrorBuilder() << "Duplicate file: `" << path << "`";
     }
     return Success();
   }


### PR DESCRIPTION
This removes the directory crawl because bazel doesn't remove files from execroot when the rule generating them would no longer generate them.

Fixes #4288