### PR TITLE
Refactor InstallPaths API and comments a little.

### DIFF
--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -12,7 +12,7 @@ package(default_visibility = ["//visibility:public"])
 # Build rules supporting the install data tree for the Carbon toolchain.
 #
 # This populates a synthetic Carbon toolchain installation under the
-# `prefix_root` directory. For details on its layout, see `install_paths.h`.
+# `prefix_root` directory. For details on its layout, see `install_dirs` below.
 
 # A library for computing install paths for the toolchain. Note that this
 # library does *not* include the data itself, as that would form a dependency
@@ -76,6 +76,15 @@ lld_aliases = [
     "wasm-ld",
 ]
 
+# Given a root `prefix_root`, the hierarchy looks like:
+#
+# - prefix_root/bin: Binaries intended for direct use.
+# - prefix_root/lib/carbon: Private data and files.
+# - prefix_root/lib/carbon/core: The `Core` package files.
+# - prefix_root/lib/carbon/llvm/bin: LLVM binaries.
+#
+# This will be how installs are provided on Unix-y platforms, and is loosely
+# based on the FHS (Filesystem Hierarchy Standard).
 install_dirs = {
     "bin": [
         install_target(

--- a/toolchain/install/install_paths.cpp
+++ b/toolchain/install/install_paths.cpp
@@ -146,13 +146,6 @@ auto InstallPaths::CheckMarkerFile() -> void {
   }
 }
 
-auto InstallPaths::driver() const -> std::string {
-  llvm::SmallString<256> path(prefix_);
-  // TODO: Adjust this to work equally well on Windows.
-  llvm::sys::path::append(path, llvm::sys::path::Style::posix, "bin/carbon");
-  return path.str().str();
-}
-
 auto InstallPaths::core_package() const -> std::string {
   llvm::SmallString<256> path(prefix_);
   // TODO: Adjust this to work equally well on Windows.


### PR DESCRIPTION
Stemming from #4331, trying to break apart InstallPaths class comments into three parts:

- Construction semantics, staying in the class comment
  - Trying to refer to methods with more detailed  documentation.
- Install prefix contents, now on `prefix_`
- Install structure, consolidating on `install_dirs`

For code refactoring, `driver()` and `prefix()` were only used by the install paths test. Rather than having a comment not to use `prefix()`, this instead extracts it out to a TestPeer model (which we have elsewhere with `TypedNodesTestPeer`, thus my choice in approaches).