### PR TITLE
Remove a couple std::string uses in diagnostics.

### DIFF
--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/call.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/handle.h"
+#include "toolchain/diagnostics/format_providers.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -127,10 +128,10 @@ static auto HandleIntOrUnsignedIntTypeLiteral(Context& context,
   if (!(context.ints().Get(size_id) & 3).isZero()) {
     CARBON_DIAGNOSTIC(IntWidthNotMultipleOf8, Error,
                       "bit width of integer type literal must be a multiple of "
-                      "8; use `Core.{0}({1})` instead",
-                      std::string, llvm::APSInt);
+                      "8; use `Core.{0:Int|UInt}({1})` instead",
+                      BoolAsSelect, llvm::APSInt);
     context.emitter().Emit(
-        node_id, IntWidthNotMultipleOf8, int_kind.is_signed() ? "Int" : "UInt",
+        node_id, IntWidthNotMultipleOf8, int_kind.is_signed(),
         llvm::APSInt(context.ints().Get(size_id), /*isUnsigned=*/true));
   }
   auto width_id = MakeI32Literal(context, node_id, size_id);

--- a/toolchain/source/BUILD
+++ b/toolchain/source/BUILD
@@ -13,6 +13,7 @@ cc_library(
     deps = [
         "//common:error",
         "//toolchain/diagnostics:diagnostic_emitter",
+        "//toolchain/diagnostics:format_providers",
         "@llvm-project//llvm:Support",
     ],
 )


### PR DESCRIPTION
We can't completely remove std::string from diagnostics because it's probably better to provide a string than something like a StringLiteralValueId or NameId (because those may be opaque for someone trying to present the diagnostic). So this change is just playing whackamole on another couple things that could easily use the new format providers.