### PR TITLE
Refactor command line errors to mirror diagnostic style

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -41,6 +41,7 @@ cc_library(
     hdrs = ["command_line.h"],
     deps = [
         ":check",
+        ":error",
         ":ostream",
         "@llvm-project//llvm:Support",
     ],
@@ -52,6 +53,7 @@ cc_test(
     srcs = ["command_line_test.cpp"],
     deps = [
         ":command_line",
+        ":error_test_helpers",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
         "@googletest//:gtest",
@@ -122,12 +124,23 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "error_test_helpers",
+    testonly = 1,
+    hdrs = ["error_test_helpers.h"],
+    deps = [
+        ":error",
+        "@googletest//:gtest",
+    ],
+)
+
 cc_test(
     name = "error_test",
     size = "small",
     srcs = ["error_test.cpp"],
     deps = [
         ":error",
+        ":error_test_helpers",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
         "@googletest//:gtest",

--- a/common/command_line.h
+++ b/common/command_line.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "common/check.h"
+#include "common/error.h"
 #include "common/ostream.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
@@ -220,15 +221,8 @@ class MetaPrinter;
 class Parser;
 class CommandBuilder;
 
-// The result of parsing arguments can be a parse error, a successfully parsed
-// command line, or a meta-success due to triggering a meta-action during the
-// parse such as rendering help text.
+// The result of parsing arguments.
 enum class ParseResult : int8_t {
-  // Signifies an error parsing arguments. It will have been diagnosed using
-  // the streams provided to the parser, and no useful parsed arguments are
-  // available.
-  Error,
-
   // Signifies that program arguments were successfully parsed and can be
   // used.
   Success,
@@ -660,9 +654,9 @@ class CommandBuilder {
 // are printed to `errors`, but meta-actions like printing a command's help go
 // to `out`.
 auto Parse(llvm::ArrayRef<llvm::StringRef> unparsed_args,
-           llvm::raw_ostream& out, llvm::raw_ostream& errors,
-           CommandInfo command_info,
-           llvm::function_ref<void(CommandBuilder&)> build) -> ParseResult;
+           llvm::raw_ostream& out, CommandInfo command_info,
+           llvm::function_ref<void(CommandBuilder&)> build)
+    -> ErrorOr<ParseResult>;
 
 // Implementation details only below.
 

--- a/common/error.h
+++ b/common/error.h
@@ -17,7 +17,9 @@ namespace Carbon {
 // Success values should be represented as the presence of a value in ErrorOr,
 // using `ErrorOr<Success>` and `return Success();` if no value needs to be
 // returned.
-struct Success {};
+struct Success : public Printable<Success> {
+  void Print(llvm::raw_ostream& out) const { out << "Success"; }
+};
 
 // Tracks an error message.
 //

--- a/common/error_test_helpers.h
+++ b/common/error_test_helpers.h
@@ -93,7 +93,7 @@ auto IsSuccess(InnerMatcher matcher) -> IsSuccessMatcher<InnerMatcher> {
 
 namespace Carbon {
 
-// Supports printing ErrorOr to std::ostream in tests.
+// Supports printing `ErrorOr<T>` to `std::ostream` in tests.
 template <typename T>
 auto operator<<(std::ostream& out, const ErrorOr<T>& error_or)
     -> std::ostream& {

--- a/common/error_test_helpers.h
+++ b/common/error_test_helpers.h
@@ -11,6 +11,8 @@
 
 namespace Carbon::Testing {
 
+// Matches the message for an error state of `ErrorOr<T>`. For example:
+//   EXPECT_THAT(my_result, IsError(StrEq("error message")));
 class IsError {
  public:
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -44,6 +46,8 @@ class IsError {
   ::testing::Matcher<std::string> matcher_;
 };
 
+// Matches the value for a non-error state of `ErrorOr<T>`. For example:
+//   EXPECT_THAT(my_result, IsSuccess(Eq(3)));
 template <typename InnerMatcher>
 class IsSuccessMatcher {
  public:
@@ -79,6 +83,7 @@ class IsSuccessMatcher {
   InnerMatcher matcher_;
 };
 
+// Wraps `IsSuccessMatcher` for the inner matcher deduction.
 template <typename InnerMatcher>
 auto IsSuccess(InnerMatcher matcher) -> IsSuccessMatcher<InnerMatcher> {
   return IsSuccessMatcher<InnerMatcher>(matcher);

--- a/common/error_test_helpers.h
+++ b/common/error_test_helpers.h
@@ -1,0 +1,106 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_ERROR_TEST_HELPERS_H_
+#define CARBON_COMMON_ERROR_TEST_HELPERS_H_
+
+#include <gmock/gmock.h>
+
+#include "common/error.h"
+
+namespace Carbon::Testing {
+
+class IsError {
+ public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using is_gtest_matcher = void;
+
+  explicit IsError(::testing::Matcher<std::string> matcher)
+      : matcher_(std::move(matcher)) {}
+
+  template <typename T>
+  auto MatchAndExplain(const ErrorOr<T>& result,
+                       ::testing::MatchResultListener* listener) const -> bool {
+    if (result.ok()) {
+      *listener->stream() << "is a success";
+      return false;
+    } else {
+      return matcher_.MatchAndExplain(result.error().message(), listener);
+    }
+  }
+
+  auto DescribeTo(std::ostream* os) const -> void {
+    *os << "is an error and matches ";
+    matcher_.DescribeTo(os);
+  }
+
+  auto DescribeNegationTo(std::ostream* os) const -> void {
+    *os << "is a success or does not match ";
+    matcher_.DescribeTo(os);
+  }
+
+ private:
+  ::testing::Matcher<std::string> matcher_;
+};
+
+template <typename InnerMatcher>
+class IsSuccessMatcher {
+ public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using is_gtest_matcher = void;
+
+  explicit IsSuccessMatcher(InnerMatcher matcher)
+      : matcher_(std::move(matcher)) {}
+
+  template <typename T>
+  auto MatchAndExplain(const ErrorOr<T>& result,
+                       ::testing::MatchResultListener* listener) const -> bool {
+    if (result.ok()) {
+      return ::testing::Matcher<T>(matcher_).MatchAndExplain(*result, listener);
+    } else {
+      *listener->stream() << "is an error with `" << result.error().message()
+                          << "`";
+      return false;
+    }
+  }
+
+  auto DescribeTo(std::ostream* os) const -> void {
+    *os << "is a success and matches ";
+    matcher_.DescribeTo(os);
+  }
+
+  auto DescribeNegationTo(std::ostream* os) const -> void {
+    *os << "is an error or does not match ";
+    matcher_.DescribeTo(os);
+  }
+
+ private:
+  InnerMatcher matcher_;
+};
+
+template <typename InnerMatcher>
+auto IsSuccess(InnerMatcher matcher) -> IsSuccessMatcher<InnerMatcher> {
+  return IsSuccessMatcher<InnerMatcher>(matcher);
+}
+
+}  // namespace Carbon::Testing
+
+namespace Carbon {
+
+// Supports printing ErrorOr to std::ostream in tests.
+template <typename T>
+auto operator<<(std::ostream& out, const ErrorOr<T>& error_or)
+    -> std::ostream& {
+  if (error_or.ok()) {
+    out << llvm::formatv("ErrorOr{{.value = `{0}`}}", *error_or);
+  } else {
+    out << llvm::formatv("ErrorOr{{.error = \"{0}\"}}",
+                         error_or.error().message());
+  }
+  return out;
+}
+
+}  // namespace Carbon
+
+#endif  // CARBON_COMMON_ERROR_TEST_HELPERS_H_

--- a/testing/base/source_gen_main.cpp
+++ b/testing/base/source_gen_main.cpp
@@ -54,9 +54,8 @@ auto Run(llvm::ArrayRef<llvm::StringRef> args) -> bool {
   int lines = 10'000;
   SourceGen::Language language;
 
-  CommandLine::ParseResult parsed_args = CommandLine::Parse(
-      args, llvm::outs(), llvm::errs(), Info,
-      [&](CommandLine::CommandBuilder& b) {
+  auto parse_result = CommandLine::Parse(
+      args, llvm::outs(), Info, [&](CommandLine::CommandBuilder& b) {
         b.AddStringOption(OutputArgInfo,
                           [&](auto& arg_b) { arg_b.Set(&output_filename); });
         b.AddIntegerOption(LinesArgInfo,
@@ -74,9 +73,10 @@ auto Run(llvm::ArrayRef<llvm::StringRef> args) -> bool {
         // No-op action as there is only one operation for this command.
         b.Do([] {});
       });
-  if (parsed_args == CommandLine::ParseResult::Error) {
+  if (!parse_result.ok()) {
+    llvm::errs() << "error: " << *parse_result << "\n";
     return false;
-  } else if (parsed_args == CommandLine::ParseResult::MetaSuccess) {
+  } else if (*parse_result == CommandLine::ParseResult::MetaSuccess) {
     // Fully handled by the CLI library.
     return true;
   }

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -105,13 +105,13 @@ class DriverTest : public testing::Test {
 
 TEST_F(DriverTest, BadCommandErrors) {
   EXPECT_FALSE(driver_.RunCommand({}).success);
-  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("ERROR"));
+  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("error:"));
 
   EXPECT_FALSE(driver_.RunCommand({"foo"}).success);
-  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("ERROR"));
+  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("error:"));
 
   EXPECT_FALSE(driver_.RunCommand({"foo --bar --baz"}).success);
-  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("ERROR"));
+  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("error:"));
 }
 
 TEST_F(DriverTest, CompileCommandErrors) {
@@ -119,8 +119,8 @@ TEST_F(DriverTest, CompileCommandErrors) {
   EXPECT_FALSE(driver_.RunCommand({"compile"}).success);
   EXPECT_THAT(
       test_error_stream_.TakeStr(),
-      StrEq("ERROR: Not all required positional arguments were provided. First "
-            "missing and required positional argument: 'FILE'\n"));
+      StrEq("error: not all required positional arguments were provided; first "
+            "missing and required positional argument: `FILE`\n"));
 
   // Invalid output filename. No reliably error message here.
   // TODO: Likely want a different filename on Windows.

--- a/toolchain/driver/testdata/fail_flag.carbon
+++ b/toolchain/driver/testdata/fail_flag.carbon
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ARGS: compile --non-existent-flag
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/fail_flag.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/fail_flag.carbon
+// CHECK:STDERR: error: unknown option `--non-existent-flag`


### PR DESCRIPTION
This changes to an `Error` return to let the driver do the "error: " prefix, except for one case with `help` that needs more work to change (I'm not planning on picking up that TODO). It also changes capitalization, backtick use, and a few minor punctuation things to try to better match the diagnostic style.

This also adds `Error` matchers so that the changes to command line testing are clearer.