### PR TITLE
Suppress readability-redundant-member-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,6 +48,9 @@ WarningsAsErrors: '*'
 #   explicit value.
 # - `readability-function-cognitive-complexity` warns too frequently.
 # - `readability-magic-numbers` warns in reasonably documented situations.
+# - `readability-redundant-member-init` warns on `= {}` which is also used to
+#   indicate which fields do not need to be explicitly initialized in aggregate
+#   initialization.
 # - `readability-suspicious-call-argument` warns when callers use similar names
 #   as different parameters.
 #
@@ -80,7 +83,7 @@ Checks:
   -readability-else-after-return, -readability-enum-initial-value,
   -readability-function-cognitive-complexity, -readability-identifier-length,
   -readability-implicit-bool-conversion, -readability-magic-numbers,
-  -readability-make-member-function-const,
+  -readability-make-member-function-const, -readability-redundant-member-init,
   -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument, -readability-use-anyofallof
 CheckOptions:

--- a/toolchain/driver/driver_subcommand.h
+++ b/toolchain/driver/driver_subcommand.h
@@ -20,7 +20,7 @@ struct DriverResult {
 
   // Per-file success results. May be empty if files aren't individually
   // processed.
-  llvm::SmallVector<std::pair<std::string, bool>> per_file_success;
+  llvm::SmallVector<std::pair<std::string, bool>> per_file_success = {};
 };
 
 // A subcommand for the driver.


### PR DESCRIPTION
This initializes the DriverResult::per_file_success field explicitly with `= {}` in order to encode that DriverResult can be constucted via aggregate initialization while omitting the per_file_success field. This prevents -Wmissing-designated-field-initializers from firing in newer clang versions when constructing DriverResult like:
```
return {.success = false};
```

Newer clang-tidy warns that the `= {}` is redundant however it is not, as its marking which fields need to be explicitly initialized. So we suppress it.
