### PR TITLE
Add support for scoped timings.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -894,10 +894,12 @@ static auto ProcessNodeIds(Context& context, llvm::raw_ostream* vlog_stream,
 }
 
 // Produces and checks the IR for the provided Parse::Tree.
-static auto CheckParseTreeInner(
+static auto CheckParseTree(
     llvm::MutableArrayRef<Parse::NodeLocConverter> node_converters,
     UnitInfo& unit_info, int total_ir_count, llvm::raw_ostream* vlog_stream)
     -> void {
+  Timings::ScopedTiming timing(unit_info.unit->timings, "check");
+
   auto package_id = IdentifierId::Invalid;
   auto library_id = StringLiteralValueId::Invalid;
   if (const auto& packaging = unit_info.unit->parse_tree->packaging_decl()) {
@@ -948,19 +950,6 @@ static auto CheckParseTreeInner(
                  verify.error());
   }
 #endif
-}
-
-// Measures duration to produce and check the IR for the provided Parse::Tree.
-static auto CheckParseTree(
-    llvm::MutableArrayRef<Parse::NodeLocConverter> node_converters,
-    UnitInfo& unit_info, int total_ir_count, llvm::raw_ostream* vlog_stream)
-    -> void {
-  auto start_time = std::chrono::steady_clock::now();
-  CheckParseTreeInner(node_converters, unit_info, total_ir_count, vlog_stream);
-  if (auto& timings = *(unit_info.unit->timings)) {
-    auto end_time = std::chrono::steady_clock::now();
-    timings->Add("check", end_time - start_time);
-  }
 }
 
 // The package and library names, used as map keys.


### PR DESCRIPTION
I think there are a few related ways to do this. I considered llvm::make_scope_exit, but the return type is difficult to work with. I particularly was thinking I could encapsulate the duration logic this way.