### PR TITLE
Do not resolve the declaration when forming a specific for use in an eval block

### DIFF
--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -187,14 +187,10 @@ static auto PopOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
         return arg;
       }
       auto& specific = context.specifics().Get(specific_id);
-      auto args_id =
+      auto args_id = SemIR::InstBlockId(
           PopOperand(context, worklist, SemIR::IdKind::For<SemIR::InstBlockId>,
-                     specific.args_id.index);
-      // TODO: Provide a location here.
-      SemIRLoc loc = SemIR::InstId::Invalid;
-      return MakeSpecific(context, loc, specific.generic_id,
-                          SemIR::InstBlockId(args_id))
-          .index;
+                     specific.args_id.index));
+      return context.specifics().GetOrAdd(specific.generic_id, args_id).index;
     }
     case SemIR::IdKind::For<SemIR::FacetTypeId>: {
       const auto& old_facet_type_info =

--- a/toolchain/check/testdata/class/fail_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_generic_method.carbon
@@ -157,20 +157,14 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@F.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@F.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @.1(constants.%N.2) {
 // CHECK:STDOUT:   %N.loc32_10.2 => constants.%N.2

--- a/toolchain/check/testdata/class/generic/adapt.carbon
+++ b/toolchain/check/testdata/class/generic/adapt.carbon
@@ -241,10 +241,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc4_9.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc4_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%i32) {
 // CHECK:STDOUT:   %T.loc4_9.2 => constants.%i32
@@ -382,10 +379,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %complete_type => constants.%complete_type.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_extend_adapt_specific_type.carbon
 // CHECK:STDOUT:
@@ -504,10 +498,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc4_9.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc4_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%i32) {
 // CHECK:STDOUT:   %T.loc4_9.2 => constants.%i32
@@ -611,10 +602,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %T.patt.loc7_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc7_9.2) {
-// CHECK:STDOUT:   %T.loc7_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc7_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc7_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%i32) {
 // CHECK:STDOUT:   %T.loc7_9.2 => constants.%i32
@@ -745,10 +733,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %complete_type => constants.%complete_type.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- adapt_generic_type.carbon
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/base_is_generic.carbon
+++ b/toolchain/check/testdata/class/generic/base_is_generic.carbon
@@ -223,10 +223,7 @@ fn H() {
 // CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(%T.loc4_17.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(%T.loc4_17.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Base(constants.%Param) {
 // CHECK:STDOUT:   %T.loc4_17.2 => constants.%Param
@@ -380,10 +377,7 @@ fn H() {
 // CHECK:STDOUT:   %complete_type => constants.%complete_type.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_extend_symbolic_base.carbon
 // CHECK:STDOUT:
@@ -673,19 +667,11 @@ fn H() {
 // CHECK:STDOUT:   %G.specific_fn.loc5_24.2 => constants.%G.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(%U.loc4_14.2) {
-// CHECK:STDOUT:   %U.loc4_14.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc4_14.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(%U.loc4_14.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(@G.%U) {
-// CHECK:STDOUT:   %U.loc4_14.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc4_14.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(@G.%U) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @G(%U) {
-// CHECK:STDOUT:   %U => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @G(%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_9.2 => constants.%T
@@ -701,15 +687,9 @@ fn H() {
 // CHECK:STDOUT:   %G => constants.%G.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(@C.%T.loc8_9.2) {
-// CHECK:STDOUT:   %U.loc4_14.2 => constants.%T
-// CHECK:STDOUT:   %U.patt.loc4_14.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(@C.%T.loc8_9.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc8_9.2) {
-// CHECK:STDOUT:   %T.loc8_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc8_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%i32) {
 // CHECK:STDOUT:   %T.loc8_9.2 => constants.%i32
@@ -903,20 +883,11 @@ fn H() {
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(%U) {
-// CHECK:STDOUT:   %U => constants.%U
-// CHECK:STDOUT:   %U.patt => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(%U) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(@C.%T) {
-// CHECK:STDOUT:   %U => constants.%T
-// CHECK:STDOUT:   %U.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(@C.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%U) {
 // CHECK:STDOUT:   %U => constants.%U
@@ -928,14 +899,9 @@ fn H() {
 // CHECK:STDOUT:   %G.specific_fn => constants.%G.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(@G.%U) {
-// CHECK:STDOUT:   %U => constants.%U
-// CHECK:STDOUT:   %U.patt => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(@G.%U) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @G(%U) {
-// CHECK:STDOUT:   %U => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @G(%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%i32) {
 // CHECK:STDOUT:   %T => constants.%i32

--- a/toolchain/check/testdata/class/generic/basic.carbon
+++ b/toolchain/check/testdata/class/generic/basic.carbon
@@ -203,10 +203,7 @@ class Declaration(T:! type);
 // CHECK:STDOUT:   %complete_type.loc22_1.2 => constants.%complete_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@GetAddr.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@GetAddr.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetAddr(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -215,20 +212,14 @@ class Declaration(T:! type);
 // CHECK:STDOUT:   %ptr.loc12_38.1 => constants.%ptr.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@GetValue.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@GetValue.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetValue(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Declaration(constants.%T) {
 // CHECK:STDOUT:   %T.loc24_19.2 => constants.%T

--- a/toolchain/check/testdata/class/generic/call.carbon
+++ b/toolchain/check/testdata/class/generic/call.carbon
@@ -717,10 +717,7 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %D => constants.%D.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(@A.%T) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(@A.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -736,10 +733,7 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Inner.generic => constants.%Inner.generic.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(@B.%U) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%U
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(@B.%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @B(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %U => constants.%U
@@ -762,15 +756,9 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %D => constants.%D.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(@C.%T) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(@C.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Inner(@C.%T, @C.%T) {
-// CHECK:STDOUT:   %U.loc3_15.2 => constants.%T
-// CHECK:STDOUT:   %U.patt.loc3_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Inner(@C.%T, @C.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -779,15 +767,9 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Inner.loc10_22.1 => constants.%Inner.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(@D.%T) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(@D.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Inner(@D.%T, @D.%U) {
-// CHECK:STDOUT:   %U.loc3_15.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc3_15.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Inner(@D.%T, @D.%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -797,13 +779,7 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Inner.loc13_22.1 => constants.%Inner.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Inner(%T, %U.loc3_15.2) {
-// CHECK:STDOUT:   %U.loc3_15.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc3_15.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Inner(%T, %U.loc3_15.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(%T.loc2_13.2) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(%T.loc2_13.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
+++ b/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
@@ -213,10 +213,7 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:   %N.patt.loc6_9.2 => constants.%N.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(%N.loc6_9.2) {
-// CHECK:STDOUT:   %N.loc6_9.2 => constants.%N.2
-// CHECK:STDOUT:   %N.patt.loc6_9.2 => constants.%N.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(%N.loc6_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%int_0.2) {
 // CHECK:STDOUT:   %N.loc6_9.2 => constants.%int_0.2

--- a/toolchain/check/testdata/class/generic/field.carbon
+++ b/toolchain/check/testdata/class/generic/field.carbon
@@ -226,10 +226,7 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%i32) {
 // CHECK:STDOUT:   %T.loc11_13.2 => constants.%i32
@@ -243,10 +240,7 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@G.%T.loc19_6.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@G.%T.loc19_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T) {
 // CHECK:STDOUT:   %T.loc19_6.2 => constants.%T
@@ -266,10 +260,7 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@H.%U.loc23_6.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%U
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@H.%U.loc23_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%U) {
 // CHECK:STDOUT:   %U.loc23_6.2 => constants.%U

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -234,10 +234,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @CompleteClass(%T.loc6_21.2) {
-// CHECK:STDOUT:   %T.loc6_21.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_21.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @CompleteClass(%T.loc6_21.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CompleteClass(constants.%i32) {
 // CHECK:STDOUT:   %T.loc6_21.2 => constants.%i32
@@ -397,10 +394,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %T.patt.1 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.1) {
-// CHECK:STDOUT:   %T.1 => constants.%T
-// CHECK:STDOUT:   %T.patt.1 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CompleteClass(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -413,10 +407,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %F => constants.%F.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @CompleteClass(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @CompleteClass(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T) {}
 // CHECK:STDOUT:
@@ -584,10 +575,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %F => constants.%F.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @CompleteClass(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @CompleteClass(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T) {}
 // CHECK:STDOUT:
@@ -720,10 +708,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %F => constants.%F.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @CompleteClass(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @CompleteClass(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/init.carbon
+++ b/toolchain/check/testdata/class/generic/init.carbon
@@ -216,20 +216,14 @@ fn InitFromAdaptedSpecific(x: i32) -> i32 {
 // CHECK:STDOUT:   %complete_type.loc6_1.2 => constants.%complete_type.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @InitFromStructGeneric(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_26.2 => constants.%T
 // CHECK:STDOUT:   %T.patt.loc8_26.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@InitFromStructGeneric.%T.loc8_26.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@InitFromStructGeneric.%T.loc8_26.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%i32) {
 // CHECK:STDOUT:   %T.loc4_13.2 => constants.%i32
@@ -396,10 +390,7 @@ fn InitFromAdaptedSpecific(x: i32) -> i32 {
 // CHECK:STDOUT:   %T.patt.loc8_27.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Adapt(@InitFromAdaptedGeneric.%T.loc8_27.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Adapt(@InitFromAdaptedGeneric.%T.loc8_27.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Adapt(constants.%i32) {
 // CHECK:STDOUT:   %T.loc4_13.2 => constants.%i32

--- a/toolchain/check/testdata/class/generic/member_access.carbon
+++ b/toolchain/check/testdata/class/generic/member_access.carbon
@@ -328,20 +328,14 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %complete_type.loc8_1.2 => constants.%complete_type.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@Get.%T) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@Get.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Get(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@GetAddr.%T) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@GetAddr.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetAddr(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -350,10 +344,7 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %ptr.loc7_38.1 => constants.%ptr.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc2_13.2) {
-// CHECK:STDOUT:   %T.loc2_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc2_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%i32) {
 // CHECK:STDOUT:   %T.loc2_13.2 => constants.%i32
@@ -535,10 +526,7 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %Make => constants.%Make
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@Make.%T) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@Make.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Make(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -549,15 +537,9 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %Class.val => constants.%Class.val
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@StaticMemberFunctionCall.%T.loc8_29.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@StaticMemberFunctionCall.%T.loc8_29.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @StaticMemberFunctionCall(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_29.2 => constants.%T
@@ -565,8 +547,5 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %Class.loc8_49.2 => constants.%Class
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Make(@StaticMemberFunctionCall.%T.loc8_29.2) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %Class.loc5_23.1 => constants.%Class
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Make(@StaticMemberFunctionCall.%T.loc8_29.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/member_inline.carbon
+++ b/toolchain/check/testdata/class/generic/member_inline.carbon
@@ -187,20 +187,14 @@ class C(T:! type) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@G.%T) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@G.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_member_inline.carbon
 // CHECK:STDOUT:
@@ -291,13 +285,7 @@ class C(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc4_9.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc4_9.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(@F.%T) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(@F.%T) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/member_lookup.carbon
+++ b/toolchain/check/testdata/class/generic/member_lookup.carbon
@@ -322,10 +322,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %complete_type.loc6_1.2 => constants.%complete_type.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(%T.loc4_17.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(%T.loc4_17.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Derived(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
@@ -342,20 +339,11 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %complete_type.loc11_1.2 => constants.%complete_type.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(@Derived.%T.loc8_15.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(@Derived.%T.loc8_15.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Derived(%T.loc8_15.2) {
-// CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Derived(%T.loc8_15.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Derived(@AccessDerived.%T.loc13_18.2) {
-// CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Derived(@AccessDerived.%T.loc13_18.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AccessDerived(constants.%T) {
 // CHECK:STDOUT:   %T.loc13_18.2 => constants.%T
@@ -363,10 +351,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %Derived.loc13_40.2 => constants.%Derived.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Derived(@AccessBase.%T.loc17_15.2) {
-// CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Derived(@AccessBase.%T.loc17_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AccessBase(constants.%T) {
 // CHECK:STDOUT:   %T.loc17_15.2 => constants.%T
@@ -374,10 +359,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %Derived.loc17_37.2 => constants.%Derived.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(@AccessBase.%T.loc17_15.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(@AccessBase.%T.loc17_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Derived(constants.%i32) {
 // CHECK:STDOUT:   %T.loc8_15.2 => constants.%i32
@@ -645,10 +627,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %complete_type.loc6_1.2 => constants.%complete_type.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(%T.loc4_17.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(%T.loc4_17.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Derived(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
@@ -665,20 +644,11 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %complete_type.loc11_1.2 => constants.%complete_type.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(@Derived.%T.loc8_15.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(@Derived.%T.loc8_15.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Derived(%T.loc8_15.2) {
-// CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Derived(%T.loc8_15.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(@AccessMissingBase.%T.loc13_22.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(@AccessMissingBase.%T.loc13_22.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AccessMissingBase(constants.%T) {
 // CHECK:STDOUT:   %T.loc13_22.2 => constants.%T
@@ -686,10 +656,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %Base.loc13_41.2 => constants.%Base.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Derived(@AccessMissingDerived.%T.loc21_25.2) {
-// CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Derived(@AccessMissingDerived.%T.loc21_25.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AccessMissingDerived(constants.%T) {
 // CHECK:STDOUT:   %T.loc21_25.2 => constants.%T
@@ -697,10 +664,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %Derived.loc21_47.2 => constants.%Derived.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Base(@AccessMissingDerived.%T.loc21_25.2) {
-// CHECK:STDOUT:   %T.loc4_17.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Base(@AccessMissingDerived.%T.loc21_25.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Derived(constants.%i32) {
 // CHECK:STDOUT:   %T.loc8_15.2 => constants.%i32

--- a/toolchain/check/testdata/class/generic/member_out_of_line.carbon
+++ b/toolchain/check/testdata/class/generic/member_out_of_line.carbon
@@ -285,20 +285,14 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %T.loc5 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@G.%T.loc6) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@G.%T.loc6) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T) {
 // CHECK:STDOUT:   %T.loc6 => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc4_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
@@ -455,11 +449,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %F => constants.%F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @B(@F.%T.loc6, @F.%N.loc6) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %N.loc5_11.2 => constants.%N
-// CHECK:STDOUT:   %N.patt.loc5_11.2 => constants.%N
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @B(@F.%T.loc6, @F.%N.loc6) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T, constants.%N) {
 // CHECK:STDOUT:   %T.loc6 => constants.%T
@@ -467,16 +457,9 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %B => constants.%B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @B(%T, %N.loc5_11.2) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %N.loc5_11.2 => constants.%N
-// CHECK:STDOUT:   %N.patt.loc5_11.2 => constants.%N
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @B(%T, %N.loc5_11.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(%T.loc4_9.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(%T.loc4_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_not_generic_vs_generic.carbon
 // CHECK:STDOUT:
@@ -616,10 +599,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @TooFew(constants.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(%T.loc4_15.2) {
-// CHECK:STDOUT:   %T.loc4_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Generic(%T.loc4_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_too_many_args.carbon
 // CHECK:STDOUT:
@@ -712,10 +692,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @TooMany(constants.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(%T.loc4_15.2) {
-// CHECK:STDOUT:   %T.loc4_15.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_15.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Generic(%T.loc4_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @.1(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %T.loc15_12.2 => constants.%T
@@ -814,10 +791,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WrongType(constants.%T.1) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(%T.loc4_15.2) {
-// CHECK:STDOUT:   %T.loc4_15.2 => constants.%T.1
-// CHECK:STDOUT:   %T.patt.loc4_15.2 => constants.%T.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Generic(%T.loc4_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @.1(constants.%T.2) {
 // CHECK:STDOUT:   %T.loc14_12.2 => constants.%T.2

--- a/toolchain/check/testdata/class/generic/method_deduce.carbon
+++ b/toolchain/check/testdata/class/generic/method_deduce.carbon
@@ -347,34 +347,15 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   %require_complete.loc16_69 => constants.%require_complete.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc14_13.2) {
-// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc14_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc14_13.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@Get.%T) {
-// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc14_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@Get.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Get(%T, %U.loc15_10.1) {
-// CHECK:STDOUT:   %U.loc15_10.1 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc15_10.1 => constants.%U
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %tuple.type => constants.%tuple.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Get(%T, %U.loc15_10.1) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@GetNoDeduce.%T) {
-// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc14_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@GetNoDeduce.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GetNoDeduce(%T, %U.loc16_24.1) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %U.loc16_24.1 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc16_24.1 => constants.%U
-// CHECK:STDOUT:   %tuple.type => constants.%tuple.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GetNoDeduce(%T, %U.loc16_24.1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%A) {
 // CHECK:STDOUT:   %T.loc14_13.2 => constants.%A

--- a/toolchain/check/testdata/class/generic/self.carbon
+++ b/toolchain/check/testdata/class/generic/self.carbon
@@ -193,10 +193,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %F => constants.%F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@MakeSelf.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@MakeSelf.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @MakeSelf(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -207,10 +204,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %Class.val => constants.%Class.val
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@MakeClass.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@MakeClass.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @MakeClass(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -223,23 +217,11 @@ class Class(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@F.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@F.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @MakeSelf(@F.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %Class => constants.%Class
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @MakeSelf(@F.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @MakeClass(@F.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %Class.loc15_28.1 => constants.%Class
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @MakeClass(@F.%T) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/stringify.carbon
+++ b/toolchain/check/testdata/class/generic/stringify.carbon
@@ -254,10 +254,7 @@ var v: C(123) = ();
 // CHECK:STDOUT:   %U.patt.loc5_15.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(%T.loc4_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Outer(constants.%ptr.1) {
 // CHECK:STDOUT:   %T.loc4_13.2 => constants.%ptr.1

--- a/toolchain/check/testdata/class/generic_method.carbon
+++ b/toolchain/check/testdata/class/generic_method.carbon
@@ -138,18 +138,12 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %complete_type.loc14_1.2 => constants.%complete_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(@F.%T.loc13) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(@F.%T.loc13) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
 // CHECK:STDOUT:   %T.loc13 => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Class(%T.loc11_13.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon
+++ b/toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon
@@ -284,10 +284,7 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %U.patt.loc10_26.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc8_9.2) {
-// CHECK:STDOUT:   %T.loc8_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc8_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GenericAndParams.1(constants.%X) {
 // CHECK:STDOUT:   %T.loc6_24.2 => constants.%X

--- a/toolchain/check/testdata/deduce/generic_type.carbon
+++ b/toolchain/check/testdata/deduce/generic_type.carbon
@@ -209,10 +209,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(@F.%T.loc7_6.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(@F.%T.loc7_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
 // CHECK:STDOUT:   %T.loc7_6.2 => constants.%T
@@ -225,11 +222,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %F.specific_fn.loc7_39.2 => constants.%F.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc7_6.2) {
-// CHECK:STDOUT:   %T.loc7_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc7_6.2 => constants.%T
-// CHECK:STDOUT:   %C.loc7_22.2 => constants.%C.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc7_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%D) {
 // CHECK:STDOUT:   %T.loc4_9.2 => constants.%D
@@ -390,10 +383,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@F.%T.loc7_6.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@F.%T.loc7_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
 // CHECK:STDOUT:   %T.loc7_6.2 => constants.%T
@@ -405,11 +395,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %F.specific_fn.loc7_39.2 => constants.%F.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc7_6.2) {
-// CHECK:STDOUT:   %T.loc7_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc7_6.2 => constants.%T
-// CHECK:STDOUT:   %I.loc7_22.2 => constants.%I.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc7_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I(constants.%C) {
 // CHECK:STDOUT:   %T.loc4_9.2 => constants.%C
@@ -669,20 +655,11 @@ fn G() -> i32 {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(%T.loc4_13.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Outer(@F.%T.loc13_6.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Outer(@F.%T.loc13_6.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Inner(@F.%T.loc13_6.2, @F.%U.loc13_16.2) {
-// CHECK:STDOUT:   %U.loc5_15.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc5_15.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Inner(@F.%T.loc13_6.2, @F.%U.loc13_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %T.loc13_6.2 => constants.%T
@@ -704,18 +681,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %require_complete.loc13_70.2 => constants.%require_complete.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc13_6.2, %U.loc13_16.2) {
-// CHECK:STDOUT:   %T.loc13_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc13_6.2 => constants.%T
-// CHECK:STDOUT:   %U.loc13_16.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc13_16.2 => constants.%U
-// CHECK:STDOUT:   %Outer.loc13_36.2 => constants.%Outer.1
-// CHECK:STDOUT:   %require_complete.loc13_37 => constants.%require_complete.1
-// CHECK:STDOUT:   %Inner.type => constants.%Inner.type.1
-// CHECK:STDOUT:   %Inner.generic => constants.%Inner.generic.1
-// CHECK:STDOUT:   %Inner.loc13_45.2 => constants.%Inner.1
-// CHECK:STDOUT:   %tuple.type => constants.%tuple.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc13_6.2, %U.loc13_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Outer(constants.%C) {
 // CHECK:STDOUT:   %T.loc4_13.2 => constants.%C
@@ -904,10 +870,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @WithNontype(@F.%N.loc6_6.2) {
-// CHECK:STDOUT:   %N.loc4_19.2 => constants.%N.2
-// CHECK:STDOUT:   %N.patt.loc4_19.2 => constants.%N.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @WithNontype(@F.%N.loc6_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%N.2) {
 // CHECK:STDOUT:   %N.loc6_6.2 => constants.%N.2

--- a/toolchain/check/testdata/deduce/tuple.carbon
+++ b/toolchain/check/testdata/deduce/tuple.carbon
@@ -200,13 +200,7 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT:   %F.specific_fn.loc7_54.2 => constants.%F.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc7_6.2, %U.loc7_16.2) {
-// CHECK:STDOUT:   %T.loc7_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc7_6.2 => constants.%T
-// CHECK:STDOUT:   %U.loc7_16.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc7_16.2 => constants.%U
-// CHECK:STDOUT:   %tuple.type => constants.%tuple.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc7_6.2, %U.loc7_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%C, constants.%D) {
 // CHECK:STDOUT:   %T.loc7_6.2 => constants.%C
@@ -416,10 +410,7 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @HasPair(@F.%tuple.loc6_40.2) {
-// CHECK:STDOUT:   %Pair.loc4_15.2 => constants.%tuple.1
-// CHECK:STDOUT:   %Pair.patt.loc4_15.2 => constants.%tuple.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @HasPair(@F.%tuple.loc6_40.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%A, constants.%B) {
 // CHECK:STDOUT:   %A.loc6_6.2 => constants.%A

--- a/toolchain/check/testdata/deduce/type_operator.carbon
+++ b/toolchain/check/testdata/deduce/type_operator.carbon
@@ -184,11 +184,7 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %F.specific_fn.loc6_37.2 => constants.%F.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc6_6.2) {
-// CHECK:STDOUT:   %T.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc6_20.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc6_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%C) {
 // CHECK:STDOUT:   %T.loc6_6.2 => constants.%C
@@ -329,12 +325,7 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %F.specific_fn.loc6_43.2 => constants.%F.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc6_6.2) {
-// CHECK:STDOUT:   %T.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %const.loc6_19.2 => constants.%const.1
-// CHECK:STDOUT:   %ptr.loc6_26.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc6_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%C) {
 // CHECK:STDOUT:   %T.loc6_6.2 => constants.%C
@@ -473,11 +464,7 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %F.specific_fn.loc6_37.2 => constants.%F.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc6_6.2) {
-// CHECK:STDOUT:   %T.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc6_20.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc6_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%const) {
 // CHECK:STDOUT:   %T.loc6_6.2 => constants.%const
@@ -613,10 +600,5 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %F.specific_fn.loc6_43.2 => constants.%F.specific_fn
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc6_6.2) {
-// CHECK:STDOUT:   %T.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_6.2 => constants.%T
-// CHECK:STDOUT:   %const.loc6_19.2 => constants.%const.1
-// CHECK:STDOUT:   %ptr.loc6_26.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc6_6.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
@@ -465,10 +465,7 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:   %T.patt.loc11_14.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @As(@Convert.1.%T) {
-// CHECK:STDOUT:   %T.loc11_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_14.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @As(@Convert.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.1(constants.%T, constants.%Self.2) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -477,20 +474,14 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:   %Self.as_type.loc12_20.1 => constants.%Self.as_type.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @As(%T.loc11_14.2) {
-// CHECK:STDOUT:   %T.loc11_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_14.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @As(%T.loc11_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
 // CHECK:STDOUT:   %T.loc15_22.2 => constants.%T
 // CHECK:STDOUT:   %T.patt.loc15_22.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(@Convert.2.%T) {
-// CHECK:STDOUT:   %T.loc15_22.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc15_22.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.2.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.2(constants.%T, constants.%Self.3) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -499,10 +490,7 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:   %Self.as_type.loc16_20.1 => constants.%Self.as_type.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(%T.loc15_22.2) {
-// CHECK:STDOUT:   %T.loc15_22.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc15_22.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc15_22.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Op.1(constants.%Add.facet) {
 // CHECK:STDOUT:   %Self => constants.%Add.facet
@@ -887,15 +875,9 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @As(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @As(%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @As(@Convert.1.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @As(@Convert.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.1(constants.%T, constants.%Self.1) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -935,15 +917,9 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(@Convert.2.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.2.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.2(constants.%T, constants.%Self.3) {
 // CHECK:STDOUT:   %T => constants.%T

--- a/toolchain/check/testdata/function/generic/deduce.carbon
+++ b/toolchain/check/testdata/function/generic/deduce.carbon
@@ -336,11 +336,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %ExplicitGenericParam.specific_fn.loc4_50.2 => constants.%ExplicitGenericParam.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ExplicitGenericParam(%T.loc4_25.2) {
-// CHECK:STDOUT:   %T.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc4_39.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ExplicitGenericParam(%T.loc4_25.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @ExplicitGenericParam(constants.%i32) {
 // CHECK:STDOUT:   %T.loc4_25.2 => constants.%i32
@@ -369,11 +365,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %ExplicitGenericParam.specific_fn.loc4_50.2 => constants.%ExplicitGenericParam.specific_fn.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ExplicitGenericParam(@CallExplicitGenericParamWithGenericArg.%struct_type.a.loc10_62.2) {
-// CHECK:STDOUT:   %T.loc4_25.2 => constants.%struct_type.a
-// CHECK:STDOUT:   %T.patt.loc4_25.2 => constants.%struct_type.a
-// CHECK:STDOUT:   %ptr.loc4_39.2 => constants.%ptr.3
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ExplicitGenericParam(@CallExplicitGenericParamWithGenericArg.%struct_type.a.loc10_62.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_deduce_explicit_non_constant.carbon
 // CHECK:STDOUT:
@@ -492,22 +484,14 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %ExplicitGenericParam.specific_fn.loc4_50.2 => constants.%ExplicitGenericParam.specific_fn
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ExplicitGenericParam(%T.loc4_25.2) {
-// CHECK:STDOUT:   %T.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc4_39.2 => constants.%ptr
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ExplicitGenericParam(%T.loc4_25.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallExplicitGenericParamConst(constants.%T) {
 // CHECK:STDOUT:   %T.loc6_34.2 => constants.%T
 // CHECK:STDOUT:   %T.patt.loc6_34.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ExplicitGenericParam(@CallExplicitGenericParamConst.%T.loc6_34.2) {
-// CHECK:STDOUT:   %T.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc4_39.2 => constants.%ptr
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ExplicitGenericParam(@CallExplicitGenericParamConst.%T.loc6_34.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- explicit_vs_deduced.carbon
 // CHECK:STDOUT:
@@ -635,11 +619,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %ExplicitAndAlsoDeduced.specific_fn.loc7_10.2 => constants.%ExplicitAndAlsoDeduced.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ExplicitAndAlsoDeduced(%T.loc6_27.2) {
-// CHECK:STDOUT:   %T.loc6_27.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_27.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc6_47.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ExplicitAndAlsoDeduced(%T.loc6_27.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @ExplicitAndAlsoDeduced(constants.%A) {
 // CHECK:STDOUT:   %T.loc6_27.2 => constants.%A
@@ -769,11 +749,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %ImplicitGenericParam.specific_fn.loc4_56.2 => constants.%ImplicitGenericParam.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitGenericParam(%T.loc4_25.2) {
-// CHECK:STDOUT:   %T.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_25.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc4_45.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitGenericParam(%T.loc4_25.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @ImplicitGenericParam(constants.%i32) {
 // CHECK:STDOUT:   %T.loc4_25.2 => constants.%i32

--- a/toolchain/check/testdata/function/generic/no_prelude/call.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/call.carbon
@@ -243,10 +243,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   %T.patt.loc8_16.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Function(@CallGeneric.%T.loc8_16.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Function(@CallGeneric.%T.loc8_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallGenericPtr(constants.%T) {
 // CHECK:STDOUT:   %T.loc12_19.2 => constants.%T
@@ -262,10 +259,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Function(@CallGenericPtr.%ptr.loc12_33.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%ptr.1
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Function(@CallGenericPtr.%ptr.loc12_33.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Function(constants.%C) {
 // CHECK:STDOUT:   %T.loc4_13.2 => constants.%C
@@ -462,10 +456,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   %T.patt.loc8_16.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Function(@CallGeneric.%T.loc8_16.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Function(@CallGeneric.%T.loc8_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallGenericPtr(constants.%T) {
 // CHECK:STDOUT:   %T.loc12_19.2 => constants.%T
@@ -481,10 +472,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Function(@CallGenericPtr.%ptr.loc12_33.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%ptr.1
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%ptr.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Function(@CallGenericPtr.%ptr.loc12_33.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Function(constants.%C) {
 // CHECK:STDOUT:   %T.loc4_13.2 => constants.%C

--- a/toolchain/check/testdata/function/generic/no_prelude/import_specific.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/import_specific.carbon
@@ -109,10 +109,7 @@ fn H() {
 // CHECK:STDOUT:   %T.patt.loc7_6.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(@G.%T.loc7_6.2) {
-// CHECK:STDOUT:   %T.loc4_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_6.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(@G.%T.loc7_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- user.carbon
 // CHECK:STDOUT:
@@ -210,10 +207,7 @@ fn H() {
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(@G.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(@G.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%C) {
 // CHECK:STDOUT:   %T => constants.%C

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -173,11 +173,7 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %F.specific_fn.loc7_10.2 => constants.%F.specific_fn
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(%T.loc4_6.2) {
-// CHECK:STDOUT:   %T.loc4_6.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4 => constants.%T
-// CHECK:STDOUT:   %ptr.loc4_20.2 => constants.%ptr
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @F(%T.loc4_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_different_return_type.carbon
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/return_slot.carbon
+++ b/toolchain/check/testdata/function/generic/return_slot.carbon
@@ -212,19 +212,11 @@ fn G() {
 // CHECK:STDOUT:   %Make.specific_fn.loc12_27.2 => constants.%Make.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Wrap(%T.loc11_12.2) {
-// CHECK:STDOUT:   %T.loc11_12.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_12.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Wrap(%T.loc11_12.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Wrap(@Make.%T) {
-// CHECK:STDOUT:   %T.loc11_12.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_12.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Wrap(@Make.%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Make(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Make(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Wrap(constants.%i32) {
 // CHECK:STDOUT:   %T.loc11_12.2 => constants.%i32

--- a/toolchain/check/testdata/generic/complete_type.carbon
+++ b/toolchain/check/testdata/generic/complete_type.carbon
@@ -175,10 +175,7 @@ fn G() { F(B); }
 // CHECK:STDOUT:   %T.patt.loc6_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(%T.loc6_9.2) {
-// CHECK:STDOUT:   %T.loc6_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(%T.loc6_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%B) {
 // CHECK:STDOUT:   %T.loc6_9.2 => constants.%B

--- a/toolchain/check/testdata/impl/extend_impl_generic.carbon
+++ b/toolchain/check/testdata/impl/extend_impl_generic.carbon
@@ -267,10 +267,7 @@ class X(U:! type) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @HasF(%T.loc4_16.2) {
-// CHECK:STDOUT:   %T.loc4_16.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_16.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @HasF(%T.loc4_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HasF(constants.%Param) {
 // CHECK:STDOUT:   %T.loc4_16.2 => constants.%Param
@@ -482,10 +479,7 @@ class X(U:! type) {
 // CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@F.1.%T) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@F.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -494,10 +488,7 @@ class X(U:! type) {
 // CHECK:STDOUT:   %Self.as_type.loc5_14.1 => constants.%Self.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T.loc4_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @X(constants.%U) {
 // CHECK:STDOUT:   %U.loc8_9.2 => constants.%U
@@ -521,15 +512,9 @@ class X(U:! type) {
 // CHECK:STDOUT:   %assoc0.loc5_25.2 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(@impl.%U) {
-// CHECK:STDOUT:   %U.loc8_9.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc8_9.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(@impl.%U) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.%U) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%U
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%U) {
 // CHECK:STDOUT:   %U => constants.%U
@@ -543,15 +528,9 @@ class X(U:! type) {
 // CHECK:STDOUT:   %interface.loc9_23.2 => constants.%interface
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(@F.2.%U) {
-// CHECK:STDOUT:   %U.loc8_9.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc8_9.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @X(@F.2.%U) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@F.2.%U) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%U
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@F.2.%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.2(constants.%U) {
 // CHECK:STDOUT:   %U => constants.%U
@@ -567,14 +546,7 @@ class X(U:! type) {
 // CHECK:STDOUT:   %Self.as_type.loc5_14.1 => constants.%X
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%U) {
-// CHECK:STDOUT:   %U => constants.%U
-// CHECK:STDOUT:   %X => constants.%X
-// CHECK:STDOUT:   %I.type.loc9_21.2 => constants.%I.type.3
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%U) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@X.%U.loc8_9.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%U
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@X.%U.loc8_9.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -184,15 +184,9 @@ class C {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GenericInterface(%T.loc11_28.2) {
-// CHECK:STDOUT:   %T.loc11_28.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_28.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GenericInterface(%T.loc11_28.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GenericInterface(@impl.%T.loc19_23.2) {
-// CHECK:STDOUT:   %T.loc11_28.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_28.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GenericInterface(@impl.%T.loc19_23.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
 // CHECK:STDOUT:   %T.loc19_23.2 => constants.%T
@@ -214,9 +208,5 @@ class C {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc19_23.2) {
-// CHECK:STDOUT:   %T.loc19_23.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc19_23.2 => constants.%T
-// CHECK:STDOUT:   %GenericInterface.type.loc19_54.2 => constants.%GenericInterface.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc19_23.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
+++ b/toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
@@ -166,12 +166,7 @@ impl i32 as I {
 // CHECK:STDOUT:   %X.patt.loc11_19.2 => constants.%Self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(constants.%I.type, @F.1.%Self) {
-// CHECK:STDOUT:   %T.loc11_9.2 => constants.%I.type
-// CHECK:STDOUT:   %T.patt.loc11_9.2 => constants.%I.type
-// CHECK:STDOUT:   %X.loc11_19.2 => constants.%Self
-// CHECK:STDOUT:   %X.patt.loc11_19.2 => constants.%Self
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(constants.%I.type, @F.1.%Self) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Self) {
 // CHECK:STDOUT:   %Self => constants.%Self

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -118,8 +118,5 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Simple.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc15_14.2) {
-// CHECK:STDOUT:   %T.loc15_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc15_14.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc15_14.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/generic.carbon
+++ b/toolchain/check/testdata/impl/lookup/generic.carbon
@@ -252,10 +252,7 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%HasF.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {
-// CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_14.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%empty_struct_type) {
 // CHECK:STDOUT:   %T.loc8_14.2 => constants.%empty_struct_type
@@ -457,10 +454,7 @@ fn G(x: A) {
 // CHECK:STDOUT:   %Self.as_type.loc5_14.1 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {
-// CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_14.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%empty_struct_type) {
 // CHECK:STDOUT:   %T.loc8_14.2 => constants.%empty_struct_type
@@ -634,10 +628,7 @@ fn G(x: A) {
 // CHECK:STDOUT:   %T.patt.loc8_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(@impl.%T.loc10_14.2) {
-// CHECK:STDOUT:   %T.loc8_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(@impl.%T.loc10_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
 // CHECK:STDOUT:   %T.loc10_14.2 => constants.%T
@@ -654,11 +645,7 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%HasF.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc10_14.2) {
-// CHECK:STDOUT:   %T.loc10_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc10_14.2 => constants.%T
-// CHECK:STDOUT:   %C.loc10_27.2 => constants.%C.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc10_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%empty_struct_type) {
 // CHECK:STDOUT:   %T.loc8_9.2 => constants.%empty_struct_type
@@ -849,15 +836,9 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @HasF(%T.loc4_16.2) {
-// CHECK:STDOUT:   %T.loc4_16.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_16.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @HasF(%T.loc4_16.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @HasF(@impl.%T.loc8_14.2) {
-// CHECK:STDOUT:   %T.loc4_16.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_16.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @HasF(@impl.%T.loc8_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
@@ -875,11 +856,7 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%HasF.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {
-// CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_14.2 => constants.%T
-// CHECK:STDOUT:   %HasF.type.loc8_36.2 => constants.%HasF.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HasF(constants.%empty_struct_type) {
 // CHECK:STDOUT:   %T.loc4_16.2 => constants.%empty_struct_type
@@ -1043,12 +1020,7 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%HasF.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc9_14.2, %U.loc9_24.2) {
-// CHECK:STDOUT:   %T.loc9_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc9_14.2 => constants.%T
-// CHECK:STDOUT:   %U.loc9_24.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc9_24.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc9_14.2, %U.loc9_24.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_inconsistent_deduction.carbon
 // CHECK:STDOUT:
@@ -1228,15 +1200,9 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @HasF(%T.loc4_16.2) {
-// CHECK:STDOUT:   %T.loc4_16.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_16.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @HasF(%T.loc4_16.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @HasF(@impl.%T.loc8_14.2) {
-// CHECK:STDOUT:   %T.loc4_16.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_16.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @HasF(@impl.%T.loc8_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
@@ -1254,11 +1220,7 @@ fn G(x: A) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%HasF.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {
-// CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_14.2 => constants.%T
-// CHECK:STDOUT:   %HasF.type.loc8_35.2 => constants.%HasF.type.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc8_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HasF(constants.%B) {
 // CHECK:STDOUT:   %T.loc4_16.2 => constants.%B

--- a/toolchain/check/testdata/impl/lookup/no_prelude/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/impl_forall.carbon
@@ -367,20 +367,14 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %T.patt.loc2_9.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(%T.loc2_9.2) {
-// CHECK:STDOUT:   %T.loc2_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc2_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(%T.loc2_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I(constants.%U) {
 // CHECK:STDOUT:   %U.loc6_13.2 => constants.%U
 // CHECK:STDOUT:   %U.patt.loc6_13.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@F.1.%U) {
-// CHECK:STDOUT:   %U.loc6_13.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc6_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@F.1.%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%U, constants.%Self) {
 // CHECK:STDOUT:   %U => constants.%U
@@ -389,10 +383,7 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %Self.as_type.loc7_14.1 => constants.%Self.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%U.loc6_13.2) {
-// CHECK:STDOUT:   %U.loc6_13.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc6_13.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%U.loc6_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%V) {
 // CHECK:STDOUT:   %T.loc2_9.2 => constants.%V
@@ -419,15 +410,9 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %assoc0.loc7_26.2 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(@impl.%V.loc10_14.2) {
-// CHECK:STDOUT:   %T.loc2_9.2 => constants.%V
-// CHECK:STDOUT:   %T.patt.loc2_9.2 => constants.%V
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(@impl.%V.loc10_14.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.%V.loc10_14.2) {
-// CHECK:STDOUT:   %U.loc6_13.2 => constants.%V
-// CHECK:STDOUT:   %U.patt.loc6_13.2 => constants.%V
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.%V.loc10_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%V) {
 // CHECK:STDOUT:   %V.loc10_14.2 => constants.%V
@@ -442,10 +427,7 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %interface.loc10_37.2 => constants.%interface.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(@F.2.%V) {
-// CHECK:STDOUT:   %T.loc2_9.2 => constants.%V
-// CHECK:STDOUT:   %T.patt.loc2_9.2 => constants.%V
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(@F.2.%V) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.2(constants.%V) {
 // CHECK:STDOUT:   %V => constants.%V
@@ -459,12 +441,7 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %Self.as_type.loc7_14.1 => constants.%A.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%V.loc10_14.2) {
-// CHECK:STDOUT:   %V.loc10_14.2 => constants.%V
-// CHECK:STDOUT:   %V.patt.loc10_14.2 => constants.%V
-// CHECK:STDOUT:   %A.loc10_27.2 => constants.%A.2
-// CHECK:STDOUT:   %I.type.loc10_35.2 => constants.%I.type.3
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%V.loc10_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%W) {
 // CHECK:STDOUT:   %T.loc2_9.2 => constants.%W
@@ -478,10 +455,7 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %complete_type.loc4_1.2 => constants.%complete_type.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @A(@TestGeneric.%W.loc16_16.2) {
-// CHECK:STDOUT:   %T.loc2_9.2 => constants.%W
-// CHECK:STDOUT:   %T.patt.loc2_9.2 => constants.%W
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @A(@TestGeneric.%W.loc16_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @TestGeneric(constants.%W) {
 // CHECK:STDOUT:   %W.loc16_16.2 => constants.%W
@@ -525,17 +499,9 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   %A.elem => constants.%A.elem.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@TestGeneric.%W.loc16_16.2) {
-// CHECK:STDOUT:   %U.loc6_13.2 => constants.%W
-// CHECK:STDOUT:   %U.patt.loc6_13.2 => constants.%W
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@TestGeneric.%W.loc16_16.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(@TestGeneric.%W.loc16_16.2) {
-// CHECK:STDOUT:   %V.loc10_14.2 => constants.%W
-// CHECK:STDOUT:   %V.patt.loc10_14.2 => constants.%W
-// CHECK:STDOUT:   %A.loc10_27.2 => constants.%A.3
-// CHECK:STDOUT:   %I.type.loc10_35.2 => constants.%I.type.4
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(@TestGeneric.%W.loc16_16.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%empty_struct_type) {
 // CHECK:STDOUT:   %T.loc2_9.2 => constants.%empty_struct_type

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -1307,10 +1307,7 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:   %U.patt.loc6_28.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GenericInterface(%U.loc6_28.2) {
-// CHECK:STDOUT:   %U.loc6_28.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc6_28.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GenericInterface(%U.loc6_28.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AnyParam(constants.%T, constants.%X) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -1483,10 +1480,7 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:   %U.patt => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GenericInterface(%U) {
-// CHECK:STDOUT:   %U => constants.%U
-// CHECK:STDOUT:   %U.patt => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GenericInterface(%U) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AnyParam(constants.%GenericInterface.type.1, constants.%GenericInterface.generic) {
 // CHECK:STDOUT:   %T => constants.%GenericInterface.type.1

--- a/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
@@ -154,10 +154,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T.loc4_13.2) {
-// CHECK:STDOUT:   %T.loc4_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T.loc4_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%T) {
 // CHECK:STDOUT:   %T.loc5_9.2 => constants.%T
@@ -279,10 +276,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
@@ -431,10 +425,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
@@ -596,10 +587,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
@@ -780,10 +768,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
@@ -148,15 +148,9 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT:   %T.patt.loc5_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T.loc5_13.2) {
-// CHECK:STDOUT:   %T.loc5_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc5_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T.loc5_13.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.1.%T.loc7_14.2) {
-// CHECK:STDOUT:   %T.loc5_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc5_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.1.%T.loc7_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.1(constants.%T) {
 // CHECK:STDOUT:   %T.loc7_14.2 => constants.%T
@@ -173,10 +167,7 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT:   %Self.2 => constants.%Self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.2.%ptr.loc8_32.2) {
-// CHECK:STDOUT:   %T.loc5_13.2 => constants.%ptr
-// CHECK:STDOUT:   %T.patt.loc5_13.2 => constants.%ptr
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.2.%ptr.loc8_32.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.2(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_14.2 => constants.%T
@@ -295,15 +286,9 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT:   %Self => constants.%Self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.1.%T.1) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.1.%T.1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.1(constants.%T) {
 // CHECK:STDOUT:   %T.1 => constants.%T
@@ -316,10 +301,7 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT:   %T.patt => constants.%ptr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.2.%ptr) {
-// CHECK:STDOUT:   %T => constants.%ptr
-// CHECK:STDOUT:   %T.patt => constants.%ptr
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.2.%ptr) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.2(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -423,15 +405,9 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.1.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.1(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -444,10 +420,7 @@ impl forall [T:! type] C as I(T*) {}
 // CHECK:STDOUT:   %T.patt => constants.%ptr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@impl.2.%ptr.1) {
-// CHECK:STDOUT:   %T => constants.%ptr
-// CHECK:STDOUT:   %T.patt => constants.%ptr
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@impl.2.%ptr.1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.2(constants.%T) {
 // CHECK:STDOUT:   %T.1 => constants.%T

--- a/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
@@ -154,10 +154,7 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(@impl.%T.loc10_14.2) {
-// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(@impl.%T.loc10_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
 // CHECK:STDOUT:   %T.loc10_14.2 => constants.%T
@@ -174,11 +171,7 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%I.facet) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc10_14.2) {
-// CHECK:STDOUT:   %T.loc10_14.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc10_14.2 => constants.%T
-// CHECK:STDOUT:   %C.loc10_27.2 => constants.%C
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T.loc10_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_use_in_fn_decl.carbon
 // CHECK:STDOUT:
@@ -328,10 +321,7 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(@impl.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(@impl.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -344,11 +334,7 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT:   %interface => constants.%interface.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT:   %C => constants.%C.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @impl(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.2(constants.%T) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
@@ -231,10 +231,7 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Op.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Action(%T.loc4_18.2) {
-// CHECK:STDOUT:   %T.loc4_18.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_18.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Action(%T.loc4_18.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Action(constants.%B) {
 // CHECK:STDOUT:   %T.loc4_18.2 => constants.%B
@@ -399,10 +396,7 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Action(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Action(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Op.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
@@ -560,10 +554,7 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Action(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Action(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Op(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
@@ -711,10 +702,7 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Factory(%T.loc4_19.2) {
-// CHECK:STDOUT:   %T.loc4_19.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_19.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Factory(%T.loc4_19.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Factory(constants.%B) {
 // CHECK:STDOUT:   %T.loc4_19.2 => constants.%B
@@ -883,10 +871,7 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Factory(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Factory(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Make.1(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -1050,10 +1035,7 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Factory(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Factory(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Make(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T

--- a/toolchain/check/testdata/interface/member_lookup.carbon
+++ b/toolchain/check/testdata/interface/member_lookup.carbon
@@ -223,15 +223,9 @@ fn AccessMissingConcrete(I:! Interface(i32)) -> i32 {
 // CHECK:STDOUT:   %assoc0.loc5_12.2 => constants.%assoc0.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Interface(%T.loc4_21.2) {
-// CHECK:STDOUT:   %T.loc4_21.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_21.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Interface(%T.loc4_21.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Interface(@AccessGeneric.%T.loc8_18.2) {
-// CHECK:STDOUT:   %T.loc4_21.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_21.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Interface(@AccessGeneric.%T.loc8_18.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AccessGeneric(constants.%T, constants.%I.1) {
 // CHECK:STDOUT:   %T.loc8_18.2 => constants.%T
@@ -417,15 +411,9 @@ fn AccessMissingConcrete(I:! Interface(i32)) -> i32 {
 // CHECK:STDOUT:   %assoc0.loc5_12.2 => constants.%assoc0.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Interface(%T.loc4_21.2) {
-// CHECK:STDOUT:   %T.loc4_21.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_21.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Interface(%T.loc4_21.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Interface(@AccessMissingGeneric.%T.loc8_25.2) {
-// CHECK:STDOUT:   %T.loc4_21.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_21.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Interface(@AccessMissingGeneric.%T.loc8_25.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @AccessMissingGeneric(constants.%T, constants.%I.1) {
 // CHECK:STDOUT:   %T.loc8_25.2 => constants.%T

--- a/toolchain/check/testdata/interface/no_prelude/assoc_const_in_generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/assoc_const_in_generic.carbon
@@ -171,20 +171,14 @@ fn H() {
 // CHECK:STDOUT:   %U.patt.loc12_8.1 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T.loc11_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T) {
 // CHECK:STDOUT:   %T.loc15_6.2 => constants.%T
 // CHECK:STDOUT:   %T.patt.loc15_6.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@G.%T.loc15_6.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@G.%T.loc15_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%empty_struct_type) {
 // CHECK:STDOUT:   %T.loc15_6.2 => constants.%empty_struct_type

--- a/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
@@ -165,10 +165,7 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT:   %T.patt.loc19_22.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%T.loc19_22.2) {
-// CHECK:STDOUT:   %T.loc19_22.2 => constants.%T.1
-// CHECK:STDOUT:   %T.patt.loc19_22.2 => constants.%T.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%T.loc19_22.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%T.1) {
 // CHECK:STDOUT:   %T.loc21_19.2 => constants.%T.1
@@ -185,8 +182,5 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT:   %T.patt.loc38_27.2 => constants.%T.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.3(%T.loc38_27.2) {
-// CHECK:STDOUT:   %T.loc38_27.2 => constants.%T.2
-// CHECK:STDOUT:   %T.patt.loc38_27.2 => constants.%T.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.3(%T.loc38_27.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
@@ -155,10 +155,7 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:   %assoc0.loc13_29.2 => constants.%assoc0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@F.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@F.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -167,15 +164,9 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:   %Self.as_type.loc13_14.1 => constants.%Self.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(%T.loc11_13.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(%T.loc11_13.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @I(@.1.%T.loc22_6.2) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc11_13.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @I(@.1.%T.loc22_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @.1(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T.loc22_6.2 => constants.%T

--- a/toolchain/check/testdata/interface/no_prelude/generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic.carbon
@@ -320,10 +320,7 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   %T.patt.loc4_18.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Simple(%T.loc4_18.2) {
-// CHECK:STDOUT:   %T.loc4_18.2 => constants.%T.1
-// CHECK:STDOUT:   %T.patt.loc4_18.2 => constants.%T.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Simple(%T.loc4_18.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WithAssocFn(constants.%T.1) {
 // CHECK:STDOUT:   %T.loc8_23.2 => constants.%T.1
@@ -332,10 +329,7 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T.1, constants.%Self.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @WithAssocFn(%T.loc8_23.2) {
-// CHECK:STDOUT:   %T.loc8_23.2 => constants.%T.1
-// CHECK:STDOUT:   %T.patt.loc8_23.2 => constants.%T.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @WithAssocFn(%T.loc8_23.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Simple(constants.%C) {
 // CHECK:STDOUT:   %T.loc4_18.2 => constants.%C
@@ -380,10 +374,7 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   %T.patt.loc25_9.2 => constants.%T.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Receive(@Pass.%T.loc25_9.2) {
-// CHECK:STDOUT:   %T.loc24_12.2 => constants.%T.2
-// CHECK:STDOUT:   %T.patt.loc24_12.2 => constants.%T.2
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Receive(@Pass.%T.loc25_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_mismatched_args.carbon
 // CHECK:STDOUT:
@@ -509,10 +500,7 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   %T.patt.loc4_19.2 => constants.%T.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(%T.loc4_19.2) {
-// CHECK:STDOUT:   %T.loc4_19.2 => constants.%T.1
-// CHECK:STDOUT:   %T.patt.loc4_19.2 => constants.%T.1
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Generic(%T.loc4_19.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%A) {
 // CHECK:STDOUT:   %T.loc4_19.2 => constants.%A

--- a/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
@@ -91,10 +91,7 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @AddWith(%T.loc4_19.2) {
-// CHECK:STDOUT:   %T.loc4_19.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc4_19.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @AddWith(%T.loc4_19.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
@@ -198,10 +195,7 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @AddWith(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @AddWith(%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/generic_vs_params.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_vs_params.carbon
@@ -285,10 +285,7 @@ interface A(T: type) {}
 // CHECK:STDOUT:   %T.patt.loc6_28.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GenericAndParams.1(%T.loc6_28.2) {
-// CHECK:STDOUT:   %T.loc6_28.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc6_28.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GenericAndParams.1(%T.loc6_28.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%T) {
 // CHECK:STDOUT:   %T.loc8_9.2 => constants.%T
@@ -304,15 +301,9 @@ interface A(T: type) {}
 // CHECK:STDOUT:   %U.patt.loc10_30.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @GenericAndParams.2(%T, %U.loc10_30.2) {
-// CHECK:STDOUT:   %U.loc10_30.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc10_30.2 => constants.%U
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @GenericAndParams.2(%T, %U.loc10_30.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @C(%T.loc8_9.2) {
-// CHECK:STDOUT:   %T.loc8_9.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_9.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @C(%T.loc8_9.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GenericAndParams.1(constants.%X) {
 // CHECK:STDOUT:   %T.loc6_28.2 => constants.%X

--- a/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
@@ -294,20 +294,14 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc7_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Foo(%a.loc7_15.2) {
-// CHECK:STDOUT:   %a.loc7_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc7_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Foo(%a.loc7_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Bar(constants.%a) {
 // CHECK:STDOUT:   %a.loc10_15.2 => constants.%a
 // CHECK:STDOUT:   %a.patt.loc10_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Bar(%a.loc10_15.2) {
-// CHECK:STDOUT:   %a.loc10_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc10_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Bar(%a.loc10_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- spacing.carbon
 // CHECK:STDOUT:
@@ -377,10 +371,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc6_21.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Foo(%a.loc6_21.2) {
-// CHECK:STDOUT:   %a.loc6_21.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc6_21.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Foo(%a.loc6_21.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_parens.carbon
 // CHECK:STDOUT:
@@ -464,10 +455,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc14_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%a.loc14_15.2) {
-// CHECK:STDOUT:   %a.loc14_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc14_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%a.loc14_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- todo_fail_raw_identifier.carbon
 // CHECK:STDOUT:
@@ -537,10 +525,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc6_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Foo(%a.loc6_15.2) {
-// CHECK:STDOUT:   %a.loc6_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc6_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Foo(%a.loc6_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- two_file.carbon
 // CHECK:STDOUT:
@@ -738,10 +723,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc12_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%a.loc12_15.2) {
-// CHECK:STDOUT:   %a.loc12_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc12_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%a.loc12_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Bar(constants.%a) {
 // CHECK:STDOUT:   %a => constants.%a
@@ -753,10 +735,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc21_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.2(%a.loc21_15.2) {
-// CHECK:STDOUT:   %a.loc21_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc21_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.2(%a.loc21_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_name_mismatch.carbon
 // CHECK:STDOUT:
@@ -845,10 +824,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %b.patt.loc15_15.2 => constants.%b
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%b.loc15_15.2) {
-// CHECK:STDOUT:   %b.loc15_15.2 => constants.%b
-// CHECK:STDOUT:   %b.patt.loc15_15.2 => constants.%b
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%b.loc15_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_alias.carbon
 // CHECK:STDOUT:
@@ -935,10 +911,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc15_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%a.loc15_15.2) {
-// CHECK:STDOUT:   %a.loc15_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc15_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%a.loc15_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_deduced_alias.carbon
 // CHECK:STDOUT:
@@ -1025,10 +998,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc15_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%a.loc15_15.2) {
-// CHECK:STDOUT:   %a.loc15_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc15_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%a.loc15_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- alias_two_file.carbon
 // CHECK:STDOUT:
@@ -1161,10 +1131,7 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc17_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%a.loc17_15.2) {
-// CHECK:STDOUT:   %a.loc17_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc17_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%a.loc17_15.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_repeat_const.carbon
 // CHECK:STDOUT:
@@ -1252,8 +1219,5 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %a.patt.loc17_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(%a.loc17_15.2) {
-// CHECK:STDOUT:   %a.loc17_15.2 => constants.%a
-// CHECK:STDOUT:   %a.patt.loc17_15.2 => constants.%a
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @.1(%a.loc17_15.2) {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
+++ b/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
@@ -284,10 +284,7 @@ fn Test() {
 // CHECK:STDOUT:   %Source.specific_fn.loc27_35.2 => constants.%Source.specific_fn.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Source(%T.loc27_11.2) {
-// CHECK:STDOUT:   %T.loc27_11.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc27_11.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Source(%T.loc27_11.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Source(constants.%X) {
 // CHECK:STDOUT:   %T.loc27_11.2 => constants.%X

--- a/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
+++ b/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
@@ -278,10 +278,7 @@ fn F() { ()[()]; }
 // CHECK:STDOUT:   %SubscriptType.patt.loc5_26.2 => constants.%SubscriptType
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @IndexWith(@At.1.%SubscriptType) {
-// CHECK:STDOUT:   %SubscriptType.loc5_26.2 => constants.%SubscriptType
-// CHECK:STDOUT:   %SubscriptType.patt.loc5_26.2 => constants.%SubscriptType
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @IndexWith(@At.1.%SubscriptType) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @At.1(constants.%SubscriptType, constants.%Self) {
 // CHECK:STDOUT:   %SubscriptType => constants.%SubscriptType
@@ -290,10 +287,7 @@ fn F() { ()[()]; }
 // CHECK:STDOUT:   %Self.as_type.loc6_15.1 => constants.%Self.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @IndexWith(%SubscriptType.loc5_26.2) {
-// CHECK:STDOUT:   %SubscriptType.loc5_26.2 => constants.%SubscriptType
-// CHECK:STDOUT:   %SubscriptType.patt.loc5_26.2 => constants.%SubscriptType
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @IndexWith(%SubscriptType.loc5_26.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @IndexWith(constants.%empty_tuple.type) {
 // CHECK:STDOUT:   %SubscriptType.loc5_26.2 => constants.%empty_tuple.type

--- a/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
+++ b/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
@@ -225,10 +225,7 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   %T.patt.loc8_22.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(@Convert.1.%T) {
-// CHECK:STDOUT:   %T.loc8_22.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_22.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.1(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -237,10 +234,7 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   %Self.as_type.loc9_20.1 => constants.%Self.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(%T.loc8_22.2) {
-// CHECK:STDOUT:   %T.loc8_22.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc8_22.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc8_22.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @ImplicitAs(constants.%i32.builtin) {
 // CHECK:STDOUT:   %T.loc8_22.2 => constants.%i32.builtin
@@ -870,15 +864,9 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(@Convert.1.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.1(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T
@@ -1568,15 +1556,9 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   %T.patt => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(%T) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @ImplicitAs(@Convert.1.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %T.patt => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.1.%T) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Convert.1(constants.%T, constants.%Self) {
 // CHECK:STDOUT:   %T => constants.%T

--- a/toolchain/check/testdata/where_expr/dot_self_index.carbon
+++ b/toolchain/check/testdata/where_expr/dot_self_index.carbon
@@ -211,10 +211,7 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:   %W.patt.loc11_17.2 => constants.%W
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Empty(%W.loc11_17.2) {
-// CHECK:STDOUT:   %W.loc11_17.2 => constants.%W
-// CHECK:STDOUT:   %W.patt.loc11_17.2 => constants.%W
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Empty(%W.loc11_17.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Empty(constants.%T) {
 // CHECK:STDOUT:   %W.loc11_17.2 => constants.%T
@@ -227,10 +224,7 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:   %assoc0.loc12_15.2 => constants.%assoc0.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Empty(@H.%T.loc18_6.2) {
-// CHECK:STDOUT:   %W.loc11_17.2 => constants.%T
-// CHECK:STDOUT:   %W.patt.loc11_17.2 => constants.%T
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Empty(@H.%T.loc18_6.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%T, constants.%V) {
 // CHECK:STDOUT:   %T.loc18_6.2 => constants.%T

--- a/toolchain/check/testdata/where_expr/equal_rewrite.carbon
+++ b/toolchain/check/testdata/where_expr/equal_rewrite.carbon
@@ -578,10 +578,7 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @OneRewrite(@RepeatedRewrite.%H.loc10_20.2) {
-// CHECK:STDOUT:   %G.loc8_15.2 => constants.%H
-// CHECK:STDOUT:   %G.patt.loc8_15.2 => constants.%H
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @OneRewrite(@RepeatedRewrite.%H.loc10_20.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @OneRewriteAgain(constants.%I) {
 // CHECK:STDOUT:   %I.loc14_20.2 => constants.%I
@@ -596,10 +593,7 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %OneRewrite.specific_fn.loc11_3.2 => constants.%OneRewrite.specific_fn.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @RepeatedRewrite(@OneRewriteAgain.%I.loc14_20.2) {
-// CHECK:STDOUT:   %H.loc10_20.2 => constants.%I
-// CHECK:STDOUT:   %H.patt.loc10_20.2 => constants.%I
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @RepeatedRewrite(@OneRewriteAgain.%I.loc14_20.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @OneRewrite(constants.%I) {
 // CHECK:STDOUT:   %G.loc8_15.2 => constants.%I
@@ -764,10 +758,7 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Alphabetical(@Reversed.%N.loc11_13.2) {
-// CHECK:STDOUT:   %M.loc9_17.2 => constants.%N
-// CHECK:STDOUT:   %M.patt.loc9_17.2 => constants.%N
-// CHECK:STDOUT: }
+// CHECK:STDOUT: specific @Alphabetical(@Reversed.%N.loc11_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_rewrites_mismatch_right.carbon
 // CHECK:STDOUT:


### PR DESCRIPTION
When substituting into a generic in order to form a generic eval block, we form `SpecificId`s to track the list of arguments that should eventually be used to form a specific referenced by the eval block. Values within that specific are not needed and won't ever be used, so it's safe to skip forming them in the first place.