### PR TITLE
Improve `-c dbg`, enabling Split DWARF and other enhancements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,8 +116,9 @@ build --enable_platform_specific_config
 build:linux --define=pfm=1
 
 # Enable split debug info on Linux, which is significantly more space efficient
-# and should work well with modern debuggers. Note that this is not currently
-# supported on macOS.
+# and should work well with modern debuggers. Note that this is Linux specific
+# as macOS has its own approach that is always partially but not completely
+# split.
 #
 # Note: if using GDB, see documentation to get that working:
 # https://docs.carbon-lang.dev/docs/project/contribution_tools.html#debugging-with-gdb-instead-of-lldb

--- a/.bazelrc
+++ b/.bazelrc
@@ -109,9 +109,19 @@ build --test_env=ASAN_SYMBOLIZER_PATH
 # `en_US`.
 build --action_env=LANG=en_US.UTF-8
 
-# Enable libpfm for google_benchmark on Linux only.
+# Allow per-platform configuration.
 build --enable_platform_specific_config
+
+# Enable libpfm for google_benchmark on Linux only.
 build:linux --define=pfm=1
+
+# Enable split debug info on Linux, which is significantly more space efficient
+# and should work well with modern debuggers. Note that this is not currently
+# supported on macOS.
+#
+# Note: if using GDB, see documentation to get that working:
+# https://docs.carbon-lang.dev/docs/project/contribution_tools.html#debugging-with-gdb-instead-of-lldb
+build:linux --fission=yes
 
 # Disables `actions.declare_symlink`. Done for cross-environment support.
 build --allow_unresolved_symlinks=false

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -260,10 +260,6 @@ def _impl(ctx):
                 actions = all_link_actions,
                 flag_groups = [
                     flag_group(
-                        flags = ["-Wl,--gdb-index"],
-                        expand_if_available = "is_using_fission",
-                    ),
-                    flag_group(
                         flags = ["-Wl,-S"],
                         expand_if_available = "strip_debug_symbols",
                     ),
@@ -350,6 +346,7 @@ def _impl(ctx):
     # minimal settings if both are enabled.
     minimal_debug_info_flags = feature(
         name = "minimal_debug_info_flags",
+        implies = ["debug_info_compression_flags"],
         flag_sets = [
             flag_set(
                 actions = codegen_compile_actions,
@@ -361,28 +358,101 @@ def _impl(ctx):
             ),
         ],
     )
-    default_debug_info_flags = feature(
-        name = "default_debug_info_flags",
-        enabled = True,
+    debug_info_flags = feature(
+        name = "debug_info_flags",
+        implies = ["debug_info_compression_flags"],
         flag_sets = [
             flag_set(
                 actions = codegen_compile_actions,
                 flag_groups = ([
                     flag_group(
-                        flags = ["-g"],
+                        flags = ["-g", "-gsimple-template-names"],
+                    ),
+                    flag_group(
+                        flags = ["-gsplit-dwarf"],
+                        expand_if_available = "per_object_debug_info_file",
                     ),
                 ]),
-                with_features = [with_feature_set(features = ["dbg"])],
             ),
+        ],
+    )
+    debug_info_compression_flags = feature(
+        name = "debug_info_compression_flags",
+        flag_sets = [
+            flag_set(
+                actions = codegen_compile_actions + all_link_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ["-gz"],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    # Define a set of mutually exclusive debugger flags.
+    debugger_flags = feature(name = "debugger_flags")
+    lldb_flags = feature(
+        # Use a convenient name for users to select if needed.
+        name = "lldb_flags",
+        # Default enable LLDB-optimized flags whenever debugging.
+        enabled = True,
+        requires = [feature_set(features = ["debug_info_flags"])],
+        provides = ["debugger_flags"],
+        flag_sets = [
             flag_set(
                 actions = codegen_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ["-glldb"],
+                    ),
+                    flag_group(
+                        flags = ["-gpubnames"],
+                        expand_if_available = "per_object_debug_info_file",
+                    ),
+                ]),
+            ),
+        ],
+    )
+    gdb_flags = feature(
+        # Use a convenient name for users to select if needed.
+        name = "gdb_flags",
+        requires = [feature_set(features = ["debug_info_flags"])],
+        provides = ["debugger_flags"],
+        flag_sets = [
+            flag_set(
+                actions = codegen_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ["-ggdb"],
+                    ),
+                    flag_group(
+                        flags = ["-ggnu-pubnames"],
+                        expand_if_available = "per_object_debug_info_file",
+                    ),
+                ]),
+            ),
+            flag_set(
+                actions = all_link_actions,
                 flag_groups = [
                     flag_group(
-                        flags = ["-gsplit-dwarf", "-g"],
+                        flags = ["-Wl,--gdb-index"],
                         expand_if_available = "per_object_debug_info_file",
                     ),
                 ],
             ),
+        ],
+    )
+
+    # An enabled feature that requires the `dbg` compilation mode. This is used
+    # to toggle on more general features to use by default, while allowing those
+    # general features to be explicitly enabled where needed.
+    enable_in_dbg = feature(
+        name = "enable_in_dbg",
+        enabled = True,
+        requires = [feature_set(["dbg"])],
+        implies = [
+            "debug_info_flags",
         ],
     )
 
@@ -1029,6 +1099,16 @@ def _impl(ctx):
         feature(name = "supports_dynamic_linker", enabled = ctx.attr.target_os == "linux"),
         feature(name = "supports_pic", enabled = True),
         feature(name = "supports_start_end_lib", enabled = ctx.attr.target_os == "linux"),
+
+        # Enable split debug info whenever debug info is requested.
+        feature(
+            name = "per_object_debug_info",
+            enabled = True,
+            # This has to be directly conditioned on requesting debug info at
+            # all, otherwise Bazel will look for an extra output file and not
+            # find one.
+            requires = [feature_set(features = ["debug_info_flags"])],
+        ),
     ]
 
     # The order of the features determines the relative order of flags used.
@@ -1038,7 +1118,12 @@ def _impl(ctx):
         minimal_optimization_flags,
         default_optimization_flags,
         minimal_debug_info_flags,
-        default_debug_info_flags,
+        debug_info_flags,
+        debug_info_compression_flags,
+        debugger_flags,
+        lldb_flags,
+        gdb_flags,
+        enable_in_dbg,
         preserve_call_stacks,
         sysroot_feature,
         sanitizer_common_flags,

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -404,11 +404,7 @@ def _impl(ctx):
                 actions = codegen_compile_actions,
                 flag_groups = ([
                     flag_group(
-                        flags = ["-glldb"],
-                    ),
-                    flag_group(
-                        flags = ["-gpubnames"],
-                        expand_if_available = "per_object_debug_info_file",
+                        flags = ["-glldb", "-gpubnames"],
                     ),
                 ]),
             ),


### PR DESCRIPTION
This should substantially reduce the total build size of `-c dbg` builds, and especially improve cache hits during incremental development. I'm seeing over 50% reduction total on Linux in just the raw size of a complete debug build. Even on macOS where we can't use split DWARF there are substantial reductions.

Note that LLDB and GDB want slightly different flags to have the best experience with split debug information, and so the build and documentation have been updated to enable LLDB's flags by default but provide clear instructions for switching to GDB's flags, and they are structured so that this can be done persistently for an individual developer.