### PR TITLE
Improve access checking code

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -299,7 +299,8 @@ auto Context::LookupNameInDecl(SemIR::LocId loc_id, SemIR::NameId name_id,
 }
 
 auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
-                                    SemIR::NameId name_id) -> LookupResult {
+                                    SemIR::NameId name_id, bool required)
+    -> LookupResult {
   // TODO: Check for shadowed lookup results.
 
   // Find the results from ancestor lexical scopes. These will be combined with
@@ -327,8 +328,11 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
             .inst_id = lexical_result};
   }
 
-  // We didn't find anything at all.
-  DiagnoseNameNotFound(node_id, name_id);
+  if (required) {
+    // We didn't find anything at all.
+    DiagnoseNameNotFound(node_id, name_id);
+  }
+
   return {.specific_id = SemIR::SpecificId::Invalid,
           .inst_id = SemIR::InstId::BuiltinError};
 }
@@ -368,18 +372,14 @@ static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
   // TODO: Support scoped entities other than just classes.
   auto class_info = context.classes().Get(class_type->class_id);
 
-  // TODO: Support passing AccessKind to diagnostics.
   CARBON_DIAGNOSTIC(ClassInvalidMemberAccess, Error,
                     "Cannot access {0} member `{1}` of type `{2}`.",
-                    llvm::StringLiteral, SemIR::NameId, SemIR::TypeId);
+                    SemIR::AccessKind, SemIR::NameId, SemIR::TypeId);
   CARBON_DIAGNOSTIC(ClassMemberDefinition, Note,
-                    "The {0} member `{1}` is defined here.",
-                    llvm::StringLiteral, SemIR::NameId);
+                    "The {0} member `{1}` is defined here.", SemIR::AccessKind,
+                    SemIR::NameId);
 
   auto parent_type_id = class_info.self_type_id;
-  auto access_desc = access_kind == SemIR::AccessKind::Private
-                         ? llvm::StringLiteral("private")
-                         : llvm::StringLiteral("protected");
 
   if (access_kind == SemIR::AccessKind::Private && is_parent_access) {
     if (auto base_decl = context.insts().TryGetAsIfValid<SemIR::BaseDecl>(
@@ -395,9 +395,9 @@ static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
   }
 
   context.emitter()
-      .Build(loc, ClassInvalidMemberAccess, access_desc, name_id,
+      .Build(loc, ClassInvalidMemberAccess, access_kind, name_id,
              parent_type_id)
-      .Note(scope_result_id, ClassMemberDefinition, access_desc, name_id)
+      .Note(scope_result_id, ClassMemberDefinition, access_kind, name_id)
       .Emit();
 }
 
@@ -409,7 +409,7 @@ static auto IsAccessProhibited(std::optional<AccessInfo> access_info,
     return false;
   }
 
-  switch (access_kind) {
+  switch (access_kind.value()) {
     case SemIR::AccessKind::Public:
       return false;
     case SemIR::AccessKind::Protected:

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -328,8 +328,8 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
             .inst_id = lexical_result};
   }
 
+  // We didn't find anything at all.
   if (required) {
-    // We didn't find anything at all.
     DiagnoseNameNotFound(node_id, name_id);
   }
 
@@ -409,7 +409,7 @@ static auto IsAccessProhibited(std::optional<AccessInfo> access_info,
     return false;
   }
 
-  switch (access_kind.value()) {
+  switch (access_kind) {
     case SemIR::AccessKind::Public:
       return false;
     case SemIR::AccessKind::Protected:

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -176,8 +176,8 @@ class Context {
                         SemIR::NameScopeId scope_id) -> SemIR::InstId;
 
   // Performs an unqualified name lookup, returning the referenced instruction.
-  auto LookupUnqualifiedName(Parse::NodeId node_id, SemIR::NameId name_id)
-      -> LookupResult;
+  auto LookupUnqualifiedName(Parse::NodeId node_id, SemIR::NameId name_id,
+                             bool required = true) -> LookupResult;
 
   // Performs a name lookup in a specified scope, returning the referenced
   // instruction. Does not look into extended scopes. Returns an invalid

--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -143,19 +143,12 @@ library "[[@TEST_NAME]]";
 
 class A {
   private let internal: i32 = 10;
-  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE+13]]:16: ERROR: Member access into incomplete class `A`.
+  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE+6]]:16: ERROR: Member access into incomplete class `A`.
   // CHECK:STDERR:   let y: i32 = Self.internal;
   // CHECK:STDERR:                ^~~~~~~~~~~~~
   // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
   // CHECK:STDERR: class A {
   // CHECK:STDERR: ^~~~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE+6]]:16: ERROR: Cannot access private member `internal` of type `A`.
-  // CHECK:STDERR:   let y: i32 = Self.internal;
-  // CHECK:STDERR:                ^~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE-11]]:15: The private member `internal` is defined here.
-  // CHECK:STDERR:   private let internal: i32 = 10;
-  // CHECK:STDERR:               ^~~~~~~~
   let y: i32 = Self.internal;
 }
 
