### PR TITLE
Fix CC1Main setting trigger undefined behavior

### DIFF
--- a/toolchain/driver/clang_runner.cpp
+++ b/toolchain/driver/clang_runner.cpp
@@ -146,13 +146,14 @@ auto ClangRunner::Run(llvm::ArrayRef<llvm::StringRef> args) -> bool {
   // Note the subprocessing will effectively call `clang -cc1`, which turns into
   // `carbon-busybox clang -cc1`, which results in an equivalent `clang_main`
   // call.
-  driver.CC1Main = [](llvm::SmallVectorImpl<const char*>& cc1_args) -> int {
+  auto cc1_main = [](llvm::SmallVectorImpl<const char*>& cc1_args) -> int {
     // cc1_args[0] will be the `clang_path` so we don't need the prepend arg.
     llvm::ToolContext tool_context = {
         .Path = cc1_args[0], .PrependArg = "clang", .NeedsPrependArg = false};
     return clang_main(cc1_args.size(), const_cast<char**>(cc1_args.data()),
                       tool_context);
   };
+  driver.CC1Main = cc1_main;
 
   std::unique_ptr<clang::driver::Compilation> compilation(
       driver.BuildCompilation(cstr_args));


### PR DESCRIPTION
This is caused by setting a temporary lambda to a `llvm::function_ref`.
The fix is to assign the lambda into a variable that outlives the `llvm::function_ref`.