### PR TITLE
Add `explicit` to match style, appease clang-tidy

### DIFF
--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -88,7 +88,7 @@ class KeywordModifierSet {
   auto ToEnum() -> auto {
     class Converter {
      public:
-      Converter(const KeywordModifierSet& set) : set_(set) {}
+      explicit Converter(const KeywordModifierSet& set) : set_(set) {}
 
       auto Case(RawEnumType raw_enumerator, T result) -> Converter& {
         if (set_.HasAnyOf(raw_enumerator)) {


### PR DESCRIPTION
Introduced by https://github.com/carbon-language/carbon-lang/pull/4290