### PR TITLE
Remove offsets from InstId formatting, trying to name more

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -63,6 +63,11 @@ struct UnitInfo {
         err_tracker(*unit.consumer),
         emitter(*unit.node_converter, err_tracker) {}
 
+  auto parse_tree() -> const Parse::Tree& { return unit->sem_ir->parse_tree(); }
+  auto source() -> const SourceBuffer& {
+    return parse_tree().tokens().source();
+  }
+
   SemIR::CheckIRId check_ir_id;
   Unit* unit;
 
@@ -485,11 +490,10 @@ static auto CheckParseTree(UnitInfo& unit_info, int total_ir_count,
   // We can safely mark this as checked at the start.
   unit_info.is_checked = true;
 
-  SemIR::File& sem_ir = *unit_info.unit->sem_ir;
+  SemIR::File* sem_ir = unit_info.unit->sem_ir;
   Context::DiagnosticEmitter emitter(*unit_info.unit->sem_ir_converter,
                                      unit_info.err_tracker);
-  Context context(*unit_info.unit->tokens, emitter, *unit_info.unit->parse_tree,
-                  unit_info.unit->get_parse_tree_and_subtrees, sem_ir,
+  Context context(&emitter, unit_info.unit->get_parse_tree_and_subtrees, sem_ir,
                   vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
@@ -515,11 +519,11 @@ static auto CheckParseTree(UnitInfo& unit_info, int total_ir_count,
 
   context.VerifyOnFinish();
 
-  sem_ir.set_has_errors(unit_info.err_tracker.seen_error());
+  sem_ir->set_has_errors(unit_info.err_tracker.seen_error());
 
 #ifndef NDEBUG
-  if (auto verify = sem_ir.Verify(); !verify.ok()) {
-    CARBON_FATAL("{0}Built invalid semantics IR: {1}\n", sem_ir,
+  if (auto verify = sem_ir->Verify(); !verify.ok()) {
+    CARBON_FATAL("{0}Built invalid semantics IR: {1}\n", *sem_ir,
                  verify.error());
   }
 #endif
@@ -566,7 +570,7 @@ static auto TrackImport(Map<ImportKey, UnitInfo*>& api_map,
                         Map<ImportKey, Parse::NodeId>* explicit_import_map,
                         UnitInfo& unit_info, Parse::Tree::PackagingNames import)
     -> void {
-  const auto& packaging = unit_info.unit->parse_tree->packaging_decl();
+  const auto& packaging = unit_info.parse_tree().packaging_decl();
 
   IdentifierId file_package_id =
       packaging ? packaging->names.package_id : IdentifierId::Invalid;
@@ -712,7 +716,7 @@ static auto BuildApiMapAndDiagnosePackaging(
     llvm::MutableArrayRef<UnitInfo> unit_infos) -> Map<ImportKey, UnitInfo*> {
   Map<ImportKey, UnitInfo*> api_map;
   for (auto& unit_info : unit_infos) {
-    const auto& packaging = unit_info.unit->parse_tree->packaging_decl();
+    const auto& packaging = unit_info.parse_tree().packaging_decl();
     // An import key formed from the `package` or `library` declaration. Or, for
     // Main//default, a placeholder key.
     auto import_key = packaging ? GetImportKey(unit_info, IdentifierId::Invalid,
@@ -749,7 +753,7 @@ static auto BuildApiMapAndDiagnosePackaging(
       auto insert_result = api_map.Insert(import_key, &unit_info);
       if (!insert_result.is_inserted()) {
         llvm::StringRef prev_filename =
-            insert_result.value()->unit->tokens->source().filename();
+            insert_result.value()->source().filename();
         if (packaging) {
           CARBON_DIAGNOSTIC(DuplicateLibraryApi, Error,
                             "library's API previously provided by `{0}`",
@@ -770,8 +774,9 @@ static auto BuildApiMapAndDiagnosePackaging(
     // Validate file extensions. Note imports rely the packaging declaration,
     // not the extension. If the input is not a regular file, for example
     // because it is stdin, no filename checking is performed.
-    if (unit_info.unit->tokens->source().is_regular_file()) {
-      auto filename = unit_info.unit->tokens->source().filename();
+    const auto& source = unit_info.source();
+    if (source.is_regular_file()) {
+      auto filename = source.filename();
       static constexpr llvm::StringLiteral ApiExt = ".carbon";
       static constexpr llvm::StringLiteral ImplExt = ".impl.carbon";
       bool is_api_with_impl_ext = !is_impl && filename.ends_with(ImplExt);
@@ -814,7 +819,7 @@ auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
   llvm::SmallVector<UnitInfo*> ready_to_check;
   ready_to_check.reserve(units.size());
   for (auto& unit_info : unit_infos) {
-    const auto& packaging = unit_info.unit->parse_tree->packaging_decl();
+    const auto& packaging = unit_info.parse_tree().packaging_decl();
     if (packaging && packaging->is_impl) {
       // An `impl` has an implicit import of its `api`.
       auto implicit_names = packaging->names;
@@ -838,7 +843,7 @@ auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
                    .library_id = prelude_id});
     }
 
-    for (const auto& import : unit_info.unit->parse_tree->imports()) {
+    for (const auto& import : unit_info.parse_tree().imports()) {
       TrackImport(api_map, &explicit_import_map, unit_info, import);
     }
 

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -774,9 +774,8 @@ static auto BuildApiMapAndDiagnosePackaging(
     // Validate file extensions. Note imports rely the packaging declaration,
     // not the extension. If the input is not a regular file, for example
     // because it is stdin, no filename checking is performed.
-    const auto& source = unit_info.source();
-    if (source.is_regular_file()) {
-      auto filename = source.filename();
+    if (unit_info.source().is_regular_file()) {
+      auto filename = unit_info.source().filename();
       static constexpr llvm::StringLiteral ApiExt = ".carbon";
       static constexpr llvm::StringLiteral ImplExt = ".impl.carbon";
       bool is_api_with_impl_ext = !is_impl && filename.ends_with(ImplExt);

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -23,8 +23,6 @@ struct Unit {
   SharedValueStores* value_stores;
   // The `timings` may be null if nothing is to be recorded.
   Timings* timings;
-  const Lex::TokenizedBuffer* tokens;
-  const Parse::Tree* parse_tree;
 
   // Returns a lazily constructed TreeAndSubtrees.
   llvm::function_ref<const Parse::TreeAndSubtrees&()>

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -38,22 +38,19 @@
 
 namespace Carbon::Check {
 
-Context::Context(const Lex::TokenizedBuffer& tokens, DiagnosticEmitter& emitter,
-                 const Parse::Tree& parse_tree,
+Context::Context(DiagnosticEmitter* emitter,
                  llvm::function_ref<const Parse::TreeAndSubtrees&()>
                      get_parse_tree_and_subtrees,
-                 SemIR::File& sem_ir, llvm::raw_ostream* vlog_stream)
-    : tokens_(&tokens),
-      emitter_(&emitter),
-      parse_tree_(&parse_tree),
+                 SemIR::File* sem_ir, llvm::raw_ostream* vlog_stream)
+    : emitter_(emitter),
       get_parse_tree_and_subtrees_(get_parse_tree_and_subtrees),
-      sem_ir_(&sem_ir),
+      sem_ir_(sem_ir),
       vlog_stream_(vlog_stream),
-      node_stack_(parse_tree, vlog_stream),
-      inst_block_stack_("inst_block_stack_", sem_ir, vlog_stream),
-      pattern_block_stack_("pattern_block_stack_", sem_ir, vlog_stream),
-      param_and_arg_refs_stack_(sem_ir, vlog_stream, node_stack_),
-      args_type_info_stack_("args_type_info_stack_", sem_ir, vlog_stream),
+      node_stack_(sem_ir->parse_tree(), vlog_stream),
+      inst_block_stack_("inst_block_stack_", *sem_ir, vlog_stream),
+      pattern_block_stack_("pattern_block_stack_", *sem_ir, vlog_stream),
+      param_and_arg_refs_stack_(*sem_ir, vlog_stream, node_stack_),
+      args_type_info_stack_("args_type_info_stack_", *sem_ir, vlog_stream),
       decl_name_stack_(this),
       scope_stack_(sem_ir_->identifiers()),
       global_init_(this) {
@@ -1415,7 +1412,7 @@ auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {
 }
 
 auto Context::DumpFormattedFile() const -> void {
-  SemIR::Formatter formatter(*tokens_, *parse_tree_, *sem_ir_);
+  SemIR::Formatter formatter(sem_ir_);
   formatter.Print(llvm::errs());
 }
 

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -69,11 +69,10 @@ class Context {
       llvm::function_ref<auto()->Context::DiagnosticBuilder>;
 
   // Stores references for work.
-  explicit Context(const Lex::TokenizedBuffer& tokens,
-                   DiagnosticEmitter& emitter, const Parse::Tree& parse_tree,
+  explicit Context(DiagnosticEmitter* emitter,
                    llvm::function_ref<const Parse::TreeAndSubtrees&()>
                        get_parse_tree_and_subtrees,
-                   SemIR::File& sem_ir, llvm::raw_ostream* vlog_stream);
+                   SemIR::File* sem_ir, llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
   auto TODO(SemIRLoc loc, std::string label) -> bool;
@@ -456,17 +455,17 @@ class Context {
     return tokens().GetKind(parse_tree().node_token(node_id));
   }
 
-  auto tokens() -> const Lex::TokenizedBuffer& { return *tokens_; }
-
   auto emitter() -> DiagnosticEmitter& { return *emitter_; }
-
-  auto parse_tree() -> const Parse::Tree& { return *parse_tree_; }
 
   auto parse_tree_and_subtrees() -> const Parse::TreeAndSubtrees& {
     return get_parse_tree_and_subtrees_();
   }
 
   auto sem_ir() -> SemIR::File& { return *sem_ir_; }
+
+  auto parse_tree() -> const Parse::Tree& { return sem_ir_->parse_tree(); }
+
+  auto tokens() -> const Lex::TokenizedBuffer& { return parse_tree().tokens(); }
 
   auto node_stack() -> NodeStack& { return node_stack_; }
 
@@ -607,14 +606,8 @@ class Context {
   // any applicable instruction lists.
   auto FinishInst(SemIR::InstId inst_id, SemIR::Inst inst) -> void;
 
-  // Tokens for getting data on literals.
-  const Lex::TokenizedBuffer* tokens_;
-
   // Handles diagnostics.
   DiagnosticEmitter* emitter_;
-
-  // The file's parse tree.
-  const Parse::Tree* parse_tree_;
 
   // Returns a lazily constructed TreeAndSubtrees.
   llvm::function_ref<const Parse::TreeAndSubtrees&()>

--- a/toolchain/check/testdata/alias/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/export_name.carbon
@@ -103,10 +103,10 @@ var d: D* = &c;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//base, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//base, inst+7, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//base, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//base, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -133,10 +133,10 @@ var d: D* = &c;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, D, unloaded
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -164,9 +164,9 @@ var d: D* = &c;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export, inst21 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -202,7 +202,7 @@ var d: D* = &c;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//export, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//export, D, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -234,10 +234,10 @@ var d: D* = &c;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//export_orig, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//export_orig, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_orig, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//export_orig, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//export_orig, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_orig, inst21 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/alias/no_prelude/import.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import.carbon
@@ -108,11 +108,11 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//class1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//class1, inst+7, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//class1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//class1, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//class1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//class1, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//class1, c_alias, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//class1, a, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//class1, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//class1, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -148,10 +148,10 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//class2, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//class2, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//class2, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//class2, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//class2, c_alias_alias, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//class2, b, unloaded
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//class2, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//class2, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -210,8 +210,8 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//var1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref %empty_tuple.type = import_ref Main//var1, inst+12, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//var1, a, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref %empty_tuple.type = import_ref Main//var1, a_alias, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -247,8 +247,8 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: ref %empty_tuple.type = import_ref Main//var2, inst+6, loaded [template = <error>]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//var2, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: ref %empty_tuple.type = import_ref Main//var2, a_alias_alias, loaded [template = <error>]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//var2, b, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/alias/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import_access.carbon
@@ -88,10 +88,10 @@ var inst: Test.A = {};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Test//def, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Test//def, inst+7, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Test//def, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Test//def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Test//def, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Test//def, A, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Test//def, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Test//def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -129,7 +129,7 @@ var inst: Test.A = {};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Test//def, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Test//def, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/alias/no_prelude/import_order.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import_order.carbon
@@ -84,14 +84,14 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//a, inst+16, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Main//a, inst+18, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//a, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//a, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.8: %C.elem = import_ref Main//a, inst+7, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, a, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, b, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//a, c, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Main//a, d, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//a, loc4_22, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//a, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.8: %C.elem = import_ref Main//a, loc4_16, loaded [template = %.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/as/overloaded.carbon
+++ b/toolchain/check/testdata/as/overloaded.carbon
@@ -62,7 +62,7 @@ let n: i32 = ((4 as i32) as X) as i32;
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %As.type.1 = import_ref Core//prelude/operators/as, inst+13, loaded [template = constants.%As.generic]
+// CHECK:STDOUT:   %import_ref.2: %As.type.1 = import_ref Core//prelude/operators/as, As, loaded [template = constants.%As.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -17,7 +17,7 @@
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   functions:       {}
 // CHECK:STDOUT:   classes:         {}
@@ -44,7 +44,7 @@
 // CHECK:STDOUT:     'inst(StringType)': {kind: StringType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(VtableType)': {kind: VtableType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(WitnessType)': {kind: WitnessType, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     'inst(TypeType)':  template_constant(inst(TypeType))
 // CHECK:STDOUT:     'inst(AutoType)':  template_constant(inst(AutoType))
@@ -58,7 +58,7 @@
 // CHECK:STDOUT:     'inst(StringType)': template_constant(inst(StringType))
 // CHECK:STDOUT:     'inst(VtableType)': template_constant(inst(VtableType))
 // CHECK:STDOUT:     'inst(WitnessType)': template_constant(inst(WitnessType))
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
 // CHECK:STDOUT:   symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
@@ -66,5 +66,5 @@
 // CHECK:STDOUT:     import_refs:     {}
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       0:               inst12
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_and_textual_ir.carbon
@@ -33,7 +33,7 @@ fn B() {
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst13}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, body: [inst_block4]}
@@ -46,35 +46,35 @@ fn B() {
 // CHECK:STDOUT:     'type(TypeType)':  {kind: copy, type: type(TypeType)}
 // CHECK:STDOUT:     'type(Error)':     {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))': {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst+2)':    {kind: none, type: type(inst+3)}
-// CHECK:STDOUT:     'type(inst+3)':    {kind: none, type: type(inst+3)}
+// CHECK:STDOUT:     'type(inst14)':    {kind: none, type: type(inst15)}
+// CHECK:STDOUT:     'type(inst15)':    {kind: none, type: type(inst15)}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst+2)}
-// CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: inst_block_empty, type: type(inst+2)}
-// CHECK:STDOUT:     'inst+5':          {kind: Return}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst13:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst14)}
+// CHECK:STDOUT:     inst14:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst15:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
+// CHECK:STDOUT:     inst16:          {kind: StructValue, arg0: inst_block_empty, type: type(inst14)}
+// CHECK:STDOUT:     inst17:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
-// CHECK:STDOUT:     'inst+1':          template_constant(inst+4)
-// CHECK:STDOUT:     'inst+2':          template_constant(inst+2)
-// CHECK:STDOUT:     'inst+3':          template_constant(inst+3)
-// CHECK:STDOUT:     'inst+4':          template_constant(inst+4)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
+// CHECK:STDOUT:     inst13:          template_constant(inst16)
+// CHECK:STDOUT:     inst14:          template_constant(inst14)
+// CHECK:STDOUT:     inst15:          template_constant(inst15)
+// CHECK:STDOUT:     inst16:          template_constant(inst16)
 // CHECK:STDOUT:   symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst13
 // CHECK:STDOUT:     import_refs:     {}
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+5
+// CHECK:STDOUT:       0:               inst17
 // CHECK:STDOUT:     inst_block5:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+1
+// CHECK:STDOUT:       0:               inst12
+// CHECK:STDOUT:       1:               inst13
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- a.carbon
@@ -101,13 +101,13 @@ fn B() {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
-// CHECK:STDOUT:     ir1:             {decl_id: inst+1, is_export: false}
+// CHECK:STDOUT:     ir1:             {decl_id: inst13, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst+1}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst+1}
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst13}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst13}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst+2, name0: inst+3}}
-// CHECK:STDOUT:     name_scope1:     {inst: inst+2, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst+8}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst14, name0: inst15}}
+// CHECK:STDOUT:     name_scope1:     {inst: inst14, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst20}}
 // CHECK:STDOUT:   entity_names:
 // CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
@@ -122,58 +122,58 @@ fn B() {
 // CHECK:STDOUT:     'type(TypeType)':  {kind: copy, type: type(TypeType)}
 // CHECK:STDOUT:     'type(Error)':     {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))': {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst+4)':    {kind: none, type: type(inst+5)}
-// CHECK:STDOUT:     'type(inst+5)':    {kind: none, type: type(inst+5)}
-// CHECK:STDOUT:     'type(inst+10)':   {kind: none, type: type(inst+5)}
+// CHECK:STDOUT:     'type(inst16)':    {kind: none, type: type(inst17)}
+// CHECK:STDOUT:     'type(inst17)':    {kind: none, type: type(inst17)}
+// CHECK:STDOUT:     'type(inst22)':    {kind: none, type: type(inst17)}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+1':          {kind: ImportDecl, arg0: name1}
-// CHECK:STDOUT:     'inst+2':          {kind: Namespace, arg0: name_scope1, arg1: inst+1, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+3':          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst+4)}
-// CHECK:STDOUT:     'inst+4':          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+5':          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+6':          {kind: StructValue, arg0: inst_block_empty, type: type(inst+4)}
-// CHECK:STDOUT:     'inst+7':          {kind: NameRef, arg0: name1, arg1: inst+2, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+8':          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+9':          {kind: FunctionDecl, arg0: function1, arg1: inst_block_empty, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+10':         {kind: FunctionType, arg0: function1, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+11':         {kind: StructValue, arg0: inst_block_empty, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+12':         {kind: NameRef, arg0: name1, arg1: inst+8, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+13':         {kind: Call, arg0: inst+12, arg1: inst_block_empty, type: type(inst+5)}
-// CHECK:STDOUT:     'inst+14':         {kind: Return}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst13:          {kind: ImportDecl, arg0: name1}
+// CHECK:STDOUT:     inst14:          {kind: Namespace, arg0: name_scope1, arg1: inst13, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst15:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst16)}
+// CHECK:STDOUT:     inst16:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst17:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
+// CHECK:STDOUT:     inst18:          {kind: StructValue, arg0: inst_block_empty, type: type(inst16)}
+// CHECK:STDOUT:     inst19:          {kind: NameRef, arg0: name1, arg1: inst14, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst20:          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst22)}
+// CHECK:STDOUT:     inst21:          {kind: FunctionDecl, arg0: function1, arg1: inst_block_empty, type: type(inst22)}
+// CHECK:STDOUT:     inst22:          {kind: FunctionType, arg0: function1, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst23:          {kind: StructValue, arg0: inst_block_empty, type: type(inst22)}
+// CHECK:STDOUT:     inst24:          {kind: NameRef, arg0: name1, arg1: inst20, type: type(inst22)}
+// CHECK:STDOUT:     inst25:          {kind: Call, arg0: inst24, arg1: inst_block_empty, type: type(inst17)}
+// CHECK:STDOUT:     inst26:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
-// CHECK:STDOUT:     'inst+2':          template_constant(inst+2)
-// CHECK:STDOUT:     'inst+3':          template_constant(inst+6)
-// CHECK:STDOUT:     'inst+4':          template_constant(inst+4)
-// CHECK:STDOUT:     'inst+5':          template_constant(inst+5)
-// CHECK:STDOUT:     'inst+6':          template_constant(inst+6)
-// CHECK:STDOUT:     'inst+7':          template_constant(inst+2)
-// CHECK:STDOUT:     'inst+8':          template_constant(inst+11)
-// CHECK:STDOUT:     'inst+9':          template_constant(inst+11)
-// CHECK:STDOUT:     'inst+10':         template_constant(inst+10)
-// CHECK:STDOUT:     'inst+11':         template_constant(inst+11)
-// CHECK:STDOUT:     'inst+12':         template_constant(inst+11)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
+// CHECK:STDOUT:     inst14:          template_constant(inst14)
+// CHECK:STDOUT:     inst15:          template_constant(inst18)
+// CHECK:STDOUT:     inst16:          template_constant(inst16)
+// CHECK:STDOUT:     inst17:          template_constant(inst17)
+// CHECK:STDOUT:     inst18:          template_constant(inst18)
+// CHECK:STDOUT:     inst19:          template_constant(inst14)
+// CHECK:STDOUT:     inst20:          template_constant(inst23)
+// CHECK:STDOUT:     inst21:          template_constant(inst23)
+// CHECK:STDOUT:     inst22:          template_constant(inst22)
+// CHECK:STDOUT:     inst23:          template_constant(inst23)
+// CHECK:STDOUT:     inst24:          template_constant(inst23)
 // CHECK:STDOUT:   symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+3
+// CHECK:STDOUT:       0:               inst15
 // CHECK:STDOUT:     import_refs:
-// CHECK:STDOUT:       0:               inst+2
-// CHECK:STDOUT:       1:               inst+8
+// CHECK:STDOUT:       0:               inst14
+// CHECK:STDOUT:       1:               inst20
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+7
-// CHECK:STDOUT:       1:               inst+12
-// CHECK:STDOUT:       2:               inst+13
-// CHECK:STDOUT:       3:               inst+14
+// CHECK:STDOUT:       0:               inst19
+// CHECK:STDOUT:       1:               inst24
+// CHECK:STDOUT:       2:               inst25
+// CHECK:STDOUT:       3:               inst26
 // CHECK:STDOUT:     inst_block5:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+1
-// CHECK:STDOUT:       2:               inst+3
+// CHECK:STDOUT:       0:               inst12
+// CHECK:STDOUT:       1:               inst13
+// CHECK:STDOUT:       2:               inst15
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
@@ -191,7 +191,7 @@ fn B() {
 // CHECK:STDOUT:     .A = %import_ref
 // CHECK:STDOUT:     import A//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: %A.type = import_ref A//default, inst+1, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref: %A.type = import_ref A//default, A, loaded [template = constants.%A]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/multifile_raw_ir.carbon
@@ -33,7 +33,7 @@ fn B() {
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst13}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, body: [inst_block4]}
@@ -46,48 +46,48 @@ fn B() {
 // CHECK:STDOUT:     'type(TypeType)':  {kind: copy, type: type(TypeType)}
 // CHECK:STDOUT:     'type(Error)':     {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))': {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst+2)':    {kind: none, type: type(inst+3)}
-// CHECK:STDOUT:     'type(inst+3)':    {kind: none, type: type(inst+3)}
+// CHECK:STDOUT:     'type(inst14)':    {kind: none, type: type(inst15)}
+// CHECK:STDOUT:     'type(inst15)':    {kind: none, type: type(inst15)}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+1':          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst+2)}
-// CHECK:STDOUT:     'inst+2':          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+3':          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+4':          {kind: StructValue, arg0: inst_block_empty, type: type(inst+2)}
-// CHECK:STDOUT:     'inst+5':          {kind: Return}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst13:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst14)}
+// CHECK:STDOUT:     inst14:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst15:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
+// CHECK:STDOUT:     inst16:          {kind: StructValue, arg0: inst_block_empty, type: type(inst14)}
+// CHECK:STDOUT:     inst17:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
-// CHECK:STDOUT:     'inst+1':          template_constant(inst+4)
-// CHECK:STDOUT:     'inst+2':          template_constant(inst+2)
-// CHECK:STDOUT:     'inst+3':          template_constant(inst+3)
-// CHECK:STDOUT:     'inst+4':          template_constant(inst+4)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
+// CHECK:STDOUT:     inst13:          template_constant(inst16)
+// CHECK:STDOUT:     inst14:          template_constant(inst14)
+// CHECK:STDOUT:     inst15:          template_constant(inst15)
+// CHECK:STDOUT:     inst16:          template_constant(inst16)
 // CHECK:STDOUT:   symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst13
 // CHECK:STDOUT:     import_refs:     {}
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+5
+// CHECK:STDOUT:       0:               inst17
 // CHECK:STDOUT:     inst_block5:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+1
+// CHECK:STDOUT:       0:               inst12
+// CHECK:STDOUT:       1:               inst13
 // CHECK:STDOUT: ...
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
-// CHECK:STDOUT:     ir1:             {decl_id: inst+1, is_export: false}
+// CHECK:STDOUT:     ir1:             {decl_id: inst13, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst+1}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst+1}
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst13}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst13}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst+2, name0: inst+3}}
-// CHECK:STDOUT:     name_scope1:     {inst: inst+2, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst+8}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst14, name0: inst15}}
+// CHECK:STDOUT:     name_scope1:     {inst: inst14, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst20}}
 // CHECK:STDOUT:   entity_names:
 // CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
@@ -102,56 +102,56 @@ fn B() {
 // CHECK:STDOUT:     'type(TypeType)':  {kind: copy, type: type(TypeType)}
 // CHECK:STDOUT:     'type(Error)':     {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))': {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst+4)':    {kind: none, type: type(inst+5)}
-// CHECK:STDOUT:     'type(inst+5)':    {kind: none, type: type(inst+5)}
-// CHECK:STDOUT:     'type(inst+10)':   {kind: none, type: type(inst+5)}
+// CHECK:STDOUT:     'type(inst16)':    {kind: none, type: type(inst17)}
+// CHECK:STDOUT:     'type(inst17)':    {kind: none, type: type(inst17)}
+// CHECK:STDOUT:     'type(inst22)':    {kind: none, type: type(inst17)}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+1':          {kind: ImportDecl, arg0: name1}
-// CHECK:STDOUT:     'inst+2':          {kind: Namespace, arg0: name_scope1, arg1: inst+1, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+3':          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst+4)}
-// CHECK:STDOUT:     'inst+4':          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+5':          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+6':          {kind: StructValue, arg0: inst_block_empty, type: type(inst+4)}
-// CHECK:STDOUT:     'inst+7':          {kind: NameRef, arg0: name1, arg1: inst+2, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+8':          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+9':          {kind: FunctionDecl, arg0: function1, arg1: inst_block_empty, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+10':         {kind: FunctionType, arg0: function1, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+11':         {kind: StructValue, arg0: inst_block_empty, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+12':         {kind: NameRef, arg0: name1, arg1: inst+8, type: type(inst+10)}
-// CHECK:STDOUT:     'inst+13':         {kind: Call, arg0: inst+12, arg1: inst_block_empty, type: type(inst+5)}
-// CHECK:STDOUT:     'inst+14':         {kind: Return}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst13:          {kind: ImportDecl, arg0: name1}
+// CHECK:STDOUT:     inst14:          {kind: Namespace, arg0: name_scope1, arg1: inst13, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst15:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst16)}
+// CHECK:STDOUT:     inst16:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst17:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
+// CHECK:STDOUT:     inst18:          {kind: StructValue, arg0: inst_block_empty, type: type(inst16)}
+// CHECK:STDOUT:     inst19:          {kind: NameRef, arg0: name1, arg1: inst14, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst20:          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst22)}
+// CHECK:STDOUT:     inst21:          {kind: FunctionDecl, arg0: function1, arg1: inst_block_empty, type: type(inst22)}
+// CHECK:STDOUT:     inst22:          {kind: FunctionType, arg0: function1, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst23:          {kind: StructValue, arg0: inst_block_empty, type: type(inst22)}
+// CHECK:STDOUT:     inst24:          {kind: NameRef, arg0: name1, arg1: inst20, type: type(inst22)}
+// CHECK:STDOUT:     inst25:          {kind: Call, arg0: inst24, arg1: inst_block_empty, type: type(inst17)}
+// CHECK:STDOUT:     inst26:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
-// CHECK:STDOUT:     'inst+2':          template_constant(inst+2)
-// CHECK:STDOUT:     'inst+3':          template_constant(inst+6)
-// CHECK:STDOUT:     'inst+4':          template_constant(inst+4)
-// CHECK:STDOUT:     'inst+5':          template_constant(inst+5)
-// CHECK:STDOUT:     'inst+6':          template_constant(inst+6)
-// CHECK:STDOUT:     'inst+7':          template_constant(inst+2)
-// CHECK:STDOUT:     'inst+8':          template_constant(inst+11)
-// CHECK:STDOUT:     'inst+9':          template_constant(inst+11)
-// CHECK:STDOUT:     'inst+10':         template_constant(inst+10)
-// CHECK:STDOUT:     'inst+11':         template_constant(inst+11)
-// CHECK:STDOUT:     'inst+12':         template_constant(inst+11)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
+// CHECK:STDOUT:     inst14:          template_constant(inst14)
+// CHECK:STDOUT:     inst15:          template_constant(inst18)
+// CHECK:STDOUT:     inst16:          template_constant(inst16)
+// CHECK:STDOUT:     inst17:          template_constant(inst17)
+// CHECK:STDOUT:     inst18:          template_constant(inst18)
+// CHECK:STDOUT:     inst19:          template_constant(inst14)
+// CHECK:STDOUT:     inst20:          template_constant(inst23)
+// CHECK:STDOUT:     inst21:          template_constant(inst23)
+// CHECK:STDOUT:     inst22:          template_constant(inst22)
+// CHECK:STDOUT:     inst23:          template_constant(inst23)
+// CHECK:STDOUT:     inst24:          template_constant(inst23)
 // CHECK:STDOUT:   symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+3
+// CHECK:STDOUT:       0:               inst15
 // CHECK:STDOUT:     import_refs:
-// CHECK:STDOUT:       0:               inst+2
-// CHECK:STDOUT:       1:               inst+8
+// CHECK:STDOUT:       0:               inst14
+// CHECK:STDOUT:       1:               inst20
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+7
-// CHECK:STDOUT:       1:               inst+12
-// CHECK:STDOUT:       2:               inst+13
-// CHECK:STDOUT:       3:               inst+14
+// CHECK:STDOUT:       0:               inst19
+// CHECK:STDOUT:       1:               inst24
+// CHECK:STDOUT:       2:               inst25
+// CHECK:STDOUT:       3:               inst26
 // CHECK:STDOUT:     inst_block5:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+1
-// CHECK:STDOUT:       2:               inst+3
+// CHECK:STDOUT:       0:               inst12
+// CHECK:STDOUT:       1:               inst13
+// CHECK:STDOUT:       2:               inst15
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
@@ -23,11 +23,11 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+19}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst31}}
 // CHECK:STDOUT:   entity_names:
 // CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, return_slot_pattern: inst+15, body: [inst_block9]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, return_slot_pattern: inst27, body: [inst_block9]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
@@ -37,132 +37,132 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     'type(TypeType)':  {kind: copy, type: type(TypeType)}
 // CHECK:STDOUT:     'type(Error)':     {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))': {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst+20)':   {kind: none, type: type(inst+1)}
-// CHECK:STDOUT:     'type(inst+1)':    {kind: none, type: type(inst+1)}
-// CHECK:STDOUT:     'type(inst+9)':    {kind: pointer, type: type(inst+22)}
-// CHECK:STDOUT:     'type(inst+22)':   {kind: copy, type: type(inst+22)}
+// CHECK:STDOUT:     'type(inst32)':    {kind: none, type: type(inst13)}
+// CHECK:STDOUT:     'type(inst13)':    {kind: none, type: type(inst13)}
+// CHECK:STDOUT:     'type(inst21)':    {kind: pointer, type: type(inst34)}
+// CHECK:STDOUT:     'type(inst34)':    {kind: copy, type: type(inst34)}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:     type_block1:
-// CHECK:STDOUT:       0:               type(inst+1)
-// CHECK:STDOUT:       1:               type(inst+1)
+// CHECK:STDOUT:       0:               type(inst13)
+// CHECK:STDOUT:       1:               type(inst13)
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+1':          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+2':          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+3':          {kind: Converted, arg0: inst+2, arg1: inst+1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+4':          {kind: BindName, arg0: entity_name0, arg1: inst+16, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+5':          {kind: BindingPattern, arg0: entity_name0, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+6':          {kind: ValueParamPattern, arg0: inst+5, arg1: runtime_param0, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+7':          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+8':          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+9':          {kind: TupleType, arg0: type_block1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+10':         {kind: TupleLiteral, arg0: inst_block5, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+11':         {kind: Converted, arg0: inst+7, arg1: inst+1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+12':         {kind: Converted, arg0: inst+8, arg1: inst+1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+13':         {kind: Converted, arg0: inst+10, arg1: inst+9, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+14':         {kind: ReturnSlotPattern, arg0: inst+10, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+15':         {kind: OutParamPattern, arg0: inst+14, arg1: runtime_param1, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+16':         {kind: ValueParam, arg0: runtime_param0, arg1: name1, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+17':         {kind: OutParam, arg0: runtime_param1, arg1: name(ReturnSlot), type: type(inst+9)}
-// CHECK:STDOUT:     'inst+18':         {kind: ReturnSlot, arg0: inst+10, arg1: inst+17, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+19':         {kind: FunctionDecl, arg0: function0, arg1: inst_block8, type: type(inst+20)}
-// CHECK:STDOUT:     'inst+20':         {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+21':         {kind: StructValue, arg0: inst_block_empty, type: type(inst+20)}
-// CHECK:STDOUT:     'inst+22':         {kind: PointerType, arg0: type(inst+9), type: type(TypeType)}
-// CHECK:STDOUT:     'inst+23':         {kind: NameRef, arg0: name1, arg1: inst+4, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+24':         {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+25':         {kind: TupleLiteral, arg0: inst_block10, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+26':         {kind: TupleAccess, arg0: inst+18, arg1: element0, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+27':         {kind: TupleInit, arg0: inst_block11, arg1: inst+26, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+28':         {kind: TupleValue, arg0: inst_block_empty, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+29':         {kind: Converted, arg0: inst+23, arg1: inst+27, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+30':         {kind: TupleAccess, arg0: inst+18, arg1: element1, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+31':         {kind: TupleInit, arg0: inst_block_empty, arg1: inst+30, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+32':         {kind: Converted, arg0: inst+24, arg1: inst+31, type: type(inst+1)}
-// CHECK:STDOUT:     'inst+33':         {kind: TupleInit, arg0: inst_block12, arg1: inst+18, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+34':         {kind: TupleValue, arg0: inst_block13, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+35':         {kind: Converted, arg0: inst+25, arg1: inst+33, type: type(inst+9)}
-// CHECK:STDOUT:     'inst+36':         {kind: ReturnExpr, arg0: inst+35, arg1: inst+18}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst13:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
+// CHECK:STDOUT:     inst14:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst13)}
+// CHECK:STDOUT:     inst15:          {kind: Converted, arg0: inst14, arg1: inst13, type: type(TypeType)}
+// CHECK:STDOUT:     inst16:          {kind: BindName, arg0: entity_name0, arg1: inst28, type: type(inst13)}
+// CHECK:STDOUT:     inst17:          {kind: BindingPattern, arg0: entity_name0, type: type(inst13)}
+// CHECK:STDOUT:     inst18:          {kind: ValueParamPattern, arg0: inst17, arg1: runtime_param0, type: type(inst13)}
+// CHECK:STDOUT:     inst19:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst13)}
+// CHECK:STDOUT:     inst20:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst13)}
+// CHECK:STDOUT:     inst21:          {kind: TupleType, arg0: type_block1, type: type(TypeType)}
+// CHECK:STDOUT:     inst22:          {kind: TupleLiteral, arg0: inst_block5, type: type(inst21)}
+// CHECK:STDOUT:     inst23:          {kind: Converted, arg0: inst19, arg1: inst13, type: type(TypeType)}
+// CHECK:STDOUT:     inst24:          {kind: Converted, arg0: inst20, arg1: inst13, type: type(TypeType)}
+// CHECK:STDOUT:     inst25:          {kind: Converted, arg0: inst22, arg1: inst21, type: type(TypeType)}
+// CHECK:STDOUT:     inst26:          {kind: ReturnSlotPattern, arg0: inst22, type: type(inst21)}
+// CHECK:STDOUT:     inst27:          {kind: OutParamPattern, arg0: inst26, arg1: runtime_param1, type: type(inst21)}
+// CHECK:STDOUT:     inst28:          {kind: ValueParam, arg0: runtime_param0, arg1: name1, type: type(inst13)}
+// CHECK:STDOUT:     inst29:          {kind: OutParam, arg0: runtime_param1, arg1: name(ReturnSlot), type: type(inst21)}
+// CHECK:STDOUT:     inst30:          {kind: ReturnSlot, arg0: inst22, arg1: inst29, type: type(inst21)}
+// CHECK:STDOUT:     inst31:          {kind: FunctionDecl, arg0: function0, arg1: inst_block8, type: type(inst32)}
+// CHECK:STDOUT:     inst32:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst33:          {kind: StructValue, arg0: inst_block_empty, type: type(inst32)}
+// CHECK:STDOUT:     inst34:          {kind: PointerType, arg0: type(inst21), type: type(TypeType)}
+// CHECK:STDOUT:     inst35:          {kind: NameRef, arg0: name1, arg1: inst16, type: type(inst13)}
+// CHECK:STDOUT:     inst36:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst13)}
+// CHECK:STDOUT:     inst37:          {kind: TupleLiteral, arg0: inst_block10, type: type(inst21)}
+// CHECK:STDOUT:     inst38:          {kind: TupleAccess, arg0: inst30, arg1: element0, type: type(inst13)}
+// CHECK:STDOUT:     inst39:          {kind: TupleInit, arg0: inst_block11, arg1: inst38, type: type(inst13)}
+// CHECK:STDOUT:     inst40:          {kind: TupleValue, arg0: inst_block_empty, type: type(inst13)}
+// CHECK:STDOUT:     inst41:          {kind: Converted, arg0: inst35, arg1: inst39, type: type(inst13)}
+// CHECK:STDOUT:     inst42:          {kind: TupleAccess, arg0: inst30, arg1: element1, type: type(inst13)}
+// CHECK:STDOUT:     inst43:          {kind: TupleInit, arg0: inst_block_empty, arg1: inst42, type: type(inst13)}
+// CHECK:STDOUT:     inst44:          {kind: Converted, arg0: inst36, arg1: inst43, type: type(inst13)}
+// CHECK:STDOUT:     inst45:          {kind: TupleInit, arg0: inst_block12, arg1: inst30, type: type(inst21)}
+// CHECK:STDOUT:     inst46:          {kind: TupleValue, arg0: inst_block13, type: type(inst21)}
+// CHECK:STDOUT:     inst47:          {kind: Converted, arg0: inst37, arg1: inst45, type: type(inst21)}
+// CHECK:STDOUT:     inst48:          {kind: ReturnExpr, arg0: inst47, arg1: inst30}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
-// CHECK:STDOUT:     'inst+1':          template_constant(inst+1)
-// CHECK:STDOUT:     'inst+3':          template_constant(inst+1)
-// CHECK:STDOUT:     'inst+9':          template_constant(inst+9)
-// CHECK:STDOUT:     'inst+11':         template_constant(inst+1)
-// CHECK:STDOUT:     'inst+12':         template_constant(inst+1)
-// CHECK:STDOUT:     'inst+13':         template_constant(inst+9)
-// CHECK:STDOUT:     'inst+19':         template_constant(inst+21)
-// CHECK:STDOUT:     'inst+20':         template_constant(inst+20)
-// CHECK:STDOUT:     'inst+21':         template_constant(inst+21)
-// CHECK:STDOUT:     'inst+22':         template_constant(inst+22)
-// CHECK:STDOUT:     'inst+27':         template_constant(inst+28)
-// CHECK:STDOUT:     'inst+28':         template_constant(inst+28)
-// CHECK:STDOUT:     'inst+29':         template_constant(inst+28)
-// CHECK:STDOUT:     'inst+31':         template_constant(inst+28)
-// CHECK:STDOUT:     'inst+32':         template_constant(inst+28)
-// CHECK:STDOUT:     'inst+33':         template_constant(inst+34)
-// CHECK:STDOUT:     'inst+34':         template_constant(inst+34)
-// CHECK:STDOUT:     'inst+35':         template_constant(inst+34)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
+// CHECK:STDOUT:     inst13:          template_constant(inst13)
+// CHECK:STDOUT:     inst15:          template_constant(inst13)
+// CHECK:STDOUT:     inst21:          template_constant(inst21)
+// CHECK:STDOUT:     inst23:          template_constant(inst13)
+// CHECK:STDOUT:     inst24:          template_constant(inst13)
+// CHECK:STDOUT:     inst25:          template_constant(inst21)
+// CHECK:STDOUT:     inst31:          template_constant(inst33)
+// CHECK:STDOUT:     inst32:          template_constant(inst32)
+// CHECK:STDOUT:     inst33:          template_constant(inst33)
+// CHECK:STDOUT:     inst34:          template_constant(inst34)
+// CHECK:STDOUT:     inst39:          template_constant(inst40)
+// CHECK:STDOUT:     inst40:          template_constant(inst40)
+// CHECK:STDOUT:     inst41:          template_constant(inst40)
+// CHECK:STDOUT:     inst43:          template_constant(inst40)
+// CHECK:STDOUT:     inst44:          template_constant(inst40)
+// CHECK:STDOUT:     inst45:          template_constant(inst46)
+// CHECK:STDOUT:     inst46:          template_constant(inst46)
+// CHECK:STDOUT:     inst47:          template_constant(inst46)
 // CHECK:STDOUT:   symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+19
+// CHECK:STDOUT:       0:               inst31
 // CHECK:STDOUT:     import_refs:     {}
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+6
+// CHECK:STDOUT:       0:               inst18
 // CHECK:STDOUT:     inst_block5:
-// CHECK:STDOUT:       0:               inst+7
-// CHECK:STDOUT:       1:               inst+8
+// CHECK:STDOUT:       0:               inst19
+// CHECK:STDOUT:       1:               inst20
 // CHECK:STDOUT:     inst_block6:
-// CHECK:STDOUT:       0:               inst+16
-// CHECK:STDOUT:       1:               inst+17
+// CHECK:STDOUT:       0:               inst28
+// CHECK:STDOUT:       1:               inst29
 // CHECK:STDOUT:     inst_block7:
-// CHECK:STDOUT:       0:               inst+5
-// CHECK:STDOUT:       1:               inst+6
-// CHECK:STDOUT:       2:               inst+14
-// CHECK:STDOUT:       3:               inst+15
+// CHECK:STDOUT:       0:               inst17
+// CHECK:STDOUT:       1:               inst18
+// CHECK:STDOUT:       2:               inst26
+// CHECK:STDOUT:       3:               inst27
 // CHECK:STDOUT:     inst_block8:
-// CHECK:STDOUT:       0:               inst+2
-// CHECK:STDOUT:       1:               inst+3
-// CHECK:STDOUT:       2:               inst+7
-// CHECK:STDOUT:       3:               inst+8
-// CHECK:STDOUT:       4:               inst+10
-// CHECK:STDOUT:       5:               inst+11
-// CHECK:STDOUT:       6:               inst+12
-// CHECK:STDOUT:       7:               inst+13
-// CHECK:STDOUT:       8:               inst+16
-// CHECK:STDOUT:       9:               inst+4
-// CHECK:STDOUT:       10:              inst+17
-// CHECK:STDOUT:       11:              inst+18
+// CHECK:STDOUT:       0:               inst14
+// CHECK:STDOUT:       1:               inst15
+// CHECK:STDOUT:       2:               inst19
+// CHECK:STDOUT:       3:               inst20
+// CHECK:STDOUT:       4:               inst22
+// CHECK:STDOUT:       5:               inst23
+// CHECK:STDOUT:       6:               inst24
+// CHECK:STDOUT:       7:               inst25
+// CHECK:STDOUT:       8:               inst28
+// CHECK:STDOUT:       9:               inst16
+// CHECK:STDOUT:       10:              inst29
+// CHECK:STDOUT:       11:              inst30
 // CHECK:STDOUT:     inst_block9:
-// CHECK:STDOUT:       0:               inst+23
-// CHECK:STDOUT:       1:               inst+24
-// CHECK:STDOUT:       2:               inst+25
-// CHECK:STDOUT:       3:               inst+26
-// CHECK:STDOUT:       4:               inst+27
-// CHECK:STDOUT:       5:               inst+29
-// CHECK:STDOUT:       6:               inst+30
-// CHECK:STDOUT:       7:               inst+31
-// CHECK:STDOUT:       8:               inst+32
-// CHECK:STDOUT:       9:               inst+33
-// CHECK:STDOUT:       10:              inst+35
-// CHECK:STDOUT:       11:              inst+36
+// CHECK:STDOUT:       0:               inst35
+// CHECK:STDOUT:       1:               inst36
+// CHECK:STDOUT:       2:               inst37
+// CHECK:STDOUT:       3:               inst38
+// CHECK:STDOUT:       4:               inst39
+// CHECK:STDOUT:       5:               inst41
+// CHECK:STDOUT:       6:               inst42
+// CHECK:STDOUT:       7:               inst43
+// CHECK:STDOUT:       8:               inst44
+// CHECK:STDOUT:       9:               inst45
+// CHECK:STDOUT:       10:              inst47
+// CHECK:STDOUT:       11:              inst48
 // CHECK:STDOUT:     inst_block10:
-// CHECK:STDOUT:       0:               inst+23
-// CHECK:STDOUT:       1:               inst+24
+// CHECK:STDOUT:       0:               inst35
+// CHECK:STDOUT:       1:               inst36
 // CHECK:STDOUT:     inst_block11:    {}
 // CHECK:STDOUT:     inst_block12:
-// CHECK:STDOUT:       0:               inst+29
-// CHECK:STDOUT:       1:               inst+32
+// CHECK:STDOUT:       0:               inst41
+// CHECK:STDOUT:       1:               inst44
 // CHECK:STDOUT:     inst_block13:
-// CHECK:STDOUT:       0:               inst+28
-// CHECK:STDOUT:       1:               inst+28
+// CHECK:STDOUT:       0:               inst40
+// CHECK:STDOUT:       1:               inst40
 // CHECK:STDOUT:     inst_block14:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+19
+// CHECK:STDOUT:       0:               inst12
+// CHECK:STDOUT:       1:               inst31
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- raw_and_textual_ir.carbon

--- a/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_ir.carbon
@@ -23,15 +23,15 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst+0, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+24}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst36}}
 // CHECK:STDOUT:   entity_names:
 // CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind0}
 // CHECK:STDOUT:     entity_name1:    {name: name2, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, return_slot_pattern: inst+19, body: [inst_block14]}
+// CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, return_slot_pattern: inst31, body: [inst_block14]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:
-// CHECK:STDOUT:     generic0:        {decl: inst+24, bindings: inst_block10}
+// CHECK:STDOUT:     generic0:        {decl: inst36, bindings: inst_block10}
 // CHECK:STDOUT:   specifics:
 // CHECK:STDOUT:     specific0:       {generic: generic0, args: inst_block12}
 // CHECK:STDOUT:   struct_type_fields:
@@ -40,8 +40,8 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     'type(TypeType)':  {kind: copy, type: type(TypeType)}
 // CHECK:STDOUT:     'type(Error)':     {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))': {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst+28)':   {kind: none, type: type(inst+11)}
-// CHECK:STDOUT:     'type(inst+11)':   {kind: none, type: type(inst+11)}
+// CHECK:STDOUT:     'type(inst40)':    {kind: none, type: type(inst23)}
+// CHECK:STDOUT:     'type(inst23)':    {kind: none, type: type(inst23)}
 // CHECK:STDOUT:     'type(symbolic_constant0)': {kind: copy, type: type(symbolic_constant0)}
 // CHECK:STDOUT:     'type(symbolic_constant2)': {kind: pointer, type: type(symbolic_constant6)}
 // CHECK:STDOUT:     'type(symbolic_constant6)': {kind: copy, type: type(symbolic_constant6)}
@@ -51,156 +51,156 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:     type_block1:
 // CHECK:STDOUT:       0:               type(TypeType)
-// CHECK:STDOUT:       1:               type(inst+11)
+// CHECK:STDOUT:       1:               type(inst23)
 // CHECK:STDOUT:     type_block2:
 // CHECK:STDOUT:       0:               type(symbolic_constant0)
-// CHECK:STDOUT:       1:               type(inst+11)
+// CHECK:STDOUT:       1:               type(inst23)
 // CHECK:STDOUT:     type_block3:
 // CHECK:STDOUT:       0:               type(symbolic_constant3)
-// CHECK:STDOUT:       1:               type(inst+11)
+// CHECK:STDOUT:       1:               type(inst23)
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     'inst+0':          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'inst+1':          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst+20, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+2':          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+3':          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+4':          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+5':          {kind: ValueParamPattern, arg0: inst+3, arg1: runtime_param<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+6':          {kind: NameRef, arg0: name1, arg1: inst+1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+7':          {kind: BindName, arg0: entity_name1, arg1: inst+21, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+8':          {kind: BindingPattern, arg0: entity_name1, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+9':          {kind: ValueParamPattern, arg0: inst+8, arg1: runtime_param0, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+10':         {kind: NameRef, arg0: name1, arg1: inst+1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+11':         {kind: TupleType, arg0: type_block0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+12':         {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst+11)}
-// CHECK:STDOUT:     'inst+13':         {kind: TupleType, arg0: type_block1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+14':         {kind: TupleLiteral, arg0: inst_block6, type: type(inst+13)}
-// CHECK:STDOUT:     'inst+15':         {kind: Converted, arg0: inst+12, arg1: inst+11, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+16':         {kind: TupleType, arg0: type_block2, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+17':         {kind: Converted, arg0: inst+14, arg1: inst+16, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+18':         {kind: ReturnSlotPattern, arg0: inst+14, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+19':         {kind: OutParamPattern, arg0: inst+18, arg1: runtime_param1, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+20':         {kind: ValueParam, arg0: runtime_param<invalid>, arg1: name1, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+21':         {kind: ValueParam, arg0: runtime_param0, arg1: name2, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+22':         {kind: OutParam, arg0: runtime_param1, arg1: name(ReturnSlot), type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+23':         {kind: ReturnSlot, arg0: inst+14, arg1: inst+22, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+24':         {kind: FunctionDecl, arg0: function0, arg1: inst_block9, type: type(inst+28)}
-// CHECK:STDOUT:     'inst+25':         {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+26':         {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+27':         {kind: TupleType, arg0: type_block3, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+28':         {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
-// CHECK:STDOUT:     'inst+29':         {kind: StructValue, arg0: inst_block_empty, type: type(inst+28)}
-// CHECK:STDOUT:     'inst+30':         {kind: PointerType, arg0: type(symbolic_constant2), type: type(TypeType)}
-// CHECK:STDOUT:     'inst+31':         {kind: NameRef, arg0: name2, arg1: inst+7, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+32':         {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst+11)}
-// CHECK:STDOUT:     'inst+33':         {kind: TupleLiteral, arg0: inst_block15, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+34':         {kind: TupleAccess, arg0: inst+23, arg1: element0, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+35':         {kind: InitializeFrom, arg0: inst+31, arg1: inst+34, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'inst+36':         {kind: TupleAccess, arg0: inst+23, arg1: element1, type: type(inst+11)}
-// CHECK:STDOUT:     'inst+37':         {kind: TupleInit, arg0: inst_block_empty, arg1: inst+36, type: type(inst+11)}
-// CHECK:STDOUT:     'inst+38':         {kind: TupleValue, arg0: inst_block_empty, type: type(inst+11)}
-// CHECK:STDOUT:     'inst+39':         {kind: Converted, arg0: inst+32, arg1: inst+37, type: type(inst+11)}
-// CHECK:STDOUT:     'inst+40':         {kind: TupleInit, arg0: inst_block16, arg1: inst+23, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+41':         {kind: Converted, arg0: inst+33, arg1: inst+40, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     'inst+42':         {kind: ReturnExpr, arg0: inst+41, arg1: inst+23}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst13:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst32, type: type(TypeType)}
+// CHECK:STDOUT:     inst14:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst15:          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
+// CHECK:STDOUT:     inst16:          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
+// CHECK:STDOUT:     inst17:          {kind: ValueParamPattern, arg0: inst15, arg1: runtime_param<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst18:          {kind: NameRef, arg0: name1, arg1: inst13, type: type(TypeType)}
+// CHECK:STDOUT:     inst19:          {kind: BindName, arg0: entity_name1, arg1: inst33, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst20:          {kind: BindingPattern, arg0: entity_name1, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst21:          {kind: ValueParamPattern, arg0: inst20, arg1: runtime_param0, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst22:          {kind: NameRef, arg0: name1, arg1: inst13, type: type(TypeType)}
+// CHECK:STDOUT:     inst23:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
+// CHECK:STDOUT:     inst24:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst23)}
+// CHECK:STDOUT:     inst25:          {kind: TupleType, arg0: type_block1, type: type(TypeType)}
+// CHECK:STDOUT:     inst26:          {kind: TupleLiteral, arg0: inst_block6, type: type(inst25)}
+// CHECK:STDOUT:     inst27:          {kind: Converted, arg0: inst24, arg1: inst23, type: type(TypeType)}
+// CHECK:STDOUT:     inst28:          {kind: TupleType, arg0: type_block2, type: type(TypeType)}
+// CHECK:STDOUT:     inst29:          {kind: Converted, arg0: inst26, arg1: inst28, type: type(TypeType)}
+// CHECK:STDOUT:     inst30:          {kind: ReturnSlotPattern, arg0: inst26, type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst31:          {kind: OutParamPattern, arg0: inst30, arg1: runtime_param1, type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst32:          {kind: ValueParam, arg0: runtime_param<invalid>, arg1: name1, type: type(TypeType)}
+// CHECK:STDOUT:     inst33:          {kind: ValueParam, arg0: runtime_param0, arg1: name2, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst34:          {kind: OutParam, arg0: runtime_param1, arg1: name(ReturnSlot), type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst35:          {kind: ReturnSlot, arg0: inst26, arg1: inst34, type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst36:          {kind: FunctionDecl, arg0: function0, arg1: inst_block9, type: type(inst40)}
+// CHECK:STDOUT:     inst37:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst38:          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
+// CHECK:STDOUT:     inst39:          {kind: TupleType, arg0: type_block3, type: type(TypeType)}
+// CHECK:STDOUT:     inst40:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst41:          {kind: StructValue, arg0: inst_block_empty, type: type(inst40)}
+// CHECK:STDOUT:     inst42:          {kind: PointerType, arg0: type(symbolic_constant2), type: type(TypeType)}
+// CHECK:STDOUT:     inst43:          {kind: NameRef, arg0: name2, arg1: inst19, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst44:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst23)}
+// CHECK:STDOUT:     inst45:          {kind: TupleLiteral, arg0: inst_block15, type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst46:          {kind: TupleAccess, arg0: inst35, arg1: element0, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst47:          {kind: InitializeFrom, arg0: inst43, arg1: inst46, type: type(symbolic_constant3)}
+// CHECK:STDOUT:     inst48:          {kind: TupleAccess, arg0: inst35, arg1: element1, type: type(inst23)}
+// CHECK:STDOUT:     inst49:          {kind: TupleInit, arg0: inst_block_empty, arg1: inst48, type: type(inst23)}
+// CHECK:STDOUT:     inst50:          {kind: TupleValue, arg0: inst_block_empty, type: type(inst23)}
+// CHECK:STDOUT:     inst51:          {kind: Converted, arg0: inst44, arg1: inst49, type: type(inst23)}
+// CHECK:STDOUT:     inst52:          {kind: TupleInit, arg0: inst_block16, arg1: inst35, type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst53:          {kind: Converted, arg0: inst45, arg1: inst52, type: type(symbolic_constant5)}
+// CHECK:STDOUT:     inst54:          {kind: ReturnExpr, arg0: inst53, arg1: inst35}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     'inst+0':          template_constant(inst+0)
-// CHECK:STDOUT:     'inst+1':          symbolic_constant3
-// CHECK:STDOUT:     'inst+2':          symbolic_constant0
-// CHECK:STDOUT:     'inst+3':          symbolic_constant4
-// CHECK:STDOUT:     'inst+4':          symbolic_constant1
-// CHECK:STDOUT:     'inst+5':          symbolic_constant4
-// CHECK:STDOUT:     'inst+6':          symbolic_constant3
-// CHECK:STDOUT:     'inst+10':         symbolic_constant3
-// CHECK:STDOUT:     'inst+11':         template_constant(inst+11)
-// CHECK:STDOUT:     'inst+13':         template_constant(inst+13)
-// CHECK:STDOUT:     'inst+15':         template_constant(inst+11)
-// CHECK:STDOUT:     'inst+16':         symbolic_constant2
-// CHECK:STDOUT:     'inst+17':         symbolic_constant5
-// CHECK:STDOUT:     'inst+24':         template_constant(inst+29)
-// CHECK:STDOUT:     'inst+25':         symbolic_constant3
-// CHECK:STDOUT:     'inst+26':         symbolic_constant4
-// CHECK:STDOUT:     'inst+27':         symbolic_constant5
-// CHECK:STDOUT:     'inst+28':         template_constant(inst+28)
-// CHECK:STDOUT:     'inst+29':         template_constant(inst+29)
-// CHECK:STDOUT:     'inst+30':         symbolic_constant6
-// CHECK:STDOUT:     'inst+37':         template_constant(inst+38)
-// CHECK:STDOUT:     'inst+38':         template_constant(inst+38)
-// CHECK:STDOUT:     'inst+39':         template_constant(inst+38)
+// CHECK:STDOUT:     inst12:          template_constant(inst12)
+// CHECK:STDOUT:     inst13:          symbolic_constant3
+// CHECK:STDOUT:     inst14:          symbolic_constant0
+// CHECK:STDOUT:     inst15:          symbolic_constant4
+// CHECK:STDOUT:     inst16:          symbolic_constant1
+// CHECK:STDOUT:     inst17:          symbolic_constant4
+// CHECK:STDOUT:     inst18:          symbolic_constant3
+// CHECK:STDOUT:     inst22:          symbolic_constant3
+// CHECK:STDOUT:     inst23:          template_constant(inst23)
+// CHECK:STDOUT:     inst25:          template_constant(inst25)
+// CHECK:STDOUT:     inst27:          template_constant(inst23)
+// CHECK:STDOUT:     inst28:          symbolic_constant2
+// CHECK:STDOUT:     inst29:          symbolic_constant5
+// CHECK:STDOUT:     inst36:          template_constant(inst41)
+// CHECK:STDOUT:     inst37:          symbolic_constant3
+// CHECK:STDOUT:     inst38:          symbolic_constant4
+// CHECK:STDOUT:     inst39:          symbolic_constant5
+// CHECK:STDOUT:     inst40:          template_constant(inst40)
+// CHECK:STDOUT:     inst41:          template_constant(inst41)
+// CHECK:STDOUT:     inst42:          symbolic_constant6
+// CHECK:STDOUT:     inst49:          template_constant(inst50)
+// CHECK:STDOUT:     inst50:          template_constant(inst50)
+// CHECK:STDOUT:     inst51:          template_constant(inst50)
 // CHECK:STDOUT:   symbolic_constants:
-// CHECK:STDOUT:     symbolic_constant0: {inst: inst+2, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant1: {inst: inst+4, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant2: {inst: inst+16, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant3: {inst: inst+2, generic: generic0, index: generic_inst_in_decl0, .Self: false}
-// CHECK:STDOUT:     symbolic_constant4: {inst: inst+4, generic: generic0, index: generic_inst_in_decl1, .Self: false}
-// CHECK:STDOUT:     symbolic_constant5: {inst: inst+16, generic: generic0, index: generic_inst_in_decl2, .Self: false}
-// CHECK:STDOUT:     symbolic_constant6: {inst: inst+30, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant0: {inst: inst14, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant1: {inst: inst16, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant2: {inst: inst28, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant3: {inst: inst14, generic: generic0, index: generic_inst_in_decl0, .Self: false}
+// CHECK:STDOUT:     symbolic_constant4: {inst: inst16, generic: generic0, index: generic_inst_in_decl1, .Self: false}
+// CHECK:STDOUT:     symbolic_constant5: {inst: inst28, generic: generic0, index: generic_inst_in_decl2, .Self: false}
+// CHECK:STDOUT:     symbolic_constant6: {inst: inst42, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst+24
+// CHECK:STDOUT:       0:               inst36
 // CHECK:STDOUT:     import_refs:     {}
 // CHECK:STDOUT:     global_init:     {}
 // CHECK:STDOUT:     inst_block4:
-// CHECK:STDOUT:       0:               inst+5
+// CHECK:STDOUT:       0:               inst17
 // CHECK:STDOUT:     inst_block5:
-// CHECK:STDOUT:       0:               inst+9
+// CHECK:STDOUT:       0:               inst21
 // CHECK:STDOUT:     inst_block6:
-// CHECK:STDOUT:       0:               inst+10
-// CHECK:STDOUT:       1:               inst+12
+// CHECK:STDOUT:       0:               inst22
+// CHECK:STDOUT:       1:               inst24
 // CHECK:STDOUT:     inst_block7:
-// CHECK:STDOUT:       0:               inst+21
-// CHECK:STDOUT:       1:               inst+22
+// CHECK:STDOUT:       0:               inst33
+// CHECK:STDOUT:       1:               inst34
 // CHECK:STDOUT:     inst_block8:
-// CHECK:STDOUT:       0:               inst+3
-// CHECK:STDOUT:       1:               inst+5
-// CHECK:STDOUT:       2:               inst+8
-// CHECK:STDOUT:       3:               inst+9
-// CHECK:STDOUT:       4:               inst+18
-// CHECK:STDOUT:       5:               inst+19
+// CHECK:STDOUT:       0:               inst15
+// CHECK:STDOUT:       1:               inst17
+// CHECK:STDOUT:       2:               inst20
+// CHECK:STDOUT:       3:               inst21
+// CHECK:STDOUT:       4:               inst30
+// CHECK:STDOUT:       5:               inst31
 // CHECK:STDOUT:     inst_block9:
-// CHECK:STDOUT:       0:               inst+6
-// CHECK:STDOUT:       1:               inst+10
-// CHECK:STDOUT:       2:               inst+12
-// CHECK:STDOUT:       3:               inst+14
-// CHECK:STDOUT:       4:               inst+15
-// CHECK:STDOUT:       5:               inst+17
-// CHECK:STDOUT:       6:               inst+20
-// CHECK:STDOUT:       7:               inst+1
-// CHECK:STDOUT:       8:               inst+21
-// CHECK:STDOUT:       9:               inst+7
-// CHECK:STDOUT:       10:              inst+22
-// CHECK:STDOUT:       11:              inst+23
+// CHECK:STDOUT:       0:               inst18
+// CHECK:STDOUT:       1:               inst22
+// CHECK:STDOUT:       2:               inst24
+// CHECK:STDOUT:       3:               inst26
+// CHECK:STDOUT:       4:               inst27
+// CHECK:STDOUT:       5:               inst29
+// CHECK:STDOUT:       6:               inst32
+// CHECK:STDOUT:       7:               inst13
+// CHECK:STDOUT:       8:               inst33
+// CHECK:STDOUT:       9:               inst19
+// CHECK:STDOUT:       10:              inst34
+// CHECK:STDOUT:       11:              inst35
 // CHECK:STDOUT:     inst_block10:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst13
 // CHECK:STDOUT:     inst_block11:
-// CHECK:STDOUT:       0:               inst+25
-// CHECK:STDOUT:       1:               inst+26
-// CHECK:STDOUT:       2:               inst+27
+// CHECK:STDOUT:       0:               inst37
+// CHECK:STDOUT:       1:               inst38
+// CHECK:STDOUT:       2:               inst39
 // CHECK:STDOUT:     inst_block12:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst14
 // CHECK:STDOUT:     inst_block13:
-// CHECK:STDOUT:       0:               inst+2
-// CHECK:STDOUT:       1:               inst+2
-// CHECK:STDOUT:       2:               inst+16
+// CHECK:STDOUT:       0:               inst14
+// CHECK:STDOUT:       1:               inst14
+// CHECK:STDOUT:       2:               inst28
 // CHECK:STDOUT:     inst_block14:
-// CHECK:STDOUT:       0:               inst+31
-// CHECK:STDOUT:       1:               inst+32
-// CHECK:STDOUT:       2:               inst+33
-// CHECK:STDOUT:       3:               inst+34
-// CHECK:STDOUT:       4:               inst+35
-// CHECK:STDOUT:       5:               inst+36
-// CHECK:STDOUT:       6:               inst+37
-// CHECK:STDOUT:       7:               inst+39
-// CHECK:STDOUT:       8:               inst+40
-// CHECK:STDOUT:       9:               inst+41
-// CHECK:STDOUT:       10:              inst+42
+// CHECK:STDOUT:       0:               inst43
+// CHECK:STDOUT:       1:               inst44
+// CHECK:STDOUT:       2:               inst45
+// CHECK:STDOUT:       3:               inst46
+// CHECK:STDOUT:       4:               inst47
+// CHECK:STDOUT:       5:               inst48
+// CHECK:STDOUT:       6:               inst49
+// CHECK:STDOUT:       7:               inst51
+// CHECK:STDOUT:       8:               inst52
+// CHECK:STDOUT:       9:               inst53
+// CHECK:STDOUT:       10:              inst54
 // CHECK:STDOUT:     inst_block15:
-// CHECK:STDOUT:       0:               inst+31
-// CHECK:STDOUT:       1:               inst+32
+// CHECK:STDOUT:       0:               inst43
+// CHECK:STDOUT:       1:               inst44
 // CHECK:STDOUT:     inst_block16:
-// CHECK:STDOUT:       0:               inst+35
-// CHECK:STDOUT:       1:               inst+39
+// CHECK:STDOUT:       0:               inst47
+// CHECK:STDOUT:       1:               inst51
 // CHECK:STDOUT:     inst_block17:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+24
+// CHECK:STDOUT:       0:               inst12
+// CHECK:STDOUT:       1:               inst36
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/no_prelude/verbose.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/verbose.carbon
@@ -13,7 +13,7 @@
 // SET-CHECK-SUBSET
 // CHECK:STDERR: Node Push 0: FunctionIntroducer -> <none>
 // CHECK:STDERR: AddPlaceholderInst: {kind: FunctionDecl, arg0: function<invalid>, arg1: inst_block_empty}
-// CHECK:STDERR: ReplaceInst: inst+{{[0-9]+}} -> {kind: FunctionDecl, arg0: function{{[0-9]+}}, arg1: inst_block_empty, type: type(inst+{{[0-9]+}})}
+// CHECK:STDERR: ReplaceInst: inst{{[0-9]+}} -> {kind: FunctionDecl, arg0: function{{[0-9]+}}, arg1: inst_block_empty, type: type(inst{{[0-9]+}})}
 // CHECK:STDERR: inst_block_stack_ Push 1
 // CHECK:STDERR: AddInst: {kind: Return}
 // CHECK:STDERR: inst_block_stack_ Pop 1: inst_block{{[0-9]+}}

--- a/toolchain/check/testdata/builtins/bool/make_type.carbon
+++ b/toolchain/check/testdata/builtins/bool/make_type.carbon
@@ -62,7 +62,7 @@ var b: Bool() = false;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %Bool.type = import_ref Main//types, inst+7, loaded [template = constants.%Bool]
+// CHECK:STDOUT:   %import_ref: %Bool.type = import_ref Main//types, Bool, loaded [template = constants.%Bool]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/builtins/float/make_type.carbon
+++ b/toolchain/check/testdata/builtins/float/make_type.carbon
@@ -111,7 +111,7 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Float.type = import_ref Main//types, inst+26, loaded [template = constants.%Float]
+// CHECK:STDOUT:   %import_ref.1: %Float.type = import_ref Main//types, Float, loaded [template = constants.%Float]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.2
 // CHECK:STDOUT:     .Int = %import_ref.38
@@ -201,7 +201,7 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Float.type = import_ref Main//types, inst+26, loaded [template = constants.%Float]
+// CHECK:STDOUT:   %import_ref.1: %Float.type = import_ref Main//types, Float, loaded [template = constants.%Float]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.2
 // CHECK:STDOUT:     .Int = %import_ref.38

--- a/toolchain/check/testdata/builtins/int/convert_checked.carbon
+++ b/toolchain/check/testdata/builtins/int/convert_checked.carbon
@@ -832,27 +832,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, inst+30, loaded [template = constants.%NegateI32]
-// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, inst+57, loaded [template = constants.%SubI32]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4: %IntLiteral.type = import_ref Main//int_ops, inst+100, loaded [template = constants.%IntLiteral]
-// CHECK:STDOUT:   %import_ref.5: %Int32ToInt32.type = import_ref Main//int_ops, inst+119, loaded [template = constants.%Int32ToInt32]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9: %IntLiteralToIntLiteral.type = import_ref Main//int_ops, inst+195, loaded [template = constants.%IntLiteralToIntLiteral]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20: %Int32ToIntLiteral.type = import_ref Main//int_ops, inst+410, loaded [template = constants.%Int32ToIntLiteral]
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, NegateI32, loaded [template = constants.%NegateI32]
+// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, SubI32, loaded [template = constants.%SubI32]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4: %IntLiteral.type = import_ref Main//int_ops, IntLiteral, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.5: %Int32ToInt32.type = import_ref Main//int_ops, Int32ToInt32, loaded [template = constants.%Int32ToInt32]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9: %IntLiteralToIntLiteral.type = import_ref Main//int_ops, IntLiteralToIntLiteral, loaded [template = constants.%IntLiteralToIntLiteral]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20: %Int32ToIntLiteral.type = import_ref Main//int_ops, Int32ToIntLiteral, loaded [template = constants.%Int32ToIntLiteral]
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -1024,27 +1024,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7: %Uint32ToInt32.type = import_ref Main//int_ops, inst+157, loaded [template = constants.%Uint32ToInt32]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7: %Uint32ToInt32.type = import_ref Main//int_ops, Uint32ToInt32, loaded [template = constants.%Uint32ToInt32]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -1194,27 +1194,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, inst+30, loaded [template = constants.%NegateI32]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, inst+216, loaded [template = constants.%Int32ToInt16]
-// CHECK:STDOUT:   %import_ref.11: %Int32ToUint16.type = import_ref Main//int_ops, inst+236, loaded [template = constants.%Int32ToUint16]
-// CHECK:STDOUT:   %import_ref.12: %Uint32ToInt16.type = import_ref Main//int_ops, inst+255, loaded [template = constants.%Uint32ToInt16]
-// CHECK:STDOUT:   %import_ref.13: %Uint32ToUint16.type = import_ref Main//int_ops, inst+274, loaded [template = constants.%Uint32ToUint16]
-// CHECK:STDOUT:   %import_ref.14: %IntLiteralToInt16.type = import_ref Main//int_ops, inst+293, loaded [template = constants.%IntLiteralToInt16]
-// CHECK:STDOUT:   %import_ref.15: %IntLiteralToUint16.type = import_ref Main//int_ops, inst+312, loaded [template = constants.%IntLiteralToUint16]
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20: %Int32ToIntLiteral.type = import_ref Main//int_ops, inst+410, loaded [template = constants.%Int32ToIntLiteral]
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, NegateI32, loaded [template = constants.%NegateI32]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, Int32ToInt16, loaded [template = constants.%Int32ToInt16]
+// CHECK:STDOUT:   %import_ref.11: %Int32ToUint16.type = import_ref Main//int_ops, Int32ToUint16, loaded [template = constants.%Int32ToUint16]
+// CHECK:STDOUT:   %import_ref.12: %Uint32ToInt16.type = import_ref Main//int_ops, Uint32ToInt16, loaded [template = constants.%Uint32ToInt16]
+// CHECK:STDOUT:   %import_ref.13: %Uint32ToUint16.type = import_ref Main//int_ops, Uint32ToUint16, loaded [template = constants.%Uint32ToUint16]
+// CHECK:STDOUT:   %import_ref.14: %IntLiteralToInt16.type = import_ref Main//int_ops, IntLiteralToInt16, loaded [template = constants.%IntLiteralToInt16]
+// CHECK:STDOUT:   %import_ref.15: %IntLiteralToUint16.type = import_ref Main//int_ops, IntLiteralToUint16, loaded [template = constants.%IntLiteralToUint16]
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20: %Int32ToIntLiteral.type = import_ref Main//int_ops, Int32ToIntLiteral, loaded [template = constants.%Int32ToIntLiteral]
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -1569,27 +1569,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3: %AddU32.type = import_ref Main//int_ops, inst+93, loaded [template = constants.%AddU32]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18: %Uint32ToInt64.type = import_ref Main//int_ops, inst+372, loaded [template = constants.%Uint32ToInt64]
-// CHECK:STDOUT:   %import_ref.19: %Uint32ToUint64.type = import_ref Main//int_ops, inst+391, loaded [template = constants.%Uint32ToUint64]
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3: %AddU32.type = import_ref Main//int_ops, AddU32, loaded [template = constants.%AddU32]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18: %Uint32ToInt64.type = import_ref Main//int_ops, Uint32ToInt64, loaded [template = constants.%Uint32ToInt64]
+// CHECK:STDOUT:   %import_ref.19: %Uint32ToUint64.type = import_ref Main//int_ops, Uint32ToUint64, loaded [template = constants.%Uint32ToUint64]
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -1830,27 +1830,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, inst+30, loaded [template = constants.%NegateI32]
-// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, inst+57, loaded [template = constants.%SubI32]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16: %Int32ToInt64.type = import_ref Main//int_ops, inst+333, loaded [template = constants.%Int32ToInt64]
-// CHECK:STDOUT:   %import_ref.17: %Int32ToUint64.type = import_ref Main//int_ops, inst+353, loaded [template = constants.%Int32ToUint64]
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, NegateI32, loaded [template = constants.%NegateI32]
+// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, SubI32, loaded [template = constants.%SubI32]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16: %Int32ToInt64.type = import_ref Main//int_ops, Int32ToInt64, loaded [template = constants.%Int32ToInt64]
+// CHECK:STDOUT:   %import_ref.17: %Int32ToUint64.type = import_ref Main//int_ops, Int32ToUint64, loaded [template = constants.%Int32ToUint64]
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2018,27 +2018,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3: %AddU32.type = import_ref Main//int_ops, inst+93, loaded [template = constants.%AddU32]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7: %Uint32ToInt32.type = import_ref Main//int_ops, inst+157, loaded [template = constants.%Uint32ToInt32]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3: %AddU32.type = import_ref Main//int_ops, AddU32, loaded [template = constants.%AddU32]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7: %Uint32ToInt32.type = import_ref Main//int_ops, Uint32ToInt32, loaded [template = constants.%Uint32ToInt32]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2146,27 +2146,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, inst+216, loaded [template = constants.%Int32ToInt16]
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, Int32ToInt16, loaded [template = constants.%Int32ToInt16]
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2251,27 +2251,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11: %Int32ToUint16.type = import_ref Main//int_ops, inst+236, loaded [template = constants.%Int32ToUint16]
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11: %Int32ToUint16.type = import_ref Main//int_ops, Int32ToUint16, loaded [template = constants.%Int32ToUint16]
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2360,27 +2360,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12: %Uint32ToInt16.type = import_ref Main//int_ops, inst+255, loaded [template = constants.%Uint32ToInt16]
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12: %Uint32ToInt16.type = import_ref Main//int_ops, Uint32ToInt16, loaded [template = constants.%Uint32ToInt16]
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2475,27 +2475,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13: %Uint32ToUint16.type = import_ref Main//int_ops, inst+274, loaded [template = constants.%Uint32ToUint16]
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13: %Uint32ToUint16.type = import_ref Main//int_ops, Uint32ToUint16, loaded [template = constants.%Uint32ToUint16]
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2593,27 +2593,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, inst+57, loaded [template = constants.%SubI32]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11: %Int32ToUint16.type = import_ref Main//int_ops, inst+236, loaded [template = constants.%Int32ToUint16]
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, SubI32, loaded [template = constants.%SubI32]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11: %Int32ToUint16.type = import_ref Main//int_ops, Int32ToUint16, loaded [template = constants.%Int32ToUint16]
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2717,27 +2717,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, inst+57, loaded [template = constants.%SubI32]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, inst+138, loaded [template = constants.%Int32ToUint32]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, SubI32, loaded [template = constants.%SubI32]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6: %Int32ToUint32.type = import_ref Main//int_ops, Int32ToUint32, loaded [template = constants.%Int32ToUint32]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2842,27 +2842,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, inst+57, loaded [template = constants.%SubI32]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, inst+216, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17: %Int32ToUint64.type = import_ref Main//int_ops, inst+353, loaded [template = constants.%Int32ToUint64]
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2: %SubI32.type = import_ref Main//int_ops, SubI32, loaded [template = constants.%SubI32]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//int_ops, Int32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17: %Int32ToUint64.type = import_ref Main//int_ops, Int32ToUint64, loaded [template = constants.%Int32ToUint64]
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .UInt = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -2963,27 +2963,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, inst+30, loaded [template = constants.%NegateI32]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, inst+119, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, inst+216, loaded [template = constants.%Int32ToInt16]
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, inst+333, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1: %NegateI32.type = import_ref Main//int_ops, NegateI32, loaded [template = constants.%NegateI32]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//int_ops, Int32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, Int32ToInt16, loaded [template = constants.%Int32ToInt16]
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//int_ops, Int32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23
@@ -3079,27 +3079,27 @@ let convert_not_constant_widen: i64 = Int32ToInt64(not_constant);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, inst+57, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, inst+93, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, inst+100, unloaded
-// CHECK:STDOUT:   %import_ref.5: %Int32ToInt32.type = import_ref Main//int_ops, inst+119, loaded [template = constants.%Int32ToInt32]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, inst+138, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, inst+157, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, inst+176, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, inst+195, unloaded
-// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, inst+216, loaded [template = constants.%Int32ToInt16]
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, inst+236, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, inst+255, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, inst+274, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, inst+293, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, inst+312, unloaded
-// CHECK:STDOUT:   %import_ref.16: %Int32ToInt64.type = import_ref Main//int_ops, inst+333, loaded [template = constants.%Int32ToInt64]
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, inst+353, unloaded
-// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, inst+372, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, inst+391, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, inst+410, unloaded
-// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, inst+429, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//int_ops, NegateI32, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//int_ops, SubI32, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//int_ops, AddU32, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//int_ops, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.5: %Int32ToInt32.type = import_ref Main//int_ops, Int32ToInt32, loaded [template = constants.%Int32ToInt32]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//int_ops, Int32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//int_ops, Uint32ToInt32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//int_ops, Uint32ToUint32, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//int_ops, IntLiteralToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.10: %Int32ToInt16.type = import_ref Main//int_ops, Int32ToInt16, loaded [template = constants.%Int32ToInt16]
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//int_ops, Int32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//int_ops, Uint32ToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//int_ops, Uint32ToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//int_ops, IntLiteralToInt16, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//int_ops, IntLiteralToUint16, unloaded
+// CHECK:STDOUT:   %import_ref.16: %Int32ToInt64.type = import_ref Main//int_ops, Int32ToInt64, loaded [template = constants.%Int32ToInt64]
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//int_ops, Int32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref Main//int_ops, Uint32ToInt64, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref Main//int_ops, Uint32ToUint64, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//int_ops, Int32ToIntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.21 = import_ref Main//int_ops, Uint32ToUintLiteral, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.22
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.23

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -163,8 +163,8 @@ var m: Int(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Main//types, inst+7, loaded [template = constants.%IntLiteral]
-// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, inst+23, loaded [template = constants.%Int]
+// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Main//types, IntLiteral, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, Int, loaded [template = constants.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -321,11 +321,11 @@ var m: Int(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, inst+23, loaded [template = constants.%Int]
-// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref Main//use_types, inst+34, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.4: %G.type = import_ref Main//use_types, inst+59, loaded [template = constants.%G]
-// CHECK:STDOUT:   %import_ref.5: %Symbolic.type = import_ref Main//use_types, inst+98, loaded [template = constants.%Symbolic]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, Int, loaded [template = constants.%Int]
+// CHECK:STDOUT:   %import_ref.3: %F.type = import_ref Main//use_types, F, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.4: %G.type = import_ref Main//use_types, G, loaded [template = constants.%G]
+// CHECK:STDOUT:   %import_ref.5: %Symbolic.type = import_ref Main//use_types, Symbolic, loaded [template = constants.%Symbolic]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -482,8 +482,8 @@ var m: Int(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, inst+23, loaded [template = constants.%Int]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, Int, loaded [template = constants.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -540,8 +540,8 @@ var m: Int(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %Int.type.2 = import_ref Main//types, inst+23, loaded [template = constants.%Int.2]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %Int.type.2 = import_ref Main//types, Int, loaded [template = constants.%Int.2]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.3
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.4
@@ -617,8 +617,8 @@ var m: Int(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, inst+23, loaded [template = constants.%Int]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Main//types, Int, loaded [template = constants.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -144,8 +144,8 @@ var m: UInt(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Main//types, inst+7, loaded [template = constants.%IntLiteral]
-// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, inst+23, loaded [template = constants.%UInt]
+// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Main//types, IntLiteral, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, UInt, loaded [template = constants.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -281,8 +281,8 @@ var m: UInt(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, inst+23, loaded [template = constants.%UInt]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, UInt, loaded [template = constants.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -339,8 +339,8 @@ var m: UInt(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, inst+23, loaded [template = constants.%UInt]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, UInt, loaded [template = constants.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.3
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.4
@@ -416,8 +416,8 @@ var m: UInt(1000000000);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, inst+23, loaded [template = constants.%UInt]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//types, IntLiteral, unloaded
+// CHECK:STDOUT:   %import_ref.2: %UInt.type = import_ref Main//types, UInt, loaded [template = constants.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/builtins/int_literal/make_type.carbon
+++ b/toolchain/check/testdata/builtins/int_literal/make_type.carbon
@@ -61,7 +61,7 @@ var i: IntLiteral();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %IntLiteral.type = import_ref Main//types, inst+7, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref: %IntLiteral.type = import_ref Main//types, IntLiteral, loaded [template = constants.%IntLiteral]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/builtins/print.carbon
+++ b/toolchain/check/testdata/builtins/print.carbon
@@ -52,7 +52,7 @@ fn Main() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.38: %Print.type.2 = import_ref Core//prelude, inst+54, loaded [template = constants.%Print.2]
+// CHECK:STDOUT:   %import_ref.38: %Print.type.2 = import_ref Core//prelude, Print, loaded [template = constants.%Print.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/adapter/extend_adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/extend_adapt.carbon
@@ -611,7 +611,7 @@ fn F(a: IntAdapter) -> i32 {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, inst+7, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, IntLiteral, loaded [template = constants.%IntLiteral]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -201,9 +201,9 @@ var c: Other.C = {};
 // CHECK:STDOUT:     .C = %import_ref.1
 // CHECK:STDOUT:     import Other//other_define
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//other_define, inst+3, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//other_define, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//other_define, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//other_define, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//other_define, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//other_define, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -251,7 +251,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:     .C = %import_ref
 // CHECK:STDOUT:     import Other//other_extern
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref Other//other_extern, inst+3, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref: type = import_ref Other//other_extern, C, loaded [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -296,9 +296,9 @@ var c: Other.C = {};
 // CHECK:STDOUT:     import Other//other_define
 // CHECK:STDOUT:     import Other//other_extern
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//other_define, inst+3, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//other_define, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//other_define, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//other_define, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//other_define, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//other_define, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -349,9 +349,9 @@ var c: Other.C = {};
 // CHECK:STDOUT:     import Other//other_define
 // CHECK:STDOUT:     import Other//other_conflict
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//other_define, inst+3, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//other_define, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//other_define, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//other_define, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//other_define, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//other_define, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -91,14 +91,14 @@ var a: Incomplete;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+3, loaded [template = constants.%Empty]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, inst+8, loaded [template = constants.%Incomplete]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, Empty, loaded [template = constants.%Empty]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, Incomplete, loaded [template = constants.%Incomplete]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//a, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//a, loc5_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/generic/adapt.carbon
+++ b/toolchain/check/testdata/class/generic/adapt.carbon
@@ -286,19 +286,19 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref Main//adapt_specific_type, inst+9, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//adapt_specific_type, inst+26, loaded [template = constants.%Adapter]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//adapt_specific_type, inst+64, unloaded
+// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref Main//adapt_specific_type, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//adapt_specific_type, Adapter, loaded [template = constants.%Adapter]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//adapt_specific_type, Access, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.10
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//adapt_specific_type, inst+20, loaded [symbolic = @C.%complete_type (constants.%complete_type.1)]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//adapt_specific_type, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.6: @C.%C.elem (%C.elem.1) = import_ref Main//adapt_specific_type, inst+18, loaded [template = %.1]
-// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref Main//adapt_specific_type, inst+50, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//adapt_specific_type, inst+27, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//adapt_specific_type, loc6_1, loaded [symbolic = @C.%complete_type (constants.%complete_type.1)]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//adapt_specific_type, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: @C.%C.elem (%C.elem.1) = import_ref Main//adapt_specific_type, loc5_8, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref Main//adapt_specific_type, loc10_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//adapt_specific_type, inst39 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -655,20 +655,20 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_adapt_specific_type_library, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//extend_adapt_specific_type_library, inst+26, loaded [template = constants.%Adapter]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_adapt_specific_type_library, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//extend_adapt_specific_type_library, Adapter, loaded [template = constants.%Adapter]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.10
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.11
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//extend_adapt_specific_type_library, inst+20, loaded [symbolic = @C.%complete_type (constants.%complete_type.1)]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extend_adapt_specific_type_library, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.5: @C.%C.elem (%C.elem.1) = import_ref Main//extend_adapt_specific_type_library, inst+18, loaded [template = %.1]
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//extend_adapt_specific_type_library, inst+50, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//extend_adapt_specific_type_library, inst+27, unloaded
-// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//extend_adapt_specific_type_library, inst+43, loaded [template = constants.%C.2]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//extend_adapt_specific_type_library, loc9_1, loaded [symbolic = @C.%complete_type (constants.%complete_type.1)]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extend_adapt_specific_type_library, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5: @C.%C.elem (%C.elem.1) = import_ref Main//extend_adapt_specific_type_library, loc8_8, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//extend_adapt_specific_type_library, loc13_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//extend_adapt_specific_type_library, inst39 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//extend_adapt_specific_type_library, loc12_21, loaded [template = constants.%C.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -887,15 +887,15 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Adapter.type = import_ref Main//adapt_generic_type, inst+9, loaded [template = constants.%Adapter.generic]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//adapt_generic_type, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.1: %Adapter.type = import_ref Main//adapt_generic_type, Adapter, loaded [template = constants.%Adapter.generic]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//adapt_generic_type, Convert, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.6
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//adapt_generic_type, inst+18, loaded [symbolic = @Adapter.%complete_type (constants.%complete_type.1)]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//adapt_generic_type, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//adapt_generic_type, loc6_1, loaded [symbolic = @Adapter.%complete_type (constants.%complete_type.1)]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//adapt_generic_type, inst27 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/generic/base_is_generic.carbon
+++ b/toolchain/check/testdata/class/generic/base_is_generic.carbon
@@ -272,25 +272,25 @@ fn H() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_generic_base, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//extend_generic_base, inst+26, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//extend_generic_base, inst+47, loaded [template = constants.%Derived]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extend_generic_base, inst+77, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_generic_base, Base, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//extend_generic_base, Param, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//extend_generic_base, Derived, loaded [template = constants.%Derived]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extend_generic_base, DoubleFieldAccess, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.16
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//extend_generic_base, inst+45, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//extend_generic_base, inst+27, unloaded
-// CHECK:STDOUT:   %import_ref.7: %Param.elem = import_ref Main//extend_generic_base, inst+43, loaded [template = %.1]
-// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref Main//extend_generic_base, inst+20, loaded [symbolic = @Base.%complete_type (constants.%complete_type.2)]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//extend_generic_base, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.10: @Base.%Base.elem (%Base.elem.1) = import_ref Main//extend_generic_base, inst+18, loaded [template = %.2]
-// CHECK:STDOUT:   %import_ref.12: <witness> = import_ref Main//extend_generic_base, inst+62, loaded [template = constants.%complete_type.3]
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//extend_generic_base, inst+48, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//extend_generic_base, inst+60, unloaded
-// CHECK:STDOUT:   %import_ref.15: type = import_ref Main//extend_generic_base, inst+51, loaded [template = constants.%Base.2]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//extend_generic_base, loc10_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//extend_generic_base, inst39 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: %Param.elem = import_ref Main//extend_generic_base, loc9_8, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref Main//extend_generic_base, loc6_1, loaded [symbolic = @Base.%complete_type (constants.%complete_type.2)]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//extend_generic_base, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.10: @Base.%Base.elem (%Base.elem.1) = import_ref Main//extend_generic_base, loc5_8, loaded [template = %.2]
+// CHECK:STDOUT:   %import_ref.12: <witness> = import_ref Main//extend_generic_base, loc14_1, loaded [template = constants.%complete_type.3]
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//extend_generic_base, inst60 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//extend_generic_base, loc13_27, unloaded
+// CHECK:STDOUT:   %import_ref.15: type = import_ref Main//extend_generic_base, loc13_26, loaded [template = constants.%Base.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -779,21 +779,21 @@ fn H() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_generic_symbolic_base, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.2: %C.type = import_ref Main//extend_generic_symbolic_base, inst+47, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//extend_generic_symbolic_base, inst+70, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_generic_symbolic_base, X, unloaded
+// CHECK:STDOUT:   %import_ref.2: %C.type = import_ref Main//extend_generic_symbolic_base, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//extend_generic_symbolic_base, F, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.4
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//extend_generic_symbolic_base, inst+26, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//extend_generic_symbolic_base, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.7: @X.%G.type (%G.type.1) = import_ref Main//extend_generic_symbolic_base, inst+21, loaded [symbolic = @X.%G (constants.%G.1)]
-// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref Main//extend_generic_symbolic_base, inst+63, loaded [symbolic = @C.%complete_type (constants.%complete_type.2)]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//extend_generic_symbolic_base, inst+52, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//extend_generic_symbolic_base, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.12: type = import_ref Main//extend_generic_symbolic_base, inst+55, loaded [symbolic = @C.%X (constants.%X.2)]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//extend_generic_symbolic_base, loc6_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//extend_generic_symbolic_base, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: @X.%G.type (%G.type.1) = import_ref Main//extend_generic_symbolic_base, loc5_15, loaded [symbolic = @X.%G (constants.%G.1)]
+// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref Main//extend_generic_symbolic_base, loc10_1, loaded [symbolic = @C.%complete_type (constants.%complete_type.2)]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//extend_generic_symbolic_base, inst64 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//extend_generic_symbolic_base, loc9_20, unloaded
+// CHECK:STDOUT:   %import_ref.12: type = import_ref Main//extend_generic_symbolic_base, loc9_19, loaded [symbolic = @C.%X (constants.%X.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -294,17 +294,17 @@ class Class(U:! type) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref Main//foo, inst+20, loaded [template = constants.%CompleteClass.generic]
+// CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref Main//foo, CompleteClass, loaded [template = constants.%CompleteClass.generic]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.42
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.43
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.38: <witness> = import_ref Main//foo, inst+54, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.39 = import_ref Main//foo, inst+25, unloaded
-// CHECK:STDOUT:   %import_ref.40 = import_ref Main//foo, inst+41, unloaded
-// CHECK:STDOUT:   %import_ref.41 = import_ref Main//foo, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.38: <witness> = import_ref Main//foo, loc9_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.39 = import_ref Main//foo, inst37 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.40 = import_ref Main//foo, loc7_8, unloaded
+// CHECK:STDOUT:   %import_ref.41 = import_ref Main//foo, loc8_17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -472,18 +472,18 @@ class Class(U:! type) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//foo, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref Main//foo, inst+20, loaded [template = constants.%CompleteClass.generic]
-// CHECK:STDOUT:   %import_ref.3: %F.type.3 = import_ref Main//foo, inst+362, loaded [template = constants.%F.3]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//foo, Class, unloaded
+// CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref Main//foo, CompleteClass, loaded [template = constants.%CompleteClass.generic]
+// CHECK:STDOUT:   %import_ref.3: %F.type.3 = import_ref Main//foo, F, loaded [template = constants.%F.3]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.4
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//foo, inst+54, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//foo, inst+25, unloaded
-// CHECK:STDOUT:   %import_ref.7: @CompleteClass.%CompleteClass.elem (%CompleteClass.elem.1) = import_ref Main//foo, inst+41, loaded [template = %.1]
-// CHECK:STDOUT:   %import_ref.8: @CompleteClass.%F.type (%F.type.1) = import_ref Main//foo, inst+50, loaded [symbolic = @CompleteClass.%F (constants.%F.1)]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//foo, loc9_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//foo, inst37 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: @CompleteClass.%CompleteClass.elem (%CompleteClass.elem.1) = import_ref Main//foo, loc7_8, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.8: @CompleteClass.%F.type (%F.type.1) = import_ref Main//foo, loc8_17, loaded [symbolic = @CompleteClass.%F (constants.%F.1)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -659,19 +659,19 @@ class Class(U:! type) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//foo, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref Main//foo, inst+20, loaded [template = constants.%CompleteClass.generic]
-// CHECK:STDOUT:   %import_ref.3: %F.type.3 = import_ref Main//foo, inst+362, loaded [template = constants.%F.3]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//foo, Class, unloaded
+// CHECK:STDOUT:   %import_ref.2: %CompleteClass.type = import_ref Main//foo, CompleteClass, loaded [template = constants.%CompleteClass.generic]
+// CHECK:STDOUT:   %import_ref.3: %F.type.3 = import_ref Main//foo, F, loaded [template = constants.%F.3]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.8
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.9
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//foo, inst+54, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//foo, inst+25, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//foo, inst+41, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//foo, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//foo, loc9_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//foo, inst37 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//foo, loc7_8, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//foo, loc8_17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -788,9 +788,9 @@ class Class(U:! type) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Class.type = import_ref Main//foo, inst+9, loaded [template = constants.%Class.generic]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//foo, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//foo, inst+362, unloaded
+// CHECK:STDOUT:   %import_ref.1: %Class.type = import_ref Main//foo, Class, loaded [template = constants.%Class.generic]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//foo, CompleteClass, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//foo, F, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -194,28 +194,28 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+3, loaded [template = constants.%Empty]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, inst+8, loaded [template = constants.%Field]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, inst+30, loaded [template = constants.%ForwardDeclared.1]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//a, inst+53, loaded [template = constants.%Incomplete]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, Empty, loaded [template = constants.%Empty]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, Field, loaded [template = constants.%Field]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, ForwardDeclared, loaded [template = constants.%ForwardDeclared.1]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//a, Incomplete, loaded [template = constants.%Incomplete]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.10
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//a, inst+6, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//a, inst+28, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//a, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.9: %Field.elem = import_ref Main//a, inst+26, loaded [template = %.1]
-// CHECK:STDOUT:   %import_ref.46: <witness> = import_ref Main//a, inst+52, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.47 = import_ref Main//a, inst+31, unloaded
-// CHECK:STDOUT:   %import_ref.48: %F.type = import_ref Main//a, inst+38, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.49: %G.type = import_ref Main//a, inst+49, loaded [template = constants.%G]
-// CHECK:STDOUT:   %import_ref.50: <witness> = import_ref Main//a, inst+52, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.51 = import_ref Main//a, inst+31, unloaded
-// CHECK:STDOUT:   %import_ref.52 = import_ref Main//a, inst+38, unloaded
-// CHECK:STDOUT:   %import_ref.53 = import_ref Main//a, inst+49, unloaded
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//a, loc5_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//a, loc9_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//a, inst21 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9: %Field.elem = import_ref Main//a, loc8_8, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.46: <witness> = import_ref Main//a, loc16_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.47 = import_ref Main//a, inst43 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.48: %F.type = import_ref Main//a, loc14_21, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.49: %G.type = import_ref Main//a, loc15_27, loaded [template = constants.%G]
+// CHECK:STDOUT:   %import_ref.50: <witness> = import_ref Main//a, loc16_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.51 = import_ref Main//a, inst43 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.52 = import_ref Main//a, loc14_21, unloaded
+// CHECK:STDOUT:   %import_ref.53 = import_ref Main//a, loc15_27, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -330,5 +330,5 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self.param_patt: %ForwardDeclared.1]() [from "a.carbon"];
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G[addr <unexpected>.inst+389: %ptr.3]() [from "a.carbon"];
+// CHECK:STDOUT: fn @G[addr <unexpected>.inst401: %ptr.3]() [from "a.carbon"];
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -170,23 +170,23 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, inst+46, loaded [template = constants.%Child]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, Base, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, Child, loaded [template = constants.%Child]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.14
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//a, inst+44, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.5: %F.type = import_ref Main//a, inst+10, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.7: %Base.elem = import_ref Main//a, inst+37, loaded [template = %.1]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//a, inst+42, unloaded
-// CHECK:STDOUT:   %import_ref.10: <witness> = import_ref Main//a, inst+53, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//a, inst+47, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//a, inst+51, unloaded
-// CHECK:STDOUT:   %import_ref.13: type = import_ref Main//a, inst+48, loaded [template = constants.%Base]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//a, loc10_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5: %F.type = import_ref Main//a, loc5_21, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, loc6_26, unloaded
+// CHECK:STDOUT:   %import_ref.7: %Base.elem = import_ref Main//a, loc8_8, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//a, loc9_13, unloaded
+// CHECK:STDOUT:   %import_ref.10: <witness> = import_ref Main//a, loc14_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//a, inst59 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//a, loc13_20, unloaded
+// CHECK:STDOUT:   %import_ref.13: type = import_ref Main//a, loc13_16, loaded [template = constants.%Base]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/import_indirect.carbon
+++ b/toolchain/check/testdata/class/import_indirect.carbon
@@ -143,13 +143,13 @@ var ptr: E* = &val;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+3, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, C, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -202,13 +202,13 @@ var ptr: E* = &val;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+3, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, C, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -261,16 +261,16 @@ var ptr: E* = &val;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+3, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//b, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//b, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//b, inst+27, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//b, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//b, b_val, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//b, b_ptr, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//a, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//a, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -323,16 +323,16 @@ var ptr: E* = &val;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//b, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//b, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//b, inst+27, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//a, inst+3, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//b, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//b, b_val, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//b, b_ptr, unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//a, C, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//a, inst+6, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//a, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -385,18 +385,18 @@ var ptr: E* = &val;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//b, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//b, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//b, inst+27, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//c, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//c, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//c, inst+27, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//b, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//b, b_val, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//b, b_ptr, unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//c, E, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//c, c_val, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//c, c_ptr, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//b, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//b, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//b, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//b, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -451,18 +451,18 @@ var ptr: E* = &val;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//c, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst+27, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//b, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//b, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//b, inst+27, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, E, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//c, c_val, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, c_ptr, unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//b, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//b, b_val, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//b, b_ptr, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//b, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//b, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//b, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//b, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/import_member_cycle.carbon
+++ b/toolchain/check/testdata/class/import_member_cycle.carbon
@@ -76,14 +76,14 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+3, loaded [template = constants.%Cycle]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, Cycle, loaded [template = constants.%Cycle]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, inst+11, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/import_struct_cyle.carbon
+++ b/toolchain/check/testdata/class/import_struct_cyle.carbon
@@ -92,15 +92,15 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref %struct_type.b = import_ref Main//a, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, Cycle, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref %struct_type.b = import_ref Main//a, a, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//a, inst+19, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.5: %Cycle.elem = import_ref Main//a, inst+17, loaded [template = %.1]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//a, loc11_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5: %Cycle.elem = import_ref Main//a, loc10_8, loaded [template = %.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/class/no_prelude/export_name.carbon
@@ -70,9 +70,9 @@ var c: C = {};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -99,9 +99,9 @@ var c: C = {};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+9, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export, inst+7, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export, inst19 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export, inst20 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/class/no_prelude/extern.carbon
@@ -495,7 +495,7 @@ extern class C;
 // CHECK:STDOUT: --- fail_import_extern_decl_then_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -508,7 +508,7 @@ extern class C;
 // CHECK:STDOUT: --- fail_import_decl_then_extern_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//decl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//decl, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -521,7 +521,7 @@ extern class C;
 // CHECK:STDOUT: --- fail_import_extern_decl_then_def.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -534,7 +534,7 @@ extern class C;
 // CHECK:STDOUT: --- fail_import_ownership_conflict.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -547,7 +547,7 @@ extern class C;
 // CHECK:STDOUT: --- fail_todo_import_extern_decl_copy.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_decl, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -604,8 +604,8 @@ extern class C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//def, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//def, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -631,8 +631,8 @@ extern class C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//def, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//def, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
@@ -155,8 +155,8 @@ class B {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//redecl_after_def, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//redecl_after_def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//redecl_after_def, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//redecl_after_def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -207,9 +207,9 @@ class B {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//redef_after_def, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//redef_after_def, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//redef_after_def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//redef_after_def, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//redef_after_def, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//redef_after_def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -263,8 +263,8 @@ class B {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//def_alias, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//def_alias, inst+4, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//def_alias, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//def_alias, B, loaded [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/class/no_prelude/import_access.carbon
@@ -207,9 +207,9 @@ private class Redecl {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//def, inst+1, loaded [template = constants.%Def]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Test//def, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Test//def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//def, Def, loaded [template = constants.%Def]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Test//def, loc4_20, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Test//def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -303,9 +303,9 @@ private class Redecl {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//forward_with_def, inst+1, loaded [template = constants.%ForwardWithDef]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Test//forward_with_def, inst+5, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Test//forward_with_def, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//forward_with_def, ForwardWithDef, loaded [template = constants.%ForwardWithDef]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Test//forward_with_def, loc6_23, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Test//forward_with_def, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -401,7 +401,7 @@ private class Redecl {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: type = import_ref Test//forward, inst+1, loaded [template = constants.%Forward]
+// CHECK:STDOUT:   %import_ref: type = import_ref Test//forward, Forward, loaded [template = constants.%Forward]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
+++ b/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
@@ -135,7 +135,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//a, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//a, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -154,10 +154,10 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//a, loc5_10, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -178,7 +178,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT: --- d.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//c, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//c, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -198,10 +198,10 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst+7, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//c, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst19 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst20 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//c, inst21 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -235,7 +235,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT: --- f.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//e, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//e, D, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -257,10 +257,10 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Main//a, inst+3, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//a, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Main//a, loc5_10, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -305,10 +305,10 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst+7, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Main//c, inst+9, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst19 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst20 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Main//c, inst21 [indirect], loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -353,10 +353,10 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst+7, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Main//c, inst+9, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst19 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst20 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Main//c, inst21 [indirect], loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -402,13 +402,13 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//e, inst+3, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//e, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst+10, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst+12, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//e, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, loc8_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//e, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, loc7_9, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst22 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst23 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst24 [indirect], loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -462,13 +462,13 @@ var x: () = D.C.F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//e, inst+3, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//e, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst+10, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst+12, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//e, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//e, loc8_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//e, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//e, loc7_9, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//e, inst22 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//e, inst23 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: %F.type = import_ref Main//e, inst24 [indirect], loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
@@ -124,7 +124,7 @@ class D;
 // CHECK:STDOUT: --- use_decl_in_api.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//decl_in_api_definition_in_impl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//decl_in_api_definition_in_impl, A, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -153,7 +153,7 @@ class D;
 // CHECK:STDOUT: --- decl_only_in_api.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//decl_only_in_api, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//decl_only_in_api, B, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
@@ -587,10 +587,10 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//two_file, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//two_file, inst+7, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//two_file, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//two_file, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//two_file, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//two_file, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//two_file, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//two_file, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -976,9 +976,9 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//alias_two_file, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//alias_two_file, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//alias_two_file, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//alias_two_file, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//alias_two_file, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//alias_two_file, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/virtual_modifiers.carbon
+++ b/toolchain/check/testdata/class/virtual_modifiers.carbon
@@ -204,10 +204,10 @@ class Derived {
 // CHECK:STDOUT:     .Base = %import_ref.1
 // CHECK:STDOUT:     import Modifiers//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Modifiers//default, inst+3, loaded [template = constants.%Base]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Modifiers//default, inst+11, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Modifiers//default, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Modifiers//default, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Modifiers//default, Base, loaded [template = constants.%Base]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Modifiers//default, loc6_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Modifiers//default, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Modifiers//default, loc5_17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -266,10 +266,10 @@ class Derived {
 // CHECK:STDOUT:     .Base = %import_ref.1
 // CHECK:STDOUT:     import Modifiers//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Modifiers//default, inst+3, loaded [template = constants.%Base]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Modifiers//default, inst+11, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Modifiers//default, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Modifiers//default, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Modifiers//default, Base, loaded [template = constants.%Base]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Modifiers//default, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Modifiers//default, inst16 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Modifiers//default, loc5_17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/const/import.carbon
+++ b/toolchain/check/testdata/const/import.carbon
@@ -109,9 +109,9 @@ var a_ptr: const i32* = a_ptr_ref;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref %const = import_ref Implicit//default, inst+33, loaded
-// CHECK:STDOUT:   %import_ref.3: ref %ptr = import_ref Implicit//default, inst+45, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, F, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref %const = import_ref Implicit//default, a_ref, loaded
+// CHECK:STDOUT:   %import_ref.3: ref %ptr = import_ref Implicit//default, a_ptr_ref, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.4
 // CHECK:STDOUT:     import Core//prelude

--- a/toolchain/check/testdata/deduce/int_float.carbon
+++ b/toolchain/check/testdata/deduce/int_float.carbon
@@ -62,8 +62,8 @@ fn G(a: f64) -> Core.IntLiteral() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, inst+7, loaded [template = constants.%IntLiteral]
-// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Core//prelude/types, inst+23, loaded [template = constants.%Int]
+// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, IntLiteral, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Core//prelude/types, Int, loaded [template = constants.%Int]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -188,8 +188,8 @@ fn G(a: f64) -> Core.IntLiteral() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, inst+7, loaded [template = constants.%IntLiteral]
-// CHECK:STDOUT:   %import_ref.2: %Float.type = import_ref Core//prelude/types, inst+53, loaded [template = constants.%Float]
+// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, IntLiteral, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.2: %Float.type = import_ref Core//prelude/types, Float, loaded [template = constants.%Float]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
@@ -659,29 +659,29 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.31
 // CHECK:STDOUT:     import Core//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3 = import_ref Core//default, inst+70, unloaded
-// CHECK:STDOUT:   %import_ref.4: @As.%Convert.assoc_type (%Convert.assoc_type.1) = import_ref Core//default, inst+94, loaded [symbolic = @As.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Core//default, inst+86, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Core//default, inst+86, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Core//default, inst+26, unloaded
-// CHECK:STDOUT:   %import_ref.9: %Op.assoc_type = import_ref Core//default, inst+56, loaded [template = constants.%assoc0.7]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Core//default, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.11: type = import_ref Core//default, inst+149, loaded [template = constants.%i32]
-// CHECK:STDOUT:   %import_ref.12: type = import_ref Core//default, inst+150, loaded [template = constants.%Add.type]
-// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref Core//default, inst+171, loaded [template = constants.%interface.2]
-// CHECK:STDOUT:   %import_ref.14: type = import_ref Core//default, inst+176, loaded [template = Core.IntLiteral]
-// CHECK:STDOUT:   %import_ref.15: type = import_ref Core//default, inst+182, loaded [template = constants.%As.type.3]
-// CHECK:STDOUT:   %import_ref.16: <witness> = import_ref Core//default, inst+206, loaded [template = constants.%interface.1]
-// CHECK:STDOUT:   %import_ref.17 = import_ref Core//default, inst+112, unloaded
-// CHECK:STDOUT:   %import_ref.18: @ImplicitAs.%Convert.assoc_type (%Convert.assoc_type.3) = import_ref Core//default, inst+136, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.8)]
-// CHECK:STDOUT:   %import_ref.19 = import_ref Core//default, inst+128, unloaded
-// CHECK:STDOUT:   %import_ref.20: type = import_ref Core//default, inst+211, loaded [template = Core.IntLiteral]
-// CHECK:STDOUT:   %import_ref.21: type = import_ref Core//default, inst+217, loaded [template = constants.%ImplicitAs.type.3]
-// CHECK:STDOUT:   %import_ref.22: <witness> = import_ref Core//default, inst+241, loaded [template = constants.%interface.4]
-// CHECK:STDOUT:   %import_ref.23 = import_ref Core//default, inst+128, unloaded
-// CHECK:STDOUT:   %import_ref.25: type = import_ref Core//default, inst+246, loaded [template = constants.%i32]
-// CHECK:STDOUT:   %import_ref.26: type = import_ref Core//default, inst+252, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.27: <witness> = import_ref Core//default, inst+276, loaded [template = constants.%interface.3]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Core//default, inst82 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: @As.%Convert.assoc_type (%Convert.assoc_type.1) = import_ref Core//default, loc12_32, loaded [symbolic = @As.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Core//default, Convert, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Core//default, loc12_32, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Core//default, inst38 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9: %Op.assoc_type = import_ref Core//default, loc8_41, loaded [template = constants.%assoc0.7]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Core//default, Op, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref Core//default, loc19_6, loaded [template = constants.%i32]
+// CHECK:STDOUT:   %import_ref.12: type = import_ref Core//default, loc19_13, loaded [template = constants.%Add.type]
+// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref Core//default, loc19_17, loaded [template = constants.%interface.2]
+// CHECK:STDOUT:   %import_ref.14: type = import_ref Core//default, loc23_17, loaded [template = Core.IntLiteral]
+// CHECK:STDOUT:   %import_ref.15: type = import_ref Core//default, loc23_28, loaded [template = constants.%As.type.3]
+// CHECK:STDOUT:   %import_ref.16: <witness> = import_ref Core//default, loc23_30, loaded [template = constants.%interface.1]
+// CHECK:STDOUT:   %import_ref.17 = import_ref Core//default, inst124 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.18: @ImplicitAs.%Convert.assoc_type (%Convert.assoc_type.3) = import_ref Core//default, loc16_32, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.8)]
+// CHECK:STDOUT:   %import_ref.19 = import_ref Core//default, Convert, unloaded
+// CHECK:STDOUT:   %import_ref.20: type = import_ref Core//default, loc27_17, loaded [template = Core.IntLiteral]
+// CHECK:STDOUT:   %import_ref.21: type = import_ref Core//default, loc27_36, loaded [template = constants.%ImplicitAs.type.3]
+// CHECK:STDOUT:   %import_ref.22: <witness> = import_ref Core//default, loc27_38, loaded [template = constants.%interface.4]
+// CHECK:STDOUT:   %import_ref.23 = import_ref Core//default, loc16_32, unloaded
+// CHECK:STDOUT:   %import_ref.25: type = import_ref Core//default, loc31_6, loaded [template = constants.%i32]
+// CHECK:STDOUT:   %import_ref.26: type = import_ref Core//default, loc31_36, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.27: <witness> = import_ref Core//default, loc31_38, loaded [template = constants.%interface.3]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/builtin/no_prelude/import.carbon
+++ b/toolchain/check/testdata/function/builtin/no_prelude/import.carbon
@@ -184,9 +184,9 @@ var arr: [i32; Core.AsIntLiteral(Core.TestAdd(Core.AsI32(1), Core.AsI32(2)))] = 
 // CHECK:STDOUT:     .AsI32 = %import_ref.4
 // CHECK:STDOUT:     import Core//core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %AsIntLiteral.type = import_ref Core//core, inst+61, loaded [template = constants.%AsIntLiteral]
-// CHECK:STDOUT:   %import_ref.3: %TestAdd.type = import_ref Core//core, inst+88, loaded [template = constants.%TestAdd]
-// CHECK:STDOUT:   %import_ref.4: %AsI32.type = import_ref Core//core, inst+42, loaded [template = constants.%AsI32]
+// CHECK:STDOUT:   %import_ref.2: %AsIntLiteral.type = import_ref Core//core, AsIntLiteral, loaded [template = constants.%AsIntLiteral]
+// CHECK:STDOUT:   %import_ref.3: %TestAdd.type = import_ref Core//core, TestAdd, loaded [template = constants.%TestAdd]
+// CHECK:STDOUT:   %import_ref.4: %AsI32.type = import_ref Core//core, AsI32, loaded [template = constants.%AsI32]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -486,15 +486,15 @@ import library "extern_api";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//api, inst+3, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//api, inst+33, loaded [template = constants.%B]
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//api, inst+58, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Main//api, inst+61, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//api, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//api, B, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//api, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Main//api, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: %E.type = import_ref Main//api, inst+65, loaded [template = constants.%E]
+// CHECK:STDOUT:   %import_ref.6: %E.type = import_ref Main//api, E, loaded [template = constants.%E]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.7
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.8
@@ -628,7 +628,7 @@ import library "extern_api";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = file.%E.decl
 // CHECK:STDOUT:   }
@@ -799,7 +799,7 @@ import library "extern_api";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//extern_api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//extern_api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = file.%E.decl
 // CHECK:STDOUT:   }
@@ -969,15 +969,15 @@ import library "extern_api";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//api, inst+3, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//api, inst+33, loaded [template = constants.%B]
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//api, inst+58, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Main//api, inst+61, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//api, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//api, B, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//api, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Main//api, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: %E.type = import_ref Main//api, inst+65, loaded [template = constants.%E]
+// CHECK:STDOUT:   %import_ref.6: %E.type = import_ref Main//api, E, loaded [template = constants.%E]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.12
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.13
@@ -1110,15 +1110,15 @@ import library "extern_api";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//extern_api, inst+3, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//extern_api, inst+33, loaded [template = constants.%B]
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//extern_api, inst+58, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Main//extern_api, inst+61, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//extern_api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//extern_api, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//extern_api, B, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//extern_api, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Main//extern_api, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//extern_api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: %E.type = import_ref Main//extern_api, inst+65, loaded [template = constants.%E]
+// CHECK:STDOUT:   %import_ref.6: %E.type = import_ref Main//extern_api, E, loaded [template = constants.%E]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.12
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.13
@@ -1221,11 +1221,11 @@ import library "extern_api";
 // CHECK:STDOUT: --- unloaded.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//api, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//api, inst+33, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//api, inst+58, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//api, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//api, A, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//api, B, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//api, C, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//api, D, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
@@ -1251,11 +1251,11 @@ import library "extern_api";
 // CHECK:STDOUT: --- unloaded_extern.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_api, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//extern_api, inst+33, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//extern_api, inst+58, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extern_api, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//extern_api, inst+64, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_api, A, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//extern_api, B, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//extern_api, C, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extern_api, D, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref Main//extern_api, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/function/declaration/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/export_name.carbon
@@ -62,7 +62,7 @@ var f: () = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %F.type = import_ref Main//base, inst+1, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref: %F.type = import_ref Main//base, F, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -84,7 +84,7 @@ var f: () = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %F.type = import_ref Main//export, inst+7, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref: %F.type = import_ref Main//export, F, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/declaration/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/extern.carbon
@@ -105,7 +105,7 @@ extern library "basic" fn F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %F.type = import_ref Main//basic, inst+1, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref: %F.type = import_ref Main//basic, F, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/declaration/no_prelude/extern_library.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/extern_library.carbon
@@ -266,7 +266,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT: --- fail_extern_library_collision.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_library, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extern_library, F, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/declaration/no_prelude/fail_import_incomplete_return.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/fail_import_incomplete_return.carbon
@@ -197,15 +197,15 @@ fn CallFAndGIncomplete() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//incomplete_return, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//incomplete_return, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: %ReturnCUnused.type = import_ref Main//incomplete_return, inst+10, loaded [template = constants.%ReturnCUnused]
-// CHECK:STDOUT:   %import_ref.4: %ReturnCUsed.type = import_ref Main//incomplete_return, inst+19, loaded [template = constants.%ReturnCUsed]
-// CHECK:STDOUT:   %import_ref.5: %ReturnDUnused.type = import_ref Main//incomplete_return, inst+27, loaded [template = constants.%ReturnDUnused]
-// CHECK:STDOUT:   %import_ref.6: %ReturnDUsed.type = import_ref Main//incomplete_return, inst+35, loaded [template = constants.%ReturnDUsed]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//incomplete_return, inst+38, unloaded
-// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref Main//incomplete_return, inst+48, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//incomplete_return, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//incomplete_return, C, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//incomplete_return, D, unloaded
+// CHECK:STDOUT:   %import_ref.3: %ReturnCUnused.type = import_ref Main//incomplete_return, ReturnCUnused, loaded [template = constants.%ReturnCUnused]
+// CHECK:STDOUT:   %import_ref.4: %ReturnCUsed.type = import_ref Main//incomplete_return, ReturnCUsed, loaded [template = constants.%ReturnCUsed]
+// CHECK:STDOUT:   %import_ref.5: %ReturnDUnused.type = import_ref Main//incomplete_return, ReturnDUnused, loaded [template = constants.%ReturnDUnused]
+// CHECK:STDOUT:   %import_ref.6: %ReturnDUsed.type = import_ref Main//incomplete_return, ReturnDUsed, loaded [template = constants.%ReturnDUsed]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//incomplete_return, Call, unloaded
+// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref Main//incomplete_return, loc37_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//incomplete_return, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/declaration/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/no_definition_in_impl_file.carbon
@@ -121,7 +121,7 @@ fn D();
 // CHECK:STDOUT: --- use_decl_in_api.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//decl_in_api_definition_in_impl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//decl_in_api_definition_in_impl, A, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn D();
 // CHECK:STDOUT: --- decl_only_in_api.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//decl_only_in_api, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//decl_only_in_api, B, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -270,10 +270,10 @@ fn D() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//fns, inst+3, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//fns, inst+34, loaded [template = constants.%B]
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//fns, inst+61, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//fns, inst+72, unloaded
+// CHECK:STDOUT:   %import_ref.1: %A.type = import_ref Main//fns, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.2: %B.type = import_ref Main//fns, B, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Main//fns, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//fns, D, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.5
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.6
@@ -365,8 +365,8 @@ fn D() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//fns, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//fns, inst+72, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//fns, C, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//fns, D, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.5
 // CHECK:STDOUT:     import Core//prelude
@@ -446,9 +446,9 @@ fn D() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//fns, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//fns, inst+34, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//fns, inst+61, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//fns, A, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//fns, B, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//fns, C, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/function/definition/import_access.carbon
+++ b/toolchain/check/testdata/function/definition/import_access.carbon
@@ -226,7 +226,7 @@ private fn Redecl() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %Def.type = import_ref Test//def, inst+3, loaded [template = constants.%Def]
+// CHECK:STDOUT:   %import_ref: %Def.type = import_ref Test//def, Def, loaded [template = constants.%Def]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -338,7 +338,7 @@ private fn Redecl() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %ForwardWithDef.type = import_ref Test//forward_with_def, inst+3, loaded [template = constants.%ForwardWithDef]
+// CHECK:STDOUT:   %import_ref: %ForwardWithDef.type = import_ref Test//forward_with_def, ForwardWithDef, loaded [template = constants.%ForwardWithDef]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -450,7 +450,7 @@ private fn Redecl() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %Forward.type = import_ref Test//forward, inst+3, loaded [template = constants.%Forward]
+// CHECK:STDOUT:   %import_ref: %Forward.type = import_ref Test//forward, Forward, loaded [template = constants.%Forward]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/function/definition/no_prelude/extern_library.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/extern_library.carbon
@@ -273,7 +273,7 @@ extern fn F() {}
 // CHECK:STDOUT: --- indirect_two_file.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//indirect_two_file_extern, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//indirect_two_file_extern, F, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/definition/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/implicit_import.carbon
@@ -352,8 +352,8 @@ fn B() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//def_alias, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: %A.type = import_ref Main//def_alias, inst+6, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//def_alias, A, unloaded
+// CHECK:STDOUT:   %import_ref.2: %A.type = import_ref Main//def_alias, B, loaded [template = constants.%A]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/definition/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/syntactic_merge.carbon
@@ -452,10 +452,10 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//two_file, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//two_file, inst+7, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//two_file, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//two_file, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//two_file, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//two_file, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//two_file, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//two_file, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -788,9 +788,9 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//alias_two_file, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//alias_two_file, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//alias_two_file, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//alias_two_file, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//alias_two_file, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//alias_two_file, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/generic/no_prelude/import_specific.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/import_specific.carbon
@@ -135,8 +135,8 @@ fn H() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Main//library, inst+7, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.2: %G.type = import_ref Main//library, inst+18, loaded [template = constants.%G]
+// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Main//library, F, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.2: %G.type = import_ref Main//library, G, loaded [template = constants.%G]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/generic/resolve_used.carbon
+++ b/toolchain/check/testdata/function/generic/resolve_used.carbon
@@ -53,8 +53,8 @@ fn CallNegative() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, inst+7, loaded [template = constants.%IntLiteral]
-// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Core//prelude/types, inst+23, loaded [template = constants.%Int]
+// CHECK:STDOUT:   %import_ref.1: %IntLiteral.type = import_ref Core//prelude/types, IntLiteral, loaded [template = constants.%IntLiteral]
+// CHECK:STDOUT:   %import_ref.2: %Int.type = import_ref Core//prelude/types, Int, loaded [template = constants.%Int]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -61,7 +61,7 @@ class C {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .x = <unexpected>.inst+18.loc23_5
+// CHECK:STDOUT:     .x = <unexpected>.inst30.loc23_5
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
@@ -78,8 +78,8 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT:   .n = <unexpected>.inst+357.loc37_8
-// CHECK:STDOUT:   complete_type_witness = <unexpected>.inst+359.loc38_1
+// CHECK:STDOUT:   .n = <unexpected>.inst369.loc37_8
+// CHECK:STDOUT:   complete_type_witness = <unexpected>.inst371.loc38_1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {

--- a/toolchain/check/testdata/impl/fail_redefinition.carbon
+++ b/toolchain/check/testdata/impl/fail_redefinition.carbon
@@ -72,6 +72,6 @@ impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: %.loc13_6.2 as %I.ref.loc13 {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <unexpected>.inst+24.loc13_15
+// CHECK:STDOUT:   witness = <unexpected>.inst36.loc13_15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -299,13 +299,13 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .HasF = %import_ref.4
 // CHECK:STDOUT:     import PackageA//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageA//default, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageA//default, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageA//default, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageA//default, inst+1, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageA//default, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref PackageA//default, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.7: %F.type.2 = import_ref PackageA//default, inst+5, loaded [template = constants.%F.2]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageA//default, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageA//default, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageA//default, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageA//default, HasF, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageA//default, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref PackageA//default, loc5_9, unloaded
+// CHECK:STDOUT:   %import_ref.7: %F.type.2 = import_ref PackageA//default, F, loaded [template = constants.%F.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -452,16 +452,16 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .HasF = %import_ref.4
 // CHECK:STDOUT:     import PackageA//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageA//default, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageA//default, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageA//default, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageA//default, inst+1, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageA//default, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref PackageA//default, inst+10, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref PackageA//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.9: type = import_ref PackageA//default, inst+17, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.10: type = import_ref PackageA//default, inst+18, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref PackageA//default, inst+24, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageA//default, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageA//default, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageA//default, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageA//default, HasF, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageA//default, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref PackageA//default, loc5_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref PackageA//default, F, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref PackageA//default, loc11_6, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.10: type = import_ref PackageA//default, loc11_11, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref PackageA//default, loc11_16, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -549,30 +549,30 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .D = %import_ref.1
 // CHECK:STDOUT:     import PackageB//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageB//default, inst+14, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageB//default, inst+17, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageB//default, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageA//default, inst+1, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageA//default, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref PackageA//default, inst+10, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref PackageA//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref PackageA//default, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.10 = import_ref PackageA//default, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.11: type = import_ref PackageA//default, inst+17, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageA//default, inst+18, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.13 = import_ref PackageA//default, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref PackageB//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref PackageB//default, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref PackageB//default, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.17: type = import_ref PackageB//default, inst+25, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.18: type = import_ref PackageB//default, inst+26, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.19 = import_ref PackageB//default, inst+32, unloaded
-// CHECK:STDOUT:   %import_ref.20: type = import_ref PackageB//default, inst+35, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.21: type = import_ref PackageB//default, inst+44, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.22: <witness> = import_ref PackageB//default, inst+53, loaded [template = constants.%interface]
-// CHECK:STDOUT:   %import_ref.23: type = import_ref PackageB//default, inst+56, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.24: type = import_ref PackageB//default, inst+57, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.25 = import_ref PackageB//default, inst+63, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageB//default, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageB//default, loc10_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageB//default, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageA//default, HasF, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageA//default, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref PackageA//default, loc5_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref PackageA//default, F, unloaded
+// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref PackageA//default, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.10 = import_ref PackageA//default, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref PackageA//default, loc11_6, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageA//default, loc11_11, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.13 = import_ref PackageA//default, loc11_16, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref PackageB//default, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref PackageB//default, loc7_9, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref PackageB//default, G, unloaded
+// CHECK:STDOUT:   %import_ref.17: type = import_ref PackageB//default, loc13_14, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.18: type = import_ref PackageB//default, loc13_20, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.19 = import_ref PackageB//default, loc13_25, unloaded
+// CHECK:STDOUT:   %import_ref.20: type = import_ref PackageB//default, loc18_6, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.21: type = import_ref PackageB//default, loc18_19, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.22: <witness> = import_ref PackageB//default, loc18_25, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.23: type = import_ref PackageB//default, loc23_6, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.24: type = import_ref PackageB//default, loc23_11, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.25 = import_ref PackageB//default, loc23_16, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -690,30 +690,30 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .HasG = %import_ref.4
 // CHECK:STDOUT:     import PackageB//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageA//default, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageA//default, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageA//default, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageB//default, inst+3, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageB//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.6: %G.assoc_type = import_ref PackageB//default, inst+12, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref PackageB//default, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref PackageA//default, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref PackageA//default, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref PackageA//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageA//default, inst+17, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.13: type = import_ref PackageA//default, inst+18, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.14 = import_ref PackageA//default, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.15: type = import_ref PackageB//default, inst+25, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.16: type = import_ref PackageB//default, inst+26, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.17: <witness> = import_ref PackageB//default, inst+32, loaded [template = constants.%interface]
-// CHECK:STDOUT:   %import_ref.18: <witness> = import_ref PackageB//default, inst+17, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.19 = import_ref PackageB//default, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.20: type = import_ref PackageB//default, inst+35, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.21: type = import_ref PackageB//default, inst+44, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.22 = import_ref PackageB//default, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.23: type = import_ref PackageB//default, inst+56, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.24: type = import_ref PackageB//default, inst+57, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.25 = import_ref PackageB//default, inst+63, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageA//default, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageA//default, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageA//default, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageB//default, HasG, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageB//default, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %G.assoc_type = import_ref PackageB//default, loc7_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref PackageB//default, G, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref PackageA//default, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref PackageA//default, loc5_9, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref PackageA//default, F, unloaded
+// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageA//default, loc11_6, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.13: type = import_ref PackageA//default, loc11_11, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.14 = import_ref PackageA//default, loc11_16, unloaded
+// CHECK:STDOUT:   %import_ref.15: type = import_ref PackageB//default, loc13_14, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.16: type = import_ref PackageB//default, loc13_20, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.17: <witness> = import_ref PackageB//default, loc13_25, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.18: <witness> = import_ref PackageB//default, loc10_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.19 = import_ref PackageB//default, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.20: type = import_ref PackageB//default, loc18_6, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.21: type = import_ref PackageB//default, loc18_19, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.22 = import_ref PackageB//default, loc18_25, unloaded
+// CHECK:STDOUT:   %import_ref.23: type = import_ref PackageB//default, loc23_6, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.24: type = import_ref PackageB//default, loc23_11, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.25 = import_ref PackageB//default, loc23_16, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -828,27 +828,27 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .HasG = %import_ref.4
 // CHECK:STDOUT:     import PackageB//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageB//default, inst+14, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageB//default, inst+17, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageB//default, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageB//default, inst+3, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageB//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.6: %G.assoc_type = import_ref PackageB//default, inst+12, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref PackageB//default, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref PackageB//default, inst+23, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.10 = import_ref PackageB//default, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.11: type = import_ref PackageB//default, inst+25, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageB//default, inst+26, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.13 = import_ref PackageB//default, inst+32, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref PackageB//default, inst+41, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref PackageB//default, inst+42, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref PackageB//default, inst+43, unloaded
-// CHECK:STDOUT:   %import_ref.17: type = import_ref PackageB//default, inst+35, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.18: type = import_ref PackageB//default, inst+44, loaded [template = constants.%HasF.type]
-// CHECK:STDOUT:   %import_ref.19 = import_ref PackageB//default, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.20: type = import_ref PackageB//default, inst+56, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.21: type = import_ref PackageB//default, inst+57, loaded [template = constants.%HasG.type]
-// CHECK:STDOUT:   %import_ref.22: <witness> = import_ref PackageB//default, inst+63, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageB//default, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageB//default, loc10_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageB//default, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageB//default, HasG, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageB//default, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %G.assoc_type = import_ref PackageB//default, loc7_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref PackageB//default, G, unloaded
+// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref PackageB//default, inst35 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.10 = import_ref PackageB//default, inst36 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref PackageB//default, loc13_14, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageB//default, loc13_20, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.13 = import_ref PackageB//default, loc13_25, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref PackageB//default, inst53 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref PackageB//default, inst54 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref PackageB//default, F, unloaded
+// CHECK:STDOUT:   %import_ref.17: type = import_ref PackageB//default, loc18_6, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.18: type = import_ref PackageB//default, loc18_19, loaded [template = constants.%HasF.type]
+// CHECK:STDOUT:   %import_ref.19 = import_ref PackageB//default, loc18_25, unloaded
+// CHECK:STDOUT:   %import_ref.20: type = import_ref PackageB//default, loc23_6, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.21: type = import_ref PackageB//default, loc23_11, loaded [template = constants.%HasG.type]
+// CHECK:STDOUT:   %import_ref.22: <witness> = import_ref PackageB//default, loc23_16, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1012,13 +1012,13 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .Z = %import_ref.1
 // CHECK:STDOUT:     import PackageAssociatedInterface//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageAssociatedInterface//default, inst+1, loaded [template = constants.%Z.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref PackageAssociatedInterface//default, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: %H.assoc_type = import_ref PackageAssociatedInterface//default, inst+10, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.4 = import_ref PackageAssociatedInterface//default, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.6: type = import_ref PackageAssociatedInterface//default, inst+13, loaded [template = constants.%empty_tuple.type]
-// CHECK:STDOUT:   %import_ref.7: type = import_ref PackageAssociatedInterface//default, inst+14, loaded [template = constants.%Z.type]
-// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref PackageAssociatedInterface//default, inst+20, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref PackageAssociatedInterface//default, Z, loaded [template = constants.%Z.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref PackageAssociatedInterface//default, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3: %H.assoc_type = import_ref PackageAssociatedInterface//default, loc5_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.4 = import_ref PackageAssociatedInterface//default, H, unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref PackageAssociatedInterface//default, loc8_7, loaded [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:   %import_ref.7: type = import_ref PackageAssociatedInterface//default, loc8_12, loaded [template = constants.%Z.type]
+// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref PackageAssociatedInterface//default, loc8_14, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1188,13 +1188,13 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .Y = %import_ref.4
 // CHECK:STDOUT:     import PackageHasParam//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %AnyParam.type = import_ref PackageHasParam//default, inst+14, loaded [template = constants.%AnyParam.generic]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageHasParam//default, inst+24, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageHasParam//default, inst+22, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageHasParam//default, inst+26, loaded [template = constants.%Y.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageHasParam//default, inst+28, unloaded
-// CHECK:STDOUT:   %import_ref.6: %K.assoc_type = import_ref PackageHasParam//default, inst+34, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7: %K.type.2 = import_ref PackageHasParam//default, inst+30, loaded [template = constants.%K.2]
+// CHECK:STDOUT:   %import_ref.1: %AnyParam.type = import_ref PackageHasParam//default, AnyParam, loaded [template = constants.%AnyParam.generic]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageHasParam//default, loc4_34, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageHasParam//default, inst34 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref PackageHasParam//default, Y, loaded [template = constants.%Y.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageHasParam//default, inst40 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %K.assoc_type = import_ref PackageHasParam//default, loc7_10, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7: %K.type.2 = import_ref PackageHasParam//default, K, loaded [template = constants.%K.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1374,18 +1374,18 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .GenericInterface = %import_ref.4
 // CHECK:STDOUT:     import PackageGenericInterface//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %AnyParam.type = import_ref PackageHasParam//default, inst+14, loaded [template = constants.%AnyParam.generic]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageHasParam//default, inst+24, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref PackageHasParam//default, inst+22, unloaded
-// CHECK:STDOUT:   %import_ref.4: %GenericInterface.type.1 = import_ref PackageGenericInterface//default, inst+9, loaded [template = constants.%GenericInterface.generic]
-// CHECK:STDOUT:   %import_ref.5 = import_ref PackageGenericInterface//default, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.6: type = import_ref PackageHasParam//default, inst+26, loaded [template = constants.%Y.type]
-// CHECK:STDOUT:   %import_ref.7 = import_ref PackageHasParam//default, inst+28, unloaded
-// CHECK:STDOUT:   %import_ref.8: %K.assoc_type = import_ref PackageHasParam//default, inst+34, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.9 = import_ref PackageHasParam//default, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.11: type = import_ref PackageGenericInterface//default, inst+45, loaded [template = constants.%AnyParam.2]
-// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageGenericInterface//default, inst+55, loaded [template = constants.%Y.type]
-// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref PackageGenericInterface//default, inst+64, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1: %AnyParam.type = import_ref PackageHasParam//default, AnyParam, loaded [template = constants.%AnyParam.generic]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref PackageHasParam//default, loc4_34, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref PackageHasParam//default, inst34 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: %GenericInterface.type.1 = import_ref PackageGenericInterface//default, GenericInterface, loaded [template = constants.%GenericInterface.generic]
+// CHECK:STDOUT:   %import_ref.5 = import_ref PackageGenericInterface//default, inst28 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref PackageHasParam//default, Y, loaded [template = constants.%Y.type]
+// CHECK:STDOUT:   %import_ref.7 = import_ref PackageHasParam//default, inst40 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.8: %K.assoc_type = import_ref PackageHasParam//default, loc7_10, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.9 = import_ref PackageHasParam//default, K, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref PackageGenericInterface//default, loc8_47, loaded [template = constants.%AnyParam.2]
+// CHECK:STDOUT:   %import_ref.12: type = import_ref PackageGenericInterface//default, loc8_67, loaded [template = constants.%Y.type]
+// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref PackageGenericInterface//default, loc8_70, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1744,24 +1744,24 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:     .I = %import_ref.4
 // CHECK:STDOUT:     import HasExtraInterfaces//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref HasExtraInterfaces//default, inst+39, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref HasExtraInterfaces//default, inst+47, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref HasExtraInterfaces//default, inst+45, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref HasExtraInterfaces//default, inst+49, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref HasExtraInterfaces//default, inst+51, unloaded
-// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref HasExtraInterfaces//default, inst+57, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref HasExtraInterfaces//default, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref HasExtraInterfaces//default, inst+31, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref HasExtraInterfaces//default, inst+27, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref HasExtraInterfaces//default, inst+23, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref HasExtraInterfaces//default, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref HasExtraInterfaces//default, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref HasExtraInterfaces//default, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref HasExtraInterfaces//default, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref HasExtraInterfaces//default, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.17: type = import_ref HasExtraInterfaces//default, inst+72, loaded [template = constants.%C.3]
-// CHECK:STDOUT:   %import_ref.18: type = import_ref HasExtraInterfaces//default, inst+74, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.19 = import_ref HasExtraInterfaces//default, inst+80, unloaded
+// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref HasExtraInterfaces//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref HasExtraInterfaces//default, loc13_20, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref HasExtraInterfaces//default, inst57 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref HasExtraInterfaces//default, I, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref HasExtraInterfaces//default, inst63 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref HasExtraInterfaces//default, loc14_21, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref HasExtraInterfaces//default, F, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref HasExtraInterfaces//default, inst43 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref HasExtraInterfaces//default, inst39 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref HasExtraInterfaces//default, inst35 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref HasExtraInterfaces//default, inst31 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref HasExtraInterfaces//default, inst27 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref HasExtraInterfaces//default, inst23 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref HasExtraInterfaces//default, inst19 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref HasExtraInterfaces//default, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.17: type = import_ref HasExtraInterfaces//default, loc16_72, loaded [template = constants.%C.3]
+// CHECK:STDOUT:   %import_ref.18: type = import_ref HasExtraInterfaces//default, loc16_77, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.19 = import_ref HasExtraInterfaces//default, loc16_79, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
@@ -193,15 +193,15 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, inst+7, loaded [template = constants.%I.generic]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//types, inst+32, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, inst+41, loaded [template = constants.%X]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//types, inst+43, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//types, inst+42, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//types, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.8: @I.%F.type (%F.type.1) = import_ref Main//types, inst+16, loaded [symbolic = @I.%F (constants.%F.1)]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, I, loaded [template = constants.%I.generic]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//types, C, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, X, loaded [template = constants.%X]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//types, loc7_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//types, inst54 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//types, loc4_31, unloaded
+// CHECK:STDOUT:   %import_ref.8: @I.%F.type (%F.type.1) = import_ref Main//types, F, loaded [symbolic = @I.%F (constants.%F.1)]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, loc4_31, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -333,21 +333,21 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, inst+7, loaded [template = constants.%I.generic]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//types, inst+32, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, inst+41, loaded [template = constants.%X]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//impl_in_interface_args, inst+5, loaded [template = constants.%InInterfaceArgs]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//types, inst+43, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst+42, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//types, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.8: @I.%F.assoc_type (%F.assoc_type.1) = import_ref Main//types, inst+20, loaded [symbolic = @I.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//types, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//impl_in_interface_args, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//impl_in_interface_args, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.14: type = import_ref Main//impl_in_interface_args, inst+14, loaded [template = constants.%X]
-// CHECK:STDOUT:   %import_ref.15: type = import_ref Main//impl_in_interface_args, inst+44, loaded [template = constants.%I.type.3]
-// CHECK:STDOUT:   %import_ref.16: <witness> = import_ref Main//impl_in_interface_args, inst+55, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, I, loaded [template = constants.%I.generic]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//types, C, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, X, loaded [template = constants.%X]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//impl_in_interface_args, InInterfaceArgs, loaded [template = constants.%InInterfaceArgs]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//types, loc7_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst54 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//types, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.8: @I.%F.assoc_type (%F.assoc_type.1) = import_ref Main//types, loc4_31, loaded [symbolic = @I.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, F, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//types, loc4_31, unloaded
+// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//impl_in_interface_args, loc5_24, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//impl_in_interface_args, inst18 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.14: type = import_ref Main//impl_in_interface_args, loc7_6, loaded [template = constants.%X]
+// CHECK:STDOUT:   %import_ref.15: type = import_ref Main//impl_in_interface_args, loc7_28, loaded [template = constants.%I.type.3]
+// CHECK:STDOUT:   %import_ref.16: <witness> = import_ref Main//impl_in_interface_args, loc7_30, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -483,17 +483,17 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, inst+7, loaded [template = constants.%I.generic]
-// CHECK:STDOUT:   %import_ref.2: %C.type = import_ref Main//types, inst+32, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, inst+41, loaded [template = constants.%X]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//types, inst+39, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//types, inst+37, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//types, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.8: @I.%F.type (%F.type.1) = import_ref Main//types, inst+16, loaded [symbolic = @I.%F (constants.%F.1)]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.10: <witness> = import_ref Main//types, inst+43, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//types, inst+42, unloaded
+// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, I, loaded [template = constants.%I.generic]
+// CHECK:STDOUT:   %import_ref.2: %C.type = import_ref Main//types, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, X, loaded [template = constants.%X]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//types, loc5_20, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//types, inst49 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//types, loc4_31, unloaded
+// CHECK:STDOUT:   %import_ref.8: @I.%F.type (%F.type.1) = import_ref Main//types, F, loaded [symbolic = @I.%F (constants.%F.1)]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, loc4_31, unloaded
+// CHECK:STDOUT:   %import_ref.10: <witness> = import_ref Main//types, loc7_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//types, inst54 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -653,23 +653,23 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, inst+7, loaded [template = constants.%I.generic]
-// CHECK:STDOUT:   %import_ref.2: %C.type = import_ref Main//types, inst+32, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, inst+41, loaded [template = constants.%X]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//impl_in_class_args, inst+5, loaded [template = constants.%InClassArgs]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//types, inst+39, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst+37, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//impl_in_class_args, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//impl_in_class_args, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.10: @I.%F.assoc_type (%F.assoc_type.1) = import_ref Main//types, inst+20, loaded [symbolic = @I.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//types, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//types, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref Main//types, inst+43, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//types, inst+42, unloaded
-// CHECK:STDOUT:   %import_ref.16: type = import_ref Main//impl_in_class_args, inst+25, loaded [template = constants.%C.2]
-// CHECK:STDOUT:   %import_ref.17: type = import_ref Main//impl_in_class_args, inst+57, loaded [template = constants.%I.type.3]
-// CHECK:STDOUT:   %import_ref.18: <witness> = import_ref Main//impl_in_class_args, inst+68, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1: %I.type.1 = import_ref Main//types, I, loaded [template = constants.%I.generic]
+// CHECK:STDOUT:   %import_ref.2: %C.type = import_ref Main//types, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//types, X, loaded [template = constants.%X]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//impl_in_class_args, InClassArgs, loaded [template = constants.%InClassArgs]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//types, loc5_20, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//types, inst49 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//impl_in_class_args, loc5_20, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//impl_in_class_args, inst18 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//types, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.10: @I.%F.assoc_type (%F.assoc_type.1) = import_ref Main//types, loc4_31, loaded [symbolic = @I.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//types, F, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//types, loc4_31, unloaded
+// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref Main//types, loc7_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//types, inst54 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref Main//impl_in_class_args, loc7_19, loaded [template = constants.%C.2]
+// CHECK:STDOUT:   %import_ref.17: type = import_ref Main//impl_in_class_args, loc7_27, loaded [template = constants.%I.type.3]
+// CHECK:STDOUT:   %import_ref.18: <witness> = import_ref Main//impl_in_class_args, loc7_29, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/lookup/transitive.carbon
+++ b/toolchain/check/testdata/impl/lookup/transitive.carbon
@@ -105,14 +105,14 @@ fn Call() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//i, inst+3, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//i, I, loaded [template = constants.%I.type]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//i, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//i, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.4: %F.type.2 = import_ref Main//i, inst+7, loaded [template = constants.%F.2]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//i, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//i, loc4_21, unloaded
+// CHECK:STDOUT:   %import_ref.4: %F.type.2 = import_ref Main//i, F, loaded [template = constants.%F.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -179,13 +179,13 @@ fn Call() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, inst+5, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//c, C, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c, loc6_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c, inst18 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -236,20 +236,20 @@ fn Call() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Get.type = import_ref Main//get, inst+16, loaded [template = constants.%Get]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//i, inst+3, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.1: %Get.type = import_ref Main//get, Get, loaded [template = constants.%Get]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//i, I, loaded [template = constants.%I.type]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//get, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//get, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//i, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref Main//i, inst+12, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//i, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//c, inst+10, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.10: type = import_ref Main//c, inst+17, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//c, inst+27, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//get, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//get, inst22 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//i, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref Main//i, loc4_21, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//i, F, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//c, loc7_6, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.10: type = import_ref Main//c, loc7_11, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//c, loc7_13, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/fail_alias.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_alias.carbon
@@ -67,7 +67,7 @@ impl AC as AI {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: %AC.ref.loc17 as %AI.ref.loc17 {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <unexpected>.inst+18.loc17_15
+// CHECK:STDOUT:   witness = <unexpected>.inst30.loc17_15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {

--- a/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
@@ -452,7 +452,7 @@ impl (C, C).0 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   impl: %.loc7 as %J.ref.loc7 {
 // CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     witness = <unexpected>.inst+26.loc7_28
+// CHECK:STDOUT:     witness = <unexpected>.inst38.loc7_28
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon
@@ -127,17 +127,17 @@ fn G(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_impl_library, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//extend_impl_library, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//extend_impl_library, inst+24, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extend_impl_library, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Main//extend_impl_library, inst+15, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//extend_impl_library, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.7: %F.assoc_type = import_ref Main//extend_impl_library, inst+10, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//extend_impl_library, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.10: type = import_ref Main//extend_impl_library, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.11: type = import_ref Main//extend_impl_library, inst+15, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.12: <witness> = import_ref Main//extend_impl_library, inst+21, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//extend_impl_library, I, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//extend_impl_library, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//extend_impl_library, loc12_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//extend_impl_library, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Main//extend_impl_library, loc9_18, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//extend_impl_library, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: %F.assoc_type = import_ref Main//extend_impl_library, loc5_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//extend_impl_library, F, unloaded
+// CHECK:STDOUT:   %import_ref.10: type = import_ref Main//extend_impl_library, loc9_15, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref Main//extend_impl_library, loc9_18, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.12: <witness> = import_ref Main//extend_impl_library, loc9_20, loaded [template = constants.%interface]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
@@ -201,16 +201,16 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//import_generic, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: %I.type.1 = import_ref Main//import_generic, inst+12, loaded [template = constants.%I.generic]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//import_generic, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//import_generic, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//import_generic, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6: type = import_ref Main//import_generic, inst+26, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.7: type = import_ref Main//import_generic, inst+29, loaded [symbolic = @impl.1.%I.type.1 (constants.%I.type.2)]
-// CHECK:STDOUT:   %import_ref.8: type = import_ref Main//import_generic, inst+38, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//import_generic, inst+43, loaded [symbolic = @impl.2.%I.type (constants.%I.type.3)]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//import_generic, inst+51, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//import_generic, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: %I.type.1 = import_ref Main//import_generic, I, loaded [template = constants.%I.generic]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//import_generic, inst31 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//import_generic, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//import_generic, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref Main//import_generic, loc7_24, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.7: type = import_ref Main//import_generic, loc7_32, loaded [symbolic = @impl.1.%I.type.1 (constants.%I.type.2)]
+// CHECK:STDOUT:   %import_ref.8: type = import_ref Main//import_generic, loc8_24, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//import_generic, loc8_33, loaded [symbolic = @impl.2.%I.type (constants.%I.type.3)]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//import_generic, loc8_35, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -339,16 +339,16 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//import_generic, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: %I.type.1 = import_ref Main//import_generic, inst+12, loaded [template = constants.%I.generic]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//import_generic, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//import_generic, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//import_generic, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6: type = import_ref Main//import_generic, inst+26, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.7: type = import_ref Main//import_generic, inst+29, loaded [symbolic = @impl.1.%I.type (constants.%I.type.2)]
-// CHECK:STDOUT:   %import_ref.8: type = import_ref Main//import_generic, inst+38, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//import_generic, inst+43, loaded [symbolic = @impl.2.%I.type.1 (constants.%I.type.3)]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//import_generic, inst+51, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//import_generic, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: %I.type.1 = import_ref Main//import_generic, I, loaded [template = constants.%I.generic]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//import_generic, inst31 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//import_generic, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//import_generic, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref Main//import_generic, loc7_24, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.7: type = import_ref Main//import_generic, loc7_32, loaded [symbolic = @impl.1.%I.type (constants.%I.type.2)]
+// CHECK:STDOUT:   %import_ref.8: type = import_ref Main//import_generic, loc8_24, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//import_generic, loc8_33, loaded [symbolic = @impl.2.%I.type.1 (constants.%I.type.3)]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//import_generic, loc8_35, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_self.carbon
@@ -116,10 +116,10 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+1, loaded [template = constants.%Add.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//a, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: %Op.assoc_type = import_ref Main//a, inst+34, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.4: %Op.type.2 = import_ref Main//a, inst+27, loaded [template = constants.%Op.2]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, Add, loaded [template = constants.%Add.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//a, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3: %Op.assoc_type = import_ref Main//a, loc5_41, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.4: %Op.type.2 = import_ref Main//a, Op, loaded [template = constants.%Op.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
@@ -210,16 +210,16 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref Main//import_generic, inst+7, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//import_generic, inst+17, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//import_generic, inst+15, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//import_generic, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//import_generic, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref Main//import_generic, inst+25, loaded [template = constants.%assoc0]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//import_generic, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//import_generic, inst+32, loaded [symbolic = @impl.%C (constants.%C.1)]
-// CHECK:STDOUT:   %import_ref.10: type = import_ref Main//import_generic, inst+33, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//import_generic, inst+43, loaded [symbolic = @impl.%interface (constants.%interface.1)]
+// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref Main//import_generic, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//import_generic, I, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//import_generic, loc4_20, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//import_generic, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//import_generic, inst31 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6: %F.assoc_type = import_ref Main//import_generic, loc7_9, loaded [template = constants.%assoc0]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//import_generic, F, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref Main//import_generic, loc10_27, loaded [symbolic = @impl.%C (constants.%C.1)]
+// CHECK:STDOUT:   %import_ref.10: type = import_ref Main//import_generic, loc10_32, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//import_generic, loc10_34, loaded [symbolic = @impl.%interface (constants.%interface.1)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
@@ -283,23 +283,23 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Action.type.1 = import_ref Main//action, inst+7, loaded [template = constants.%Action.generic]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//action, inst+28, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//action, inst+33, loaded [template = constants.%B]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//action, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//action, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//action, inst+35, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//action, inst+34, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//action, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.9: @Action.%Op.assoc_type (%Op.assoc_type.1) = import_ref Main//action, inst+20, loaded [symbolic = @Action.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//action, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//action, inst+31, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//action, inst+29, unloaded
-// CHECK:STDOUT:   %import_ref.13: type = import_ref Main//action, inst+39, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.14: type = import_ref Main//action, inst+42, loaded [template = constants.%Action.type.3]
-// CHECK:STDOUT:   %import_ref.15: <witness> = import_ref Main//action, inst+53, loaded [template = constants.%interface]
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//action, inst+45, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//action, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.1: %Action.type.1 = import_ref Main//action, Action, loaded [template = constants.%Action.generic]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//action, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//action, B, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//action, C, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//action, F, unloaded
+// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//action, loc9_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//action, inst46 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//action, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9: @Action.%Op.assoc_type (%Op.assoc_type.1) = import_ref Main//action, loc5_10, loaded [symbolic = @Action.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//action, Op, unloaded
+// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//action, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//action, inst41 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.13: type = import_ref Main//action, loc12_6, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.14: type = import_ref Main//action, loc12_19, loaded [template = constants.%Action.type.3]
+// CHECK:STDOUT:   %import_ref.15: <witness> = import_ref Main//action, loc12_21, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//action, loc13_11, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//action, loc5_10, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -440,25 +440,25 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Action.type.1 = import_ref Main//action, inst+7, loaded [template = constants.%Action.generic]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//action, inst+28, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//action, inst+33, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//action, inst+36, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//action, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//action, inst+35, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//action, inst+34, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//action, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.9: @Action.%Op.assoc_type (%Op.assoc_type.1) = import_ref Main//action, inst+20, loaded [symbolic = @Action.%assoc0 (constants.%assoc0.4)]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//action, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//action, inst+31, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.12 = import_ref Main//action, inst+29, unloaded
-// CHECK:STDOUT:   %import_ref.13: type = import_ref Main//action, inst+39, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.14: type = import_ref Main//action, inst+42, loaded [template = constants.%Action.type.3]
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//action, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.16 = import_ref Main//action, inst+45, unloaded
-// CHECK:STDOUT:   %import_ref.17 = import_ref Main//action, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.19: <witness> = import_ref Main//action, inst+38, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.20 = import_ref Main//action, inst+37, unloaded
+// CHECK:STDOUT:   %import_ref.1: %Action.type.1 = import_ref Main//action, Action, loaded [template = constants.%Action.generic]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//action, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//action, B, unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//action, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//action, F, unloaded
+// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//action, loc9_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//action, inst46 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//action, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9: @Action.%Op.assoc_type (%Op.assoc_type.1) = import_ref Main//action, loc5_10, loaded [symbolic = @Action.%assoc0 (constants.%assoc0.4)]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//action, Op, unloaded
+// CHECK:STDOUT:   %import_ref.11: <witness> = import_ref Main//action, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.12 = import_ref Main//action, inst41 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.13: type = import_ref Main//action, loc12_6, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.14: type = import_ref Main//action, loc12_19, loaded [template = constants.%Action.type.3]
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//action, loc12_21, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref Main//action, loc13_11, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref Main//action, loc5_10, unloaded
+// CHECK:STDOUT:   %import_ref.19: <witness> = import_ref Main//action, loc10_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.20 = import_ref Main//action, inst49 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -764,21 +764,21 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Factory.type.1 = import_ref Main//factory, inst+7, loaded [template = constants.%Factory.generic]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//factory, inst+34, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//factory, inst+39, loaded [template = constants.%B]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//factory, inst+41, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//factory, inst+40, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//factory, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.7: @Factory.%Make.assoc_type (%Make.assoc_type.1) = import_ref Main//factory, inst+26, loaded [symbolic = @Factory.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//factory, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref Main//factory, inst+37, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//factory, inst+35, unloaded
-// CHECK:STDOUT:   %import_ref.11: type = import_ref Main//factory, inst+42, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.12: type = import_ref Main//factory, inst+45, loaded [template = constants.%Factory.type.3]
-// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref Main//factory, inst+61, loaded [template = constants.%interface]
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//factory, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//factory, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.1: %Factory.type.1 = import_ref Main//factory, Factory, loaded [template = constants.%Factory.generic]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//factory, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//factory, B, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//factory, loc9_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//factory, inst52 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//factory, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: @Factory.%Make.assoc_type (%Make.assoc_type.1) = import_ref Main//factory, loc5_17, loaded [symbolic = @Factory.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//factory, Make, unloaded
+// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref Main//factory, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//factory, inst47 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref Main//factory, loc11_6, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.12: type = import_ref Main//factory, loc11_20, loaded [template = constants.%Factory.type.3]
+// CHECK:STDOUT:   %import_ref.13: <witness> = import_ref Main//factory, loc11_22, loaded [template = constants.%interface]
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//factory, loc12_17, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//factory, loc5_17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -926,21 +926,21 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %Factory.type.1 = import_ref Main//factory, inst+7, loaded [template = constants.%Factory.generic]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//factory, inst+34, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//factory, inst+39, unloaded
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//factory, inst+41, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//factory, inst+40, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//factory, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.7: @Factory.%Make.assoc_type (%Make.assoc_type.1) = import_ref Main//factory, inst+26, loaded [symbolic = @Factory.%assoc0 (constants.%assoc0.4)]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//factory, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref Main//factory, inst+37, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//factory, inst+35, unloaded
-// CHECK:STDOUT:   %import_ref.11: type = import_ref Main//factory, inst+42, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.12: type = import_ref Main//factory, inst+45, loaded [template = constants.%Factory.type.3]
-// CHECK:STDOUT:   %import_ref.13 = import_ref Main//factory, inst+61, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//factory, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//factory, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.1: %Factory.type.1 = import_ref Main//factory, Factory, loaded [template = constants.%Factory.generic]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//factory, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//factory, B, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//factory, loc9_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//factory, inst52 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//factory, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: @Factory.%Make.assoc_type (%Make.assoc_type.1) = import_ref Main//factory, loc5_17, loaded [symbolic = @Factory.%assoc0 (constants.%assoc0.4)]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//factory, Make, unloaded
+// CHECK:STDOUT:   %import_ref.9: <witness> = import_ref Main//factory, loc8_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//factory, inst47 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref Main//factory, loc11_6, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.12: type = import_ref Main//factory, loc11_20, loaded [template = constants.%Factory.type.3]
+// CHECK:STDOUT:   %import_ref.13 = import_ref Main//factory, loc11_22, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//factory, loc12_17, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//factory, loc5_17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
@@ -118,10 +118,10 @@ impl () as D;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//decl_in_api_definition_in_impl, inst+1, loaded [template = constants.%A.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//decl_in_api_definition_in_impl, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//decl_in_api_definition_in_impl, inst+7, loaded [template = constants.%empty_tuple.type]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//decl_in_api_definition_in_impl, inst+8, loaded [template = constants.%A.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//decl_in_api_definition_in_impl, A, loaded [template = constants.%A.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//decl_in_api_definition_in_impl, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//decl_in_api_definition_in_impl, loc6_7, loaded [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//decl_in_api_definition_in_impl, loc6_12, loaded [template = constants.%A.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -164,7 +164,7 @@ impl () as D;
 // CHECK:STDOUT: --- use_decl_in_api.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//decl_in_api_definition_in_impl, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//decl_in_api_definition_in_impl, A, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -213,10 +213,10 @@ impl () as D;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//decl_only_in_api, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//decl_only_in_api, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//decl_only_in_api, inst+7, loaded [template = constants.%empty_tuple.type]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//decl_only_in_api, inst+8, loaded [template = constants.%B.type]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//decl_only_in_api, B, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//decl_only_in_api, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//decl_only_in_api, loc6_7, loaded [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//decl_only_in_api, loc6_12, loaded [template = constants.%B.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -273,10 +273,10 @@ impl () as D;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//decl_in_api_decl_in_impl, inst+1, loaded [template = constants.%C.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//decl_in_api_decl_in_impl, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//decl_in_api_decl_in_impl, inst+7, loaded [template = constants.%empty_tuple.type]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//decl_in_api_decl_in_impl, inst+8, loaded [template = constants.%C.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//decl_in_api_decl_in_impl, C, loaded [template = constants.%C.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//decl_in_api_decl_in_impl, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//decl_in_api_decl_in_impl, loc6_7, loaded [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Main//decl_in_api_decl_in_impl, loc6_12, loaded [template = constants.%C.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/export_name.carbon
@@ -67,8 +67,8 @@ fn UseEmpty(i: I) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, I, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, inst15 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -94,8 +94,8 @@ fn UseEmpty(i: I) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+7, loaded [template = constants.%I.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//export, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, I, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//export, inst18 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/fail_assoc_const_not_binding.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_assoc_const_not_binding.carbon
@@ -24,7 +24,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = <unexpected>.inst+3
+// CHECK:STDOUT:   .Self = <unexpected>.inst15
 // CHECK:STDOUT:   witness = invalid
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_assoc_const_template.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_assoc_const_template.carbon
@@ -24,7 +24,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = <unexpected>.inst+3
+// CHECK:STDOUT:   .Self = <unexpected>.inst15
 // CHECK:STDOUT:   witness = invalid
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_definition_imported.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_definition_imported.carbon
@@ -52,7 +52,7 @@ interface I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: type = import_ref Main//a, inst+1, loaded [template = constants.%I.type]
+// CHECK:STDOUT:   %import_ref: type = import_ref Main//a, I, loaded [template = constants.%I.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
@@ -124,11 +124,11 @@ impl C as AddWith(C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %AddWith.type.1 = import_ref Main//a, inst+7, loaded [template = constants.%AddWith.generic]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//a, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.4: @AddWith.%F.type (%F.type.1) = import_ref Main//a, inst+16, loaded [symbolic = @AddWith.%F (constants.%F.1)]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//a, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.1: %AddWith.type.1 = import_ref Main//a, AddWith, loaded [template = constants.%AddWith.generic]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//a, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//a, loc5_9, unloaded
+// CHECK:STDOUT:   %import_ref.4: @AddWith.%F.type (%F.type.1) = import_ref Main//a, F, loaded [symbolic = @AddWith.%F (constants.%F.1)]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//a, loc5_9, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import.carbon
@@ -167,21 +167,21 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, inst+1, loaded [template = constants.%Empty.type]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, inst+5, loaded [template = constants.%Basic.type]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, inst+20, loaded [template = constants.%ForwardDeclared.type]
-// CHECK:STDOUT:   %import_ref.4: ref %struct_type.f.1 = import_ref Main//a, inst+39, loaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//a, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.7: %assoc_type.1 = import_ref Main//a, inst+11, loaded [template = constants.%assoc0.1]
-// CHECK:STDOUT:   %import_ref.8: %F.assoc_type.1 = import_ref Main//a, inst+18, loaded [template = constants.%assoc1.1]
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//a, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref Main//a, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Main//a, inst+22, unloaded
-// CHECK:STDOUT:   %import_ref.12: %assoc_type.2 = import_ref Main//a, inst+26, loaded [template = constants.%assoc0.2]
-// CHECK:STDOUT:   %import_ref.13: %F.assoc_type.2 = import_ref Main//a, inst+32, loaded [template = constants.%assoc1.2]
-// CHECK:STDOUT:   %import_ref.14 = import_ref Main//a, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref Main//a, inst+28, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//a, Empty, loaded [template = constants.%Empty.type]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, Basic, loaded [template = constants.%Basic.type]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, ForwardDeclared, loaded [template = constants.%ForwardDeclared.type]
+// CHECK:STDOUT:   %import_ref.4: ref %struct_type.f.1 = import_ref Main//a, f_ref, loaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//a, inst15 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//a, inst19 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.7: %assoc_type.1 = import_ref Main//a, loc8_15, loaded [template = constants.%assoc0.1]
+// CHECK:STDOUT:   %import_ref.8: %F.assoc_type.1 = import_ref Main//a, loc9_9, loaded [template = constants.%assoc1.1]
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//a, T, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref Main//a, F, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Main//a, inst34 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.12: %assoc_type.2 = import_ref Main//a, loc16_15, loaded [template = constants.%assoc0.2]
+// CHECK:STDOUT:   %import_ref.13: %F.assoc_type.2 = import_ref Main//a, loc17_9, loaded [template = constants.%assoc1.2]
+// CHECK:STDOUT:   %import_ref.14 = import_ref Main//a, T, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref Main//a, F, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import_access.carbon
@@ -200,8 +200,8 @@ private interface Redecl {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//def, inst+1, loaded [template = constants.%Def.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Test//def, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//def, Def, loaded [template = constants.%Def.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Test//def, inst15 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -303,8 +303,8 @@ private interface Redecl {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//forward_with_def, inst+1, loaded [template = constants.%ForwardWithDef.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Test//forward_with_def, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Test//forward_with_def, ForwardWithDef, loaded [template = constants.%ForwardWithDef.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Test//forward_with_def, inst16 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/import_interface_decl.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import_interface_decl.carbon
@@ -48,9 +48,9 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, inst+5, loaded [template = constants.%empty_tuple.type]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, inst+6, loaded [template = constants.%A.type]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//a, A, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//a, loc3_7, loaded [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//a, loc3_12, loaded [template = constants.%A.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
@@ -639,12 +639,12 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//two_file, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//two_file, inst+7, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: %Foo.type = import_ref Main//two_file, inst+15, loaded [template = constants.%Foo.generic]
-// CHECK:STDOUT:   %import_ref.4: %Bar.type = import_ref Main//two_file, inst+26, loaded [template = constants.%Bar.generic]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//two_file, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//two_file, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//two_file, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//two_file, D, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: %Foo.type = import_ref Main//two_file, Foo, loaded [template = constants.%Foo.generic]
+// CHECK:STDOUT:   %import_ref.4: %Bar.type = import_ref Main//two_file, Bar, loaded [template = constants.%Bar.generic]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//two_file, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//two_file, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1095,10 +1095,10 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//alias_two_file, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: %Foo.type = import_ref Main//alias_two_file, inst+13, loaded [template = constants.%Foo.generic]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//alias_two_file, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//alias_two_file, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//alias_two_file, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: %Foo.type = import_ref Main//alias_two_file, Foo, loaded [template = constants.%Foo.generic]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//alias_two_file, loc4_10, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//alias_two_file, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -70,7 +70,7 @@ let a: T = 0;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: type = import_ref Implicit//default, inst+3, loaded
+// CHECK:STDOUT:   %import_ref: type = import_ref Implicit//default, T, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -70,7 +70,7 @@ var b: T = *a;
 // CHECK:STDOUT: --- fail_implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: type = import_ref Implicit//default, inst+3, loaded
+// CHECK:STDOUT:   %import_ref: type = import_ref Implicit//default, T, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/let/no_prelude/import.carbon
+++ b/toolchain/check/testdata/let/no_prelude/import.carbon
@@ -63,7 +63,7 @@ let b: () = Other.a;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %empty_tuple.type = import_ref Implicit//default, inst+4, loaded
+// CHECK:STDOUT:   %import_ref: %empty_tuple.type = import_ref Implicit//default, a, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -119,7 +119,7 @@ let b: () = Other.a;
 // CHECK:STDOUT:     .a = %import_ref
 // CHECK:STDOUT:     import Other//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: %empty_tuple.type = import_ref Other//default, inst+4, loaded
+// CHECK:STDOUT:   %import_ref: %empty_tuple.type = import_ref Other//default, a, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/let/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/let/no_prelude/import_access.carbon
@@ -82,7 +82,7 @@ let v2: () = Test.v;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %empty_tuple.type = import_ref Test//def, inst+4, loaded
+// CHECK:STDOUT:   %import_ref: %empty_tuple.type = import_ref Test//def, v, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/namespace/add_to_import.carbon
+++ b/toolchain/check/testdata/namespace/add_to_import.carbon
@@ -60,7 +60,7 @@ var a: i32 = NS.A();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Implicit//default, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Implicit//default, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = file.%A.decl
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
@@ -75,7 +75,7 @@ fn NS();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Example//namespace, inst+3, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Example//namespace, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
@@ -59,7 +59,7 @@ fn NS.Foo();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Example//namespace, inst+3, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Example//namespace, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .Foo = file.%Foo.decl
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_nested.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_nested.carbon
@@ -67,7 +67,7 @@ fn Other.Nested.F();
 // CHECK:STDOUT:     .Nested = %Nested
 // CHECK:STDOUT:     import Other//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Other//default, inst+3, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Other//default, Nested, loaded
 // CHECK:STDOUT:   %Nested: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .F = file.%F.decl
 // CHECK:STDOUT:     import Other//default

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
@@ -74,7 +74,7 @@ fn NS.Foo();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %NS.type = import_ref Example//fn, inst+3, loaded [template = constants.%NS]
+// CHECK:STDOUT:   %import_ref: %NS.type = import_ref Example//fn, NS, loaded [template = constants.%NS]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
@@ -105,7 +105,7 @@ fn NS.Bar() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Example//namespace, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Example//namespace, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.2
 // CHECK:STDOUT:     .Bar = file.%Bar.decl

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
@@ -105,7 +105,7 @@ fn NS.Bar() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Example//namespace, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Example//namespace, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.3
 // CHECK:STDOUT:     .Bar = file.%Bar.decl

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -76,17 +76,17 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Implicit//default, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Implicit//default, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = %import_ref.2
 // CHECK:STDOUT:     .ChildNS = %ChildNS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %A.type = import_ref Implicit//default, inst+5, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref Implicit//default, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.2: %A.type = import_ref Implicit//default, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref Implicit//default, ChildNS, loaded
 // CHECK:STDOUT:   %ChildNS: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .B = %import_ref.4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: %B.type = import_ref Implicit//default, inst+9, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref.4: %B.type = import_ref Implicit//default, B, loaded [template = constants.%B]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -63,7 +63,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Same//a, inst+3, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref Same//a, A, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .B = file.%B
 // CHECK:STDOUT:   }
@@ -86,7 +86,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT: --- c.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Same//b, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Same//b, A, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
@@ -114,7 +114,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Same//c, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Same//c, A, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
@@ -148,19 +148,19 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Same//d, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Same//d, A, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Same//d, inst+6, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Same//d, B, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref Same//d, inst+8, loaded
+// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref Same//d, C, loaded
 // CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Same//d, inst+10, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.4: %D.type = import_ref Same//d, D, loaded [template = constants.%D]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/namespace/merging.carbon
+++ b/toolchain/check/testdata/namespace/merging.carbon
@@ -138,16 +138,16 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Example//a, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Example//a, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = %import_ref.2
 // CHECK:STDOUT:     .B1 = %import_ref.3
 // CHECK:STDOUT:     .B2 = %import_ref.4
 // CHECK:STDOUT:     .C = file.%C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %A.type = import_ref Example//a, inst+4, loaded [template = constants.%A]
-// CHECK:STDOUT:   %import_ref.3: %B1.type = import_ref Example//b, inst+4, loaded [template = constants.%B1]
-// CHECK:STDOUT:   %import_ref.4: %B2.type = import_ref Example//b, inst+10, loaded [template = constants.%B2]
+// CHECK:STDOUT:   %import_ref.2: %A.type = import_ref Example//a, A, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.3: %B1.type = import_ref Example//b, B1, loaded [template = constants.%B1]
+// CHECK:STDOUT:   %import_ref.4: %B2.type = import_ref Example//b, B2, loaded [template = constants.%B2]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/namespace/merging_with_indirections.carbon
+++ b/toolchain/check/testdata/namespace/merging_with_indirections.carbon
@@ -89,18 +89,18 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Other//a, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Other//a, NS1, loaded
 // CHECK:STDOUT:   %NS1: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = %import_ref.2
 // CHECK:STDOUT:     .B = file.%B.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Other//a, inst+4, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Other//a, A, loaded [template = constants.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Other//a, inst+7, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//a, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Other//a, loc5_14, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//a, inst17 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -172,16 +172,16 @@ fn Run() {
 // CHECK:STDOUT:     import Other//b
 // CHECK:STDOUT:     import Other//a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//b, inst+23, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//b, inst+16, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//b, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4: <namespace> = import_ref Other//b, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//b, F, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//b, inst28 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//b, inst29 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4: <namespace> = import_ref Other//b, NS1, loaded
 // CHECK:STDOUT:   %NS1: <namespace> = namespace %import_ref.4, [template] {
 // CHECK:STDOUT:     .A = %import_ref.5
 // CHECK:STDOUT:     import Other//b
 // CHECK:STDOUT:     import Other//a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Other//a, inst+4, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Other//a, A, loaded [template = constants.%A]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
@@ -59,7 +59,7 @@ var or_: F(true or true);
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   %.loc42_17: bool = block_arg <unexpected instblockref inst_block23> [template = constants.%true]
-// CHECK:STDOUT:   %F.call: init type = call <unexpected>.inst+73.loc42_10(%.loc42_17)
+// CHECK:STDOUT:   %F.call: init type = call <unexpected>.inst85.loc42_10(%.loc42_17)
 // CHECK:STDOUT:   %.loc42_24.1: type = value_of_initializer %F.call
 // CHECK:STDOUT:   %.loc42_24.2: type = converted %F.call, %.loc42_24.1
 // CHECK:STDOUT:   %or_.var: ref <error> = var or_
@@ -68,7 +68,7 @@ var or_: F(true or true);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b.param_patt: bool) -> type {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %b.ref: bool = name_ref b, <unexpected>.inst+13.loc12_6
+// CHECK:STDOUT:   %b.ref: bool = name_ref b, <unexpected>.inst25.loc12_6
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+1, loaded [template = constants.%Add.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+36, loaded [template = constants.%AddAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Add, loaded [template = constants.%Add.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, AddAssign, loaded [template = constants.%AddAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, inst+29, loaded [template = constants.%BitAnd.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, inst+63, loaded [template = constants.%BitAndAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, BitAnd, loaded [template = constants.%BitAnd.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, BitAndAssign, loaded [template = constants.%BitAndAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -46,7 +46,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, inst+1, loaded [template = constants.%BitComplement.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, BitComplement, loaded [template = constants.%BitComplement.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, inst+94, loaded [template = constants.%BitOr.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, inst+128, loaded [template = constants.%BitOrAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, BitOr, loaded [template = constants.%BitOr.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, BitOrAssign, loaded [template = constants.%BitOrAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, inst+159, loaded [template = constants.%BitXor.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, inst+193, loaded [template = constants.%BitXorAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, BitXor, loaded [template = constants.%BitXor.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, BitXorAssign, loaded [template = constants.%BitXorAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -47,7 +47,7 @@ fn TestOp() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+183, loaded [template = constants.%Dec.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Dec, loaded [template = constants.%Dec.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+272, loaded [template = constants.%Div.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+306, loaded [template = constants.%DivAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Div, loaded [template = constants.%Div.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, DivAssign, loaded [template = constants.%DivAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -111,7 +111,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/comparison, inst+3, loaded [template = constants.%Eq.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/comparison, Eq, loaded [template = constants.%Eq.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -381,7 +381,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/comparison, inst+3, loaded [template = constants.%Eq.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/comparison, Eq, loaded [template = constants.%Eq.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -71,8 +71,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+67, loaded [template = constants.%Inc.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+36, loaded [template = constants.%AddAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Inc, loaded [template = constants.%Inc.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, AddAssign, loaded [template = constants.%AddAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -82,8 +82,8 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+1, loaded [template = constants.%Add.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+36, loaded [template = constants.%AddAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Add, loaded [template = constants.%Add.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, AddAssign, loaded [template = constants.%AddAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
+++ b/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
@@ -77,7 +77,7 @@ fn Test() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %ImplicitAs.type.1 = import_ref Core//prelude/operators/as, inst+56, loaded [template = constants.%ImplicitAs.generic]
+// CHECK:STDOUT:   %import_ref.2: %ImplicitAs.type.1 = import_ref Core//prelude/operators/as, ImplicitAs, loaded [template = constants.%ImplicitAs.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -47,7 +47,7 @@ fn TestOp() {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+67, loaded [template = constants.%Inc.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Inc, loaded [template = constants.%Inc.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/index.carbon
+++ b/toolchain/check/testdata/operators/overloaded/index.carbon
@@ -102,7 +102,7 @@ let x: i32 = c[0];
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %IndexWith.type.1 = import_ref Core//prelude/operators/index, inst+13, loaded [template = constants.%IndexWith.generic]
+// CHECK:STDOUT:   %import_ref.1: %IndexWith.type.1 = import_ref Core//prelude/operators/index, IndexWith, loaded [template = constants.%IndexWith.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -262,7 +262,7 @@ let x: i32 = c[0];
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %IndexWith.type.1 = import_ref Core//prelude/operators/index, inst+13, loaded [template = constants.%IndexWith.generic]
+// CHECK:STDOUT:   %import_ref.2: %IndexWith.type.1 = import_ref Core//prelude/operators/index, IndexWith, loaded [template = constants.%IndexWith.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -415,7 +415,7 @@ let x: i32 = c[0];
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %IndexWith.type.1 = import_ref Core//prelude/operators/index, inst+13, loaded [template = constants.%IndexWith.generic]
+// CHECK:STDOUT:   %import_ref.1: %IndexWith.type.1 = import_ref Core//prelude/operators/index, IndexWith, loaded [template = constants.%IndexWith.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, inst+224, loaded [template = constants.%LeftShift.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, inst+258, loaded [template = constants.%LeftShiftAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, LeftShift, loaded [template = constants.%LeftShift.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, LeftShiftAssign, loaded [template = constants.%LeftShiftAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+337, loaded [template = constants.%Mod.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+371, loaded [template = constants.%ModAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Mod, loaded [template = constants.%Mod.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, ModAssign, loaded [template = constants.%ModAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+207, loaded [template = constants.%Mul.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+241, loaded [template = constants.%MulAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Mul, loaded [template = constants.%Mul.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, MulAssign, loaded [template = constants.%MulAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -46,7 +46,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+91, loaded [template = constants.%Negate.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Negate, loaded [template = constants.%Negate.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -113,7 +113,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/comparison, inst+72, loaded [template = constants.%Ordered.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/comparison, Ordered, loaded [template = constants.%Ordered.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, inst+289, loaded [template = constants.%RightShift.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, inst+323, loaded [template = constants.%RightShiftAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/bitwise, RightShift, loaded [template = constants.%RightShift.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/bitwise, RightShiftAssign, loaded [template = constants.%RightShiftAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -63,8 +63,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, inst+118, loaded [template = constants.%Sub.type]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, inst+152, loaded [template = constants.%SubAssign.type]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Core//prelude/operators/arithmetic, Sub, loaded [template = constants.%Sub.type]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref Core//prelude/operators/arithmetic, SubAssign, loaded [template = constants.%SubAssign.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
@@ -94,7 +94,7 @@ import library "var";
 // CHECK:STDOUT: --- fail_conflict.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Example//fn, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Example//fn, Foo, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/packages/fail_import_type_error.carbon
+++ b/toolchain/check/testdata/packages/fail_import_type_error.carbon
@@ -88,10 +88,10 @@ var d: i32 = d_ref;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: ref <error> = import_ref Implicit//default, inst+5, loaded
-// CHECK:STDOUT:   %import_ref.2: ref <error> = import_ref Implicit//default, inst+9, loaded
-// CHECK:STDOUT:   %import_ref.3: ref <error> = import_ref Implicit//default, inst+13, loaded
-// CHECK:STDOUT:   %import_ref.4: ref <error> = import_ref Implicit//default, inst+17, loaded
+// CHECK:STDOUT:   %import_ref.1: ref <error> = import_ref Implicit//default, a_ref, loaded
+// CHECK:STDOUT:   %import_ref.2: ref <error> = import_ref Implicit//default, b_ref, loaded
+// CHECK:STDOUT:   %import_ref.3: ref <error> = import_ref Implicit//default, c_ref, loaded
+// CHECK:STDOUT:   %import_ref.4: ref <error> = import_ref Implicit//default, d_ref, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.5
 // CHECK:STDOUT:     import Core//prelude

--- a/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
+++ b/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
@@ -84,7 +84,7 @@ var b: i32 = a;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: ref %i32 = import_ref Main//lib, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: ref %i32 = import_ref Main//lib, a, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.36
 // CHECK:STDOUT:     import Core//prelude

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -72,7 +72,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %A.type = import_ref Implicit//default, inst+3, loaded [template = constants.%A]
+// CHECK:STDOUT:   %import_ref: %A.type = import_ref Implicit//default, A, loaded [template = constants.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
@@ -147,7 +147,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %B.type = import_ref SamePackage//default, inst+3, loaded [template = constants.%B]
+// CHECK:STDOUT:   %import_ref: %B.type = import_ref SamePackage//default, B, loaded [template = constants.%B]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/packages/no_prelude/cross_package_export.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/cross_package_export.carbon
@@ -242,7 +242,7 @@ alias C = Other.C;
 // CHECK:STDOUT: --- export_import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Other//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Other//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -255,7 +255,7 @@ alias C = Other.C;
 // CHECK:STDOUT: --- export_import_copy.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Other//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Other//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -268,7 +268,7 @@ alias C = Other.C;
 // CHECK:STDOUT: --- export_import_indirect.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Other//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Other//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -288,10 +288,10 @@ alias C = Other.C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -319,10 +319,10 @@ alias C = Other.C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -350,10 +350,10 @@ alias C = Other.C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst21 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -388,10 +388,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//export_import
 // CHECK:STDOUT:     import Other//base
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -444,10 +444,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//export_import_copy
 // CHECK:STDOUT:     import Other//base
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -500,10 +500,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//export_import
 // CHECK:STDOUT:     import Other//base
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -554,10 +554,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     .C = %import_ref.1
 // CHECK:STDOUT:     import Other//export_name
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst21 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -609,10 +609,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//export_name
 // CHECK:STDOUT:     import Other//export_name_copy
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst21 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -663,10 +663,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     .C = %import_ref.1
 // CHECK:STDOUT:     import Other//export_name_indirect
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name_indirect, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name_indirect, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name_indirect, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name_indirect, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name_indirect, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name_indirect, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name_indirect, inst21 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name_indirect, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -723,10 +723,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//export_name_indirect
 // CHECK:STDOUT:     import Other//base
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst21 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -808,7 +808,7 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//conflict
 // CHECK:STDOUT:     import Other//base
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref Other//conflict, inst+1, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: %C.type = import_ref Other//conflict, C, loaded [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -839,10 +839,10 @@ alias C = Other.C;
 // CHECK:STDOUT:     import Other//export_name
 // CHECK:STDOUT:     import Other//conflict
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, inst+11, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst+8, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//export_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//export_name, inst20 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//export_name, inst21 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Other//export_name, inst22 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/no_prelude/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/cross_package_import.carbon
@@ -299,7 +299,7 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: %F.type = import_ref Other//other_fn, inst+1, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref: %F.type = import_ref Other//other_fn, F, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -348,8 +348,8 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT:     import Other//other_fn
 // CHECK:STDOUT:     import Other//other_fn2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//other_fn, inst+1, loaded [template = constants.%F]
-// CHECK:STDOUT:   %import_ref.2: %F2.type = import_ref Other//other_fn2, inst+1, loaded [template = constants.%F2]
+// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//other_fn, F, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.2: %F2.type = import_ref Other//other_fn2, F2, loaded [template = constants.%F2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -392,7 +392,7 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT:     import Other//other_fn
 // CHECK:STDOUT:     import Other//other_fn_extern
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//other_fn, inst+1, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//other_fn, F, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -446,7 +446,7 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT:     import Other//other_fn
 // CHECK:STDOUT:     import Other//other_fn_conflict
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//other_fn, inst+1, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: %F.type = import_ref Other//other_fn, F, loaded [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -476,7 +476,7 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Main//main_other_ns, inst+1, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Main//main_other_ns, Other, loaded
 // CHECK:STDOUT:   %Other: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .F = file.%F.decl
 // CHECK:STDOUT:     import Other//other_fn

--- a/toolchain/check/testdata/packages/no_prelude/export_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_import.carbon
@@ -198,7 +198,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: --- export.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -211,7 +211,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: --- export_copy.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -224,7 +224,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: --- non_export.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -237,7 +237,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: --- export_export.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -250,7 +250,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: --- import_then_export.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//base, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//base, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -278,10 +278,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -327,10 +327,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -377,10 +377,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_export, inst+2, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -427,10 +427,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -476,10 +476,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -525,10 +525,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -574,10 +574,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -623,10 +623,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -672,10 +672,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -732,10 +732,10 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -781,11 +781,11 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//use_non_export_then_base, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//use_non_export_then_base, c, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/no_prelude/export_mixed.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_mixed.carbon
@@ -163,8 +163,8 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: --- export_import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//base, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//base, C, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, D, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -185,11 +185,11 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, D, unloaded
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -218,11 +218,11 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//base, D, unloaded
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -244,7 +244,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: --- export_name_then_import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//export_name, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//export_name, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -266,10 +266,10 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_import_then_name, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_import_then_name, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_import_then_name, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_import_then_name, inst22 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst23 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -315,10 +315,10 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_name, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_name, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_name, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_name, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_name, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_name, inst22 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_name, inst23 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -364,10 +364,10 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_import_then_name, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_import_then_name, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_import_then_name, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_import_then_name, inst22 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst23 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -409,7 +409,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//export_import_then_name, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//export_import_then_name, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -443,10 +443,10 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_import_then_name, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_import_then_name, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//export_import_then_name, inst21 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//export_import_then_name, inst22 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst23 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -496,14 +496,14 @@ var d: D = {.y = ()};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, inst+12, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//base, inst+11, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//export_import_then_name, inst+9, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export_import_then_name, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//base, inst+18, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//base, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//base, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_import_then_name, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//base, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//export_import_then_name, inst21 [indirect], loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//export_import_then_name, inst22 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export_import_then_name, inst23 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.6: <witness> = import_ref Main//base, loc10_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//base, inst24 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//base, loc9_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_name.carbon
@@ -263,18 +263,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = file.%NSC
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//base, inst+12, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//base, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//base, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//base, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//base, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, loc5_8, unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//base, loc11_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//base, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//base, loc10_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -304,8 +304,8 @@ private export C;
 // CHECK:STDOUT: --- not_reexporting.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//export, inst+14, unloaded
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//export, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
@@ -332,18 +332,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = file.%NSC
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export, inst+22, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export, inst+11, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export, inst23 [indirect], loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export, inst24 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export, inst25 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export, inst31 [indirect], loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export, inst32 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export, inst33 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -392,18 +392,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export, inst+22, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export, inst+11, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export, inst23 [indirect], loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export, inst24 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export, inst25 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export, inst31 [indirect], loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export, inst32 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export, inst33 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -474,18 +474,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_export, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export_export, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export_export, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export_export, inst+22, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export_export, inst+11, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export_export, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export_export, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export_export, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export_export, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export_export, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export_export, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export_export, inst23 [indirect], loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export_export, inst24 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export_export, inst25 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export_export, inst31 [indirect], loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export_export, inst32 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export_export, inst33 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -557,18 +557,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_export, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export_export, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export_export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export_export, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export_export, inst+22, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export_export, inst+11, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export_export, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export_export, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export_export, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export_export, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export_export, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export_export, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export_export, inst23 [indirect], loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export_export, inst24 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export_export, inst25 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export_export, inst31 [indirect], loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export_export, inst32 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export_export, inst33 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -626,8 +626,8 @@ private export C;
 // CHECK:STDOUT: --- fail_export_ns.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//base, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//base, C, unloaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
@@ -674,14 +674,14 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -715,18 +715,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//base, inst+12, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//base, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//base, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//base, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//base, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, loc5_8, unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//base, loc11_1, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//base, inst25 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//base, loc10_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -797,18 +797,18 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//export, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export, inst+22, loaded [template = constants.%NSC]
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export, inst+11, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export, inst+19, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref Main//export, NSC, loaded [template = constants.%NSC]
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//export, inst23 [indirect], loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//export, inst24 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//export, inst25 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.7: <witness> = import_ref Main//export, inst31 [indirect], loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref Main//export, inst32 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref Main//export, inst33 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -888,14 +888,14 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -926,10 +926,10 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//repeat_export, inst+14, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//repeat_export, inst+11, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//repeat_export, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//repeat_export, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//repeat_export, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//repeat_export, inst23 [indirect], loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//repeat_export, inst24 [indirect], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//repeat_export, inst25 [indirect], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -973,14 +973,14 @@ private export C;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, inst+11, loaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//base, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref Main//base, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .NSC = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, inst+9, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.4: <witness> = import_ref Main//base, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//base, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//base, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_member.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_member.carbon
@@ -72,10 +72,10 @@ export C.n;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Foo//a, inst+1, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Foo//a, inst+10, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Foo//a, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref Foo//a, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Foo//a, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Foo//a, loc6_1, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Foo//a, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref Foo//a, loc5_8, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
@@ -96,8 +96,8 @@ export C2(T:! type);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: %C1.type = import_ref Foo//a, inst+7, loaded [template = constants.%C1.generic]
-// CHECK:STDOUT:   %import_ref.2: %C2.type = import_ref Foo//a, inst+18, loaded [template = constants.%C2.generic]
+// CHECK:STDOUT:   %import_ref.1: %C1.type = import_ref Foo//a, C1, loaded [template = constants.%C1.generic]
+// CHECK:STDOUT:   %import_ref.2: %C2.type = import_ref Foo//a, C2, loaded [template = constants.%C2.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/no_prelude/implicit_imports_entities.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/implicit_imports_entities.carbon
@@ -308,7 +308,7 @@ import Other library "o1";
 // CHECK:STDOUT: --- mix_current_package.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//c1, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//c1, C1, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -330,12 +330,12 @@ import Other library "o1";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//mix_current_package, inst+2, loaded [template = constants.%C1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//c2, inst+1, loaded [template = constants.%C2]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//c1, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//c1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//c2, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//c2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//mix_current_package, C1, loaded [template = constants.%C1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//c2, C2, loaded [template = constants.%C2]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//c1, loc4_11, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//c1, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Main//c2, loc4_11, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//c2, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -383,7 +383,7 @@ import Other library "o1";
 // CHECK:STDOUT: --- dup_c1.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//c1, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//c1, C1, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -403,9 +403,9 @@ import Other library "o1";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//dup_c1, inst+2, loaded [template = constants.%C1]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c1, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//dup_c1, C1, loaded [template = constants.%C1]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Main//c1, loc4_11, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//c1, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -438,7 +438,7 @@ import Other library "o1";
 // CHECK:STDOUT: --- use_ns.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Main//ns, inst+1, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Main//ns, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .C = %import_ref.2
 // CHECK:STDOUT:   }
@@ -461,13 +461,13 @@ import Other library "o1";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Main//use_ns, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref Main//use_ns, NS, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .C = %import_ref.2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//use_ns, inst+4, loaded [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//ns, inst+5, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.4 = import_ref Main//ns, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref Main//use_ns, C, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref Main//ns, loc5_13, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.4 = import_ref Main//ns, inst15 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -531,12 +531,12 @@ import Other library "o1";
 // CHECK:STDOUT:     import Other//o2
 // CHECK:STDOUT:     import Other//o1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//o1, inst+1, loaded [template = constants.%O1]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//o1, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//o1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4: type = import_ref Other//o2, inst+1, loaded [template = constants.%O2]
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Other//o2, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Other//o2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//o1, O1, loaded [template = constants.%O1]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//o1, loc4_11, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//o1, inst14 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: type = import_ref Other//o2, O2, loaded [template = constants.%O2]
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref Other//o2, loc4_11, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Other//o2, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -612,9 +612,9 @@ import Other library "o1";
 // CHECK:STDOUT:     .O1 = %import_ref.1
 // CHECK:STDOUT:     import Other//o1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//o1, inst+1, loaded [template = constants.%O1]
-// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//o1, inst+4, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Other//o1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Other//o1, O1, loaded [template = constants.%O1]
+// CHECK:STDOUT:   %import_ref.2: <witness> = import_ref Other//o1, loc4_11, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Other//o1, inst14 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -681,7 +681,7 @@ import Other library "o1";
 // CHECK:STDOUT: --- import_conflict_reverse.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Main//local_other, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Main//local_other, Other, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/unused_lazy_import.carbon
+++ b/toolchain/check/testdata/packages/unused_lazy_import.carbon
@@ -46,7 +46,7 @@ impl package Implicit;
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref = import_ref Implicit//default, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref Implicit//default, A, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...

--- a/toolchain/check/testdata/pointer/import.carbon
+++ b/toolchain/check/testdata/pointer/import.carbon
@@ -96,8 +96,8 @@ var a: i32* = a_ref;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref %ptr = import_ref Implicit//default, inst+317, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, a_orig, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref %ptr = import_ref Implicit//default, a_ref, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.37
 // CHECK:STDOUT:     import Core//prelude

--- a/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
+++ b/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
@@ -381,14 +381,14 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.2
 // CHECK:STDOUT:     import Core//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: %ImplicitAs.type.1 = import_ref Core//default, inst+30, loaded [template = constants.%ImplicitAs.generic]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Core//default, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.4: @ImplicitAs.%Convert.assoc_type (%Convert.assoc_type.1) = import_ref Core//default, inst+60, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.5: @ImplicitAs.%Convert.type (%Convert.type.1) = import_ref Core//default, inst+52, loaded [symbolic = @ImplicitAs.%Convert (constants.%Convert.1)]
-// CHECK:STDOUT:   %import_ref.6 = import_ref Core//default, inst+52, unloaded
-// CHECK:STDOUT:   %import_ref.8: type = import_ref Core//default, inst+71, loaded [template = Core.IntLiteral]
-// CHECK:STDOUT:   %import_ref.9: type = import_ref Core//default, inst+79, loaded [template = constants.%ImplicitAs.type.3]
-// CHECK:STDOUT:   %import_ref.10: <witness> = import_ref Core//default, inst+103, loaded [template = constants.%interface.1]
+// CHECK:STDOUT:   %import_ref.2: %ImplicitAs.type.1 = import_ref Core//default, ImplicitAs, loaded [template = constants.%ImplicitAs.generic]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Core//default, inst48 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.4: @ImplicitAs.%Convert.assoc_type (%Convert.assoc_type.1) = import_ref Core//default, loc9_32, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.5: @ImplicitAs.%Convert.type (%Convert.type.1) = import_ref Core//default, Convert, loaded [symbolic = @ImplicitAs.%Convert (constants.%Convert.1)]
+// CHECK:STDOUT:   %import_ref.6 = import_ref Core//default, loc9_32, unloaded
+// CHECK:STDOUT:   %import_ref.8: type = import_ref Core//default, loc12_17, loaded [template = Core.IntLiteral]
+// CHECK:STDOUT:   %import_ref.9: type = import_ref Core//default, loc12_36, loaded [template = constants.%ImplicitAs.type.3]
+// CHECK:STDOUT:   %import_ref.10: <witness> = import_ref Core//default, loc12_38, loaded [template = constants.%interface.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1147,46 +1147,46 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.10
 // CHECK:STDOUT:     import Core//default
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: type = import_ref P//library, inst+33, loaded [template = constants.%D]
-// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref P//library, inst+47, loaded [template = constants.%complete_type.1]
-// CHECK:STDOUT:   %import_ref.4 = import_ref P//library, inst+34, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref P//library, inst+40, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref P//library, inst+45, unloaded
-// CHECK:STDOUT:   %import_ref.7: %C.type = import_ref P//library, inst+24, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref P//library, inst+31, loaded [template = constants.%complete_type.2]
-// CHECK:STDOUT:   %import_ref.9 = import_ref P//library, inst+29, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref Core//default, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.12: @ImplicitAs.%Convert.assoc_type (%Convert.assoc_type.1) = import_ref Core//default, inst+60, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.3)]
-// CHECK:STDOUT:   %import_ref.13 = import_ref Core//default, inst+52, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref Core//default, inst+52, unloaded
-// CHECK:STDOUT:   %import_ref.16: type = import_ref Core//default, inst+71, loaded [template = Core.IntLiteral]
-// CHECK:STDOUT:   %import_ref.17: type = import_ref Core//default, inst+79, loaded [template = constants.%ImplicitAs.type.3]
-// CHECK:STDOUT:   %import_ref.18: <witness> = import_ref Core//default, inst+103, loaded [template = constants.%interface.1]
-// CHECK:STDOUT:   %import_ref.19: type = import_ref P//library, inst+143, loaded [template = constants.%C.2]
-// CHECK:STDOUT:   %import_ref.20: type = import_ref P//library, inst+148, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.21: <witness> = import_ref P//library, inst+169, loaded [template = constants.%interface.2]
-// CHECK:STDOUT:   %import_ref.22: type = import_ref P//library, inst+186, loaded [template = constants.%C.3]
-// CHECK:STDOUT:   %import_ref.23: type = import_ref P//library, inst+191, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.24: <witness> = import_ref P//library, inst+207, loaded [template = constants.%interface.3]
-// CHECK:STDOUT:   %import_ref.25: type = import_ref P//library, inst+223, loaded [template = constants.%C.4]
-// CHECK:STDOUT:   %import_ref.26: type = import_ref P//library, inst+228, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.27: <witness> = import_ref P//library, inst+244, loaded [template = constants.%interface.4]
-// CHECK:STDOUT:   %import_ref.28: type = import_ref P//library, inst+260, loaded [template = constants.%C.5]
-// CHECK:STDOUT:   %import_ref.29: type = import_ref P//library, inst+265, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.30: <witness> = import_ref P//library, inst+281, loaded [template = constants.%interface.5]
-// CHECK:STDOUT:   %import_ref.31: type = import_ref P//library, inst+297, loaded [template = constants.%C.6]
-// CHECK:STDOUT:   %import_ref.32: type = import_ref P//library, inst+302, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.33: <witness> = import_ref P//library, inst+318, loaded [template = constants.%interface.6]
-// CHECK:STDOUT:   %import_ref.34: type = import_ref P//library, inst+334, loaded [template = constants.%C.7]
-// CHECK:STDOUT:   %import_ref.35: type = import_ref P//library, inst+339, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.36: <witness> = import_ref P//library, inst+355, loaded [template = constants.%interface.7]
-// CHECK:STDOUT:   %import_ref.37: type = import_ref P//library, inst+371, loaded [template = constants.%C.8]
-// CHECK:STDOUT:   %import_ref.38: type = import_ref P//library, inst+376, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref P//library, inst+392, loaded [template = constants.%interface.8]
-// CHECK:STDOUT:   %import_ref.40: type = import_ref P//library, inst+408, loaded [template = constants.%C.9]
-// CHECK:STDOUT:   %import_ref.41: type = import_ref P//library, inst+413, loaded [template = constants.%ImplicitAs.type.4]
-// CHECK:STDOUT:   %import_ref.42: <witness> = import_ref P//library, inst+429, loaded [template = constants.%interface.9]
-// CHECK:STDOUT:   %import_ref.43: %Make.type = import_ref P//library, inst+54, loaded [template = constants.%Make]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref P//library, D, loaded [template = constants.%D]
+// CHECK:STDOUT:   %import_ref.3: <witness> = import_ref P//library, loc7_35, loaded [template = constants.%complete_type.1]
+// CHECK:STDOUT:   %import_ref.4 = import_ref P//library, inst46 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref P//library, loc7_16, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref P//library, loc7_28, unloaded
+// CHECK:STDOUT:   %import_ref.7: %C.type = import_ref P//library, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.8: <witness> = import_ref P//library, loc6_19, loaded [template = constants.%complete_type.2]
+// CHECK:STDOUT:   %import_ref.9 = import_ref P//library, inst41 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref Core//default, inst48 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.12: @ImplicitAs.%Convert.assoc_type (%Convert.assoc_type.1) = import_ref Core//default, loc9_32, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.3)]
+// CHECK:STDOUT:   %import_ref.13 = import_ref Core//default, Convert, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref Core//default, loc9_32, unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref Core//default, loc12_17, loaded [template = Core.IntLiteral]
+// CHECK:STDOUT:   %import_ref.17: type = import_ref Core//default, loc12_36, loaded [template = constants.%ImplicitAs.type.3]
+// CHECK:STDOUT:   %import_ref.18: <witness> = import_ref Core//default, loc12_38, loaded [template = constants.%interface.1]
+// CHECK:STDOUT:   %import_ref.19: type = import_ref P//library, loc10_9, loaded [template = constants.%C.2]
+// CHECK:STDOUT:   %import_ref.20: type = import_ref P//library, loc10_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.21: <witness> = import_ref P//library, loc10_33, loaded [template = constants.%interface.2]
+// CHECK:STDOUT:   %import_ref.22: type = import_ref P//library, loc11_9, loaded [template = constants.%C.3]
+// CHECK:STDOUT:   %import_ref.23: type = import_ref P//library, loc11_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.24: <witness> = import_ref P//library, loc11_33, loaded [template = constants.%interface.3]
+// CHECK:STDOUT:   %import_ref.25: type = import_ref P//library, loc12_9, loaded [template = constants.%C.4]
+// CHECK:STDOUT:   %import_ref.26: type = import_ref P//library, loc12_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.27: <witness> = import_ref P//library, loc12_33, loaded [template = constants.%interface.4]
+// CHECK:STDOUT:   %import_ref.28: type = import_ref P//library, loc13_9, loaded [template = constants.%C.5]
+// CHECK:STDOUT:   %import_ref.29: type = import_ref P//library, loc13_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.30: <witness> = import_ref P//library, loc13_33, loaded [template = constants.%interface.5]
+// CHECK:STDOUT:   %import_ref.31: type = import_ref P//library, loc14_9, loaded [template = constants.%C.6]
+// CHECK:STDOUT:   %import_ref.32: type = import_ref P//library, loc14_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.33: <witness> = import_ref P//library, loc14_33, loaded [template = constants.%interface.6]
+// CHECK:STDOUT:   %import_ref.34: type = import_ref P//library, loc15_9, loaded [template = constants.%C.7]
+// CHECK:STDOUT:   %import_ref.35: type = import_ref P//library, loc15_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.36: <witness> = import_ref P//library, loc15_33, loaded [template = constants.%interface.7]
+// CHECK:STDOUT:   %import_ref.37: type = import_ref P//library, loc16_9, loaded [template = constants.%C.8]
+// CHECK:STDOUT:   %import_ref.38: type = import_ref P//library, loc16_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref P//library, loc16_33, loaded [template = constants.%interface.8]
+// CHECK:STDOUT:   %import_ref.40: type = import_ref P//library, loc17_9, loaded [template = constants.%C.9]
+// CHECK:STDOUT:   %import_ref.41: type = import_ref P//library, loc17_31, loaded [template = constants.%ImplicitAs.type.4]
+// CHECK:STDOUT:   %import_ref.42: <witness> = import_ref P//library, loc17_33, loaded [template = constants.%interface.9]
+// CHECK:STDOUT:   %import_ref.43: %Make.type = import_ref P//library, Make, loaded [template = constants.%Make]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -43,10 +43,10 @@ var c_bad: C({.c = 1, .d = 2}) = F();
 // --- fail_bad_value.impl.carbon
 
 impl package Implicit;
-// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+6]]:1: error: cannot implicitly convert from `C(<cannot stringify inst+345 kind StructValue>)` to `C(<cannot stringify inst+333 kind StructValue>)` [ImplicitAsConversionFailure]
+// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+6]]:1: error: cannot implicitly convert from `C(<cannot stringify inst357 kind StructValue>)` to `C(<cannot stringify inst345 kind StructValue>)` [ImplicitAsConversionFailure]
 // CHECK:STDERR: var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+3]]:1: note: type `C(<cannot stringify inst+345 kind StructValue>)` does not implement interface `ImplicitAs(C(<cannot stringify inst+333 kind StructValue>))` [MissingImplInMemberAccessNote]
+// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+3]]:1: note: type `C(<cannot stringify inst357 kind StructValue>)` does not implement interface `ImplicitAs(C(<cannot stringify inst345 kind StructValue>))` [MissingImplInMemberAccessNote]
 // CHECK:STDERR: var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var c_bad: C({.a = 3, .b = 4}) = F();
@@ -305,18 +305,18 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: ref %struct_type.a = import_ref Implicit//default, inst+21, loaded
-// CHECK:STDOUT:   %import_ref.2: ref %struct_type.a.d.1 = import_ref Implicit//default, inst+342, loaded
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, inst+401, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, inst+445, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: ref %struct_type.a = import_ref Implicit//default, a_ref, loaded
+// CHECK:STDOUT:   %import_ref.2: ref %struct_type.a.d.1 = import_ref Implicit//default, b_ref, loaded
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, F, loaded [template = constants.%F]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.39
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.42
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.40: <witness> = import_ref Implicit//default, inst+408, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.41 = import_ref Implicit//default, inst+406, unloaded
+// CHECK:STDOUT:   %import_ref.40: <witness> = import_ref Implicit//default, loc8_34, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.41 = import_ref Implicit//default, inst418 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -470,16 +470,16 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, inst+342, unloaded
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, inst+401, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, inst+445, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, a_ref, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, b_ref, unloaded
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, F, loaded [template = constants.%F]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, inst+408, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst+406, unloaded
+// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, loc8_34, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst418 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -574,17 +574,17 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, inst+342, unloaded
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, inst+401, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, inst+445, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, a_ref, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, b_ref, unloaded
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, F, loaded [template = constants.%F]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.41
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, inst+408, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst+406, unloaded
+// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, loc8_34, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst418 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/tuple/import.carbon
+++ b/toolchain/check/testdata/tuple/import.carbon
@@ -45,10 +45,10 @@ var c_bad: C((1, 2, 3)) = F();
 
 impl package Implicit;
 
-// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+6]]:1: error: cannot implicitly convert from `C(<cannot stringify inst+345 kind TupleValue>)` to `C(<cannot stringify inst+333 kind TupleValue>)` [ImplicitAsConversionFailure]
+// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+6]]:1: error: cannot implicitly convert from `C(<cannot stringify inst357 kind TupleValue>)` to `C(<cannot stringify inst345 kind TupleValue>)` [ImplicitAsConversionFailure]
 // CHECK:STDERR: var c_bad: C((3, 4)) = F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+3]]:1: note: type `C(<cannot stringify inst+345 kind TupleValue>)` does not implement interface `ImplicitAs(C(<cannot stringify inst+333 kind TupleValue>))` [MissingImplInMemberAccessNote]
+// CHECK:STDERR: fail_bad_value.impl.carbon:[[@LINE+3]]:1: note: type `C(<cannot stringify inst357 kind TupleValue>)` does not implement interface `ImplicitAs(C(<cannot stringify inst345 kind TupleValue>))` [MissingImplInMemberAccessNote]
 // CHECK:STDERR: var c_bad: C((3, 4)) = F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 var c_bad: C((3, 4)) = F();
@@ -336,18 +336,18 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: ref %tuple.type.2 = import_ref Implicit//default, inst+23, loaded
-// CHECK:STDOUT:   %import_ref.2: ref %tuple.type.8 = import_ref Implicit//default, inst+355, loaded
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, inst+438, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, inst+472, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1: ref %tuple.type.2 = import_ref Implicit//default, a_ref, loaded
+// CHECK:STDOUT:   %import_ref.2: ref %tuple.type.8 = import_ref Implicit//default, b_ref, loaded
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, F, loaded [template = constants.%F]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Int = %import_ref.39
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.42
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.40: <witness> = import_ref Implicit//default, inst+445, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.41 = import_ref Implicit//default, inst+443, unloaded
+// CHECK:STDOUT:   %import_ref.40: <witness> = import_ref Implicit//default, loc7_26, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.41 = import_ref Implicit//default, inst455 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -519,16 +519,16 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, inst+23, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, inst+355, unloaded
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, inst+438, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, inst+472, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, a_ref, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, b_ref, unloaded
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, F, loaded [template = constants.%F]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, inst+445, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst+443, unloaded
+// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, loc7_26, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst455 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -624,17 +624,17 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, inst+23, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, inst+355, unloaded
-// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, inst+438, loaded [template = constants.%C.generic]
-// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, inst+472, loaded [template = constants.%F]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Implicit//default, a_ref, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref Implicit//default, b_ref, unloaded
+// CHECK:STDOUT:   %import_ref.3: %C.type = import_ref Implicit//default, C, loaded [template = constants.%C.generic]
+// CHECK:STDOUT:   %import_ref.4: %F.type = import_ref Implicit//default, F, loaded [template = constants.%F]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.41
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, inst+445, loaded [template = constants.%complete_type]
-// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst+443, unloaded
+// CHECK:STDOUT:   %import_ref.39: <witness> = import_ref Implicit//default, loc7_26, loaded [template = constants.%complete_type]
+// CHECK:STDOUT:   %import_ref.40 = import_ref Implicit//default, inst455 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/var/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/var/no_prelude/export_name.carbon
@@ -66,7 +66,7 @@ var w: () = v;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Main//base, inst+5, loaded
+// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Main//base, v, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -85,7 +85,7 @@ var w: () = v;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Main//export, inst+4, loaded [template = <error>]
+// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Main//export, v, loaded [template = <error>]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/var/no_prelude/import.carbon
+++ b/toolchain/check/testdata/var/no_prelude/import.carbon
@@ -54,7 +54,7 @@ var a: () = a_ref;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Implicit//default, inst+5, loaded
+// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Implicit//default, a_ref, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/var/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/var/no_prelude/import_access.carbon
@@ -85,7 +85,7 @@ var v2: () = Test.v;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Test//def, inst+5, loaded
+// CHECK:STDOUT:   %import_ref: ref %empty_tuple.type = import_ref Test//def, v, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/where_expr/constraints.carbon
+++ b/toolchain/check/testdata/where_expr/constraints.carbon
@@ -575,17 +575,17 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//state_constraints, inst+3, loaded [template = constants.%J.type]
-// CHECK:STDOUT:   %import_ref.2 = import_ref Main//state_constraints, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//state_constraints, inst+35, unloaded
-// CHECK:STDOUT:   %import_ref.4: %Impls.type = import_ref Main//state_constraints, inst+57, loaded [template = constants.%Impls]
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//state_constraints, inst+85, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref Main//state_constraints, J, loaded [template = constants.%J.type]
+// CHECK:STDOUT:   %import_ref.2 = import_ref Main//state_constraints, I, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//state_constraints, EqualEqual, unloaded
+// CHECK:STDOUT:   %import_ref.4: %Impls.type = import_ref Main//state_constraints, Impls, loaded [template = constants.%Impls]
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//state_constraints, And, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.7
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//state_constraints, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//state_constraints, inst17 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/where_expr/equal_rewrite.carbon
+++ b/toolchain/check/testdata/where_expr/equal_rewrite.carbon
@@ -1084,10 +1084,10 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %import_ref.1 = import_ref Main//equal_constraint, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2: %Equal.type = import_ref Main//equal_constraint, inst+33, loaded [template = constants.%Equal]
-// CHECK:STDOUT:   %import_ref.3 = import_ref Main//nested_rewrites, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: %NestedRewrite.type = import_ref Main//nested_rewrites, inst+55, loaded [template = constants.%NestedRewrite]
+// CHECK:STDOUT:   %import_ref.1 = import_ref Main//equal_constraint, N, unloaded
+// CHECK:STDOUT:   %import_ref.2: %Equal.type = import_ref Main//equal_constraint, Equal, loaded [template = constants.%Equal]
+// CHECK:STDOUT:   %import_ref.3 = import_ref Main//nested_rewrites, A, unloaded
+// CHECK:STDOUT:   %import_ref.4: %NestedRewrite.type = import_ref Main//nested_rewrites, NestedRewrite, loaded [template = constants.%NestedRewrite]
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
 // CHECK:STDOUT:     .Bool = %import_ref.8
 // CHECK:STDOUT:     .ImplicitAs = %import_ref.9
@@ -1095,14 +1095,14 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5 = import_ref Main//equal_constraint, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref Main//equal_constraint, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref Main//equal_constraint, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.45 = import_ref Main//nested_rewrites, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.46 = import_ref Main//nested_rewrites, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.47 = import_ref Main//nested_rewrites, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.48 = import_ref Main//nested_rewrites, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.49 = import_ref Main//nested_rewrites, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref Main//equal_constraint, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref Main//equal_constraint, loc5_15, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref Main//equal_constraint, P, unloaded
+// CHECK:STDOUT:   %import_ref.45 = import_ref Main//nested_rewrites, inst17 [no loc], unloaded
+// CHECK:STDOUT:   %import_ref.46 = import_ref Main//nested_rewrites, loc5_15, unloaded
+// CHECK:STDOUT:   %import_ref.47 = import_ref Main//nested_rewrites, loc6_15, unloaded
+// CHECK:STDOUT:   %import_ref.48 = import_ref Main//nested_rewrites, B, unloaded
+// CHECK:STDOUT:   %import_ref.49 = import_ref Main//nested_rewrites, C, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -190,6 +190,8 @@ class Tree : public Printable<Tree> {
   // CHECK so that it can be used within a debugger.
   auto Verify() const -> ErrorOr<Success>;
 
+  auto tokens() const -> const Lex::TokenizedBuffer& { return *tokens_; }
+
  private:
   friend class Context;
   friend class TypedNodesTestPeer;

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -18,10 +18,11 @@
 
 namespace Carbon::SemIR {
 
-File::File(CheckIRId check_ir_id,
+File::File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
            const std::optional<Parse::Tree::PackagingDecl>& packaging_decl,
            SharedValueStores& value_stores, std::string filename)
-    : check_ir_id_(check_ir_id),
+    : parse_tree_(parse_tree),
+      check_ir_id_(check_ir_id),
       package_id_(packaging_decl ? packaging_decl->names.package_id
                                  : IdentifierId::Invalid),
       library_id_(packaging_decl ? LibraryNameId::ForStringLiteralValueId(

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -39,7 +39,7 @@ namespace Carbon::SemIR {
 class File : public Printable<File> {
  public:
   // Starts a new file for Check::CheckParseTree.
-  explicit File(CheckIRId check_ir_id,
+  explicit File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
                 const std::optional<Parse::Tree::PackagingDecl>& packaging_decl,
                 SharedValueStores& value_stores, std::string filename);
 
@@ -181,7 +181,11 @@ class File : public Printable<File> {
 
   auto filename() const -> llvm::StringRef { return filename_; }
 
+  auto parse_tree() const -> const Parse::Tree& { return *parse_tree_; }
+
  private:
+  const Parse::Tree* parse_tree_;
+
   // True if parts of the IR may be invalid.
   bool has_errors_ = false;
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1040,7 +1040,7 @@ class FormatterImpl {
         // GetCanonicalImportIRInst?
         out_ << import_ir_inst.inst_id << " [indirect]";
       } else if (loc_id.is_node_id()) {
-        // Formats a NodeId from the provided file.
+        // Formats a NodeId from the import.
         const auto& tree = import_ir.sem_ir->parse_tree();
         auto token = tree.node_token(loc_id.node_id());
         out_ << "loc" << tree.tokens().GetLineNumber(token) << "_"

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1036,8 +1036,8 @@ class FormatterImpl {
       if (!loc_id.is_valid()) {
         out_ << import_ir_inst.inst_id << " [no loc]";
       } else if (loc_id.is_import_ir_inst_id()) {
-        // TODO: Probably don't want to format each indirection, but maybe the
-        // canonical location?
+        // TODO: Probably don't want to format each indirection, but maybe reuse
+        // GetCanonicalImportIRInst?
         out_ << import_ir_inst.inst_id << " [indirect]";
       } else if (loc_id.is_node_id()) {
         // Formats a NodeId from the provided file.

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1040,7 +1040,11 @@ class FormatterImpl {
         // canonical location?
         out_ << import_ir_inst.inst_id << " [indirect]";
       } else if (loc_id.is_node_id()) {
-        FormatNodeId(import_ir.sem_ir, loc_id.node_id());
+        // Formats a NodeId from the provided file.
+        const auto& tree = import_ir.sem_ir->parse_tree();
+        auto token = tree.node_token(loc_id.node_id());
+        out_ << "loc" << tree.tokens().GetLineNumber(token) << "_"
+             << tree.tokens().GetColumnNumber(token);
       } else {
         CARBON_FATAL("Unexpected LocId: {0}", loc_id);
       }
@@ -1157,22 +1161,6 @@ class FormatterImpl {
   auto FormatArg(IntId id) -> void {
     // We don't know the signedness to use here. Default to unsigned.
     sem_ir_->ints().Get(id).print(out_, /*isSigned=*/false);
-  }
-
-  auto FormatArg(LocId id) -> void {
-    if (!id.is_valid()) {
-      out_ << id;
-    } else if (id.is_import_ir_inst_id()) {
-      auto import_ir_inst =
-          sem_ir_->import_ir_insts().Get(id.import_ir_inst_id());
-      out_ << "{";
-      FormatArg(import_ir_inst.ir_id);
-      out_ << ", " << import_ir_inst.inst_id << "}";
-    } else if (id.is_node_id()) {
-      FormatNodeId(sem_ir_, id.node_id());
-    } else {
-      CARBON_FATAL("Unexpected LocId: {0}", id);
-    }
   }
 
   auto FormatArg(ElementIndex index) -> void { out_ << index; }
@@ -1319,14 +1307,6 @@ class FormatterImpl {
                   import_ir.library_id().AsStringLiteralValueId())
             : "default";
     return llvm::formatv("{0}//{1}", package_name, library_name);
-  }
-
-  // Formats a NodeId from the provided file.
-  auto FormatNodeId(const SemIR::File* sem_ir, Parse::NodeId node_id) -> void {
-    const auto& tree = sem_ir->parse_tree();
-    auto token = tree.node_token(node_id);
-    out_ << "loc" << tree.tokens().GetLineNumber(token) << "_"
-         << tree.tokens().GetColumnNumber(token);
   }
 
   const File* sem_ir_;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -25,7 +25,7 @@ namespace Carbon::SemIR {
 // Formatter for printing textual Semantics IR.
 class FormatterImpl {
  public:
-  explicit FormatterImpl(const File& sem_ir, InstNamer* inst_namer,
+  explicit FormatterImpl(const File* sem_ir, InstNamer* inst_namer,
                          Formatter::ShouldFormatEntityFn should_format_entity,
                          int indent)
       : sem_ir_(sem_ir),
@@ -35,7 +35,7 @@ class FormatterImpl {
     // Create the first chunk and assign it to all instructions that don't have
     // a chunk of their own.
     auto first_chunk = AddChunkNoFlush(true);
-    tentative_inst_chunks_.resize(sem_ir.insts().size(), first_chunk);
+    tentative_inst_chunks_.resize(sem_ir_->insts().size(), first_chunk);
   }
 
   // Prints the SemIR.
@@ -44,12 +44,12 @@ class FormatterImpl {
   // including file-scoped instructions. The file scope may contain entity
   // declarations which are defined later, such as classes.
   auto Format() -> void {
-    out_ << "--- " << sem_ir_.filename() << "\n\n";
+    out_ << "--- " << sem_ir_->filename() << "\n\n";
 
     FormatScopeIfUsed(InstNamer::ScopeId::Constants,
-                      sem_ir_.constants().array_ref());
+                      sem_ir_->constants().array_ref());
     FormatScopeIfUsed(InstNamer::ScopeId::ImportRefs,
-                      sem_ir_.inst_blocks().Get(InstBlockId::ImportRefs));
+                      sem_ir_->inst_blocks().Get(InstBlockId::ImportRefs));
 
     out_ << inst_namer_->GetScopeName(InstNamer::ScopeId::File) << " ";
     OpenBrace();
@@ -57,7 +57,7 @@ class FormatterImpl {
     // TODO: Handle the case where there are multiple top-level instruction
     // blocks. For example, there may be branching in the initializer of a
     // global or a type expression.
-    if (auto block_id = sem_ir_.top_inst_block_id(); block_id.is_valid()) {
+    if (auto block_id = sem_ir_->top_inst_block_id(); block_id.is_valid()) {
       llvm::SaveAndRestore file_scope(scope_, InstNamer::ScopeId::File);
       FormatCodeBlock(block_id);
     }
@@ -65,23 +65,23 @@ class FormatterImpl {
     CloseBrace();
     out_ << '\n';
 
-    for (int i : llvm::seq(sem_ir_.interfaces().size())) {
+    for (int i : llvm::seq(sem_ir_->interfaces().size())) {
       FormatInterface(InterfaceId(i));
     }
 
-    for (int i : llvm::seq(sem_ir_.impls().size())) {
+    for (int i : llvm::seq(sem_ir_->impls().size())) {
       FormatImpl(ImplId(i));
     }
 
-    for (int i : llvm::seq(sem_ir_.classes().size())) {
+    for (int i : llvm::seq(sem_ir_->classes().size())) {
       FormatClass(ClassId(i));
     }
 
-    for (int i : llvm::seq(sem_ir_.functions().size())) {
+    for (int i : llvm::seq(sem_ir_->functions().size())) {
       FormatFunction(FunctionId(i));
     }
 
-    for (int i : llvm::seq(sem_ir_.specifics().size())) {
+    for (int i : llvm::seq(sem_ir_->specifics().size())) {
       FormatSpecific(SpecificId(i));
     }
 
@@ -258,7 +258,7 @@ class FormatterImpl {
 
   // Formats a full class.
   auto FormatClass(ClassId id) -> void {
-    const Class& class_info = sem_ir_.classes().Get(id);
+    const Class& class_info = sem_ir_->classes().Get(id);
     if (!ShouldFormatEntity(class_info)) {
       return;
     }
@@ -289,7 +289,7 @@ class FormatterImpl {
 
   // Formats a full interface.
   auto FormatInterface(InterfaceId id) -> void {
-    const Interface& interface_info = sem_ir_.interfaces().Get(id);
+    const Interface& interface_info = sem_ir_->interfaces().Get(id);
     if (!ShouldFormatEntity(interface_info)) {
       return;
     }
@@ -325,7 +325,7 @@ class FormatterImpl {
 
   // Formats a full impl.
   auto FormatImpl(ImplId id) -> void {
-    const Impl& impl_info = sem_ir_.impls().Get(id);
+    const Impl& impl_info = sem_ir_->impls().Get(id);
     if (!ShouldFormatEntity(impl_info)) {
       return;
     }
@@ -368,7 +368,7 @@ class FormatterImpl {
 
   // Formats a full function.
   auto FormatFunction(FunctionId id) -> void {
-    const Function& fn = sem_ir_.functions().Get(id);
+    const Function& fn = sem_ir_->functions().Get(id);
     if (!ShouldFormatEntity(fn)) {
       return;
     }
@@ -400,13 +400,13 @@ class FormatterImpl {
 
     if (fn.return_slot_pattern_id.is_valid()) {
       out_ << " -> ";
-      auto return_info = ReturnTypeInfo::ForFunction(sem_ir_, fn);
+      auto return_info = ReturnTypeInfo::ForFunction(*sem_ir_, fn);
       if (!fn.body_block_ids.empty() && return_info.is_valid() &&
           return_info.has_return_slot()) {
         FormatName(fn.return_slot_pattern_id);
         out_ << ": ";
       }
-      FormatType(sem_ir_.insts().Get(fn.return_slot_pattern_id).type_id());
+      FormatType(sem_ir_->insts().Get(fn.return_slot_pattern_id).type_id());
     }
 
     if (fn.builtin_function_kind != BuiltinFunctionKind::None) {
@@ -450,8 +450,8 @@ class FormatterImpl {
       out_ << "!" << region_name << ":\n";
     }
     for (auto [generic_inst_id, specific_inst_id] : llvm::zip_longest(
-             sem_ir_.inst_blocks().GetOrEmpty(generic.GetEvalBlock(region)),
-             sem_ir_.inst_blocks().GetOrEmpty(
+             sem_ir_->inst_blocks().GetOrEmpty(generic.GetEvalBlock(region)),
+             sem_ir_->inst_blocks().GetOrEmpty(
                  specific.GetValueBlock(region)))) {
       Indent();
       if (generic_inst_id) {
@@ -471,8 +471,8 @@ class FormatterImpl {
 
   // Formats a full specific.
   auto FormatSpecific(SpecificId id) -> void {
-    const auto& specific = sem_ir_.specifics().Get(id);
-    const auto& generic = sem_ir_.generics().Get(specific.generic_id);
+    const auto& specific = sem_ir_->specifics().Get(id);
+    const auto& generic = sem_ir_->generics().Get(specific.generic_id);
     if (!should_format_entity_(generic.decl_id)) {
       // Omit specifics if we also omitted the generic.
       return;
@@ -500,7 +500,7 @@ class FormatterImpl {
   // Handles generic-specific setup for FormatEntityStart.
   auto FormatGenericStart(llvm::StringRef entity_kind, GenericId generic_id)
       -> void {
-    const auto& generic = sem_ir_.generics().Get(generic_id);
+    const auto& generic = sem_ir_->generics().Get(generic_id);
     out_ << "\n";
     Indent();
     out_ << "generic " << entity_kind << " ";
@@ -529,11 +529,12 @@ class FormatterImpl {
     // If this entity was imported from a different IR, annotate the name of
     // that IR in the output before the `{` or `;`.
     if (entity.first_owning_decl_id.is_valid()) {
-      auto loc_id = sem_ir_.insts().GetLocId(entity.first_owning_decl_id);
+      auto loc_id = sem_ir_->insts().GetLocId(entity.first_owning_decl_id);
       if (loc_id.is_import_ir_inst_id()) {
         auto import_ir_id =
-            sem_ir_.import_ir_insts().Get(loc_id.import_ir_inst_id()).ir_id;
-        const auto* import_file = sem_ir_.import_irs().Get(import_ir_id).sem_ir;
+            sem_ir_->import_ir_insts().Get(loc_id.import_ir_inst_id()).ir_id;
+        const auto* import_file =
+            sem_ir_->import_irs().Get(import_ir_id).sem_ir;
         pending_imported_from_ = import_file->filename();
       }
     }
@@ -575,19 +576,19 @@ class FormatterImpl {
     out_ << (is_implicit ? "[" : "(");
 
     llvm::ListSeparator sep;
-    for (InstId param_id : sem_ir_.inst_blocks().Get(param_patterns_id)) {
+    for (InstId param_id : sem_ir_->inst_blocks().Get(param_patterns_id)) {
       out_ << sep;
       if (!param_id.is_valid()) {
         out_ << "invalid";
         continue;
       }
-      if (auto addr = sem_ir_.insts().TryGetAs<SemIR::AddrPattern>(param_id)) {
+      if (auto addr = sem_ir_->insts().TryGetAs<SemIR::AddrPattern>(param_id)) {
         out_ << "addr ";
         param_id = addr->inner_id;
       }
       FormatName(param_id);
       out_ << ": ";
-      FormatType(sem_ir_.insts().Get(param_id).type_id());
+      FormatType(sem_ir_->insts().Get(param_id).type_id());
     }
 
     out_ << (is_implicit ? "]" : ")");
@@ -595,7 +596,7 @@ class FormatterImpl {
 
   // Prints instructions for a code block.
   auto FormatCodeBlock(InstBlockId block_id) -> void {
-    for (const InstId inst_id : sem_ir_.inst_blocks().GetOrEmpty(block_id)) {
+    for (const InstId inst_id : sem_ir_->inst_blocks().GetOrEmpty(block_id)) {
       FormatInst(inst_id);
     }
   }
@@ -611,7 +612,7 @@ class FormatterImpl {
 
   // Prints the contents of a name scope, with an optional label.
   auto FormatNameScope(NameScopeId id, llvm::StringRef label = "") -> void {
-    const auto& scope = sem_ir_.name_scopes().Get(id);
+    const auto& scope = sem_ir_->name_scopes().Get(id);
 
     if (scope.names.empty() && scope.extended_scopes.empty() &&
         scope.import_ir_scopes.empty() && !scope.has_error) {
@@ -684,7 +685,7 @@ class FormatterImpl {
       return;
     }
 
-    FormatInst(inst_id, sem_ir_.insts().Get(inst_id));
+    FormatInst(inst_id, sem_ir_->insts().Get(inst_id));
   }
 
   auto FormatInst(InstId inst_id, Inst inst) -> void {
@@ -703,9 +704,9 @@ class FormatterImpl {
     Indent();
     FormatInstLHS(inst_id, inst);
     out_ << InstT::Kind.ir_name();
-    pending_constant_value_ = sem_ir_.constant_values().Get(inst_id);
+    pending_constant_value_ = sem_ir_->constant_values().Get(inst_id);
     pending_constant_value_is_self_ =
-        sem_ir_.constant_values().GetInstIdIfValid(pending_constant_value_) ==
+        sem_ir_->constant_values().GetInstIdIfValid(pending_constant_value_) ==
         inst_id;
     FormatInstRHS(inst);
     FormatPendingConstantValue(AddSpace::Before);
@@ -774,7 +775,7 @@ class FormatterImpl {
       case InstValueKind::Typed:
         FormatName(inst_id);
         out_ << ": ";
-        switch (GetExprCategory(sem_ir_, inst_id)) {
+        switch (GetExprCategory(*sem_ir_, inst_id)) {
           case ExprCategory::NotExpr:
           case ExprCategory::Error:
           case ExprCategory::Value:
@@ -898,9 +899,9 @@ class FormatterImpl {
       return;
     }
 
-    llvm::ArrayRef<InstId> args = sem_ir_.inst_blocks().Get(inst.args_id);
+    llvm::ArrayRef<InstId> args = sem_ir_->inst_blocks().Get(inst.args_id);
 
-    auto return_info = ReturnTypeInfo::ForType(sem_ir_, inst.type_id);
+    auto return_info = ReturnTypeInfo::ForType(*sem_ir_, inst.type_id);
     bool has_return_slot = return_info.has_return_slot();
     InstId return_slot_arg_id = InstId::Invalid;
     if (has_return_slot) {
@@ -975,7 +976,7 @@ class FormatterImpl {
     llvm::SaveAndRestore class_scope(
         scope_, inst_namer_->GetScopeFor(inst.function_id));
     FormatTrailingBlock(
-        sem_ir_.functions().Get(inst.function_id).pattern_block_id);
+        sem_ir_->functions().Get(inst.function_id).pattern_block_id);
     FormatTrailingBlock(inst.decl_block_id);
   }
 
@@ -983,7 +984,7 @@ class FormatterImpl {
     FormatArgs(inst.class_id);
     llvm::SaveAndRestore class_scope(scope_,
                                      inst_namer_->GetScopeFor(inst.class_id));
-    FormatTrailingBlock(sem_ir_.classes().Get(inst.class_id).pattern_block_id);
+    FormatTrailingBlock(sem_ir_->classes().Get(inst.class_id).pattern_block_id);
     FormatTrailingBlock(inst.decl_block_id);
   }
 
@@ -991,7 +992,7 @@ class FormatterImpl {
     FormatArgs(inst.impl_id);
     llvm::SaveAndRestore class_scope(scope_,
                                      inst_namer_->GetScopeFor(inst.impl_id));
-    FormatTrailingBlock(sem_ir_.impls().Get(inst.impl_id).pattern_block_id);
+    FormatTrailingBlock(sem_ir_->impls().Get(inst.impl_id).pattern_block_id);
     FormatTrailingBlock(inst.decl_block_id);
   }
 
@@ -1000,31 +1001,59 @@ class FormatterImpl {
     llvm::SaveAndRestore class_scope(
         scope_, inst_namer_->GetScopeFor(inst.interface_id));
     FormatTrailingBlock(
-        sem_ir_.interfaces().Get(inst.interface_id).pattern_block_id);
+        sem_ir_->interfaces().Get(inst.interface_id).pattern_block_id);
     FormatTrailingBlock(inst.decl_block_id);
   }
 
   auto FormatInstRHS(IntValue inst) -> void {
     out_ << " ";
-    sem_ir_.ints()
+    sem_ir_->ints()
         .Get(inst.int_id)
-        .print(out_, sem_ir_.types().IsSignedInt(inst.type_id));
+        .print(out_, sem_ir_->types().IsSignedInt(inst.type_id));
   }
 
   auto FormatInstRHS(FloatLiteral inst) -> void {
     llvm::SmallVector<char, 16> buffer;
-    sem_ir_.floats().Get(inst.float_id).toString(buffer);
+    sem_ir_->floats().Get(inst.float_id).toString(buffer);
     out_ << " " << buffer;
   }
 
-  auto FormatInstRHS(ImportRefUnloaded inst) -> void {
-    FormatArgs(inst.import_ir_inst_id);
-    out_ << ", unloaded";
+  auto FormatImportRefRHS(ImportIRInstId import_ir_inst_id,
+                          EntityNameId entity_name_id,
+                          llvm::StringLiteral loaded_label) -> void {
+    out_ << " ";
+    auto import_ir_inst = sem_ir_->import_ir_insts().Get(import_ir_inst_id);
+    FormatArg(import_ir_inst.ir_id);
+    out_ << ", ";
+    if (entity_name_id.is_valid()) {
+      // Prefer to show the entity name when possible.
+      FormatArg(entity_name_id);
+    } else {
+      // Show a name based on the location when possible, or the numeric
+      // instruction as a last resort.
+      const auto& import_ir = sem_ir_->import_irs().Get(import_ir_inst.ir_id);
+      auto loc_id = import_ir.sem_ir->insts().GetLocId(import_ir_inst.inst_id);
+      if (!loc_id.is_valid()) {
+        out_ << import_ir_inst.inst_id << " [no loc]";
+      } else if (loc_id.is_import_ir_inst_id()) {
+        // TODO: Probably don't want to format each indirection, but maybe the
+        // canonical location?
+        out_ << import_ir_inst.inst_id << " [indirect]";
+      } else if (loc_id.is_node_id()) {
+        FormatNodeId(import_ir.sem_ir, loc_id.node_id());
+      } else {
+        CARBON_FATAL("Unexpected LocId: {0}", loc_id);
+      }
+    }
+    out_ << ", " << loaded_label;
   }
 
   auto FormatInstRHS(ImportRefLoaded inst) -> void {
-    FormatArgs(inst.import_ir_inst_id);
-    out_ << ", loaded";
+    FormatImportRefRHS(inst.import_ir_inst_id, inst.entity_name_id, "loaded");
+  }
+
+  auto FormatInstRHS(ImportRefUnloaded inst) -> void {
+    FormatImportRefRHS(inst.import_ir_inst_id, inst.entity_name_id, "unloaded");
   }
 
   auto FormatInstRHS(SpliceBlock inst) -> void {
@@ -1040,7 +1069,7 @@ class FormatterImpl {
   auto FormatInstRHS(StructType inst) -> void {
     out_ << " {";
     llvm::ListSeparator sep;
-    for (auto field : sem_ir_.struct_type_fields().Get(inst.fields_id)) {
+    for (auto field : sem_ir_->struct_type_fields().Get(inst.fields_id)) {
       out_ << sep << ".";
       FormatName(field.name_id);
       out_ << ": ";
@@ -1069,7 +1098,7 @@ class FormatterImpl {
   auto FormatArg(BoolValue v) -> void { out_ << v; }
 
   auto FormatArg(EntityNameId id) -> void {
-    const auto& info = sem_ir_.entity_names().Get(id);
+    const auto& info = sem_ir_->entity_names().Get(id);
     FormatName(info.name_id);
     if (info.bind_index.is_valid()) {
       out_ << ", " << info.bind_index.index;
@@ -1077,7 +1106,7 @@ class FormatterImpl {
   }
 
   auto FormatArg(FacetTypeId id) -> void {
-    const auto& info = sem_ir_.facet_types().Get(id);
+    const auto& info = sem_ir_->facet_types().Get(id);
     // Nothing output to indicate that this is a facet type since this is only
     // used as the argument to a `facet_type` instruction.
     out_ << "<";
@@ -1125,29 +1154,24 @@ class FormatterImpl {
     }
   }
 
-  auto FormatArg(ImportIRInstId id) -> void {
-    // Don't format the inst_id because it refers to a different IR.
-    // TODO: Consider a better way to format the InstID from other IRs.
-    auto import_ir_inst = sem_ir_.import_ir_insts().Get(id);
-    FormatArg(import_ir_inst.ir_id);
-    out_ << ", " << import_ir_inst.inst_id;
-  }
-
   auto FormatArg(IntId id) -> void {
     // We don't know the signedness to use here. Default to unsigned.
-    sem_ir_.ints().Get(id).print(out_, /*isSigned=*/false);
+    sem_ir_->ints().Get(id).print(out_, /*isSigned=*/false);
   }
 
   auto FormatArg(LocId id) -> void {
-    if (id.is_import_ir_inst_id()) {
-      out_ << "{";
-      FormatArg(id.import_ir_inst_id());
-      out_ << "}";
-    } else {
-      // TODO: For a NodeId, this prints the index of the node. Do we want it to
-      // print a line number or something in order to make it less dependent on
-      // parse?
+    if (!id.is_valid()) {
       out_ << id;
+    } else if (id.is_import_ir_inst_id()) {
+      auto import_ir_inst =
+          sem_ir_->import_ir_insts().Get(id.import_ir_inst_id());
+      out_ << "{";
+      FormatArg(import_ir_inst.ir_id);
+      out_ << ", " << import_ir_inst.inst_id << "}";
+    } else if (id.is_node_id()) {
+      FormatNodeId(sem_ir_, id.node_id());
+    } else {
+      CARBON_FATAL("Unexpected LocId: {0}", id);
     }
   }
 
@@ -1169,7 +1193,7 @@ class FormatterImpl {
 
     out_ << '(';
     llvm::ListSeparator sep;
-    for (auto inst_id : sem_ir_.inst_blocks().Get(id)) {
+    for (auto inst_id : sem_ir_->inst_blocks().Get(id)) {
       out_ << sep;
       FormatArg(inst_id);
     }
@@ -1178,14 +1202,14 @@ class FormatterImpl {
 
   auto FormatArg(RealId id) -> void {
     // TODO: Format with a `.` when the exponent is near zero.
-    const auto& real = sem_ir_.reals().Get(id);
+    const auto& real = sem_ir_->reals().Get(id);
     real.mantissa.print(out_, /*isSigned=*/false);
     out_ << (real.is_decimal ? 'e' : 'p') << real.exponent;
   }
 
   auto FormatArg(StringLiteralValueId id) -> void {
     out_ << '"';
-    out_.write_escaped(sem_ir_.string_literal_values().Get(id),
+    out_.write_escaped(sem_ir_->string_literal_values().Get(id),
                        /*UseHexEscapes=*/true);
     out_ << '"';
   }
@@ -1195,7 +1219,7 @@ class FormatterImpl {
   auto FormatArg(TypeBlockId id) -> void {
     out_ << '(';
     llvm::ListSeparator sep;
-    for (auto type_id : sem_ir_.type_blocks().Get(id)) {
+    for (auto type_id : sem_ir_->type_blocks().Get(id)) {
       out_ << sep;
       FormatArg(type_id);
     }
@@ -1216,7 +1240,7 @@ class FormatterImpl {
   }
 
   auto FormatName(NameId id) -> void {
-    out_ << sem_ir_.names().GetFormatted(id);
+    out_ << sem_ir_->names().GetFormatted(id);
   }
 
   auto FormatName(InstId id) -> void {
@@ -1231,7 +1255,7 @@ class FormatterImpl {
   }
 
   auto FormatName(SpecificId id) -> void {
-    const auto& specific = sem_ir_.specifics().Get(id);
+    const auto& specific = sem_ir_->specifics().Get(id);
     FormatName(specific.generic_id);
     FormatArg(specific.args_id);
   }
@@ -1250,21 +1274,21 @@ class FormatterImpl {
     // generic first, and the canonical constant second.
     if (id.is_symbolic()) {
       const auto& symbolic_constant =
-          sem_ir_.constant_values().GetSymbolicConstant(id);
+          sem_ir_->constant_values().GetSymbolicConstant(id);
       if (symbolic_constant.generic_id.is_valid()) {
         const auto& generic =
-            sem_ir_.generics().Get(symbolic_constant.generic_id);
-        FormatName(sem_ir_.inst_blocks().Get(generic.GetEvalBlock(
+            sem_ir_->generics().Get(symbolic_constant.generic_id);
+        FormatName(sem_ir_->inst_blocks().Get(generic.GetEvalBlock(
             symbolic_constant.index
                 .region()))[symbolic_constant.index.index()]);
         out_ << " (";
-        FormatName(sem_ir_.constant_values().GetInstId(id));
+        FormatName(sem_ir_->constant_values().GetInstId(id));
         out_ << ")";
         return;
       }
     }
 
-    FormatName(sem_ir_.constant_values().GetInstId(id));
+    FormatName(sem_ir_->constant_values().GetInstId(id));
   }
 
   auto FormatType(TypeId id) -> void {
@@ -1274,7 +1298,7 @@ class FormatterImpl {
       // Types are formatted in the `constants` scope because they only refer to
       // constants.
       llvm::SaveAndRestore file_scope(scope_, InstNamer::ScopeId::Constants);
-      FormatConstant(sem_ir_.types().GetConstantId(id));
+      FormatConstant(sem_ir_->types().GetConstantId(id));
     }
   }
 
@@ -1282,7 +1306,7 @@ class FormatterImpl {
   auto GetImportIRLabel(ImportIRId id) -> std::string {
     CARBON_CHECK(id.is_valid(),
                  "GetImportIRLabel should only be called where we a valid ID.");
-    const auto& import_ir = *sem_ir_.import_irs().Get(id).sem_ir;
+    const auto& import_ir = *sem_ir_->import_irs().Get(id).sem_ir;
     CARBON_CHECK(import_ir.library_id().is_valid());
 
     llvm::StringRef package_name =
@@ -1297,7 +1321,15 @@ class FormatterImpl {
     return llvm::formatv("{0}//{1}", package_name, library_name);
   }
 
-  const File& sem_ir_;
+  // Formats a NodeId from the provided file.
+  auto FormatNodeId(const SemIR::File* sem_ir, Parse::NodeId node_id) -> void {
+    const auto& tree = sem_ir->parse_tree();
+    auto token = tree.node_token(node_id);
+    out_ << "loc" << tree.tokens().GetLineNumber(token) << "_"
+         << tree.tokens().GetColumnNumber(token);
+  }
+
+  const File* sem_ir_;
   InstNamer* const inst_namer_;
   Formatter::ShouldFormatEntityFn should_format_entity_;
 
@@ -1347,12 +1379,11 @@ class FormatterImpl {
   llvm::SmallVector<size_t, 0> tentative_inst_chunks_;
 };
 
-Formatter::Formatter(const Lex::TokenizedBuffer& tokenized_buffer,
-                     const Parse::Tree& parse_tree, const File& sem_ir,
+Formatter::Formatter(const File* sem_ir,
                      ShouldFormatEntityFn should_format_entity)
     : sem_ir_(sem_ir),
       should_format_entity_(should_format_entity),
-      inst_namer_(tokenized_buffer, parse_tree, sem_ir) {}
+      inst_namer_(sem_ir) {}
 
 Formatter::~Formatter() = default;
 

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -22,8 +22,7 @@ class Formatter {
       llvm::function_ref<auto(InstId decl_inst_id)->bool>;
 
   explicit Formatter(
-      const Lex::TokenizedBuffer& tokenized_buffer,
-      const Parse::Tree& parse_tree, const File& sem_ir,
+      const File* sem_ir,
       ShouldFormatEntityFn should_format_entity = [](InstId) { return true; });
   ~Formatter();
 
@@ -31,7 +30,7 @@ class Formatter {
   auto Print(llvm::raw_ostream& out) -> void;
 
  private:
-  const File& sem_ir_;
+  const File* sem_ir_;
   ShouldFormatEntityFn should_format_entity_;
   // Caches naming between Print calls.
   InstNamer inst_namer_;

--- a/toolchain/sem_ir/ids.cpp
+++ b/toolchain/sem_ir/ids.cpp
@@ -10,17 +10,10 @@
 namespace Carbon::SemIR {
 
 auto InstId::Print(llvm::raw_ostream& out) const -> void {
-  if (!is_valid()) {
-    IdBase::Print(out);
-    return;
-  }
-  out << Label;
-  if (index < static_cast<int>(SingletonInstKinds.size())) {
-    out << "(" << SingletonInstKinds[index] << ")";
+  if (IsSingletonInstId(*this)) {
+    out << Label << "(" << SingletonInstKinds[index] << ")";
   } else {
-    // Use the `+` as a small reminder that this is a delta, rather than an
-    // absolute index.
-    out << "+" << index - SingletonInstKinds.size();
+    IdBase::Print(out);
   }
 }
 

--- a/toolchain/sem_ir/inst_namer.h
+++ b/toolchain/sem_ir/inst_namer.h
@@ -31,8 +31,7 @@ class InstNamer {
 
   // Construct the instruction namer, and assign names to all instructions in
   // the provided file.
-  InstNamer(const Lex::TokenizedBuffer& tokenized_buffer,
-            const Parse::Tree& parse_tree, const File& sem_ir);
+  explicit InstNamer(const File* sem_ir);
 
   // Returns the scope ID corresponding to an ID of a function, class, or
   // interface.
@@ -41,13 +40,13 @@ class InstNamer {
     auto index = static_cast<int32_t>(ScopeId::FirstFunction);
 
     if constexpr (!std::same_as<FunctionId, IdT>) {
-      index += sem_ir_.functions().size();
+      index += sem_ir_->functions().size();
       if constexpr (!std::same_as<ClassId, IdT>) {
-        index += sem_ir_.classes().size();
+        index += sem_ir_->classes().size();
         if constexpr (!std::same_as<InterfaceId, IdT>) {
-          index += sem_ir_.interfaces().size();
+          index += sem_ir_->interfaces().size();
           if constexpr (!std::same_as<ImplId, IdT>) {
-            index += sem_ir_.impls().size();
+            index += sem_ir_->impls().size();
             static_assert(std::same_as<NumberOfScopesTag, IdT>,
                           "Unknown ID kind for scope");
           }
@@ -165,9 +164,7 @@ class InstNamer {
 
   auto CollectNamesInGeneric(ScopeId scope_id, GenericId generic_id) -> void;
 
-  const Lex::TokenizedBuffer& tokenized_buffer_;
-  const Parse::Tree& parse_tree_;
-  const File& sem_ir_;
+  const File* sem_ir_;
 
   // The namespace for entity names. Names within this namespace are prefixed
   // with `@` in formatted SemIR.

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -48,12 +48,12 @@ TEST(SemIRTest, YAML) {
   // Matches the ID of an instruction. Instruction counts may change as various
   // support changes, so this code is only doing loose structural checks.
   auto type_block_id = Yaml::Scalar(MatchesRegex(R"(type_block\d+)"));
-  auto inst_id = Yaml::Scalar(MatchesRegex(R"(inst\+\d+)"));
+  auto inst_id = Yaml::Scalar(MatchesRegex(R"(inst\d+)"));
   auto constant_id =
       Yaml::Scalar(MatchesRegex(R"(template_constant\(inst(\w+|\+\d+)\))"));
   auto inst_builtin = Yaml::Scalar(MatchesRegex(R"(inst\(\w+\))"));
   auto type_id =
-      Yaml::Scalar(MatchesRegex(R"(type\((\w+|inst\(\w+\)|inst\+\d+)\))"));
+      Yaml::Scalar(MatchesRegex(R"(type\((\w+|inst\(\w+\)|inst\d+)\))"));
   auto type_builtin = Pair(type_id, Yaml::Mapping(_));
 
   auto file = Yaml::Mapping(ElementsAre(


### PR DESCRIPTION
The offsets were originally added to deal with churn from builtins in the raw semir. In textual semir, we mostly see instruction IDs for imports, and builtins have also settled down more.

On imports, where possible, use the `EntityNameId` for an import instead of printing an instruction. Next, show the source location if we have a node. Only show the instruction if there's no location.

This also exposes `Parse::Tree` and `TokenizedBuffer`, so that we can pass a `SemIR::File` without the component parts. In particular this allows us to get the `TokenizedBuffer` for import IRs without substantial structural modifications. We may want to make these optional for serialized `SemIR` later, but the nodes/tokens contain source location, which we'd need for debug information -- so it's not clear how much we can really make them optional without substantial information loss.

Reduce arguments to just `File` in a few spots, as a result of the accompanying `TokenizedBuffer` and `Parse::Tree`. Also updates style to pass around `const File*` where the reference is maintained, instead of `const File&`.

I was considering keeping a direct reference to the tree and tokens on `Context`, but initially my thought was it wouldn't make much difference. I can re-add those if desired, just as direct caching of the `File` fields.