### PR TITLE
Fix path to carbon binary in nightly builder

### DIFF
--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -88,11 +88,11 @@ jobs:
       - name: Extract the release version
         run: |
           # Make sure we can run the toolchain to get the version.
-          ./bazel-bin/toolchain/install/run_carbon version
+          ./bazel-bin/toolchain/carbon version
 
           # Now stash it in a variable and export it.
           VERSION=$( \
-            ./bazel-bin/toolchain/install/run_carbon version \
+            ./bazel-bin/toolchain/carbon version \
             | cut -d' ' -f5 | cut -d'+' -f1)
           echo "release_version=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
The path moved from ./bazel-bin/toolchain/install/run_carbon to ./bazel-bin/toolchain/carbon in 13502b7c8907b90bb045dc1512ca65.

Part of issue https://github.com/carbon-language/carbon-lang/issues/4734
