### PR TITLE
Fix a case of `InvalidParse` with `has_error = false`

### DIFF
--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -336,7 +336,8 @@ auto Context::ConsumeListToken(NodeKind comma_kind, Lex::TokenKind close_kind,
   if (PositionIs(close_kind)) {
     return ListTokenKind::Close;
   } else {
-    AddLeafNode(comma_kind, Consume());
+    AddLeafNode(comma_kind, Consume(),
+                /*has_error=*/comma_kind == NodeKind::InvalidParse);
     return PositionIs(close_kind) ? ListTokenKind::CommaClose
                                   : ListTokenKind::Comma;
   }

--- a/toolchain/parse/testdata/struct/fail_comma_only.carbon
+++ b/toolchain/parse/testdata/struct/fail_comma_only.carbon
@@ -20,7 +20,7 @@ var x: {,} = {};
 // CHECK:STDOUT:         {kind: 'IdentifierName', text: 'x'},
 // CHECK:STDOUT:           {kind: 'StructLiteralStart', text: '{'},
 // CHECK:STDOUT:           {kind: 'InvalidParse', text: ',', has_error: yes},
-// CHECK:STDOUT:           {kind: 'InvalidParse', text: ','},
+// CHECK:STDOUT:           {kind: 'InvalidParse', text: ',', has_error: yes},
 // CHECK:STDOUT:         {kind: 'StructLiteral', text: '}', has_error: yes, subtree_size: 4},
 // CHECK:STDOUT:       {kind: 'BindingPattern', text: ':', subtree_size: 6},
 // CHECK:STDOUT:       {kind: 'VariableInitializer', text: '='},


### PR DESCRIPTION
Introduced in #4470.