### PR TITLE
In indirect_import_member test, make the alias avoid name poisoning

### DIFF
--- a/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
+++ b/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
@@ -47,7 +47,7 @@ library "[[@TEST_NAME]]";
 import library "c";
 
 class D {
-  alias C = C;
+  alias C = package.C;
 }
 
 // --- f.carbon
@@ -214,6 +214,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
+// CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package [template = package]
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %C: type = bind_alias C, imports.%import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
@@ -402,12 +403,12 @@ var x: () = D.C.F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %import_ref.1: type = import_ref Main//e, inst+3, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, inst+14, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, inst+15, loaded [template = constants.%complete_type]
 // CHECK:STDOUT:   %import_ref.3 = import_ref Main//e, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, inst+13, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst+11, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, inst+14, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst+10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst+12, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -462,12 +463,12 @@ var x: () = D.C.F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %import_ref.1: type = import_ref Main//e, inst+3, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, inst+14, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, inst+15, loaded [template = constants.%complete_type]
 // CHECK:STDOUT:   %import_ref.3 = import_ref Main//e, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, inst+13, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst+11, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, inst+14, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst+10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst+12, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {


### PR DESCRIPTION
This is a preparation change for introducing name poisoning (https://github.com/carbon-language/carbon-lang/issues/4622), which would have broken this test.