### PR TITLE
Disable the Bazel disk cache on CI.

### DIFF
--- a/.github/actions/build-setup-common/action.yml
+++ b/.github/actions/build-setup-common/action.yml
@@ -57,6 +57,12 @@ runs:
       shell: bash
       run: |
         cat >user.bazelrc <<EOF
+        # Disable the local disk cache as we use a remote cache and don't want
+        # two copies of every output taking up disk space. The only way to
+        # disable the disk cache is with an empty string:
+        # https://github.com/bazelbuild/bazel/issues/5308
+        build --disk_cache=
+
         # Enable remote cache for our CI but minimize downloads.
         build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}
         build --remote_download_minimal


### PR DESCRIPTION
This should free up quite a bit of space and even make our builds faster by avoiding duplicating every output. The syntax for this flag is counter intuitive, so I've left a comment explaining it.