### PR TITLE
Fix lowering of array indexing with an int literal.

### DIFF
--- a/toolchain/lower/testdata/array/array_in_place.carbon
+++ b/toolchain/lower/testdata/array/array_in_place.carbon
@@ -22,9 +22,9 @@ fn G() {
 // CHECK:STDOUT: define void @_CG.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %v.var = alloca [2 x { i32, i32, i32 }], align 8, !dbg !7
-// CHECK:STDOUT:   %.loc14_42.1.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, {} zeroinitializer, !dbg !8
+// CHECK:STDOUT:   %.loc14_42.1.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, i64 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc14_42.1.array.index), !dbg !9
-// CHECK:STDOUT:   %.loc14_42.3.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, {} zeroinitializer, !dbg !8
+// CHECK:STDOUT:   %.loc14_42.3.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, i64 1, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc14_42.3.array.index), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -34,11 +34,11 @@ fn Run() {
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc14_23.1.temp), !dbg !11
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc14_23.1.temp, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc14_23.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !11
-// CHECK:STDOUT:   %.loc14_23.4.array.index = getelementptr inbounds [2 x i32], ptr %t.var, i32 0, {} zeroinitializer, !dbg !11
+// CHECK:STDOUT:   %.loc14_23.4.array.index = getelementptr inbounds [2 x i32], ptr %t.var, i32 0, i64 0, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc14_23.3, ptr %.loc14_23.4.array.index, align 4, !dbg !11
 // CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc14_23.1.temp, i32 0, i32 1, !dbg !11
 // CHECK:STDOUT:   %.loc14_23.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !11
-// CHECK:STDOUT:   %.loc14_23.7.array.index = getelementptr inbounds [2 x i32], ptr %t.var, i32 0, {} zeroinitializer, !dbg !11
+// CHECK:STDOUT:   %.loc14_23.7.array.index = getelementptr inbounds [2 x i32], ptr %t.var, i32 0, i64 1, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc14_23.6, ptr %.loc14_23.7.array.index, align 4, !dbg !11
 // CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -27,18 +27,18 @@ fn Run() {
 // CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [1 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %.loc12_24.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, {} zeroinitializer, !dbg !8
+// CHECK:STDOUT:   %.loc12_24.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, i64 0, !dbg !8
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @array.1.loc12_25, i64 4, i1 false), !dbg !9
 // CHECK:STDOUT:   %b.var = alloca [2 x double], align 8, !dbg !10
-// CHECK:STDOUT:   %.loc13_32.2.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, {} zeroinitializer, !dbg !11
-// CHECK:STDOUT:   %.loc13_32.4.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, {} zeroinitializer, !dbg !11
+// CHECK:STDOUT:   %.loc13_32.2.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 0, !dbg !11
+// CHECK:STDOUT:   %.loc13_32.4.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 1, !dbg !11
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b.var, ptr align 8 @array.2.loc13_33, i64 16, i1 false), !dbg !12
 // CHECK:STDOUT:   %c.var = alloca [5 x {}], align 8, !dbg !13
-// CHECK:STDOUT:   %.loc14_40.2.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, {} zeroinitializer, !dbg !14
-// CHECK:STDOUT:   %.loc14_40.4.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, {} zeroinitializer, !dbg !14
-// CHECK:STDOUT:   %.loc14_40.6.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, {} zeroinitializer, !dbg !14
-// CHECK:STDOUT:   %.loc14_40.8.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, {} zeroinitializer, !dbg !14
-// CHECK:STDOUT:   %.loc14_40.10.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, {} zeroinitializer, !dbg !14
+// CHECK:STDOUT:   %.loc14_40.2.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 0, !dbg !14
+// CHECK:STDOUT:   %.loc14_40.4.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 1, !dbg !14
+// CHECK:STDOUT:   %.loc14_40.6.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 2, !dbg !14
+// CHECK:STDOUT:   %.loc14_40.8.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 3, !dbg !14
+// CHECK:STDOUT:   %.loc14_40.10.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @array.3.loc14_41, i64 0, i1 false), !dbg !15
 // CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !16
 // CHECK:STDOUT:   %tuple.elem0.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !17
