### PR TITLE
Change the test timeouts for the benchmarks to moderate.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -435,7 +435,7 @@ sh_test(
     name = "set_benchmark_test",
     # The benchmark allocates a large amount of memory.
     size = "enormous",
-    # We configure the test to run quickly.
+    # We configure the test to run somewhat quickly.
     timeout = "moderate",
     srcs = [":set_benchmark"],
     args = [

--- a/common/BUILD
+++ b/common/BUILD
@@ -298,8 +298,8 @@ sh_test(
     name = "map_benchmark_test",
     # The benchmark allocates a large amount of memory.
     size = "enormous",
-    # We configure the test to run quickly.
-    timeout = "short",
+    # We configure the test to run somewhat quickly.
+    timeout = "moderate",
     srcs = [":map_benchmark"],
     args = [
         "--benchmark_min_time=1x",
@@ -436,7 +436,7 @@ sh_test(
     # The benchmark allocates a large amount of memory.
     size = "enormous",
     # We configure the test to run quickly.
-    timeout = "short",
+    timeout = "moderate",
     srcs = [":set_benchmark"],
     args = [
         "--benchmark_min_time=1x",


### PR DESCRIPTION
After some poking, it would take a more significant change to restructure the string generation to take less time when run under ASan, and it's not worth it at the moment.

For future reference, nearly half the time here is in building the global data structures of random string contents, not in the actual benchmark functions. If/when we want to improve this, we should switch to a growing pool of random strings similar to what `SourceGen` uses. That lets it not allocate the full size of data when just testing that the benchmark doesn't crash.

I thought about having these benchmarks switch to use `SourceGen`, but I'd like to keep them stand-alone if easy, and there are some important differences that would have to be adapted around which wouldn't be trivial. I'd rather come back in with a better generation strategy than re-use the source code one here.