### PR TITLE
Try running 'bazel cquery //...' before target-determinator

### DIFF
--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -114,7 +114,7 @@ runs:
         git fetch --depth=1 origin $GIT_BASE_SHA
 
         # Do a retried query to try to download things for target-determinator.
-        ./scripts/run_bazel.py --attempts=5 cquery //...
+        ./scripts/run_bazel.py --attempts=5 cquery //... > /dev/null
 
         # Then use `target-determinator` as wrapped by our script.
         ./scripts/target_determinator.py $GIT_BASE_SHA >$TARGETS_FILE

--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -113,6 +113,9 @@ runs:
         # First fetch the relevant base into the git repository.
         git fetch --depth=1 origin $GIT_BASE_SHA
 
+        # Do a retried query to try to download things for target-determinator.
+        ./scripts/run_bazel.py --attempts=5 cquery //...
+
         # Then use `target-determinator` as wrapped by our script.
         ./scripts/target_determinator.py $GIT_BASE_SHA >$TARGETS_FILE
 


### PR DESCRIPTION
Trying to improve robustness against failures such as [here](https://github.com/carbon-language/carbon-lang/actions/runs/11845529962/job/33011203628):

```
WARNING: Download from https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz failed: class java.net.ConnectException Connection refused
```

Which is coming from the target-determinator invocation:

```
subprocess.CalledProcessError: Command '['/home/runner/.cache/carbon-lang-scripts/target-determinator', '--bazel=/usr/local/bin/bazelisk', 'a720921dfb99c21f08832663c91a1f9e48a1bcc4']' returned non-zero exit status 1.
```

My thought is that the `bazel cquery` should trigger equivalent downloads (equally though, I'd thought the `bazel mod deps` would do that, so I don't want to give the impression of confidence).

It's harder to inject this into the target-determinator command line, since we'd need something that retries by default.