### PR TITLE
Remove redundant optional wrapping llvm::function_ref

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -301,9 +301,8 @@ class Context {
   // If the type is not complete, `diagnoser` is invoked to diagnose the issue,
   // if a `diagnoser` is provided. The builder it returns will be annotated to
   // describe the reason why the type is not complete.
-  auto TryToCompleteType(
-      SemIR::TypeId type_id,
-      std::optional<BuildDiagnosticFn> diagnoser = std::nullopt) -> bool;
+  auto TryToCompleteType(SemIR::TypeId type_id,
+                         BuildDiagnosticFn diagnoser = nullptr) -> bool;
 
   // Attempts to complete and define the type `type_id`. Returns `true` if the
   // type is defined, or `false` if no definition is available. A defined type
@@ -311,9 +310,8 @@ class Context {
   //
   // This is the same as `TryToCompleteType` except for interfaces, which are
   // complete before they are fully defined.
-  auto TryToDefineType(
-      SemIR::TypeId type_id,
-      std::optional<BuildDiagnosticFn> diagnoser = std::nullopt) -> bool;
+  auto TryToDefineType(SemIR::TypeId type_id,
+                       BuildDiagnosticFn diagnoser = nullptr) -> bool;
 
   // Returns the type `type_id` as a complete type, or produces an incomplete
   // type error and returns an error type. This is a convenience wrapper around

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -316,8 +316,8 @@ class Context {
   // Returns the type `type_id` as a complete type, or produces an incomplete
   // type error and returns an error type. This is a convenience wrapper around
   // TryToCompleteType.
-  auto AsCompleteType(SemIR::TypeId type_id, BuildDiagnosticFn diagnoser)
-      -> SemIR::TypeId {
+  auto AsCompleteType(SemIR::TypeId type_id,
+                      BuildDiagnosticFn diagnoser = nullptr) -> SemIR::TypeId {
     return TryToCompleteType(type_id, diagnoser) ? type_id
                                                  : SemIR::TypeId::Error;
   }

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -315,9 +315,10 @@ class Context {
 
   // Returns the type `type_id` as a complete type, or produces an incomplete
   // type error and returns an error type. This is a convenience wrapper around
-  // TryToCompleteType.
-  auto AsCompleteType(SemIR::TypeId type_id,
-                      BuildDiagnosticFn diagnoser = nullptr) -> SemIR::TypeId {
+  // TryToCompleteType. `diagnoser` must not be null.
+  auto AsCompleteType(SemIR::TypeId type_id, BuildDiagnosticFn diagnoser)
+      -> SemIR::TypeId {
+    CARBON_CHECK(diagnoser);
     return TryToCompleteType(type_id, diagnoser) ? type_id
                                                  : SemIR::TypeId::Error;
   }

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -205,11 +205,10 @@ static auto LookupInterfaceWitness(Context& context,
 
 // Performs impl lookup for a member name expression. This finds the relevant
 // impl witness and extracts the corresponding impl member.
-static auto PerformImplLookup(Context& context, SemIR::LocId loc_id,
-                              SemIR::ConstantId type_const_id,
-                              SemIR::AssociatedEntityType assoc_type,
-                              SemIR::InstId member_id,
-                              Context::BuildDiagnosticFn missing_impl_diagnoser)
+static auto PerformImplLookup(
+    Context& context, SemIR::LocId loc_id, SemIR::ConstantId type_const_id,
+    SemIR::AssociatedEntityType assoc_type, SemIR::InstId member_id,
+    Context::BuildDiagnosticFn missing_impl_diagnoser = nullptr)
     -> SemIR::InstId {
   auto interface_type =
       context.types().GetAs<SemIR::InterfaceType>(assoc_type.interface_type_id);
@@ -321,7 +320,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
           context.types().TryGetAs<SemIR::AssociatedEntityType>(type_id)) {
     if (ScopeNeedsImplLookup(context, lookup_scope)) {
       member_id = PerformImplLookup(context, loc_id, name_scope_const_id,
-                                    *assoc_type, member_id, nullptr);
+                                    *assoc_type, member_id);
     }
   }
 

--- a/toolchain/check/member_access.h
+++ b/toolchain/check/member_access.h
@@ -23,8 +23,8 @@ auto PerformMemberAccess(Context& context, SemIR::LocId loc_id,
 auto PerformCompoundMemberAccess(
     Context& context, SemIR::LocId loc_id, SemIR::InstId base_id,
     SemIR::InstId member_expr_id,
-    std::optional<Context::BuildDiagnosticFn> missing_impl_diagnoser =
-        std::nullopt) -> SemIR::InstId;
+    Context::BuildDiagnosticFn missing_impl_diagnoser = nullptr)
+    -> SemIR::InstId;
 
 // Creates SemIR to perform a tuple index with base expression `tuple_inst_id`
 // and index expression `index_inst_id`. Returns the result of the access.

--- a/toolchain/check/operator.cpp
+++ b/toolchain/check/operator.cpp
@@ -29,10 +29,9 @@ static auto GetOperatorOpFunction(Context& context, SemIR::LocId loc_id,
   return PerformMemberAccess(context, loc_id, interface_id, op_name_id);
 }
 
-auto BuildUnaryOperator(
-    Context& context, SemIR::LocId loc_id, Operator op,
-    SemIR::InstId operand_id,
-    std::optional<Context::BuildDiagnosticFn> missing_impl_diagnoser)
+auto BuildUnaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
+                        SemIR::InstId operand_id,
+                        Context::BuildDiagnosticFn missing_impl_diagnoser)
     -> SemIR::InstId {
   // Look up the operator function.
   auto op_fn = GetOperatorOpFunction(context, loc_id, op);
@@ -48,10 +47,9 @@ auto BuildUnaryOperator(
   return PerformCall(context, loc_id, bound_op_id, {});
 }
 
-auto BuildBinaryOperator(
-    Context& context, SemIR::LocId loc_id, Operator op, SemIR::InstId lhs_id,
-    SemIR::InstId rhs_id,
-    std::optional<Context::BuildDiagnosticFn> missing_impl_diagnoser)
+auto BuildBinaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
+                         SemIR::InstId lhs_id, SemIR::InstId rhs_id,
+                         Context::BuildDiagnosticFn missing_impl_diagnoser)
     -> SemIR::InstId {
   // Look up the operator function.
   auto op_fn = GetOperatorOpFunction(context, loc_id, op);

--- a/toolchain/check/operator.h
+++ b/toolchain/check/operator.h
@@ -23,9 +23,8 @@ struct Operator {
 // operator fails.
 auto BuildUnaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
                         SemIR::InstId operand_id,
-                        std::optional<Context::BuildDiagnosticFn>
-                            missing_impl_diagnoser = std::nullopt)
-    -> SemIR::InstId;
+                        Context::BuildDiagnosticFn missing_impl_diagnoser =
+                            nullptr) -> SemIR::InstId;
 
 // Checks and builds SemIR for a binary operator expression. For example,
 // `lhs_id * rhs_id`. If specified, `missing_impl_diagnoser` is used to build a
@@ -33,9 +32,8 @@ auto BuildUnaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
 // fails.
 auto BuildBinaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
                          SemIR::InstId lhs_id, SemIR::InstId rhs_id,
-                         std::optional<Context::BuildDiagnosticFn>
-                             missing_impl_diagnoser = std::nullopt)
-    -> SemIR::InstId;
+                         Context::BuildDiagnosticFn missing_impl_diagnoser =
+                             nullptr) -> SemIR::InstId;
 
 }  // namespace Carbon::Check
 


### PR DESCRIPTION
llvm::function_ref (like std::unique_ptr, for instance) already has a null/empty state, so use that to avoid confusion/duplication of empty states between optional and the nested function_refs.

