### PR TITLE
Refactor compile-related tests to share construction.

### DIFF
--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -257,6 +257,7 @@ cc_test(
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:mocks",
+        "//toolchain/testing:compile_helper",
         "//toolchain/testing:yaml_test_helpers",
         "@googletest//:gtest",
         "@llvm-project//llvm:Support",

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -23,15 +23,14 @@
 namespace Carbon::Lex {
 namespace {
 
+using ::Carbon::Testing::ExpectedToken;
+using ::Carbon::Testing::IsSingleDiagnostic;
+using ::Carbon::Testing::TestRawOstream;
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Pair;
-
-using ::Carbon::Testing::ExpectedToken;
-using ::Carbon::Testing::IsSingleDiagnostic;
-using ::Carbon::Testing::TestRawOstream;
 
 namespace Yaml = ::Carbon::Testing::Yaml;
 

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -17,14 +17,12 @@
 #include "toolchain/diagnostics/mocks.h"
 #include "toolchain/lex/lex.h"
 #include "toolchain/lex/tokenized_buffer_test_helpers.h"
+#include "toolchain/testing/compile_helper.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Lex {
+namespace Carbon::Testing {
 namespace {
 
-using ::Carbon::Testing::ExpectedToken;
-using ::Carbon::Testing::IsSingleDiagnostic;
-using ::Carbon::Testing::TestRawOstream;
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Eq;
@@ -35,264 +33,294 @@ namespace Yaml = ::Carbon::Testing::Yaml;
 
 class LexerTest : public ::testing::Test {
  protected:
-  auto GetSourceBuffer(llvm::StringRef text) -> SourceBuffer& {
-    std::string filename = llvm::formatv("test{0}.carbon", ++file_index_);
-    CARBON_CHECK(fs_.addFile(filename, /*ModificationTime=*/0,
-                             llvm::MemoryBuffer::getMemBuffer(text)));
-    source_storage_.push_front(std::move(*SourceBuffer::MakeFromFile(
-        fs_, filename, ConsoleDiagnosticConsumer())));
-    return source_storage_.front();
-  }
-
-  auto Lex(llvm::StringRef text,
-           DiagnosticConsumer& consumer = ConsoleDiagnosticConsumer())
-      -> TokenizedBuffer {
-    return Lex::Lex(value_stores_, GetSourceBuffer(text), consumer);
-  }
-
-  SharedValueStores value_stores_;
-  llvm::vfs::InMemoryFileSystem fs_;
-  int file_index_ = 0;
-  std::forward_list<SourceBuffer> source_storage_;
+  CompileHelper compile_helper_;
 };
 
 TEST_F(LexerTest, HandlesEmptyBuffer) {
-  auto buffer = Lex("");
+  auto& buffer = compile_helper_.GetTokenizedBuffer("");
   EXPECT_FALSE(buffer.has_errors());
   EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::FileEnd}}));
+                          {.kind = Lex::TokenKind::FileStart},
+                          {.kind = Lex::TokenKind::FileEnd}}));
 }
 
 TEST_F(LexerTest, TracksLinesAndColumns) {
-  auto buffer = Lex("\n  ;;\n   ;;;\n   x\"foo\" '''baz\n  a\n ''' y");
+  auto& buffer = compile_helper_.GetTokenizedBuffer(
+      "\n  ;;\n   ;;;\n   x\"foo\" '''baz\n  a\n ''' y");
   EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(
-      buffer,
-      HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart,
-           .line = 1,
-           .column = 1,
-           .indent_column = 1},
-          {.kind = TokenKind::Semi, .line = 2, .column = 3, .indent_column = 3},
-          {.kind = TokenKind::Semi, .line = 2, .column = 4, .indent_column = 3},
-          {.kind = TokenKind::Semi, .line = 3, .column = 4, .indent_column = 4},
-          {.kind = TokenKind::Semi, .line = 3, .column = 5, .indent_column = 4},
-          {.kind = TokenKind::Semi, .line = 3, .column = 6, .indent_column = 4},
-          {.kind = TokenKind::Identifier,
-           .line = 4,
-           .column = 4,
-           .indent_column = 4,
-           .text = "x"},
-          {.kind = TokenKind::StringLiteral,
-           .line = 4,
-           .column = 5,
-           .indent_column = 4},
-          {.kind = TokenKind::StringLiteral,
-           .line = 4,
-           .column = 11,
-           .indent_column = 4},
-          {.kind = TokenKind::Identifier,
-           .line = 6,
-           .column = 6,
-           .indent_column = 11,
-           .text = "y"},
-          {.kind = TokenKind::FileEnd, .line = 6, .column = 7},
-      }));
+  EXPECT_THAT(buffer,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart,
+                   .line = 1,
+                   .column = 1,
+                   .indent_column = 1},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 3,
+                   .indent_column = 3},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 4,
+                   .indent_column = 3},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 4,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 5,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 6,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Identifier,
+                   .line = 4,
+                   .column = 4,
+                   .indent_column = 4,
+                   .text = "x"},
+                  {.kind = Lex::TokenKind::StringLiteral,
+                   .line = 4,
+                   .column = 5,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::StringLiteral,
+                   .line = 4,
+                   .column = 11,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Identifier,
+                   .line = 6,
+                   .column = 6,
+                   .indent_column = 11,
+                   .text = "y"},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 6, .column = 7},
+              }));
 }
 
 TEST_F(LexerTest, TracksLinesAndColumnsCRLF) {
-  auto buffer =
-      Lex("\r\n  ;;\r\n   ;;;\r\n   x\"foo\" '''baz\r\n  a\r\n ''' y");
+  auto& buffer = compile_helper_.GetTokenizedBuffer(
+      "\r\n  ;;\r\n   ;;;\r\n   x\"foo\" '''baz\r\n  a\r\n ''' y");
   EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(
-      buffer,
-      HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart,
-           .line = 1,
-           .column = 1,
-           .indent_column = 1},
-          {.kind = TokenKind::Semi, .line = 2, .column = 3, .indent_column = 3},
-          {.kind = TokenKind::Semi, .line = 2, .column = 4, .indent_column = 3},
-          {.kind = TokenKind::Semi, .line = 3, .column = 4, .indent_column = 4},
-          {.kind = TokenKind::Semi, .line = 3, .column = 5, .indent_column = 4},
-          {.kind = TokenKind::Semi, .line = 3, .column = 6, .indent_column = 4},
-          {.kind = TokenKind::Identifier,
-           .line = 4,
-           .column = 4,
-           .indent_column = 4,
-           .text = "x"},
-          {.kind = TokenKind::StringLiteral,
-           .line = 4,
-           .column = 5,
-           .indent_column = 4},
-          {.kind = TokenKind::StringLiteral,
-           .line = 4,
-           .column = 11,
-           .indent_column = 4},
-          {.kind = TokenKind::Identifier,
-           .line = 6,
-           .column = 6,
-           .indent_column = 11,
-           .text = "y"},
-          {.kind = TokenKind::FileEnd, .line = 6, .column = 7},
-      }));
+  EXPECT_THAT(buffer,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart,
+                   .line = 1,
+                   .column = 1,
+                   .indent_column = 1},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 3,
+                   .indent_column = 3},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 4,
+                   .indent_column = 3},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 4,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 5,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 6,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Identifier,
+                   .line = 4,
+                   .column = 4,
+                   .indent_column = 4,
+                   .text = "x"},
+                  {.kind = Lex::TokenKind::StringLiteral,
+                   .line = 4,
+                   .column = 5,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::StringLiteral,
+                   .line = 4,
+                   .column = 11,
+                   .indent_column = 4},
+                  {.kind = Lex::TokenKind::Identifier,
+                   .line = 6,
+                   .column = 6,
+                   .indent_column = 11,
+                   .text = "y"},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 6, .column = 7},
+              }));
 }
 
 TEST_F(LexerTest, InvalidCR) {
-  auto buffer = Lex("\n ;;\r ;\n   x");
+  auto& buffer = compile_helper_.GetTokenizedBuffer("\n ;;\r ;\n   x");
   EXPECT_TRUE(buffer.has_errors());
-  EXPECT_THAT(
-      buffer,
-      HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart,
-           .line = 1,
-           .column = 1,
-           .indent_column = 1},
-          {.kind = TokenKind::Semi, .line = 2, .column = 2, .indent_column = 2},
-          {.kind = TokenKind::Semi, .line = 2, .column = 3, .indent_column = 2},
-          {.kind = TokenKind::Semi, .line = 2, .column = 6, .indent_column = 2},
-          {.kind = TokenKind::Identifier,
-           .line = 3,
-           .column = 4,
-           .indent_column = 4,
-           .text = "x"},
-          {.kind = TokenKind::FileEnd, .line = 3, .column = 5},
-      }));
+  EXPECT_THAT(buffer,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart,
+                   .line = 1,
+                   .column = 1,
+                   .indent_column = 1},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 2,
+                   .indent_column = 2},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 3,
+                   .indent_column = 2},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 6,
+                   .indent_column = 2},
+                  {.kind = Lex::TokenKind::Identifier,
+                   .line = 3,
+                   .column = 4,
+                   .indent_column = 4,
+                   .text = "x"},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 3, .column = 5},
+              }));
 }
 
 TEST_F(LexerTest, InvalidLFCR) {
-  auto buffer = Lex("\n ;;\n\r ;\n   x");
+  auto& buffer = compile_helper_.GetTokenizedBuffer("\n ;;\n\r ;\n   x");
   EXPECT_TRUE(buffer.has_errors());
-  EXPECT_THAT(
-      buffer,
-      HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart,
-           .line = 1,
-           .column = 1,
-           .indent_column = 1},
-          {.kind = TokenKind::Semi, .line = 2, .column = 2, .indent_column = 2},
-          {.kind = TokenKind::Semi, .line = 2, .column = 3, .indent_column = 2},
-          {.kind = TokenKind::Semi, .line = 3, .column = 3, .indent_column = 1},
-          {.kind = TokenKind::Identifier,
-           .line = 4,
-           .column = 4,
-           .indent_column = 4,
-           .text = "x"},
-          {.kind = TokenKind::FileEnd, .line = 4, .column = 5},
-      }));
+  EXPECT_THAT(buffer,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart,
+                   .line = 1,
+                   .column = 1,
+                   .indent_column = 1},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 2,
+                   .indent_column = 2},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 2,
+                   .column = 3,
+                   .indent_column = 2},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 3,
+                   .indent_column = 1},
+                  {.kind = Lex::TokenKind::Identifier,
+                   .line = 4,
+                   .column = 4,
+                   .indent_column = 4,
+                   .text = "x"},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 4, .column = 5},
+              }));
 }
 
 TEST_F(LexerTest, HandlesNumericLiteral) {
-  auto buffer = Lex("12-578\n  1  2\n0x12_3ABC\n0b10_10_11\n1_234_567\n1.5e9");
+  auto [buffer, value_stores] =
+      compile_helper_.GetTokenizedBufferWithSharedValueStore(
+          "12-578\n  1  2\n0x12_3ABC\n0b10_10_11\n1_234_567\n1.5e9");
   EXPECT_FALSE(buffer.has_errors());
   ASSERT_THAT(buffer,
               HasTokens(llvm::ArrayRef<ExpectedToken>{
-                  {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 1,
                    .column = 1,
                    .indent_column = 1,
                    .text = "12"},
-                  {.kind = TokenKind::Minus,
+                  {.kind = Lex::TokenKind::Minus,
                    .line = 1,
                    .column = 3,
                    .indent_column = 1},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 1,
                    .column = 4,
                    .indent_column = 1,
                    .text = "578"},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 2,
                    .column = 3,
                    .indent_column = 3,
                    .text = "1"},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 2,
                    .column = 6,
                    .indent_column = 3,
                    .text = "2"},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 3,
                    .column = 1,
                    .indent_column = 1,
                    .text = "0x12_3ABC"},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 4,
                    .column = 1,
                    .indent_column = 1,
                    .text = "0b10_10_11"},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 5,
                    .column = 1,
                    .indent_column = 1,
                    .text = "1_234_567"},
-                  {.kind = TokenKind::RealLiteral,
+                  {.kind = Lex::TokenKind::RealLiteral,
                    .line = 6,
                    .column = 1,
                    .indent_column = 1,
                    .text = "1.5e9"},
-                  {.kind = TokenKind::FileEnd, .line = 6, .column = 6},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 6, .column = 6},
               }));
   auto token_start = buffer.tokens().begin();
   auto token_12 = token_start + 1;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_12)), 12);
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_12)), 12);
   auto token_578 = token_12 + 2;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_578)), 578);
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_578)), 578);
   auto token_1 = token_578 + 1;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_1)), 1);
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_1)), 1);
   auto token_2 = token_1 + 1;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_2)), 2);
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_2)), 2);
   auto token_0x12_3abc = token_2 + 1;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_0x12_3abc)),
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_0x12_3abc)),
             0x12'3abc);
   auto token_0b10_10_11 = token_0x12_3abc + 1;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_0b10_10_11)),
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_0b10_10_11)),
             0b10'10'11);
   auto token_1_234_567 = token_0b10_10_11 + 1;
