### PR TITLE
Clarify what specific name in the Core package is looked for when diagnosing that the Core package is not found

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -607,7 +607,7 @@ auto Context::LookupQualifiedName(SemIRLoc loc, SemIR::NameId name_id,
 //
 // TODO: Consider tracking the Core package in SemIR so we don't need to use
 // name lookup to find it.
-static auto GetCorePackage(Context& context, SemIRLoc loc)
+static auto GetCorePackage(Context& context, SemIRLoc loc, llvm::StringRef name)
     -> SemIR::NameScopeId {
   auto core_ident_id = context.identifiers().Add("Core");
   auto packaging = context.parse_tree().packaging_decl();
@@ -629,15 +629,17 @@ static auto GetCorePackage(Context& context, SemIRLoc loc)
     }
   }
 
-  CARBON_DIAGNOSTIC(CoreNotFound, Error,
-                    "package `Core` implicitly referenced here, but not found");
-  context.emitter().Emit(loc, CoreNotFound);
+  CARBON_DIAGNOSTIC(
+      CoreNotFound, Error,
+      "`Core.{0}` implicitly referenced here, but package `Core` not found",
+      std::string);
+  context.emitter().Emit(loc, CoreNotFound, name.str());
   return SemIR::NameScopeId::Invalid;
 }
 
 auto Context::LookupNameInCore(SemIRLoc loc, llvm::StringRef name)
     -> SemIR::InstId {
-  auto core_package_id = GetCorePackage(*this, loc);
+  auto core_package_id = GetCorePackage(*this, loc, name);
   if (!core_package_id.is_valid()) {
     return SemIR::InstId::BuiltinError;
   }

--- a/toolchain/check/testdata/alias/no_prelude/fail_aliased_name_in_diag.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_aliased_name_in_diag.carbon
@@ -14,7 +14,7 @@ class D {}
 alias c = C;
 var d: D = {};
 
-// CHECK:STDERR: fail_aliased_name_in_diag.carbon:[[@LINE+3]]:1: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_aliased_name_in_diag.carbon:[[@LINE+3]]:1: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: let c_var: c = d;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 let c_var: c = d;

--- a/toolchain/check/testdata/function/definition/no_prelude/fail_decl_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/fail_decl_param_mismatch.carbon
@@ -29,7 +29,7 @@ fn G(x: ());
 fn G() {}
 
 fn H(x: ());
-// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+4]]:9: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+4]]:9: error: `Core.Bool` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: fn H(x: bool) {}
 // CHECK:STDERR:         ^~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
@@ -10,7 +10,7 @@
 
 fn F(T:! type, U:! type) {
   var p: T*;
-  // CHECK:STDERR: fail_type_param_mismatch.carbon:[[@LINE+3]]:3: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+  // CHECK:STDERR: fail_type_param_mismatch.carbon:[[@LINE+3]]:3: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
   // CHECK:STDERR:   let n: U = *p;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~
   let n: U = *p;

--- a/toolchain/check/testdata/impl/no_prelude/fail_impl_bad_type.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_impl_bad_type.carbon
@@ -10,7 +10,7 @@
 
 interface I {}
 
-// CHECK:STDERR: fail_impl_bad_type.carbon:[[@LINE+3]]:6: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_impl_bad_type.carbon:[[@LINE+3]]:6: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: impl true as I {}
 // CHECK:STDERR:      ^~~~
 impl true as I {}

--- a/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
@@ -30,7 +30,7 @@ import library "import_generic";
 
 var c: C({}) = {};
 // We're just checking that this doesn't crash. It's not expected to compile.
-// CHECK:STDERR: fail_use_in_fn_decl.carbon:[[@LINE+7]]:11: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_use_in_fn_decl.carbon:[[@LINE+7]]:11: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: fn F() -> c.(I.F)() {}
 // CHECK:STDERR:           ^~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/interface/no_prelude/fail_assoc_const_not_constant.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_assoc_const_not_constant.carbon
@@ -13,7 +13,7 @@ interface I {
   // CHECK:STDERR:   let a: i32;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_assoc_const_not_constant.carbon:[[@LINE+3]]:10: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+  // CHECK:STDERR: fail_assoc_const_not_constant.carbon:[[@LINE+3]]:10: error: `Core.Int` implicitly referenced here, but package `Core` not found [CoreNotFound]
   // CHECK:STDERR:   let a: i32;
   // CHECK:STDERR:          ^~~
   let a: i32;

--- a/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
@@ -21,7 +21,7 @@ fn F() {
   // CHECK:STDERR:
   Interface.F();
 
-  // CHECK:STDERR: fail_member_lookup.carbon:[[@LINE+3]]:10: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+  // CHECK:STDERR: fail_member_lookup.carbon:[[@LINE+3]]:10: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
   // CHECK:STDERR:   var v: Interface.T;
   // CHECK:STDERR:          ^~~~~~~~~~~
   var v: Interface.T;

--- a/toolchain/check/testdata/interface/no_prelude/generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic.carbon
@@ -49,7 +49,7 @@ class B {}
 fn F(T:! Generic(A));
 fn G(T:! Generic(B)) {
   // TODO: Include generic arguments in the type name.
-  // CHECK:STDERR: fail_mismatched_args.carbon:[[@LINE+6]]:3: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+  // CHECK:STDERR: fail_mismatched_args.carbon:[[@LINE+6]]:3: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
   // CHECK:STDERR:   F(T);
   // CHECK:STDERR:   ^~
   // CHECK:STDERR: fail_mismatched_args.carbon:[[@LINE-6]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]

--- a/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
+++ b/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
@@ -24,7 +24,7 @@ fn F() { 0[1]; }
 
 library "[[@TEST_NAME]]";
 
-// CHECK:STDERR: fail_missing_index_with.carbon:[[@LINE+7]]:10: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_missing_index_with.carbon:[[@LINE+7]]:10: error: `Core.IndexWith` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: fn F() { 0[1]; }
 // CHECK:STDERR:          ^~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/packages/no_prelude/missing_prelude.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/missing_prelude.carbon
@@ -12,7 +12,7 @@
 
 library "[[@TEST_NAME]]";
 
-// CHECK:STDERR: fail_missing_prelude.carbon:[[@LINE+4]]:8: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_missing_prelude.carbon:[[@LINE+4]]:8: error: `Core.Int` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: var n: i32;
 // CHECK:STDERR:        ^~~
 // CHECK:STDERR:
@@ -80,7 +80,7 @@ class Core {
   fn Int[T:! type](N:! T) -> {} { return {}; }
 }
 
-// CHECK:STDERR: fail_prelude_as_class.carbon:[[@LINE+3]]:13: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+// CHECK:STDERR: fail_prelude_as_class.carbon:[[@LINE+3]]:13: error: `Core.Int` implicitly referenced here, but package `Core` not found [CoreNotFound]
 // CHECK:STDERR: var n: {} = i32;
 // CHECK:STDERR:             ^~~
 var n: {} = i32;

--- a/toolchain/check/testdata/var/no_prelude/fail_init_type_mismatch.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_init_type_mismatch.carbon
@@ -9,7 +9,7 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/var/no_prelude/fail_init_type_mismatch.carbon
 
 fn Main() {
-  // CHECK:STDERR: fail_init_type_mismatch.carbon:[[@LINE+3]]:3: error: package `Core` implicitly referenced here, but not found [CoreNotFound]
+  // CHECK:STDERR: fail_init_type_mismatch.carbon:[[@LINE+3]]:3: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
   // CHECK:STDERR:   var x: {} = ();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   var x: {} = ();


### PR DESCRIPTION
I believe this makes the error easier to understand.