@@ -631,12 +624,12 @@ class A {
 // CHECK:STDOUT:   %.loc5_25.2: type = converted %int.make_type_32.loc5, %.loc5_25.1 [template = i32]
 // CHECK:STDOUT:   %.loc5_31: i32 = int_literal 10 [template = constants.%.2]
 // CHECK:STDOUT:   %internal: i32 = bind_name internal, %.loc5_31
-// CHECK:STDOUT:   %int.make_type_32.loc19: init type = call constants.%Int32() [template = i32]
-// CHECK:STDOUT:   %.loc19_10.1: type = value_of_initializer %int.make_type_32.loc19 [template = i32]
-// CHECK:STDOUT:   %.loc19_10.2: type = converted %int.make_type_32.loc19, %.loc19_10.1 [template = i32]
+// CHECK:STDOUT:   %int.make_type_32.loc12: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc12_10.1: type = value_of_initializer %int.make_type_32.loc12 [template = i32]
+// CHECK:STDOUT:   %.loc12_10.2: type = converted %int.make_type_32.loc12, %.loc12_10.1 [template = i32]
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%A [template = constants.%A]
-// CHECK:STDOUT:   %internal.ref: <error> = name_ref internal, <error> [template = <error>]
-// CHECK:STDOUT:   %y: i32 = bind_name y, <error>
+// CHECK:STDOUT:   %internal.ref: i32 = name_ref internal, %internal
+// CHECK:STDOUT:   %y: i32 = bind_name y, %internal.ref
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A

--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -137,19 +137,19 @@ let x: i32 = A.x;
 // CHECK:STDERR:
 let y: i32 = A.y;
 
-// --- fail_todo_global_self_access.carbon
+// --- fail_global_self_access.carbon
 
 library "[[@TEST_NAME]]";
 
 class A {
-  private let internal: i32 = 10;
-  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE+6]]:16: ERROR: Member access into incomplete class `A`.
-  // CHECK:STDERR:   let y: i32 = Self.internal;
-  // CHECK:STDERR:                ^~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_global_self_access.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
-  // CHECK:STDERR: class A {
-  // CHECK:STDERR: ^~~~~~~~~
-  let y: i32 = Self.internal;
+  private fn F() {}
+  // CHECK:STDERR: fail_global_self_access.carbon:[[@LINE+6]]:20: ERROR: No return expression should be provided in this context.
+  // CHECK:STDERR:   private fn G() { return Self.F(); }
+  // CHECK:STDERR:                    ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_global_self_access.carbon:[[@LINE+3]]:3: There was no return type provided.
+  // CHECK:STDERR:   private fn G() { return Self.F(); }
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
+  private fn G() { return Self.F(); }
 }
 
 // CHECK:STDOUT: --- fail_private_field_access.carbon
