### PR TITLE
Suppress unused-includes in clangd for false positives

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,3 +5,7 @@
 CompileFlags:
   # Workaround for https://github.com/clangd/clangd/issues/1582
   Remove: [-march=*]
+Diagnostics:
+  # `unused-includes`: has false positives, reporting includes unused when
+  #   they are used.
+  Suppress: [unused-includes]


### PR DESCRIPTION
clangd-17 reports includes as being unused when they are used, such as in common/ostream.h. There it says the `<concepts>` include is unused but `std::derived_from` is present in the same file (and clangd points out that it is coming from `<concepts>` on hover).
