### PR TITLE
Allow defining .h files in tests without trying to compile them as Carbon files

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -378,8 +378,11 @@ auto FileTestBase::DoArgReplacements(
         }
         it = test_args.erase(it);
         for (const auto& file : test_files) {
-          it = test_args.insert(it, file.filename);
-          ++it;
+          const std::string& filename = file.filename;
+          if (!filename.ends_with(".h")) {
+            it = test_args.insert(it, filename);
+            ++it;
+          }
         }
         // Back up once because the for loop will advance.
         --it;

--- a/toolchain/check/testdata/interop/cpp/no_prelude/test_support.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/test_support.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/no_prelude/test_support.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/no_prelude/test_support.carbon
+
+// --- cpp_file.h
+
+void foo();
+
+// --- carbon_file.carbon
+
+library "[[@TEST_NAME]]";
+
+// CHECK:STDOUT: --- carbon_file.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:


### PR DESCRIPTION
This would be used to test interop with C++.
#4666