### PR TITLE
Stitch together adjacent comments using the indent.

### DIFF
--- a/toolchain/format/testdata/basics/comments.carbon
+++ b/toolchain/format/testdata/basics/comments.carbon
@@ -47,11 +47,7 @@ class C {
 // CHECK:STDOUT:  }
 // CHECK:STDOUT: // Another
 // CHECK:STDOUT:   // Block
-// CHECK:STDOUT:
-// CHECK:STDOUT:
-// CHECK:STDOUT: //
-// CHECK:STDOUT:
-// CHECK:STDOUT:
-// CHECK:STDOUT: // Comment
+// CHECK:STDOUT:   //
+// CHECK:STDOUT:   // Comment
 // CHECK:STDOUT:
 // CHECK:STDOUT:

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -200,6 +200,8 @@ class [[clang::internal_linkage]] Lexer {
  private:
   class ErrorRecoveryBuffer;
 
+  auto AddLexedComment() -> void;
+
   TokenizedBuffer buffer_;
 
   ssize_t line_index_;
@@ -858,6 +860,75 @@ auto Lexer::LexCommentOrSlash(llvm::StringRef source_text, ssize_t& position)
   CARBON_CHECK(result, "Failed to form a token!");
 }
 
+// Lexes for a comment prefix using SIMD support. Returns true if the end of
+// lines with the provided prefix has been found. Returns false if it's unable
+// to finish lexing (but may be partially lexed).
+//
+// TODO: We should extend this to 32-byte SIMD on platforms with support.
+static auto LexCommentPrefixInSimd(llvm::StringRef source_text,
+                                   ssize_t& position, ssize_t prefix_size,
+                                   ssize_t first_line_start,
+                                   llvm::function_ref<void()> skip_to_next_line)
+    -> bool {
+  constexpr ssize_t ByteSize = 16;
+  if (!CARBON_USE_SIMD ||
+      position + ByteSize >= static_cast<ssize_t>(source_text.size()) ||
+      prefix_size > ByteSize) {
+    return false;
+  }
+
+  // Load a mask based on the amount of text we want to compare.
+  auto mask = PrefixMasks[prefix_size];
+#if __ARM_NEON
+  // Load and mask the prefix of the current line.
+  auto prefix = vld1q_u8(
+      reinterpret_cast<const uint8_t*>(source_text.data() + first_line_start));
+  prefix = vandq_u8(mask, prefix);
+#elif __x86_64__
+  // Use the current line's prefix as the exemplar to compare against.
+  // We don't mask here as we will mask when doing the comparison.
+  auto prefix = _mm_loadu_si128(
+      reinterpret_cast<const __m128i*>(source_text.data() + first_line_start));
+#else
+#error "Unsupported SIMD architecture!"
+#endif
+
+  while (true) {
+#if __ARM_NEON
+    // Load and mask the next line to consider's prefix.
+    auto next_prefix = vld1q_u8(
+        reinterpret_cast<const uint8_t*>(source_text.data() + position));
+    next_prefix = vandq_u8(mask, next_prefix);
+    // Compare the two prefixes and if any lanes differ, break.
+    auto compare = vceqq_u8(prefix, next_prefix);
+    bool has_prefix = vminvq_u8(compare) != 0;
+#elif __x86_64__
+    // Load the next line to consider's prefix.
+    auto next_prefix = _mm_loadu_si128(
+        reinterpret_cast<const __m128i*>(source_text.data() + position));
+    // Compute the difference between the next line and our exemplar. Again,
+    // we don't mask the difference because the comparison below will be
+    // masked.
+    auto prefix_diff = _mm_xor_si128(prefix, next_prefix);
+    // If we have any differences (non-zero bits) within the mask, we can't
+    // skip the next line too.
+    bool has_prefix = _mm_test_all_zeros(mask, prefix_diff);
+#else
+#error "Unsupported SIMD architecture!"
+#endif
+
+    if (!has_prefix) {
+      return true;
+    }
+
+    skip_to_next_line();
+
+    if (position + ByteSize >= static_cast<ssize_t>(source_text.size())) {
+      return false;
+    }
+  }
+}
+
 auto Lexer::LexComment(llvm::StringRef source_text, ssize_t& position) -> void {
   CARBON_DCHECK(source_text.substr(position).starts_with("//"));
   int32_t comment_start = position;
@@ -875,9 +946,7 @@ auto Lexer::LexComment(llvm::StringRef source_text, ssize_t& position) -> void {
     // whitespace, which already is designed to skip over any erroneous text at
     // the end of the line.
     LexVerticalWhitespace(source_text, position);
-    buffer_.comments_.push_back(
-        {.start = comment_start,
-         .length = static_cast<int32_t>(position) - comment_start});
+    buffer_.AddComment(line_info->indent, comment_start, position);
     return;
   }
 
@@ -902,14 +971,11 @@ auto Lexer::LexComment(llvm::StringRef source_text, ssize_t& position) -> void {
   // A very common pattern is a long block of comment lines all with the same
   // indent and comment start. We skip these comment blocks in bulk both for
   // speed and to reduce redundant diagnostics if each line has the same
-  // erroneous comment start like `//!`.
+  // erroneous comment start, such as `//!`.
   //
   // When we have SIMD support this is even more important for speed, as short
   // indents can be scanned extremely quickly with SIMD and we expect these to
   // be the dominant cases.
-  //
-  // TODO: We should extend this to 32-byte SIMD on platforms with support.
-  constexpr int MaxIndent = 13;
   const int indent = line_info->indent;
   const ssize_t first_line_start = line_info->start;
   ssize_t prefix_size = indent + (is_valid_after_slashes ? 3 : 2);
@@ -921,59 +987,8 @@ auto Lexer::LexComment(llvm::StringRef source_text, ssize_t& position) -> void {
     next_line_info->indent = indent;
     position = next_line_info->start;
   };
-  if (CARBON_USE_SIMD &&
-      position + 16 < static_cast<ssize_t>(source_text.size()) &&
-      indent <= MaxIndent) {
-    // Load a mask based on the amount of text we want to compare.
-    auto mask = PrefixMasks[prefix_size];
-#if __ARM_NEON
-    // Load and mask the prefix of the current line.
-    auto prefix = vld1q_u8(reinterpret_cast<const uint8_t*>(source_text.data() +
-                                                            first_line_start));
-    prefix = vandq_u8(mask, prefix);
-    do {
-      // Load and mask the next line to consider's prefix.
-      auto next_prefix = vld1q_u8(
-          reinterpret_cast<const uint8_t*>(source_text.data() + position));
-      next_prefix = vandq_u8(mask, next_prefix);
-      // Compare the two prefixes and if any lanes differ, break.
-      auto compare = vceqq_u8(prefix, next_prefix);
-      if (vminvq_u8(compare) == 0) {
-        break;
-      }
-
-      skip_to_next_line();
-    } while (position + 16 < static_cast<ssize_t>(source_text.size()));
-#elif __x86_64__
-    // Use the current line's prefix as the exemplar to compare against.
-    // We don't mask here as we will mask when doing the comparison.
-    auto prefix = _mm_loadu_si128(reinterpret_cast<const __m128i*>(
-        source_text.data() + first_line_start));
-    do {
-      // Load the next line to consider's prefix.
-      auto next_prefix = _mm_loadu_si128(
-          reinterpret_cast<const __m128i*>(source_text.data() + position));
-      // Compute the difference between the next line and our exemplar. Again,
-      // we don't mask the difference because the comparison below will be
-      // masked.
-      auto prefix_diff = _mm_xor_si128(prefix, next_prefix);
-      // If we have any differences (non-zero bits) within the mask, we can't
-      // skip the next line too.
-      if (!_mm_test_all_zeros(mask, prefix_diff)) {
-        break;
-      }
-
-      skip_to_next_line();
-    } while (position + 16 < static_cast<ssize_t>(source_text.size()));
-#else
-#error "Unsupported SIMD architecture!"
-#endif
-    // TODO: If we finish the loop due to the position approaching the end of
-    // the buffer we may fail to skip the last line in a comment block that
-    // has an invalid initial sequence and thus emit extra diagnostics. We
-    // should really fall through to the generic skipping logic, but the code
-    // organization will need to change significantly to allow that.
-  } else {
+  if (!LexCommentPrefixInSimd(source_text, position, prefix_size,
+                              first_line_start, skip_to_next_line)) {
     while (position + prefix_size < static_cast<ssize_t>(source_text.size()) &&
            memcmp(source_text.data() + first_line_start,
                   source_text.data() + position, prefix_size) == 0) {
@@ -981,9 +996,7 @@ auto Lexer::LexComment(llvm::StringRef source_text, ssize_t& position) -> void {
     }
   }
 
-  buffer_.comments_.push_back(
-      {.start = comment_start,
-       .length = static_cast<int32_t>(position) - comment_start});
+  buffer_.AddComment(indent, comment_start, position);
 
   // Now compute the indent of this next line before we finish.
   ssize_t line_start = position;

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -357,6 +357,18 @@ auto TokenizedBuffer::GetCommentText(CommentIndex comment_index) const
   return source_->text().substr(comment_data.start, comment_data.length);
 }
 
+auto TokenizedBuffer::AddComment(int32_t indent, int32_t start, int32_t end)
+    -> void {
+  if (!comments_.empty()) {
+    auto& comment = comments_.back();
+    if (comment.start + comment.length + indent == start) {
+      comment.length = end - comment.start;
+      return;
+    }
+  }
+  comments_.push_back({.start = start, .length = end - start});
+}
+
 auto TokenizedBuffer::CollectMemUsage(MemUsage& mem_usage,
                                       llvm::StringRef label) const -> void {
   mem_usage.Add(MemUsage::ConcatLabel(label, "allocator_"), allocator_);

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -214,6 +214,8 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
                             CommentIterator(CommentIndex(comments_.size())));
   }
 
+  auto comments_size() const -> size_t { return comments_.size(); }
+
   // This is an upper bound on the number of output parse nodes in the absence
   // of errors.
   auto expected_max_parse_tree_size() const -> int {
@@ -456,6 +458,19 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   auto GetTokenPrintWidths(TokenIndex token) const -> PrintWidths;
   auto PrintToken(llvm::raw_ostream& output_stream, TokenIndex token,
                   PrintWidths widths) const -> void;
+
+  // Adds a comment. This uses the indent to potential stitch together two
+  // adjacent comments.
+  auto AddComment(int32_t indent, int32_t start, int32_t end) -> void {
+    if (!comments_.empty()) {
+      auto& comment = comments_.back();
+      if (comment.start + comment.length + indent == start) {
+        comment.length = end - comment.start;
+        return;
+      }
+    }
+    comments_.push_back({.start = start, .length = end - start});
+  }
 
   // Used to allocate computed string literals.
   llvm::BumpPtrAllocator allocator_;

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -459,7 +459,7 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   auto PrintToken(llvm::raw_ostream& output_stream, TokenIndex token,
                   PrintWidths widths) const -> void;
 
-  // Adds a comment. This uses the indent to potential stitch together two
+  // Adds a comment. This uses the indent to potentially stitch together two
   // adjacent comments.
   auto AddComment(int32_t indent, int32_t start, int32_t end) -> void {
     if (!comments_.empty()) {

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -461,16 +461,7 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
 
   // Adds a comment. This uses the indent to potentially stitch together two
   // adjacent comments.
-  auto AddComment(int32_t indent, int32_t start, int32_t end) -> void {
-    if (!comments_.empty()) {
-      auto& comment = comments_.back();
-      if (comment.start + comment.length + indent == start) {
-        comment.length = end - comment.start;
-        return;
-      }
-    }
-    comments_.push_back({.start = start, .length = end - start});
-  }
+  auto AddComment(int32_t indent, int32_t start, int32_t end) -> void;
 
   // Used to allocate computed string literals.
   llvm::BumpPtrAllocator allocator_;

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -1200,9 +1200,9 @@ x
   auto& buffer = compile_helper_.GetTokenizedBuffer(source);
   EXPECT_TRUE(buffer.has_errors());
 
-  EXPECT_THAT(buffer.comments_size(), Eq(5));
+  EXPECT_THAT(buffer.comments_size(), Eq(std::size(Comments)));
   for (int i :
-       llvm::seq(std::min(static_cast<int>(buffer.comments_size()), 5))) {
+       llvm::seq(std::min<int>(buffer.comments_size(), std::size(Comments)))) {
     EXPECT_THAT(buffer.GetCommentText(CommentIndex(i)).str(),
                 testing::StrEq(Comments[i]));
   }

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -1181,7 +1181,9 @@ x
       // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
       "// This comment should be possible to parse with SIMD.\n"
       "// This one too.\n",
-      "// This one as well, though it's a different indent.\n",
+      "// This one as well, though it's a different indent.\n"
+      "        // And mixes indent.\n"
+      "   // And mixes indent more.\n",
       "// This is one comment:\n"
       "//Invalid\n"
       "// Valid\n"


### PR DESCRIPTION
This is improving the comment production to produce fewer distinct comments.

At present, comment processing uses strict prefix matching. It either expects `// ` (with a space) for valid comments, or just `//` (without a space) for invalid comments that lacked the space.

As a consequence, the following would be three comments:

```
// Comment 1
//
//
// Comment 4
```

This is because a 3-character prefix is used for valid comments. The prefix switches between lines 1 and 2, and again between lines 3 and 4, each resulting in a separate comment.

For contrast, this is one comment because only a 2-character prefix is used:

```
//Comment 1
//
//
//Comment 4
```

That's because all lines lack a suffix space.

Additionally, with SIMD 16-byte boundaries, further splits can occur if processing needs to transition to non-SIMD.

Here, I'm trying to just address all of this by stitching together adjacent comments. Since a lexed comment starts at the `//` excluding the indent, the delta from the prior comment must be precisely the indent.

