### PR TITLE
Rename the builtin FloatType to LegacyFloatType, Error to ErrorInst

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -94,7 +94,7 @@ static auto PerformCallToGenericClass(Context& context, SemIR::LocId loc_id,
                           EntityKind::GenericClass, enclosing_specific_id,
                           /*self_id=*/SemIR::InstId::Invalid, arg_ids);
   if (!callee_specific_id) {
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
   return context.GetOrAddInst<SemIR::ClassType>(
       loc_id, {.type_id = SemIR::TypeId::TypeType,
@@ -114,7 +114,7 @@ static auto PerformCallToGenericInterface(
                           EntityKind::GenericInterface, enclosing_specific_id,
                           /*self_id=*/SemIR::InstId::Invalid, arg_ids);
   if (!callee_specific_id) {
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
   return context.GetOrAddInst(loc_id, context.FacetTypeFromInterface(
                                           interface_id, *callee_specific_id));
@@ -144,7 +144,7 @@ auto PerformCall(Context& context, SemIR::LocId loc_id, SemIR::InstId callee_id,
                             "value of type {0} is not callable", TypeOfInstId);
           context.emitter().Emit(loc_id, CallToNonCallable, callee_id);
         }
-        return SemIR::InstId::BuiltinError;
+        return SemIR::InstId::BuiltinErrorInst;
       }
     }
   }
@@ -156,7 +156,7 @@ auto PerformCall(Context& context, SemIR::LocId loc_id, SemIR::InstId callee_id,
       EntityKind::Function, callee_function.enclosing_specific_id,
       callee_function.self_id, arg_ids);
   if (!callee_specific_id) {
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
   if (callee_specific_id->is_valid()) {
     callee_id = context.GetOrAddInst(

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -1010,7 +1010,7 @@ class TypeCompleter {
       case SemIR::BuiltinInstKind::Invalid:
       case SemIR::BuiltinInstKind::BoolType:
       case SemIR::BuiltinInstKind::IntLiteralType:
-      case SemIR::BuiltinInstKind::FloatType:
+      case SemIR::BuiltinInstKind::LegacyFloatType:
       case SemIR::BuiltinInstKind::NamespaceType:
       case SemIR::BuiltinInstKind::BoundMethodType:
       case SemIR::BuiltinInstKind::WitnessType:

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -60,7 +60,7 @@ Context::Context(const Lex::TokenizedBuffer& tokens, DiagnosticEmitter& emitter,
   // Map the builtin `<error>` and `type` type constants to their corresponding
   // special `TypeId` values.
   type_ids_for_type_constants_.Insert(
-      SemIR::ConstantId::ForTemplateConstant(SemIR::InstId::BuiltinError),
+      SemIR::ConstantId::ForTemplateConstant(SemIR::InstId::BuiltinErrorInst),
       SemIR::TypeId::Error);
   type_ids_for_type_constants_.Insert(
       SemIR::ConstantId::ForTemplateConstant(SemIR::InstId::BuiltinTypeType),
@@ -345,7 +345,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
   }
 
   return {.specific_id = SemIR::SpecificId::Invalid,
-          .inst_id = SemIR::InstId::BuiltinError};
+          .inst_id = SemIR::InstId::BuiltinErrorInst};
 }
 
 auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
@@ -571,7 +571,7 @@ auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
       emitter_->Emit(loc, NameAmbiguousDueToExtend, name_id);
       // TODO: Add notes pointing to the scopes.
       return {.specific_id = SemIR::SpecificId::Invalid,
-              .inst_id = SemIR::InstId::BuiltinError};
+              .inst_id = SemIR::InstId::BuiltinErrorInst};
     }
 
     result.inst_id = scope_result_id;
@@ -597,7 +597,7 @@ auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
     }
 
     return {.specific_id = SemIR::SpecificId::Invalid,
-            .inst_id = SemIR::InstId::BuiltinError};
+            .inst_id = SemIR::InstId::BuiltinErrorInst};
   }
 
   return result;
