### PR TITLE
Expose InstKind::FromInt for Inst instead of InstKind::Make

### DIFF
--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -208,9 +208,7 @@ class Inst : public Printable<Inst> {
     }
   }
 
-  auto kind() const -> InstKind {
-    return InstKind::Make(static_cast<InstKind::RawEnumType>(kind_));
-  }
+  auto kind() const -> InstKind { return InstKind::FromInt(kind_); }
 
   // Gets the type of the value produced by evaluating this instruction.
   auto type_id() const -> TypeId { return type_id_; }

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -103,7 +103,7 @@ class InstKind : public CARBON_ENUM_BASE(InstKind) {
   constexpr auto Define(DefinitionInfo info) const -> Definition<TypedNodeId>;
 
   using EnumBase::AsInt;
-  using EnumBase::Make;
+  using EnumBase::FromInt;
 
   // Returns true if the kind matches any of the provided instructions' kinds.
   template <typename... InstT>


### PR DESCRIPTION
The Inst type will type erase a specific typed instruction by storing the kind as an integer. It does this by calling InstKind::AsInt on a runtime or compile-time InstKind. Then it returns the kind as InstKind by reconstituting it from the integer.

Currently it does a cast to a raw enumerator and then calls InstKind::Make. However Make is designed to be more of an internal detail. The more clearly paired inverse operation is InstKind::FromInt, which is documented as being intended to be exposed by derived classes like InstKind.
