### PR TITLE
Add support for capturing console output to FileTest.

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -19,8 +19,8 @@ namespace {
 class ExplorerFileTest : public FileTestBase {
  public:
   explicit ExplorerFileTest(llvm::StringRef /*exe_path*/,
-                            llvm::StringRef test_name)
-      : FileTestBase(test_name),
+                            std::mutex* output_mutex, llvm::StringRef test_name)
+      : FileTestBase(output_mutex, test_name),
         prelude_line_re_(R"(prelude.carbon:(\d+))"),
         timing_re_(R"((Time elapsed in \w+: )\d+(ms))") {
     CARBON_CHECK(prelude_line_re_.ok(), "{0}", prelude_line_re_.error());

--- a/testing/file_test/README.md
+++ b/testing/file_test/README.md
@@ -149,6 +149,19 @@ Supported comment markers are:
     is responsible for providing default arguments.
 
 -   ```
+    // SET-CAPTURE-CONSOLE-OUTPUT
+    ```
+
+    By default, stderr and stdout are expected to be piped through provided
+    streams. Adding this causes the test's own stderr and stdout to be captured
+    and added as well.
+
+    This should be avoided because weare partly ensuring that streams are an
+    API, but is helpful when wrapping Clang, where stderr is used directly.
+
+    SET-CAPTURE-CONSOLE-OUTPUT can be specified at most once.
+
+-   ```
     // SET-CHECK-SUBSET
     ```
 

--- a/testing/file_test/README.md
+++ b/testing/file_test/README.md
@@ -156,7 +156,7 @@ Supported comment markers are:
     streams. Adding this causes the test's own stderr and stdout to be captured
     and added as well.
 
-    This should be avoided because weare partly ensuring that streams are an
+    This should be avoided because we are partly ensuring that streams are an
     API, but is helpful when wrapping Clang, where stderr is used directly.
 
     SET-CAPTURE-CONSOLE-OUTPUT can be specified at most once.

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -326,11 +326,10 @@ auto FileTestBase::ProcessTestFileAndRun(TestContext& context)
 
   // Conditionally capture console output. We use a scope exit to ensure the
   // captures terminate even on run failures.
-  std::unique_ptr<std::unique_lock<std::mutex>> console_lock;
+  std::unique_lock<std::mutex> output_lock;
   if (context.capture_console_output) {
     if (output_mutex_) {
-      console_lock =
-          std::make_unique<std::unique_lock<std::mutex>>(*output_mutex_);
+      output_lock = std::unique_lock<std::mutex>(*output_mutex_);
     }
     CaptureStderr();
     CaptureStdout();

--- a/testing/file_test/testdata/capture_console_output.carbon
+++ b/testing/file_test/testdata/capture_console_output.carbon
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// SET-CAPTURE-CONSOLE-OUTPUT
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //testing/file_test:file_test_base_test --test_arg=--file_tests=testing/file_test/testdata/capture_console_output.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/capture_console_output.carbon
+// CHECK:STDERR: params.stderr
+// CHECK:STDERR: llvm::errs
+
+// CHECK:STDOUT: 2 args: `default_args`, `capture_console_output.carbon`
+// CHECK:STDOUT: params.stdout
+// CHECK:STDOUT: llvm::outs

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -10,7 +10,10 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    data = glob([
+        "testdata/**/*.carbon",
+        "testdata/**/*.cpp",
+    ]),
 )
 
 cc_library(

--- a/toolchain/driver/clang_runner_test.cpp
+++ b/toolchain/driver/clang_runner_test.cpp
@@ -152,23 +152,6 @@ TEST(ClangRunnerTest, LinkCommandEcho) {
   EXPECT_THAT(out, StrEq(""));
 }
 
-TEST(ClangRunnerTest, NoArgs) {
-  const auto install_paths =
-      InstallPaths::MakeForBazelRunfiles(Testing::GetExePath());
-  std::string verbose_out;
-  llvm::raw_string_ostream verbose_os(verbose_out);
-  std::string target = llvm::sys::getDefaultTargetTriple();
-  ClangRunner runner(&install_paths, target, &verbose_os);
-  std::string out;
-  std::string err;
-  EXPECT_FALSE(RunWithCapturedOutput(out, err, [&] { return runner.Run({}); }))
-      << "Verbose output from runner:\n"
-      << verbose_out << "\n";
-
-  EXPECT_THAT(out, StrEq(""));
-  EXPECT_THAT(err, HasSubstr("error: no input files"));
-}
-
 TEST(ClangRunnerTest, DashC) {
   std::filesystem::path test_file =
       WriteTestFile("test.cpp", "int test() { return 0; }");

--- a/toolchain/driver/testdata/fail_clang_no_args.cpp
+++ b/toolchain/driver/testdata/fail_clang_no_args.cpp
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ARGS: clang --
+//
+// SET-CAPTURE-CONSOLE-OUTPUT
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test
+// --test_arg=--file_tests=toolchain/driver/testdata/fail_clang_no_args.cpp TIP:
+// To dump output, run: TIP:   bazel run //toolchain/testing:file_test --
+// --dump_output --file_tests=toolchain/driver/testdata/fail_clang_no_args.cpp
+// CHECK:STDERR: error: no input files

--- a/toolchain/driver/testdata/fail_clang_no_args.cpp
+++ b/toolchain/driver/testdata/fail_clang_no_args.cpp
@@ -5,10 +5,10 @@
 // ARGS: clang --
 //
 // SET-CAPTURE-CONSOLE-OUTPUT
+// clang-format off
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test
-// --test_arg=--file_tests=toolchain/driver/testdata/fail_clang_no_args.cpp TIP:
-// To dump output, run: TIP:   bazel run //toolchain/testing:file_test --
-// --dump_output --file_tests=toolchain/driver/testdata/fail_clang_no_args.cpp
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/fail_clang_no_args.cpp
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/fail_clang_no_args.cpp
 // CHECK:STDERR: error: no input files

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -23,9 +23,9 @@ namespace {
 // phase subdirectories.
 class ToolchainFileTest : public FileTestBase {
  public:
-  explicit ToolchainFileTest(llvm::StringRef exe_path,
+  explicit ToolchainFileTest(llvm::StringRef exe_path, std::mutex* output_mutex,
                              llvm::StringRef test_name)
-      : FileTestBase(test_name),
+      : FileTestBase(output_mutex, test_name),
         component_(GetComponent(test_name)),
         installation_(InstallPaths::MakeForBazelRunfiles(exe_path)) {}
 


### PR DESCRIPTION
One of the things that ClangRunnerTest is doing is capturing stderr/stdout because clang prints to it directly. This adds support for that to FileTest.

I'm renaming the current `capture_output` field to `dump_output` because the name is ambiguous after this change, and the flag is already named `--dump_output`. It's still not great, but at least it's more distinct.

Note ClangRunner still doesn't use the vfs; that still needs work. I'm just moving the NoArgs test over as a trivial test of the functionality.