@@ -48,15 +48,15 @@ fn Run() {
 // CHECK:STDOUT:   %e.var = alloca [3 x i32], align 4, !dbg !19
 // CHECK:STDOUT:   %tuple.elem0.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !20
 // CHECK:STDOUT:   %.loc16_21.1 = load i32, ptr %tuple.elem0.loc16.tuple.elem, align 4, !dbg !20
-// CHECK:STDOUT:   %.loc16_21.2.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, {} zeroinitializer, !dbg !20
+// CHECK:STDOUT:   %.loc16_21.2.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 0, !dbg !20
 // CHECK:STDOUT:   store i32 %.loc16_21.1, ptr %.loc16_21.2.array.index, align 4, !dbg !20
 // CHECK:STDOUT:   %tuple.elem1.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !20
 // CHECK:STDOUT:   %.loc16_21.4 = load i32, ptr %tuple.elem1.loc16.tuple.elem, align 4, !dbg !20
-// CHECK:STDOUT:   %.loc16_21.5.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, {} zeroinitializer, !dbg !20
+// CHECK:STDOUT:   %.loc16_21.5.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 1, !dbg !20
 // CHECK:STDOUT:   store i32 %.loc16_21.4, ptr %.loc16_21.5.array.index, align 4, !dbg !20
 // CHECK:STDOUT:   %tuple.elem2.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !20
 // CHECK:STDOUT:   %.loc16_21.7 = load i32, ptr %tuple.elem2.loc16.tuple.elem, align 4, !dbg !20
-// CHECK:STDOUT:   %.loc16_21.8.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, {} zeroinitializer, !dbg !20
+// CHECK:STDOUT:   %.loc16_21.8.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 2, !dbg !20
 // CHECK:STDOUT:   store i32 %.loc16_21.7, ptr %.loc16_21.8.array.index, align 4, !dbg !20
 // CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/array/field.carbon
+++ b/toolchain/lower/testdata/array/field.carbon
@@ -1,0 +1,85 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/array/field.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/array/field.carbon
+
+class A {
+  var v: [i32; 2];
+
+  // TODO: The LLVM IR we create for this crashes LLVM instruction selection.
+  // The gep indexes are completely bogus.
+  fn Init() -> A { return {.v = (1, 2)}; }
+
+  fn Access[self: Self]() -> i32 {
+    return self.v[0];
+  }
+
+  fn Use[addr self: Self*]() -> i32 {
+    self->v[0] = 1;
+    return self->v[1];
+  }
+}
+
+// CHECK:STDOUT: ; ModuleID = 'field.carbon'
+// CHECK:STDOUT: source_filename = "field.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @A.val.loc16_40 = internal constant { [2 x i32] } { [2 x i32] [i32 1, i32 2] }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CInit.A.Main(ptr sret({ [2 x i32] }) %return) !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc16_39.2.v = getelementptr inbounds nuw { [2 x i32] }, ptr %return, i32 0, i32 0, !dbg !7
+// CHECK:STDOUT:   %.loc16_38.3.array.index = getelementptr inbounds [2 x i32], ptr %.loc16_39.2.v, i32 0, i64 0, !dbg !8
+// CHECK:STDOUT:   %.loc16_38.6.array.index = getelementptr inbounds [2 x i32], ptr %.loc16_39.2.v, i32 0, i64 1, !dbg !8
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @A.val.loc16_40, i64 8, i1 false), !dbg !9
+// CHECK:STDOUT:   ret void, !dbg !9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define i32 @_CAccess.A.Main(ptr %self) !dbg !10 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc19_16.1.v = getelementptr inbounds nuw { [2 x i32] }, ptr %self, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc19_20.4.array.index = getelementptr inbounds [2 x i32], ptr %.loc19_16.1.v, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc19_20.5 = load i32, ptr %.loc19_20.4.array.index, align 4, !dbg !11
+// CHECK:STDOUT:   ret i32 %.loc19_20.5, !dbg !12
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define i32 @_CUse.A.Main(ptr %self) !dbg !13 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc23_9.2.v = getelementptr inbounds nuw { [2 x i32] }, ptr %self, i32 0, i32 0, !dbg !14
+// CHECK:STDOUT:   %.loc23_14.3.array.index = getelementptr inbounds [2 x i32], ptr %.loc23_9.2.v, i32 0, i32 0, !dbg !14
+// CHECK:STDOUT:   store i32 1, ptr %.loc23_14.3.array.index, align 4, !dbg !14
+// CHECK:STDOUT:   %.loc24_16.2.v = getelementptr inbounds nuw { [2 x i32] }, ptr %self, i32 0, i32 0, !dbg !15
+// CHECK:STDOUT:   %.loc24_21.3.array.index = getelementptr inbounds [2 x i32], ptr %.loc24_16.2.v, i32 0, i32 1, !dbg !15
+// CHECK:STDOUT:   %.loc24_21.4 = load i32, ptr %.loc24_21.3.array.index, align 4, !dbg !15
+// CHECK:STDOUT:   ret i32 %.loc24_21.4, !dbg !16
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "field.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Init", linkageName: "_CInit.A.Main", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 16, column: 27, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 33, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 20, scope: !4)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Access", linkageName: "_CAccess.A.Main", scope: null, file: !3, line: 18, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 12, scope: !10)
+// CHECK:STDOUT: !12 = !DILocation(line: 19, column: 5, scope: !10)
+// CHECK:STDOUT: !13 = distinct !DISubprogram(name: "Use", linkageName: "_CUse.A.Main", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !14 = !DILocation(line: 23, column: 5, scope: !13)
+// CHECK:STDOUT: !15 = !DILocation(line: 24, column: 12, scope: !13)
+// CHECK:STDOUT: !16 = !DILocation(line: 24, column: 5, scope: !13)

