### PR TITLE
Change Dump functions to static where appropriate.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -95,8 +95,6 @@ cc_library(
 cc_library(
     name = "dump",
     srcs = ["dump.cpp"],
-    # Contains Dump methods without a forward declaration.
-    copts = ["-Wno-missing-prototypes"],
     deps = [
         ":context",
         "//common:check",

--- a/toolchain/check/dump.cpp
+++ b/toolchain/check/dump.cpp
@@ -57,17 +57,17 @@ static auto DumpNoNewline(const Context& context, SemIR::LocId loc_id) -> void {
   }
 }
 
-LLVM_DUMP_METHOD auto Dump(const Context& context, Lex::TokenIndex token)
+LLVM_DUMP_METHOD static auto Dump(const Context& context, Lex::TokenIndex token)
     -> void {
   Parse::Dump(context.parse_tree(), token);
 }
 
-LLVM_DUMP_METHOD auto Dump(const Context& context, Parse::NodeId node_id)
+LLVM_DUMP_METHOD static auto Dump(const Context& context, Parse::NodeId node_id)
     -> void {
   Parse::Dump(context.parse_tree(), node_id);
 }
 
-LLVM_DUMP_METHOD auto Dump(const Context& context, SemIR::LocId loc_id)
+LLVM_DUMP_METHOD static auto Dump(const Context& context, SemIR::LocId loc_id)
     -> void {
   DumpNoNewline(context, loc_id);
   llvm::errs() << '\n';


### PR DESCRIPTION
Verified under LLDB these still appear callable; I'm expecting GDB to be the same. My concern about debugger calls to static functions was just wrong.