### PR TITLE
Abort rather than exiting "normally" if an autoupdate step crashes.

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -1015,7 +1015,9 @@ static auto RunAutoupdate(llvm::StringRef exe_path,
 
   pool.wait();
   if (crashed) {
-    return EXIT_FAILURE;
+    // Abort rather than returning so that we don't get a LeakSanitizer report.
+    // We expect to have leaked memory if one or more of our tests crashed.
+    std::abort();
   }
   llvm::errs() << "\nDone!\n";
   return EXIT_SUCCESS;


### PR DESCRIPTION
This avoids producing an LSan leak report for the objects that got leaked by the crash, which would otherwise scroll all the useful information about the crash off the terminal.