### PR TITLE
Break out driver environment info into its own type.

### DIFF
--- a/common/vlog.h
+++ b/common/vlog.h
@@ -26,9 +26,11 @@ template <TemplateString FormatStr, typename... Ts>
 
 }  // namespace Carbon::Internal
 
-// Logs when verbose logging is enabled (vlog_stream_ is non-null).
+// Logs when verbose logging is enabled. CARBON_VLOG_TO uses a provided stream;
+// CARBON_VLOG requires a member named `vlog_stream_`.
 //
 // For example:
+//   CARBON_VLOG_TO(vlog_stream, "Verbose message: {0}", "extra information");
 //   CARBON_VLOG("Verbose message: {0}", "extra information");
 //
 // The first argument must be a string literal format string valid for passing
@@ -42,10 +44,13 @@ template <TemplateString FormatStr, typename... Ts>
 // However, the streaming syntax has higher overhead and can inhibit inlining.
 // Code should prefer the format string form, and eventually when all code has
 // migrated the streaming interface will be removed.
-#define CARBON_VLOG(FormatStr, ...)                                          \
-  __builtin_expect(vlog_stream_ == nullptr, true)                            \
-      ? (void)0                                                              \
-      : Carbon::Internal::VLogImpl<"" FormatStr>(vlog_stream_ __VA_OPT__(, ) \
+#define CARBON_VLOG_TO(Stream, FormatStr, ...)                         \
+  __builtin_expect(Stream == nullptr, true)                            \
+      ? (void)0                                                        \
+      : Carbon::Internal::VLogImpl<"" FormatStr>(Stream __VA_OPT__(, ) \
                                                      __VA_ARGS__)
+
+#define CARBON_VLOG(FormatStr, ...) \
+  CARBON_VLOG_TO(vlog_stream_, FormatStr, __VA_ARGS__)
 
 #endif  // CARBON_COMMON_VLOG_H_

--- a/common/vlog_test.cpp
+++ b/common/vlog_test.cpp
@@ -49,5 +49,13 @@ TEST(VLogTest, Disabled) {
   EXPECT_THAT(vlog.TakeStr(), IsEmpty());
 }
 
+TEST(VLogTest, To) {
+  TestRawOstream buffer;
+  CARBON_VLOG_TO(&buffer, "Test");
+  EXPECT_THAT(buffer.TakeStr(), "Test");
+}
+
+TEST(VLogTest, ToNull) { CARBON_VLOG_TO(nullptr, "Unused"); }
+
 }  // namespace
 }  // namespace Carbon::Testing

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -76,7 +76,10 @@ sh_test(
 
 cc_library(
     name = "driver",
-    srcs = ["driver.cpp"],
+    srcs = [
+        "driver.cpp",
+        "driver_env.h",
+    ],
     hdrs = ["driver.h"],
     data = [
         "//toolchain/install:install_lib_data",
@@ -85,6 +88,7 @@ cc_library(
     deps = [
         ":clang_runner",
         "//common:command_line",
+        "//common:ostream",
         "//common:version",
         "//common:vlog",
         "//toolchain/base:value_store",

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -443,7 +443,7 @@ For questions, issues, or bug reports, please use our GitHub project:
 auto Driver::ParseArgs(llvm::ArrayRef<llvm::StringRef> args, Options& options)
     -> CommandLine::ParseResult {
   return CommandLine::Parse(
-      args, output_stream_, error_stream_, Options::Info,
+      args, driver_env_.output_stream, driver_env_.error_stream, Options::Info,
       [&](CommandLine::CommandBuilder& b) { options.Build(b); });
 }
 
@@ -458,7 +458,7 @@ auto Driver::RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> RunResult {
 
   if (options.verbose) {
     // Note this implies streamed output in order to interleave.
-    vlog_stream_ = &error_stream_;
+    driver_env_.vlog_stream = &driver_env_.error_stream;
   }
 
   switch (options.subcommand) {
@@ -476,25 +476,28 @@ auto Driver::ValidateCompileOptions(const CompileOptions& options) const
   switch (options.phase) {
     case Phase::Lex:
       if (options.dump_parse_tree) {
-        error_stream_ << "ERROR: Requested dumping the parse tree but compile "
-                         "phase is limited to '"
-                      << options.phase << "'.\n";
+        driver_env_.error_stream
+            << "ERROR: Requested dumping the parse tree but compile "
+               "phase is limited to '"
+            << options.phase << "'.\n";
         return false;
       }
       [[fallthrough]];
     case Phase::Parse:
       if (options.dump_sem_ir) {
-        error_stream_ << "ERROR: Requested dumping the SemIR but compile phase "
-                         "is limited to '"
-                      << options.phase << "'.\n";
+        driver_env_.error_stream
+            << "ERROR: Requested dumping the SemIR but compile phase "
+               "is limited to '"
+            << options.phase << "'.\n";
         return false;
       }
       [[fallthrough]];
     case Phase::Check:
       if (options.dump_llvm_ir) {
-        error_stream_ << "ERROR: Requested dumping the LLVM IR but compile "
-                         "phase is limited to '"
-                      << options.phase << "'.\n";
+        driver_env_.error_stream
+            << "ERROR: Requested dumping the LLVM IR but compile "
+               "phase is limited to '"
+            << options.phase << "'.\n";
         return false;
       }
       [[fallthrough]];
@@ -509,15 +512,15 @@ auto Driver::ValidateCompileOptions(const CompileOptions& options) const
 // Ties together information for a file being compiled.
 class Driver::CompilationUnit {
  public:
-  explicit CompilationUnit(Driver* driver, const CompileOptions& options,
+  explicit CompilationUnit(DriverEnv& driver_env, const CompileOptions& options,
                            const CodegenOptions& codegen_options,
                            DiagnosticConsumer* consumer,
                            llvm::StringRef input_filename)
-      : driver_(driver),
+      : driver_env_(driver_env),
         options_(options),
         codegen_options_(codegen_options),
         input_filename_(input_filename),
-        vlog_stream_(driver_->vlog_stream_) {
+        vlog_stream_(driver_env_.vlog_stream) {
     if (vlog_stream_ != nullptr || options_.stream_errors) {
       consumer_ = consumer;
     } else {
@@ -535,7 +538,7 @@ class Driver::CompilationUnit {
       if (input_filename_ == "-") {
         source_ = SourceBuffer::MakeFromStdin(*consumer_);
       } else {
-        source_ = SourceBuffer::MakeFromFile(driver_->fs_, input_filename_,
+        source_ = SourceBuffer::MakeFromFile(driver_env_.fs, input_filename_,
                                              *consumer_);
       }
     });
@@ -553,7 +556,7 @@ class Driver::CompilationUnit {
             [&] { tokens_ = Lex::Lex(value_stores_, *source_, *consumer_); });
     if (options_.dump_tokens && IncludeInDumps()) {
       consumer_->Flush();
-      driver_->output_stream_ << tokens_;
+      driver_env_.output_stream << tokens_;
     }
     if (mem_usage_) {
       mem_usage_->Collect("tokens_", *tokens_);
@@ -575,9 +578,9 @@ class Driver::CompilationUnit {
       consumer_->Flush();
       const auto& tree_and_subtrees = GetParseTreeAndSubtrees();
       if (options_.preorder_parse_tree) {
-        tree_and_subtrees.PrintPreorder(driver_->output_stream_);
+        tree_and_subtrees.PrintPreorder(driver_env_.output_stream);
       } else {
-        tree_and_subtrees.Print(driver_->output_stream_);
+        tree_and_subtrees.Print(driver_env_.output_stream);
       }
     }
     if (mem_usage_) {
@@ -618,9 +621,9 @@ class Driver::CompilationUnit {
 
     if (options_.dump_raw_sem_ir && IncludeInDumps()) {
       CARBON_VLOG("*** Raw SemIR::File ***\n{0}\n", *sem_ir_);
-      sem_ir_->Print(driver_->output_stream_, options_.builtin_sem_ir);
+      sem_ir_->Print(driver_env_.output_stream, options_.builtin_sem_ir);
       if (options_.dump_sem_ir) {
-        driver_->output_stream_ << "\n";
+        driver_env_.output_stream << "\n";
       }
     }
 
@@ -632,7 +635,7 @@ class Driver::CompilationUnit {
         formatter.Print(*vlog_stream_);
       }
       if (print) {
-        formatter.Print(driver_->output_stream_);
+        formatter.Print(driver_env_.output_stream);
       }
     }
     if (sem_ir_->has_errors()) {
@@ -660,7 +663,7 @@ class Driver::CompilationUnit {
                      /*IsForDebug=*/true);
     }
     if (options_.dump_llvm_ir && IncludeInDumps()) {
-      module_->print(driver_->output_stream_, /*AAW=*/nullptr,
+      module_->print(driver_env_.output_stream, /*AAW=*/nullptr,
                      /*ShouldPreserveUseListOrder=*/true);
     }
   }
@@ -674,12 +677,12 @@ class Driver::CompilationUnit {
   // actions on the CompilationUnit.
   auto PostCompile() -> void {
     if (options_.dump_shared_values && IncludeInDumps()) {
-      Yaml::Print(driver_->output_stream_,
+      Yaml::Print(driver_env_.output_stream,
                   value_stores_.OutputYaml(input_filename_));
     }
     if (mem_usage_) {
       mem_usage_->Collect("value_stores_", value_stores_);
-      Yaml::Print(driver_->output_stream_,
+      Yaml::Print(driver_env_.output_stream,
                   mem_usage_->OutputYaml(input_filename_));
     }
 
@@ -696,7 +699,7 @@ class Driver::CompilationUnit {
   // Do codegen. Returns true on success.
   auto RunCodeGenHelper() -> bool {
     std::optional<CodeGen> codegen = CodeGen::Make(
-        *module_, codegen_options_.target, driver_->error_stream_);
+        *module_, codegen_options_.target, driver_env_.error_stream);
     if (!codegen) {
       return false;
     }
@@ -710,11 +713,11 @@ class Driver::CompilationUnit {
       // textual assembly output are all somewhat linked flags. We should add
       // some validation that they are used correctly.
       if (options_.force_obj_output) {
-        if (!codegen->EmitObject(driver_->output_stream_)) {
+        if (!codegen->EmitObject(driver_env_.output_stream)) {
           return false;
         }
       } else {
-        if (!codegen->EmitAssembly(driver_->output_stream_)) {
+        if (!codegen->EmitAssembly(driver_env_.output_stream)) {
           return false;
         }
       }
@@ -723,7 +726,7 @@ class Driver::CompilationUnit {
       if (output_filename.empty()) {
         if (!source_->is_regular_file()) {
           // Don't invent file names like `-.o` or `/dev/stdin.o`.
-          driver_->error_stream_
+          driver_env_.error_stream
               << "ERROR: Output file name must be specified for input '"
               << input_filename_ << "' that is not a regular file.\n";
           return false;
@@ -744,9 +747,9 @@ class Driver::CompilationUnit {
       llvm::raw_fd_ostream output_file(output_filename, ec,
                                        llvm::sys::fs::OF_None);
       if (ec) {
-        driver_->error_stream_ << "ERROR: Could not open output file '"
-                               << output_filename << "': " << ec.message()
-                               << "\n";
+        driver_env_.error_stream << "ERROR: Could not open output file '"
+                                 << output_filename << "': " << ec.message()
+                                 << "\n";
         return false;
       }
       if (options_.asm_output) {
@@ -789,7 +792,7 @@ class Driver::CompilationUnit {
            !input_filename_.starts_with(options_.exclude_dump_file_prefix);
   }
 
-  Driver* driver_;
+  DriverEnv& driver_env_;
   SharedValueStores value_stores_;
   const CompileOptions& options_;
   const CodegenOptions& codegen_options_;
@@ -828,29 +831,32 @@ auto Driver::Compile(const CompileOptions& options,
   // package-specific search path based on the library name.
   llvm::SmallVector<std::string> prelude;
   if (options.prelude_import && options.phase >= CompileOptions::Phase::Check) {
-    if (auto find = installation_->ReadPreludeManifest(); find.ok()) {
+    if (auto find = driver_env_.installation->ReadPreludeManifest();
+        find.ok()) {
       prelude = std::move(*find);
     } else {
-      error_stream_ << "ERROR: " << find.error() << "\n";
+      driver_env_.error_stream << "ERROR: " << find.error() << "\n";
       return {.success = false};
     }
   }
 
   // Prepare CompilationUnits before building scope exit handlers.
-  StreamDiagnosticConsumer stream_consumer(error_stream_);
+  StreamDiagnosticConsumer stream_consumer(driver_env_.error_stream);
   llvm::SmallVector<std::unique_ptr<CompilationUnit>> units;
   units.reserve(prelude.size() + options.input_filenames.size());
 
   // Add the prelude files.
   for (const auto& input_filename : prelude) {
-    units.push_back(std::make_unique<CompilationUnit>(
-        this, options, codegen_options, &stream_consumer, input_filename));
+    units.push_back(
+        std::make_unique<CompilationUnit>(driver_env_, options, codegen_options,
+                                          &stream_consumer, input_filename));
   }
 
   // Add the input source files.
   for (const auto& input_filename : options.input_filenames) {
-    units.push_back(std::make_unique<CompilationUnit>(
-        this, options, codegen_options, &stream_consumer, input_filename));
+    units.push_back(
+        std::make_unique<CompilationUnit>(driver_env_, options, codegen_options,
+                                          &stream_consumer, input_filename));
   }
 
   auto on_exit = llvm::make_scope_exit([&]() {
@@ -909,10 +915,11 @@ auto Driver::Compile(const CompileOptions& options,
     node_converters.emplace_back(unit.tokens, unit.tokens->source().filename(),
                                  unit.get_parse_tree_and_subtrees);
   }
-  CARBON_VLOG("*** Check::CheckParseTrees ***\n");
+  CARBON_VLOG_TO(driver_env_.vlog_stream, "*** Check::CheckParseTrees ***\n");
   Check::CheckParseTrees(check_units, node_converters, options.prelude_import,
-                         vlog_stream_);
-  CARBON_VLOG("*** Check::CheckParseTrees done ***\n");
+                         driver_env_.vlog_stream);
+  CARBON_VLOG_TO(driver_env_.vlog_stream,
+                 "*** Check::CheckParseTrees done ***\n");
   for (auto& unit : units) {
     if (unit->has_source()) {
       unit->PostCheck();
@@ -925,7 +932,8 @@ auto Driver::Compile(const CompileOptions& options,
   // Unlike previous steps, errors block further progress.
   if (std::any_of(units.begin(), units.end(),
                   [&](const auto& unit) { return !unit->success(); })) {
-    CARBON_VLOG("*** Stopping before lowering due to errors ***");
+    CARBON_VLOG_TO(driver_env_.vlog_stream,
+                   "*** Stopping before lowering due to errors ***");
     return make_result();
   }
 
@@ -1010,7 +1018,8 @@ auto Driver::Link(const LinkOptions& options,
   clang_args.append(options.object_filenames.begin(),
                     options.object_filenames.end());
 
-  ClangRunner runner(installation_, codegen_options.target, vlog_stream_);
+  ClangRunner runner(driver_env_.installation, codegen_options.target,
+                     driver_env_.vlog_stream);
   return {.success = runner.Run(clang_args)};
 }
 

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -8,9 +8,7 @@
 #include "common/command_line.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/VirtualFileSystem.h"
-#include "llvm/Support/raw_ostream.h"
-#include "toolchain/install/install_paths.h"
+#include "toolchain/driver/driver_env.h"
 
 namespace Carbon {
 
@@ -36,10 +34,10 @@ class Driver {
   Driver(llvm::vfs::FileSystem& fs, const InstallPaths* installation,
          llvm::raw_pwrite_stream& output_stream,
          llvm::raw_pwrite_stream& error_stream)
-      : fs_(fs),
-        installation_(installation),
-        output_stream_(output_stream),
-        error_stream_(error_stream) {}
+      : driver_env_{.fs = fs,
+                    .installation = installation,
+                    .output_stream = output_stream,
+                    .error_stream = error_stream} {}
 
   // Parses the given arguments into both a subcommand to select the operation
   // to perform and any arguments to that subcommand.
@@ -73,19 +71,7 @@ class Driver {
   auto Link(const LinkOptions& options, const CodegenOptions& codegen_options)
       -> RunResult;
 
-  // The filesystem for source code.
-  llvm::vfs::FileSystem& fs_;
-
-  // Helper to locate the toolchain installation's files.
-  const InstallPaths* installation_;
-
-  // Standard output; stdout.
-  llvm::raw_pwrite_stream& output_stream_;
-  // Error output; stderr.
-  llvm::raw_pwrite_stream& error_stream_;
-
-  // For CARBON_VLOG.
-  llvm::raw_pwrite_stream* vlog_stream_ = nullptr;
+  DriverEnv driver_env_;
 };
 
 }  // namespace Carbon

--- a/toolchain/driver/driver_env.h
+++ b/toolchain/driver/driver_env.h
@@ -1,0 +1,32 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_ENV_H_
+#define CARBON_TOOLCHAIN_DRIVER_DRIVER_ENV_H_
+
+#include "common/ostream.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "toolchain/install/install_paths.h"
+
+namespace Carbon {
+
+struct DriverEnv {
+  // The filesystem for source code.
+  llvm::vfs::FileSystem& fs;
+
+  // Helper to locate the toolchain installation's files.
+  const InstallPaths* installation;
+
+  // Standard output; stdout.
+  llvm::raw_pwrite_stream& output_stream;
+  // Error output; stderr.
+  llvm::raw_pwrite_stream& error_stream;
+
+  // For CARBON_VLOG.
+  llvm::raw_pwrite_stream* vlog_stream = nullptr;
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_TOOLCHAIN_DRIVER_DRIVER_ENV_H_


### PR DESCRIPTION
I want to split commands out so that we don't keep piling onto driver (particularly as I'm eyeing clang-related commands). This extracts out the DriverEnv so that it can be easily shared, with the CompilationUnit as an example.

CARBON_VLOG_TO is to remove the vlog_stream_ requirement of CARBON_VLOG.