### PR TITLE
Enable libc++ hardening mode in opt builds

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -663,12 +663,10 @@ def _impl(ctx):
         # Clang 18 changes HARDENED_MODE to use 4 values:
         # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
         libcpp_debug_flags = [
-            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
-            _LIBCPP_HARDENING_MODE_EXTENSIVE",
+            "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
         ]
         libcpp_release_flags = [
-            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
-            _LIBCPP_HARDENING_MODE_FAST",
+            "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_FAST",
         ]
 
     linux_flags_feature = feature(

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -103,8 +103,52 @@ def _impl(ctx):
     std_compile_flags = ["-std=c++20"]
 
     # libc++ is only used on non-Windows platforms.
-    if ctx.attr.target_os != "windows":
+    use_libcpp = ctx.attr.target_os != "windows"
+
+    if use_libcpp:
+        if clang_version and clang_version <= 16:
+            libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
+            libcpp_release_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=0"]
+        elif clang_version and clang_version <= 17:
+            # Clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of
+            # HARDENED_MODE and DEBUG_MODE.
+            libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
+            libcpp_release_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
+        else:
+            # Clang 18 changes HARDENED_MODE to use 4 values:
+            # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
+            libcpp_debug_flags = [
+                "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
+            ]
+            libcpp_release_flags = [
+                "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_FAST",
+            ]
+
+        # This needs to appear earlier in the command line, so we can't put it in libcpp_flags.
         std_compile_flags.append("-stdlib=libc++")
+
+        # Configure libc++ based on debug or release build.
+        libcpp_flags = feature(
+            name = "libcpp_flags",
+            flag_sets = [
+                flag_set(
+                    actions = all_cpp_compile_actions,
+                    flag_groups = [flag_group(flags = libcpp_release_flags)],
+                    with_features = [
+                        with_feature_set(features = ["opt"]),
+                    ],
+                ),
+                flag_set(
+                    actions = all_cpp_compile_actions,
+                    flag_groups = [flag_group(flags = libcpp_debug_flags)],
+                    with_features = [
+                        with_feature_set(not_features = ["opt"]),
+                    ],
+                ),
+            ],
+        )
+    else:
+        libcpp_flags = []
 
     # TODO: Regression that warns on anonymous unions; remove depending on fix.
     # Sets the flag for unknown clang versions, which are assumed to be at head.
@@ -651,26 +695,6 @@ def _impl(ctx):
         )],
     )
 
-    if clang_version and clang_version <= 16:
-        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
-        libcpp_release_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=0"]
-    elif clang_version and clang_version <= 17:
-        # Clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of
-        # HARDENED_MODE and DEBUG_MODE.
-        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-        libcpp_release_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-    else:
-        # Clang 18 changes HARDENED_MODE to use 4 values:
-        # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
-        libcpp_debug_flags = [
-            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
-            _LIBCPP_HARDENING_MODE_EXTENSIVE",
-        ]
-        libcpp_release_flags = [
-            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
-            _LIBCPP_HARDENING_MODE_FAST",
-        ]
-
     linux_flags_feature = feature(
         name = "linux_flags",
         enabled = True,
@@ -708,20 +732,6 @@ def _impl(ctx):
                         ],
                     ),
                 ]),
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [flag_group(flags = libcpp_debug_flags)],
-                with_features = [
-                    with_feature_set(not_features = ["opt"]),
-                ],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [flag_group(flags = libcpp_release_flags)],
-                with_features = [
-                    with_feature_set(features = ["opt"]),
-                ],
             ),
             flag_set(
                 actions = [
@@ -1152,6 +1162,9 @@ def _impl(ctx):
         use_module_maps,
         default_archiver_flags_feature,
     ]
+
+    if use_libcpp:
+        features.append(libcpp_flags)
 
     # Next, add the features based on the target platform. Here too the
     # features are order sensitive. We also setup the sysroot here.

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -103,52 +103,8 @@ def _impl(ctx):
     std_compile_flags = ["-std=c++20"]
 
     # libc++ is only used on non-Windows platforms.
-    use_libcpp = ctx.attr.target_os != "windows"
-
-    if use_libcpp:
-        if clang_version and clang_version <= 16:
-            libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
-            libcpp_release_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=0"]
-        elif clang_version and clang_version <= 17:
-            # Clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of
-            # HARDENED_MODE and DEBUG_MODE.
-            libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-            libcpp_release_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-        else:
-            # Clang 18 changes HARDENED_MODE to use 4 values:
-            # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
-            libcpp_debug_flags = [
-                "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
-            ]
-            libcpp_release_flags = [
-                "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_FAST",
-            ]
-
-        # This needs to appear earlier in the command line, so we can't put it in libcpp_flags.
+    if ctx.attr.target_os != "windows":
         std_compile_flags.append("-stdlib=libc++")
-
-        # Configure libc++ based on debug or release build.
-        libcpp_flags = feature(
-            name = "libcpp_flags",
-            flag_sets = [
-                flag_set(
-                    actions = all_cpp_compile_actions,
-                    flag_groups = [flag_group(flags = libcpp_release_flags)],
-                    with_features = [
-                        with_feature_set(features = ["opt"]),
-                    ],
-                ),
-                flag_set(
-                    actions = all_cpp_compile_actions,
-                    flag_groups = [flag_group(flags = libcpp_debug_flags)],
-                    with_features = [
-                        with_feature_set(not_features = ["opt"]),
-                    ],
-                ),
-            ],
-        )
-    else:
-        libcpp_flags = []
 
     # TODO: Regression that warns on anonymous unions; remove depending on fix.
     # Sets the flag for unknown clang versions, which are assumed to be at head.
@@ -695,6 +651,26 @@ def _impl(ctx):
         )],
     )
 
