### PR TITLE
Update conduct team member list

### DIFF
--- a/docs/project/teams/conduct_team.md
+++ b/docs/project/teams/conduct_team.md
@@ -21,7 +21,6 @@ The current members of this list are:
 -   Céline Dedaj (@celineausberlin on Discord and GitHub)
 -   Christopher Di Bella (@cjdb.work on Discord, @cjdb on GitHub)
 -   Lexi Bromfield (@lexinadia on Discord and @lexi-nadia on GitHub)
--   flysand (@flysand on Discord and @flysand7 on GitHub)
 
 For more details on reporting conduct to the team, please see the
 [reporting conduct](/CODE_OF_CONDUCT.md#reporting-conduct) documentation.


### PR DESCRIPTION
deleted @flysand7 from the conduct team member list after they left the team