-  EXPECT_EQ(value_stores_.ints().Get(buffer.GetIntLiteral(*token_1_234_567)),
+  EXPECT_EQ(value_stores.ints().Get(buffer.GetIntLiteral(*token_1_234_567)),
             1'234'567);
   auto token_1_5e9 = token_1_234_567 + 1;
   auto value_1_5e9 =
-      value_stores_.reals().Get(buffer.GetRealLiteral(*token_1_5e9));
+      value_stores.reals().Get(buffer.GetRealLiteral(*token_1_5e9));
   EXPECT_EQ(value_1_5e9.mantissa.getZExtValue(), 15);
   EXPECT_EQ(value_1_5e9.exponent.getSExtValue(), 8);
   EXPECT_EQ(value_1_5e9.is_decimal, true);
 }
 
 TEST_F(LexerTest, HandlesInvalidNumericLiterals) {
-  auto buffer = Lex("14x 15_49 0x3.5q 0x3_4.5_6 0ops");
+  auto& buffer =
+      compile_helper_.GetTokenizedBuffer("14x 15_49 0x3.5q 0x3_4.5_6 0ops");
   EXPECT_TRUE(buffer.has_errors());
   ASSERT_THAT(buffer,
               HasTokens(llvm::ArrayRef<ExpectedToken>{
-                  {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-                  {.kind = TokenKind::Error,
+                  {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+                  {.kind = Lex::TokenKind::Error,
                    .line = 1,
                    .column = 1,
                    .indent_column = 1,
                    .text = "14x"},
-                  {.kind = TokenKind::IntLiteral,
+                  {.kind = Lex::TokenKind::IntLiteral,
                    .line = 1,
                    .column = 5,
                    .indent_column = 1,
                    .text = "15_49"},
-                  {.kind = TokenKind::Error,
+                  {.kind = Lex::TokenKind::Error,
                    .line = 1,
                    .column = 11,
                    .indent_column = 1,
                    .text = "0x3.5q"},
-                  {.kind = TokenKind::RealLiteral,
+                  {.kind = Lex::TokenKind::RealLiteral,
                    .line = 1,
                    .column = 18,
                    .indent_column = 1,
                    .text = "0x3_4.5_6"},
-                  {.kind = TokenKind::Error,
+                  {.kind = Lex::TokenKind::Error,
                    .line = 1,
                    .column = 28,
                    .indent_column = 1,
                    .text = "0ops"},
-                  {.kind = TokenKind::FileEnd, .line = 1, .column = 32},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 1, .column = 32},
               }));
 }
 
@@ -312,90 +340,104 @@ TEST_F(LexerTest, SplitsNumericLiteralsProperly) {
     12e+1
     13._
   )";
-  auto buffer = Lex(source_text);
+  auto& buffer = compile_helper_.GetTokenizedBuffer(source_text);
   EXPECT_TRUE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::IntLiteral, .text = "1"},
-                          {.kind = TokenKind::Period},
-                          // newline
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::IntLiteral, .text = "2"},
-                          // newline
-                          {.kind = TokenKind::IntLiteral, .text = "3"},
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::Plus},
-                          {.kind = TokenKind::Identifier, .text = "foo"},
-                          // newline
-                          {.kind = TokenKind::RealLiteral, .text = "4.0"},
-                          {.kind = TokenKind::Minus},
-                          {.kind = TokenKind::Identifier, .text = "bar"},
-                          // newline
-                          {.kind = TokenKind::RealLiteral, .text = "5.0e+123"},
-                          {.kind = TokenKind::Plus},
-                          {.kind = TokenKind::IntLiteral, .text = "456"},
-                          // newline
-                          {.kind = TokenKind::Error, .text = "6.0e+1e"},
-                          {.kind = TokenKind::Plus},
-                          {.kind = TokenKind::IntLiteral, .text = "2"},
-                          // newline
-                          {.kind = TokenKind::Error, .text = "1e7"},
-                          // newline
-                          {.kind = TokenKind::IntLiteral, .text = "8"},
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::IntLiteral, .text = "10"},
-                          // newline
-                          {.kind = TokenKind::RealLiteral, .text = "9.0"},
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::RealLiteral, .text = "9.5"},
-                          // newline
-                          {.kind = TokenKind::Error, .text = "10.foo"},
-                          // newline
-                          {.kind = TokenKind::RealLiteral, .text = "11.0"},
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::Identifier, .text = "foo"},
-                          // newline
-                          {.kind = TokenKind::Error, .text = "12e"},
-                          {.kind = TokenKind::Plus},
-                          {.kind = TokenKind::IntLiteral, .text = "1"},
-                          // newline
-                          {.kind = TokenKind::IntLiteral, .text = "13"},
-                          {.kind = TokenKind::Period},
-                          {.kind = TokenKind::Underscore},
-                          // newline
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  EXPECT_THAT(buffer,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart},
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "1"},
+                  {.kind = Lex::TokenKind::Period},
+                  // newline
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "2"},
+                  // newline
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "3"},
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::Plus},
+                  {.kind = Lex::TokenKind::Identifier, .text = "foo"},
+                  // newline
+                  {.kind = Lex::TokenKind::RealLiteral, .text = "4.0"},
+                  {.kind = Lex::TokenKind::Minus},
+                  {.kind = Lex::TokenKind::Identifier, .text = "bar"},
+                  // newline
+                  {.kind = Lex::TokenKind::RealLiteral, .text = "5.0e+123"},
+                  {.kind = Lex::TokenKind::Plus},
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "456"},
+                  // newline
+                  {.kind = Lex::TokenKind::Error, .text = "6.0e+1e"},
+                  {.kind = Lex::TokenKind::Plus},
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "2"},
+                  // newline
+                  {.kind = Lex::TokenKind::Error, .text = "1e7"},
+                  // newline
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "8"},
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "10"},
+                  // newline
+                  {.kind = Lex::TokenKind::RealLiteral, .text = "9.0"},
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::RealLiteral, .text = "9.5"},
+                  // newline
+                  {.kind = Lex::TokenKind::Error, .text = "10.foo"},
+                  // newline
+                  {.kind = Lex::TokenKind::RealLiteral, .text = "11.0"},
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::Identifier, .text = "foo"},
+                  // newline
+                  {.kind = Lex::TokenKind::Error, .text = "12e"},
+                  {.kind = Lex::TokenKind::Plus},
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "1"},
+                  // newline
+                  {.kind = Lex::TokenKind::IntLiteral, .text = "13"},
+                  {.kind = Lex::TokenKind::Period},
+                  {.kind = Lex::TokenKind::Underscore},
+                  // newline
+                  {.kind = Lex::TokenKind::FileEnd},
+              }));
 }
 
 TEST_F(LexerTest, HandlesGarbageCharacters) {
   constexpr char GarbageText[] = "$$💩-$\n$\0$12$\n\\\"\\\n\"x";
-  auto buffer = Lex(llvm::StringRef(GarbageText, sizeof(GarbageText) - 1));
+  auto& buffer = compile_helper_.GetTokenizedBuffer(
+      llvm::StringRef(GarbageText, sizeof(GarbageText) - 1));
   EXPECT_TRUE(buffer.has_errors());
   EXPECT_THAT(
       buffer,
       HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-          {.kind = TokenKind::Error,
+          {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+          {.kind = Lex::TokenKind::Error,
            .line = 1,
            .column = 1,
            // 💩 takes 4 bytes, and we count column as bytes offset.
            .text = llvm::StringRef("$$💩", 6)},
-          {.kind = TokenKind::Minus, .line = 1, .column = 7},
-          {.kind = TokenKind::Error, .line = 1, .column = 8, .text = "$"},
+          {.kind = Lex::TokenKind::Minus, .line = 1, .column = 7},
+          {.kind = Lex::TokenKind::Error, .line = 1, .column = 8, .text = "$"},
           // newline
-          {.kind = TokenKind::Error,
+          {.kind = Lex::TokenKind::Error,
            .line = 2,
            .column = 1,
            .text = llvm::StringRef("$\0$", 3)},
-          {.kind = TokenKind::IntLiteral, .line = 2, .column = 4, .text = "12"},
-          {.kind = TokenKind::Error, .line = 2, .column = 6, .text = "$"},
+          {.kind = Lex::TokenKind::IntLiteral,
+           .line = 2,
+           .column = 4,
+           .text = "12"},
+          {.kind = Lex::TokenKind::Error, .line = 2, .column = 6, .text = "$"},
           // newline
-          {.kind = TokenKind::Backslash, .line = 3, .column = 1, .text = "\\"},
-          {.kind = TokenKind::Error, .line = 3, .column = 2, .text = "\"\\"},
+          {.kind = Lex::TokenKind::Backslash,
+           .line = 3,
+           .column = 1,
+           .text = "\\"},
+          {.kind = Lex::TokenKind::Error,
+           .line = 3,
+           .column = 2,
+           .text = "\"\\"},
           // newline
-          {.kind = TokenKind::Error, .line = 4, .column = 1, .text = "\"x"},
-          {.kind = TokenKind::FileEnd, .line = 4, .column = 3},
+          {.kind = Lex::TokenKind::Error,
+           .line = 4,
+           .column = 1,
+           .text = "\"x"},
+          {.kind = Lex::TokenKind::FileEnd, .line = 4, .column = 3},
       }));
 }
 
@@ -403,104 +445,104 @@ TEST_F(LexerTest, Symbols) {
   // We don't need to exhaustively test symbols here as they're handled with
   // common code, but we want to check specific patterns to verify things like
   // max-munch rule and handling of interesting symbols.
-  auto buffer = Lex("<<<");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::LessLess},
-                          {.kind = TokenKind::Less},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer1 = compile_helper_.GetTokenizedBuffer("<<<");
+  EXPECT_FALSE(buffer1.has_errors());
+  EXPECT_THAT(buffer1, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::LessLess},
+                           {.kind = Lex::TokenKind::Less},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("<<=>>");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::LessLessEqual},
-                          {.kind = TokenKind::GreaterGreater},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer2 = compile_helper_.GetTokenizedBuffer("<<=>>");
+  EXPECT_FALSE(buffer2.has_errors());
+  EXPECT_THAT(buffer2, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::LessLessEqual},
+                           {.kind = Lex::TokenKind::GreaterGreater},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("< <=> >");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Less},
-                          {.kind = TokenKind::LessEqualGreater},
-                          {.kind = TokenKind::Greater},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer3 = compile_helper_.GetTokenizedBuffer("< <=> >");
+  EXPECT_FALSE(buffer3.has_errors());
+  EXPECT_THAT(buffer3, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::Less},
+                           {.kind = Lex::TokenKind::LessEqualGreater},
+                           {.kind = Lex::TokenKind::Greater},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("\\/?@&^!");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Backslash},
-                          {.kind = TokenKind::Slash},
-                          {.kind = TokenKind::Question},
-                          {.kind = TokenKind::At},
-                          {.kind = TokenKind::Amp},
-                          {.kind = TokenKind::Caret},
-                          {.kind = TokenKind::Exclaim},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer4 = compile_helper_.GetTokenizedBuffer("\\/?@&^!");
+  EXPECT_FALSE(buffer4.has_errors());
+  EXPECT_THAT(buffer4, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::Backslash},
+                           {.kind = Lex::TokenKind::Slash},
+                           {.kind = Lex::TokenKind::Question},
+                           {.kind = Lex::TokenKind::At},
+                           {.kind = Lex::TokenKind::Amp},
+                           {.kind = Lex::TokenKind::Caret},
+                           {.kind = Lex::TokenKind::Exclaim},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 }
 
 TEST_F(LexerTest, Parens) {
-  auto buffer = Lex("()");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::OpenParen},
-                          {.kind = TokenKind::CloseParen},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer1 = compile_helper_.GetTokenizedBuffer("()");
+  EXPECT_FALSE(buffer1.has_errors());
+  EXPECT_THAT(buffer1, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::OpenParen},
+                           {.kind = Lex::TokenKind::CloseParen},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("((()()))");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::OpenParen},
-                          {.kind = TokenKind::OpenParen},
-                          {.kind = TokenKind::OpenParen},
-                          {.kind = TokenKind::CloseParen},
-                          {.kind = TokenKind::OpenParen},
-                          {.kind = TokenKind::CloseParen},
-                          {.kind = TokenKind::CloseParen},
-                          {.kind = TokenKind::CloseParen},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer2 = compile_helper_.GetTokenizedBuffer("((()()))");
+  EXPECT_FALSE(buffer2.has_errors());
+  EXPECT_THAT(buffer2, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::OpenParen},
+                           {.kind = Lex::TokenKind::OpenParen},
+                           {.kind = Lex::TokenKind::OpenParen},
+                           {.kind = Lex::TokenKind::CloseParen},
+                           {.kind = Lex::TokenKind::OpenParen},
+                           {.kind = Lex::TokenKind::CloseParen},
+                           {.kind = Lex::TokenKind::CloseParen},
+                           {.kind = Lex::TokenKind::CloseParen},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 }
 
 TEST_F(LexerTest, CurlyBraces) {
-  auto buffer = Lex("{}");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::OpenCurlyBrace},
-                          {.kind = TokenKind::CloseCurlyBrace},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer1 = compile_helper_.GetTokenizedBuffer("{}");
+  EXPECT_FALSE(buffer1.has_errors());
+  EXPECT_THAT(buffer1, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::OpenCurlyBrace},
+                           {.kind = Lex::TokenKind::CloseCurlyBrace},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("{{{}{}}}");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::OpenCurlyBrace},
-                          {.kind = TokenKind::OpenCurlyBrace},
-                          {.kind = TokenKind::OpenCurlyBrace},
-                          {.kind = TokenKind::CloseCurlyBrace},
-                          {.kind = TokenKind::OpenCurlyBrace},
-                          {.kind = TokenKind::CloseCurlyBrace},
-                          {.kind = TokenKind::CloseCurlyBrace},
-                          {.kind = TokenKind::CloseCurlyBrace},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer2 = compile_helper_.GetTokenizedBuffer("{{{}{}}}");
+  EXPECT_FALSE(buffer2.has_errors());
+  EXPECT_THAT(buffer2, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::OpenCurlyBrace},
+                           {.kind = Lex::TokenKind::OpenCurlyBrace},
+                           {.kind = Lex::TokenKind::OpenCurlyBrace},
+                           {.kind = Lex::TokenKind::CloseCurlyBrace},
+                           {.kind = Lex::TokenKind::OpenCurlyBrace},
+                           {.kind = Lex::TokenKind::CloseCurlyBrace},
+                           {.kind = Lex::TokenKind::CloseCurlyBrace},
+                           {.kind = Lex::TokenKind::CloseCurlyBrace},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 }
 
 TEST_F(LexerTest, MatchingGroups) {
   {
-    TokenizedBuffer buffer = Lex("(){}");
+    auto& buffer = compile_helper_.GetTokenizedBuffer("(){}");
     ASSERT_FALSE(buffer.has_errors());
     auto it = ++buffer.tokens().begin();
     auto open_paren_token = *it++;
@@ -516,19 +558,20 @@ TEST_F(LexerTest, MatchingGroups) {
     EXPECT_EQ(open_curly_token,
               buffer.GetMatchedOpeningToken(close_curly_token));
     auto eof_token = *it++;
-    EXPECT_EQ(buffer.GetKind(eof_token), TokenKind::FileEnd);
+    EXPECT_EQ(buffer.GetKind(eof_token), Lex::TokenKind::FileEnd);
     EXPECT_EQ(buffer.tokens().end(), it);
   }
 
   {
-    TokenizedBuffer buffer = Lex("({x}){(y)} {{((z))}}");
+    auto [buffer, value_stores] =
+        compile_helper_.GetTokenizedBufferWithSharedValueStore(
+            "({x}){(y)} {{((z))}}");
     ASSERT_FALSE(buffer.has_errors());
     auto it = ++buffer.tokens().begin();
     auto open_paren_token = *it++;
     auto open_curly_token = *it++;
 
-    ASSERT_EQ("x",
-              value_stores_.identifiers().Get(buffer.GetIdentifier(*it++)));
+    ASSERT_EQ("x", value_stores.identifiers().Get(buffer.GetIdentifier(*it++)));
     auto close_curly_token = *it++;
     auto close_paren_token = *it++;
     EXPECT_EQ(close_paren_token,
@@ -542,8 +585,7 @@ TEST_F(LexerTest, MatchingGroups) {
 
     open_curly_token = *it++;
     open_paren_token = *it++;
-    ASSERT_EQ("y",
-              value_stores_.identifiers().Get(buffer.GetIdentifier(*it++)));
+    ASSERT_EQ("y", value_stores.identifiers().Get(buffer.GetIdentifier(*it++)));
     close_paren_token = *it++;
     close_curly_token = *it++;
     EXPECT_EQ(close_curly_token,
@@ -559,8 +601,7 @@ TEST_F(LexerTest, MatchingGroups) {
     auto inner_open_curly_token = *it++;
     open_paren_token = *it++;
     auto inner_open_paren_token = *it++;
-    ASSERT_EQ("z",
-              value_stores_.identifiers().Get(buffer.GetIdentifier(*it++)));
+    ASSERT_EQ("z", value_stores.identifiers().Get(buffer.GetIdentifier(*it++)));
     auto inner_close_paren_token = *it++;
     close_paren_token = *it++;
     auto inner_close_curly_token = *it++;
@@ -583,58 +624,59 @@ TEST_F(LexerTest, MatchingGroups) {
               buffer.GetMatchedOpeningToken(inner_close_paren_token));
 
     auto eof_token = *it++;
-    EXPECT_EQ(buffer.GetKind(eof_token), TokenKind::FileEnd);
+    EXPECT_EQ(buffer.GetKind(eof_token), Lex::TokenKind::FileEnd);
     EXPECT_EQ(buffer.tokens().end(), it);
   }
 }
 
 TEST_F(LexerTest, MismatchedGroups) {
-  auto buffer = Lex("{");
-  EXPECT_TRUE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Error, .text = "{"},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer1 = compile_helper_.GetTokenizedBuffer("{");
+  EXPECT_TRUE(buffer1.has_errors());
+  EXPECT_THAT(buffer1, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::Error, .text = "{"},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("}");
-  EXPECT_TRUE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Error, .text = "}"},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer2 = compile_helper_.GetTokenizedBuffer("}");
+  EXPECT_TRUE(buffer2.has_errors());
+  EXPECT_THAT(buffer2, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::Error, .text = "}"},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
-  buffer = Lex("{(}");
-  EXPECT_TRUE(buffer.has_errors());
+  auto& buffer3 = compile_helper_.GetTokenizedBuffer("{(}");
+  EXPECT_TRUE(buffer3.has_errors());
   EXPECT_THAT(
-      buffer,
+      buffer3,
       HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart},
-          {.kind = TokenKind::OpenCurlyBrace, .column = 1},
-          {.kind = TokenKind::OpenParen, .column = 2},
-          {.kind = TokenKind::CloseParen, .column = 3, .recovery = true},
-          {.kind = TokenKind::CloseCurlyBrace, .column = 3},
-          {.kind = TokenKind::FileEnd},
+          {.kind = Lex::TokenKind::FileStart},
+          {.kind = Lex::TokenKind::OpenCurlyBrace, .column = 1},
+          {.kind = Lex::TokenKind::OpenParen, .column = 2},
+          {.kind = Lex::TokenKind::CloseParen, .column = 3, .recovery = true},
+          {.kind = Lex::TokenKind::CloseCurlyBrace, .column = 3},
+          {.kind = Lex::TokenKind::FileEnd},
       }));
 
-  buffer = Lex(")({)");
-  EXPECT_TRUE(buffer.has_errors());
-  EXPECT_THAT(
-      buffer,
-      HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart},
-          {.kind = TokenKind::Error, .column = 1, .text = ")"},
-          {.kind = TokenKind::OpenParen, .column = 2},
-          {.kind = TokenKind::OpenCurlyBrace, .column = 3},
-          {.kind = TokenKind::CloseCurlyBrace, .column = 4, .recovery = true},
-          {.kind = TokenKind::CloseParen, .column = 4},
-          {.kind = TokenKind::FileEnd},
-      }));
+  auto& buffer4 = compile_helper_.GetTokenizedBuffer(")({)");
+  EXPECT_TRUE(buffer4.has_errors());
+  EXPECT_THAT(buffer4,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart},
+                  {.kind = Lex::TokenKind::Error, .column = 1, .text = ")"},
+                  {.kind = Lex::TokenKind::OpenParen, .column = 2},
+                  {.kind = Lex::TokenKind::OpenCurlyBrace, .column = 3},
+                  {.kind = Lex::TokenKind::CloseCurlyBrace,
+                   .column = 4,
+                   .recovery = true},
+                  {.kind = Lex::TokenKind::CloseParen, .column = 4},
+                  {.kind = Lex::TokenKind::FileEnd},
+              }));
 }
 
 TEST_F(LexerTest, Whitespace) {
-  auto buffer = Lex("{( } {(");
+  auto& buffer = compile_helper_.GetTokenizedBuffer("{( } {(");
 
   // Whether there should be whitespace before/after each token.
   bool space[] = {false,
@@ -655,7 +697,7 @@ TEST_F(LexerTest, Whitespace) {
                   // EOF
                   false};
   int pos = 0;
-  for (TokenIndex token : buffer.tokens()) {
+  for (Lex::TokenIndex token : buffer.tokens()) {
     SCOPED_TRACE(
         llvm::formatv("Token #{0}: '{1}'", token, buffer.GetTokenText(token)));
 
@@ -669,53 +711,59 @@ TEST_F(LexerTest, Whitespace) {
 }
 
 TEST_F(LexerTest, Keywords) {
-  TokenKind keywords[] = {
+  Lex::TokenKind keywords[] = {
 #define CARBON_TOKEN(TokenName)
-#define CARBON_KEYWORD_TOKEN(TokenName, ...) TokenKind::TokenName,
+#define CARBON_KEYWORD_TOKEN(TokenName, ...) Lex::TokenKind::TokenName,
 #include "toolchain/lex/token_kind.def"
   };
   for (const auto& keyword : keywords) {
-    auto buffer = Lex(keyword.fixed_spelling());
+    auto& buffer = compile_helper_.GetTokenizedBuffer(keyword.fixed_spelling());
     EXPECT_FALSE(buffer.has_errors());
     EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                            {.kind = TokenKind::FileStart},
+                            {.kind = Lex::TokenKind::FileStart},
                             {.kind = keyword, .column = 1, .indent_column = 1},
-                            {.kind = TokenKind::FileEnd},
+                            {.kind = Lex::TokenKind::FileEnd},
                         }));
   }
 }
 
 TEST_F(LexerTest, Comments) {
-  auto buffer = Lex(" ;\n  // foo\n  ;\n");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(
-      buffer,
-      HasTokens(llvm::ArrayRef<ExpectedToken>{
-          {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-          {.kind = TokenKind::Semi, .line = 1, .column = 2, .indent_column = 2},
-          {.kind = TokenKind::Semi, .line = 3, .column = 3, .indent_column = 3},
-          {.kind = TokenKind::FileEnd, .line = 3, .column = 4},
-      }));
+  auto& buffer1 = compile_helper_.GetTokenizedBuffer(" ;\n  // foo\n  ;\n");
+  EXPECT_FALSE(buffer1.has_errors());
+  EXPECT_THAT(buffer1,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 1,
+                   .column = 2,
+                   .indent_column = 2},
+                  {.kind = Lex::TokenKind::Semi,
+                   .line = 3,
+                   .column = 3,
+                   .indent_column = 3},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 3, .column = 4},
+              }));
 
