### PR TITLE
Fix crash in lowering use of a global variable

### DIFF
--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -57,12 +57,7 @@ class FunctionContext {
     if (auto result = file_context_->global_variables().Lookup(inst_id)) {
       return result.value();
     }
-    if (auto bind_name = sem_ir().insts().TryGetAs<SemIR::BindName>(inst_id)) {
-      if (auto result =
-              file_context_->global_variables().Lookup(bind_name->value_id)) {
-        return result.value();
-      }
-    }
+
     return file_context_->GetGlobal(inst_id);
   }
 

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -57,6 +57,12 @@ class FunctionContext {
     if (auto result = file_context_->global_variables().Lookup(inst_id)) {
       return result.value();
     }
+    if (auto bind_name = sem_ir().insts().TryGetAs<SemIR::BindName>(inst_id)) {
+      if (auto result =
+              file_context_->global_variables().Lookup(bind_name->value_id)) {
+        return result.value();
+      }
+    }
     return file_context_->GetGlobal(inst_id);
   }
 

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -174,7 +174,14 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
     return;
   }
 
-  context.SetLocal(inst_id, context.GetValue(inst.value_id));
+  auto inner_inst_id = inst.value_id;
+
+  if (auto bind_name =
+          context.sem_ir().insts().TryGetAs<SemIR::BindName>(inner_inst_id)) {
+    inner_inst_id = bind_name->value_id;
+  }
+
+  context.SetLocal(inst_id, context.GetValue(inner_inst_id));
 }
 
 auto HandleInst(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,

--- a/toolchain/lower/testdata/global/fun_use.carbon
+++ b/toolchain/lower/testdata/global/fun_use.carbon
@@ -7,22 +7,21 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/global/fun_use.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/fun_use.carbon
-class A {};
+var a: i32;
 
-var a: A;
-
-fn F() {
-  a;
+fn F() -> i32 {
+  return a;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'fun_use.carbon'
 // CHECK:STDOUT: source_filename = "fun_use.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @a = internal global {}
+// CHECK:STDOUT: @a = internal global i32
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main() !dbg !4 {
+// CHECK:STDOUT: define i32 @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !7
+// CHECK:STDOUT:   %.loc16 = load i32, ptr @a, align 4, !dbg !7
+// CHECK:STDOUT:   ret i32 %.loc16, !dbg !8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
@@ -32,7 +31,8 @@ fn F() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "fun_use.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 1, scope: !4)
+// CHECK:STDOUT: !7 = !DILocation(line: 16, column: 10, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 3, scope: !4)

--- a/toolchain/lower/testdata/global/fun_use.carbon
+++ b/toolchain/lower/testdata/global/fun_use.carbon
@@ -1,0 +1,38 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/global/fun_use.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/fun_use.carbon
+class A {};
+
+var a: A;
+
+fn F() {
+  a;
+}
+
+// CHECK:STDOUT: ; ModuleID = 'fun_use.carbon'
+// CHECK:STDOUT: source_filename = "fun_use.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @a = internal global {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CF.Main() !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !7
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "fun_use.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 1, scope: !4)

--- a/toolchain/lower/testdata/global/fun_use.carbon
+++ b/toolchain/lower/testdata/global/fun_use.carbon
@@ -20,8 +20,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc16 = load i32, ptr @a, align 4, !dbg !7
-// CHECK:STDOUT:   ret i32 %.loc16, !dbg !8
+// CHECK:STDOUT:   %.loc13 = load i32, ptr @a, align 4, !dbg !7
+// CHECK:STDOUT:   ret i32 %.loc13, !dbg !8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
@@ -34,5 +34,5 @@ fn F() -> i32 {
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 16, column: 10, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !7 = !DILocation(line: 13, column: 10, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)

--- a/toolchain/lower/testdata/global/use.carbon
+++ b/toolchain/lower/testdata/global/use.carbon
@@ -9,6 +9,8 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/use.carbon
 var a: i32;
 
+var b: i32 = a;
+
 fn F() -> i32 {
   return a;
 }
@@ -17,11 +19,20 @@ fn F() -> i32 {
 // CHECK:STDOUT: source_filename = "use.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: @a = internal global i32
+// CHECK:STDOUT: @b = internal global i32
+// CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @_C__global_init.Main, ptr null }]
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc13 = load i32, ptr @a, align 4, !dbg !7
-// CHECK:STDOUT:   ret i32 %.loc13, !dbg !8
+// CHECK:STDOUT:   %.loc15 = load i32, ptr @a, align 4, !dbg !7
+// CHECK:STDOUT:   ret i32 %.loc15, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_C__global_init.Main() !dbg !9 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc12 = load i32, ptr @a, align 4, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc12, ptr @b, align 4, !dbg !11
+// CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
@@ -31,8 +42,12 @@ fn F() -> i32 {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "use.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 13, column: 10, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !7 = !DILocation(line: 15, column: 10, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !3, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = !DILocation(line: 12, column: 14, scope: !9)
+// CHECK:STDOUT: !11 = !DILocation(line: 12, column: 1, scope: !9)
+// CHECK:STDOUT: !12 = !DILocation(line: 0, scope: !9)

--- a/toolchain/lower/testdata/global/use.carbon
+++ b/toolchain/lower/testdata/global/use.carbon
@@ -7,7 +7,7 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/global/use.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/use.carbon
-var a: i32;
+var a: i32 = 5;
 
 var b: i32 = a;
 
@@ -30,9 +30,10 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_C__global_init.Main() !dbg !9 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc12 = load i32, ptr @a, align 4, !dbg !10
-// CHECK:STDOUT:   store i32 %.loc12, ptr @b, align 4, !dbg !11
-// CHECK:STDOUT:   ret void, !dbg !12
+// CHECK:STDOUT:   store i32 5, ptr @a, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc12 = load i32, ptr @a, align 4, !dbg !11
+// CHECK:STDOUT:   store i32 %.loc12, ptr @b, align 4, !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
@@ -48,6 +49,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: !7 = !DILocation(line: 15, column: 10, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !3, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !10 = !DILocation(line: 12, column: 14, scope: !9)
-// CHECK:STDOUT: !11 = !DILocation(line: 12, column: 1, scope: !9)
-// CHECK:STDOUT: !12 = !DILocation(line: 0, scope: !9)
+// CHECK:STDOUT: !10 = !DILocation(line: 10, column: 1, scope: !9)
+// CHECK:STDOUT: !11 = !DILocation(line: 12, column: 14, scope: !9)
+// CHECK:STDOUT: !12 = !DILocation(line: 12, column: 1, scope: !9)
+// CHECK:STDOUT: !13 = !DILocation(line: 0, scope: !9)

--- a/toolchain/lower/testdata/global/use.carbon
+++ b/toolchain/lower/testdata/global/use.carbon
@@ -4,17 +4,17 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/global/fun_use.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/global/use.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/fun_use.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/use.carbon
 var a: i32;
 
 fn F() -> i32 {
   return a;
 }
 
-// CHECK:STDOUT: ; ModuleID = 'fun_use.carbon'
-// CHECK:STDOUT: source_filename = "fun_use.carbon"
+// CHECK:STDOUT: ; ModuleID = 'use.carbon'
+// CHECK:STDOUT: source_filename = "use.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: @a = internal global i32
 // CHECK:STDOUT:
@@ -30,7 +30,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !3 = !DIFile(filename: "fun_use.carbon", directory: "")
+// CHECK:STDOUT: !3 = !DIFile(filename: "use.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}


### PR DESCRIPTION
Actually presenting two options in this one review - if you look at the specific
commits in this PR, the first commit represents my first attempt - and if you
look at the overall PR change for the second attempt.

But I'm totally open to completely different approaches/ideas - these were just
my rough guesses.
