### PR TITLE
Drop std:: on size_t in various spots.

### DIFF
--- a/testing/fuzzing/libfuzzer.h
+++ b/testing/fuzzing/libfuzzer.h
@@ -14,8 +14,7 @@ namespace Carbon::Testing {
 // defining an undeclared extern function due to a Clang warning bug:
 // https://github.com/llvm/llvm-project/issues/94138
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
-extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
-                                      std::size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size);
 
 // Optional API that can be implemented but isn't required. This allows fuzzers
 // to observe the `argv` during initialization.

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -387,7 +387,7 @@ class NextDeferredDefinitionCache {
   // be encountered.
   auto SkipTo(Parse::DeferredDefinitionIndex next_index) -> void {
     index_ = next_index;
-    if (static_cast<std::size_t>(index_.index) ==
+    if (static_cast<size_t>(index_.index) ==
         tree_->deferred_definitions().size()) {
       start_id_ = Parse::NodeId::Invalid;
     } else {

--- a/toolchain/check/check_fuzzer.cpp
+++ b/toolchain/check/check_fuzzer.cpp
@@ -22,8 +22,7 @@ extern "C" auto LLVMFuzzerInitialize(int* argc, char*** argv) -> int {
 }
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
-extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
-                                      std::size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   // Ignore large inputs.
   // TODO: See tokenized_buffer_fuzzer.cpp.
   if (size > 100000) {

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -1022,7 +1022,7 @@ class TypeCompleter {
     llvm_unreachable("All builtin kinds were handled above");
   }
 
-  auto BuildStructOrTupleValueRepr(std::size_t num_elements,
+  auto BuildStructOrTupleValueRepr(size_t num_elements,
                                    SemIR::TypeId elementwise_rep,
                                    bool same_as_object_rep) const
       -> SemIR::ValueRepr {

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -147,7 +147,7 @@ template <typename AccessInstT, typename InstBlockT>
 static auto MakeElementAccessInst(Context& context, SemIR::LocId loc_id,
                                   SemIR::InstId aggregate_id,
                                   SemIR::TypeId elem_type_id, InstBlockT& block,
-                                  std::size_t i) {
+                                  size_t i) {
   if constexpr (std::is_same_v<AccessInstT, SemIR::ArrayIndex>) {
     // TODO: Add a new instruction kind for indexing an array at a constant
     // index so that we don't need an integer literal instruction here, and
@@ -183,7 +183,7 @@ static auto ConvertAggregateElement(
     SemIR::TypeId src_elem_type,
     llvm::ArrayRef<SemIR::InstId> src_literal_elems,
     ConversionTarget::Kind kind, SemIR::InstId target_id,
-    SemIR::TypeId target_elem_type, PendingBlock* target_block, std::size_t i) {
+    SemIR::TypeId target_elem_type, PendingBlock* target_block, size_t i) {
   // Compute the location of the source element. This goes into the current code
   // block, not into the target block.
   // TODO: Ideally we would discard this instruction if it's unused.

--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -151,7 +151,7 @@ class DiagnosticEmitter {
     // TODO: Custom formatting can be provided with an format_provider, but that
     // affects all formatv calls. Consider replacing formatv with a custom call
     // that allows diagnostic-specific formatting.
-    template <typename... Args, std::size_t... N>
+    template <typename... Args, size_t... N>
     static auto FormatFn(const DiagnosticMessage& message,
                          std::index_sequence<N...> /*indices*/) -> std::string {
       static_assert(sizeof...(Args) == sizeof...(N), "Invalid template args");

--- a/toolchain/lex/numeric_literal_fuzzer.cpp
+++ b/toolchain/lex/numeric_literal_fuzzer.cpp
@@ -12,8 +12,7 @@
 namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
-extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
-                                      std::size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   auto token = Lex::NumericLiteral::Lex(
       llvm::StringRef(reinterpret_cast<const char*>(data), size));
   if (!token) {

--- a/toolchain/lex/string_literal_fuzzer.cpp
+++ b/toolchain/lex/string_literal_fuzzer.cpp
@@ -13,8 +13,7 @@
 namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
-extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
-                                      std::size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   auto token = Lex::StringLiteral::Lex(
       llvm::StringRef(reinterpret_cast<const char*>(data), size));
   if (!token) {

--- a/toolchain/lex/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lex/tokenized_buffer_fuzzer.cpp
@@ -14,8 +14,7 @@
 namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
-extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
-                                      std::size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   // Ignore large inputs.
   // TODO: Investigate replacement with an error limit. Content with errors on
   // escaped quotes (`\"` repeated) have O(M * N) behavior for M errors in a

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -71,7 +71,7 @@ class NodeExtractor {
 
   // Extracts a tuple-like type `T` by extracting its components and then
   // assembling a `T` value.
-  template <typename T, typename... U, std::size_t... Index>
+  template <typename T, typename... U, size_t... Index>
   auto ExtractTupleLikeType(std::index_sequence<Index...> /*indices*/,
                             std::tuple<U...>* /*type*/) -> std::optional<T>;
 
@@ -334,7 +334,7 @@ struct Extractable<Lex::TokenIndex> {
   }
 };
 
-template <typename T, typename... U, std::size_t... Index>
+template <typename T, typename... U, size_t... Index>
 auto NodeExtractor::ExtractTupleLikeType(
     std::index_sequence<Index...> /*indices*/, std::tuple<U...>* /*type*/)
     -> std::optional<T> {

--- a/toolchain/parse/parse_fuzzer.cpp
+++ b/toolchain/parse/parse_fuzzer.cpp
@@ -15,8 +15,7 @@
 namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
-extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
-                                      std::size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   // Ignore large inputs.
   // TODO: See tokenized_buffer_fuzzer.cpp.
   if (size > 100000) {

--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -123,7 +123,7 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
   class KeyContext;
 
   // Allocates an uninitialized array using our slab allocator.
-  auto AllocateUninitialized(std::size_t size)
+  auto AllocateUninitialized(size_t size)
       -> llvm::MutableArrayRef<ElementType> {
     // We're not going to run a destructor, so ensure that's OK.
     static_assert(std::is_trivially_destructible_v<ElementType>);

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -137,7 +137,7 @@ static auto ValidateSignature(const File& sem_ir,
   }
 
   // Argument types must match.
-  if (![&]<std::size_t... Indexes>(std::index_sequence<Indexes...>) {
+  if (![&]<size_t... Indexes>(std::index_sequence<Indexes...>) {
         return ((SignatureTraits::template arg_t<Indexes>::Check(
                     sem_ir, state, arg_types[Indexes])) &&
                 ...);

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -16,8 +16,8 @@ namespace Carbon::SemIR {
 template <typename... Types>
 class TypeEnum {
  public:
-  static constexpr std::size_t NumTypes = sizeof...(Types);
-  static constexpr std::size_t NumValues = NumTypes + 2;
+  static constexpr size_t NumTypes = sizeof...(Types);
+  static constexpr size_t NumValues = NumTypes + 2;
 
   static_assert(NumValues <= 256, "Too many types for raw enum.");
 
@@ -87,8 +87,8 @@ class TypeEnum {
 
   // Returns a value that can be used as an array index. Returned value will be
   // < NumValues.
-  constexpr auto ToIndex() const -> std::size_t {
-    return static_cast<std::size_t>(value_);
+  constexpr auto ToIndex() const -> size_t {
+    return static_cast<size_t>(value_);
   }
 
   // Returns whether this is a valid value, not `Invalid`.

--- a/toolchain/sem_ir/typed_insts_test.cpp
+++ b/toolchain/sem_ir/typed_insts_test.cpp
@@ -95,7 +95,7 @@ TEST(TypedInstTest, RoundTrip) {
 #include "toolchain/sem_ir/inst_kind.def"
 }
 
-auto StructLayoutHelper(void* typed_inst, std::size_t typed_inst_size,
+auto StructLayoutHelper(void* typed_inst, size_t typed_inst_size,
                         bool has_type_id) -> void {
   // Check that the memory representation of the typed instruction is what we
   // expect.


### PR DESCRIPTION
We predominantly omit the `std::` in these cases already. This is for style: "Prefer to omit the std:: prefix for these types, as the extra 5 characters do not merit the added clutter." (https://google.github.io/styleguide/cppguide.html#Integer_Types)