### PR TITLE
Drop macos-12 runners due to shutdown

### DIFF
--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -18,10 +18,9 @@ runs:
         xcrun simctl delete all
         sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
-    # Install and cache LLVM 16 from Homebrew.
-    # TODO: We can potentially remove this and simplify things when the
-    # Homebrew version of LLVM updates to 16 here:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+    # Install and cache LLVM 16 from Homebrew. Some runners may have LLVM 16,
+    # but this is reliable (including with libc++), and gives us testing at the
+    # minimum supported LLVM version.
     - name: Cache Homebrew
       id: cache-homebrew-macos
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,12 +24,8 @@ jobs:
   test:
     strategy:
       matrix:
-        # On PRs and in the merge queue test a recent version of each supported
-        # OS. On push (post-submit), also run on `macos-12` to get Intel macOS
-        # coverage.
-        runner:
-          ${{ fromJSON(github.event_name != 'push' && '["ubuntu-22.04",
-          "macos-14"]' || '["ubuntu-22.04", "macos-14", "macos-12"]') }}
+        # Test a recent version of each supported OS.
+        runner: ['ubuntu-22.04', 'macos-14']
         build_mode: [fastbuild, opt]
         include:
           # The clang-tidy config doesn't work on macos (missing `truncate`).


### PR DESCRIPTION
macos-12 is being shut down; it will have outages in November, and will be fully removed in December:
https://github.com/actions/runner-images/issues/10721