### PR TITLE
Suppress readability-enum-initial-value in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,9 @@ WarningsAsErrors: '*'
 #   not non-const, which yields distracting results on accessors.
 # - performance-unnecessary-value-param is disabled because it duplicate
 #   modernize-pass-by-value.
+# - readability-enum-initial-value is disabled because it warns on enums which
+#   use the `LastValue = Value` pattern if all the other discriminants aren't
+#   given an explicit value.
 Checks:
   -*, bugprone-*, -bugprone-branch-clone, -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape, -bugprone-macro-parentheses,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -43,9 +43,10 @@ Checks:
   -modernize-use-emplace, -modernize-use-nodiscard, performance-*,
   -performance-unnecessary-value-param, readability-*,
   -readability-convert-member-functions-to-static,
-  -readability-function-cognitive-complexity, -readability-else-after-return,
-  -readability-identifier-length, -readability-implicit-bool-conversion,
-  -readability-magic-numbers, -readability-make-member-function-const,
+  -readability-else-after-return, -readability-enum-initial-value,
+  -readability-function-cognitive-complexity, -readability-identifier-length,
+  -readability-implicit-bool-conversion, -readability-magic-numbers,
+  -readability-make-member-function-const,
   -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument, -readability-use-anyofallof
 CheckOptions:


### PR DESCRIPTION
This warns unhelpfully on enums like:

```
enum Kind: int8_t {
  Value,
  ValueOrRef,
  ...
  FullInitializer,
  Last = FullInitializer
};
```

It claims that all enum values should have explicit values if any of the
values do, but that's not what we would want to write here.
