### PR TITLE
[NFC] In DeclNameStack::AddName(), use NameScope::AddRequired() instead of duplicating its logic

### DIFF
--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -154,20 +154,9 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id,
           context_->AddExport(target_id);
         }
 
-        auto add_scope = [&] {
-          int index = name_scope.names.size();
-          name_scope.names.push_back(
-              {.name_id = name_context.unresolved_name_id,
-               .inst_id = target_id,
-               .access_kind = access_kind});
-          return index;
-        };
-        auto result = name_scope.name_map.Insert(
-            name_context.unresolved_name_id, add_scope);
-        CARBON_CHECK(
-            result.is_inserted(),
-            "Duplicate names should have been resolved previously: {0} in {1}",
-            name_context.unresolved_name_id, name_context.parent_scope_id);
+        name_scope.AddRequired({.name_id = name_context.unresolved_name_id,
+                                .inst_id = target_id,
+                                .access_kind = access_kind});
       }
       break;
 


### PR DESCRIPTION
This is a pure code deduplication change.