### PR TITLE
Pass the manifest path by flag.

### DIFF
--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -67,14 +67,16 @@ cc_test(
     name = "emitted_diagnostics_test",
     size = "small",
     srcs = ["emitted_diagnostics_test.cpp"],
+    args = ["--testdata_manifest=$(location :all_testdata.txt)"],
     data = [
-        "all_testdata.txt",
+        ":all_testdata.txt",
         "//toolchain/testing:all_testdata",
     ],
     deps = [
         ":diagnostic_kind",
         "//common:set",
         "//testing/base:gtest_main",
+        "@abseil-cpp//absl/flags:flag",
         "@googletest//:gtest",
         "@llvm-project//llvm:Support",
         "@re2",

--- a/toolchain/diagnostics/emitted_diagnostics_test.cpp
+++ b/toolchain/diagnostics/emitted_diagnostics_test.cpp
@@ -7,10 +7,14 @@
 #include <fstream>
 #include <string>
 
+#include "absl/flags/flag.h"
 #include "common/set.h"
 #include "llvm/ADT/StringExtras.h"
 #include "re2/re2.h"
 #include "toolchain/diagnostics/diagnostic_kind.h"
+
+ABSL_FLAG(std::string, testdata_manifest, "",
+          "A path to a file containing repo-relative names of test files.");
 
 namespace Carbon {
 namespace {
@@ -70,7 +74,7 @@ static auto IsUntestedDiagnostic(DiagnosticKind diagnostic_kind) -> bool {
 }
 
 TEST(EmittedDiagnostics, Verify) {
-  std::ifstream manifest_in("toolchain/diagnostics/all_testdata.txt");
+  std::ifstream manifest_in(absl::GetFlag(FLAGS_testdata_manifest));
   ASSERT_TRUE(manifest_in.good());
 
   RE2 diagnostic_re(R"(\w\((\w+)\): )");


### PR DESCRIPTION
This is just a cleanup to remove the hardcoded path, since it's not really necessary in context.