### PR TITLE
Refresh the ValueStore api description in idioms.md

### DIFF
--- a/toolchain/docs/idioms.md
+++ b/toolchain/docs/idioms.md
@@ -145,7 +145,8 @@ The indices typically use `IdBase`.
 `ValueStore`s APIs follow the shape of simple array access and mutation:
 
 -   `Add` which takes a value and returns the index.
--   `Set` which takes a value and index to modify.
+-   `AddDefaultValue` which adds a default-constructed value and returns the
+    index.
 -   `Get` takes an index and returns a reference to the value (possibly a
     constant reference).
 -   Other vector-like functionality, including `size` or `Reserve`


### PR DESCRIPTION
There is no `Set` method, so remove that, and include `AddDefaultValue` instead.
