### PR TITLE
Switch back to the system llvm-symbolizer.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -129,7 +129,7 @@
   "moduleExtensions": {
     "//bazel/cc_toolchains:clang_configuration.bzl%clang_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "zhZDHLTJB1MzuZXa9Ro50GY6j6P/cJVHY+vpabJkz8w=",
+        "bzlTransitiveDigest": "K2JE5G8tvZ+UBmAPF5s/YSUNg53pTvAZi2ause87buQ=",
         "usagesDigest": "FiqDwj5QoiCFb1PRYvajLeyuRjRXbsy2CVC+VsEEt7Q=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -220,6 +220,7 @@ def _configure_clang_toolchain_impl(repository_ctx):
             "{CLANG_VERSION_FOR_CACHE}": clang_version_for_cache.replace('"', "_").replace("\\", "_"),
             "{CLANG_VERSION}": str(clang_version),
             "{LLVM_BINDIR}": str(ar_path.dirname),
+            "{LLVM_SYMBOLIZER}": str(ar_path.dirname.get_child("llvm-symbolizer")),
             "{SYSROOT}": str(sysroot_dir),
         },
         executable = False,

--- a/bazel/cc_toolchains/clang_detected_variables.tpl.bzl
+++ b/bazel/cc_toolchains/clang_detected_variables.tpl.bzl
@@ -9,6 +9,7 @@ This file gets processed by a repository rule, substituting the
 """
 
 llvm_bindir = "{LLVM_BINDIR}"
+llvm_symbolizer = "{LLVM_SYMBOLIZER}"
 clang_bindir = "{CLANG_BINDIR}"
 clang_version = {CLANG_VERSION}
 clang_version_for_cache = "{CLANG_VERSION_FOR_CACHE}"

--- a/bazel/cc_toolchains/defs.bzl
+++ b/bazel/cc_toolchains/defs.bzl
@@ -4,20 +4,18 @@
 
 """Provides helpers for cc rules. Intended for general consumption."""
 
-# The hermetic llvm-symbolizer target.
-_llvm_symbolizer = "@llvm-project//llvm:llvm-symbolizer"
+load("@bazel_cc_toolchain//:clang_detected_variables.bzl", "llvm_symbolizer")
 
 def cc_env():
     """Returns standard environment settings for a cc_binary.
 
-    In use, this should set both `data` and `env`, as in:
+    In use, this looks like:
 
     ```
-    load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
+    load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 
     cc_binary(
       ...
-      data = cc_env_data(),
       env = cc_env(),
     )
     ```
@@ -25,7 +23,7 @@ def cc_env():
     We're currently setting this on a target-by-target basis, mainly because
     it's difficult to modify default behaviors.
     """
-    env = {"LLVM_SYMBOLIZER_PATH": "$(location {0})".format(_llvm_symbolizer)}
+    env = {"LLVM_SYMBOLIZER_PATH": llvm_symbolizer}
 
     # On macOS, there's a nano zone allocation warning due to asan (arises
     # in fastbuild/dbg). This suppresses the warning in `bazel run`.
@@ -37,10 +35,3 @@ def cc_env():
         "//bazel/cc_toolchains:macos_asan": env.update({"MallocNanoZone": "0"}),
         "//conditions:default": env,
     })
-
-def cc_env_data():
-    """Returns data needed for cc_env().
-
-    Set up as a function mainly for parity, and in case we need future changes.
-    """
-    return [_llvm_symbolizer]

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("//testing/file_test:rules.bzl", "file_test")
 
 package(default_visibility = [
@@ -36,7 +36,6 @@ cc_library(
 cc_binary(
     name = "explorer",
     srcs = ["main_bin.cpp"],
-    data = cc_env_data(),
     env = cc_env(),
     # Running clang-tidy is slow, and explorer is currently feature frozen, so
     # don't spend time linting it.

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -170,7 +170,6 @@ cc_fuzz_test(
 cc_binary(
     name = "carbon",
     srcs = ["driver_main.cpp"],
-    data = cc_env_data(),
     env = cc_env(),
     deps = [
         ":driver",

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("install_filegroups.bzl", "install_filegroup", "install_symlink", "install_target", "make_install_filegroups")
 load("pkg_helpers.bzl", "pkg_naming_variables", "pkg_tar_and_test")
 load("run_tool.bzl", "run_tool")
@@ -142,7 +142,7 @@ pkg_tar_and_test(
 # Support `bazel run` on specific binaries.
 run_tool(
     name = "run_carbon",
-    data = [":install_data"] + cc_env_data(),
+    data = [":install_data"],
     env = cc_env(),
     tool = "prefix_root/bin/carbon",
 )

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("//bazel/cc_toolchains:defs.bzl", "cc_env", "cc_env_data")
+load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("//testing/file_test:rules.bzl", "file_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -28,7 +28,6 @@ file_test(
     size = "small",
     timeout = "moderate",  # Taking >60 seconds in GitHub actions
     srcs = ["file_test.cpp"],
-    data = cc_env_data(),
     env = cc_env(),
     tests = [
         "//toolchain/check:testdata",


### PR DESCRIPTION
Undoes most of #4347, because of [performance complaints](https://discord.com/channels/655572317891461132/707150492370862090/1295527235133898772). With a 30-ish frame stack trace and `-c dbg`, my installed `llvm-symbolizer` still seems slow (~6s), but the hermetic `llvm-symbolizer` adds ~4s (i.e., ~10s total). I don't think we can easily force the hermetic version to build in opt configuration, so I'm backing it out.