### PR TITLE
always use a vptr (possibly with an empty type) in object representations

### DIFF
--- a/common/array_stack.h
+++ b/common/array_stack.h
@@ -47,6 +47,13 @@ class ArrayStack {
     return llvm::ArrayRef(values_).slice(array_offsets_.back());
   }
 
+  // Returns the top array from the stack in such a way that the array's
+  // contents can be modified by the caller.
+  auto PeekMutableArray() -> llvm::MutableArrayRef<ValueT> {
+    CARBON_CHECK(!array_offsets_.empty());
+    return llvm::MutableArrayRef(values_).slice(array_offsets_.back());
+  }
+
   // Returns the array at a specific index.
   auto PeekArrayAt(int index) const -> llvm::ArrayRef<ValueT> {
     auto ref = llvm::ArrayRef(values_).slice(array_offsets_[index]);

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -296,6 +296,8 @@ auto HandleParseNode(Context& context, Parse::ClassDefinitionStartId node_id)
   context.inst_block_stack().Push();
   context.node_stack().Push(node_id, class_id);
   context.struct_type_fields_stack().PushArray();
+  context.struct_type_fields_stack().AppendToTop(
+      {.name_id = SemIR::NameId::Vptr, .type_id = context.GetTupleType({})});
 
   // TODO: Handle the case where there's control flow in the class body. For
   // example:
@@ -668,10 +670,9 @@ static auto CheckCompleteClassType(Context& context, Parse::NodeId node_id,
   }
 
   if (defining_vtable_ptr) {
-    context.struct_type_fields_stack().PrependToTop(
-        {.name_id = SemIR::NameId::Vptr,
-         .type_id = context.GetPointerType(
-             context.GetBuiltinType(SemIR::BuiltinInstKind::VtableType))});
+    context.struct_type_fields_stack().PeekMutableArray().front().type_id =
+        context.GetPointerType(
+            context.GetBuiltinType(SemIR::BuiltinInstKind::VtableType));
   }
 
   auto fields_id = context.struct_type_fields().AddCanonical(

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -8,35 +8,73 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/class/virtual.carbon
 
+// --- classes.carbon
+
+package Classes;
+
 base class Base {
 }
+
 base class Intermediate {
   extend base: Base;
   virtual fn Fn();
 }
+
 class Derived {
   extend base: Intermediate;
   impl fn Fn();
 }
 
+// --- create.carbon
+
+package Create;
+
+import Classes;
+
 fn Create() {
-  var b: Base;
-  var i: Intermediate;
-  var d: Derived;
+  var b: Classes.Base;
+  var i: Classes.Intermediate;
+  var d: Classes.Derived;
 }
 
-fn Use(v: Intermediate*) {
+fn Use(v: Classes.Intermediate*) {
   v->Fn();
 }
 
-// CHECK:STDOUT: ; ModuleID = 'virtual.carbon'
-// CHECK:STDOUT: source_filename = "virtual.carbon"
+// --- member_init.carbon
+
+package MemberInit;
+
+base class Base {
+  var m: i32;
+  virtual fn Fn();
+}
+
+fn Fn() {
+  var i: i32 = 3;
+  var v: Base = {.m = i};
+  // var v: Base = {.m = 3}; // crashes
+  v.m = 5;
+}
+
+// CHECK:STDOUT: ; ModuleID = 'classes.carbon'
+// CHECK:STDOUT: source_filename = "classes.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CFn.Intermediate.Main()
+// CHECK:STDOUT: declare void @_CFn.Intermediate.Classes()
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CFn.Derived.Main()
+// CHECK:STDOUT: declare void @_CFn.Derived.Classes()
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CCreate.Main() !dbg !4 {
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "classes.carbon", directory: "")
+// CHECK:STDOUT: ; ModuleID = 'create.carbon'
+// CHECK:STDOUT: source_filename = "create.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CCreate.Create() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !7
 // CHECK:STDOUT:   %i.var = alloca { ptr, {} }, align 8, !dbg !8
@@ -44,9 +82,46 @@ fn Use(v: Intermediate*) {
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CUse.Main(ptr %v) !dbg !11 {
+// CHECK:STDOUT: define void @_CUse.Create(ptr %v) !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CFn.Intermediate.Main(), !dbg !12
+// CHECK:STDOUT:   call void @_CFn.Intermediate.Classes(), !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CFn.Intermediate.Classes()
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "create.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Create", linkageName: "_CCreate.Create", scope: null, file: !3, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 7, column: 7, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 8, column: 7, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 9, column: 7, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 6, column: 1, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Use", linkageName: "_CUse.Create", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !12 = !DILocation(line: 13, column: 3, scope: !11)
+// CHECK:STDOUT: !13 = !DILocation(line: 12, column: 1, scope: !11)
+// CHECK:STDOUT: ; ModuleID = 'member_init.carbon'
+// CHECK:STDOUT: source_filename = "member_init.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CFn.Base.MemberInit()
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CFn.MemberInit() !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %i.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   store i32 3, ptr %i.var, align 4, !dbg !8
+// CHECK:STDOUT:   %v.var = alloca { ptr, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %.loc11_23 = load i32, ptr %i.var, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc11_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   store i32 %.loc11_23, ptr %.loc11_24.2.vptr, align 4, !dbg !11
+// CHECK:STDOUT:   %.loc13_4.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   store i32 5, ptr %.loc13_4.vptr, align 4, !dbg !12
 // CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -56,14 +131,14 @@ fn Use(v: Intermediate*) {
 // CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !3 = !DIFile(filename: "virtual.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Create", linkageName: "_CCreate.Main", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !3 = !DIFile(filename: "member_init.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Fn", linkageName: "_CFn.MemberInit", scope: null, file: !3, line: 9, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 23, column: 7, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 24, column: 7, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 25, column: 7, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 22, column: 1, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Use", linkageName: "_CUse.Main", scope: null, file: !3, line: 28, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !12 = !DILocation(line: 29, column: 3, scope: !11)
-// CHECK:STDOUT: !13 = !DILocation(line: 28, column: 1, scope: !11)
+// CHECK:STDOUT: !7 = !DILocation(line: 10, column: 7, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 10, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 11, column: 7, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 23, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 11, column: 17, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 9, column: 1, scope: !4)


### PR DESCRIPTION
This breaks a lot of tests and lowering (with a pre-existing crash, probably just due to the lack of lowering of the initializer (or lowering it in check into an Error builtin, specifically), that only happens currently in dynamic classes, but by putting a vptr (even a zero-length one) in every class means they all hit that crash) so the presubmit checks aren't clear, but that's not really the fault of this patch.
