### PR TITLE
Fix default for Carbon Path

### DIFF
--- a/utils/vscode/package-lock.json
+++ b/utils/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carbon-vscode",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carbon-vscode",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
       },

--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-vscode",
   "displayName": "Carbon Language",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "carbon-lang",
   "description": "Carbon language support for Visual Studio Code.",
   "repository": {
@@ -42,7 +42,8 @@
       "properties": {
         "carbon.carbonPath": {
           "type": "string",
-          "description": "The path to the 'carbon' binary."
+          "description": "The path to the 'carbon' binary.",
+          "default": "./bazel-bin/toolchain/install/run_carbon"
         }
       }
     }


### PR DESCRIPTION
The extension.ts tries to provide a default, but it's not working the way I expect. So in addition, provide it in properties, which seems to work better.