-  buffer = Lex("// foo\n//\n// bar");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::FileEnd}}));
+  auto& buffer2 = compile_helper_.GetTokenizedBuffer("// foo\n//\n// bar");
+  EXPECT_FALSE(buffer2.has_errors());
+  EXPECT_THAT(buffer2, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::FileEnd}}));
 
   // Make sure weird characters aren't a problem.
-  buffer = Lex("  // foo#$!^?@-_💩🍫⃠ [̲̅$̲̅(̲̅ ͡° ͜ʖ ͡°̲̅)̲̅$̲̅]");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::FileEnd}}));
+  auto& buffer3 =
+      compile_helper_.GetTokenizedBuffer("  // foo#$!^?@-_💩🍫⃠ [̲̅$̲̅(̲̅ ͡° ͜ʖ ͡°̲̅)̲̅$̲̅]");
+  EXPECT_FALSE(buffer3.has_errors());
+  EXPECT_THAT(buffer3, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::FileEnd}}));
 
   // Make sure we can lex a comment at the end of the input.
-  buffer = Lex("//");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::FileEnd}}));
+  auto& buffer4 = compile_helper_.GetTokenizedBuffer("//");
+  EXPECT_FALSE(buffer4.has_errors());
+  EXPECT_THAT(buffer4, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::FileEnd}}));
 }
 
 TEST_F(LexerTest, InvalidComments) {
@@ -726,82 +774,86 @@ TEST_F(LexerTest, InvalidComments) {
       " //world",
   };
   for (llvm::StringLiteral testcase : testcases) {
-    auto buffer = Lex(testcase);
+    auto& buffer = compile_helper_.GetTokenizedBuffer(testcase);
     EXPECT_TRUE(buffer.has_errors());
   }
 }
 
 TEST_F(LexerTest, Identifiers) {
-  auto buffer = Lex("   foobar");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Identifier,
-                           .column = 4,
-                           .indent_column = 4,
-                           .text = "foobar"},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer1 = compile_helper_.GetTokenizedBuffer("   foobar");
+  EXPECT_FALSE(buffer1.has_errors());
+  EXPECT_THAT(buffer1, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                           {.kind = Lex::TokenKind::FileStart},
+                           {.kind = Lex::TokenKind::Identifier,
+                            .column = 4,
+                            .indent_column = 4,
+                            .text = "foobar"},
+                           {.kind = Lex::TokenKind::FileEnd},
+                       }));
 
   // Check different kinds of identifier character sequences.
-  buffer = Lex("_foo_bar");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Identifier, .text = "_foo_bar"},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer2 = compile_helper_.GetTokenizedBuffer("_foo_bar");
+  EXPECT_FALSE(buffer2.has_errors());
+  EXPECT_THAT(buffer2,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart},
+                  {.kind = Lex::TokenKind::Identifier, .text = "_foo_bar"},
+                  {.kind = Lex::TokenKind::FileEnd},
+              }));
 
-  buffer = Lex("foo2bar00");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Identifier, .text = "foo2bar00"},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer3 = compile_helper_.GetTokenizedBuffer("foo2bar00");
+  EXPECT_FALSE(buffer3.has_errors());
+  EXPECT_THAT(buffer3,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart},
+                  {.kind = Lex::TokenKind::Identifier, .text = "foo2bar00"},
+                  {.kind = Lex::TokenKind::FileEnd},
+              }));
 
   // Check that we can parse identifiers that start with a keyword.
-  buffer = Lex("fnord");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
-                          {.kind = TokenKind::FileStart},
-                          {.kind = TokenKind::Identifier, .text = "fnord"},
-                          {.kind = TokenKind::FileEnd},
-                      }));
+  auto& buffer4 = compile_helper_.GetTokenizedBuffer("fnord");
+  EXPECT_FALSE(buffer4.has_errors());
+  EXPECT_THAT(buffer4,
+              HasTokens(llvm::ArrayRef<ExpectedToken>{
+                  {.kind = Lex::TokenKind::FileStart},
+                  {.kind = Lex::TokenKind::Identifier, .text = "fnord"},
+                  {.kind = Lex::TokenKind::FileEnd},
+              }));
 
   // Check multiple identifiers with indent and interning.
-  buffer = Lex("   foo;bar\nbar \n  foo\tfoo");
-  EXPECT_FALSE(buffer.has_errors());
-  EXPECT_THAT(buffer,
+  auto& buffer5 =
+      compile_helper_.GetTokenizedBuffer("   foo;bar\nbar \n  foo\tfoo");
+  EXPECT_FALSE(buffer5.has_errors());
+  EXPECT_THAT(buffer5,
               HasTokens(llvm::ArrayRef<ExpectedToken>{
-                  {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 1,
                    .column = 4,
                    .indent_column = 4,
                    .text = "foo"},
-                  {.kind = TokenKind::Semi},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Semi},
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 1,
                    .column = 8,
                    .indent_column = 4,
                    .text = "bar"},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 2,
                    .column = 1,
                    .indent_column = 1,
                    .text = "bar"},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 3,
                    .column = 3,
                    .indent_column = 3,
                    .text = "foo"},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 3,
                    .column = 7,
                    .indent_column = 3,
                    .text = "foo"},
-                  {.kind = TokenKind::FileEnd, .line = 3, .column = 10},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 3, .column = 10},
               }));
 }
 
@@ -823,68 +875,69 @@ TEST_F(LexerTest, StringLiterals) {
     """x"""
   )";
 
-  auto buffer = Lex(testcase);
+  auto [buffer, value_stores] =
+      compile_helper_.GetTokenizedBufferWithSharedValueStore(testcase);
   EXPECT_FALSE(buffer.has_errors());
   EXPECT_THAT(buffer,
               HasTokens(llvm::ArrayRef<ExpectedToken>{
-                  {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 2,
                    .column = 5,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {"hello world\n"}},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 4,
                    .column = 5,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {" test  \xAB\n"}},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 7,
                    .column = 10,
                    .indent_column = 5,
                    .text = "trailing"},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 9,
                    .column = 7,
                    .indent_column = 7,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {"\""}},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 11,
                    .column = 5,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = llvm::StringLiteral::withInnerNUL("\0")},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 13,
                    .column = 5,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {"\\0\"foo\"\\1"}},
 
                   // """x""" is three string literals, not one invalid
                   // attempt at a block string literal.
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 15,
                    .column = 5,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {""}},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 15,
                    .column = 7,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {"x"}},
