### PR TITLE
Fix the forty_two.carbon example in getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ wget https://github.com/carbon-language/carbon-lang/releases/download/v${VERSION
 tar -xvf carbon_toolchain-${VERSION}.tar.gz
 
 # Create a simple Carbon source file:
-echo "fn Run() { Core.Print(42); }" > forty_two.carbon
+echo "import Core library \"io\"; fn Run() { Core.Print(42); }" > forty_two.carbon
 
 # Compile to an object file:
 ./carbon_toolchain-${VERSION}/bin/carbon compile \


### PR DESCRIPTION
The Core.Print function has moved into the "io" library, so it needs to be imported into scope.

Part of issue #4734
