### PR TITLE
Mark some //common, //toolchain/driver, //‎toolchain/install tests as small per 'Test execution time' warning

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -181,6 +181,7 @@ cc_library(
 
 cc_test(
     name = "hashing_test",
+    size = "small",
     srcs = ["hashing_test.cpp"],
     deps = [
         ":hashing",
@@ -217,6 +218,7 @@ cc_library(
 
 cc_test(
     name = "hashtable_key_context_test",
+    size = "small",
     srcs = ["hashtable_key_context_test.cpp"],
     deps = [
         ":hashtable_key_context",
@@ -281,6 +283,7 @@ cc_library(
 
 cc_test(
     name = "map_test",
+    size = "small",
     srcs = ["map_test.cpp"],
     deps = [
         ":map",
@@ -368,6 +371,7 @@ cc_binary(
 
 sh_test(
     name = "raw_hashtable_metadata_group_benchmark_test",
+    size = "small",
     srcs = ["raw_hashtable_metadata_group_benchmark"],
     args = [
         "--benchmark_min_time=1x",
@@ -420,6 +424,7 @@ cc_library(
 
 cc_test(
     name = "set_test",
+    size = "small",
     srcs = ["set_test.cpp"],
     deps = [
         ":raw_hashtable_test_helpers",

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -74,6 +74,7 @@ cc_binary(
 
 sh_test(
     name = "compile_benchmark_test",
+    size = "small",
     srcs = [":compile_benchmark"],
     args = [
         "--benchmark_min_time=1x",

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -82,6 +82,7 @@ cc_library(
 
 cc_test(
     name = "busybox_info_test",
+    size = "small",
     srcs = ["busybox_info_test.cpp"],
     deps = [
         ":busybox_info",


### PR DESCRIPTION
These tests only take between 0.1s and 1.4s.