### PR TITLE
Use llvm::any_of instead of std::ranges::any_of

### DIFF
--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/driver/compile_subcommand.h"
 
 #include "common/vlog.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "toolchain/base/pretty_stack_trace_function.h"
 #include "toolchain/base/timings.h"
@@ -787,8 +788,7 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   }
 
   // Unlike previous steps, errors block further progress.
-  if (std::ranges::any_of(units,
-                          [&](const auto& unit) { return !unit->success(); })) {
+  if (llvm::any_of(units, [&](const auto& unit) { return !unit->success(); })) {
     CARBON_VLOG_TO(driver_env.vlog_stream,
                    "*** Stopping before lowering due to errors ***");
     return make_result();


### PR DESCRIPTION
We do not intend to use std::ranges in the Carbon implementation due to concerns of compile time cost, largely due to implicit instantiation of types involved in calling and typechecking the functions and their requires clauses.

In #4539, we converted std::any_of to std::ranges::any_of, but this replaces that with llvm::any_of from llvm/ADT/STLExtras.h.

This conversion was suggested by the modernize-use-ranges clang-tidy check. We can keep the check on, and use it to guide conversion to llvm helpers that do similar things (as was done in this CL now). If it's being too confusing, then it can be disabled as well.