-                  {.kind = TokenKind::StringLiteral,
+                  {.kind = Lex::TokenKind::StringLiteral,
                    .line = 15,
                    .column = 10,
                    .indent_column = 5,
-                   .value_stores = &value_stores_,
+                   .value_stores = &value_stores,
                    .string_contents = {""}},
-                  {.kind = TokenKind::FileEnd, .line = 16, .column = 3},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 16, .column = 3},
               }));
 }
 
@@ -909,13 +962,13 @@ TEST_F(LexerTest, InvalidStringLiterals) {
 
   for (llvm::StringLiteral test : invalid) {
     SCOPED_TRACE(test);
-    auto buffer = Lex(test);
+    auto& buffer = compile_helper_.GetTokenizedBuffer(test);
     EXPECT_TRUE(buffer.has_errors());
 
     // We should have formed at least one error token.
     bool found_error = false;
-    for (TokenIndex token : buffer.tokens()) {
-      if (buffer.GetKind(token) == TokenKind::Error) {
+    for (Lex::TokenIndex token : buffer.tokens()) {
+      if (buffer.GetKind(token) == Lex::TokenKind::Error) {
         found_error = true;
         break;
       }
@@ -932,92 +985,93 @@ TEST_F(LexerTest, TypeLiterals) {
     s1
   )";
 
-  auto buffer = Lex(testcase);
+  auto [buffer, value_stores] =
+      compile_helper_.GetTokenizedBufferWithSharedValueStore(testcase);
   EXPECT_FALSE(buffer.has_errors());
   ASSERT_THAT(buffer,
               HasTokens(llvm::ArrayRef<ExpectedToken>{
-                  {.kind = TokenKind::FileStart, .line = 1, .column = 1},
+                  {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
 
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 2,
                    .column = 5,
                    .indent_column = 5,
                    .text = {"i0"}},
-                  {.kind = TokenKind::IntTypeLiteral,
+                  {.kind = Lex::TokenKind::IntTypeLiteral,
                    .line = 2,
                    .column = 8,
                    .indent_column = 5,
                    .text = {"i1"}},
-                  {.kind = TokenKind::IntTypeLiteral,
+                  {.kind = Lex::TokenKind::IntTypeLiteral,
                    .line = 2,
                    .column = 11,
                    .indent_column = 5,
                    .text = {"i20"}},
-                  {.kind = TokenKind::IntTypeLiteral,
+                  {.kind = Lex::TokenKind::IntTypeLiteral,
                    .line = 2,
                    .column = 15,
                    .indent_column = 5,
                    .text = {"i999999999999"}},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 2,
                    .column = 29,
                    .indent_column = 5,
                    .text = {"i0x1"}},
 
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 3,
                    .column = 5,
                    .indent_column = 5,
                    .text = {"u0"}},
-                  {.kind = TokenKind::UnsignedIntTypeLiteral,
+                  {.kind = Lex::TokenKind::UnsignedIntTypeLiteral,
                    .line = 3,
                    .column = 8,
                    .indent_column = 5,
                    .text = {"u1"}},
-                  {.kind = TokenKind::UnsignedIntTypeLiteral,
+                  {.kind = Lex::TokenKind::UnsignedIntTypeLiteral,
                    .line = 3,
                    .column = 11,
                    .indent_column = 5,
                    .text = {"u64"}},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 3,
                    .column = 15,
                    .indent_column = 5,
                    .text = {"u64b"}},
 
-                  {.kind = TokenKind::FloatTypeLiteral,
+                  {.kind = Lex::TokenKind::FloatTypeLiteral,
                    .line = 4,
                    .column = 5,
                    .indent_column = 5,
                    .text = {"f32"}},
-                  {.kind = TokenKind::FloatTypeLiteral,
+                  {.kind = Lex::TokenKind::FloatTypeLiteral,
                    .line = 4,
                    .column = 9,
                    .indent_column = 5,
                    .text = {"f80"}},
-                  {.kind = TokenKind::FloatTypeLiteral,
+                  {.kind = Lex::TokenKind::FloatTypeLiteral,
                    .line = 4,
                    .column = 13,
                    .indent_column = 5,
                    .text = {"f1"}},
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 4,
                    .column = 16,
                    .indent_column = 5,
                    .text = {"fi"}},
 
-                  {.kind = TokenKind::Identifier,
+                  {.kind = Lex::TokenKind::Identifier,
                    .line = 5,
                    .column = 5,
                    .indent_column = 5,
                    .text = {"s1"}},
 
-                  {.kind = TokenKind::FileEnd, .line = 6, .column = 3},
+                  {.kind = Lex::TokenKind::FileEnd, .line = 6, .column = 3},
               }));
 
   auto type_size = [&](int token_index) {
     auto token = buffer.tokens().begin()[token_index];
-    return value_stores_.ints().Get(buffer.GetTypeLiteralSize(token));
+    return value_stores.ints().Get(buffer.GetTypeLiteralSize(token));
   };
 
   EXPECT_EQ(type_size(2), 1);
@@ -1040,18 +1094,19 @@ TEST_F(LexerTest, TypeLiteralTooManyDigits) {
               HandleDiagnostic(IsSingleDiagnostic(
                   DiagnosticKind::TooManyDigits, DiagnosticLevel::Error, 1, 2,
                   HasSubstr(llvm::formatv(" {0} ", Count)))));
-  auto buffer = Lex(code, consumer);
+  auto& buffer = compile_helper_.GetTokenizedBuffer(code, &consumer);
   EXPECT_TRUE(buffer.has_errors());
-  ASSERT_THAT(buffer,
-              HasTokens(llvm::ArrayRef<ExpectedToken>{
-                  {.kind = TokenKind::FileStart, .line = 1, .column = 1},
-                  {.kind = TokenKind::Error,
-                   .line = 1,
-                   .column = 1,
-                   .indent_column = 1,
-                   .text = code},
-                  {.kind = TokenKind::FileEnd, .line = 1, .column = Count + 2},
-              }));
+  ASSERT_THAT(
+      buffer,
+      HasTokens(llvm::ArrayRef<ExpectedToken>{
+          {.kind = Lex::TokenKind::FileStart, .line = 1, .column = 1},
+          {.kind = Lex::TokenKind::Error,
+           .line = 1,
+           .column = 1,
+           .indent_column = 1,
+           .text = code},
+          {.kind = Lex::TokenKind::FileEnd, .line = 1, .column = Count + 2},
+      }));
 }
 
 TEST_F(LexerTest, DiagnosticTrailingComment) {
@@ -1064,7 +1119,7 @@ TEST_F(LexerTest, DiagnosticTrailingComment) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::TrailingComment,
                             DiagnosticLevel::Error, 3, 19, _)));
-  Lex(testcase, consumer);
+  compile_helper_.GetTokenizedBuffer(testcase, &consumer);
 }
 
 TEST_F(LexerTest, DiagnosticWhitespace) {
@@ -1072,7 +1127,7 @@ TEST_F(LexerTest, DiagnosticWhitespace) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::NoWhitespaceAfterCommentIntroducer,
                             DiagnosticLevel::Error, 1, 3, _)));
-  Lex("//no space after comment", consumer);
+  compile_helper_.GetTokenizedBuffer("//no space after comment", &consumer);
 }
 
 TEST_F(LexerTest, DiagnosticUnrecognizedEscape) {
@@ -1080,7 +1135,7 @@ TEST_F(LexerTest, DiagnosticUnrecognizedEscape) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::UnknownEscapeSequence,
                             DiagnosticLevel::Error, 1, 8, HasSubstr("`b`"))));
-  Lex(R"("hello\bworld")", consumer);
+  compile_helper_.GetTokenizedBuffer(R"("hello\bworld")", &consumer);
 }
 
 TEST_F(LexerTest, DiagnosticBadHex) {
@@ -1088,7 +1143,7 @@ TEST_F(LexerTest, DiagnosticBadHex) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::HexadecimalEscapeMissingDigits,
                             DiagnosticLevel::Error, 1, 9, _)));
-  Lex(R"("hello\xabworld")", consumer);
+  compile_helper_.GetTokenizedBuffer(R"("hello\xabworld")", &consumer);
 }
 
 TEST_F(LexerTest, DiagnosticInvalidDigit) {
@@ -1096,7 +1151,7 @@ TEST_F(LexerTest, DiagnosticInvalidDigit) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::InvalidDigit,
                             DiagnosticLevel::Error, 1, 6, HasSubstr("'a'"))));
-  Lex("0x123abc", consumer);
+  compile_helper_.GetTokenizedBuffer("0x123abc", &consumer);
 }
 
 TEST_F(LexerTest, DiagnosticMissingTerminator) {
@@ -1104,7 +1159,7 @@ TEST_F(LexerTest, DiagnosticMissingTerminator) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::UnterminatedString,
                             DiagnosticLevel::Error, 1, 1, _)));