@@ -583,20 +583,21 @@ class A {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_todo_global_self_access.carbon
+// CHECK:STDOUT: --- fail_global_self_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %A: type = class_type @A [template]
-// CHECK:STDOUT:   %Int32.type: type = fn_type @Int32 [template]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %Int32: %Int32.type = struct_value () [template]
-// CHECK:STDOUT:   %.2: i32 = int_literal 10 [template]
-// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %.3: type = ptr_type %.2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
-// CHECK:STDOUT:     .Int32 = %import_ref
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/operators
 // CHECK:STDOUT:     import Core//prelude/types
@@ -606,7 +607,6 @@ class A {
 // CHECK:STDOUT:     import Core//prelude/operators/comparison
 // CHECK:STDOUT:     import Core//prelude/types/bool
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: %Int32.type = import_ref Core//prelude/types, inst+4, loaded [template = constants.%Int32]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -619,23 +619,25 @@ class A {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
-// CHECK:STDOUT:   %int.make_type_32.loc5: init type = call constants.%Int32() [template = i32]
-// CHECK:STDOUT:   %.loc5_25.1: type = value_of_initializer %int.make_type_32.loc5 [template = i32]
-// CHECK:STDOUT:   %.loc5_25.2: type = converted %int.make_type_32.loc5, %.loc5_25.1 [template = i32]
-// CHECK:STDOUT:   %.loc5_31: i32 = int_literal 10 [template = constants.%.2]
-// CHECK:STDOUT:   %internal: i32 = bind_name internal, %.loc5_31
-// CHECK:STDOUT:   %int.make_type_32.loc12: init type = call constants.%Int32() [template = i32]
-// CHECK:STDOUT:   %.loc12_10.1: type = value_of_initializer %int.make_type_32.loc12 [template = i32]
-// CHECK:STDOUT:   %.loc12_10.2: type = converted %int.make_type_32.loc12, %.loc12_10.1 [template = i32]
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%A [template = constants.%A]
-// CHECK:STDOUT:   %internal.ref: i32 = name_ref internal, %internal
-// CHECK:STDOUT:   %y: i32 = bind_name y, %internal.ref
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A
-// CHECK:STDOUT:   .internal [private] = %internal
-// CHECK:STDOUT:   .y = %y
+// CHECK:STDOUT:   .F [private] = %F.decl
+// CHECK:STDOUT:   .G [private] = %G.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Int32() -> type = "int.make_type_32";
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%A [template = constants.%A]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @A.%F.decl [template = constants.%F]
+// CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
+// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -128,28 +128,21 @@ class A {
 // CHECK:STDERR:                 ^
 // CHECK:STDERR:
 let x: i32 = A.x;
-// CHECK:STDERR: fail_global_access.carbon:[[@LINE+7]]:14: ERROR: Cannot access private member `y` of type `A`.
+// CHECK:STDERR: fail_global_access.carbon:[[@LINE+6]]:14: ERROR: Cannot access private member `y` of type `A`.
 // CHECK:STDERR: let y: i32 = A.y;
 // CHECK:STDERR:              ^~~
 // CHECK:STDERR: fail_global_access.carbon:[[@LINE-14]]:15: The private member `y` is defined here.
 // CHECK:STDERR:   private let y: i32 = 5;
 // CHECK:STDERR:               ^
-// CHECK:STDERR:
 let y: i32 = A.y;
 
-// --- fail_global_self_access.carbon
+// --- self_access.carbon
 
 library "[[@TEST_NAME]]";
 
 class A {
   private fn F() {}
-  // CHECK:STDERR: fail_global_self_access.carbon:[[@LINE+6]]:20: ERROR: No return expression should be provided in this context.
-  // CHECK:STDERR:   private fn G() { return Self.F(); }
-  // CHECK:STDERR:                    ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_global_self_access.carbon:[[@LINE+3]]:3: There was no return type provided.
-  // CHECK:STDERR:   private fn G() { return Self.F(); }
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
-  private fn G() { return Self.F(); }
+  private fn G() { Self.F(); }
 }
 
 // CHECK:STDOUT: --- fail_private_field_access.carbon
@@ -583,7 +576,7 @@ class A {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_global_self_access.carbon
+// CHECK:STDOUT: --- self_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %A: type = class_type @A [template]
@@ -638,6 +631,6 @@ class A {
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%A [template = constants.%A]
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @A.%F.decl [template = constants.%F]
 // CHECK:STDOUT:   %F.call: init %.1 = call %F.ref()
-// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -540,9 +540,9 @@ class A {
 // CHECK:STDOUT:   %int.make_type_32.loc16: init type = call constants.%Int32() [template = i32]
 // CHECK:STDOUT:   %.loc16_8.1: type = value_of_initializer %int.make_type_32.loc16 [template = i32]
 // CHECK:STDOUT:   %.loc16_8.2: type = converted %int.make_type_32.loc16, %.loc16_8.1 [template = i32]
-// CHECK:STDOUT:   %int.make_type_32.loc24: init type = call constants.%Int32() [template = i32]
-// CHECK:STDOUT:   %.loc24_8.1: type = value_of_initializer %int.make_type_32.loc24 [template = i32]
-// CHECK:STDOUT:   %.loc24_8.2: type = converted %int.make_type_32.loc24, %.loc24_8.1 [template = i32]
+// CHECK:STDOUT:   %int.make_type_32.loc23: init type = call constants.%Int32() [template = i32]
+// CHECK:STDOUT:   %.loc23_8.1: type = value_of_initializer %int.make_type_32.loc23 [template = i32]
+// CHECK:STDOUT:   %.loc23_8.2: type = converted %int.make_type_32.loc23, %.loc23_8.1 [template = i32]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
@@ -570,7 +570,7 @@ class A {
 // CHECK:STDOUT:   %A.ref.loc16: type = name_ref A, file.%A.decl [template = constants.%A]
 // CHECK:STDOUT:   %x.ref: <error> = name_ref x, <error> [template = <error>]
 // CHECK:STDOUT:   %x: i32 = bind_name x, <error>
-// CHECK:STDOUT:   %A.ref.loc24: type = name_ref A, file.%A.decl [template = constants.%A]
+// CHECK:STDOUT:   %A.ref.loc23: type = name_ref A, file.%A.decl [template = constants.%A]
 // CHECK:STDOUT:   %y.ref: <error> = name_ref y, <error> [template = <error>]
 // CHECK:STDOUT:   %y: i32 = bind_name y, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -519,7 +519,7 @@ class FormatterImpl {
       Indent();
       out_ << ".";
       FormatName(name_id);
-      switch (access_kind.value()) {
+      switch (access_kind) {
         case SemIR::AccessKind::Public:
           break;
         case SemIR::AccessKind::Protected:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -519,7 +519,7 @@ class FormatterImpl {
       Indent();
       out_ << ".";
       FormatName(name_id);
-      switch (access_kind) {
+      switch (access_kind.value()) {
         case SemIR::AccessKind::Public:
           break;
         case SemIR::AccessKind::Protected:

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -6,7 +6,6 @@
 #define CARBON_TOOLCHAIN_SEM_IR_NAME_SCOPE_H_
 
 #include "common/map.h"
-#include "llvm/Support/FormatVariadicDetails.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -6,16 +6,46 @@
 #define CARBON_TOOLCHAIN_SEM_IR_NAME_SCOPE_H_
 
 #include "common/map.h"
+#include "common/ostream.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::SemIR {
 
 // Access control for an entity.
-enum class AccessKind : int8_t {
-  Public,
-  Protected,
-  Private,
+class AccessKind : public Printable<AccessKind> {
+ public:
+  enum RawEnumType : int8_t {
+    Public,
+    Protected,
+    Private,
+  };
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  AccessKind(RawEnumType value) : value_(value) {}
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    switch (value_) {
+      case RawEnumType::Public:
+        out << "public";
+        break;
+      case RawEnumType::Protected:
+        out << "protected";
+        break;
+      case RawEnumType::Private:
+        out << "private";
+        break;
+    }
+  }
+
+  auto value() -> RawEnumType { return value_; }
+
+  auto operator==(const AccessKind& other) const -> bool {
+    return other.value_ == value_;
+  }
+
+ private:
+  RawEnumType value_;
 };
 
 struct NameScope : Printable<NameScope> {

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -6,47 +6,41 @@
 #define CARBON_TOOLCHAIN_SEM_IR_NAME_SCOPE_H_
 
 #include "common/map.h"
-#include "common/ostream.h"
+#include "llvm/Support/FormatVariadicDetails.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::SemIR {
 
 // Access control for an entity.
-class AccessKind : public Printable<AccessKind> {
- public:
-  enum RawEnumType : int8_t {
-    Public,
-    Protected,
-    Private,
-  };
+enum class AccessKind : int8_t {
+  Public,
+  Protected,
+  Private,
+};
 
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  AccessKind(RawEnumType value) : value_(value) {}
+}  // namespace Carbon::SemIR
 
-  auto Print(llvm::raw_ostream& out) const -> void {
-    switch (value_) {
-      case RawEnumType::Public:
-        out << "public";
+template <>
+struct llvm::format_provider<Carbon::SemIR::AccessKind> {
+  using AccessKind = Carbon::SemIR::AccessKind;
+  static void format(const AccessKind& loc, raw_ostream& out,
+                     StringRef /*style*/) {
+    switch (loc) {
+      case AccessKind::Private:
+        out << "private";
         break;
-      case RawEnumType::Protected:
+      case AccessKind::Protected:
         out << "protected";
         break;
-      case RawEnumType::Private:
-        out << "private";
+      case AccessKind::Public:
+        out << "public";
         break;
     }
   }
-
-  auto value() -> RawEnumType { return value_; }
-
-  auto operator==(const AccessKind& other) const -> bool {
-    return other.value_ == value_;
-  }
-
- private:
-  RawEnumType value_;
 };
+
+namespace Carbon::SemIR {
 
 struct NameScope : Printable<NameScope> {
   struct Entry {


### PR DESCRIPTION
This change accomplishes the TODOs for access checking. More specifically it,
- makes `SemIR::AccessKind` formattable using `llvm::formatv`.
- makes use of `LookupUnqualifiedName` to find `Self`.