### PR TITLE
Switch to LLD on macOS.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -630,6 +630,16 @@ def _impl(ctx):
         enabled = True,
         flag_sets = [
             flag_set(
+                actions = all_link_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-fuse-ld=lld",
+                        ],
+                    ),
+                ]),
+            ),
+            flag_set(
                 actions = [
                     ACTION_NAMES.cpp_link_executable,
                 ],
@@ -1003,7 +1013,7 @@ def _impl(ctx):
         feature(name = "opt"),
         feature(name = "supports_dynamic_linker", enabled = ctx.attr.target_os == "linux"),
         feature(name = "supports_pic", enabled = True),
-        feature(name = "supports_start_end_lib", enabled = ctx.attr.target_os == "linux"),
+        feature(name = "supports_start_end_lib", enabled = True),
     ]
 
     # The order of the features determines the relative order of flags used.


### PR DESCRIPTION
This gives us a consistent linker with Linux, and allows us to use `--start-lib`/`--end-lib` flags that remove the need to actually build archive files. The result of skipping archive files should significantly shrink the macOS build output as well as making it a bit faster.

I've checked and the other flags we use for linking on Linux are either unnecessary (clang-rt is already used for example) or incompatible (there is no static libc++ linking AFAICT on macOS).