### PR TITLE
Add data_runfiles to manifests

### DIFF
--- a/bazel/manifest/defs.bzl
+++ b/bazel/manifest/defs.bzl
@@ -20,10 +20,12 @@ def _manifest(ctx):
 
     ctx.actions.write(out, "\n".join(content) + "\n")
 
+    runfiles = ctx.runfiles(files = [out])
     return [
         DefaultInfo(
             files = depset(direct = [out]),
-            default_runfiles = ctx.runfiles(files = [out]),
+            data_runfiles = runfiles,
+            default_runfiles = runfiles,
         ),
     ]
 


### PR DESCRIPTION
This is trying to help systems that don't use --incompatible_always_include_files_in_data