### PR TITLE
Shuffle around yaml formatting in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -107,11 +107,11 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.UnionCase
     value: CamelCase
-  - key: readability-identifier-naming.VariableCase
+  - key: readability-identifier-naming.ClassMemberCase
     value: lower_case
   - key: readability-identifier-naming.ParameterCase
     value: lower_case
-  - key: readability-identifier-naming.ClassMemberCase
+  - key: readability-identifier-naming.VariableCase
     value: lower_case
   - key: readability-identifier-naming.MethodIgnoredRegexp
     value: '^classof$'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,14 +9,14 @@ UseColor: true
 WarningsAsErrors: '*'
 
 Checks:
-  # We turn on all `bugprone`, `google`, `modernize`, `performance`, and
-  # `readability` by default.
+  # We turn on all of a few categories by default.
   - '-*'
   - 'bugprone-*'
   - 'google-*'
   - 'modernize-*'
   - 'performance-*'
   - 'readability-*'
+
   # `misc` is selectively enabled because we want a minority of them.
   - 'misc-definitions-in-headers'
   - 'misc-misplaced-const'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,110 +8,114 @@ UseColor: true
 # This is necessary for `--config=clang-tidy` to catch errors.
 WarningsAsErrors: '*'
 
-# We turn on all `bugprone`, `google`, `modernize`, `performance`, and
-# `readability` by default. A few `misc` are selectively enabled, and a few
-# other checks are selectively disabled.
-#
-# Checks with nuanced reasons for disabling are:
-#
-# - `bugprone-branch-clone` warns when we have multiple empty cases in switches,
-#    which we do for comment reasons.
-# - `bugprone-easily-swappable-parameters` frequently warns on multiple
-#   parameters of the same type.
-# - `bugprone-exception-escape` finds issues like out-of-memory in main(). We
-#   don't use exceptions, so it's unlikely to find real issues.
-# - `bugprone-macro-parentheses` has false positives in places such as using an
-#   argument to declare a name, which cannot have parentheses. For our limited
-#   use of macros, this is a common conflict.
-# - `bugprone-narrowing-conversions` conflicts with integer type C++ style.
-# - `google-readability-todo` suggests usernames on TODOs, which we don't want.
-# - `bugprone-switch-missing-default-case` has false positives for
-#   `enum_base.h`. Clang's built-in switch warnings cover most of our risk of
-#   bugs here.
-# - `bugprone-unchecked-optional-access` in clang-tidy 16 has false positives on
-#   code like:
-#     while (auto name_ref = insts().Get(inst_id).TryAs<SemIR::NameRef>()) {
-#       inst_id = name_ref->value_id;
-#                 ^ unchecked access to optional value
-#     }
-# - `google-readability-function-size` overlaps with
-#   `readability-function-size`.
-# - `modernize-avoid-c-arrays` suggests `std::array`, which we could migrate to,
-#   but conflicts with the status quo.
-# - `modernize-use-designated-initializers` fires on creation of SemIR typed
-#   insts, for which we do not currently want to use designated initialization.
-# - `modernize-use-nodiscard` is disabled because it only fixes const methods,
-#   not non-const, which yields distracting results on accessors.
-# - `performance-unnecessary-value-param` duplicates `modernize-pass-by-value`.
-# - `readability-enum-initial-value` warns on enums which use the
-#   `LastValue = Value` pattern if all the other discriminants aren't given an
-#   explicit value.
-# - `readability-function-cognitive-complexity` warns too frequently.
-# - `readability-magic-numbers` warns in reasonably documented situations.
-# - `readability-redundant-member-init` warns on `= {}` which is also used to
-#   indicate which fields do not need to be explicitly initialized in aggregate
-#   initialization.
-# - `readability-suspicious-call-argument` warns when callers use similar names
-#   as different parameters.
-#
-# Checks that are essentially style choices we don't apply are:
-#
-# - `modernize-return-braced-init-list`
-# - `modernize-use-default-member-init`
-# - `modernize-use-emplace`
-# - `readability-convert-member-functions-to-static`
-# - `readability-else-after-return`
-# - `readability-identifier-length`
-# - `readability-implicit-bool-conversion`
-# - `readability-make-member-function-const`
-# - `readability-static-definition-in-anonymous-namespace`
-# - `readability-use-anyofallof`
 Checks:
