### PR TITLE
Fix bug introduced in #4613

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1233,8 +1233,14 @@ static auto AddAssociatedEntities(ImportContext& context,
       auto function =
           context.import_functions().Get(function_decl->function_id);
       import_name_id = function.name_id;
+    } else if (auto import_ref =
+                   context.import_insts().TryGetAs<SemIR::AnyImportRef>(
+                       inst_id)) {
+      import_name_id =
+          context.import_entity_names().Get(import_ref->entity_name_id).name_id;
     } else {
-      CARBON_FATAL("Unhandled associated entity type");
+      CARBON_FATAL("Unhandled associated entity type: {0}",
+                   context.import_insts().Get(inst_id).kind().ir_name());
     }
     auto name_id = GetLocalNameId(context, import_name_id);
     auto entity_name_id = context.local_entity_names().Add(

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1239,7 +1239,7 @@ static auto AddAssociatedEntities(ImportContext& context,
       import_name_id =
           context.import_entity_names().Get(import_ref->entity_name_id).name_id;
     } else {
-      CARBON_FATAL("Unhandled associated entity type: {0}",
+      CARBON_FATAL("Unhandled associated entity kind: {0}",
                    context.import_insts().Get(inst_id).kind());
     }
     auto name_id = GetLocalNameId(context, import_name_id);

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1234,7 +1234,7 @@ static auto AddAssociatedEntities(ImportContext& context,
           context.import_functions().Get(function_decl->function_id);
       import_name_id = function.name_id;
     } else {
-      CARBON_CHECK("Unhandled associated entity type");
+      CARBON_FATAL("Unhandled associated entity type");
     }
     auto name_id = GetLocalNameId(context, import_name_id);
     auto entity_name_id = context.local_entity_names().Add(

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1221,7 +1221,7 @@ static auto AddAssociatedEntities(ImportContext& context,
   llvm::SmallVector<SemIR::InstId> new_associated_entities;
   new_associated_entities.reserve(associated_entities.size());
   for (auto inst_id : associated_entities) {
-    // Determine the name of the associated entity, by switching on its type.
+    // Determine the name of the associated entity, by switching on its kind.
     SemIR::NameId import_name_id = SemIR::NameId::Invalid;
     if (auto associated_const =
             context.import_insts().TryGetAs<SemIR::AssociatedConstantDecl>(

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1240,7 +1240,7 @@ static auto AddAssociatedEntities(ImportContext& context,
           context.import_entity_names().Get(import_ref->entity_name_id).name_id;
     } else {
       CARBON_FATAL("Unhandled associated entity type: {0}",
-                   context.import_insts().Get(inst_id).kind().ir_name());
+                   context.import_insts().Get(inst_id).kind());
     }
     auto name_id = GetLocalNameId(context, import_name_id);
     auto entity_name_id = context.local_entity_names().Add(


### PR DESCRIPTION
Issue was not properly handling `ImportRef` instructions in `AddAssociatedEntities` in `check/import_ref.cpp`. Using `CARBON_CHECK` instead of `CARBON_FATAL` was hiding the error.