### PR TITLE
Fix lowering of `specific_function`s referring to methods.

### DIFF
--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -219,6 +219,11 @@ auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
   }
 }
 
+auto HandleInst(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
+                SemIR::SpecificFunction /*inst*/) -> void {
+  // Nothing to do. This value should never be consumed.
+}
+
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::SpliceBlock inst) -> void {
   context.LowerBlock(inst.block_id);

--- a/toolchain/lower/testdata/function/generic/call_method.carbon
+++ b/toolchain/lower/testdata/function/generic/call_method.carbon
@@ -1,0 +1,62 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/function/generic/call_method.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/generic/call_method.carbon
+
+class C {
+  fn F[self: Self, T:! type](x: T) -> T {
+    return x;
+  }
+}
+
+fn CallF() -> i32 {
+  var c: C = {};
+  var n: i32 = 0;
+  return c.F(n);
+}
+
+// CHECK:STDOUT: ; ModuleID = 'call_method.carbon'
+// CHECK:STDOUT: source_filename = "call_method.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @struct.loc18_16 = internal constant {} zeroinitializer
+// CHECK:STDOUT:
+// CHECK:STDOUT: define i32 @_CCallF.Main() !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @struct.loc18_16, i64 0, i1 false), !dbg !8
+// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !9
+// CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc20_14 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %F.call = call i32 @_CF.C.Main.1(ptr %c.var, i32 %.loc20_14), !dbg !12
+// CHECK:STDOUT:   ret i32 %F.call, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare i32 @_CF.C.Main.1(ptr, i32)
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "call_method.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "CallF", linkageName: "_CCallF.Main", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 18, column: 7, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 19, column: 7, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 19, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 20, column: 14, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 20, column: 10, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 20, column: 3, scope: !4)

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -1029,7 +1029,7 @@ struct SpecificConstant {
 struct SpecificFunction {
   static constexpr auto Kind = InstKind::SpecificFunction.Define<Parse::NodeId>(
       {.ir_name = "specific_function",
-       .constant_kind = InstConstantKind::Always});
+       .constant_kind = InstConstantKind::Conditional});
 
   // Always the builtin SpecificFunctionType.
   TypeId type_id;


### PR DESCRIPTION
In this case, the callee may be non-constant because it includes a reference to `self`, so we need to be able to lower a non-constant `specific_function`.