### PR TITLE
Fix invocation issues with clang runner

### DIFF
--- a/toolchain/driver/clang_runner.cpp
+++ b/toolchain/driver/clang_runner.cpp
@@ -135,7 +135,10 @@ auto ClangRunner::Run(llvm::ArrayRef<llvm::StringRef> args) -> bool {
   // busybox of LLD as well, and having even the subprocesses consistently run
   // the Carbon install toolchain and not a system toolchain whenever possible.
   driver.CC1Main = [](llvm::SmallVectorImpl<const char*>& argv) -> int {
-    llvm::ToolContext tool_context;
+    // TODO: Try to a better path for argv[0] (maybe in the LLVM install paths).
+    // This works for now.
+    llvm::ToolContext tool_context = {
+        .Path = argv[0], .PrependArg = "clang", .NeedsPrependArg = true};
     return clang_main(argv.size(), const_cast<char**>(argv.data()),
                       tool_context);
   };

--- a/toolchain/driver/clang_runner.cpp
+++ b/toolchain/driver/clang_runner.cpp
@@ -135,8 +135,8 @@ auto ClangRunner::Run(llvm::ArrayRef<llvm::StringRef> args) -> bool {
   // busybox of LLD as well, and having even the subprocesses consistently run
   // the Carbon install toolchain and not a system toolchain whenever possible.
   driver.CC1Main = [](llvm::SmallVectorImpl<const char*>& argv) -> int {
-    // TODO: Try to a better path for argv[0] (maybe in the LLVM install paths).
-    // This works for now.
+    // TODO: Try to use a better path for argv[0] (maybe in the LLVM install
+    // paths). This works for now.
     llvm::ToolContext tool_context = {
         .Path = argv[0], .PrependArg = "clang", .NeedsPrependArg = true};
     return clang_main(argv.size(), const_cast<char**>(argv.data()),

--- a/toolchain/driver/clang_runner_test.cpp
+++ b/toolchain/driver/clang_runner_test.cpp
@@ -155,6 +155,7 @@ TEST(ClangRunnerTest, LinkCommandEcho) {
 TEST(ClangRunnerTest, DashC) {
   std::filesystem::path test_file =
       WriteTestFile("test.cpp", "int test() { return 0; }");
+  std::filesystem::path test_output = WriteTestFile("test.o", "");
 
   const auto install_paths =
       InstallPaths::MakeForBazelRunfiles(Testing::GetExePath());
@@ -164,11 +165,12 @@ TEST(ClangRunnerTest, DashC) {
   ClangRunner runner(&install_paths, target, &verbose_os);
   std::string out;
   std::string err;
-  EXPECT_TRUE(
-      RunWithCapturedOutput(out, err,
-                            [&] {
-                              return runner.Run({"-c", test_file.string()});
-                            }))
+  EXPECT_TRUE(RunWithCapturedOutput(out, err,
+                                    [&] {
+                                      return runner.Run(
+                                          {"-c", test_file.string(), "-o",
+                                           test_output.string()});
+                                    }))
       << "Verbose output from runner:\n"
       << verbose_out << "\n";
 


### PR DESCRIPTION
`ToolContext` should be explicitly initialized.

`-c` can still require a valid, writable `-o` path.