+    if clang_version and clang_version <= 16:
+        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
+        libcpp_release_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=0"]
+    elif clang_version and clang_version <= 17:
+        # Clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of
+        # HARDENED_MODE and DEBUG_MODE.
+        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
+        libcpp_release_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
+    else:
+        # Clang 18 changes HARDENED_MODE to use 4 values:
+        # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
+        libcpp_debug_flags = [
+            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
+            _LIBCPP_HARDENING_MODE_EXTENSIVE",
+        ]
+        libcpp_release_flags = [
+            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
+            _LIBCPP_HARDENING_MODE_FAST",
+        ]
+
     linux_flags_feature = feature(
         name = "linux_flags",
         enabled = True,
@@ -732,6 +708,20 @@ def _impl(ctx):
                         ],
                     ),
                 ]),
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = libcpp_debug_flags)],
+                with_features = [
+                    with_feature_set(not_features = ["opt"]),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = libcpp_release_flags)],
+                with_features = [
+                    with_feature_set(features = ["opt"]),
+                ],
             ),
             flag_set(
                 actions = [
@@ -1162,9 +1152,6 @@ def _impl(ctx):
         use_module_maps,
         default_archiver_flags_feature,
     ]
-
-    if use_libcpp:
-        features.append(libcpp_flags)
 
     # Next, add the features based on the target platform. Here too the
     # features are order sensitive. We also setup the sysroot here.

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -653,10 +653,23 @@ def _impl(ctx):
 
     if clang_version and clang_version <= 16:
         libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
-    else:
+        libcpp_release_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=0"]
+    elif clang_version and clang_version <= 17:
         # Clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of
-        # HARDENED_MODE.
+        # HARDENED_MODE and DEBUG_MODE.
         libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
+        libcpp_release_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
+    else:
+        # Clang 18 changes HARDENED_MODE to use 4 values:
+        # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
+        libcpp_debug_flags = [
+            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
+            _LIBCPP_HARDENING_MODE_EXTENSIVE",
+        ]
+        libcpp_release_flags = [
+            "-D_LIBCPP_ENABLE_HARDENED_MODE=\
+            _LIBCPP_HARDENING_MODE_FAST",
+        ]
 
     linux_flags_feature = feature(
         name = "linux_flags",
@@ -701,6 +714,13 @@ def _impl(ctx):
                 flag_groups = [flag_group(flags = libcpp_debug_flags)],
                 with_features = [
                     with_feature_set(not_features = ["opt"]),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = libcpp_release_flags)],
+                with_features = [
+                    with_feature_set(features = ["opt"]),
                 ],
             ),
             flag_set(


### PR DESCRIPTION
In llvm 17 the _LIBCPP_ENABLE_ASSERTIONS flag was split into two:
- _LIBCPP_ENABLE_HARDENED_MODE for fast checks
- _LIBCPP_ENABLE_DEBUG_MODE for expensive checks

We kept HARDENED_MODE enabled in debug, but we can also turn it on for opt builds.

In llvm 18, the _LIBCPP_ENABLE_HARDENED_MODE was further split into 4 settings, NONE, FAST, EXTENSIVE, DEBUG. As seen in the recent blog post https://security.googleblog.com/2024/11/retrofitting-spatial-safety-to-hundreds.html the FAST hardening mode is indeed very fast and has minimal impact, while helping to catch a lot of bugs.

So we enable the FAST checks in opt builds, and EXTENSIVE checks in debug builds.

The EXTENSIVE checks are the same that Chrome enables in every build configuration, so we could consider enabling it in opt builds as well: https://source.chromium.org/chromium/chromium/src/+/main:build/config/compiler/BUILD.gn;l=1127;drc=a8260dee097dde71ca4464c0c8d897a80c353db2
