### PR TITLE
Remove verbose formatting of instructions on crash messages.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -205,7 +205,6 @@ cc_library(
         "//common:vlog",
         "//toolchain/parse:node_kind",
         "//toolchain/parse:tree",
-        "//toolchain/sem_ir:formatter",
         "//toolchain/sem_ir:ids",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -1299,12 +1299,11 @@ auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {
   // spaces then add a couple to indent past the Context label.
   constexpr int Indent = 10;
 
-  SemIR::Formatter formatter(*tokens_, *parse_tree_, *sem_ir_);
-  node_stack_.PrintForStackDump(formatter, Indent, output);
-  inst_block_stack_.PrintForStackDump(formatter, Indent, output);
-  pattern_block_stack_.PrintForStackDump(formatter, Indent, output);
-  param_and_arg_refs_stack_.PrintForStackDump(formatter, Indent, output);
-  args_type_info_stack_.PrintForStackDump(formatter, Indent, output);
+  node_stack_.PrintForStackDump(Indent, output);
+  inst_block_stack_.PrintForStackDump(Indent, output);
+  pattern_block_stack_.PrintForStackDump(Indent, output);
+  param_and_arg_refs_stack_.PrintForStackDump(Indent, output);
+  args_type_info_stack_.PrintForStackDump(Indent, output);
 }
 
 auto Context::DumpFormattedFile() const -> void {

--- a/toolchain/check/inst_block_stack.cpp
+++ b/toolchain/check/inst_block_stack.cpp
@@ -61,17 +61,19 @@ auto InstBlockStack::PopAndDiscard() -> void {
   CARBON_VLOG("{0} PopAndDiscard {1}\n", name_, id_stack_.size());
 }
 
-auto InstBlockStack::PrintForStackDump(SemIR::Formatter& formatter, int indent,
+auto InstBlockStack::PrintForStackDump(int indent,
                                        llvm::raw_ostream& output) const
     -> void {
   output.indent(indent);
   output << name_ << ":\n";
   for (const auto& [i, id] : llvm::enumerate(id_stack_)) {
     output.indent(indent + 2);
-    output << i << ". " << id;
-    formatter.PrintPartialTrailingCodeBlock(insts_stack_.PeekArrayAt(i),
-                                            indent + 4, output);
-    output << "\n";
+    output << i << ".\t" << id << "\t{";
+    llvm::ListSeparator sep;
+    for (auto id : insts_stack_.PeekArrayAt(i)) {
+      output << sep << id;
+    }
+    output << "}\n";
   }
 }
 

--- a/toolchain/check/inst_block_stack.h
+++ b/toolchain/check/inst_block_stack.h
@@ -77,8 +77,7 @@ class InstBlockStack {
   }
 
   // Prints the stack for a stack dump.
-  auto PrintForStackDump(SemIR::Formatter& formatter, int indent,
-                         llvm::raw_ostream& output) const -> void;
+  auto PrintForStackDump(int indent, llvm::raw_ostream& output) const -> void;
 
   // Runs verification that the processing cleanly finished.
   auto VerifyOnFinish() const -> void {

--- a/toolchain/check/node_stack.cpp
+++ b/toolchain/check/node_stack.cpp
@@ -8,19 +8,15 @@
 
 namespace Carbon::Check {
 
-auto NodeStack::PrintForStackDump(SemIR::Formatter& formatter, int indent,
-                                  llvm::raw_ostream& output) const -> void {
+auto NodeStack::PrintForStackDump(int indent, llvm::raw_ostream& output) const
+    -> void {
   auto print_id = [&]<Id::Kind Kind>(Id id) {
     if constexpr (Kind == Id::Kind::None) {
-      output << "no value\n";
+      output << "no value";
     } else if constexpr (Kind == Id::Kind::Invalid) {
       CARBON_FATAL("Should not be in node stack");
-    } else if constexpr (Kind == Id::KindFor<SemIR::InstId>()) {
-      output << "\n";
-      formatter.PrintInst(id.As<Id::KindFor<SemIR::InstId>()>(), indent + 4,
-                          output);
     } else {
-      output << id.As<Kind>() << "\n";
+      output << id.As<Kind>();
     }
   };
 
@@ -37,6 +33,7 @@ auto NodeStack::PrintForStackDump(SemIR::Formatter& formatter, int indent,
     break;
 #include "toolchain/parse/node_kind.def"
     }
+    output << "\n";
   }
 }
 

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -11,7 +11,6 @@
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/tree.h"
 #include "toolchain/parse/typed_nodes.h"
-#include "toolchain/sem_ir/formatter.h"
 #include "toolchain/sem_ir/id_kind.h"
 #include "toolchain/sem_ir/ids.h"
 
@@ -335,8 +334,7 @@ class NodeStack {
   }
 
   // Prints the stack for a stack dump.
-  auto PrintForStackDump(SemIR::Formatter& formatter, int indent,
-                         llvm::raw_ostream& output) const -> void;
+  auto PrintForStackDump(int indent, llvm::raw_ostream& output) const -> void;
 
   auto empty() const -> bool { return stack_.empty(); }
   auto size() const -> size_t { return stack_.size(); }

--- a/toolchain/check/param_and_arg_refs_stack.h
+++ b/toolchain/check/param_and_arg_refs_stack.h
@@ -72,9 +72,8 @@ class ParamAndArgRefsStack {
   auto VerifyOnFinish() -> void { stack_.VerifyOnFinish(); }
 
   // Prints the stack for a stack dump.
-  auto PrintForStackDump(SemIR::Formatter& formatter, int indent,
-                         llvm::raw_ostream& output) const -> void {
-    return stack_.PrintForStackDump(formatter, indent, output);
+  auto PrintForStackDump(int indent, llvm::raw_ostream& output) const -> void {
+    return stack_.PrintForStackDump(indent, output);
   }
 
  private:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -78,34 +78,6 @@ class FormatterImpl {
     out_ << "\n";
   }
 
-  // Prints a code block.
-  auto FormatPartialTrailingCodeBlock(llvm::ArrayRef<SemIR::InstId> block)
-      -> void {
-    out_ << ' ';
-    OpenBrace();
-    constexpr int NumPrintedOnSkip = 9;
-    // Avoid only skipping one item.
-    if (block.size() > NumPrintedOnSkip + 1) {
-      Indent();
-      out_ << "... skipping " << (block.size() - NumPrintedOnSkip)
-           << " insts ...\n";
-      block = block.take_back(NumPrintedOnSkip);
-    }
-    FormatCodeBlock(block);
-    CloseBrace();
-  }
-
-  // Prints a single instruction.
-  auto FormatInst(InstId inst_id) -> void {
-    if (!inst_id.is_valid()) {
-      Indent();
-      out_ << "invalid\n";
-      return;
-    }
-
-    FormatInst(inst_id, sem_ir_.insts().Get(inst_id));
-  }
-
  private:
   enum class AddSpace : bool { Before, After };
 
@@ -566,6 +538,17 @@ class FormatterImpl {
       Indent();
       out_ << "has_error\n";
     }
+  }
+
+  // Prints a single instruction.
+  auto FormatInst(InstId inst_id) -> void {
+    if (!inst_id.is_valid()) {
+      Indent();
+      out_ << "invalid\n";
+      return;
+    }
+
+    FormatInst(inst_id, sem_ir_.insts().Get(inst_id));
   }
 
   auto FormatInst(InstId inst_id, Inst inst) -> void {
@@ -1190,19 +1173,6 @@ Formatter::~Formatter() = default;
 auto Formatter::Print(llvm::raw_ostream& out) -> void {
   FormatterImpl formatter(sem_ir_, &inst_namer_, out, /*indent=*/0);
   formatter.Format();
-}
-
-auto Formatter::PrintPartialTrailingCodeBlock(
-    llvm::ArrayRef<SemIR::InstId> block, int indent, llvm::raw_ostream& out)
-    -> void {
-  FormatterImpl formatter(sem_ir_, &inst_namer_, out, indent);
-  formatter.FormatPartialTrailingCodeBlock(block);
-}
-
-auto Formatter::PrintInst(SemIR::InstId inst_id, int indent,
-                          llvm::raw_ostream& out) -> void {
-  FormatterImpl formatter(sem_ir_, &inst_namer_, out, indent);
-  formatter.FormatInst(inst_id);
 }
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -22,14 +22,6 @@ class Formatter {
 
   // Prints the full IR.
   auto Print(llvm::raw_ostream& out) -> void;
-  // Prints a single code block. Only prints the last several instructions of
-  // large blocks.
-  auto PrintPartialTrailingCodeBlock(llvm::ArrayRef<SemIR::InstId> block,
-                                     int indent, llvm::raw_ostream& out)
-      -> void;
-  // Prints a single instruction.
-  auto PrintInst(SemIR::InstId inst_id, int indent, llvm::raw_ostream& out)
-      -> void;
 
  private:
   const File& sem_ir_;


### PR DESCRIPTION
Undoes a chunk of #4125 because nobody's really in favor of keeping the formatting, and it's occasionally caused a crash in Formatter to dominate output (and even when working, it can be verbose; the source location in (5) is often more helpful).

Basically goes back to:

```
4.	Check::Context
          NodeStack:
            0. LetIntroducer: no value
            1. BindingPattern: inst+15
            2. LetInitializer: no value
            3. StructLiteralStart: no value
          inst_block_stack_:
            0.	block<invalid>	{inst+0, inst+1, inst+6, inst+7, inst+8, inst+9, inst+10, inst+11, inst+12}
            1.	global_init	{}
          pattern_block_stack_:
            0.	block<invalid>	{}
          param_and_arg_refs_stack:
            0.	block<invalid>	{}
          args_type_info_stack_:
            0.	block<invalid>	{}
5.	alias_of_alias.carbon:15:12: checking StructLiteral
          let d: c = {};
                     ^~
```

Fixes #4145