--- a/toolchain/lower/testdata/array/function_param.carbon
+++ b/toolchain/lower/testdata/array/function_param.carbon
@@ -31,9 +31,9 @@ fn G() -> i32 {
 // CHECK:STDOUT: define i32 @_CG.Main() !dbg !9 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc16_20.3.temp = alloca [3 x i32], align 4, !dbg !10
-// CHECK:STDOUT:   %.loc16_20.4.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.3.temp, i32 0, {} zeroinitializer, !dbg !10
-// CHECK:STDOUT:   %.loc16_20.7.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.3.temp, i32 0, {} zeroinitializer, !dbg !10
-// CHECK:STDOUT:   %.loc16_20.10.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.3.temp, i32 0, {} zeroinitializer, !dbg !10
+// CHECK:STDOUT:   %.loc16_20.4.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.3.temp, i32 0, i64 0, !dbg !10
+// CHECK:STDOUT:   %.loc16_20.7.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.3.temp, i32 0, i64 1, !dbg !10
+// CHECK:STDOUT:   %.loc16_20.10.array.index = getelementptr inbounds [3 x i32], ptr %.loc16_20.3.temp, i32 0, i64 2, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc16_20.3.temp, ptr align 4 @array.loc16_20.13, i64 12, i1 false), !dbg !10
 // CHECK:STDOUT:   %F.call = call i32 @_CF.Main(ptr %.loc16_20.3.temp, i32 1), !dbg !11
 // CHECK:STDOUT:   ret i32 %F.call, !dbg !12

--- a/toolchain/lower/testdata/basics/numeric_literals.carbon
+++ b/toolchain/lower/testdata/basics/numeric_literals.carbon
@@ -36,18 +36,18 @@ fn F() {
 // CHECK:STDOUT: define void @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %ints.var = alloca [4 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %.loc19_3.3.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, {} zeroinitializer, !dbg !8
-// CHECK:STDOUT:   %.loc19_3.6.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, {} zeroinitializer, !dbg !8
-// CHECK:STDOUT:   %.loc19_3.9.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, {} zeroinitializer, !dbg !8
-// CHECK:STDOUT:   %.loc19_3.12.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, {} zeroinitializer, !dbg !8
+// CHECK:STDOUT:   %.loc19_3.3.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 0, !dbg !8
+// CHECK:STDOUT:   %.loc19_3.6.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 1, !dbg !8
+// CHECK:STDOUT:   %.loc19_3.9.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 2, !dbg !8
+// CHECK:STDOUT:   %.loc19_3.12.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 3, !dbg !8
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %ints.var, ptr align 4 @array.1.loc19_4, i64 16, i1 false), !dbg !9
 // CHECK:STDOUT:   %floats.var = alloca [6 x double], align 8, !dbg !10
-// CHECK:STDOUT:   %.loc27_3.2.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, {} zeroinitializer, !dbg !11
-// CHECK:STDOUT:   %.loc27_3.4.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, {} zeroinitializer, !dbg !11
-// CHECK:STDOUT:   %.loc27_3.6.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, {} zeroinitializer, !dbg !11
-// CHECK:STDOUT:   %.loc27_3.8.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, {} zeroinitializer, !dbg !11
-// CHECK:STDOUT:   %.loc27_3.10.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, {} zeroinitializer, !dbg !11
-// CHECK:STDOUT:   %.loc27_3.12.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, {} zeroinitializer, !dbg !11
+// CHECK:STDOUT:   %.loc27_3.2.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 0, !dbg !11
+// CHECK:STDOUT:   %.loc27_3.4.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 1, !dbg !11
+// CHECK:STDOUT:   %.loc27_3.6.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 2, !dbg !11
+// CHECK:STDOUT:   %.loc27_3.8.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 3, !dbg !11
+// CHECK:STDOUT:   %.loc27_3.10.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 4, !dbg !11
+// CHECK:STDOUT:   %.loc27_3.12.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 5, !dbg !11
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %floats.var, ptr align 8 @array.2.loc27_4, i64 48, i1 false), !dbg !12
 // CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -34,8 +34,8 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CB.Main(ptr sret([2 x i32]) %return) !dbg !9 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc12_34.3.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, {} zeroinitializer, !dbg !10
