### PR TITLE
Add tracking of lexed comments, with skeletal formatting.

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -12,6 +12,7 @@ crossreference
 falsy
 forin
 groupt
+indext
 inout
 parameteras
 pullrequest

--- a/toolchain/format/format.cpp
+++ b/toolchain/format/format.cpp
@@ -16,8 +16,20 @@ auto Format(const Lex::TokenizedBuffer& tokens, llvm::raw_ostream& out)
     // TODO: Error recovery.
     return false;
   }
+
+  auto comments = tokens.comments();
+  auto comment_it = comments.begin();
+
   llvm::ListSeparator sep(" ");
+
   for (auto token : tokens.tokens()) {
+    while (comment_it != comments.end() &&
+           tokens.IsBeforeComment(token, *comment_it)) {
+      // TODO: Fix newlines and indent.
+      out << "\n" << tokens.GetCommentText(*comment_it) << "\n";
+      ++comment_it;
+    }
+
     switch (tokens.GetKind(token)) {
       case Lex::TokenKind::FileStart:
         break;

--- a/toolchain/format/format.cpp
+++ b/toolchain/format/format.cpp
@@ -24,7 +24,7 @@ auto Format(const Lex::TokenizedBuffer& tokens, llvm::raw_ostream& out)
 
   for (auto token : tokens.tokens()) {
     while (comment_it != comments.end() &&
-           tokens.IsBeforeComment(token, *comment_it)) {
+           tokens.IsAfterComment(token, *comment_it)) {
       // TODO: Fix newlines and indent.
       out << "\n" << tokens.GetCommentText(*comment_it) << "\n";
       ++comment_it;

--- a/toolchain/format/testdata/basics/comments.carbon
+++ b/toolchain/format/testdata/basics/comments.carbon
@@ -1,0 +1,57 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/format/testdata/basics/comments.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/format/testdata/basics/comments.carbon
+
+// --- test.carbon
+
+// A comment
+fn F() {}
+
+// Another comment
+
+  // Block
+  // comment
+
+
+class C {
+    // Internal comment
+}
+
+
+  // Another
+  // Block
+  //
+  // Comment
+
+// --- AUTOUPDATE-SPLIT
+
+// CHECK:STDOUT:
+// CHECK:STDOUT: // A comment
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn F ( ) { }
+// CHECK:STDOUT: // Another comment
+// CHECK:STDOUT:
+// CHECK:STDOUT:
+// CHECK:STDOUT: // Block
+// CHECK:STDOUT:   // comment
+// CHECK:STDOUT:
+// CHECK:STDOUT:  class C {
+// CHECK:STDOUT: // Internal comment
+// CHECK:STDOUT:
+// CHECK:STDOUT:  }
+// CHECK:STDOUT: // Another
+// CHECK:STDOUT:   // Block
+// CHECK:STDOUT:
+// CHECK:STDOUT:
+// CHECK:STDOUT: //
+// CHECK:STDOUT:
+// CHECK:STDOUT:
+// CHECK:STDOUT: // Comment
+// CHECK:STDOUT:
+// CHECK:STDOUT:

--- a/toolchain/format/testdata/basics/fail_invalid_comment.carbon
+++ b/toolchain/format/testdata/basics/fail_invalid_comment.carbon
@@ -8,7 +8,6 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/format/testdata/basics/fail_invalid_comment.carbon
 
-
 // --- fail_test.carbon
 
 //f

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -506,8 +506,7 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
 // and continuing the dispatch.
 #define CARBON_DISPATCH_LEX_TOKEN(LexMethod)                                 \
   static auto Dispatch##LexMethod(Lexer& lexer, llvm::StringRef source_text, \
-                                  ssize_t position)                          \
-      ->void {                                                               \
+                                  ssize_t position) -> void {                \
     Lexer::LexResult result = lexer.LexMethod(source_text, position);        \
     CARBON_CHECK(result, "Failed to form a token!");                         \
     [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
@@ -520,17 +519,16 @@ CARBON_DISPATCH_LEX_TOKEN(LexNumericLiteral)
 CARBON_DISPATCH_LEX_TOKEN(LexStringLiteral)
 
 // A custom dispatch functions that pre-select the symbol token to lex.
-#define CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexMethod)                        \
-  static auto Dispatch##LexMethod##SymbolToken(                            \
-      Lexer& lexer, llvm::StringRef source_text, ssize_t position)         \
-      ->void {                                                             \
-    Lexer::LexResult result = lexer.LexMethod##SymbolToken(                \
-        source_text,                                                       \
-        OneCharTokenKindTable[static_cast<unsigned char>(                  \
-            source_text[position])],                                       \
-        position);                                                         \
-    CARBON_CHECK(result, "Failed to form a token!");                       \
-    [[clang::musttail]] return DispatchNext(lexer, source_text, position); \
+#define CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexMethod)                          \
+  static auto Dispatch##LexMethod##SymbolToken(                              \
+      Lexer& lexer, llvm::StringRef source_text, ssize_t position) -> void { \
+    Lexer::LexResult result = lexer.LexMethod##SymbolToken(                  \
+        source_text,                                                         \
+        OneCharTokenKindTable[static_cast<unsigned char>(                    \
+            source_text[position])],                                         \
+        position);                                                           \
+    CARBON_CHECK(result, "Failed to form a token!");                         \
+    [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
   }
 CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexOneChar)
 CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexOpening)
@@ -540,8 +538,7 @@ CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexClosing)
 // whitespace and comments.
 #define CARBON_DISPATCH_LEX_NON_TOKEN(LexMethod)                             \
   static auto Dispatch##LexMethod(Lexer& lexer, llvm::StringRef source_text, \
