### PR TITLE
Switch to ctx.label.package for rule, and adjust relative path handling

### DIFF
--- a/core/manifest.bzl
+++ b/core/manifest.bzl
@@ -5,7 +5,7 @@
 """Rule for producing a manifest for a filegroup."""
 
 def _manifest(ctx):
-    dir = ctx.build_file_path.removesuffix("BUILD")
+    dir = ctx.label.package + "/"
     content = [f.path.removeprefix(dir) for f in ctx.files.srcs]
     ctx.actions.write(ctx.outputs.out, "\n".join(content) + "\n")
 

--- a/toolchain/install/symlink_filegroup.bzl
+++ b/toolchain/install/symlink_filegroup.bzl
@@ -9,7 +9,11 @@ def _symlink_filegroup_impl(ctx):
 
     outputs = []
     for f in ctx.files.srcs:
-        out = ctx.actions.declare_file(prefix + f.short_path)
+        # We normalize the path to be package-relative in order to ensure
+        # consistent paths across possible repositories.
+        relative_path = f.short_path.removeprefix(f.owner.package)
+
+        out = ctx.actions.declare_file(prefix + "core/" + relative_path)
         outputs.append(out)
         ctx.actions.symlink(output = out, target_file = f)
 


### PR DESCRIPTION
build_file_path works with bazel but I'd missed it's [deprecated](https://bazel.build/rules/lib/builtins/ctx#build_file_path).

Relative path handling also could use some improvements.

Both of these are really to support non-standard environments, essentially.