### PR TITLE
Delete `Function::ParamInfo::GetNameId`

### DIFF
--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -113,14 +113,6 @@ auto Function::GetParamFromParamRefId(const File& sem_ir, InstId param_ref_id)
   return {param_ref_id, ref.As<Param>(), bind_name};
 }
 
-auto Function::ParamInfo::GetNameId(const File& sem_ir) -> NameId {
-  if (bind_name) {
-    return sem_ir.entity_names().Get(bind_name->entity_name_id).name_id;
-  } else {
-    return NameId::Invalid;
-  }
-}
-
 auto Function::GetDeclaredReturnType(const File& file,
                                      SpecificId specific_id) const -> TypeId {
   if (!return_storage_id.is_valid()) {

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -80,11 +80,8 @@ struct Function : public EntityWithParamsBase,
                                                InstId param_pattern_id)
       -> ParamPatternInfo;
 
-  // Equivalent to
-  // GetParamPatternInfoFromPatternId(sem_ir, param_pattern_id)
-  //   .GetNameId(sem_ir)
-  // but works even if there is no such ParamPattern inst, e.g. because
-  // it's been replaced with BuiltinError.
+  // Gets the name from the name binding instruction, or invalid if this pattern
+  // has been replaced with BuiltinError.
   static auto GetNameFromPatternId(const File& sem_ir, InstId param_pattern_id)
       -> SemIR::NameId;
 
@@ -95,9 +92,6 @@ struct Function : public EntityWithParamsBase,
     InstId inst_id;
     Param inst;
     std::optional<AnyBindName> bind_name;
-
-    // Gets the name from `bind_name`. Returns invalid if that is not present.
-    auto GetNameId(const File& sem_ir) -> NameId;
   };
   static auto GetParamFromParamRefId(const File& sem_ir, InstId param_ref_id)
       -> ParamInfo;


### PR DESCRIPTION
No longer used as of #4422 .