### PR TITLE
Collect timing data per unit for each phase

### DIFF
--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -43,6 +43,17 @@ cc_library(
 )
 
 cc_library(
+    name = "timings",
+    hdrs = ["timings.h"],
+    deps = [
+        ":yaml",
+        "//common:map",
+        "//common:set",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "value_ids",
     hdrs = ["value_ids.h"],
     deps = [

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -47,8 +47,6 @@ cc_library(
     hdrs = ["timings.h"],
     deps = [
         ":yaml",
-        "//common:map",
-        "//common:set",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/base/timings.h
+++ b/toolchain/base/timings.h
@@ -25,7 +25,7 @@ class Timings {
       map.Add("filename", filename);
       map.Add("nanoseconds",
               Yaml::OutputMapping([&](Yaml::OutputMapping::Map label_map) {
-                auto total_nanoseconds = std::chrono::nanoseconds(0);
+                std::chrono::nanoseconds total_nanoseconds(0);
                 for (const auto& entry : timings_) {
                   total_nanoseconds += entry.nanoseconds;
                   label_map.Add(entry.label, entry.nanoseconds.count());

--- a/toolchain/base/timings.h
+++ b/toolchain/base/timings.h
@@ -1,0 +1,51 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_BASE_TIMINGS_H_
+#define CARBON_TOOLCHAIN_BASE_TIMINGS_H_
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "toolchain/base/yaml.h"
+
+namespace Carbon {
+
+// Helps track timings for a compile.
+class Timings {
+ public:
+  // Adds tracking for nanoseconds, paired with the given label.
+  auto Add(std::string label, std::chrono::nanoseconds nanoseconds) -> void {
+    timings_.push_back({.label = std::move(label), .nanoseconds = nanoseconds});
+  }
+
+  auto OutputYaml(llvm::StringRef filename) const -> Yaml::OutputMapping {
+    // Explicitly copy the filename.
+    return Yaml::OutputMapping([&, filename](Yaml::OutputMapping::Map map) {
+      map.Add("filename", filename);
+      map.Add("nanoseconds",
+              Yaml::OutputMapping([&](Yaml::OutputMapping::Map label_map) {
+                auto total_nanoseconds = std::chrono::nanoseconds(0);
+                for (const auto& entry : timings_) {
+                  total_nanoseconds += entry.nanoseconds;
+                  label_map.Add(entry.label, entry.nanoseconds.count());
+                }
+                label_map.Add("Total", total_nanoseconds.count());
+              }));
+    });
+  }
+
+ private:
+  // Timing for a specific label.
+  struct Entry {
+    std::string label;
+    std::chrono::nanoseconds nanoseconds;
+  };
+
+  // The accumulated data on timings.
+  llvm::SmallVector<Entry> timings_;
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_TOOLCHAIN_BASE_TIMINGS_H_

--- a/toolchain/base/timings.h
+++ b/toolchain/base/timings.h
@@ -28,9 +28,11 @@ class Timings {
                 std::chrono::nanoseconds total_nanoseconds(0);
                 for (const auto& entry : timings_) {
                   total_nanoseconds += entry.nanoseconds;
-                  label_map.Add(entry.label, entry.nanoseconds.count());
+                  label_map.Add(entry.label, static_cast<int64_t>(
+                                                 entry.nanoseconds.count()));
                 }
-                label_map.Add("Total", total_nanoseconds.count());
+                label_map.Add("Total",
+                              static_cast<int64_t>(total_nanoseconds.count()));
               }));
     });
   }

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -118,6 +118,7 @@ cc_library(
         "//toolchain/base:kind_switch",
         "//toolchain/base:pretty_stack_trace_function",
         "//toolchain/base:shared_value_stores",
+        "//toolchain/base:timings",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:format_providers",
         "//toolchain/lex:token_index",

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -958,9 +958,9 @@ static auto CheckParseTree(
   auto start_time = std::chrono::steady_clock::now();
   CheckParseTreeInner(node_converters, unit_info, total_ir_count, vlog_stream);
   auto end_time = std::chrono::steady_clock::now();
-  auto timings = unit_info.unit->timings;
-  if (timings) {
-    (*timings)->Add("check", end_time - start_time);
+  if (auto& timings = *(unit_info.unit->timings)) {
+    auto end_time = std::chrono::steady_clock::now();
+    timings->Add("check", end_time - start_time);
   }
 }
 

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -957,7 +957,6 @@ static auto CheckParseTree(
     -> void {
   auto start_time = std::chrono::steady_clock::now();
   CheckParseTreeInner(node_converters, unit_info, total_ir_count, vlog_stream);
-  auto end_time = std::chrono::steady_clock::now();
   if (auto& timings = *(unit_info.unit->timings)) {
     auto end_time = std::chrono::steady_clock::now();
     timings->Add("check", end_time - start_time);

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -894,7 +894,7 @@ static auto ProcessNodeIds(Context& context, llvm::raw_ostream* vlog_stream,
 }
 
 // Produces and checks the IR for the provided Parse::Tree.
-static auto CheckParseTree(
+static auto CheckParseTreeInner(
     llvm::MutableArrayRef<Parse::NodeLocConverter> node_converters,
     UnitInfo& unit_info, int total_ir_count, llvm::raw_ostream* vlog_stream)
     -> void {
@@ -948,6 +948,20 @@ static auto CheckParseTree(
                  verify.error());
   }
 #endif
+}
+
+// Measures duration to produce and check the IR for the provided Parse::Tree.
+static auto CheckParseTree(
+    llvm::MutableArrayRef<Parse::NodeLocConverter> node_converters,
+    UnitInfo& unit_info, int total_ir_count, llvm::raw_ostream* vlog_stream)
+    -> void {
+  auto start_time = std::chrono::steady_clock::now();
+  CheckParseTreeInner(node_converters, unit_info, total_ir_count, vlog_stream);
+  auto end_time = std::chrono::steady_clock::now();
+  auto timings = unit_info.unit->timings;
+  if (timings) {
+    (*timings)->Add("check", end_time - start_time);
+  }
 }
 
 // The package and library names, used as map keys.

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -20,7 +20,7 @@ namespace Carbon::Check {
 // Checking information that's tracked per file.
 struct Unit {
   SharedValueStores* value_stores;
-  std::optional<Timings*> timings;
+  std::optional<Timings>* timings;
   const Lex::TokenizedBuffer* tokens;
   const Parse::Tree* parse_tree;
   DiagnosticConsumer* consumer;

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -7,6 +7,7 @@
 
 #include "common/ostream.h"
 #include "toolchain/base/shared_value_stores.h"
+#include "toolchain/base/timings.h"
 #include "toolchain/check/sem_ir_diagnostic_converter.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/tokenized_buffer.h"
@@ -19,6 +20,7 @@ namespace Carbon::Check {
 // Checking information that's tracked per file.
 struct Unit {
   SharedValueStores* value_stores;
+  std::optional<Timings*> timings;
   const Lex::TokenizedBuffer* tokens;
   const Parse::Tree* parse_tree;
   DiagnosticConsumer* consumer;

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -112,6 +112,7 @@ cc_library(
         "//common:vlog",
         "//toolchain/base:pretty_stack_trace_function",
         "//toolchain/base:shared_value_stores",
+        "//toolchain/base:timings",
         "//toolchain/check",
         "//toolchain/codegen",
         "//toolchain/diagnostics:diagnostic_emitter",

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -379,7 +379,10 @@ class CompilationUnit {
     auto start_time = std::chrono::steady_clock::now();
     LogCall("Lex::Lex",
             [&] { tokens_ = Lex::Lex(value_stores_, *source_, *consumer_); });
-    auto end_time = std::chrono::steady_clock::now();
+    if (timings_) {
+      auto end_time = std::chrono::steady_clock::now();
+      timings_->Add("lex", end_time - start_time);
+    }
     if (options_.dump_tokens && IncludeInDumps()) {
       consumer_->Flush();
       tokens_->Print(driver_env_->output_stream,
@@ -387,9 +390,6 @@ class CompilationUnit {
     }
     if (mem_usage_) {
       mem_usage_->Collect("tokens_", *tokens_);
-    }
-    if (timings_) {
-      timings_->Add("lex", end_time - start_time);
     }
     CARBON_VLOG("*** Lex::TokenizedBuffer ***\n{0}", tokens_);
     if (tokens_->has_errors()) {
@@ -405,7 +405,10 @@ class CompilationUnit {
     LogCall("Parse::Parse", [&] {
       parse_tree_ = Parse::Parse(*tokens_, *consumer_, vlog_stream_);
     });
-    auto end_time = std::chrono::steady_clock::now();
+    if (timings_) {
+      auto end_time = std::chrono::steady_clock::now();
+      timings_->Add("parse", end_time - start_time);
+    }
     if (options_.dump_parse_tree && IncludeInDumps()) {
       consumer_->Flush();
       const auto& tree_and_subtrees = GetParseTreeAndSubtrees();
@@ -417,9 +420,6 @@ class CompilationUnit {
     }
     if (mem_usage_) {
       mem_usage_->Collect("parse_tree_", *parse_tree_);
-    }
-    if (timings_) {
-      timings_->Add("parse", end_time - start_time);
     }
     CARBON_VLOG("*** Parse::Tree ***\n{0}", parse_tree_);
     if (parse_tree_->has_errors()) {
@@ -493,7 +493,10 @@ class CompilationUnit {
                                    converter, input_filename_, *sem_ir_,
                                    &inst_namer, vlog_stream_);
     });
-    auto end_time = std::chrono::steady_clock::now();
+    if (timings_) {
+      auto end_time = std::chrono::steady_clock::now();
+      timings_->Add("lower", end_time - start_time);
+    }
     if (vlog_stream_) {
       CARBON_VLOG("*** llvm::Module ***\n");
       module_->print(*vlog_stream_, /*AAW=*/nullptr,
@@ -503,9 +506,6 @@ class CompilationUnit {
     if (options_.dump_llvm_ir && IncludeInDumps()) {
       module_->print(driver_env_->output_stream, /*AAW=*/nullptr,
                      /*ShouldPreserveUseListOrder=*/true);
-    }
-    if (timings_) {
-      timings_->Add("lower", end_time - start_time);
     }
   }
 

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -7,6 +7,7 @@
 #include "common/vlog.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "toolchain/base/pretty_stack_trace_function.h"
+#include "toolchain/base/timings.h"
 #include "toolchain/check/check.h"
 #include "toolchain/codegen/codegen.h"
 #include "toolchain/diagnostics/sorting_diagnostic_consumer.h"
@@ -238,6 +239,14 @@ Dumps the amount of memory used.
       [&](auto& arg_b) { arg_b.Set(&dump_mem_usage); });
   b.AddFlag(
       {
+          .name = "dump-timings",
+          .help = R"""(
+Dump timing information from each phase for each input source file.
+)""",
+      },
+      [&](auto& arg_b) { arg_b.Set(&dump_timings); });
+  b.AddFlag(
+      {
           .name = "prelude-import",
           .help = R"""(
 Whether to use the implicit prelude import. Enabled by default.
@@ -346,6 +355,9 @@ class CompilationUnit {
     if (options_.dump_mem_usage && IncludeInDumps()) {
       mem_usage_ = MemUsage();
     }
+    if (options_.dump_timings && IncludeInDumps()) {
+      timings_ = Timings();
+    }
   }
 
   // Loads source and lexes it. Returns true on success.
@@ -364,8 +376,10 @@ class CompilationUnit {
     }
     CARBON_VLOG("*** SourceBuffer ***\n```\n{0}\n```\n", source_->text());
 
+    auto start_time = std::chrono::steady_clock::now();
     LogCall("Lex::Lex",
             [&] { tokens_ = Lex::Lex(value_stores_, *source_, *consumer_); });
+    auto end_time = std::chrono::steady_clock::now();
     if (options_.dump_tokens && IncludeInDumps()) {
       consumer_->Flush();
       tokens_->Print(driver_env_->output_stream,
@@ -373,6 +387,9 @@ class CompilationUnit {
     }
     if (mem_usage_) {
       mem_usage_->Collect("tokens_", *tokens_);
+    }
+    if (timings_) {
+      timings_->Add("lex", end_time - start_time);
     }
     CARBON_VLOG("*** Lex::TokenizedBuffer ***\n{0}", tokens_);
     if (tokens_->has_errors()) {
@@ -384,9 +401,11 @@ class CompilationUnit {
   auto RunParse() -> void {
     CARBON_CHECK(tokens_);
 
+    auto start_time = std::chrono::steady_clock::now();
     LogCall("Parse::Parse", [&] {
       parse_tree_ = Parse::Parse(*tokens_, *consumer_, vlog_stream_);
     });
+    auto end_time = std::chrono::steady_clock::now();
     if (options_.dump_parse_tree && IncludeInDumps()) {
       consumer_->Flush();
       const auto& tree_and_subtrees = GetParseTreeAndSubtrees();
@@ -399,6 +418,9 @@ class CompilationUnit {
     if (mem_usage_) {
       mem_usage_->Collect("parse_tree_", *parse_tree_);
     }
+    if (timings_) {
+      timings_->Add("parse", end_time - start_time);
+    }
     CARBON_VLOG("*** Parse::Tree ***\n{0}", parse_tree_);
     if (parse_tree_->has_errors()) {
       success_ = false;
@@ -410,6 +432,7 @@ class CompilationUnit {
     CARBON_CHECK(parse_tree_);
     return {
         .value_stores = &value_stores_,
+        .timings = &*timings_,
         .tokens = &*tokens_,
         .parse_tree = &*parse_tree_,
         .consumer = consumer_,
@@ -460,6 +483,7 @@ class CompilationUnit {
   auto RunLower(const Check::SemIRDiagnosticConverter& converter) -> void {
     CARBON_CHECK(sem_ir_);
 
+    auto start_time = std::chrono::steady_clock::now();
     LogCall("Lower::LowerToLLVM", [&] {
       llvm_context_ = std::make_unique<llvm::LLVMContext>();
       // TODO: Consider disabling instruction naming by default if we're not
@@ -469,6 +493,7 @@ class CompilationUnit {
                                    converter, input_filename_, *sem_ir_,
                                    &inst_namer, vlog_stream_);
     });
+    auto end_time = std::chrono::steady_clock::now();
     if (vlog_stream_) {
       CARBON_VLOG("*** llvm::Module ***\n");
       module_->print(*vlog_stream_, /*AAW=*/nullptr,
@@ -479,11 +504,19 @@ class CompilationUnit {
       module_->print(driver_env_->output_stream, /*AAW=*/nullptr,
                      /*ShouldPreserveUseListOrder=*/true);
     }
+    if (timings_) {
+      timings_->Add("lower", end_time - start_time);
+    }
   }
 
   auto RunCodeGen() -> void {
     CARBON_CHECK(module_);
+    auto start_time = std::chrono::steady_clock::now();
     LogCall("CodeGen", [&] { success_ = RunCodeGenHelper(); });
+    auto end_time = std::chrono::steady_clock::now();
+    if (timings_) {
+      timings_->Add("codegen", end_time - start_time);
+    }
   }
 
   // Runs post-compile logic. This is always called, and called after all other
@@ -497,6 +530,10 @@ class CompilationUnit {
       mem_usage_->Collect("value_stores_", value_stores_);
       Yaml::Print(driver_env_->output_stream,
                   mem_usage_->OutputYaml(input_filename_));
+    }
+    if (timings_) {
+      Yaml::Print(driver_env_->output_stream,
+                  timings_->OutputYaml(input_filename_));
     }
 
     // The diagnostics consumer must be flushed before compilation artifacts are
@@ -625,6 +662,8 @@ class CompilationUnit {
 
   // Tracks memory usage of the compile.
   std::optional<MemUsage> mem_usage_;
+  // Tracks timings of the compile.
+  std::optional<Timings> timings_;
 
   // These are initialized as steps are run.
   std::optional<SourceBuffer> source_;

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -241,7 +241,7 @@ Dumps the amount of memory used.
       {
           .name = "dump-timings",
           .help = R"""(
-Dump timing information from each phase for each input source file.
+Dumps the duration of each phase for each compilation unit.
 )""",
       },
       [&](auto& arg_b) { arg_b.Set(&dump_timings); });

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -432,7 +432,7 @@ class CompilationUnit {
     CARBON_CHECK(parse_tree_);
     return {
         .value_stores = &value_stores_,
-        .timings = &*timings_,
+        .timings = &timings_,
         .tokens = &*tokens_,
         .parse_tree = &*parse_tree_,
         .consumer = consumer_,
@@ -513,8 +513,8 @@ class CompilationUnit {
     CARBON_CHECK(module_);
     auto start_time = std::chrono::steady_clock::now();
     LogCall("CodeGen", [&] { success_ = RunCodeGenHelper(); });
-    auto end_time = std::chrono::steady_clock::now();
     if (timings_) {
+      auto end_time = std::chrono::steady_clock::now();
       timings_->Add("codegen", end_time - start_time);
     }
   }

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -50,6 +50,7 @@ struct CompileOptions {
   bool dump_llvm_ir = false;
   bool dump_asm = false;
   bool dump_mem_usage = false;
+  bool dump_timings = false;
   bool include_diagnostic_kind = false;
   bool stream_errors = false;
   bool preorder_parse_tree = false;

--- a/toolchain/driver/testdata/dump_timings.carbon
+++ b/toolchain/driver/testdata/dump_timings.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ARGS: compile --dump-timings --phase=check %s
+//
+// SET-CHECK-SUBSET
+//
+// NOAUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/dump_timings.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/dump_timings.carbon
+
+// CHECK:STDOUT: filename:        dump_timings.carbon
+// CHECK:STDOUT: nanoseconds:
+// CHECK:STDOUT:   lex:             {{\d+}}
+// CHECK:STDOUT:   parse:           {{\d+}}
+// CHECK:STDOUT:   check:           {{\d+}}
+// CHECK:STDOUT:   Total:           {{\d+}}
+// CHECK:STDOUT: ...


### PR DESCRIPTION
This PR adds a `--dump-timings` flag to the `compile` subcommand (similar to the existing `--dump-mem-usage` flag), which collects timing data per compilation unit for each compilation phase. For example, on my 2020 M1 MacBook:

```
$ bazel build -c opt //toolchain
$ bazel-bin/toolchain/install/run_carbon compile --phase=lower --dump-timings examples/sieve.carbon | tail
...
---
filename:        'examples/sieve.carbon'
nanoseconds:
  lex:             30792
  parse:           25458
  check:           226625
  lower:           1136958
  Total:           1419833
...
```

Most of the changes are pretty straightforward. There were a couple I wasn't sure about though; let me know if I should change:

- new `Timings` class in its own file, pretty similar to the existing `MemUsage` class
- added a `timings_` field to the `CompilationUnit` class
- added a `timings` field to the `Check::Unit` struct
- renamed `CheckParseTree` function to `CheckParseTreeInner` for ease of timing with early `return`