### PR TITLE
Try working around xcrun failures

### DIFF
--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -14,8 +14,13 @@ runs:
     - name: Free up disk space
       shell: bash
       run: |
+        # The xcrun occasionally fails (maybe a race condition?), so retry a few
+        # times. Example failure:
+        #   "data" couldn't be moved to "Deleting-<ID>"
         echo '*** Delete iOS simulators'
-        xcrun simctl delete all
+        xcrun simctl delete all || \
+          xcrun simctl delete all || \
+          xcrun simctl delete all
         sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
     # Install and cache LLVM 16 from Homebrew. Some runners may have LLVM 16,


### PR DESCRIPTION
I expect the change here will try rerunning a couple times, then fail if it's a permanent failure. 

I've seen similar failures, and believe this is flaky. Here's the specific example that caused me to try a workaround:
https://github.com/carbon-language/carbon-lang/actions/runs/11560505812/job/32177497296

I don't see a difference in the runner information between failing and passing runs, which might've indicated a canary. That's why I'm doing this as a trivial retry.