### PR TITLE
Refactor link and compile into subcommand objects.

### DIFF
--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -86,7 +86,10 @@ cc_library(
         "link_subcommand.cpp",
         "link_subcommand.h",
     ],
-    hdrs = ["driver.h"],
+    hdrs = [
+        "driver.h",
+        "driver_subcommand.h",
+    ],
     data = [
         "//toolchain/install:install_lib_data",
     ],

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -10,6 +10,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/codegen_options.h"
+#include "toolchain/driver/driver_env.h"
+#include "toolchain/driver/driver_subcommand.h"
 
 namespace Carbon {
 
@@ -30,8 +32,9 @@ struct CompileOptions {
   friend auto operator<<(llvm::raw_ostream& out, Phase phase)
       -> llvm::raw_ostream&;
 
-  auto Build(CommandLine::CommandBuilder& b, CodegenOptions& codegen_options)
-      -> void;
+  auto Build(CommandLine::CommandBuilder& b) -> void;
+
+  CodegenOptions codegen_options;
 
   Phase phase;
 
@@ -55,6 +58,21 @@ struct CompileOptions {
   bool include_debug_info = true;
 
   llvm::StringRef exclude_dump_file_prefix;
+};
+
+// Implements the compile subcommand of the driver.
+class CompileSubcommand : public DriverSubcommand {
+ public:
+  auto BuildOptions(CommandLine::CommandBuilder& b) { options_.Build(b); }
+
+  auto Run(DriverEnv& driver_env) -> DriverResult override;
+
+ private:
+  // Does custom validation of the compile-subcommand options structure beyond
+  // what the command line parsing library supports.
+  auto ValidateOptions(DriverEnv& driver_env) const -> bool;
+
+  CompileOptions options_;
 };
 
 }  // namespace Carbon

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -95,7 +95,7 @@ auto Driver::RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> DriverResult {
     driver_env_.vlog_stream = &driver_env_.error_stream;
   }
 
-  options.subcommand->Run(driver_env_);
+  return options.subcommand->Run(driver_env_);
 }
 
 }  // namespace Carbon

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -96,8 +96,6 @@ auto Driver::RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> DriverResult {
   }
 
   options.subcommand->Run(driver_env_);
-
-  llvm_unreachable("All subcommands handled!");
 }
 
 }  // namespace Carbon

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -94,7 +94,7 @@ auto Driver::RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> DriverResult {
     // Note this implies streamed output in order to interleave.
     driver_env_.vlog_stream = &driver_env_.error_stream;
   }
-
+  CARBON_CHECK(options.subcommand != nullptr);
   return options.subcommand->Run(driver_env_);
 }
 

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -11,6 +11,7 @@
 #include "toolchain/driver/codegen_options.h"
 #include "toolchain/driver/compile_subcommand.h"
 #include "toolchain/driver/driver_env.h"
+#include "toolchain/driver/driver_subcommand.h"
 #include "toolchain/driver/link_subcommand.h"
 
 namespace Carbon {
@@ -22,16 +23,6 @@ namespace Carbon {
 // with the language.
 class Driver {
  public:
-  // The result of RunCommand().
-  struct RunResult {
-    // Overall success result.
-    bool success;
-
-    // Per-file success results. May be empty if files aren't individually
-    // processed.
-    llvm::SmallVector<std::pair<std::string, bool>> per_file_success;
-  };
-
   // Constructs a driver with any error or informational output directed to a
   // specified stream.
   Driver(llvm::vfs::FileSystem& fs, const InstallPaths* installation,
@@ -48,38 +39,9 @@ class Driver {
   // Returns true if the operation succeeds. If the operation fails, returns
   // false and any information about the failure is printed to the registered
   // error stream (stderr by default).
-  auto RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> RunResult;
+  auto RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> DriverResult;
 
  private:
-  struct Options;
-
-  // Implementation is in compile_subcommand.cpp.
-  // TODO: Remove from Driver.
-  class CompilationUnit;
-
-  // Delegates to the command line library to parse the arguments and store the
-  // results in a custom `Options` structure that the rest of the driver uses.
-  auto ParseArgs(llvm::ArrayRef<llvm::StringRef> args, Options& options)
-      -> CommandLine::ParseResult;
-
-  // Does custom validation of the compile-subcommand options structure beyond
-  // what the command line parsing library supports.
-  // Implementation is in compile_subcommand.cpp.
-  // TODO: Remove from Driver.
-  auto ValidateCompileOptions(const CompileOptions& options) const -> bool;
-
-  // Implements the compile subcommand of the driver.
-  // Implementation is in compile_subcommand.cpp.
-  // TODO: Remove from Driver.
-  auto Compile(const CompileOptions& options,
-               const CodegenOptions& codegen_options) -> RunResult;
-
-  // Implements the link subcommand of the driver.
-  // Implementation is in link_subcommand.cpp.
-  // TODO: Remove from Driver.
-  auto Link(const LinkOptions& options, const CodegenOptions& codegen_options)
-      -> RunResult;
-
   DriverEnv driver_env_;
 };
 

--- a/toolchain/driver/driver_subcommand.h
+++ b/toolchain/driver/driver_subcommand.h
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_SUBCOMMAND_H_
+#define CARBON_TOOLCHAIN_DRIVER_DRIVER_SUBCOMMAND_H_
+
+#include "common/ostream.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "toolchain/driver/driver_env.h"
+#include "toolchain/install/install_paths.h"
+
+namespace Carbon {
+
+// The result of a driver run.
+struct DriverResult {
+  // Overall success result.
+  bool success;
+
+  // Per-file success results. May be empty if files aren't individually
+  // processed.
+  llvm::SmallVector<std::pair<std::string, bool>> per_file_success;
+};
+
+// A subcommand for the driver.
+class DriverSubcommand {
+ public:
+  virtual auto Run(DriverEnv& driver_env) -> DriverResult = 0;
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_TOOLCHAIN_DRIVER_DRIVER_SUBCOMMAND_H_

--- a/toolchain/driver/link_subcommand.h
+++ b/toolchain/driver/link_subcommand.h
@@ -9,6 +9,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/codegen_options.h"
+#include "toolchain/driver/driver_env.h"
+#include "toolchain/driver/driver_subcommand.h"
 
 namespace Carbon {
 
@@ -18,11 +20,22 @@ namespace Carbon {
 struct LinkOptions {
   static const CommandLine::CommandInfo Info;
 
-  auto Build(CommandLine::CommandBuilder& b, CodegenOptions& codegen_options)
-      -> void;
+  auto Build(CommandLine::CommandBuilder& b) -> void;
 
+  CodegenOptions codegen_options;
   llvm::StringRef output_filename;
   llvm::SmallVector<llvm::StringRef> object_filenames;
+};
+
+// Implements the link subcommand of the driver.
+class LinkSubcommand : public DriverSubcommand {
+ public:
+  auto BuildOptions(CommandLine::CommandBuilder& b) { options_.Build(b); }
+
+  auto Run(DriverEnv& driver_env) -> DriverResult override;
+
+ private:
+  LinkOptions options_;
 };
 
 }  // namespace Carbon


### PR DESCRIPTION
Note the purpose here is to make it simpler to add more subcommands, without adding a lot of things to Driver.

This creates a copy of CodegenOptions, but it was double-registered at present which felt odd. It's also fairly small right now. If this becomes an issue, maybe we can look into using optional for delayed initialization, or just go back to straight sharing.