### PR TITLE
Correct name of ComparableFromDifference in Generics details

### DIFF
--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -1852,7 +1852,7 @@ class IntWrapper {
       return left.x - right.x;
     }
   }
-  impl as Comparable = ComparableFromDifferenceFn(IntWrapper);
+  impl as Comparable = ComparableFromDifference(IntWrapper);
 }
 ```
 


### PR DESCRIPTION
The name ComparableFromDifferenceFn comes from the next example. In this example ComparableFromDifference is the name of the class that will be implictly cast to a Facet matching Comparable.