### PR TITLE
Remove declare_symlink use

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -111,6 +111,9 @@ build:linux --define=pfm=1
 # Enable TCMalloc on Linux as well.
 build:linux --custom_malloc=@tcmalloc//tcmalloc
 
+# Disables `actions.declare_symlink`. Done for cross-environment support.
+build --allow_unresolved_symlinks=false
+
 # Allow users to override any of the flags desired by importing a user-specific
 # RC file here if present.
 try-import %workspace%/user.bazelrc

--- a/toolchain/install/install_filegroups.bzl
+++ b/toolchain/install/install_filegroups.bzl
@@ -116,9 +116,10 @@ def make_install_filegroups(name, no_driver_name, pkg_name, install_dirs, prefix
                     strip_prefix = strip_prefix.from_pkg(prefix),
                 )
             elif "symlink" in entry:
+                symlink_to = "{0}/{1}/{2}".format(prefix, dir, entry["symlink"])
                 symlink_file(
                     name = prefixed_path,
-                    symlink_relative = entry["symlink"],
+                    symlink_label = symlink_to,
                 )
                 pkg_mklink(
                     name = pkg_path,

--- a/toolchain/install/symlink_helpers.bzl
+++ b/toolchain/install/symlink_helpers.bzl
@@ -52,12 +52,6 @@ def _symlink_file_impl(ctx):
             output = out,
             target_file = ctx.file.symlink_label,
         )
-    elif ctx.attr.symlink_relative:
-        out = ctx.actions.declare_symlink(ctx.label.name)
-        ctx.actions.symlink(
-            output = out,
-            target_path = ctx.attr.symlink_relative,
-        )
     else:
         fail("Missing symlink target")
 
@@ -79,6 +73,5 @@ symlink_file = rule(
             cfg = "target",
         ),
         "symlink_label": attr.label(allow_single_file = True),
-        "symlink_relative": attr.string(),
     },
 )


### PR DESCRIPTION
We're trying to remain compatible with an environment where `declare_symlink` is (apparently) disallowed. `--allow_unresolved_symlinks=false` will prevent regressions.