### PR TITLE
Update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -45,7 +45,7 @@ repos:
 
   # Formatters should be run late so that they can re-format any prior changes.
   - repo: https://github.com/psf/black
-    rev: 3702ba224ecffbcec30af640c149f231d90aebdb # frozen: 24.4.2
+    rev: 1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # frozen: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -131,11 +131,11 @@ repos:
         files: ^.*/BUILD$
         pass_filenames: false
   - repo: https://github.com/PyCQA/flake8
-    rev: 7d37d9032d0d161634be4554273c30efd4dea0b3 # frozen: 7.0.0
+    rev: e43806be3607110919eff72939fda031776e885a # frozen: 7.1.1
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'e5ea6670624c24f8321f6328ef3176dbba76db46' # frozen: v1.10.0
+    rev: 'f56614daa94d5cd733d3b7004c5df9caad267b4a' # frozen: v1.13.0
     hooks:
       - id: mypy
         # Use setup.cfg to match the command line.
@@ -157,7 +157,7 @@ repos:
               .*_test\.py
           )$
   - repo: https://github.com/codespell-project/codespell
-    rev: 6e41aba91fb32e9feb741a6258eefeb9c6e4a482 # frozen: v2.2.6
+    rev: 193cd7d27cd571f79358af09a8fb8997e54f8fff # frozen: v2.3.0
     hooks:
       - id: codespell
         args: ['-I', '.codespell_ignore', '--uri-ignore-words-list', '*']

--- a/common/raw_hashtable_metadata_group.h
+++ b/common/raw_hashtable_metadata_group.h
@@ -477,7 +477,7 @@ class MetadataGroup : public Printable<MetadataGroup> {
       -> bool;
 
   // SIMD implementations of each operation. We minimize platform-specific APIs
-  // to reduce the scope of errors that can only be discoverd building on one
+  // to reduce the scope of errors that can only be discovered building on one
   // platform, so the bodies of these contain the platform specific code. Their
   // behavior and semantics exactly match the documentation for the un-prefixed
   // functions.

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         -   [Imports from the current package](#imports-from-the-current-package)
         -   [Exporting imported names](#exporting-imported-names)
     -   [Namespaces](#namespaces)
-        -   [Re-declaring imported namespaces](#re-declaring-imported-namespaces)
+        -   [Redeclaring imported namespaces](#redeclaring-imported-namespaces)
         -   [Declaring namespace members](#declaring-namespace-members)
         -   [Aliasing](#aliasing)
 -   [Caveats](#caveats)
@@ -684,7 +684,7 @@ the file's namespace. In the above example, after declaring
 `namespace Timezones.Internal;`, `Timezones` is available as an identifier and
 `Internal` is reached through `Timezones`.
 
-#### Re-declaring imported namespaces
+#### Redeclaring imported namespaces
 
 Namespaces may exist in imported package entities, in addition to being declared
 in the current file. However, even if the namespace already exists in an

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -110,7 +110,7 @@ echo "build --repo_env=CC=$(readlink -f $(which clang-16))" >> user.bazelrc
 ### macOS
 
 ```shell
-# Install Hombrew.
+# Install Homebrew.
 /bin/bash -c "$(curl -fsSL \
   https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 

--- a/docs/project/pull_request_workflow.md
+++ b/docs/project/pull_request_workflow.md
@@ -122,8 +122,8 @@ and any previously queued merge. Checks run on this commit help to ensure that
 the `trunk` stays "green" in presence of conflicting merges.
 
 After the merge queue checks pass, the `trunk` branch pointer is updated to
-include the now merged changset. The resulting commit title and description will
-match exactly those of the pull request, so it is important to set those
+include the now merged changeset. The resulting commit title and description
+will match exactly those of the pull request, so it is important to set those
 appropriately before merging. Co-authors are preserved by this operation. If a
 failure happens at any point, the merge fails, with both `trunk` and the pull
 request branch kept in their original state.

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -48,7 +48,7 @@ class TypeEnum {
     requires(K != RawEnumType::Invalid)
   using TypeFor = __type_pack_element<static_cast<size_t>(K), Types...>;
 
-  // Workarond for Clang bug https://github.com/llvm/llvm-project/issues/85461
+  // Workaround for Clang bug https://github.com/llvm/llvm-project/issues/85461
   template <RawEnumType Value>
   static constexpr auto FromRaw = TypeEnum(Value);
 


### PR DESCRIPTION
Skipping prettier because the relevant repo is archived and not working well. Issues being fixed are from codespell.