-                                  ssize_t position)                          \
-      ->void {                                                               \
+                                  ssize_t position) -> void {                \
     lexer.LexMethod(source_text, position);                                  \
     [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
   }

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -345,15 +345,25 @@ auto TokenizedBuffer::AddLine(LineInfo info) -> LineIndex {
   return LineIndex(static_cast<int>(line_infos_.size()) - 1);
 }
 
+auto TokenizedBuffer::IsBeforeComment(TokenIndex token,
+                                      CommentIndex comment_index) const
+    -> bool {
+  const auto& comment_data = comments_[comment_index.index];
+  return comment_data.start < GetTokenInfo(token).byte_offset();
+}
+
+auto TokenizedBuffer::GetCommentText(CommentIndex comment_index) const
+    -> llvm::StringRef {
+  const auto& comment_data = comments_[comment_index.index];
+  return source_->text().substr(comment_data.start, comment_data.length);
+}
+
 auto TokenizedBuffer::CollectMemUsage(MemUsage& mem_usage,
                                       llvm::StringRef label) const -> void {
   mem_usage.Add(MemUsage::ConcatLabel(label, "allocator_"), allocator_);
   mem_usage.Add(MemUsage::ConcatLabel(label, "token_infos_"), token_infos_);
   mem_usage.Add(MemUsage::ConcatLabel(label, "line_infos_"), line_infos_);
-}
-
-auto TokenIterator::Print(llvm::raw_ostream& output) const -> void {
-  output << token_.index;
+  mem_usage.Add(MemUsage::ConcatLabel(label, "comments_"), comments_);
 }
 
 auto TokenizedBuffer::SourceBufferDiagnosticConverter::ConvertLoc(

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -345,11 +345,10 @@ auto TokenizedBuffer::AddLine(LineInfo info) -> LineIndex {
   return LineIndex(static_cast<int>(line_infos_.size()) - 1);
 }
 
-auto TokenizedBuffer::IsBeforeComment(TokenIndex token,
-                                      CommentIndex comment_index) const
-    -> bool {
+auto TokenizedBuffer::IsAfterComment(TokenIndex token,
+                                     CommentIndex comment_index) const -> bool {
   const auto& comment_data = comments_[comment_index.index];
-  return comment_data.start < GetTokenInfo(token).byte_offset();
+  return GetTokenInfo(token).byte_offset() > comment_data.start;
 }
 
 auto TokenizedBuffer::GetCommentText(CommentIndex comment_index) const

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -163,7 +163,7 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   auto GetPrevLine(LineIndex line) const -> LineIndex;
 
   // Returns true if the token comes after the comment.
-  auto IsBeforeComment(TokenIndex token, CommentIndex comment_index) const
+  auto IsAfterComment(TokenIndex token, CommentIndex comment_index) const
       -> bool;
 
   // Returns the comment's full text range.

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -5,15 +5,12 @@
 #ifndef CARBON_TOOLCHAIN_LEX_TOKENIZED_BUFFER_H_
 #define CARBON_TOOLCHAIN_LEX_TOKENIZED_BUFFER_H_
 
-#include <compare>
 #include <cstdint>
-#include <iterator>
 
 #include "common/ostream.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/raw_ostream.h"
@@ -45,50 +42,21 @@ struct LineIndex : public IndexBase {
   using IndexBase::IndexBase;
 };
 
-constexpr LineIndex LineIndex::Invalid(LineIndex::InvalidIndex);
+constexpr LineIndex LineIndex::Invalid(InvalidIndex);
+
+// Indices for comments within the buffer.
+struct CommentIndex : public IndexBase {
+  static const CommentIndex Invalid;
+  using IndexBase::IndexBase;
+};
+
+constexpr CommentIndex CommentIndex::Invalid(InvalidIndex);
+
+// Random-access iterator over comments within the buffer.
+using CommentIterator = IndexIterator<CommentIndex>;
 
 // Random-access iterator over tokens within the buffer.
-class TokenIterator
-    : public llvm::iterator_facade_base<TokenIterator,
-                                        std::random_access_iterator_tag,
-                                        const TokenIndex, int>,
-      public Printable<TokenIterator> {
- public:
-  TokenIterator() = delete;
-
-  explicit TokenIterator(TokenIndex token) : token_(token) {}
-
-  auto operator==(const TokenIterator& rhs) const -> bool {
-    return token_ == rhs.token_;
-  }
-  auto operator<=>(const TokenIterator& rhs) const -> std::strong_ordering {
-    return token_ <=> rhs.token_;
-  }
-
-  auto operator*() const -> const TokenIndex& { return token_; }
-
-  using iterator_facade_base::operator-;
-  auto operator-(const TokenIterator& rhs) const -> int {
-    return token_.index - rhs.token_.index;
-  }
-
-  auto operator+=(int n) -> TokenIterator& {
-    token_.index += n;
-    return *this;
-  }
-  auto operator-=(int n) -> TokenIterator& {
-    token_.index -= n;
-    return *this;
-  }
-
-  // Prints the raw token index.
-  auto Print(llvm::raw_ostream& output) const -> void;
-
- private:
-  friend class TokenizedBuffer;
-
-  TokenIndex token_;
-};
+using TokenIterator = IndexIterator<TokenIndex>;
 
 // A diagnostic location converter that maps token locations into source
 // buffer locations.
@@ -115,6 +83,21 @@ class TokenDiagnosticConverter : public DiagnosticConverter<TokenIndex> {
 // `HasError` returning true.
 class TokenizedBuffer : public Printable<TokenizedBuffer> {
  public:
+  // A comment, which can be a block of lines.
+  //
+  // This is the API version of `CommentData`.
+  struct CommentInfo {
+    // The comment's full text, including `//` symbols. This may have several
+    // lines for block comments.
+    llvm::StringRef text;
+
+    // The comment's indent.
+    int32_t indent;
+
+    // The first line of the comment.
+    LineIndex start_line;
+  };
+
   auto GetKind(TokenIndex token) const -> TokenKind;
   auto GetLine(TokenIndex token) const -> LineIndex;
 
@@ -179,6 +162,13 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   // Returns the previous line handle.
   auto GetPrevLine(LineIndex line) const -> LineIndex;
 
+  // Returns true if the token comes after the comment.
+  auto IsBeforeComment(TokenIndex token, CommentIndex comment_index) const
+      -> bool;
+
+  // Returns the comment's full text range.
+  auto GetCommentText(CommentIndex comment_index) const -> llvm::StringRef;
+
   // Prints a description of the tokenized stream to the provided `raw_ostream`.
   //
   // It prints one line of information for each token in the buffer, including
@@ -218,6 +208,11 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   }
 
   auto size() const -> int { return token_infos_.size(); }
+
+  auto comments() const -> llvm::iterator_range<CommentIterator> {
+    return llvm::make_range(CommentIterator(CommentIndex(0)),
+                            CommentIterator(CommentIndex(comments_.size())));
+  }
 
   // This is an upper bound on the number of output parse nodes in the absence
   // of errors.
@@ -418,6 +413,20 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   static_assert(sizeof(TokenInfo) == 8,
                 "Expected `TokenInfo` to pack to an 8-byte structure.");
 
+  // A comment, which can be a block of lines. These are tracked separately from
+  // tokens because they don't affect parse; if they were part of tokens, we'd
+  // need more general special-casing within token logic.
+  //
+  // Note that `CommentInfo` is used for an API to expose the comment.
+  struct CommentData {
+    // Zero-based byte offset of the start of the comment within the source
+    // buffer provided.
+    int32_t start;
+
+    // The comment's length.
+    int32_t length;
+  };
+
   struct LineInfo {
     explicit LineInfo(int32_t start) : start(start), indent(0) {}
 
@@ -457,6 +466,9 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   llvm::SmallVector<TokenInfo> token_infos_;
 
   llvm::SmallVector<LineInfo> line_infos_;
+
+  // Comments in the file.
+  llvm::SmallVector<CommentData> comments_;
 
   // An upper bound on the number of parse tree nodes that we expect to be
   // created for the tokens in this buffer.


### PR DESCRIPTION
In order to format comments, it's helpful if they're tracked. This tracks them separately from tokens in order to avoid interfering with parse; it'd be inconvenient if comment tokens could show up in arbitrary locations, albeit possible to support.

This additionally extracts out the TokenIterator support into a template in order to generally have it available for IndexBase types. I'm only adding it for CommentInfo, not sure if we'll want it elsewhere, but this structure still felt like a good fit.