### PR TITLE
Improve install_paths handling for relative paths.

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -6,5 +6,5 @@
 # available.
 alias(
     name = "toolchain",
-    actual = "//toolchain/install:prefix_root/bin/carbon",
+    actual = "//toolchain/install:carbon.bin",
 )

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -6,5 +6,5 @@
 # available.
 alias(
     name = "toolchain",
-    actual = "//toolchain/install:carbon.bin",
+    actual = "//toolchain/install:run_carbon",
 )

--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -19,14 +19,18 @@ auto main(int argc, char** argv) -> int {
     return EXIT_FAILURE;
   }
 
+  // Resolve paths before calling SetWorkingDirForBazel.
   std::string exe_path = Carbon::FindExecutablePath(argv[0]);
+  const auto install_paths = Carbon::InstallPaths::MakeExeRelative(exe_path);
+  if (install_paths.error()) {
+    llvm::errs() << "error: " << *install_paths.error();
+    return EXIT_FAILURE;
+  }
 
   Carbon::SetWorkingDirForBazel();
 
   llvm::SmallVector<llvm::StringRef> args(argv + 1, argv + argc);
   auto fs = llvm::vfs::getRealFileSystem();
-
-  const auto install_paths = Carbon::InstallPaths::MakeExeRelative(exe_path);
 
   Carbon::Driver driver(*fs, &install_paths, llvm::outs(), llvm::errs());
   bool success = driver.RunCommand(args).success;

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -234,7 +234,7 @@ pkg_tar_and_test(
 
 # Support `bazel run` on specific binaries.
 run_tool(
-    name = "carbon.bin",
+    name = "run_carbon",
     data = [":install_data"],
     tool = "prefix_root/bin/carbon",
 )

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -7,6 +7,7 @@ load("@llvm-project//llvm:binary_alias.bzl", "binary_alias")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink", "strip_prefix")
 load("pkg_helpers.bzl", "pkg_naming_variables", "pkg_tar_and_test")
+load("run_tool.bzl", "run_tool")
 load("symlink_filegroup.bzl", "symlink_filegroup")
 
 package(default_visibility = ["//visibility:public"])
@@ -229,4 +230,11 @@ pkg_tar_and_test(
         ":install_data",
     ],
     test_install_marker = ":install_marker",
+)
+
+# Support `bazel run` on specific binaries.
+run_tool(
+    name = "carbon.bin",
+    data = [":install_data"],
+    tool = "prefix_root/bin/carbon",
 )

--- a/toolchain/install/install_paths.h
+++ b/toolchain/install/install_paths.h
@@ -32,10 +32,15 @@ namespace Carbon {
 //   - MakeForBazelRunfiles for locating through Bazel's runfile tree.
 //   - Make for an explicit path, for example in tests.
 //
-// When locating an install, we verify it by
-// looking for the `carbon_install.txt` marker file at a specific location
-// below. When errors occur, the install prefix is made empty, and error() can
-// be used for diagnostics; InstallPaths remains minimally functional.
+// When locating an install, we verify it by looking for the
+// `carbon_install.txt` marker file at a specific location below. When errors
+// occur, the install prefix is made empty, and error() can be used for
+// diagnostics; InstallPaths remains minimally functional.
+//
+// The install path is stored as an absolute path. This addresses cases where
+// the command line uses a relative path (`./bin/carbon`) and the working
+// directory changes after initialization (for example, to Bazel's working
+// directory).
 //
 // Within this prefix, we expect a hierarchy on Unix-y platforms:
 //

--- a/toolchain/install/install_paths.h
+++ b/toolchain/install/install_paths.h
@@ -37,11 +37,6 @@ namespace Carbon {
 // occur, the install prefix is made empty, and error() can be used for
 // diagnostics; InstallPaths remains minimally functional.
 //
-// The install path is stored as an absolute path. This addresses cases where
-// the command line uses a relative path (`./bin/carbon`) and the working
-// directory changes after initialization (for example, to Bazel's working
-// directory).
-//
 // Within this prefix, we expect a hierarchy on Unix-y platforms:
 //
 // - `prefix_root/bin/carbon` - the main CLI driver
@@ -111,6 +106,11 @@ class InstallPaths {
   // The computed installation prefix. This should correspond to the
   // `prefix_root` directory in Bazel's output, or to some prefix the toolchain
   // is installed into on a system such as `/usr/local` or `/home/$USER`.
+  //
+  // This will be an absolute path. We keep an absolute path for when the
+  // command line uses a relative path (`./bin/carbon`) and the working
+  // directory changes after initialization (for example, to Bazel's working
+  // directory).
   //
   // In the event of an error, this will be the empty string.
   auto prefix() const -> llvm::StringRef { return prefix_; }

--- a/toolchain/install/install_paths.h
+++ b/toolchain/install/install_paths.h
@@ -83,8 +83,9 @@ class InstallPaths {
   // fails for any reason, it will `CARBON_CHECK` fail with the error message.
   static auto MakeForBazelRunfiles(llvm::StringRef exe_path) -> InstallPaths;
 
-  // Provide an explicit install paths prefix. This is useful for testing or for
-  // using Carbon in an environment with an unusual path to the installed files.
+  // Provide an explicit install paths prefix, which must be absolute. This is
+  // useful for testing or for using Carbon in an environment with an unusual
+  // path to the installed files.
   static auto Make(llvm::StringRef install_prefix) -> InstallPaths;
 
   // Returns the contents of the prelude manifest file. This is the list of

--- a/toolchain/install/install_paths_test.cpp
+++ b/toolchain/install/install_paths_test.cpp
@@ -118,7 +118,7 @@ TEST_F(InstallPathsTest, BinaryRunfiles) {
 }
 
 TEST_F(InstallPathsTest, Errors) {
-  auto paths = InstallPaths::Make("foo/bar/baz");
+  auto paths = InstallPaths::Make("/foo/bar/baz");
   EXPECT_THAT(paths.error(), Optional(HasSubstr("foo/bar/baz")));
   EXPECT_THAT(paths.prefix(), Eq(""));
 

--- a/toolchain/install/run_tool.bzl
+++ b/toolchain/install/run_tool.bzl
@@ -1,0 +1,17 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Supports running a tool from the install filegroup."""
+
+load("@rules_python//python:defs.bzl", "py_binary")
+
+def run_tool(name, tool, data):
+    # TODO: Fix the driver file discovery in order to allow symlinks.
+    py_binary(
+        name = name,
+        main = "run_tool.py",
+        srcs = ["run_tool.py"],
+        args = ["$(location {})".format(tool)],
+        data = [tool] + data,
+    )

--- a/toolchain/install/run_tool.py
+++ b/toolchain/install/run_tool.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+"""Runs the tool specified in argv.
+
+This script is essentially just a bounce-through to get an appropriate arg0.
+See the TODO in run_tool.bzl.
+"""
+
+__copyright__ = """
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+import os
+import sys
+
+if __name__ == "__main__":
+    os.execv(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
Because install_paths is not presently validated, and it's resolved after the `SetWorkingDirForBazel` call, if a relative path is used with bazel then it would fail silently. This starts making the driver share install path errors, and starts changing how `//toolchain` launches `carbon`.

Note the implementation is still brittle and will break with symlinks. That's something I plan to address as part of busyboxing.