### PR TITLE
Add "Whether to" in the description of 'debug-info' switch

### DIFF
--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -270,7 +270,7 @@ Excludes files with the given prefix from dumps.
       {
           .name = "debug-info",
           .help = R"""(
-Emit DWARF debug information.
+Whether to emit DWARF debug information.
 )""",
       },
       [&](auto& arg_b) {


### PR DESCRIPTION
The switch defaults to true, so it's displayed as `--no-debug-info` in the help. The description should be agnostic about whether the flag will enable or disable the behaviour.