-// CHECK:STDOUT:   %.loc12_34.6.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, {} zeroinitializer, !dbg !10
+// CHECK:STDOUT:   %.loc12_34.3.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, i64 0, !dbg !10
+// CHECK:STDOUT:   %.loc12_34.6.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, i64 1, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @array.loc12_35, i64 8, i1 false), !dbg !11
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
@@ -47,11 +47,11 @@ fn Run() {
 // CHECK:STDOUT:   call void @_CA.Main(ptr %.loc15_23.1.temp), !dbg !14
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc15_23.1.temp, i32 0, i32 0, !dbg !14
 // CHECK:STDOUT:   %.loc15_23.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc15_23.4.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, {} zeroinitializer, !dbg !14
+// CHECK:STDOUT:   %.loc15_23.4.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 0, !dbg !14
 // CHECK:STDOUT:   store i32 %.loc15_23.3, ptr %.loc15_23.4.array.index, align 4, !dbg !14
 // CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc15_23.1.temp, i32 0, i32 1, !dbg !14
 // CHECK:STDOUT:   %.loc15_23.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc15_23.7.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, {} zeroinitializer, !dbg !14
+// CHECK:STDOUT:   %.loc15_23.7.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 1, !dbg !14
 // CHECK:STDOUT:   store i32 %.loc15_23.6, ptr %.loc15_23.7.array.index, align 4, !dbg !14
 // CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !15
 // CHECK:STDOUT:   store i32 1, ptr %b.var, align 4, !dbg !16


### PR DESCRIPTION
Such indexing operations are created by array initialization. Since we switched integer literals to be of type IntLiteral we've been attempting to index arrays with the (empty) representation of an IntLiteral rather than with an actual integer value.