### PR TITLE
Use @bazel_tools//tools/cpp:malloc instead of defining a library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,7 +94,7 @@ build --custom_malloc=//bazel/malloc:tcmalloc_if_linux_opt
 # optimized or other build configurations. Note that ASan and TCMalloc are
 # incompatible so this explicitly forces the system malloc.
 build:asan --features=asan
-build:asan --custom_malloc=//bazel/malloc:system_malloc
+build:asan --custom_malloc=@bazel_tools//tools/cpp:malloc
 
 # Configuration for enabling LibFuzzer (along with ASan).
 build:fuzzer --features=fuzzer

--- a/bazel/malloc/BUILD
+++ b/bazel/malloc/BUILD
@@ -23,17 +23,12 @@ selects.config_setting_group(
     ],
 )
 
-# A placeholder empty library that can be used as a `malloc` attribute or with
-# the `--custom_malloc` bazel flag to have no custom malloc and use the system
-# malloc instead.
-cc_library(name = "system_malloc")
-
 # A library that enables TCMalloc for optimized builds on Linux. On other
 # platforms and configurations, this falls back on the system malloc.
 cc_library(
     name = "tcmalloc_if_linux_opt",
     deps = select({
         ":linux_opt": ["@tcmalloc//tcmalloc"],
-        "//conditions:default": [":system_malloc"],
+        "//conditions:default": ["@bazel_tools//tools/cpp:malloc"],
     }),
 )


### PR DESCRIPTION
@bazel_tools//tools/cpp:malloc is equivalent and comes from https://bazel.build/reference/be/c-cpp#cc_binary.malloc. This also avoids some confusion in the documentation, since while system_malloc _can_ be used with `malloc`, it has no effect when it's used with `--custom_malloc`. But, rather than trying to adjust that, maybe we can just use @bazel_tools//tools/cpp:malloc