### PR TITLE
Assert that the llvm::Function is created with the same name as requested

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -250,7 +250,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
                              mangled_name, llvm_module());
 
   CARBON_CHECK(llvm_function->getName() == mangled_name,
-               "Do not rely on llvm::Function overload renaming");
+               "Mangled name collision: {0}", mangled_name);
 
   // Set up parameters and the return slot.
   for (auto [inst_id, arg] :

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -249,6 +249,9 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
       llvm::Function::Create(function_type, llvm::Function::ExternalLinkage,
                              mangled_name, llvm_module());
 
+  CARBON_CHECK(llvm_function->getName() == mangled_name,
+               "Do not rely on llvm::Function overload renaming");
+
   // Set up parameters and the return slot.
   for (auto [inst_id, arg] :
        llvm::zip_equal(param_inst_ids, llvm_function->args())) {


### PR DESCRIPTION
This will catch some cases of bugs in the name mangling logic - if within a single file we incorrectly mangle two distinct entities to the same name, llvm::Function will assign a new name to the second copy showing one of the two entities should have a distinct name/is missing something in their mangling.

