### PR TITLE
Add a framework for typed InstIds.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -207,6 +207,7 @@ cc_library(
         "//toolchain/parse:tree",
         "//toolchain/sem_ir:formatter",
         "//toolchain/sem_ir:ids",
+        "//toolchain/sem_ir:inst_kind",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -90,9 +90,9 @@ class Context {
 
   // Convenience for AddInst with typed nodes.
   template <typename InstT, typename LocT>
-  auto AddInst(LocT loc, InstT inst)
-      -> decltype(AddInst(SemIR::LocIdAndInst(loc, inst))) {
-    return AddInst(SemIR::LocIdAndInst(loc, inst));
+  auto AddInst(LocT loc, InstT inst) -> SemIR::TypedInstId<InstT::Kind> {
+    return SemIR::TypedInstId<InstT::Kind>(
+        AddInst(SemIR::LocIdAndInst(loc, inst)).index);
   }
 
   // Returns a LocIdAndInst for an instruction with an imported location. Checks

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -100,15 +100,12 @@ static auto FinalizeTemporary(Context& context, SemIR::InstId init_id,
   auto return_slot_id = FindReturnSlotForInitializer(sem_ir, init_id);
   if (return_slot_id.is_valid()) {
     // The return slot should already have a materialized temporary in it.
-    CARBON_CHECK(sem_ir.insts().Get(return_slot_id).kind() ==
-                     SemIR::TemporaryStorage::Kind,
-                 "Return slot for initializer does not contain a temporary; "
-                 "initialized multiple times? Have {0}",
-                 sem_ir.insts().Get(return_slot_id));
+    auto storage_id =
+        sem_ir.insts().InstIdAs<SemIR::TemporaryStorage::Kind>(return_slot_id);
     auto init = sem_ir.insts().Get(init_id);
     return context.AddInst<SemIR::Temporary>(sem_ir.insts().GetLocId(init_id),
                                              {.type_id = init.type_id(),
-                                              .storage_id = return_slot_id,
+                                              .storage_id = storage_id,
                                               .init_id = init_id});
   }
 
@@ -551,22 +548,24 @@ static auto ConvertStructToClass(Context& context, SemIR::StructType src_type,
 
   // If we're trying to create a class value, form a temporary for the value to
   // point to.
-  bool need_temporary = !target.is_initializer();
-  if (need_temporary) {
+  SemIR::TemporaryStorageInstId temporary_storage =
+      SemIR::TemporaryStorageInstId::Invalid;
+  if (!target.is_initializer()) {
     target.kind = ConversionTarget::Initializer;
     target.init_block = &target_block;
-    target.init_id = target_block.AddInst<SemIR::TemporaryStorage>(
+    temporary_storage = target_block.AddInst<SemIR::TemporaryStorage>(
         context.insts().GetLocId(value_id), {.type_id = target.type_id});
+    target.init_id = temporary_storage;
   }
 
   auto result_id = ConvertStructToStructOrClass<SemIR::ClassElementAccess>(
       context, src_type, dest_struct_type, value_id, target);
 
-  if (need_temporary) {
+  if (temporary_storage.is_valid()) {
     target_block.InsertHere();
     result_id = context.AddInst<SemIR::Temporary>(
         context.insts().GetLocId(value_id), {.type_id = target.type_id,
-                                             .storage_id = target.init_id,
+                                             .storage_id = temporary_storage,
                                              .init_id = result_id});
   }
   return result_id;
@@ -641,7 +640,7 @@ static auto ConvertDerivedPointerToBasePointer(
     const InheritancePath& path) -> SemIR::InstId {
   // Form `*p`.
   ptr_id = ConvertToValueExpr(context, ptr_id);
-  auto ref_id = context.AddInst<SemIR::Deref>(
+  SemIR::InstId ref_id = context.AddInst<SemIR::Deref>(
       loc_id, {.type_id = src_ptr_type.pointee_id, .pointer_id = ptr_id});
 
   // Convert as a reference expression.

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -140,7 +140,7 @@ auto HandleParseNode(Context& context, Parse::IndexExprId node_id) -> bool {
       }
       // Constant evaluation will perform a bounds check on this array indexing
       // if the index is constant.
-      auto elem_id = context.AddInst<SemIR::ArrayIndex>(
+      SemIR::InstId elem_id = context.AddInst<SemIR::ArrayIndex>(
           node_id, {.type_id = array_type.element_type_id,
                     .array_id = operand_inst_id,
                     .index_id = cast_index_id});

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -275,7 +275,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
 
   // TODO: Use a different kind of instruction that also references the
   // `base_id` so that `SemIR` consumers can find it.
-  auto member_id = context.AddInst<SemIR::NameRef>(
+  SemIR::InstId member_id = context.AddInst<SemIR::NameRef>(
       loc_id,
       {.type_id = type_id, .name_id = name_id, .value_id = result.inst_id});
 
@@ -316,7 +316,7 @@ static auto PerformInstanceBinding(Context& context, SemIR::LocId loc_id,
                    "Non-constant value {0} of unbound element type",
                    context.insts().Get(member_id));
       auto index = GetClassElementIndex(context, element_id);
-      auto access_id = context.AddInst<SemIR::ClassElementAccess>(
+      SemIR::InstId access_id = context.AddInst<SemIR::ClassElementAccess>(
           loc_id, {.type_id = unbound_element_type.element_type_id,
                    .base_id = base_id,
                    .index = index});

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -87,6 +87,12 @@ class NodeStack {
     stack_.push_back({.node_id = node_id, .id = Id()});
   }
 
+  // Collapse TypedInstId to InstId.
+  template <SemIR::InstKind::RawEnumType Kind>
+  auto Push(Parse::NodeId node_id, SemIR::TypedInstId<Kind> id) -> void {
+    Push(node_id, static_cast<SemIR::InstId>(id));
+  }
+
   // Pushes a parse tree node onto the stack with an ID.
   template <typename IdT>
   auto Push(Parse::NodeId node_id, IdT id) -> void {

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -41,10 +41,10 @@ class PendingBlock {
   };
 
   template <typename InstT, typename LocT>
-  auto AddInst(LocT loc_id, InstT inst) -> SemIR::InstId {
+  auto AddInst(LocT loc_id, InstT inst) -> SemIR::TypedInstId<InstT::Kind> {
     auto inst_id = context_.AddInstInNoBlock(loc_id, inst);
     insts_.push_back(inst_id);
-    return inst_id;
+    return SemIR::TypedInstId<InstT::Kind>(inst_id.index);
   }
 
   // Insert the pending block of code at the current position.

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -29,11 +29,9 @@ cc_library(
 cc_library(
     name = "ids",
     hdrs = [
-        "id_kind.h",
         "ids.h",
     ],
     deps = [
-        ":inst_kind",
         "//common:check",
         "//common:ostream",
         "//toolchain/base:index_base",
@@ -48,7 +46,9 @@ cc_library(
     name = "inst_kind",
     srcs = ["inst_kind.cpp"],
     hdrs = [
+        "id_kind.h",
         "inst_kind.h",
+        "typed_inst_id.h",
         "typed_insts.h",
     ],
     textual_hdrs = ["inst_kind.def"],

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "ids.h",
     ],
     deps = [
+        ":inst_kind",
         "//common:check",
         "//common:ostream",
         "//toolchain/base:index_base",

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1053,6 +1053,11 @@ class FormatterImpl {
   // `FormatName` is used when we need the name from an id. Most id types use
   // equivalent name formatting from InstNamer, although there are a few special
   // formats below.
+  template <InstKind::RawEnumType Kind>
+  auto FormatName(TypedInstId<Kind> id) -> void {
+    return FormatName(InstId(id));
+  }
+
   template <typename IdT>
   auto FormatName(IdT id) -> void {
     out_ << inst_namer_->GetNameFor(id);

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -115,8 +115,6 @@ class TypeEnum {
 
 // An enum of all the ID types used as instruction operands.
 using IdKind = TypeEnum<
-    // From sem_ir/builtin_inst_kind.h.
-    BuiltinInstKind,
     // From base/value_store.h.
     IntId, RealId, FloatId, StringLiteralValueId,
     // From sem_ir/id.h.
@@ -124,7 +122,12 @@ using IdKind = TypeEnum<
     CompileTimeBindIndex, RuntimeParamIndex, FunctionId, ClassId, InterfaceId,
     ImplId, GenericId, SpecificId, ImportIRId, ImportIRInstId, LocId, BoolValue,
     IntKind, NameId, NameScopeId, InstBlockId, TypeId, TypeBlockId,
-    ElementIndex, LibraryNameId, FloatKind>;
+    ElementIndex, LibraryNameId, FloatKind,
+// Subtyped InstId variants.
+#define CARBON_SEM_IR_INST_KIND(Name) Name##InstId,
+#include "toolchain/sem_ir/inst_kind.def"
+    // From sem_ir/builtin_inst_kind.h.
+    BuiltinInstKind>;
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/typed_inst_id.h"
 
 namespace Carbon::SemIR {
 

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -12,6 +12,7 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/builtin_inst_kind.h"
+#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::SemIR {
 
@@ -85,6 +86,24 @@ constexpr InstId InstId::Invalid = InstId(InvalidIndex);
   constexpr InstId InstId::Builtin##Name =         \
       InstId::ForBuiltin(BuiltinInstKind::Name);
 #include "toolchain/sem_ir/builtin_inst_kind.def"
+
+// Use a template on the InstKind to help provide unique InstId types
+// per-instruction.
+template <SemIR::InstKind::RawEnumType Kind>
+class TypedInstId : public InstId {
+ public:
+  static const TypedInstId Invalid;
+  using InstId::InstId;
+};
+
+template <SemIR::InstKind::RawEnumType Kind>
+constexpr TypedInstId<Kind> TypedInstId<Kind>::Invalid =
+    TypedInstId(InvalidIndex);
+
+// Provide names for the per-instruction InstId types.
+#define CARBON_SEM_IR_INST_KIND(Name) \
+  using Name##InstId = TypedInstId<SemIR::InstKind::Name>;
+#include "toolchain/sem_ir/inst_kind.def"
 
 // An ID of an instruction that is referenced absolutely by another instruction.
 // This should only be used as the type of a field within a typed instruction

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -12,7 +12,6 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/builtin_inst_kind.h"
-#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::SemIR {
 
@@ -86,24 +85,6 @@ constexpr InstId InstId::Invalid = InstId(InvalidIndex);
   constexpr InstId InstId::Builtin##Name =         \
       InstId::ForBuiltin(BuiltinInstKind::Name);
 #include "toolchain/sem_ir/builtin_inst_kind.def"
-
-// Use a template on the InstKind to help provide unique InstId types
-// per-instruction.
-template <SemIR::InstKind::RawEnumType Kind>
-class TypedInstId : public InstId {
- public:
-  static const TypedInstId Invalid;
-  using InstId::InstId;
-};
-
-template <SemIR::InstKind::RawEnumType Kind>
-constexpr TypedInstId<Kind> TypedInstId<Kind>::Invalid =
-    TypedInstId(InvalidIndex);
-
-// Provide names for the per-instruction InstId types.
-#define CARBON_SEM_IR_INST_KIND(Name) \
-  using Name##InstId = TypedInstId<SemIR::InstKind::Name>;
-#include "toolchain/sem_ir/inst_kind.def"
 
 // An ID of an instruction that is referenced absolutely by another instruction.
 // This should only be used as the type of a field within a typed instruction

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -426,6 +426,14 @@ class InstStore {
     mem_usage.Collect(MemUsage::ConcatLabel(label, "values_"), values_);
   }
 
+  template <InstKind::RawEnumType Kind>
+  auto InstIdAs(InstId id) -> TypedInstId<Kind> {
+    CARBON_CHECK(Get(id).kind() == Kind,
+                 "InstId `{0}` has incorrect kind `{1}` in `InstIdAs<{2}>`", id,
+                 Get(id).kind(), InstKind::Make(Kind));
+    return TypedInstId<Kind>(id.index);
+  }
+
   auto array_ref() const -> llvm::ArrayRef<Inst> { return values_.array_ref(); }
   auto size() const -> int { return values_.size(); }
 

--- a/toolchain/sem_ir/typed_inst_id.h
+++ b/toolchain/sem_ir/typed_inst_id.h
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_SEM_IR_TYPED_INST_ID_H_
+#define CARBON_TOOLCHAIN_SEM_IR_TYPED_INST_ID_H_
+
+#include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst_kind.h"
+
+namespace Carbon::SemIR {
+
+// Use a template on the InstKind to help provide unique InstId types
+// per-instruction.
+template <SemIR::InstKind::RawEnumType Kind>
+class TypedInstId : public InstId {
+ public:
+  static const TypedInstId Invalid;
+  using InstId::InstId;
+};
+
+template <SemIR::InstKind::RawEnumType Kind>
+constexpr TypedInstId<Kind> TypedInstId<Kind>::Invalid =
+    TypedInstId(InvalidIndex);
+
+// Provide names for the per-instruction InstId types.
+#define CARBON_SEM_IR_INST_KIND(Name) \
+  using Name##InstId = TypedInstId<SemIR::InstKind::Name>;
+#include "toolchain/sem_ir/inst_kind.def"
+
+}  // namespace Carbon::SemIR
+
+#endif  // CARBON_TOOLCHAIN_SEM_IR_TYPED_INST_ID_H_

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -9,6 +9,7 @@
 #include "toolchain/sem_ir/builtin_inst_kind.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_kind.h"
+#include "toolchain/sem_ir/typed_inst_id.h"
 
 // Representations for specific kinds of instructions.
 //

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -1138,7 +1138,7 @@ struct Temporary {
       InstKind::Temporary.Define<Parse::NodeId>({.ir_name = "temporary"});
 
   TypeId type_id;
-  InstId storage_id;
+  TemporaryStorageInstId storage_id;
   InstId init_id;
 };
 


### PR DESCRIPTION
I'm switching `Temporary::storage_id` to a `TemporaryStorageInstId` as an example of this. Other than that, I'm not sure whether there are obvious low hanging fruit to change -- I figured starting to add the capability would be helpful towards use in future code.

Note, if you don't think this is more broadly helpful, I can abort this, but I think this is something you'd brought up so just trying  to provide it while feeling a little blocked elsewhere.