### PR TITLE
Move 'core' directory prefix

### DIFF
--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -35,7 +35,7 @@ write_file(
 symlink_filegroup(
     name = "symlink_core",
     srcs = ["//core:prelude"],
-    out_prefix = "prefix_root/lib/carbon/",
+    out_prefix = "prefix_root/lib/carbon/core/",
     visibility = ["//visibility:private"],
 )
 

--- a/toolchain/install/symlink_filegroup.bzl
+++ b/toolchain/install/symlink_filegroup.bzl
@@ -13,7 +13,7 @@ def _symlink_filegroup_impl(ctx):
         # consistent paths across possible repositories.
         relative_path = f.short_path.removeprefix(f.owner.package)
 
-        out = ctx.actions.declare_file(prefix + "core/" + relative_path)
+        out = ctx.actions.declare_file(prefix + relative_path)
         outputs.append(out)
         ctx.actions.symlink(output = out, target_file = f)
 


### PR DESCRIPTION
This fixes a bit of sloppiness from #4305, the prefix should really be specified in one place.