### PR TITLE
Use std::ranges::any_of instead of std::any_of

### DIFF
--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -803,8 +803,8 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   }
 
   // Unlike previous steps, errors block further progress.
-  if (std::any_of(units.begin(), units.end(),
-                  [&](const auto& unit) { return !unit->success(); })) {
+  if (std::ranges::any_of(units,
+                          [&](const auto& unit) { return !unit->success(); })) {
     CARBON_VLOG_TO(driver_env.vlog_stream,
                    "*** Stopping before lowering due to errors ***");
     return make_result();


### PR DESCRIPTION
This is suggested by clang-tidy's modernize checks, and is a safer coding practice.
