### PR TITLE
Change the IdBase operator== to fix reversed operator warnings

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -58,14 +58,8 @@ struct IdBase : public AnyIdBase, public Printable<IdT> {
   }
 
   // Support simple equality comparison for ID types.
-  friend constexpr auto operator==(IdT lhs, IdT rhs) -> bool {
-    return lhs.index == rhs.index;
-  }
-  // Support equality comparison when the RHS is convertible to IdT.
-  template <typename RHSType>
-    requires std::convertible_to<RHSType, IdT>
-  friend auto operator==(IdT lhs, RHSType rhs) -> bool {
-    return lhs.index == IdT(rhs).index;
+  constexpr auto operator==(IdBase<IdT> rhs) const -> bool {
+    return index == rhs.index;
   }
 };
 
@@ -79,8 +73,8 @@ struct IndexBase : public IdBase<IdT> {
   using IdBase<IdT>::IdBase;
 
   // Support relational comparisons for index types.
-  friend auto operator<=>(IdT lhs, IdT rhs) -> std::strong_ordering {
-    return lhs.index <=> rhs.index;
+  auto operator<=>(IndexBase<IdT> rhs) const -> std::strong_ordering {
+    return this->index <=> rhs.index;
   }
 };
 

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -71,7 +71,7 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
     for (auto later_order = static_cast<int8_t>(order) + 1;
          later_order <= static_cast<int8_t>(ModifierOrder::Last);
          ++later_order) {
-      if (s.ordered_modifier_node_ids[later_order] != Parse::NodeId::Invalid) {
+      if (s.ordered_modifier_node_ids[later_order].is_valid()) {
         closest_later_modifier = s.ordered_modifier_node_ids[later_order];
         break;
       }


### PR DESCRIPTION
I believe our flags enable the warning by default, it's just that it doesn't catch this in clang-16 (maybe more; I reproduced with clang-18 and didn't keep digging). For example:

```
toolchain/parse/tree_test.cpp:86:28: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'value_type' (aka 'Carbon::Parse::NodeIdInCategory<Carbon::Parse::NodeCategory::Decl>') and 'AnyDeclId' (aka 'NodeIdInCategory<NodeCategory::Decl>')) to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
   86 |   EXPECT_TRUE(*any_decl_id == any_decl_id2);
      |               ~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
```

The different `operator==` approach works except for with `Parse::NodeId::Invalid`, which seems easy to replace with a `.is_valid()` check.