### PR TITLE
Rename mutable accessor in `InstBlock` store.

### DIFF
--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -51,7 +51,7 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
   }
 
   // Returns the requested block.
-  auto Get(IdT id) -> llvm::MutableArrayRef<ElementType> {
+  auto GetMutable(IdT id) -> llvm::MutableArrayRef<ElementType> {
     return values_.Get(id);
   }
 

--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -50,7 +50,9 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
     return values_.Get(id);
   }
 
-  // Returns the requested block.
+  // Returns a mutable view of the requested block. This operation should be
+  // avoided where possible; we generally want blocks to be immutable once
+  // created.
   auto GetMutable(IdT id) -> llvm::MutableArrayRef<ElementType> {
     return values_.Get(id);
   }

--- a/toolchain/sem_ir/copy_on_write_block.h
+++ b/toolchain/sem_ir/copy_on_write_block.h
@@ -58,7 +58,7 @@ class CopyOnWriteBlock {
     if (id_ == source_id_) {
       id_ = (file_.*ValueStore)().Add((file_.*ValueStore)().Get(source_id_));
     }
-    (file_.*ValueStore)().Get(id_)[i] = value;
+    (file_.*ValueStore)().GetMutable(id_)[i] = value;
   }
 
  private:


### PR DESCRIPTION
Mutating a block is a strange and rare operation and shouldn't have an innocuous name like `Get`.