### PR TITLE
Clean up comment about node ID.

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -130,14 +130,12 @@ class Context {
   auto AddConstant(SemIR::Inst inst, bool is_symbolic) -> SemIR::ConstantId;
 
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
-  // result. Only valid if the LocId is for a NodeId.
+  // result.
   template <typename InstT>
     requires(SemIR::Internal::HasNodeId<InstT>)
   auto AddInstAndPush(decltype(InstT::Kind)::TypedNodeId node_id, InstT inst)
       -> void {
-    SemIR::LocIdAndInst arg(node_id, inst);
-    auto inst_id = AddInst(arg);
-    node_stack_.Push(arg.loc_id.node_id(), inst_id);
+    node_stack_.Push(node_id, AddInst(node_id, inst));
   }
 
   // Replaces the instruction `inst_id` with `loc_id_and_inst`. The instruction


### PR DESCRIPTION
Without researching, I think this just predates the templating. Also refactoring the body since there's not really a benefit to having each line be its own expression, and the `arg.loc_id.node_id()` is a little indirect when `node_id` is an argument.