### PR TITLE
Disable modernize-use-trailing-return-type on MATCHER_P

### DIFF
--- a/toolchain/sem_ir/name_scope_test.cpp
+++ b/toolchain/sem_ir/name_scope_test.cpp
@@ -14,6 +14,7 @@ using ::testing::ElementsAre;
 using ::testing::Field;
 using ::testing::Pair;
 
+// NOLINTNEXTLINE(modernize-use-trailing-return-type): From the macro.
 MATCHER_P(NameScopeEntryEquals, entry, "") {
   return ExplainMatchResult(
       AllOf(Field("name_id", &NameScope::Entry::name_id, entry.name_id),


### PR DESCRIPTION
clang-tidy gives a false positive on the use of the MATCHER_P macro.
