### PR TITLE
Move InstKinds out to their own vector.

### DIFF
--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -442,10 +442,6 @@ class CompilationUnit {
 
     sem_ir_.emplace(&*parse_tree_, check_ir_id, parse_tree_->packaging_decl(),
                     value_stores_, input_filename_);
-    if (mem_usage_) {
-      mem_usage_->Collect("sem_ir_", *sem_ir_);
-    }
-
     sem_ir_converter_.emplace(node_converters, &*sem_ir_);
     return {.consumer = consumer_,
             .value_stores = &value_stores_,
@@ -464,6 +460,10 @@ class CompilationUnit {
     // diagnostics now, so that the developer sees them sooner and doesn't need
     // to wait for code generation.
     consumer_->Flush();
+
+    if (mem_usage_) {
+      mem_usage_->Collect("sem_ir_", *sem_ir_);
+    }
 
     if (options_.dump_raw_sem_ir && IncludeInDumps()) {
       CARBON_VLOG("*** Raw SemIR::File ***\n{0}\n", *sem_ir_);

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -16,7 +16,6 @@ namespace Carbon::SemIR {
 
 // Forward declare indexed types, for integration with ValueStore.
 class File;
-class Inst;
 class NameScope;
 struct EntityName;
 struct Class;
@@ -30,11 +29,14 @@ struct Impl;
 struct Interface;
 struct StructTypeField;
 struct TypeInfo;
+namespace Internal {
+struct InstTypeAndArgs;
+}
 
 // The ID of an instruction.
 struct InstId : public IdBase<InstId> {
   static constexpr llvm::StringLiteral Label = "inst";
-  using ValueType = Inst;
+  using ValueType = Internal::InstTypeAndArgs;
 
   // An explicitly invalid ID.
   static const InstId Invalid;

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -397,7 +397,7 @@ class InstStore {
   // Returns whether the requested instruction is the specified type.
   template <typename InstT>
   auto Is(InstId inst_id) const -> bool {
-    return Get(inst_id).Is<InstT>();
+    return Internal::InstLikeTypeInfo<InstT>::IsKind(kinds_[inst_id.index]);
   }
 
   // Returns the requested instruction, which is known to have the specified
@@ -411,7 +411,10 @@ class InstStore {
   // type.
   template <typename InstT>
   auto TryGetAs(InstId inst_id) const -> std::optional<InstT> {
-    return Get(inst_id).TryAs<InstT>();
+    if (!Is<InstT>(inst_id)) {
+      return std::nullopt;
+    }
+    return GetAs<InstT>(inst_id);
   }
 
   // Returns the requested instruction as the specified type, if it is valid and

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -23,6 +23,8 @@
 
 namespace Carbon::SemIR {
 
+class Inst;
+
 // InstLikeTypeInfo is an implementation detail, and not public API.
 namespace Internal {
 
@@ -104,6 +106,16 @@ struct InstLikeTypeInfo<InstCat> : InstLikeTypeInfoBase<InstCat> {
 template <typename T>
 concept InstLikeType = requires { sizeof(InstLikeTypeInfo<T>); };
 
+// Supports storage of an `Inst` object's `kind` separate from its other
+// members.
+struct InstTypeAndArgs {
+  explicit InstTypeAndArgs(Inst inst);
+
+  TypeId type_id;
+  int32_t arg0;
+  int32_t arg1;
+};
+
 }  // namespace Internal
 
 // A type-erased representation of a SemIR instruction, that may be constructed
@@ -164,6 +176,12 @@ class Inst : public Printable<Inst> {
       arg1_ = ToRaw(Info::template Get<1>(typed_inst));
     }
   }
+
+  explicit Inst(InstKind kind, Internal::InstTypeAndArgs fields)
+      : kind_(kind.AsInt()),
+        type_id_(fields.type_id),
+        arg0_(fields.arg0),
+        arg1_(fields.arg1) {}
 
   // Returns whether this instruction has the specified type.
   template <typename TypedInst>
@@ -362,11 +380,14 @@ class InstStore {
   // block.
   auto AddInNoBlock(LocIdAndInst loc_id_and_inst) -> InstId {
     loc_ids_.push_back(loc_id_and_inst.loc_id);
-    return values_.Add(loc_id_and_inst.inst);
+    kinds_.push_back(loc_id_and_inst.inst.kind());
+    return types_and_args_.Add(Internal::InstTypeAndArgs(loc_id_and_inst.inst));
   }
 
   // Returns the requested instruction.
-  auto Get(InstId inst_id) const -> Inst { return values_.Get(inst_id); }
+  auto Get(InstId inst_id) const -> Inst {
+    return Inst(kinds_[inst_id.index], types_and_args_.Get(inst_id));
+  }
 
   // Returns the requested instruction and its location ID.
   auto GetWithLocId(InstId inst_id) const -> LocIdAndInst {
@@ -411,7 +432,10 @@ class InstStore {
   }
 
   // Overwrites a given instruction with a new value.
-  auto Set(InstId inst_id, Inst inst) -> void { values_.Get(inst_id) = inst; }
+  auto Set(InstId inst_id, Inst inst) -> void {
+    kinds_[inst_id.index] = inst.kind();
+    types_and_args_.Get(inst_id) = Internal::InstTypeAndArgs(inst);
+  }
 
   // Overwrites a given instruction's location with a new value.
   auto SetLocId(InstId inst_id, LocId loc_id) -> void {
@@ -427,22 +451,32 @@ class InstStore {
   // Reserves space.
   auto Reserve(size_t size) -> void {
     loc_ids_.reserve(size);
-    values_.Reserve(size);
+    types_and_args_.Reserve(size);
   }
 
   // Collects memory usage of members.
   auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
       -> void {
     mem_usage.Collect(MemUsage::ConcatLabel(label, "loc_ids_"), loc_ids_);
-    mem_usage.Collect(MemUsage::ConcatLabel(label, "values_"), values_);
+    mem_usage.Collect(MemUsage::ConcatLabel(label, "kinds_"), kinds_);
+    mem_usage.Collect(MemUsage::ConcatLabel(label, "types_and_args_"),
+                      types_and_args_);
   }
 
-  auto array_ref() const -> llvm::ArrayRef<Inst> { return values_.array_ref(); }
-  auto size() const -> int { return values_.size(); }
+  auto size() const -> int { return types_and_args_.size(); }
 
  private:
+  // Locations are tracked separately because we expect to read them back out
+  // infrequently, as compared to the number of times we read the instruction.
   llvm::SmallVector<LocId> loc_ids_;
-  ValueStore<InstId> values_;
+
+  // Kinds are 1 byte, so storing them in a separate vector allows some space
+  // savings. This also allows for efficiently reading the kind separately from
+  // the rest of the instruction.
+  llvm::SmallVector<InstKind> kinds_;
+
+  // Remaining instruction information: the type and args.
+  ValueStore<InstId> types_and_args_;
 };
 
 // Adapts BlockValueStore for instruction blocks.
@@ -481,6 +515,9 @@ inline auto CarbonHashValue(const Inst& value, uint64_t seed) -> HashCode {
   hasher.HashRaw(value);
   return static_cast<HashCode>(hasher);
 }
+
+inline Internal::InstTypeAndArgs::InstTypeAndArgs(Inst inst)
+    : type_id(inst.type_id()), arg0(inst.arg0()), arg1(inst.arg1()) {}
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -283,6 +283,9 @@ class Inst : public Printable<Inst> {
  private:
   friend class InstTestHelper;
 
+  // For FromRaw.
+  friend class InstStore;
+
   // Table mapping instruction kinds to their argument kinds.
   static const std::pair<IdKind, IdKind> ArgKindTable[];
 
@@ -332,14 +335,14 @@ inline auto operator<<(llvm::raw_ostream& out, TypedInst inst)
 }
 
 // Associates a LocId and Inst in order to provide type-checking that the
-// TypedNodeId corresponds to the InstT.
+// TypedNodeId corresponds to the TypedInst.
 struct LocIdAndInst {
   // Constructs a LocIdAndInst with no associated location. This should be used
   // very sparingly: only when it doesn't make sense to store a location even
   // when the instruction kind usually has one, such as for instructions in the
   // constants block.
-  template <typename InstT>
-  static auto NoLoc(InstT inst) -> LocIdAndInst {
+  template <typename TypedInst>
+  static auto NoLoc(TypedInst inst) -> LocIdAndInst {
     return LocIdAndInst(LocId::Invalid, inst, /*is_unchecked=*/true);
   }
 
@@ -350,16 +353,17 @@ struct LocIdAndInst {
   }
 
   // Construction for the common case with a typed node.
-  template <typename InstT>
-    requires(Internal::HasNodeId<InstT>)
-  LocIdAndInst(decltype(InstT::Kind)::TypedNodeId node_id, InstT inst)
+  template <typename TypedInst>
+    requires(Internal::HasNodeId<TypedInst>)
+  LocIdAndInst(decltype(TypedInst::Kind)::TypedNodeId node_id, TypedInst inst)
       : loc_id(node_id), inst(inst) {}
 
   // Construction for the case where the instruction can have any associated
   // node.
-  template <typename InstT>
-    requires(Internal::HasUntypedNodeId<InstT>)
-  LocIdAndInst(SemIR::LocId loc_id, InstT inst) : loc_id(loc_id), inst(inst) {}
+  template <typename TypedInst>
+    requires(Internal::HasUntypedNodeId<TypedInst>)
+  LocIdAndInst(SemIR::LocId loc_id, TypedInst inst)
+      : loc_id(loc_id), inst(inst) {}
 
   LocId loc_id;
   Inst inst;
@@ -395,36 +399,67 @@ class InstStore {
   }
 
   // Returns whether the requested instruction is the specified type.
-  template <typename InstT>
+  template <typename TypedInst>
   auto Is(InstId inst_id) const -> bool {
-    return Internal::InstLikeTypeInfo<InstT>::IsKind(kinds_[inst_id.index]);
+    return Internal::InstLikeTypeInfo<TypedInst>::IsKind(kinds_[inst_id.index]);
   }
 
   // Returns the requested instruction, which is known to have the specified
   // type.
-  template <typename InstT>
-  auto GetAs(InstId inst_id) const -> InstT {
-    return Get(inst_id).As<InstT>();
+  template <typename TypedInst>
+  auto GetAs(InstId inst_id) const -> TypedInst {
+    using Info = Internal::InstLikeTypeInfo<TypedInst>;
+    CARBON_DCHECK(Is<TypedInst>(inst_id), "Casting inst {0} to wrong kind {1}",
+                  Get(inst_id), Info::DebugName());
+    auto type_and_args = types_and_args_.Get(inst_id);
+
+    auto build_with_type_id_onwards = [&](auto... type_id_onwards) {
+      if constexpr (Internal::HasKindMemberAsField<TypedInst>) {
+        return TypedInst{kinds_[inst_id.index], type_id_onwards...};
+      } else {
+        return TypedInst{type_id_onwards...};
+      }
+    };
+
+    auto build_with_args = [&](auto... args) {
+      if constexpr (Internal::HasTypeIdMember<TypedInst>) {
+        return build_with_type_id_onwards(type_and_args.type_id, args...);
+      } else {
+        return build_with_type_id_onwards(args...);
+      }
+    };
+
+    if constexpr (Info::NumArgs == 0) {
+      return build_with_args();
+    } else if constexpr (Info::NumArgs == 1) {
+      return build_with_args(Inst::FromRaw<typename Info::template ArgType<0>>(
+          type_and_args.arg0));
+    } else if constexpr (Info::NumArgs == 2) {
+      return build_with_args(
+          Inst::FromRaw<typename Info::template ArgType<0>>(type_and_args.arg0),
+          Inst::FromRaw<typename Info::template ArgType<1>>(
+              type_and_args.arg1));
+    }
   }
 
   // Returns the requested instruction as the specified type, if it is of that
   // type.
-  template <typename InstT>
-  auto TryGetAs(InstId inst_id) const -> std::optional<InstT> {
-    if (!Is<InstT>(inst_id)) {
+  template <typename TypedInst>
+  auto TryGetAs(InstId inst_id) const -> std::optional<TypedInst> {
+    if (!Is<TypedInst>(inst_id)) {
       return std::nullopt;
     }
-    return GetAs<InstT>(inst_id);
+    return GetAs<TypedInst>(inst_id);
   }
 
   // Returns the requested instruction as the specified type, if it is valid and
   // of that type. Otherwise returns nullopt.
-  template <typename InstT>
-  auto TryGetAsIfValid(InstId inst_id) const -> std::optional<InstT> {
+  template <typename TypedInst>
+  auto TryGetAsIfValid(InstId inst_id) const -> std::optional<TypedInst> {
     if (!inst_id.is_valid()) {
       return std::nullopt;
     }
-    return TryGetAs<InstT>(inst_id);
+    return TryGetAs<TypedInst>(inst_id);
   }
 
   auto GetLocId(InstId inst_id) const -> LocId {

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -196,8 +196,8 @@ class Inst : public Printable<Inst> {
     requires Internal::InstLikeType<TypedInst>
   auto As() const -> TypedInst {
     using Info = Internal::InstLikeTypeInfo<TypedInst>;
-    CARBON_CHECK(Is<TypedInst>(), "Casting inst {0} to wrong kind {1}", *this,
-                 Info::DebugName());
+    CARBON_DCHECK(Is<TypedInst>(), "Casting inst {0} to wrong kind {1}", *this,
+                  Info::DebugName());
     auto build_with_type_id_onwards = [&](auto... type_id_onwards) {
       if constexpr (Internal::HasKindMemberAsField<TypedInst>) {
         return TypedInst{kind(), type_id_onwards...};
@@ -454,6 +454,7 @@ class InstStore {
   // Reserves space.
   auto Reserve(size_t size) -> void {
     loc_ids_.reserve(size);
+    kinds_.reserve(size);
     types_and_args_.Reserve(size);
   }
 


### PR DESCRIPTION
This is intended to make InstKind consume a quarter the current space (1 byte instead of 4). The expectation is this'll be roughly performance neutral (but currently looks slightly negative), although we can start changing things to enable better performance for things that are happy to only examine the InstKind.

For a file generated by `source_gen`, before (with the mem usage fix):

```
sem_ir_.insts_.loc_ids_:
  used_bytes:      34694064
  reserved_bytes:  54525948
sem_ir_.insts_.values_:
  used_bytes:      138776256
  reserved_bytes:  218103792
```

After:

```
sem_ir_.insts_.loc_ids_:
  used_bytes:      34694064
  reserved_bytes:  54525948
sem_ir_.insts_.kinds_:
  used_bytes:      8673516
  reserved_bytes:  10747903
sem_ir_.insts_.types_and_args_:
  used_bytes:      104082192
  reserved_bytes:  163577844
...
Total:
  used_bytes:      493221460
  reserved_bytes:  650325525
```

And for `bazel run -c opt :compile_benchmark -- --benchmark_filter=Check`, before:

```
----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations      Bytes      Lines     Tokens
----------------------------------------------------------------------------------------------------------------------------
BM_CompileAPIFileDenseDecls<Phase::Check>/256       1057130 ns      1056661 ns         1024 4.98457M/s 184.543k/s 1.04196M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/1024      1960553 ns      1959331 ns         1024 16.5817M/s  499.66k/s  2.9357M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/4096      5503917 ns      5500405 ns          256  25.795M/s  732.31k/s 4.33768M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/16384    19112623 ns     19102923 ns           64  31.982M/s 853.953k/s 5.06682M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/65536    79289121 ns     79233317 ns           16 31.8608M/s 826.168k/s 4.90462M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/262144  346024763 ns    345771854 ns            8 29.5566M/s 758.098k/s 4.50093M/s
```

Without `InstStore::Is` changes:

```
----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations      Bytes      Lines     Tokens
----------------------------------------------------------------------------------------------------------------------------
BM_CompileAPIFileDenseDecls<Phase::Check>/256       1079970 ns      1079691 ns         1024 4.87825M/s 180.607k/s 1.01974M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/1024      2028099 ns      2027076 ns         1024 16.0275M/s 482.962k/s 2.83758M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/4096      5584768 ns      5581419 ns          256 25.4206M/s  721.68k/s 4.27472M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/16384    20294882 ns     20283454 ns           64 30.1206M/s 804.252k/s 4.77192M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/65536    83486939 ns     83452746 ns           16 30.2499M/s 784.396k/s 4.65664M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/262144  351386153 ns    351165409 ns            8 29.1027M/s 746.455k/s  4.4318M/s
```

With `InstStore::Is` changes:

```
----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations      Bytes      Lines     Tokens
----------------------------------------------------------------------------------------------------------------------------
BM_CompileAPIFileDenseDecls<Phase::Check>/256       1077198 ns      1076381 ns         1024 4.89325M/s 181.163k/s 1.02287M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/1024      2017288 ns      2015795 ns         1024 16.1172M/s 485.665k/s 2.85347M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/4096      5578900 ns      5574719 ns          256 25.4511M/s 722.548k/s 4.27986M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/16384    20038101 ns     20024204 ns           64 30.5106M/s 814.664k/s  4.8337M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/65536    81702279 ns     81648274 ns           16 30.9184M/s 801.732k/s 4.75955M/s
BM_CompileAPIFileDenseDecls<Phase::Check>/262144  349500301 ns    349287794 ns            8 29.2591M/s 750.467k/s 4.45562M/s
```

Note, benchmarks on my machine are expected to be noisy. But it does look like an incremental performance decrease in this test case.