-  -*, bugprone-*, -bugprone-branch-clone, -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape, -bugprone-macro-parentheses,
-  -bugprone-narrowing-conversions, -bugprone-switch-missing-default-case,
-  -bugprone-unchecked-optional-access, google-*,
-  -google-readability-function-size, -google-readability-todo,
-  misc-definitions-in-headers, misc-misplaced-const, misc-redundant-expression,
-  misc-static-assert, misc-unconventional-assign-operator,
-  misc-uniqueptr-reset-release, misc-unused-*, modernize-*,
-  -modernize-avoid-c-arrays, -modernize-return-braced-init-list,
-  -modernize-use-default-member-init, -modernize-use-designated-initializers,
-  -modernize-use-emplace, -modernize-use-nodiscard, performance-*,
-  -performance-unnecessary-value-param, readability-*,
-  -readability-convert-member-functions-to-static,
-  -readability-else-after-return, -readability-enum-initial-value,
-  -readability-function-cognitive-complexity, -readability-identifier-length,
-  -readability-implicit-bool-conversion, -readability-magic-numbers,
-  -readability-make-member-function-const, -readability-redundant-member-init,
-  -readability-static-definition-in-anonymous-namespace,
-  -readability-suspicious-call-argument, -readability-use-anyofallof
+  # We turn on all `bugprone`, `google`, `modernize`, `performance`, and
+  # `readability` by default.
+  - '-*'
+  - 'bugprone-*'
+  - 'google-*'
+  - 'modernize-*'
+  - 'performance-*'
+  - 'readability-*'
+  # `misc` is selectively enabled because we want a minority of them.
+  - 'misc-definitions-in-headers'
+  - 'misc-misplaced-const'
+  - 'misc-redundant-expression'
+  - 'misc-static-assert'
+  - 'misc-unconventional-assign-operator'
+  - 'misc-uniqueptr-reset-release'
+  - 'misc-unused-*'
+
+  # Disabled due to the implied style choices.
+  - '-modernize-return-braced-init-list'
+  - '-modernize-use-default-member-init'
+  - '-modernize-use-emplace'
+  - '-readability-convert-member-functions-to-static'
+  - '-readability-else-after-return'
+  - '-readability-identifier-length'
+  - '-readability-implicit-bool-conversion'
+  - '-readability-make-member-function-const'
+  - '-readability-static-definition-in-anonymous-namespace'
+  - '-readability-use-anyofallof'
+
+  # Warns when we have multiple empty cases in switches, which we do for comment
+  # reasons.
+  - '-bugprone-branch-clone'
+  # Frequently warns on multiple parameters of the same type.
+  - '-bugprone-easily-swappable-parameters'
+  # Finds issues like out-of-memory in main(). We don't use exceptions, so it's
+  # unlikely to find real issues.
+  - '-bugprone-exception-escape'
+  # Has false positives in places such as using an argument to declare a name,
+  # which cannot have parentheses. For our limited use of macros, this is a
+  # common conflict.
+  - '-bugprone-macro-parentheses'
+  # Conflicts with integer type C++ style.
+  - '-bugprone-narrowing-conversions'
+  # Has false positives for `enum_base.h`. Clang's built-in switch warnings
+  # cover most of our risk of bugs here.
+  - '-bugprone-switch-missing-default-case'
+  # In clang-tidy 16, has false positives on code like:
+  #     while (auto name_ref = insts().Get(inst_id).TryAs<SemIR::NameRef>()) {
+  #       inst_id = name_ref->value_id;
+  #                 ^ unchecked access to optional value
+  #     }
+  - '-bugprone-unchecked-optional-access'
+  # Overlaps with `readability-function-size`.
+  - '-google-readability-function-size'
+  # Suggests usernames on TODOs, which we don't want.
+  - '-google-readability-todo'
+  # Suggests `std::array`, which we could migrate to, but conflicts with the
+  # status quo.
+  - '-modernize-avoid-c-arrays'
+  # Warns on creation of SemIR typed insts, for which we do not currently want
+  # to use designated initialization.
+  - '-modernize-use-designated-initializers'
+  # Only fixes const methods, not non-const, which yields distracting results on
+  # accessors.
+  - '-modernize-use-nodiscard'
+  # Duplicates `modernize-pass-by-value`.
+  - '-performance-unnecessary-value-param'
+  # Warns on enums which use the `LastValue = Value` pattern if all the other
+  # discriminants aren't given an explicit value.
+  - '-readability-enum-initial-value'
+  # Warns too frequently.
+  - '-readability-function-cognitive-complexity'
+  # Warns in reasonably documented situations.
+  - '-readability-magic-numbers'
+  # Warns on `= {}` which is also used to indicate which fields do not need to
+  # be explicitly initialized in aggregate initialization.
+  - '-readability-redundant-member-init'
+  # Warns when callers use similar names as different parameters.
+  - '-readability-suspicious-call-argument'
 CheckOptions:
-  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
-  - { key: readability-identifier-naming.ClassConstantCase, value: CamelCase }
-  - {
-      key: readability-identifier-naming.ConstexprVariableCase,
-      value: CamelCase,
-    }
-  - { key: readability-identifier-naming.NamespaceCase, value: CamelCase }
-  - { key: readability-identifier-naming.StructCase, value: CamelCase }
-  - {
-      key: readability-identifier-naming.TemplateParameterCase,
-      value: CamelCase,
-    }
-  - { key: readability-identifier-naming.TypeAliasCase, value: CamelCase }
-  - { key: readability-identifier-naming.TypedefCase, value: CamelCase }
-  - { key: readability-identifier-naming.UnionCase, value: CamelCase }
-  - { key: readability-identifier-naming.VariableCase, value: lower_case }
-  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
-  - { key: readability-identifier-naming.ClassMemberCase, value: lower_case }
-  - {
-      key: readability-identifier-naming.MethodIgnoredRegexp,
-      value: '^classof$',
-    }
-  - {
-      # This erroneously fires in C++20 mode with LLVM 16 clang-tidy, due to:
-      # https://github.com/llvm/llvm-project/issues/46097
-      key: readability-identifier-naming.TemplateParameterIgnoredRegexp,
-      value: '^expr-type$',
-    }
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.NamespaceCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.MethodIgnoredRegexp
+    value: '^classof$'
+  # This erroneously fires in C++20 mode with LLVM 16 clang-tidy, due to:
+  # https://github.com/llvm/llvm-project/issues/46097
+  - key: readability-identifier-naming.TemplateParameterIgnoredRegexp
+    value: '^expr-type$'


### PR DESCRIPTION
I was looking at this again, considering how best to add new checks, and realized we could just change the format and probably get better deltas in the future.

This change should just be formatting, with no functional impact.