### PR TITLE
Fix Devcontainer build errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,11 @@
   ],
   "containerUser": "ubuntu",
   "remoteUser": "ubuntu",
-  "runArgs": [
-    "--userns=keep-id"
-  ],
+  // When using devcontainer with podman, you may see /workspace being owned
+  // by root. To work around this, uncomment the following lines
+  // "runArgs": [
+  //   "--userns=keep-id"
+  // ],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,20 @@
 {
   "name": "carbon-lang",
   "build": {
-    "dockerfile": "../docker/ubuntu2204/base/Dockerfile"
+    "dockerfile": "../docker/ubuntu2404/base/Dockerfile"
   },
+  "mounts": [
+    {
+      "source": "carbon-cache",
+      "target": "/home/ubuntu/.cache",
+      "type": "volume"
+    }
+  ],
+  "containerUser": "ubuntu",
+  "remoteUser": "ubuntu",
+  "runArgs": [
+    "--userns=keep-id"
+  ],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,31 +15,31 @@ ubuntu:22.04
 Building the base image is required.
 
 ```
-docker build -t carbon-ubuntu2204-base ./ubuntu2204/base
+docker build -t carbon-ubuntu2404-base ./ubuntu2404/base
 ```
 
 Build image using git repository
 
 ```bash
-docker build -t carbon-ubuntu2204 ./ubuntu2204/github
+docker build -t carbon-ubuntu2404 ./ubuntu2404/github
 ```
 
 Build image using copy instruction
 
 ```bash
-docker build -f ./ubuntu2204/Dockerfile -t carbon-ubuntu2204 ..
+docker build -f ./ubuntu2404/Dockerfile -t carbon-ubuntu2404 ..
 ```
 
 Run image
 
 ```bash
-docker run carbon-ubuntu2204
+docker run carbon-ubuntu2404
 ```
 
 Run image using specific file
 
 ```bash
-docker run carbon-ubuntu2204 bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
+docker run carbon-ubuntu2404 bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
 ```
 
 ### Using a mounted volume
@@ -51,5 +51,5 @@ cd ..
 ```
 
 ```bash
-docker run -w "/carbon-lang" -v "${PWD}:/carbon-lang" "carbon-ubuntu2204-base" bazel run "//explorer" -- "./explorer/testdata/print/format_only.carbon"
+docker run -w "/carbon-lang" -v "${PWD}:/carbon-lang" "carbon-ubuntu2404-base" bazel run "//explorer" -- "./explorer/testdata/print/format_only.carbon"
 ```

--- a/docker/ubuntu2404/Dockerfile
+++ b/docker/ubuntu2404/Dockerfile
@@ -2,19 +2,14 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-FROM carbon-ubuntu2204-base as carbon-ubuntu2204-github-build
+FROM carbon-ubuntu2404-base as carbon-ubuntu2404-build
 
-# Clone git repository
-RUN git clone https://github.com/carbon-language/carbon-lang
-
+COPY . /carbon-lang
 WORKDIR /carbon-lang
-
-# Setup pre-commit
-RUN pre-commit install
 
 # Build
 RUN bazel build //explorer
 
-FROM carbon-ubuntu2204-github-build
+FROM carbon-ubuntu2404-build
 
 CMD ["bazel", "run", "//explorer", "--", "./explorer/testdata/print/format_only.carbon"]

--- a/docker/ubuntu2404/base/Dockerfile
+++ b/docker/ubuntu2404/base/Dockerfile
@@ -43,3 +43,7 @@ ENV PATH="/usr/lib/llvm-18/bin:${PATH}"
 
 # Update pip and install black and pre-commit.
 RUN pip3 install black pre-commit --break-system-packages
+
+# Create .cache directory with proper ownership. We will mount a named volume
+# at this location to allow caching of bazel build files.
+RUN mkdir /home/ubuntu/.cache && chown -R ubuntu:ubuntu /home/ubuntu/.cache

--- a/docker/ubuntu2404/base/Dockerfile
+++ b/docker/ubuntu2404/base/Dockerfile
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-FROM ubuntu:22.04 as carbon-ubuntu2204-base
+FROM ubuntu:24.04 as carbon-ubuntu2404-base
 
 # Install apt tools:
 #   git: Used by VS Code.
@@ -16,9 +16,11 @@ RUN apt-get update && \
   gnupg \
   golang \
   python3-pip \
-  python3.9 \
+  python3 \
   software-properties-common \
-  wget
+  wget \
+  nodejs \
+  npm
 
 ENV PATH="/root/go/bin:${PATH}"
 
@@ -32,13 +34,12 @@ RUN go install github.com/bazelbuild/buildtools/buildifier@5.1.0
 # Install LLVM from apt.llvm.org.
 RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
-RUN ./llvm.sh 15 all
+RUN ./llvm.sh 18 all
 RUN rm llvm.sh
 
 # Add the lib dir to the PATH. This helps Bazel find clang and VS Code find
 # clangd, without version suffixes.
-ENV PATH="/usr/lib/llvm-15/bin:${PATH}"
+ENV PATH="/usr/lib/llvm-18/bin:${PATH}"
 
 # Update pip and install black and pre-commit.
-RUN pip3 install -U pip
-RUN pip3 install black pre-commit
+RUN pip3 install black pre-commit --break-system-packages

--- a/docker/ubuntu2404/github/Dockerfile
+++ b/docker/ubuntu2404/github/Dockerfile
@@ -2,14 +2,19 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-FROM carbon-ubuntu2204-base as carbon-ubuntu2204-build
+FROM carbon-ubuntu2404-base as carbon-ubuntu2404-github-build
 
-COPY . /carbon-lang
+# Clone git repository
+RUN git clone https://github.com/carbon-language/carbon-lang
+
 WORKDIR /carbon-lang
+
+# Setup pre-commit
+RUN pre-commit install
 
 # Build
 RUN bazel build //explorer
 
-FROM carbon-ubuntu2204-build
+FROM carbon-ubuntu2404-github-build
 
 CMD ["bazel", "run", "//explorer", "--", "./explorer/testdata/print/format_only.carbon"]


### PR DESCRIPTION
Devcontainer Dockerfile has been updated to use Ubuntu 24.04 as the base. Now devcontainer builds without errors. Tested with Podman on Linux and Docker Desktop on Windows.

To avoid re-downloading and re-compiling whenever the container is deleted, a named volume is mounted at /home/ubuntu/.cache.

Closes #4065
