### PR TITLE
Enable gdb_index unconditionally for gdb usage

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -366,7 +366,7 @@ def _impl(ctx):
                 actions = codegen_compile_actions,
                 flag_groups = ([
                     flag_group(
-                        flags = ["-g", "-gsimple-template-names"],
+                        flags = ["-g"],
                     ),
                     flag_group(
                         flags = ["-gsplit-dwarf"],
@@ -404,7 +404,11 @@ def _impl(ctx):
                 actions = codegen_compile_actions,
                 flag_groups = ([
                     flag_group(
-                        flags = ["-glldb", "-gpubnames"],
+                        flags = [
+                            "-glldb",
+                            "-gpubnames",
+                            "-gsimple-template-names",
+                        ],
                     ),
                 ]),
             ),
@@ -424,7 +428,6 @@ def _impl(ctx):
                     ),
                     flag_group(
                         flags = ["-ggnu-pubnames"],
-                        expand_if_available = "per_object_debug_info_file",
                     ),
                 ]),
             ),
@@ -433,7 +436,6 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = ["-Wl,--gdb-index"],
-                        expand_if_available = "per_object_debug_info_file",
                     ),
                 ],
             ),


### PR DESCRIPTION
Also make `-gsimple-template-names` lldb-only due to it tripping up gdb
in some cases (I came across it breaking SmallVector pretty printing
where gdb wouldn't associate a simplified type named declaration with a
simplified type named definition in another translation unit - seems gdb
can associate a type decl/def when it sees both (if you step into both
translation units or otherwise trigger gdb loading/parsing them) but it
doesn't seem able to /search/ for the type definition). Filed
https://sourceware.org/bugzilla/show_bug.cgi?id=32421 for this.

A couple of other things I'd like to do, but don't know how:
* It might be nice to allow opting into or out of gdb_index (with the
  default being 'on' for gdb_flags, but you could opt out). But doesn't
  seem super important.
* We should turn off fission by default, it seems - bazel has trouble
  making the .dwo files available at the same path as is in the binary
  especially on partial rebuilds. (not sure if we can do that, I guess
  we can make fission a no-op/doesn't add any flags, even if we can't
  change the fission default in bazel itself)
* can we have gdb_flags imply/disable lldb_flags? (so you can use
  --features=gdb_flags without always having to add
  --features=-lldb_flags)

