### PR TITLE
Enable misc-non-private-member-variables-in-classes and adjust style to match

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -65,9 +65,6 @@ WarningsAsErrors: '*'
 # - '-google-readability-function-size'
 # # Suggests usernames on TODOs, which we don't want.
 # - '-google-readability-todo'
-# # Even with `IgnoreClassesWithAllMemberVariablesBeingPublic` to allow structs,
-# # we use `protected` members in too many tests.
-# - '-misc-non-private-member-variables-in-classes'
 # # Overlaps with `-Wno-missing-prototypes`.
 # - '-misc-use-internal-linkage'
 # # Suggests `std::array`, which we could migrate to, but conflicts with the
@@ -110,13 +107,17 @@ Checks:
   -bugprone-macro-parentheses, -bugprone-narrowing-conversions,
   -bugprone-switch-missing-default-case, -bugprone-unchecked-optional-access,
   -google-readability-function-size, -google-readability-todo,
-  -misc-non-private-member-variables-in-classes, -misc-use-internal-linkage,
-  -modernize-avoid-c-arrays, -modernize-use-designated-initializers,
-  -modernize-use-nodiscard, -performance-unnecessary-value-param,
-  -readability-enum-initial-value, -readability-function-cognitive-complexity,
-  -readability-magic-numbers, -readability-redundant-member-init,
-  -readability-suspicious-call-argument
+  -misc-use-internal-linkage, -modernize-avoid-c-arrays,
+  -modernize-use-designated-initializers, -modernize-use-nodiscard,
+  -performance-unnecessary-value-param, -readability-enum-initial-value,
+  -readability-function-cognitive-complexity, -readability-magic-numbers,
+  -readability-redundant-member-init, -readability-suspicious-call-argument
 CheckOptions:
+  # Don't warn on structs; done by ignoring when there are only public members.
+  - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: true
+
+  # CamelCase names.
   - key: readability-identifier-naming.ClassCase
     value: CamelCase
   - key: readability-identifier-naming.ClassConstantCase
@@ -135,14 +136,20 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.UnionCase
     value: CamelCase
+
+  # lower_case names.
   - key: readability-identifier-naming.ClassMemberCase
     value: lower_case
   - key: readability-identifier-naming.ParameterCase
     value: lower_case
   - key: readability-identifier-naming.VariableCase
     value: lower_case
+
+  # TODO: This is for explorer's use of LLVM casting support, so we should be
+  # able to remove it once explorer is deleted.
   - key: readability-identifier-naming.MethodIgnoredRegexp
     value: '^classof$'
+
   # This erroneously fires in C++20 mode with LLVM 16 clang-tidy, due to:
   # https://github.com/llvm/llvm-project/issues/46097
   - key: readability-identifier-naming.TemplateParameterIgnoredRegexp

--- a/docs/project/cpp_style_guide.md
+++ b/docs/project/cpp_style_guide.md
@@ -184,6 +184,11 @@ these.
     -   Tests are an exception and should typically be wrapped in an anonymous
         namespace under the namespace of the code under test, to keep everything
         internal.
