### PR TITLE
Replace llvm_symbolizer with a cc_env_data() array.

### DIFF
--- a/bazel/cc_toolchains/defs.bzl
+++ b/bazel/cc_toolchains/defs.bzl
@@ -5,7 +5,7 @@
 """Provides helpers for cc rules. Intended for general consumption."""
 
 # The hermetic llvm-symbolizer target.
-llvm_symbolizer = "@llvm-project//llvm:llvm-symbolizer"
+_llvm_symbolizer = "@llvm-project//llvm:llvm-symbolizer"
 
 def cc_env():
     """Returns standard environment settings for a cc_binary.
@@ -13,11 +13,11 @@ def cc_env():
     In use, this should set both `data` and `env`, as in:
 
     ```
-    load("//bazel/cc_toolchains:defs.bzl", "cc_env", "llvm_symbolizer")
+    load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
 
     cc_binary(
       ...
-      data = [llvm_symbolizer],
+      data = cc_env_data(),
       env = cc_env(),
     )
     ```
@@ -25,7 +25,7 @@ def cc_env():
     We're currently setting this on a target-by-target basis, mainly because
     it's difficult to modify default behaviors.
     """
-    env = {"LLVM_SYMBOLIZER_PATH": "$(location {0})".format(llvm_symbolizer)}
+    env = {"LLVM_SYMBOLIZER_PATH": "$(location {0})".format(_llvm_symbolizer)}
 
     # On macOS, there's a nano zone allocation warning due to asan (arises
     # in fastbuild/dbg). This suppresses the warning in `bazel run`.
@@ -37,3 +37,10 @@ def cc_env():
         "//bazel/cc_toolchains:macos_asan": env.update({"MallocNanoZone": "0"}),
         "//conditions:default": env,
     })
+
+def cc_env_data():
+    """Returns data needed for cc_env().
+
+    Set up as a function mainly for parity, and in case we need future changes.
+    """
+    return [_llvm_symbolizer]

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "llvm_symbolizer")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
 load("//testing/file_test:rules.bzl", "file_test")
 
 package(default_visibility = [
@@ -36,7 +36,7 @@ cc_library(
 cc_binary(
     name = "explorer",
     srcs = ["main_bin.cpp"],
-    data = [llvm_symbolizer],
+    data = cc_env_data(),
     env = cc_env(),
     # Running clang-tidy is slow, and explorer is currently feature frozen, so
     # don't spend time linting it.

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "llvm_symbolizer")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
 load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -167,7 +167,7 @@ cc_fuzz_test(
 cc_binary(
     name = "carbon",
     srcs = ["driver_main.cpp"],
-    data = [llvm_symbolizer],
+    data = cc_env_data(),
     env = cc_env(),
     deps = [
         ":driver",

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "llvm_symbolizer")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
 load("install_filegroups.bzl", "install_filegroup", "install_symlink", "install_target", "make_install_filegroups")
 load("pkg_helpers.bzl", "pkg_naming_variables", "pkg_tar_and_test")
 load("run_tool.bzl", "run_tool")
@@ -142,10 +142,7 @@ pkg_tar_and_test(
 # Support `bazel run` on specific binaries.
 run_tool(
     name = "run_carbon",
-    data = [
-        ":install_data",
-        llvm_symbolizer,
-    ],
+    data = [":install_data"] + cc_env_data(),
     env = cc_env(),
     tool = "prefix_root/bin/carbon",
 )

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "llvm_symbolizer")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
 load("//testing/file_test:rules.bzl", "file_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -12,7 +12,7 @@ file_test(
     name = "file_test",
     size = "small",
     srcs = ["file_test.cpp"],
-    data = [llvm_symbolizer],
+    data = cc_env_data(),
     env = cc_env(),
     tests = [
         "//toolchain/check:testdata",


### PR DESCRIPTION
This is a minor adjustment to make it easier to modify (or omit) data where needed. Also, makes it pair better with cc_env().