### PR TITLE
Add usage tips to NOAUTOUPDATE tests

### DIFF
--- a/toolchain/check/testdata/basics/no_prelude/verbose.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/verbose.carbon
@@ -5,6 +5,10 @@
 // ARGS: -v compile --no-prelude-import --phase=check %s
 //
 // Only checks a couple statements in order to minimize manual update churn.
+// To test this file alone, run:
+//   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/basics/no_prelude/verbose.carbon
+// To dump output, run:
+//   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/basics/no_prelude/verbose.carbon
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
 // CHECK:STDERR: Node Push 0: FunctionIntroducer -> <none>

--- a/toolchain/codegen/testdata/assembly/basic.carbon
+++ b/toolchain/codegen/testdata/assembly/basic.carbon
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // ARGS: compile --no-prelude-import --target=x86_64-unknown-linux-gnu --output=- %s
+//
+// To test this file alone, run:
+//   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/codegen/testdata/assembly/basic.carbon
+// To dump output, run:
+//   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/codegen/testdata/assembly/basic.carbon
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
 // CHECK:STDOUT: _CMain.Main:

--- a/toolchain/codegen/testdata/fail_target_triple.carbon
+++ b/toolchain/codegen/testdata/fail_target_triple.carbon
@@ -4,6 +4,10 @@
 //
 // ARGS: compile --no-prelude-import --target=x86_687-unknown-linux-gnu --output=- %s
 // No autoupdate because the message comes from LLVM.
+// To test this file alone, run:
+//   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/codegen/testdata/fail_target_triple.carbon
+// To dump output, run:
+//   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/codegen/testdata/fail_target_triple.carbon
 // NOAUTOUPDATE
 // CHECK:STDERR: ERROR: Invalid target: {{.*}}x86_687{{.*}}
 

--- a/toolchain/driver/testdata/dump_mem_usage.carbon
+++ b/toolchain/driver/testdata/dump_mem_usage.carbon
@@ -4,6 +4,10 @@
 //
 // ARGS: compile --phase=check --dump-mem-usage %s
 //
+// To test this file alone, run:
+//   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/dump_mem_usage.carbon
+// To dump output, run:
+//   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/dump_mem_usage.carbon
 // NOAUTOUPDATE
 //
 // Avoid testing specific values:


### PR DESCRIPTION
These tips are especially valuable in these cases, because you can't use `autoupdate_testdata.py` to identify the output difference, so dumping the output is pretty much the only option.