+-   For
+    [Access Control](https://google.github.io/styleguide/cppguide.html#Access_Control),
+    specifically for test fixtures in `.cpp` files, we use `public` instead of
+    `protected`. This is motivated by the
+    `misc-non-private-member-variables-in-classes` tidy check.
 
 ### Copyable and movable types
 

--- a/migrate_cpp/cpp_refactoring/matcher_test_base.h
+++ b/migrate_cpp/cpp_refactoring/matcher_test_base.h
@@ -19,25 +19,25 @@ namespace Carbon::Testing {
 template <typename MatcherFactoryType>
 class MatcherTestBase : public ::testing::Test {
  protected:
-  MatcherTestBase() : matchers(&replacements) {
-    matchers.Register(std::make_unique<MatcherFactoryType>());
+  MatcherTestBase() : matchers_(&replacements_) {
+    matchers_.Register(std::make_unique<MatcherFactoryType>());
   }
 
   // Expects that the replacements produced by running the finder result in
   // the specified code transformation.
   void ExpectReplacement(llvm::StringRef before, llvm::StringRef after) {
     auto factory =
-        clang::tooling::newFrontendActionFactory(matchers.GetFinder());
+        clang::tooling::newFrontendActionFactory(matchers_.GetFinder());
     constexpr char Filename[] = "test.cc";
-    replacements.clear();
-    replacements.insert({Filename, {}});
+    replacements_.clear();
+    replacements_.insert({Filename, {}});
     ASSERT_TRUE(clang::tooling::runToolOnCodeWithArgs(
         factory->create(), before, {}, Filename, "clang-tool",
         std::make_shared<clang::PCHContainerOperations>(),
         clang::tooling::FileContentMappings()));
-    EXPECT_THAT(replacements, testing::ElementsAre(testing::Key(Filename)));
+    EXPECT_THAT(replacements_, testing::ElementsAre(testing::Key(Filename)));
     llvm::Expected<std::string> actual =
-        clang::tooling::applyAllReplacements(before, replacements[Filename]);
+        clang::tooling::applyAllReplacements(before, replacements_[Filename]);
 
     // Make a specific note if the matcher didn't make any changes.
     std::string unchanged;
@@ -57,8 +57,9 @@ class MatcherTestBase : public ::testing::Test {
     }
   }
 
-  Matcher::ReplacementMap replacements;
-  MatcherManager matchers;
+ private:
+  Matcher::ReplacementMap replacements_;
+  MatcherManager matchers_;
 };
 
 }  // namespace Carbon::Testing

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -339,7 +339,7 @@ class NodeStack {
   auto empty() const -> bool { return stack_.empty(); }
   auto size() const -> size_t { return stack_.size(); }
 
- protected:
+ private:
   // An ID that can be associated with a parse node.
   //
   // Each parse node kind has a corresponding Id::Kind indicating which kind of

--- a/toolchain/diagnostics/diagnostic_emitter_test.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter_test.cpp
@@ -25,7 +25,7 @@ struct FakeDiagnosticConverter : DiagnosticConverter<int> {
 };
 
 class DiagnosticEmitterTest : public ::testing::Test {
- protected:
+ public:
   DiagnosticEmitterTest() : emitter_(converter_, consumer_) {}
 
   FakeDiagnosticConverter converter_;

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -40,7 +40,7 @@ static auto ReadFile(std::filesystem::path path) -> std::string {
 }
 
 class DriverTest : public testing::Test {
- protected:
+ public:
   DriverTest()
       : installation_(
             InstallPaths::MakeForBazelRunfiles(Testing::GetExePath())),

--- a/toolchain/install/busybox_info_test.cpp
+++ b/toolchain/install/busybox_info_test.cpp
@@ -18,7 +18,7 @@ namespace {
 using ::testing::Eq;
 
 class BusyboxInfoTest : public ::testing::Test {
- protected:
+ public:
   // Set up a temp directory for the test case.
   explicit BusyboxInfoTest() {
     const char* tmpdir = std::getenv("TEST_TMPDIR");

--- a/toolchain/install/install_paths_test.cpp
+++ b/toolchain/install/install_paths_test.cpp
@@ -33,7 +33,7 @@ using ::testing::Optional;
 using ::testing::StartsWith;
 
 class InstallPathsTest : public ::testing::Test {
- protected:
+ public:
   InstallPathsTest() {
     std::string error;
     test_runfiles_.reset(Runfiles::Create(Testing::GetExePath().str(), &error));

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -37,7 +37,7 @@ using ::testing::Pair;
 namespace Yaml = ::Carbon::Testing::Yaml;
 
 class LexerTest : public ::testing::Test {
- protected:
+ public:
   Testing::CompileHelper compile_helper_;
 };
 

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -45,7 +45,7 @@ namespace {
 #include "toolchain/parse/node_kind.def"
 
 class TypedNodeTest : public ::testing::Test {
- protected:
+ public:
   using Peer = TypedNodesTestPeer;
 
   Testing::CompileHelper compile_helper_;


### PR DESCRIPTION
Pursuant to discussion regarding #4699, turn on `misc-non-private-member-variables-in-classes` using the `IgnoreClassesWithAllMemberVariablesBeingPublic` flag (the check treats structs as classes, so we need this for structs with all-public members). Updates the style guide notes to match, which should be pretty minor due to the scoping of test fixtures.

Also fixes some underscore uses in test files on the way. Basically this is keeping the style for [class data member naming](https://google.github.io/styleguide/cppguide.html#Variable_Names) even while making them public.