### PR TITLE
Change how CheckParseTrees receives NodeLocConverters

### DIFF
--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -19,23 +19,28 @@ namespace Carbon::Check {
 
 // Checking information that's tracked per file.
 struct Unit {
+  DiagnosticConsumer* consumer;
   SharedValueStores* value_stores;
   std::optional<Timings>* timings;
   const Lex::TokenizedBuffer* tokens;
   const Parse::Tree* parse_tree;
-  DiagnosticConsumer* consumer;
+
   // Returns a lazily constructed TreeAndSubtrees.
-  std::function<const Parse::TreeAndSubtrees&()> get_parse_tree_and_subtrees;
-  // The generated IR. Unset on input, set on output.
-  std::optional<SemIR::File>* sem_ir;
+  llvm::function_ref<const Parse::TreeAndSubtrees&()>
+      get_parse_tree_and_subtrees;
+
+  // The unit's SemIR, provided as empty and filled in by CheckParseTrees.
+  SemIR::File* sem_ir;
+
+  // Diagnostic converters.
+  Parse::NodeLocConverter* node_converter;
+  SemIRDiagnosticConverter* sem_ir_converter;
 };
 
 // Checks a group of parse trees. This will use imports to decide the order of
 // checking.
-auto CheckParseTrees(
-    llvm::MutableArrayRef<Unit> units,
-    llvm::MutableArrayRef<Parse::NodeLocConverter> node_converters,
-    bool prelude_import, llvm::raw_ostream* vlog_stream) -> void;
+auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
+                     llvm::raw_ostream* vlog_stream) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/sem_ir_diagnostic_converter.cpp
+++ b/toolchain/check/sem_ir_diagnostic_converter.cpp
@@ -173,7 +173,7 @@ auto SemIRDiagnosticConverter::ConvertLocInFile(const SemIR::File* sem_ir,
                                                 bool token_only,
                                                 ContextFnT context_fn) const
     -> DiagnosticLoc {
-  return node_converters_[sem_ir->check_ir_id().index].ConvertLoc(
+  return node_converters_[sem_ir->check_ir_id().index]->ConvertLoc(
       Parse::NodeLoc(node_id, token_only), context_fn);
 }
 

--- a/toolchain/check/sem_ir_diagnostic_converter.h
+++ b/toolchain/check/sem_ir_diagnostic_converter.h
@@ -17,7 +17,7 @@ namespace Carbon::Check {
 class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLoc> {
  public:
   explicit SemIRDiagnosticConverter(
-      llvm::ArrayRef<Parse::NodeLocConverter> node_converters,
+      llvm::ArrayRef<Parse::NodeLocConverter*> node_converters,
       const SemIR::File* sem_ir)
       : node_converters_(node_converters), sem_ir_(sem_ir) {}
 
@@ -38,7 +38,7 @@ class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLoc> {
       -> DiagnosticLoc;
 
   // Converters for each SemIR.
-  llvm::ArrayRef<Parse::NodeLocConverter> node_converters_;
+  llvm::ArrayRef<Parse::NodeLocConverter*> node_converters_;
 
   // The current SemIR being processed.
   const SemIR::File* sem_ir_;

--- a/toolchain/driver/testdata/fail_missing_stdin_output.carbon
+++ b/toolchain/driver/testdata/fail_missing_stdin_output.carbon
@@ -9,4 +9,4 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/fail_missing_stdin_output.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/fail_missing_stdin_output.carbon
-// CHECK:STDERR: error: output file name must be specified for input '-' that is not a regular file
+// CHECK:STDERR: error: output file name must be specified for input `-` that is not a regular file

--- a/toolchain/driver/testdata/stdin.carbon
+++ b/toolchain/driver/testdata/stdin.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/stdin.carbon
 
-// CHECK:STDOUT: --- <stdin>
+// CHECK:STDOUT: --- -
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -118,6 +118,7 @@ cc_library(
         "//toolchain/base:yaml",
         "//toolchain/lex:token_kind",
         "//toolchain/parse:node_kind",
+        "//toolchain/parse:tree",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -19,12 +19,15 @@
 
 namespace Carbon::SemIR {
 
-File::File(CheckIRId check_ir_id, IdentifierId package_id,
-           LibraryNameId library_id, SharedValueStores& value_stores,
-           std::string filename)
+File::File(CheckIRId check_ir_id,
+           const std::optional<Parse::Tree::PackagingDecl>& packaging_decl,
+           SharedValueStores& value_stores, std::string filename)
     : check_ir_id_(check_ir_id),
-      package_id_(package_id),
-      library_id_(library_id),
+      package_id_(packaging_decl ? packaging_decl->names.package_id
+                                 : IdentifierId::Invalid),
+      library_id_(packaging_decl ? LibraryNameId::ForStringLiteralValueId(
+                                       packaging_decl->names.library_id)
+                                 : LibraryNameId::Default),
       value_stores_(&value_stores),
       filename_(std::move(filename)),
       impls_(*this),

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -14,6 +14,7 @@
 #include "toolchain/base/shared_value_stores.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/base/yaml.h"
+#include "toolchain/parse/tree.h"
 #include "toolchain/sem_ir/class.h"
 #include "toolchain/sem_ir/constant.h"
 #include "toolchain/sem_ir/entity_name.h"
@@ -43,9 +44,9 @@ class File : public Printable<File> {
   };
 
   // Starts a new file for Check::CheckParseTree.
-  explicit File(CheckIRId check_ir_id, IdentifierId package_id,
-                LibraryNameId library_id, SharedValueStores& value_stores,
-                std::string filename);
+  explicit File(CheckIRId check_ir_id,
+                const std::optional<Parse::Tree::PackagingDecl>& packaging_decl,
+                SharedValueStores& value_stores, std::string filename);
 
   File(const File&) = delete;
   auto operator=(const File&) -> File& = delete;


### PR DESCRIPTION
This is really a set of closely related changes:

1) We really shouldn't be creating a Check::Unit for _Lower_. This fixes that by storing the diagnostic converter for reuse.
2) Rather than passing in node converters to Check as their own array, pass diagnostic converters as part of Check::Unit.
3) To support creating the converters early, pass SemIR::File pre-constructed.
4) Since SemIR::File construction was used to track "checked", add `is_checked` for that.
5) Clarifies a subtle edge case around `input_filename_` use with `-`.

Note the key consequence of this change, where I actually started, is that `Check` only has one array of `Check::Unit` instead of receiving `NodeLocConverter` as a separate array.