### PR TITLE
Avoid relying on an implicit conversion in builtin lowering test.

### DIFF
--- a/toolchain/lower/testdata/builtins/no_prelude/types.carbon
+++ b/toolchain/lower/testdata/builtins/no_prelude/types.carbon
@@ -4,9 +4,9 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/builtins/types.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/builtins/no_prelude/types.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/builtins/types.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/builtins/no_prelude/types.carbon
 
 fn IntLiteral() -> type = "int_literal.make_type";
 fn Int(size: IntLiteral()) -> type = "int.make_type_signed";

--- a/toolchain/lower/testdata/builtins/types.carbon
+++ b/toolchain/lower/testdata/builtins/types.carbon
@@ -12,9 +12,10 @@ fn IntLiteral() -> type = "int_literal.make_type";
 fn Int(size: IntLiteral()) -> type = "int.make_type_signed";
 fn Float(size: IntLiteral()) -> type = "float.make_type";
 fn Bool() -> type = "bool.make_type";
+fn AsI32(n: IntLiteral()) -> Int(32) = "int.convert_checked";
 
 fn F() {
-  var i: Int(32) = 0;
+  var i: Int(32) = AsI32(0);
   var f: Float(64) = 0.0;
   var b: Bool() = false;
 }
@@ -40,13 +41,13 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "types.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 17, column: 7, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 17, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 18, column: 7, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 18, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 7, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 19, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 16, column: 1, scope: !4)
+// CHECK:STDOUT: !7 = !DILocation(line: 18, column: 7, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 19, column: 7, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 19, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 20, column: 7, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 20, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !4)


### PR DESCRIPTION
This test is trying to explicitly test builtin functions, so use an explicit call to a builtin function for the conversion too.