### PR TITLE
Add blank lines between EntityWithParamsBase members.

### DIFF
--- a/toolchain/sem_ir/entity_with_params_base.h
+++ b/toolchain/sem_ir/entity_with_params_base.h
@@ -83,40 +83,52 @@ struct EntityWithParamsBase {
 
   // The class name.
   NameId name_id;
+
   // The parent scope.
   NameScopeId parent_scope_id;
+
   // If this is a generic function, information about the generic.
   GenericId generic_id;
+
   // Parse tree bounds for the parameters, including both implicit and explicit
   // parameters. These will be compared to match between declaration and
   // definition.
   Parse::NodeId first_param_node_id;
   Parse::NodeId last_param_node_id;
+
   // A block containing the pattern insts for the parameter lists.
   InstBlockId pattern_block_id;
+
   // A block containing, for each implicit parameter, a reference to the
   // instruction in the entity's declaration block that depends on all other
   // pattern-match insts pertaining to that parameter.
   InstBlockId implicit_param_refs_id;
+
   // A block containing, for each implicit parameter, a reference to the
   // instruction in the entity's pattern block that depends on all other
   // pattern insts pertaining to that parameter.
   InstBlockId implicit_param_patterns_id;
+
   // A block containing, for each explicit parameter, a reference to the
   // instruction in the entity's declaration block that depends on all other
   // pattern-match insts pertaining to that parameter.
   InstBlockId param_refs_id;
+
   // A block containing, for each explicit parameter, a reference to the
   // instruction in the entity's pattern block that depends on all other
   // pattern insts pertaining to that parameter.
   InstBlockId param_patterns_id;
+
   // True if declarations are `extern`.
   bool is_extern;
+
   // For an `extern library` declaration, the library name.
   SemIR::LibraryNameId extern_library_id;
+
   // The non-owning declaration of the entity, if present. This will be a
   // <entity>Decl.
   InstId non_owning_decl_id;
+
   // The first owning declaration of the entity, if present. This will be a
   // <entity>Decl. It may either be a forward declaration, or the same as
   // `definition_id`.


### PR DESCRIPTION
This is at a point where it's getting difficult to read, and #4479 is adding a large block comment. In order to more clearly delineate members, add blank lines between.