### PR TITLE
Exempt the `clang` subcommand when fuzzing.

### DIFF
--- a/toolchain/driver/clang_subcommand.cpp
+++ b/toolchain/driver/clang_subcommand.cpp
@@ -44,6 +44,15 @@ Arguments passed to Clang.
 auto ClangSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   std::string target = llvm::sys::getDefaultTargetTriple();
   ClangRunner runner(driver_env.installation, target, driver_env.vlog_stream);
+
+  // Don't run Clang when fuzzing, it is known to not be reliable under fuzzing
+  // due to many unfixed issues.
+  if (driver_env.fuzzing) {
+    driver_env.error_stream
+        << "error: cannot run `clang` subcommand productively when fuzzing\n";
+    return {.success = false};
+  }
+
   return {.success = runner.Run(options_.args)};
 }
 

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -38,6 +38,10 @@ class Driver {
   // error stream (stderr by default).
   auto RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> DriverResult;
 
+  // Configure the driver for fuzzing. This allows specific commands to error
+  // rather than perform operations that aren't well behaved during fuzzing.
+  auto SetFuzzing() -> void;
+
  private:
   DriverEnv driver_env_;
 };

--- a/toolchain/driver/driver_env.h
+++ b/toolchain/driver/driver_env.h
@@ -25,6 +25,9 @@ struct DriverEnv {
 
   // For CARBON_VLOG.
   llvm::raw_pwrite_stream* vlog_stream = nullptr;
+
+  // Tracks when the driver is being fuzzed.
+  bool fuzzing = false;
 };
 
 }  // namespace Carbon

--- a/toolchain/driver/driver_fuzzer.cpp
+++ b/toolchain/driver/driver_fuzzer.cpp
@@ -82,6 +82,7 @@ extern "C" auto LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
   TestRawOstream error_stream;
   llvm::raw_null_ostream dest;
   Driver d(fs, install_paths, dest, error_stream);
+  d.SetFuzzing();
   if (!d.RunCommand(args).success) {
     auto str = error_stream.TakeStr();
     // TODO: Fix command_line to use `error`, switch back to `find`.


### PR DESCRIPTION
This teaches the driver library to track when its being used with fuzzing and disables the `clang` subcommand from actually running Clang.

The Clang libraries have a large backlog of fuzzer-found issues that isn't being actively reduced, so we can't productively fuzz into it. This lets us more productively fuzz at the top level.

This is also available on the command line itself, which should be useful if anyone wants to fuzz Carbon from the command line using tools like AFL -- they can inject this flag to avoid getting noise from the fuzzer hitting known issues in Clang.
