### PR TITLE
Preserve the is_dynamic property of classes when importing them

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1418,7 +1418,8 @@ class ImportRefResolver {
     class_decl.class_id = context_.classes().Add(
         {GetIncompleteLocalEntityBase(class_decl_id, import_class),
          {.self_type_id = SemIR::TypeId::Invalid,
-          .inheritance_kind = import_class.inheritance_kind}});
+          .inheritance_kind = import_class.inheritance_kind,
+          .is_dynamic = import_class.is_dynamic}});
 
     if (import_class.has_parameters()) {
       class_decl.type_id = context_.GetGenericClassType(class_decl.class_id,

--- a/toolchain/check/testdata/class/virtual_modifiers.carbon
+++ b/toolchain/check/testdata/class/virtual_modifiers.carbon
@@ -133,7 +133,7 @@ fn F() {
 // CHECK:STDOUT:   %.3: <witness> = complete_type_witness %.2 [template]
 // CHECK:STDOUT:   %.4: type = ptr_type %.2 [template]
 // CHECK:STDOUT:   %.5: type = unbound_element_type %Derived, %Base [template]
-// CHECK:STDOUT:   %.6: type = struct_type {.<vptr>: %.1, .base: %Base} [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: %Base} [template]
 // CHECK:STDOUT:   %.7: <witness> = complete_type_witness %.6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
The test update shows a class derived from an imported base class with a vptr, and without this change the derived class got its own vptr, with this change the derived class can see the base is dynamic, so the derived doesn't need to add a vptr and can rely on the base class's vptr instead.