### PR TITLE
Fix use of runfiles

### DIFF
--- a/bazel/manifest/defs.bzl
+++ b/bazel/manifest/defs.bzl
@@ -20,12 +20,10 @@ def _manifest(ctx):
 
     ctx.actions.write(out, "\n".join(content) + "\n")
 
-    runfiles = ctx.runfiles(files = [out])
     return [
         DefaultInfo(
             files = depset(direct = [out]),
-            data_runfiles = runfiles,
-            default_runfiles = runfiles,
+            runfiles = ctx.runfiles(files = [out]),
         ),
     ]
 


### PR DESCRIPTION
I was looking at the documentation again, and I realized that while this works, I think the intention is that `runfiles` is set _instead_ of both fields (I was a little confused by the error I was getting when setting `runfiles` _with_ `default_runfiles`)

I believe I've verified this works in necessary situations.