### PR TITLE
Use a single `=` in 'impl as where' to assign an associated constant

### DIFF
--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -2164,7 +2164,7 @@ specifying the values of associated facets, as in:
 ```carbon
 impl VeryLongTypeName as Add
     // `Self` here means `VeryLongTypeName`
-    where .Result == Self {
+    where .Result = Self {
   ...
 }
 ```


### PR DESCRIPTION
This was written as `==` but is inconsistent with the rest of the documentation for assigning associated constants.