@@ -639,7 +639,7 @@ auto Context::LookupNameInCore(SemIRLoc loc, llvm::StringRef name)
     -> SemIR::InstId {
   auto core_package_id = GetCorePackage(*this, loc);
   if (!core_package_id.is_valid()) {
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   auto name_id = SemIR::NameId::ForIdentifier(identifiers().Add(name));
@@ -651,7 +651,7 @@ auto Context::LookupNameInCore(SemIRLoc loc, llvm::StringRef name)
         "name `Core.{0}` implicitly referenced here, but not found",
         SemIR::NameId);
     emitter_->Emit(loc, CoreNameNotFound, name_id);
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   // Look through import_refs and aliases.
@@ -1006,7 +1006,7 @@ class TypeCompleter {
     switch (builtin.builtin_inst_kind) {
       case SemIR::BuiltinInstKind::TypeType:
       case SemIR::BuiltinInstKind::AutoType:
-      case SemIR::BuiltinInstKind::Error:
+      case SemIR::BuiltinInstKind::ErrorInst:
       case SemIR::BuiltinInstKind::Invalid:
       case SemIR::BuiltinInstKind::BoolType:
       case SemIR::BuiltinInstKind::IntLiteralType:

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -242,7 +242,7 @@ class Context {
       -> LookupResult;
 
   // Returns the instruction corresponding to a name in the core package, or
-  // BuiltinError if not found.
+  // BuiltinErrorInst if not found.
   auto LookupNameInCore(SemIRLoc loc, llvm::StringRef name) -> SemIR::InstId;
 
   // Prints a diagnostic for a duplicate name.

--- a/toolchain/check/convert.h
+++ b/toolchain/check/convert.h
@@ -102,7 +102,7 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
 
 // A type that has been converted for use as a type expression.
 struct TypeExpr {
-  // The converted expression of type `type`, or `InstId::BuiltinError`.
+  // The converted expression of type `type`, or `InstId::BuiltinErrorInst`.
   SemIR::InstId inst_id;
   // The corresponding type, or `TypeId::Error`.
   SemIR::TypeId type_id;

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -322,7 +322,7 @@ auto DeductionContext::Deduce() -> bool {
       DiagnosticAnnotationScope annotate_diagnostics(&context().emitter(),
                                                      note_initializing_param);
       arg_id = ConvertToValueOfType(context(), loc_id_, arg_id, param_type_id);
-      if (arg_id == SemIR::InstId::BuiltinError) {
+      if (arg_id == SemIR::InstId::BuiltinErrorInst) {
         return false;
       }
     }

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1075,7 +1075,8 @@ static auto MakeConstantForBuiltinCall(Context& context, SemIRLoc loc,
       if (!ValidateFloatBitWidth(context, loc, arg_ids[0])) {
         return SemIR::ConstantId::Error;
       }
-      return context.constant_values().Get(SemIR::InstId::BuiltinFloatType);
+      return context.constant_values().Get(
+          SemIR::InstId::BuiltinLegacyFloatType);
     }
 
     case SemIR::BuiltinFunctionKind::BoolMakeType: {

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1717,7 +1717,8 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::SpecificId specific_id,
     result[i] = context.constant_values().GetInstId(const_id);
 
     // TODO: If this becomes possible through monomorphization failure, produce
-    // a diagnostic and put `SemIR::InstId::BuiltinError` in the table entry.
+    // a diagnostic and put `SemIR::InstId::BuiltinErrorInst` in the table
+    // entry.
     CARBON_CHECK(result[i].is_valid());
   }
 

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -62,7 +62,7 @@ auto HandleParseNode(Context& context, Parse::AliasId /*node_id*/) -> bool {
                       "alias initializer must be a name reference");
     context.emitter().Emit(expr_node, AliasRequiresNameRef);
     alias_type_id = SemIR::TypeId::Error;
-    alias_value_id = SemIR::InstId::BuiltinError;
+    alias_value_id = SemIR::InstId::BuiltinErrorInst;
   }
   auto alias_id = context.AddInst<SemIR::BindAlias>(
       name_context.loc_id, {.type_id = alias_type_id,

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -46,7 +46,7 @@ auto HandleParseNode(Context& context, Parse::ArrayExprId node_id) -> bool {
   if (!context.constant_values().Get(bound_inst_id).is_constant()) {
     CARBON_DIAGNOSTIC(InvalidArrayExpr, Error, "array bound is not a constant");
     context.emitter().Emit(bound_inst_id, InvalidArrayExpr);
-    context.node_stack().Push(node_id, SemIR::InstId::BuiltinError);
+    context.node_stack().Push(node_id, SemIR::InstId::BuiltinErrorInst);
     return true;
   }
 

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -201,10 +201,10 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
           break;
       }
       if (had_error) {
-        context.AddNameToLookup(name_id, SemIR::InstId::BuiltinError);
+        context.AddNameToLookup(name_id, SemIR::InstId::BuiltinErrorInst);
         // Replace the parameter with an invalid instruction so that we don't
         // try constructing a generic based on it.
-        param_pattern_id = SemIR::InstId::BuiltinError;
+        param_pattern_id = SemIR::InstId::BuiltinErrorInst;
       } else {
         auto bind_id = context.AddInstInNoBlock(
             make_bind_name(cast_type_id, SemIR::InstId::Invalid));

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -569,7 +569,7 @@ static auto CheckCompleteAdapterClassType(Context& context,
         .Build(class_info.adapt_id, AdaptWithBase)
         .Note(class_info.base_id, AdaptWithBaseHere)
         .Emit();
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   if (auto fields = context.struct_type_fields().Get(fields_id);
@@ -584,7 +584,7 @@ static auto CheckCompleteAdapterClassType(Context& context,
         .Build(class_info.adapt_id, AdaptWithFields)
         .Note(first_field_inst_id, AdaptWithFieldHere)
         .Emit();
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   for (auto inst_id : context.inst_block_stack().PeekCurrentBlockContents()) {
@@ -601,7 +601,7 @@ static auto CheckCompleteAdapterClassType(Context& context,
             .Build(class_info.adapt_id, AdaptWithVirtual)
             .Note(inst_id, AdaptWithVirtualHere)
             .Emit();
-        return SemIR::InstId::BuiltinError;
+        return SemIR::InstId::BuiltinErrorInst;
       }
     }
   }

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -345,7 +345,7 @@ static auto HandleFunctionDefinitionAfterSignature(
   for (auto param_ref_id : llvm::concat<const SemIR::InstId>(
            context.inst_blocks().GetOrEmpty(function.implicit_param_refs_id),
            context.inst_blocks().GetOrEmpty(function.param_refs_id))) {
-    if (param_ref_id == SemIR::InstId::BuiltinError) {
+    if (param_ref_id == SemIR::InstId::BuiltinErrorInst) {
       continue;
     }
     auto param_info =

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -97,7 +97,7 @@ static auto PerformIndexWith(Context& context, Parse::NodeId node_id,
     CARBON_DIAGNOSTIC(TypeNotIndexable, Error,
                       "type {0} does not support indexing", SemIR::TypeId);
     context.emitter().Emit(node_id, TypeNotIndexable, operand_type_id);
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   Operator op{
@@ -160,7 +160,7 @@ auto HandleParseNode(Context& context, Parse::IndexExprId node_id) -> bool {
     }
 
     default: {
-      auto elem_id = SemIR::InstId::BuiltinError;
+      auto elem_id = SemIR::InstId::BuiltinErrorInst;
       if (operand_type_id != SemIR::TypeId::Error) {
         elem_id = PerformIndexWith(context, node_id, operand_inst_id,
                                    operand_type_id, index_inst_id);

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -245,8 +245,8 @@ auto HandleParseNode(Context& context, Parse::LetDeclId node_id) -> bool {
   auto bind_name = pattern.inst.As<SemIR::AnyBindName>();
   CARBON_CHECK(!bind_name.value_id.is_valid(),
                "Binding should not already have a value!");
-  bind_name.value_id =
-      decl_info->init_id ? *decl_info->init_id : SemIR::InstId::BuiltinError;
+  bind_name.value_id = decl_info->init_id ? *decl_info->init_id
+                                          : SemIR::InstId::BuiltinErrorInst;
   context.ReplaceInstBeforeConstantUse(decl_info->pattern_id, bind_name);
   context.inst_block_stack().AddInstId(decl_info->pattern_id);
 

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -84,9 +84,9 @@ auto HandleParseNode(Context& context, Parse::RealLiteralId node_id) -> bool {
 
   auto float_id = context.sem_ir().floats().Add(llvm::APFloat(double_val));
   context.AddInstAndPush<SemIR::FloatLiteral>(
-      node_id,
-      {.type_id = context.GetBuiltinType(SemIR::BuiltinInstKind::FloatType),
-       .float_id = float_id});
+      node_id, {.type_id = context.GetBuiltinType(
+                    SemIR::BuiltinInstKind::LegacyFloatType),
+                .float_id = float_id});
   return true;
 }
 

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -64,7 +64,7 @@ auto HandleParseNode(Context& context, Parse::RealLiteralId node_id) -> bool {
                       llvm::APSInt);
     context.emitter().Emit(node_id, RealMantissaTooLargeForI64,
                            llvm::APSInt(real_value.mantissa, true));
-    context.node_stack().Push(node_id, SemIR::InstId::BuiltinError);
+    context.node_stack().Push(node_id, SemIR::InstId::BuiltinErrorInst);
     return true;
   }
 
@@ -74,7 +74,7 @@ auto HandleParseNode(Context& context, Parse::RealLiteralId node_id) -> bool {
                       llvm::APSInt);
     context.emitter().Emit(node_id, RealExponentTooLargeForI64,
                            llvm::APSInt(real_value.exponent, false));
-    context.node_stack().Push(node_id, SemIR::InstId::BuiltinError);
+    context.node_stack().Push(node_id, SemIR::InstId::BuiltinErrorInst);
     return true;
   }
 

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -233,13 +233,13 @@ auto HandleParseNode(Context& context, Parse::PrefixOperatorAmpId node_id)
       CARBON_DIAGNOSTIC(AddrOfEphemeralRef, Error,
                         "cannot take the address of a temporary object");
       context.emitter().Emit(TokenOnly(node_id), AddrOfEphemeralRef);
-      value_id = SemIR::InstId::BuiltinError;
+      value_id = SemIR::InstId::BuiltinErrorInst;
       break;
     default:
       CARBON_DIAGNOSTIC(AddrOfNonRef, Error,
                         "cannot take the address of non-reference expression");
       context.emitter().Emit(TokenOnly(node_id), AddrOfNonRef);
-      value_id = SemIR::InstId::BuiltinError;
+      value_id = SemIR::InstId::BuiltinErrorInst;
       break;
   }
   context.AddInstAndPush<SemIR::AddrOf>(

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -139,7 +139,7 @@ auto HandleParseNode(Context& context, Parse::StructLiteralId node_id) -> bool {
 
   if (DiagnoseDuplicateNames(context, field_name_nodes, fields,
                              /*is_struct_type_literal=*/false)) {
-    context.node_stack().Push(node_id, SemIR::InstId::BuiltinError);
+    context.node_stack().Push(node_id, SemIR::InstId::BuiltinErrorInst);
   } else {
     auto type_id = context.GetStructType(
         context.struct_type_fields().AddCanonical(fields));
@@ -165,7 +165,7 @@ auto HandleParseNode(Context& context, Parse::StructTypeLiteralId node_id)
 
   if (DiagnoseDuplicateNames(context, field_name_nodes, fields,
                              /*is_struct_type_literal=*/true)) {
-    context.node_stack().Push(node_id, SemIR::InstId::BuiltinError);
+    context.node_stack().Push(node_id, SemIR::InstId::BuiltinErrorInst);
   } else {
     auto fields_id = context.struct_type_fields().AddCanonical(fields);
     context.AddInstAndPush<SemIR::StructType>(

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -103,7 +103,7 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
         ImplsOnNonFacetType, Error,
         "right argument of `impls` requirement must be a facet type");
     context.emitter().Emit(rhs_node, ImplsOnNonFacetType);
-    rhs_as_type.inst_id = SemIR::InstId::BuiltinError;
+    rhs_as_type.inst_id = SemIR::InstId::BuiltinErrorInst;
   }
   // TODO: Require that at least one side uses a designator.
 

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -993,7 +993,7 @@ class ImportRefResolver {
         break;
       }
       default: {
-        if (const_inst_id == SemIR::InstId::BuiltinError) {
+        if (const_inst_id == SemIR::InstId::BuiltinErrorInst) {
           return SemIR::NameScopeId::Invalid;
         }
         break;

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -18,7 +18,7 @@ auto BuildAssociatedEntity(Context& context, SemIR::InterfaceId interface_id,
     // This should only happen if the interface is erroneously defined more than
     // once.
     // TODO: Find a way to CHECK this.
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   // The interface type is the type of `Self`.

--- a/toolchain/check/operator.cpp
+++ b/toolchain/check/operator.cpp
@@ -39,8 +39,8 @@ auto BuildUnaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
   // Form `operand.(Op)`.
   auto bound_op_id = PerformCompoundMemberAccess(context, loc_id, operand_id,
                                                  op_fn, missing_impl_diagnoser);
-  if (bound_op_id == SemIR::InstId::BuiltinError) {
-    return SemIR::InstId::BuiltinError;
+  if (bound_op_id == SemIR::InstId::BuiltinErrorInst) {
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   // Form `bound_op()`.
@@ -57,8 +57,8 @@ auto BuildBinaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
   // Form `lhs.(Op)`.
   auto bound_op_id = PerformCompoundMemberAccess(context, loc_id, lhs_id, op_fn,
                                                  missing_impl_diagnoser);
-  if (bound_op_id == SemIR::InstId::BuiltinError) {
-    return SemIR::InstId::BuiltinError;
+  if (bound_op_id == SemIR::InstId::BuiltinErrorInst) {
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   // Form `bound_op(rhs)`.

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -133,8 +133,8 @@ auto MatchContext::DoWork(Context& context) -> SemIR::InstBlockId {
 
 auto MatchContext::EmitPatternMatch(Context& context,
                                     MatchContext::WorkItem entry) -> void {
-  if (entry.pattern_id == SemIR::InstId::BuiltinError) {
-    results_.push_back(SemIR::InstId::BuiltinError);
+  if (entry.pattern_id == SemIR::InstId::BuiltinErrorInst) {
+    results_.push_back(SemIR::InstId::BuiltinErrorInst);
     return;
   }
   DiagnosticAnnotationScope annotate_diagnostics(
@@ -187,7 +187,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
           context.emitter().Emit(
               TokenOnly(context.insts().GetLocId(entry.scrutinee_id)),
               AddrSelfIsNonRef);
-          results_.push_back(SemIR::InstId::BuiltinError);
+          results_.push_back(SemIR::InstId::BuiltinErrorInst);
           return;
       }
       auto scrutinee_ref = context.insts().Get(scrutinee_ref_id);
@@ -208,8 +208,8 @@ auto MatchContext::EmitPatternMatch(Context& context,
       switch (kind_) {
         case MatchKind::Caller: {
           CARBON_CHECK(entry.scrutinee_id.is_valid());
-          if (entry.scrutinee_id == SemIR::InstId::BuiltinError) {
-            results_.push_back(SemIR::InstId::BuiltinError);
+          if (entry.scrutinee_id == SemIR::InstId::BuiltinErrorInst) {
+            results_.push_back(SemIR::InstId::BuiltinErrorInst);
           } else {
             results_.push_back(ConvertToValueOfType(
                 context, context.insts().GetLocId(entry.scrutinee_id),

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -78,7 +78,7 @@ auto CheckReturnedVar(Context& context, Parse::NodeId returned_node,
         context.emitter().Build(returned_node, ReturnedVarWithNoReturnType);
     NoteNoReturnTypeProvided(diag, function);
     diag.Emit();
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   // The declared type of the var must match the return type of the function.
@@ -91,7 +91,7 @@ auto CheckReturnedVar(Context& context, Parse::NodeId returned_node,
         context.emitter().Build(type_node, ReturnedVarWrongType, type_id);
     NoteReturnType(context, diag, function);
     diag.Emit();
-    return SemIR::InstId::BuiltinError;
+    return SemIR::InstId::BuiltinErrorInst;
   }
 
   // The variable aliases the return slot if there is one. If not, it has its
@@ -146,7 +146,7 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
     auto diag = context.emitter().Build(node_id, ReturnStatementDisallowExpr);
     NoteNoReturnTypeProvided(diag, function);
     diag.Emit();
-    expr_id = SemIR::InstId::BuiltinError;
+    expr_id = SemIR::InstId::BuiltinErrorInst;
   } else if (returned_var_id.is_valid()) {
     CARBON_DIAGNOSTIC(
         ReturnExprWithReturnedVar, Error,
@@ -154,11 +154,11 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
     auto diag = context.emitter().Build(node_id, ReturnExprWithReturnedVar);
     NoteReturnedVar(diag, returned_var_id);
     diag.Emit();
-    expr_id = SemIR::InstId::BuiltinError;
+    expr_id = SemIR::InstId::BuiltinErrorInst;
   } else if (!return_info.is_valid()) {
     // We already diagnosed that the return type is invalid. Don't try to
     // convert to it.
-    expr_id = SemIR::InstId::BuiltinError;
+    expr_id = SemIR::InstId::BuiltinErrorInst;
   } else if (return_info.has_return_slot()) {
     return_slot_id = function.return_slot_id;
     // Note that this can import a function and invalidate `function`.
@@ -181,7 +181,7 @@ auto BuildReturnVar(Context& context, Parse::ReturnStatementId node_id)
     CARBON_DIAGNOSTIC(ReturnVarWithNoReturnedVar, Error,
                       "`return var;` with no `returned var` in scope");
     context.emitter().Emit(node_id, ReturnVarWithNoReturnedVar);
-    returned_var_id = SemIR::InstId::BuiltinError;
+    returned_var_id = SemIR::InstId::BuiltinErrorInst;
   }
 
   auto return_slot_id = function.return_slot_id;

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -122,7 +122,7 @@ auto ScopeStack::LookupInLexicalScopes(SemIR::NameId name_id)
 
   // If we have no lexical results, check all non-lexical scopes.
   if (lexical_results.empty()) {
-    return {LexicalLookupHasLoadError() ? SemIR::InstId::BuiltinError
+    return {LexicalLookupHasLoadError() ? SemIR::InstId::BuiltinErrorInst
                                         : SemIR::InstId::Invalid,
             non_lexical_scope_stack_};
   }

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -37,7 +37,7 @@
 // CHECK:STDOUT:     instAutoType:    {kind: BuiltinInst, arg0: AutoType, type: typeTypeType}
 // CHECK:STDOUT:     instBoolType:    {kind: BuiltinInst, arg0: BoolType, type: typeTypeType}
 // CHECK:STDOUT:     instIntLiteralType: {kind: BuiltinInst, arg0: IntLiteralType, type: typeTypeType}
-// CHECK:STDOUT:     instFloatType:   {kind: BuiltinInst, arg0: FloatType, type: typeTypeType}
+// CHECK:STDOUT:     instLegacyFloatType: {kind: BuiltinInst, arg0: LegacyFloatType, type: typeTypeType}
 // CHECK:STDOUT:     instStringType:  {kind: BuiltinInst, arg0: StringType, type: typeTypeType}
 // CHECK:STDOUT:     instBoundMethodType: {kind: BuiltinInst, arg0: BoundMethodType, type: typeTypeType}
 // CHECK:STDOUT:     instSpecificFunctionType: {kind: BuiltinInst, arg0: SpecificFunctionType, type: typeTypeType}
@@ -51,7 +51,7 @@
 // CHECK:STDOUT:     instAutoType:    templateConstant(instAutoType)
 // CHECK:STDOUT:     instBoolType:    templateConstant(instBoolType)
 // CHECK:STDOUT:     instIntLiteralType: templateConstant(instIntLiteralType)
-// CHECK:STDOUT:     instFloatType:   templateConstant(instFloatType)
+// CHECK:STDOUT:     instLegacyFloatType: templateConstant(instLegacyFloatType)
 // CHECK:STDOUT:     instStringType:  templateConstant(instStringType)
 // CHECK:STDOUT:     instBoundMethodType: templateConstant(instBoundMethodType)
 // CHECK:STDOUT:     instSpecificFunctionType: templateConstant(instSpecificFunctionType)

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -33,7 +33,7 @@
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instTypeType:    {kind: BuiltinInst, arg0: TypeType, type: typeTypeType}
-// CHECK:STDOUT:     instError:       {kind: BuiltinInst, arg0: Error, type: typeError}
+// CHECK:STDOUT:     instErrorInst:   {kind: BuiltinInst, arg0: ErrorInst, type: typeError}
 // CHECK:STDOUT:     instAutoType:    {kind: BuiltinInst, arg0: AutoType, type: typeTypeType}
 // CHECK:STDOUT:     instBoolType:    {kind: BuiltinInst, arg0: BoolType, type: typeTypeType}
 // CHECK:STDOUT:     instIntLiteralType: {kind: BuiltinInst, arg0: IntLiteralType, type: typeTypeType}
@@ -47,7 +47,7 @@
 // CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(instNamespaceType)}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     instTypeType:    templateConstant(instTypeType)
-// CHECK:STDOUT:     instError:       templateConstant(instError)
+// CHECK:STDOUT:     instErrorInst:   templateConstant(instErrorInst)
 // CHECK:STDOUT:     instAutoType:    templateConstant(instAutoType)
 // CHECK:STDOUT:     instBoolType:    templateConstant(instBoolType)
 // CHECK:STDOUT:     instIntLiteralType: templateConstant(instIntLiteralType)

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -473,7 +473,7 @@ static auto BuildTypeForInst(FileContext& context, SemIR::BuiltinInst inst)
     case SemIR::BuiltinInstKind::Invalid:
     case SemIR::BuiltinInstKind::AutoType:
       CARBON_FATAL("Unexpected builtin type in lowering: {0}", inst);
-    case SemIR::BuiltinInstKind::Error:
+    case SemIR::BuiltinInstKind::ErrorInst:
       // This is a complete type but uses of it should never be lowered.
       return nullptr;
     case SemIR::BuiltinInstKind::TypeType:

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -478,7 +478,7 @@ static auto BuildTypeForInst(FileContext& context, SemIR::BuiltinInst inst)
       return nullptr;
     case SemIR::BuiltinInstKind::TypeType:
       return context.GetTypeType();
-    case SemIR::BuiltinInstKind::FloatType:
+    case SemIR::BuiltinInstKind::LegacyFloatType:
       return llvm::Type::getDoubleTy(context.llvm_context());
     case SemIR::BuiltinInstKind::BoolType:
       // TODO: We may want to have different representations for `bool`

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -91,7 +91,8 @@ struct AnyInt {
 struct AnyFloat {
   static auto Check(const File& sem_ir, ValidateState& state, TypeId type_id)
       -> bool {
-    if (BuiltinType<InstId::BuiltinFloatType>::Check(sem_ir, state, type_id)) {
+    if (BuiltinType<InstId::BuiltinLegacyFloatType>::Check(sem_ir, state,
+                                                           type_id)) {
       return true;
     }
     return sem_ir.types().Is<FloatType>(type_id);

--- a/toolchain/sem_ir/builtin_inst_kind.def
+++ b/toolchain/sem_ir/builtin_inst_kind.def
@@ -64,8 +64,10 @@ CARBON_SEM_IR_BUILTIN_INST_KIND(BoolType, "bool")
 // runtime.
 CARBON_SEM_IR_BUILTIN_INST_KIND(IntLiteralType, "Core.IntLiteral")
 
-// The type of floating point values and real literals, currently always f64.
-CARBON_SEM_IR_BUILTIN_INST_KIND(FloatType, "f64")
+// The legacy float type. This is currently used for real literals, and is
+// treated as f64. It's separate from `FloatType`, and should change to mirror
+// integers, likely replacing this with a `FloatLiteralType`.
+CARBON_SEM_IR_BUILTIN_INST_KIND(LegacyFloatType, "f64")
 
 // The type of string values and String literals.
 CARBON_SEM_IR_BUILTIN_INST_KIND(StringType, "String")

--- a/toolchain/sem_ir/builtin_inst_kind.def
+++ b/toolchain/sem_ir/builtin_inst_kind.def
@@ -44,7 +44,7 @@ CARBON_SEM_IR_BUILTIN_INST_KIND(TypeType, "type")
 // required. For example, when there is a type checking issue, this will be used
 // in the type_id. It's typically used as a cue that semantic checking doesn't
 // need to issue further diagnostics.
-CARBON_SEM_IR_BUILTIN_INST_KIND(Error, "<error>")
+CARBON_SEM_IR_BUILTIN_INST_KIND(ErrorInst, "<error>")
 
 // Used for the type of patterns that do not match a fixed type.
 CARBON_SEM_IR_BUILTIN_INST_KIND(AutoType, "auto")

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -43,11 +43,11 @@ File::File(CheckIRId check_ir_id, IdentifierId package_id,
 // Error uses a self-referential type so that it's not accidentally treated as
 // a normal type. Every other builtin is a type, including the
 // self-referential TypeType.
-#define CARBON_SEM_IR_BUILTIN_INST_KIND(Name, ...)                \
-  insts_.AddInNoBlock(LocIdAndInst::NoLoc<BuiltinInst>(           \
-      {.type_id = BuiltinInstKind::Name == BuiltinInstKind::Error \
-                      ? TypeId::Error                             \
-                      : TypeId::TypeType,                         \
+#define CARBON_SEM_IR_BUILTIN_INST_KIND(Name, ...)                    \
+  insts_.AddInNoBlock(LocIdAndInst::NoLoc<BuiltinInst>(               \
+      {.type_id = BuiltinInstKind::Name == BuiltinInstKind::ErrorInst \
+                      ? TypeId::Error                                 \
+                      : TypeId::TypeType,                             \
        .builtin_inst_kind = BuiltinInstKind::Name}));
 #include "toolchain/sem_ir/builtin_inst_kind.def"
   CARBON_CHECK(insts_.size() == BuiltinInstKind::ValidCount,
@@ -288,7 +288,7 @@ auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
         return value_category;
 
       case CARBON_KIND(BuiltinInst inst): {
-        if (inst.builtin_inst_kind == BuiltinInstKind::Error) {
+        if (inst.builtin_inst_kind == BuiltinInstKind::ErrorInst) {
           return ExprCategory::Error;
         }
         return value_category;

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -86,7 +86,7 @@ auto Function::GetNameFromPatternId(const File& sem_ir, InstId pattern_id)
     inst = sem_ir.insts().Get(inst_id);
   }
 
-  if (inst_id == SemIR::InstId::BuiltinError) {
+  if (inst_id == SemIR::InstId::BuiltinErrorInst) {
     return SemIR::NameId::Invalid;
   }
 

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -88,7 +88,7 @@ struct Function : public EntityWithParamsBase,
       -> ParamPatternInfo;
 
   // Gets the name from the name binding instruction, or invalid if this pattern
-  // has been replaced with BuiltinError.
+  // has been replaced with BuiltinErrorInst.
   static auto GetNameFromPatternId(const File& sem_ir, InstId param_pattern_id)
       -> SemIR::NameId;
 

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -212,7 +212,7 @@ struct ConstantId : public IdBase, public Printable<ConstantId> {
 
 constexpr ConstantId ConstantId::NotConstant = ConstantId(NotConstantIndex);
 constexpr ConstantId ConstantId::Error =
-    ConstantId::ForTemplateConstant(InstId::BuiltinError);
+    ConstantId::ForTemplateConstant(InstId::BuiltinErrorInst);
 constexpr ConstantId ConstantId::Invalid = ConstantId(InvalidIndex);
 
 // The ID of a EntityName.

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -31,7 +31,7 @@ struct ImplFields {
 
   // The following members are set at the `}` of the impl definition.
 
-  // The witness for the impl. This can be `BuiltinError`.
+  // The witness for the impl. This can be `BuiltinErrorInst`.
   InstId witness_id = InstId::Invalid;
 };
 


### PR DESCRIPTION
This is for more clearly distinct names, and to make it a clearer transition from `BuiltinInst` for name conflicts. `FloatType` is also an instruction, and we have `Carbon::Error` (common/error.h). This avoids affecting tests, although the name is embedded in the builtin test.

In `LegacyFloatType`, `Legacy` because I was having trouble coming up with a more appropriate name. I'm not clear this is a `FloatLiteralType` at present, it needs some work to mirror `IntLiteralType`.

In `ErrorInst`, the suffix `Inst` was discussed as good and similar to `BuiltinInst` (although I'm trying to get rid of that).