-  Lex(R"(#" ")", consumer);
+  compile_helper_.GetTokenizedBuffer(R"(#" ")", &consumer);
 }
 
 TEST_F(LexerTest, DiagnosticUnrecognizedChar) {
@@ -1112,12 +1167,13 @@ TEST_F(LexerTest, DiagnosticUnrecognizedChar) {
   EXPECT_CALL(consumer, HandleDiagnostic(IsSingleDiagnostic(
                             DiagnosticKind::UnrecognizedCharacters,
                             DiagnosticLevel::Error, 1, 1, _)));
-  Lex("\b", consumer);
+  compile_helper_.GetTokenizedBuffer("\b", &consumer);
 }
 
 TEST_F(LexerTest, PrintingOutputYaml) {
   // Test that we can parse this into YAML and verify line and indent data.
-  auto buffer = Lex("\n ;\n\n\n; ;\n\n\n\n\n\n\n\n\n\n\n");
+  auto& buffer =
+      compile_helper_.GetTokenizedBuffer("\n ;\n\n\n; ;\n\n\n\n\n\n\n\n\n\n\n");
   ASSERT_FALSE(buffer.has_errors());
   TestRawOstream print_stream;
   buffer.Print(print_stream);
@@ -1125,7 +1181,7 @@ TEST_F(LexerTest, PrintingOutputYaml) {
   EXPECT_THAT(
       Yaml::Value::FromText(print_stream.TakeStr()),
       IsYaml(ElementsAre(Yaml::Sequence(ElementsAre(Yaml::Mapping(ElementsAre(
-          Pair("filename", source_storage_.front().filename().str()),
+          Pair("filename", buffer.source().filename().str()),
           Pair("tokens", Yaml::Sequence(ElementsAre(
                              Yaml::Mapping(ElementsAre(
                                  Pair("index", "0"), Pair("kind", "FileStart"),
@@ -1154,4 +1210,4 @@ TEST_F(LexerTest, PrintingOutputYaml) {
 }
 
 }  // namespace
-}  // namespace Carbon::Lex
+}  // namespace Carbon::Testing

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -45,6 +45,7 @@ cc_test(
         "//toolchain/diagnostics:mocks",
         "//toolchain/lex",
         "//toolchain/lex:tokenized_buffer",
+        "//toolchain/testing:compile_helper",
         "@googletest//:gtest",
     ],
 )
@@ -139,6 +140,7 @@ cc_test(
         "//toolchain/diagnostics:mocks",
         "//toolchain/lex",
         "//toolchain/lex:tokenized_buffer",
+        "//toolchain/testing:compile_helper",
         "//toolchain/testing:yaml_test_helpers",
         "@googletest//:gtest",
         "@llvm-project//llvm:Support",

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -23,10 +23,9 @@
 namespace Carbon::Parse {
 namespace {
 
+using ::Carbon::Testing::TestRawOstream;
 using ::testing::ElementsAre;
 using ::testing::Pair;
-
-using ::Carbon::Testing::TestRawOstream;
 
 namespace Yaml = ::Carbon::Testing::Yaml;
 

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -17,99 +17,80 @@
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/parse.h"
 #include "toolchain/parse/tree_and_subtrees.h"
+#include "toolchain/testing/compile_helper.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Parse {
+namespace Carbon::Testing {
 namespace {
 
-using ::Carbon::Testing::TestRawOstream;
 using ::testing::ElementsAre;
 using ::testing::Pair;
 
-namespace Yaml = ::Carbon::Testing::Yaml;
-
 class TreeTest : public ::testing::Test {
  protected:
-  auto GetSourceBuffer(llvm::StringRef t) -> SourceBuffer& {
-    CARBON_CHECK(fs_.addFile("test.carbon", /*ModificationTime=*/0,
-                             llvm::MemoryBuffer::getMemBuffer(t)));
-    source_storage_.push_front(
-        std::move(*SourceBuffer::MakeFromFile(fs_, "test.carbon", consumer_)));
-    return source_storage_.front();
-  }
-
-  auto GetTokenizedBuffer(llvm::StringRef t) -> Lex::TokenizedBuffer& {
-    token_storage_.push_front(
-        Lex::Lex(value_stores_, GetSourceBuffer(t), consumer_));
-    return token_storage_.front();
-  }
-
-  SharedValueStores value_stores_;
-  llvm::vfs::InMemoryFileSystem fs_;
-  std::forward_list<SourceBuffer> source_storage_;
-  std::forward_list<Lex::TokenizedBuffer> token_storage_;
-  DiagnosticConsumer& consumer_ = ConsoleDiagnosticConsumer();
+  CompileHelper compile_helper_;
 };
 
 TEST_F(TreeTest, IsValid) {
-  Lex::TokenizedBuffer& tokens = GetTokenizedBuffer("");
-  Tree tree = Parse(tokens, consumer_, /*vlog_stream=*/nullptr);
+  Parse::Tree& tree = compile_helper_.GetTree("");
   EXPECT_TRUE((*tree.postorder().begin()).is_valid());
 }
 
 TEST_F(TreeTest, AsAndTryAs) {
-  Lex::TokenizedBuffer& tokens = GetTokenizedBuffer("fn F();");
-  Tree tree = Parse(tokens, consumer_, /*vlog_stream=*/nullptr);
+  auto [tokens, tree_and_subtrees] =
+      compile_helper_.GetTokenizedBufferWithTreeAndSubtrees("fn F();");
+  const auto& tree = tree_and_subtrees.tree();
   ASSERT_FALSE(tree.has_errors());
-  TreeAndSubtrees tree_and_subtrees(tokens, tree);
   auto it = tree_and_subtrees.roots().begin();
   // A FileEnd node, so won't match.
-  NodeId n = *it;
+  Parse::NodeId n = *it;
 
   // NodeIdForKind
-  std::optional<FunctionDeclId> fn_decl_id = tree.TryAs<FunctionDeclId>(n);
+  std::optional<Parse::FunctionDeclId> fn_decl_id =
+      tree.TryAs<Parse::FunctionDeclId>(n);
   EXPECT_FALSE(fn_decl_id.has_value());
   // NodeIdOneOf
-  std::optional<AnyFunctionDeclId> any_fn_decl_id =
-      tree.TryAs<AnyFunctionDeclId>(n);
+  std::optional<Parse::AnyFunctionDeclId> any_fn_decl_id =
+      tree.TryAs<Parse::AnyFunctionDeclId>(n);
   EXPECT_FALSE(any_fn_decl_id.has_value());
   // NodeIdInCategory
-  std::optional<AnyDeclId> any_decl_id = tree.TryAs<AnyDeclId>(n);
+  std::optional<Parse::AnyDeclId> any_decl_id = tree.TryAs<Parse::AnyDeclId>(n);
   EXPECT_FALSE(any_decl_id.has_value());
 
   ++it;
   n = *it;
   // A FunctionDecl node, so will match.
-  fn_decl_id = tree.TryAs<FunctionDeclId>(n);
+  fn_decl_id = tree.TryAs<Parse::FunctionDeclId>(n);
   ASSERT_TRUE(fn_decl_id.has_value());
   EXPECT_TRUE(*fn_decl_id == n);
   // Under normal usage, this function should be used with `auto`, but for
   // a test it is nice to verify that it is returning the expected type.
   // NOLINTNEXTLINE(modernize-use-auto).
-  FunctionDeclId fn_decl_id2 = tree.As<FunctionDeclId>(n);
+  Parse::FunctionDeclId fn_decl_id2 = tree.As<Parse::FunctionDeclId>(n);
   EXPECT_TRUE(*fn_decl_id == fn_decl_id2);
 
-  any_fn_decl_id = tree.TryAs<AnyFunctionDeclId>(n);
+  any_fn_decl_id = tree.TryAs<Parse::AnyFunctionDeclId>(n);
   ASSERT_TRUE(any_fn_decl_id.has_value());
   EXPECT_TRUE(*any_fn_decl_id == n);
   // NOLINTNEXTLINE(modernize-use-auto).
-  AnyFunctionDeclId any_fn_decl_id2 = tree.As<AnyFunctionDeclId>(n);
+  Parse::AnyFunctionDeclId any_fn_decl_id2 =
+      tree.As<Parse::AnyFunctionDeclId>(n);
   EXPECT_TRUE(*any_fn_decl_id == any_fn_decl_id2);
 
-  any_decl_id = tree.TryAs<AnyDeclId>(n);
+  any_decl_id = tree.TryAs<Parse::AnyDeclId>(n);
   ASSERT_TRUE(any_decl_id.has_value());
   EXPECT_TRUE(*any_decl_id == n);
   // NOLINTNEXTLINE(modernize-use-auto).
-  AnyDeclId any_decl_id2 = tree.As<AnyDeclId>(n);
+  Parse::AnyDeclId any_decl_id2 = tree.As<Parse::AnyDeclId>(n);
   EXPECT_TRUE(*any_decl_id == any_decl_id2);
 }
 
 TEST_F(TreeTest, PrintPostorderAsYAML) {
-  Lex::TokenizedBuffer& tokens = GetTokenizedBuffer("fn F();");
-  Tree tree = Parse(tokens, consumer_, /*vlog_stream=*/nullptr);
-  EXPECT_FALSE(tree.has_errors());
+  auto [tokens, tree_and_subtrees] =
+      compile_helper_.GetTokenizedBufferWithTreeAndSubtrees("fn F();");
+  EXPECT_FALSE(tree_and_subtrees.tree().has_errors());
   TestRawOstream print_stream;
-  tree.Print(print_stream);
+  tree_and_subtrees.tree().Print(print_stream);
 
   auto file = Yaml::Sequence(ElementsAre(
       Yaml::Mapping(ElementsAre(Pair("kind", "FileStart"), Pair("text", ""))),
@@ -126,17 +107,17 @@ TEST_F(TreeTest, PrintPostorderAsYAML) {
       Yaml::Mapping(ElementsAre(Pair("kind", "FileEnd"), Pair("text", "")))));
 
   auto root = Yaml::Sequence(ElementsAre(Yaml::Mapping(
-      ElementsAre(Pair("filename", "test.carbon"), Pair("parse_tree", file)))));
+      ElementsAre(Pair("filename", tokens.source().filename().str()),
+                  Pair("parse_tree", file)))));
 
   EXPECT_THAT(Yaml::Value::FromText(print_stream.TakeStr()),
               IsYaml(ElementsAre(root)));
 }
 
 TEST_F(TreeTest, PrintPreorderAsYAML) {
-  Lex::TokenizedBuffer& tokens = GetTokenizedBuffer("fn F();");
-  Tree tree = Parse(tokens, consumer_, /*vlog_stream=*/nullptr);
-  EXPECT_FALSE(tree.has_errors());
-  TreeAndSubtrees tree_and_subtrees(tokens, tree);
+  auto [tokens, tree_and_subtrees] =
+      compile_helper_.GetTokenizedBufferWithTreeAndSubtrees("fn F();");
+  EXPECT_FALSE(tree_and_subtrees.tree().has_errors());
   TestRawOstream print_stream;
   tree_and_subtrees.PrintPreorder(print_stream);
 
@@ -167,7 +148,8 @@ TEST_F(TreeTest, PrintPreorderAsYAML) {
                                 Pair("kind", "FileEnd"), Pair("text", "")))));
 
   auto root = Yaml::Sequence(ElementsAre(Yaml::Mapping(
-      ElementsAre(Pair("filename", "test.carbon"), Pair("parse_tree", file)))));
+      ElementsAre(Pair("filename", tokens.source().filename().str()),
+                  Pair("parse_tree", file)))));
 
   EXPECT_THAT(Yaml::Value::FromText(print_stream.TakeStr()),
               IsYaml(ElementsAre(root)));
@@ -178,12 +160,12 @@ TEST_F(TreeTest, HighRecursion) {
   code.append(10000, '(');
   code.append(10000, ')');
   code += "; }";
-  Lex::TokenizedBuffer& tokens = GetTokenizedBuffer(code);
+  Lex::TokenizedBuffer& tokens = compile_helper_.GetTokenizedBuffer(code);
   ASSERT_FALSE(tokens.has_errors());
   Testing::MockDiagnosticConsumer consumer;
-  Tree tree = Parse(tokens, consumer, /*vlog_stream=*/nullptr);
+  Parse::Tree tree = Parse::Parse(tokens, consumer, /*vlog_stream=*/nullptr);
   EXPECT_FALSE(tree.has_errors());
 }
 
 }  // namespace
-}  // namespace Carbon::Parse
+}  // namespace Carbon::Testing

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -20,19 +20,23 @@
 #include "toolchain/testing/compile_helper.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Parse {
 namespace {
 
 using ::testing::ElementsAre;
 using ::testing::Pair;
 
+using ::Carbon::Testing::TestRawOstream;
+
+namespace Yaml = ::Carbon::Testing::Yaml;
+
 class TreeTest : public ::testing::Test {
  protected:
-  CompileHelper compile_helper_;
+  Testing::CompileHelper compile_helper_;
 };
 
 TEST_F(TreeTest, IsValid) {
-  Parse::Tree& tree = compile_helper_.GetTree("");
+  Tree& tree = compile_helper_.GetTree("");
   EXPECT_TRUE((*tree.postorder().begin()).is_valid());
 }
 
@@ -43,45 +47,43 @@ TEST_F(TreeTest, AsAndTryAs) {
   ASSERT_FALSE(tree.has_errors());
   auto it = tree_and_subtrees.roots().begin();
   // A FileEnd node, so won't match.
-  Parse::NodeId n = *it;
+  NodeId n = *it;
 
   // NodeIdForKind
-  std::optional<Parse::FunctionDeclId> fn_decl_id =
-      tree.TryAs<Parse::FunctionDeclId>(n);
+  std::optional<FunctionDeclId> fn_decl_id = tree.TryAs<FunctionDeclId>(n);
   EXPECT_FALSE(fn_decl_id.has_value());
   // NodeIdOneOf
-  std::optional<Parse::AnyFunctionDeclId> any_fn_decl_id =
-      tree.TryAs<Parse::AnyFunctionDeclId>(n);
+  std::optional<AnyFunctionDeclId> any_fn_decl_id =
+      tree.TryAs<AnyFunctionDeclId>(n);
   EXPECT_FALSE(any_fn_decl_id.has_value());
   // NodeIdInCategory
-  std::optional<Parse::AnyDeclId> any_decl_id = tree.TryAs<Parse::AnyDeclId>(n);
+  std::optional<AnyDeclId> any_decl_id = tree.TryAs<AnyDeclId>(n);
   EXPECT_FALSE(any_decl_id.has_value());
 
   ++it;
   n = *it;
   // A FunctionDecl node, so will match.
-  fn_decl_id = tree.TryAs<Parse::FunctionDeclId>(n);
+  fn_decl_id = tree.TryAs<FunctionDeclId>(n);
   ASSERT_TRUE(fn_decl_id.has_value());
   EXPECT_TRUE(*fn_decl_id == n);
   // Under normal usage, this function should be used with `auto`, but for
   // a test it is nice to verify that it is returning the expected type.
   // NOLINTNEXTLINE(modernize-use-auto).
-  Parse::FunctionDeclId fn_decl_id2 = tree.As<Parse::FunctionDeclId>(n);
+  FunctionDeclId fn_decl_id2 = tree.As<FunctionDeclId>(n);
   EXPECT_TRUE(*fn_decl_id == fn_decl_id2);
 
-  any_fn_decl_id = tree.TryAs<Parse::AnyFunctionDeclId>(n);
+  any_fn_decl_id = tree.TryAs<AnyFunctionDeclId>(n);
   ASSERT_TRUE(any_fn_decl_id.has_value());
   EXPECT_TRUE(*any_fn_decl_id == n);
   // NOLINTNEXTLINE(modernize-use-auto).
-  Parse::AnyFunctionDeclId any_fn_decl_id2 =
-      tree.As<Parse::AnyFunctionDeclId>(n);
+  AnyFunctionDeclId any_fn_decl_id2 = tree.As<AnyFunctionDeclId>(n);
   EXPECT_TRUE(*any_fn_decl_id == any_fn_decl_id2);
 
-  any_decl_id = tree.TryAs<Parse::AnyDeclId>(n);
+  any_decl_id = tree.TryAs<AnyDeclId>(n);
   ASSERT_TRUE(any_decl_id.has_value());
   EXPECT_TRUE(*any_decl_id == n);
   // NOLINTNEXTLINE(modernize-use-auto).
-  Parse::AnyDeclId any_decl_id2 = tree.As<Parse::AnyDeclId>(n);
+  AnyDeclId any_decl_id2 = tree.As<AnyDeclId>(n);
   EXPECT_TRUE(*any_decl_id == any_decl_id2);
 }
 
@@ -163,9 +165,9 @@ TEST_F(TreeTest, HighRecursion) {
   Lex::TokenizedBuffer& tokens = compile_helper_.GetTokenizedBuffer(code);
   ASSERT_FALSE(tokens.has_errors());
   Testing::MockDiagnosticConsumer consumer;
-  Parse::Tree tree = Parse::Parse(tokens, consumer, /*vlog_stream=*/nullptr);
+  Tree tree = Parse(tokens, consumer, /*vlog_stream=*/nullptr);
   EXPECT_FALSE(tree.has_errors());
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Parse

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -36,22 +36,19 @@ class TypedNodesTestPeer {
   }
 };
 
-}  // namespace Carbon::Parse
-
-namespace Carbon::Testing {
 namespace {
 
 // Check that each node kind defines a Kind member using the correct
 // NodeKind enumerator.
 #define CARBON_PARSE_NODE_KIND(Name) \
-  static_assert(Parse::Name::Kind == Parse::NodeKind::Name, #Name);
+  static_assert(Name::Kind == NodeKind::Name, #Name);
 #include "toolchain/parse/node_kind.def"
 
 class TypedNodeTest : public ::testing::Test {
  protected:
-  using Peer = Parse::TypedNodesTestPeer;
+  using Peer = TypedNodesTestPeer;
 
-  CompileHelper compile_helper_;
+  Testing::CompileHelper compile_helper_;
 };
 
 TEST_F(TypedNodeTest, Empty) {
@@ -59,15 +56,15 @@ TEST_F(TypedNodeTest, Empty) {
   auto file = tree.ExtractFile();
 
   EXPECT_TRUE(tree.tree().IsValid(file.start));
-  EXPECT_TRUE(tree.ExtractAs<Parse::FileStart>(file.start).has_value());
+  EXPECT_TRUE(tree.ExtractAs<FileStart>(file.start).has_value());
   EXPECT_TRUE(tree.Extract(file.start).has_value());
 
   EXPECT_TRUE(tree.tree().IsValid(file.end));
-  EXPECT_TRUE(tree.ExtractAs<Parse::FileEnd>(file.end).has_value());
+  EXPECT_TRUE(tree.ExtractAs<FileEnd>(file.end).has_value());
   EXPECT_TRUE(tree.Extract(file.end).has_value());
 
-  EXPECT_FALSE(tree.tree().IsValid<Parse::FileEnd>(file.start));
-  EXPECT_FALSE(tree.ExtractAs<Parse::FileEnd>(file.start).has_value());
+  EXPECT_FALSE(tree.tree().IsValid<FileEnd>(file.start));
+  EXPECT_FALSE(tree.ExtractAs<FileEnd>(file.start).has_value());
 }
 
 TEST_F(TypedNodeTest, Function) {
@@ -79,14 +76,14 @@ TEST_F(TypedNodeTest, Function) {
 
   ASSERT_EQ(file.decls.size(), 2);
 
-  auto f_fn = tree.ExtractAs<Parse::FunctionDefinition>(file.decls[0]);
+  auto f_fn = tree.ExtractAs<FunctionDefinition>(file.decls[0]);
   ASSERT_TRUE(f_fn.has_value());
   auto f_sig = tree.Extract(f_fn->signature);
   ASSERT_TRUE(f_sig.has_value());
   EXPECT_FALSE(f_sig->return_type.has_value());
   EXPECT_TRUE(f_sig->modifiers.empty());
 
-  auto g_fn = tree.ExtractAs<Parse::FunctionDecl>(file.decls[1]);
+  auto g_fn = tree.ExtractAs<FunctionDecl>(file.decls[1]);
   ASSERT_TRUE(g_fn.has_value());
   EXPECT_TRUE(g_fn->return_type.has_value());
   EXPECT_FALSE(g_fn->modifiers.empty());
@@ -100,19 +97,15 @@ TEST_F(TypedNodeTest, ModifierOrder) {
 
   ASSERT_EQ(file.decls.size(), 1);
 
-  auto decl = tree.ExtractAs<Parse::InterfaceDecl>(file.decls[0]);
+  auto decl = tree.ExtractAs<InterfaceDecl>(file.decls[0]);
   ASSERT_TRUE(decl.has_value());
   ASSERT_EQ(decl->modifiers.size(), 4);
   // Note that the order here matches the source order, but is reversed from
   // sibling iteration order.
-  ASSERT_TRUE(
-      tree.ExtractAs<Parse::PrivateModifier>(decl->modifiers[0]).has_value());
-  ASSERT_TRUE(
-      tree.ExtractAs<Parse::AbstractModifier>(decl->modifiers[1]).has_value());
-  ASSERT_TRUE(
-      tree.ExtractAs<Parse::VirtualModifier>(decl->modifiers[2]).has_value());
-  ASSERT_TRUE(
-      tree.ExtractAs<Parse::DefaultModifier>(decl->modifiers[3]).has_value());
+  ASSERT_TRUE(tree.ExtractAs<PrivateModifier>(decl->modifiers[0]).has_value());
+  ASSERT_TRUE(tree.ExtractAs<AbstractModifier>(decl->modifiers[1]).has_value());
+  ASSERT_TRUE(tree.ExtractAs<VirtualModifier>(decl->modifiers[2]).has_value());
+  ASSERT_TRUE(tree.ExtractAs<DefaultModifier>(decl->modifiers[3]).has_value());
 }
 
 TEST_F(TypedNodeTest, For) {
@@ -126,20 +119,18 @@ TEST_F(TypedNodeTest, For) {
   auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
-  auto fn = tree.ExtractAs<Parse::FunctionDefinition>(file.decls[0]);
+  auto fn = tree.ExtractAs<FunctionDefinition>(file.decls[0]);
   ASSERT_TRUE(fn.has_value());
   ASSERT_EQ(fn->body.size(), 1);
-  auto for_stmt = tree.ExtractAs<Parse::ForStatement>(fn->body[0]);
+  auto for_stmt = tree.ExtractAs<ForStatement>(fn->body[0]);
   ASSERT_TRUE(for_stmt.has_value());
   auto for_header = tree.Extract(for_stmt->header);
   ASSERT_TRUE(for_header.has_value());
   auto for_var = tree.Extract(for_header->var);
   ASSERT_TRUE(for_var.has_value());
-  auto for_var_binding =
-      tree.ExtractAs<Parse::BindingPattern>(for_var->pattern);
+  auto for_var_binding = tree.ExtractAs<BindingPattern>(for_var->pattern);
   ASSERT_TRUE(for_var_binding.has_value());
-  auto for_var_name =
-      tree.ExtractAs<Parse::IdentifierName>(for_var_binding->name);
+  auto for_var_name = tree.ExtractAs<IdentifierName>(for_var_binding->name);
   ASSERT_TRUE(for_var_name.has_value());
 }
 
@@ -152,7 +143,7 @@ TEST_F(TypedNodeTest, VerifyExtractTraceLibrary) {
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
   auto library =
-      Peer::VerifyExtractAs<Parse::LibraryDecl>(tree, file.decls[0], &trace);
+      Peer::VerifyExtractAs<LibraryDecl>(tree, file.decls[0], &trace);
   EXPECT_TRUE(library.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -176,8 +167,7 @@ TEST_F(TypedNodeTest, VerifyExtractTraceVarNoInit) {
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto var =
-      Peer::VerifyExtractAs<Parse::VariableDecl>(tree, file.decls[0], &trace);
+  auto var = Peer::VerifyExtractAs<VariableDecl>(tree, file.decls[0], &trace);
   ASSERT_TRUE(var.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -208,8 +198,7 @@ TEST_F(TypedNodeTest, VerifyExtractTraceExpression) {
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace1;
-  auto var =
-      Peer::VerifyExtractAs<Parse::VariableDecl>(tree, file.decls[0], &trace1);
+  auto var = Peer::VerifyExtractAs<VariableDecl>(tree, file.decls[0], &trace1);
   ASSERT_TRUE(var.has_value());
   Error err1 = trace1;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -234,7 +223,7 @@ Aggregate [^:]*: success
 
   ASSERT_TRUE(var->initializer.has_value());
   ErrorBuilder trace2;
-  auto value = Peer::VerifyExtractAs<Parse::MemberAccessExpr>(
+  auto value = Peer::VerifyExtractAs<MemberAccessExpr>(
       tree, var->initializer->value, &trace2);
   ASSERT_TRUE(value.has_value());
   Error err2 = trace2;
@@ -256,7 +245,7 @@ TEST_F(TypedNodeTest, VerifyExtractTraceClassDecl) {
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
   auto class_decl =
-      Peer::VerifyExtractAs<Parse::ClassDecl>(tree, file.decls[0], &trace);
+      Peer::VerifyExtractAs<ClassDecl>(tree, file.decls[0], &trace);
   EXPECT_TRUE(class_decl.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -296,15 +285,15 @@ TEST_F(TypedNodeTest, Token) {
 
   ASSERT_EQ(file.decls.size(), 1);
 
-  auto n_var = tree.ExtractAs<Parse::VariableDecl>(file.decls[0]);
+  auto n_var = tree.ExtractAs<VariableDecl>(file.decls[0]);
   ASSERT_TRUE(n_var.has_value());
   EXPECT_EQ(tokens.GetKind(n_var->token), Lex::TokenKind::Semi);
 
-  auto n_intro = tree.ExtractAs<Parse::VariableIntroducer>(n_var->introducer);
+  auto n_intro = tree.ExtractAs<VariableIntroducer>(n_var->introducer);
   ASSERT_TRUE(n_intro.has_value());
   EXPECT_EQ(tokens.GetKind(n_intro->token), Lex::TokenKind::Var);
 
-  auto n_patt = tree.ExtractAs<Parse::BindingPattern>(n_var->pattern);
+  auto n_patt = tree.ExtractAs<BindingPattern>(n_var->pattern);
   ASSERT_TRUE(n_patt.has_value());
   EXPECT_EQ(tokens.GetKind(n_patt->token), Lex::TokenKind::Colon);
 }
@@ -317,22 +306,21 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   auto file = tree.ExtractFile();
   ASSERT_EQ(file.decls.size(), 1);
 
-  auto f_fn = tree.ExtractAs<Parse::FunctionDefinition>(file.decls[0]);
+  auto f_fn = tree.ExtractAs<FunctionDefinition>(file.decls[0]);
   ASSERT_TRUE(f_fn.has_value());
-  auto f_sig = tree.ExtractAs<Parse::FunctionDefinitionStart>(f_fn->signature);
+  auto f_sig = tree.ExtractAs<FunctionDefinitionStart>(f_fn->signature);
   ASSERT_TRUE(f_sig.has_value());
-  auto f_intro = tree.ExtractAs<Parse::FunctionIntroducer>(f_sig->introducer);
+  auto f_intro = tree.ExtractAs<FunctionIntroducer>(f_sig->introducer);
   ASSERT_TRUE(f_intro.has_value());
 
   // Change the kind of the introducer and check we get a good trace log.
-  Peer::SetNodeKind(tree.tree(), f_sig->introducer,
-                    Parse::NodeKind::ClassIntroducer);
+  Peer::SetNodeKind(tree.tree(), f_sig->introducer, NodeKind::ClassIntroducer);
 
   // The introducer should not extract as a FunctionIntroducer any more because
   // the kind is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(Peer::VerifyExtractAs<Parse::FunctionIntroducer>(
+    EXPECT_FALSE(Peer::VerifyExtractAs<FunctionIntroducer>(
         tree, f_sig->introducer, &trace));
 
     Error err = trace;
@@ -345,8 +333,8 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   // token kind is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(Peer::VerifyExtractAs<Parse::ClassIntroducer>(
-        tree, f_sig->introducer, &trace));
+    EXPECT_FALSE(Peer::VerifyExtractAs<ClassIntroducer>(tree, f_sig->introducer,
+                                                        &trace));
 
     Error err = trace;
     EXPECT_THAT(err.message(),
@@ -358,7 +346,7 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   // kind for the introducer is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(Peer::VerifyExtractAs<Parse::FunctionDefinitionStart>(
+    EXPECT_FALSE(Peer::VerifyExtractAs<FunctionDefinitionStart>(
         tree, f_fn->signature, &trace));
 
     Error err = trace;
@@ -370,16 +358,16 @@ Error: ClassIntroducer node left unconsumed.)Trace"));
   }
 }
 
-auto CategoryMatches(const Parse::NodeKind::Definition& def,
-                     Parse::NodeKind kind, const char* name) {
+auto CategoryMatches(const NodeKind::Definition& def, NodeKind kind,
+                     const char* name) {
   EXPECT_EQ(def.category(), kind.category()) << name;
 }
 
 TEST_F(TypedNodeTest, CategoryMatches) {
 #define CARBON_PARSE_NODE_KIND(Name) \
-  CategoryMatches(Parse::Name::Kind, Parse::NodeKind::Name, #Name);
+  CategoryMatches(Name::Kind, NodeKind::Name, #Name);
 #include "toolchain/parse/node_kind.def"
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Parse

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -13,6 +13,7 @@
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/parse.h"
 #include "toolchain/parse/tree_and_subtrees.h"
+#include "toolchain/testing/compile_helper.h"
 
 namespace Carbon::Parse {
 
@@ -21,160 +22,137 @@ namespace Carbon::Parse {
 class TypedNodesTestPeer {
  public:
   template <typename T>
-  static auto VerifyExtractAs(const TreeAndSubtrees* tree, NodeId node_id,
+  static auto VerifyExtractAs(const TreeAndSubtrees& tree, NodeId node_id,
                               ErrorBuilder* trace) -> std::optional<T> {
-    return tree->VerifyExtractAs<T>(node_id, trace);
+    return tree.VerifyExtractAs<T>(node_id, trace);
   }
 
   // Sets the kind of a node. This is intended to allow putting the tree into a
   // state where verification can fail, in order to make the failure path of
   // `Verify` testable.
-  static auto SetNodeKind(Tree* tree, NodeId node_id, NodeKind kind) -> void {
-    tree->SetNodeKindForTesting(node_id, kind);
+  static auto SetNodeKind(const Tree& tree, NodeId node_id, NodeKind kind)
+      -> void {
+    const_cast<Tree&>(tree).SetNodeKindForTesting(node_id, kind);
   }
 };
 
+}  // namespace Carbon::Parse
+
+namespace Carbon::Testing {
 namespace {
 
 // Check that each node kind defines a Kind member using the correct
 // NodeKind enumerator.
 #define CARBON_PARSE_NODE_KIND(Name) \
-  static_assert(Name::Kind == NodeKind::Name, #Name);
+  static_assert(Parse::Name::Kind == Parse::NodeKind::Name, #Name);
 #include "toolchain/parse/node_kind.def"
 
 class TypedNodeTest : public ::testing::Test {
  protected:
-  auto GetSourceBuffer(llvm::StringRef t) -> SourceBuffer& {
-    CARBON_CHECK(fs_.addFile("test.carbon", /*ModificationTime=*/0,
-                             llvm::MemoryBuffer::getMemBuffer(t)));
-    source_storage_.push_front(
-        std::move(*SourceBuffer::MakeFromFile(fs_, "test.carbon", consumer_)));
-    return source_storage_.front();
-  }
+  using Peer = Parse::TypedNodesTestPeer;
 
-  auto GetTokenizedBuffer(llvm::StringRef t) -> Lex::TokenizedBuffer& {
-    token_storage_.push_front(
-        Lex::Lex(value_stores_, GetSourceBuffer(t), consumer_));
-    return token_storage_.front();
-  }
-
-  auto GetTree(llvm::StringRef t) -> TreeAndSubtrees& {
-    tree_storage_.push_front(Parse(GetTokenizedBuffer(t), consumer_,
-                                   /*vlog_stream=*/nullptr));
-    tree_and_subtrees_storage_.push_front(
-        TreeAndSubtrees(token_storage_.front(), tree_storage_.front()));
-    return tree_and_subtrees_storage_.front();
-  }
-
-  auto GetTokenizedBufferAndTree(llvm::StringRef t)
-      -> std::pair<Lex::TokenizedBuffer*, TreeAndSubtrees*> {
-    auto* tree = &GetTree(t);
-    return {&token_storage_.front(), tree};
-  }
-
-  SharedValueStores value_stores_;
-  llvm::vfs::InMemoryFileSystem fs_;
-  std::forward_list<SourceBuffer> source_storage_;
-  std::forward_list<Lex::TokenizedBuffer> token_storage_;
-  std::forward_list<Tree> tree_storage_;
-  std::forward_list<TreeAndSubtrees> tree_and_subtrees_storage_;
-  DiagnosticConsumer& consumer_ = ConsoleDiagnosticConsumer();
+  CompileHelper compile_helper_;
 };
 
 TEST_F(TypedNodeTest, Empty) {
-  auto* tree = &GetTree("");
-  auto file = tree->ExtractFile();
+  auto& tree = compile_helper_.GetTreeAndSubtrees("");
+  auto file = tree.ExtractFile();
 
-  EXPECT_TRUE(tree->tree().IsValid(file.start));
-  EXPECT_TRUE(tree->ExtractAs<FileStart>(file.start).has_value());
-  EXPECT_TRUE(tree->Extract(file.start).has_value());
+  EXPECT_TRUE(tree.tree().IsValid(file.start));
+  EXPECT_TRUE(tree.ExtractAs<Parse::FileStart>(file.start).has_value());
+  EXPECT_TRUE(tree.Extract(file.start).has_value());
 
-  EXPECT_TRUE(tree->tree().IsValid(file.end));
-  EXPECT_TRUE(tree->ExtractAs<FileEnd>(file.end).has_value());
-  EXPECT_TRUE(tree->Extract(file.end).has_value());
+  EXPECT_TRUE(tree.tree().IsValid(file.end));
+  EXPECT_TRUE(tree.ExtractAs<Parse::FileEnd>(file.end).has_value());
+  EXPECT_TRUE(tree.Extract(file.end).has_value());
 
-  EXPECT_FALSE(tree->tree().IsValid<FileEnd>(file.start));
-  EXPECT_FALSE(tree->ExtractAs<FileEnd>(file.start).has_value());
+  EXPECT_FALSE(tree.tree().IsValid<Parse::FileEnd>(file.start));
+  EXPECT_FALSE(tree.ExtractAs<Parse::FileEnd>(file.start).has_value());
 }
 
 TEST_F(TypedNodeTest, Function) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     fn F() {}
     virtual fn G() -> i32;
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 2);
 
-  auto f_fn = tree->ExtractAs<FunctionDefinition>(file.decls[0]);
+  auto f_fn = tree.ExtractAs<Parse::FunctionDefinition>(file.decls[0]);
   ASSERT_TRUE(f_fn.has_value());
-  auto f_sig = tree->Extract(f_fn->signature);
+  auto f_sig = tree.Extract(f_fn->signature);
   ASSERT_TRUE(f_sig.has_value());
   EXPECT_FALSE(f_sig->return_type.has_value());
   EXPECT_TRUE(f_sig->modifiers.empty());
 
-  auto g_fn = tree->ExtractAs<FunctionDecl>(file.decls[1]);
+  auto g_fn = tree.ExtractAs<Parse::FunctionDecl>(file.decls[1]);
   ASSERT_TRUE(g_fn.has_value());
   EXPECT_TRUE(g_fn->return_type.has_value());
   EXPECT_FALSE(g_fn->modifiers.empty());
 }
 
 TEST_F(TypedNodeTest, ModifierOrder) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     private abstract virtual default interface I;
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
 
-  auto decl = tree->ExtractAs<InterfaceDecl>(file.decls[0]);
+  auto decl = tree.ExtractAs<Parse::InterfaceDecl>(file.decls[0]);
   ASSERT_TRUE(decl.has_value());
   ASSERT_EQ(decl->modifiers.size(), 4);
   // Note that the order here matches the source order, but is reversed from
   // sibling iteration order.
-  ASSERT_TRUE(tree->ExtractAs<PrivateModifier>(decl->modifiers[0]).has_value());
   ASSERT_TRUE(
-      tree->ExtractAs<AbstractModifier>(decl->modifiers[1]).has_value());
-  ASSERT_TRUE(tree->ExtractAs<VirtualModifier>(decl->modifiers[2]).has_value());
-  ASSERT_TRUE(tree->ExtractAs<DefaultModifier>(decl->modifiers[3]).has_value());
+      tree.ExtractAs<Parse::PrivateModifier>(decl->modifiers[0]).has_value());
+  ASSERT_TRUE(
+      tree.ExtractAs<Parse::AbstractModifier>(decl->modifiers[1]).has_value());
+  ASSERT_TRUE(
+      tree.ExtractAs<Parse::VirtualModifier>(decl->modifiers[2]).has_value());
+  ASSERT_TRUE(
+      tree.ExtractAs<Parse::DefaultModifier>(decl->modifiers[3]).has_value());
 }
 
 TEST_F(TypedNodeTest, For) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     fn F(arr: [i32; 5]) {
       for (var v: i32 in arr) {
         Print(v);
       }
     }
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
-  auto fn = tree->ExtractAs<FunctionDefinition>(file.decls[0]);
+  auto fn = tree.ExtractAs<Parse::FunctionDefinition>(file.decls[0]);
   ASSERT_TRUE(fn.has_value());
   ASSERT_EQ(fn->body.size(), 1);
-  auto for_stmt = tree->ExtractAs<ForStatement>(fn->body[0]);
+  auto for_stmt = tree.ExtractAs<Parse::ForStatement>(fn->body[0]);
   ASSERT_TRUE(for_stmt.has_value());
-  auto for_header = tree->Extract(for_stmt->header);
+  auto for_header = tree.Extract(for_stmt->header);
   ASSERT_TRUE(for_header.has_value());
-  auto for_var = tree->Extract(for_header->var);
+  auto for_var = tree.Extract(for_header->var);
   ASSERT_TRUE(for_var.has_value());
-  auto for_var_binding = tree->ExtractAs<BindingPattern>(for_var->pattern);
+  auto for_var_binding =
+      tree.ExtractAs<Parse::BindingPattern>(for_var->pattern);
   ASSERT_TRUE(for_var_binding.has_value());
-  auto for_var_name = tree->ExtractAs<IdentifierName>(for_var_binding->name);
+  auto for_var_name =
+      tree.ExtractAs<Parse::IdentifierName>(for_var_binding->name);
   ASSERT_TRUE(for_var_name.has_value());
 }
 
 TEST_F(TypedNodeTest, VerifyExtractTraceLibrary) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     impl library default;
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto library = TypedNodesTestPeer::VerifyExtractAs<LibraryDecl>(
-      tree, file.decls[0], &trace);
+  auto library =
+      Peer::VerifyExtractAs<Parse::LibraryDecl>(tree, file.decls[0], &trace);
   EXPECT_TRUE(library.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -191,15 +169,15 @@ Aggregate [^:]*: success
 }
 
 TEST_F(TypedNodeTest, VerifyExtractTraceVarNoInit) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     var x: bool;
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto var = TypedNodesTestPeer::VerifyExtractAs<VariableDecl>(
-      tree, file.decls[0], &trace);
+  auto var =
+      Peer::VerifyExtractAs<Parse::VariableDecl>(tree, file.decls[0], &trace);
   ASSERT_TRUE(var.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -223,15 +201,15 @@ Aggregate [^:]*: success
 }
 
 TEST_F(TypedNodeTest, VerifyExtractTraceExpression) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     var x: i32 = p->q.r;
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace1;
-  auto var = TypedNodesTestPeer::VerifyExtractAs<VariableDecl>(
-      tree, file.decls[0], &trace1);
+  auto var =
+      Peer::VerifyExtractAs<Parse::VariableDecl>(tree, file.decls[0], &trace1);
   ASSERT_TRUE(var.has_value());
   Error err1 = trace1;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -256,7 +234,7 @@ Aggregate [^:]*: success
 
   ASSERT_TRUE(var->initializer.has_value());
   ErrorBuilder trace2;
-  auto value = TypedNodesTestPeer::VerifyExtractAs<MemberAccessExpr>(
+  auto value = Peer::VerifyExtractAs<Parse::MemberAccessExpr>(
       tree, var->initializer->value, &trace2);
   ASSERT_TRUE(value.has_value());
   Error err2 = trace2;
@@ -270,15 +248,15 @@ Aggregate [^:]*: success
 }
 
 TEST_F(TypedNodeTest, VerifyExtractTraceClassDecl) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     private abstract class N.C(T:! type);
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto class_decl = TypedNodesTestPeer::VerifyExtractAs<ClassDecl>(
-      tree, file.decls[0], &trace);
+  auto class_decl =
+      Peer::VerifyExtractAs<Parse::ClassDecl>(tree, file.decls[0], &trace);
   EXPECT_TRUE(class_decl.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -310,50 +288,51 @@ Aggregate [^:]*: success
 }
 
 TEST_F(TypedNodeTest, Token) {
-  auto [tokens, tree] = GetTokenizedBufferAndTree(R"carbon(
+  auto [tokens, tree] =
+      compile_helper_.GetTokenizedBufferWithTreeAndSubtrees(R"carbon(
     var n: i32 = 0;
   )carbon");
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
 
   ASSERT_EQ(file.decls.size(), 1);
 
-  auto n_var = tree->ExtractAs<VariableDecl>(file.decls[0]);
+  auto n_var = tree.ExtractAs<Parse::VariableDecl>(file.decls[0]);
   ASSERT_TRUE(n_var.has_value());
-  EXPECT_EQ(tokens->GetKind(n_var->token), Lex::TokenKind::Semi);
+  EXPECT_EQ(tokens.GetKind(n_var->token), Lex::TokenKind::Semi);
 
-  auto n_intro = tree->ExtractAs<VariableIntroducer>(n_var->introducer);
+  auto n_intro = tree.ExtractAs<Parse::VariableIntroducer>(n_var->introducer);
   ASSERT_TRUE(n_intro.has_value());
-  EXPECT_EQ(tokens->GetKind(n_intro->token), Lex::TokenKind::Var);
+  EXPECT_EQ(tokens.GetKind(n_intro->token), Lex::TokenKind::Var);
 
-  auto n_patt = tree->ExtractAs<BindingPattern>(n_var->pattern);
+  auto n_patt = tree.ExtractAs<Parse::BindingPattern>(n_var->pattern);
   ASSERT_TRUE(n_patt.has_value());
-  EXPECT_EQ(tokens->GetKind(n_patt->token), Lex::TokenKind::Colon);
+  EXPECT_EQ(tokens.GetKind(n_patt->token), Lex::TokenKind::Colon);
 }
 
 TEST_F(TypedNodeTest, VerifyInvalid) {
-  auto* tree = &GetTree(R"carbon(
+  auto& tree = compile_helper_.GetTreeAndSubtrees(R"carbon(
     fn F() -> i32 { return 0; }
   )carbon");
 
-  auto file = tree->ExtractFile();
+  auto file = tree.ExtractFile();
   ASSERT_EQ(file.decls.size(), 1);
 
-  auto f_fn = tree->ExtractAs<FunctionDefinition>(file.decls[0]);
+  auto f_fn = tree.ExtractAs<Parse::FunctionDefinition>(file.decls[0]);
   ASSERT_TRUE(f_fn.has_value());
-  auto f_sig = tree->ExtractAs<FunctionDefinitionStart>(f_fn->signature);
+  auto f_sig = tree.ExtractAs<Parse::FunctionDefinitionStart>(f_fn->signature);
   ASSERT_TRUE(f_sig.has_value());
-  auto f_intro = tree->ExtractAs<FunctionIntroducer>(f_sig->introducer);
+  auto f_intro = tree.ExtractAs<Parse::FunctionIntroducer>(f_sig->introducer);
   ASSERT_TRUE(f_intro.has_value());
 
   // Change the kind of the introducer and check we get a good trace log.
-  TypedNodesTestPeer::SetNodeKind(&tree_storage_.front(), f_sig->introducer,
-                                  NodeKind::ClassIntroducer);
+  Peer::SetNodeKind(tree.tree(), f_sig->introducer,
+                    Parse::NodeKind::ClassIntroducer);
 
   // The introducer should not extract as a FunctionIntroducer any more because
   // the kind is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(TypedNodesTestPeer::VerifyExtractAs<FunctionIntroducer>(
+    EXPECT_FALSE(Peer::VerifyExtractAs<Parse::FunctionIntroducer>(
         tree, f_sig->introducer, &trace));
 
     Error err = trace;
@@ -366,7 +345,7 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   // token kind is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(TypedNodesTestPeer::VerifyExtractAs<ClassIntroducer>(
+    EXPECT_FALSE(Peer::VerifyExtractAs<Parse::ClassIntroducer>(
         tree, f_sig->introducer, &trace));
 
     Error err = trace;
@@ -379,7 +358,7 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   // kind for the introducer is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(TypedNodesTestPeer::VerifyExtractAs<FunctionDefinitionStart>(
+    EXPECT_FALSE(Peer::VerifyExtractAs<Parse::FunctionDefinitionStart>(
         tree, f_fn->signature, &trace));
 
     Error err = trace;
@@ -391,16 +370,16 @@ Error: ClassIntroducer node left unconsumed.)Trace"));
   }
 }
 
-auto CategoryMatches(const NodeKind::Definition& def, NodeKind kind,
-                     const char* name) {
+auto CategoryMatches(const Parse::NodeKind::Definition& def,
+                     Parse::NodeKind kind, const char* name) {
   EXPECT_EQ(def.category(), kind.category()) << name;
 }
 
 TEST_F(TypedNodeTest, CategoryMatches) {
 #define CARBON_PARSE_NODE_KIND(Name) \
-  CategoryMatches(Name::Kind, NodeKind::Name, #Name);
+  CategoryMatches(Parse::Name::Kind, Parse::NodeKind::Name, #Name);
 #include "toolchain/parse/node_kind.def"
 }
 
 }  // namespace
-}  // namespace Carbon::Parse
+}  // namespace Carbon::Testing

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -46,8 +46,6 @@ namespace {
 
 class TypedNodeTest : public ::testing::Test {
  protected:
-  using Peer = TypedNodesTestPeer;
-
   Testing::CompileHelper compile_helper_;
 };
 
@@ -142,8 +140,8 @@ TEST_F(TypedNodeTest, VerifyExtractTraceLibrary) {
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto library =
-      Peer::VerifyExtractAs<LibraryDecl>(tree, file.decls[0], &trace);
+  auto library = TypedNodesTestPeer::VerifyExtractAs<LibraryDecl>(
+      tree, file.decls[0], &trace);
   EXPECT_TRUE(library.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -167,7 +165,8 @@ TEST_F(TypedNodeTest, VerifyExtractTraceVarNoInit) {
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto var = Peer::VerifyExtractAs<VariableDecl>(tree, file.decls[0], &trace);
+  auto var = TypedNodesTestPeer::VerifyExtractAs<VariableDecl>(
+      tree, file.decls[0], &trace);
   ASSERT_TRUE(var.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -198,7 +197,8 @@ TEST_F(TypedNodeTest, VerifyExtractTraceExpression) {
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace1;
-  auto var = Peer::VerifyExtractAs<VariableDecl>(tree, file.decls[0], &trace1);
+  auto var = TypedNodesTestPeer::VerifyExtractAs<VariableDecl>(
+      tree, file.decls[0], &trace1);
   ASSERT_TRUE(var.has_value());
   Error err1 = trace1;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -223,7 +223,7 @@ Aggregate [^:]*: success
 
   ASSERT_TRUE(var->initializer.has_value());
   ErrorBuilder trace2;
-  auto value = Peer::VerifyExtractAs<MemberAccessExpr>(
+  auto value = TypedNodesTestPeer::VerifyExtractAs<MemberAccessExpr>(
       tree, var->initializer->value, &trace2);
   ASSERT_TRUE(value.has_value());
   Error err2 = trace2;
@@ -244,8 +244,8 @@ TEST_F(TypedNodeTest, VerifyExtractTraceClassDecl) {
 
   ASSERT_EQ(file.decls.size(), 1);
   ErrorBuilder trace;
-  auto class_decl =
-      Peer::VerifyExtractAs<ClassDecl>(tree, file.decls[0], &trace);
+  auto class_decl = TypedNodesTestPeer::VerifyExtractAs<ClassDecl>(
+      tree, file.decls[0], &trace);
   EXPECT_TRUE(class_decl.has_value());
   Error err = trace;
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
@@ -314,13 +314,14 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   ASSERT_TRUE(f_intro.has_value());
 
   // Change the kind of the introducer and check we get a good trace log.
-  Peer::SetNodeKind(tree.tree(), f_sig->introducer, NodeKind::ClassIntroducer);
+  TypedNodesTestPeer::SetNodeKind(tree.tree(), f_sig->introducer,
+                                  NodeKind::ClassIntroducer);
 
   // The introducer should not extract as a FunctionIntroducer any more because
   // the kind is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(Peer::VerifyExtractAs<FunctionIntroducer>(
+    EXPECT_FALSE(TypedNodesTestPeer::VerifyExtractAs<FunctionIntroducer>(
         tree, f_sig->introducer, &trace));
 
     Error err = trace;
@@ -333,8 +334,8 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   // token kind is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(Peer::VerifyExtractAs<ClassIntroducer>(tree, f_sig->introducer,
-                                                        &trace));
+    EXPECT_FALSE(TypedNodesTestPeer::VerifyExtractAs<ClassIntroducer>(
+        tree, f_sig->introducer, &trace));
 
     Error err = trace;
     EXPECT_THAT(err.message(),
@@ -346,7 +347,7 @@ TEST_F(TypedNodeTest, VerifyInvalid) {
   // kind for the introducer is wrong.
   {
     ErrorBuilder trace;
-    EXPECT_FALSE(Peer::VerifyExtractAs<FunctionDefinitionStart>(
+    EXPECT_FALSE(TypedNodesTestPeer::VerifyExtractAs<FunctionDefinitionStart>(
         tree, f_fn->signature, &trace));
 
     Error err = trace;

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -11,6 +11,7 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "compile_helper",
     testonly = 1,
+    srcs = ["compile_helper.cpp"],
     hdrs = ["compile_helper.h"],
     deps = [
         "//toolchain/diagnostics:diagnostic_emitter",

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -8,6 +8,20 @@ load("//testing/file_test:rules.bzl", "file_test")
 
 package(default_visibility = ["//visibility:public"])
 
+cc_library(
+    name = "compile_helper",
+    testonly = 1,
+    hdrs = ["compile_helper.h"],
+    deps = [
+        "//toolchain/diagnostics:diagnostic_emitter",
+        "//toolchain/lex",
+        "//toolchain/parse",
+        "//toolchain/parse:tree",
+        "//toolchain/source:source_buffer",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
 file_test(
     name = "file_test",
     size = "small",

--- a/toolchain/testing/compile_helper.cpp
+++ b/toolchain/testing/compile_helper.cpp
@@ -1,0 +1,56 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/testing/compile_helper.h"
+
+namespace Carbon::Testing {
+
+auto CompileHelper::GetTokenizedBuffer(llvm::StringRef text,
+                                       DiagnosticConsumer* consumer)
+    -> Lex::TokenizedBuffer& {
+  auto& source = GetSourceBuffer(text);
+
+  value_store_storage_.emplace_front();
+  token_storage_.push_front(Lex::Lex(value_store_storage_.front(), source,
+                                     consumer ? *consumer : consumer_));
+  return token_storage_.front();
+}
+
+auto CompileHelper::GetTokenizedBufferWithSharedValueStore(llvm::StringRef text)
+    -> std::pair<Lex::TokenizedBuffer&, SharedValueStores&> {
+  auto& tokens = GetTokenizedBuffer(text);
+  return {tokens, value_store_storage_.front()};
+}
+
+auto CompileHelper::GetTree(llvm::StringRef text) -> Parse::Tree& {
+  auto& tokens = GetTokenizedBuffer(text);
+  tree_storage_.push_front(Parse::Parse(tokens, consumer_,
+                                        /*vlog_stream=*/nullptr));
+  return tree_storage_.front();
+}
+
+auto CompileHelper::GetTreeAndSubtrees(llvm::StringRef text)
+    -> Parse::TreeAndSubtrees& {
+  auto& tree = GetTree(text);
+  tree_and_subtrees_storage_.push_front(
+      Parse::TreeAndSubtrees(token_storage_.front(), tree));
+  return tree_and_subtrees_storage_.front();
+}
+
+auto CompileHelper::GetTokenizedBufferWithTreeAndSubtrees(llvm::StringRef text)
+    -> std::pair<Lex::TokenizedBuffer&, Parse::TreeAndSubtrees&> {
+  auto& tree_and_subtrees = GetTreeAndSubtrees(text);
+  return {token_storage_.front(), tree_and_subtrees};
+}
+
+auto CompileHelper::GetSourceBuffer(llvm::StringRef text) -> SourceBuffer& {
+  std::string filename = llvm::formatv("test{0}.carbon", ++file_index_);
+  CARBON_CHECK(fs_.addFile(filename, /*ModificationTime=*/0,
+                           llvm::MemoryBuffer::getMemBuffer(text)));
+  source_storage_.push_front(
+      std::move(*SourceBuffer::MakeFromFile(fs_, filename, consumer_)));
+  return source_storage_.front();
+}
+
+}  // namespace Carbon::Testing

--- a/toolchain/testing/compile_helper.h
+++ b/toolchain/testing/compile_helper.h
@@ -1,0 +1,93 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_TESTING_COMPILE_HELPER_H_
+#define CARBON_TOOLCHAIN_TESTING_COMPILE_HELPER_H_
+
+#include <forward_list>
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "toolchain/diagnostics/diagnostic_consumer.h"
+#include "toolchain/lex/lex.h"
+#include "toolchain/parse/parse.h"
+#include "toolchain/parse/tree_and_subtrees.h"
+#include "toolchain/source/source_buffer.h"
+
+namespace Carbon::Testing {
+
+// A test helper for compile-related functionality.
+class CompileHelper {
+ public:
+  // Returns the result of lex.
+  auto GetTokenizedBuffer(llvm::StringRef text,
+                          DiagnosticConsumer* consumer = nullptr)
+      -> Lex::TokenizedBuffer& {
+    auto& source = GetSourceBuffer(text);
+
+    value_store_storage_.emplace_front();
+    token_storage_.push_front(Lex::Lex(value_store_storage_.front(), source,
+                                       consumer ? *consumer : consumer_));
+    return token_storage_.front();
+  }
+
+  auto GetTokenizedBufferWithSharedValueStore(llvm::StringRef text)
+      -> std::pair<Lex::TokenizedBuffer&, SharedValueStores&> {
+    auto& tokens = GetTokenizedBuffer(text);
+    return {tokens, value_store_storage_.front()};
+  }
+
+  // Returns the result of parse.
+  auto GetTree(llvm::StringRef text) -> Parse::Tree& {
+    auto& tokens = GetTokenizedBuffer(text);
+    tree_storage_.push_front(Parse::Parse(tokens, consumer_,
+                                          /*vlog_stream=*/nullptr));
+    return tree_storage_.front();
+  }
+
+  // Returns the result of parse (with extra subtree information).
+  auto GetTreeAndSubtrees(llvm::StringRef text) -> Parse::TreeAndSubtrees& {
+    auto& tree = GetTree(text);
+    tree_and_subtrees_storage_.push_front(
+        Parse::TreeAndSubtrees(token_storage_.front(), tree));
+    return tree_and_subtrees_storage_.front();
+  }
+
+  // Returns the results of both lex and parse (with extra subtree information).
+  auto GetTokenizedBufferWithTreeAndSubtrees(llvm::StringRef text)
+      -> std::pair<Lex::TokenizedBuffer&, Parse::TreeAndSubtrees&> {
+    auto& tree_and_subtrees = GetTreeAndSubtrees(text);
+    return {token_storage_.front(), tree_and_subtrees};
+  }
+
+ private:
+  // Produces a source buffer for the input text.s
+  auto GetSourceBuffer(llvm::StringRef text) -> SourceBuffer& {
+    std::string filename = llvm::formatv("test{0}.carbon", ++file_index_);
+    CARBON_CHECK(fs_.addFile(filename, /*ModificationTime=*/0,
+                             llvm::MemoryBuffer::getMemBuffer(text)));
+    source_storage_.push_front(
+        std::move(*SourceBuffer::MakeFromFile(fs_, filename, consumer_)));
+    return source_storage_.front();
+  }
+
+  // Diagnostics will be printed to console.
+  DiagnosticConsumer& consumer_ = ConsoleDiagnosticConsumer();
+
+  // An index to generate unique filenames.
+  int file_index_ = 0;
+
+  // A filesystem for storing test files.
+  llvm::vfs::InMemoryFileSystem fs_;
+
+  // Storage for various compile artifacts.
+  std::forward_list<SourceBuffer> source_storage_;
+  std::forward_list<SharedValueStores> value_store_storage_;
+  std::forward_list<Lex::TokenizedBuffer> token_storage_;
+  std::forward_list<Parse::Tree> tree_storage_;
+  std::forward_list<Parse::TreeAndSubtrees> tree_and_subtrees_storage_;
+};
+
+}  // namespace Carbon::Testing
+
+#endif  // CARBON_TOOLCHAIN_TESTING_COMPILE_HELPER_H_

--- a/toolchain/testing/compile_helper.h
+++ b/toolchain/testing/compile_helper.h
@@ -22,54 +22,25 @@ class CompileHelper {
   // Returns the result of lex.
   auto GetTokenizedBuffer(llvm::StringRef text,
                           DiagnosticConsumer* consumer = nullptr)
-      -> Lex::TokenizedBuffer& {
-    auto& source = GetSourceBuffer(text);
+      -> Lex::TokenizedBuffer&;
 
-    value_store_storage_.emplace_front();
-    token_storage_.push_front(Lex::Lex(value_store_storage_.front(), source,
-                                       consumer ? *consumer : consumer_));
-    return token_storage_.front();
-  }
-
+  // Returns the result of lex along with shared values.
   auto GetTokenizedBufferWithSharedValueStore(llvm::StringRef text)
-      -> std::pair<Lex::TokenizedBuffer&, SharedValueStores&> {
-    auto& tokens = GetTokenizedBuffer(text);
-    return {tokens, value_store_storage_.front()};
-  }
+      -> std::pair<Lex::TokenizedBuffer&, SharedValueStores&>;
 
   // Returns the result of parse.
-  auto GetTree(llvm::StringRef text) -> Parse::Tree& {
-    auto& tokens = GetTokenizedBuffer(text);
-    tree_storage_.push_front(Parse::Parse(tokens, consumer_,
-                                          /*vlog_stream=*/nullptr));
-    return tree_storage_.front();
-  }
+  auto GetTree(llvm::StringRef text) -> Parse::Tree&;
 
   // Returns the result of parse (with extra subtree information).
-  auto GetTreeAndSubtrees(llvm::StringRef text) -> Parse::TreeAndSubtrees& {
-    auto& tree = GetTree(text);
-    tree_and_subtrees_storage_.push_front(
-        Parse::TreeAndSubtrees(token_storage_.front(), tree));
-    return tree_and_subtrees_storage_.front();
-  }
+  auto GetTreeAndSubtrees(llvm::StringRef text) -> Parse::TreeAndSubtrees&;
 
   // Returns the results of both lex and parse (with extra subtree information).
   auto GetTokenizedBufferWithTreeAndSubtrees(llvm::StringRef text)
-      -> std::pair<Lex::TokenizedBuffer&, Parse::TreeAndSubtrees&> {
-    auto& tree_and_subtrees = GetTreeAndSubtrees(text);
-    return {token_storage_.front(), tree_and_subtrees};
-  }
+      -> std::pair<Lex::TokenizedBuffer&, Parse::TreeAndSubtrees&>;
 
  private:
-  // Produces a source buffer for the input text.s
-  auto GetSourceBuffer(llvm::StringRef text) -> SourceBuffer& {
-    std::string filename = llvm::formatv("test{0}.carbon", ++file_index_);
-    CARBON_CHECK(fs_.addFile(filename, /*ModificationTime=*/0,
-                             llvm::MemoryBuffer::getMemBuffer(text)));
-    source_storage_.push_front(
-        std::move(*SourceBuffer::MakeFromFile(fs_, filename, consumer_)));
-    return source_storage_.front();
-  }
+  // Produces a source buffer for the input text.
+  auto GetSourceBuffer(llvm::StringRef text) -> SourceBuffer&;
 
   // Diagnostics will be printed to console.
   DiagnosticConsumer& consumer_ = ConsoleDiagnosticConsumer();


### PR DESCRIPTION
Note in particular that this fixes an issue where SharedValueStore had been shared across files, when they should be per-file. This is only visible when doing multiple compilations in a single test, which was rare before.

This also moves these tests into the Testing namespace. My memory of the various namespacing changes is that we'd generally agreed to have tests in Testing so that we'd see SemIR:: and similar, same as we would in a lot of the implementation.