### PR TITLE
Remove stale comment

### DIFF
--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -89,7 +89,6 @@ TEST(SemIRTest, YAML) {
       Pair("constant_values",
            Yaml::Mapping(AllOf(Each(Pair(inst_id, constant_id))))),
       Pair("symbolic_constants", Yaml::Mapping(SizeIs(0))),
-      // This production has only two instruction blocks.
       Pair("inst_blocks",
            Yaml::Mapping(ElementsAre(
                Pair("inst_block_empty", Yaml::Mapping(IsEmpty())),


### PR DESCRIPTION
Comment became out of date with #4698 . Seems better to delete instead of update this comment.
