### PR TITLE
Update Read*To* to improve operation dependency graph.

### DIFF
--- a/common/hashing.h
+++ b/common/hashing.h
@@ -703,7 +703,7 @@ inline auto Hasher::Read1To3(const std::byte* data, ssize_t size) -> uint64_t {
   uint64_t byte0 = static_cast<uint8_t>(data[0]);
   uint64_t byte1 = static_cast<uint8_t>(data[size - 1]);
   uint64_t byte2 = static_cast<uint8_t>(data[size >> 1]);
-  return byte0 | (byte1 << 16) | (byte2 << 8);
+  return (byte0 << 8) | (byte1 << 16) | byte2;
 }
 
 inline auto Hasher::Read4To8(const std::byte* data, ssize_t size) -> uint64_t {
@@ -711,7 +711,7 @@ inline auto Hasher::Read4To8(const std::byte* data, ssize_t size) -> uint64_t {
   std::memcpy(&low, data, sizeof(low));
   uint32_t high;
   std::memcpy(&high, data + size - sizeof(high), sizeof(high));
-  return low | (static_cast<uint64_t>(high) << 32);
+  return (static_cast<uint64_t>(low) << 32) | high;
 }
 
 inline auto Hasher::Read8To16(const std::byte* data, ssize_t size)


### PR DESCRIPTION
Benchmarks for StringRef key seem slightly positive.

```
name                                                               old CYCLES/op        new CYCLES/op        delta
BM_MapContainsHit<Map<llvm::StringRef, int>>/1/256                   24.2 ± 0%            23.9 ± 0%  -1.14%        (p=0.000 n=54+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/2/256                   24.2 ± 0%            23.9 ± 0%  -1.15%        (p=0.000 n=53+54)
BM_MapContainsHit<Map<llvm::StringRef, int>>/3/256                   24.2 ± 0%            23.9 ± 0%  -1.15%        (p=0.000 n=53+54)
BM_MapContainsHit<Map<llvm::StringRef, int>>/4/256                   24.2 ± 0%            23.9 ± 0%  -1.14%        (p=0.000 n=56+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/8/256                   25.4 ± 3%            26.3 ± 4%  +3.61%        (p=0.000 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/16/256                  29.1 ± 2%            29.0 ± 2%  -0.28%        (p=0.030 n=56+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/32/256                  29.2 ± 2%            29.0 ± 1%  -0.59%        (p=0.000 n=57+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/64/256                  30.1 ± 2%            30.0 ± 2%  -0.43%        (p=0.045 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/256/256                 30.5 ± 1%            30.3 ± 1%  -0.56%        (p=0.000 n=56+56)
BM_MapContainsHit<Map<llvm::StringRef, int>>/256/64                  29.2 ± 1%            29.2 ± 2%    ~           (p=0.513 n=55+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/256/128                 29.6 ± 1%            29.5 ± 1%  -0.34%        (p=0.002 n=55+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/4096/256                32.0 ± 2%            31.9 ± 2%    ~           (p=0.082 n=55+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/4096/1024               37.8 ± 2%            37.8 ± 1%    ~           (p=0.751 n=57+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/4096/2048               45.3 ± 2%            45.5 ± 2%  +0.46%        (p=0.001 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/65536/256               34.3 ± 2%            34.2 ± 2%  -0.46%        (p=0.000 n=57+56)
BM_MapContainsHit<Map<llvm::StringRef, int>>/65536/16384             72.4 ± 3%            72.3 ± 2%    ~           (p=0.458 n=54+50)
BM_MapContainsHit<Map<llvm::StringRef, int>>/65536/32768             77.7 ± 3%            77.6 ± 3%    ~           (p=0.774 n=56+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/1048576/256             34.9 ± 1%            34.8 ± 2%    ~           (p=0.051 n=56+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/1048576/262144           115 ± 5%             115 ± 5%    ~           (p=0.660 n=57+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/1048576/524288           145 ± 4%             145 ± 5%    ~           (p=0.917 n=57+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/16777216/256            36.5 ± 2%            36.5 ± 2%    ~           (p=0.250 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/16777216/4194304         288 ± 3%             287 ± 4%    ~           (p=0.058 n=56+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/16777216/8388608         303 ± 2%             302 ± 3%  -0.47%        (p=0.044 n=53+54)
BM_MapContainsHit<Map<llvm::StringRef, int>>/56/256                  29.1 ± 3%            29.0 ± 3%    ~           (p=0.147 n=56+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/224/256                 30.7 ± 2%            30.6 ± 2%    ~           (p=0.140 n=56+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/3584/256                31.4 ± 1%            31.3 ± 1%  -0.42%        (p=0.003 n=53+54)
BM_MapContainsHit<Map<llvm::StringRef, int>>/3584/896                35.8 ± 2%            36.0 ± 2%  +0.58%        (p=0.000 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/3584/1792               43.5 ± 1%            43.6 ± 2%  +0.21%        (p=0.032 n=51+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/57344/256               34.3 ± 2%            34.1 ± 1%  -0.43%        (p=0.003 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/57344/14336             67.1 ± 2%            66.8 ± 2%    ~           (p=0.057 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/57344/28672             72.8 ± 3%            72.5 ± 3%  -0.45%        (p=0.032 n=57+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/917504/256              34.7 ± 2%            34.6 ± 2%    ~           (p=0.065 n=56+57)
BM_MapContainsHit<Map<llvm::StringRef, int>>/917504/229376            104 ± 4%             104 ± 5%    ~           (p=0.853 n=55+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/917504/458752            114 ± 6%             114 ± 5%    ~           (p=0.643 n=56+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/14680064/256            36.4 ± 2%            36.2 ± 2%  -0.58%        (p=0.001 n=56+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/14680064/3670016         271 ± 2%             271 ± 4%    ~           (p=0.632 n=55+55)
BM_MapContainsHit<Map<llvm::StringRef, int>>/14680064/7340032         285 ± 3%             285 ± 3%    ~           (p=0.658 n=57+55)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/1                      19.3 ± 1%            19.3 ± 2%    ~           (p=0.201 n=55+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/2                      19.4 ± 1%            19.3 ± 1%    ~           (p=0.191 n=56+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/3                      19.4 ± 1%            19.4 ± 2%    ~           (p=0.422 n=55+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/4                      19.4 ± 1%            19.4 ± 1%    ~           (p=0.179 n=56+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/8                      19.5 ± 2%            19.5 ± 1%    ~           (p=0.148 n=54+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/16                     19.7 ± 2%            19.6 ± 2%    ~           (p=0.204 n=54+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/32                     20.0 ± 3%            20.0 ± 3%    ~           (p=0.917 n=56+54)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/64                     19.8 ± 3%            19.8 ± 3%    ~           (p=0.245 n=57+54)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/256                    20.1 ± 3%            20.1 ± 3%    ~           (p=0.307 n=57+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/4096                   20.1 ± 3%            20.2 ± 2%    ~           (p=0.070 n=57+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/65536                  20.5 ± 3%            20.5 ± 3%    ~           (p=0.174 n=56+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/1048576                20.9 ± 2%            20.8 ± 3%    ~           (p=0.476 n=53+55)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/16777216               22.2 ± 4%            22.2 ± 3%    ~           (p=0.807 n=57+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/56                     24.9 ±28%            23.9 ±16%    ~           (p=0.058 n=57+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/224                    27.1 ±19%            26.6 ±19%    ~           (p=0.122 n=57+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/3584                   28.9 ±10%            28.7 ±10%    ~           (p=0.405 n=56+57)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/57344                  30.5 ± 7%            31.2 ± 7%  +2.32%        (p=0.000 n=57+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/917504                 31.8 ± 7%            31.7 ± 7%    ~           (p=0.713 n=57+56)
BM_MapContainsMiss<Map<llvm::StringRef, int>>/14680064               33.4 ± 9%            33.5 ± 7%    ~           (p=0.921 n=56+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/1/256                     49.3 ± 0%            48.2 ± 0%  -2.17%        (p=0.000 n=55+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/2/256                     49.3 ± 0%            48.2 ± 0%  -2.17%        (p=0.000 n=56+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/3/256                     49.3 ± 0%            48.2 ± 0%  -2.17%        (p=0.000 n=54+55)
BM_MapLookupHit<Map<llvm::StringRef, int>>/4/256                     49.3 ± 0%            48.2 ± 0%  -2.17%        (p=0.000 n=54+53)
BM_MapLookupHit<Map<llvm::StringRef, int>>/8/256                     49.0 ± 0%            48.0 ± 0%  -2.02%        (p=0.000 n=51+51)
BM_MapLookupHit<Map<llvm::StringRef, int>>/16/256                    51.8 ± 1%            51.3 ± 1%  -0.89%        (p=0.000 n=50+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/32/256                    51.8 ± 1%            51.3 ± 1%  -1.07%        (p=0.000 n=56+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/64/256                    52.4 ± 1%            51.8 ± 1%  -1.12%        (p=0.000 n=57+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/256/256                   54.6 ± 1%            54.1 ± 1%  -0.94%        (p=0.000 n=53+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/256/64                    51.9 ± 1%            51.4 ± 1%  -0.95%        (p=0.000 n=55+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/256/128                   52.5 ± 1%            52.0 ± 1%  -1.07%        (p=0.000 n=57+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/4096/256                  62.0 ± 3%            61.6 ± 3%  -0.62%        (p=0.002 n=55+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/4096/1024                 74.6 ± 1%            73.5 ± 1%  -1.38%        (p=0.000 n=56+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/4096/2048                 80.9 ± 1%            79.8 ± 1%  -1.34%        (p=0.000 n=57+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/65536/256                 72.0 ± 2%            71.4 ± 2%  -0.77%        (p=0.000 n=56+55)
BM_MapLookupHit<Map<llvm::StringRef, int>>/65536/16384                145 ± 4%             145 ± 3%    ~           (p=0.662 n=57+55)
BM_MapLookupHit<Map<llvm::StringRef, int>>/65536/32768                155 ± 4%             156 ± 4%    ~           (p=0.541 n=57+54)
BM_MapLookupHit<Map<llvm::StringRef, int>>/1048576/256               73.1 ± 2%            72.5 ± 2%  -0.73%        (p=0.000 n=56+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/1048576/262144             281 ± 7%             283 ± 5%    ~           (p=0.284 n=57+49)
BM_MapLookupHit<Map<llvm::StringRef, int>>/1048576/524288             342 ± 5%             342 ± 5%    ~           (p=0.684 n=57+53)
BM_MapLookupHit<Map<llvm::StringRef, int>>/16777216/256              77.5 ± 2%            76.9 ± 2%  -0.74%        (p=0.000 n=55+54)
BM_MapLookupHit<Map<llvm::StringRef, int>>/16777216/4194304           750 ± 3%             749 ± 3%    ~           (p=0.458 n=57+53)
BM_MapLookupHit<Map<llvm::StringRef, int>>/16777216/8388608           802 ± 2%             801 ± 3%    ~           (p=0.518 n=57+55)
BM_MapLookupHit<Map<llvm::StringRef, int>>/56/256                    51.9 ± 1%            51.3 ± 1%  -1.10%        (p=0.000 n=57+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/224/256                   54.0 ± 1%            53.5 ± 1%  -1.01%        (p=0.000 n=56+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/3584/256                  58.8 ± 2%            58.1 ± 2%  -1.28%        (p=0.000 n=56+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/3584/896                  69.7 ± 2%            68.7 ± 1%  -1.35%        (p=0.000 n=57+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/3584/1792                 77.1 ± 1%            76.0 ± 1%  -1.45%        (p=0.000 n=55+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/57344/256                 71.3 ± 2%            70.7 ± 3%  -0.85%        (p=0.000 n=55+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/57344/14336                128 ± 3%             128 ± 3%    ~           (p=0.556 n=57+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/57344/28672                140 ± 4%             140 ± 3%    ~           (p=0.735 n=57+51)
BM_MapLookupHit<Map<llvm::StringRef, int>>/917504/256                72.8 ± 2%            72.3 ± 2%  -0.76%        (p=0.000 n=57+57)
BM_MapLookupHit<Map<llvm::StringRef, int>>/917504/229376              242 ± 7%             243 ± 6%    ~           (p=0.303 n=57+55)
BM_MapLookupHit<Map<llvm::StringRef, int>>/917504/458752              264 ± 7%             264 ± 6%    ~           (p=0.823 n=57+55)
BM_MapLookupHit<Map<llvm::StringRef, int>>/14680064/256              76.4 ± 2%            75.8 ± 3%  -0.78%        (p=0.000 n=57+56)
BM_MapLookupHit<Map<llvm::StringRef, int>>/14680064/3670016           696 ± 3%             698 ± 3%    ~           (p=0.189 n=56+53)
BM_MapLookupHit<Map<llvm::StringRef, int>>/14680064/7340032           749 ± 3%             750 ± 3%    ~           (p=0.266 n=55+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/1/256                     34.9 ± 0%            35.0 ± 0%  +0.36%        (p=0.000 n=56+50)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/2/256                     34.9 ± 0%            35.0 ± 0%  +0.35%        (p=0.000 n=55+53)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/3/256                     34.9 ± 0%            35.0 ± 0%  +0.35%        (p=0.000 n=55+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/4/256                     34.9 ± 0%            35.0 ± 0%  +0.36%        (p=0.000 n=56+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/8/256                     37.5 ± 3%            37.6 ± 2%    ~           (p=0.081 n=57+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/16/256                    39.4 ± 1%            39.5 ± 2%    ~           (p=0.054 n=55+57)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/32/256                    40.0 ± 3%            39.9 ± 4%    ~           (p=0.449 n=56+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/64/256                    40.0 ± 1%            40.1 ± 2%    ~           (p=0.796 n=54+54)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/256/256                   41.1 ± 2%            41.2 ± 2%    ~           (p=0.061 n=53+50)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/256/64                    39.6 ± 2%            39.6 ± 2%    ~           (p=0.695 n=55+52)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/256/128                   40.2 ± 2%            40.1 ± 2%    ~           (p=0.507 n=53+49)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/4096/256                  43.4 ± 2%            43.5 ± 2%    ~           (p=0.300 n=53+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/4096/1024                 50.9 ± 2%            51.8 ± 2%  +1.79%        (p=0.000 n=56+57)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/4096/2048                 58.2 ± 1%            58.3 ± 1%    ~           (p=0.072 n=57+57)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/65536/256                 46.1 ± 1%            46.1 ± 2%    ~           (p=0.197 n=54+53)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/65536/16384               88.1 ± 5%            88.9 ± 4%  +0.90%        (p=0.011 n=57+57)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/65536/32768               92.4 ± 3%            93.6 ± 3%  +1.35%        (p=0.000 n=57+57)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/1048576/256               46.6 ± 2%            46.7 ± 2%    ~           (p=0.687 n=51+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/1048576/262144             144 ± 7%             145 ± 6%    ~           (p=0.130 n=57+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/1048576/524288             181 ± 4%             182 ± 4%    ~           (p=0.057 n=56+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/16777216/256              48.9 ± 2%            48.7 ± 2%  -0.30%        (p=0.042 n=56+53)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/16777216/4194304           351 ± 2%             350 ± 3%    ~           (p=0.287 n=57+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/16777216/8388608           368 ± 3%             367 ± 3%    ~           (p=0.710 n=57+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/56/256                    39.7 ± 3%            39.6 ± 3%    ~           (p=0.572 n=57+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/224/256                   41.7 ± 2%            41.6 ± 3%    ~           (p=0.233 n=55+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/3584/256                  42.6 ± 2%            42.5 ± 2%    ~           (p=0.309 n=54+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/3584/896                  49.1 ± 1%            49.8 ± 1%  +1.51%        (p=0.000 n=57+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/3584/1792                 57.0 ± 1%            57.1 ± 2%  +0.30%        (p=0.022 n=56+57)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/57344/256                 46.1 ± 2%            46.0 ± 1%  -0.28%        (p=0.013 n=55+53)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/57344/14336               82.0 ± 2%            82.6 ± 2%  +0.71%        (p=0.000 n=57+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/57344/28672               88.7 ± 2%            89.8 ± 2%  +1.22%        (p=0.000 n=57+53)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/917504/256                46.5 ± 1%            46.5 ± 2%    ~           (p=0.961 n=53+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/917504/229376              126 ± 5%             128 ± 5%  +1.64%        (p=0.000 n=57+54)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/917504/458752              140 ± 5%             141 ± 6%    ~           (p=0.162 n=57+55)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/14680064/256              48.5 ± 2%            48.3 ± 2%    ~           (p=0.094 n=55+54)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/14680064/3670016           328 ± 4%             328 ± 3%    ~           (p=0.925 n=57+56)
BM_MapUpdateHit<Map<llvm::StringRef, int>>/14680064/7340032           345 ± 3%             345 ± 3%    ~           (p=0.489 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/1/256                76.0 ± 0%            75.9 ± 0%  -0.03%        (p=0.006 n=54+47)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/2/256                71.3 ± 1%            72.1 ± 5%    ~           (p=0.750 n=52+54)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/3/256                70.9 ± 2%            70.7 ± 2%    ~           (p=0.095 n=54+52)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/4/256                70.4 ± 2%            70.6 ± 3%    ~           (p=0.458 n=47+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/8/256                75.0 ± 1%            74.2 ± 1%  -1.16%        (p=0.000 n=52+54)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/16/256               80.5 ± 3%            79.0 ± 3%  -1.88%        (p=0.000 n=51+53)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/32/256               83.2 ± 4%            82.3 ± 5%  -1.01%        (p=0.009 n=56+57)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/64/256               80.6 ± 3%            79.4 ± 4%  -1.48%        (p=0.000 n=52+54)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/256/256              83.6 ± 3%            82.6 ± 5%  -1.23%        (p=0.000 n=54+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/256/64               79.1 ± 6%            78.8 ± 8%    ~           (p=0.359 n=55+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/256/128              81.1 ± 6%            80.3 ± 9%  -1.04%        (p=0.010 n=55+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/4096/256             85.5 ± 5%            84.1 ± 4%  -1.61%        (p=0.000 n=54+57)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/4096/1024            95.7 ± 3%            95.2 ± 2%  -0.47%        (p=0.033 n=56+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/4096/2048             101 ± 2%             101 ± 1%  -0.68%        (p=0.000 n=56+54)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/65536/256            90.5 ± 4%            88.1 ± 4%  -2.57%        (p=0.000 n=56+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/65536/16384           134 ± 3%             133 ± 2%  -0.71%        (p=0.002 n=57+57)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/65536/32768           142 ± 3%             141 ± 2%  -0.90%        (p=0.000 n=57+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/1048576/256          91.2 ± 3%            89.3 ± 4%  -2.08%        (p=0.000 n=56+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/1048576/262144        209 ± 5%             208 ± 5%    ~           (p=0.170 n=57+54)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/1048576/524288        243 ± 5%             240 ± 5%  -1.05%        (p=0.020 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/16777216/256         94.3 ± 3%            92.5 ± 5%  -1.91%        (p=0.000 n=55+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/16777216/4194304      542 ± 3%             537 ± 4%  -1.02%        (p=0.000 n=57+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/16777216/8388608      566 ± 3%             561 ± 4%  -1.01%        (p=0.000 n=57+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/56/256               83.7 ±10%            81.3 ± 8%  -2.84%        (p=0.000 n=55+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/224/256              88.7 ± 8%            86.6 ± 9%  -2.40%        (p=0.001 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/3584/256             94.0 ± 5%            91.3 ± 4%  -2.83%        (p=0.000 n=56+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/3584/896              118 ± 4%             118 ± 5%    ~           (p=0.930 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/3584/1792             143 ± 4%             141 ± 4%  -1.10%        (p=0.002 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/57344/256             102 ± 4%             100 ± 4%  -2.31%        (p=0.000 n=56+57)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/57344/14336           191 ± 2%             190 ± 1%  -0.32%        (p=0.024 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/57344/28672           197 ± 2%             197 ± 1%    ~           (p=0.059 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/917504/256            103 ± 4%             101 ± 4%  -1.99%        (p=0.000 n=57+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/917504/229376         280 ± 3%             279 ± 3%    ~           (p=0.145 n=57+52)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/917504/458752         298 ± 4%             296 ± 3%    ~           (p=0.116 n=57+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/14680064/256          107 ± 4%             104 ± 4%  -2.11%        (p=0.000 n=55+56)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/14680064/3670016      613 ± 3%             612 ± 2%    ~           (p=0.224 n=57+55)
BM_MapEraseUpdateHit<Map<llvm::StringRef, int>>/14680064/7340032      637 ± 2%             635 ± 1%    ~           (p=0.075 n=56+55)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/1                          132 ± 0%             132 ± 0%  -0.26%        (p=0.000 n=47+41)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/2                          160 ± 0%             161 ± 4%  +0.57%        (p=0.001 n=45+57)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/3                          188 ± 2%             189 ± 3%    ~           (p=0.327 n=54+54)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/4                          217 ± 3%             218 ± 5%    ~           (p=0.240 n=54+56)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/8                          342 ± 5%             341 ± 4%    ~           (p=0.282 n=53+54)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/16                         640 ± 3%             648 ± 8%  +1.26%        (p=0.023 n=49+54)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/32                       1.20k ± 8%           1.20k ± 8%    ~           (p=0.423 n=53+54)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/64                       3.57k ± 8%           3.55k ± 6%    ~           (p=0.557 n=57+54)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/256                      18.6k ± 5%           18.6k ± 6%    ~           (p=0.799 n=57+57)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/4096                      492k ± 4%            491k ± 3%    ~           (p=0.378 n=56+57)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/65536                    10.5M ± 2%           10.4M ± 1%    ~           (p=0.143 n=57+48)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/1048576                   323M ± 2%            322M ± 3%    ~           (p=0.098 n=56+56)
BM_MapInsertSeq<Map<ll::StringRef, int>>/16777216                 7.07G ± 3%           7.05G ± 4%    ~           (p=0.195 n=56+57)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/56                       2.04k ± 8%           2.03k ± 7%    ~           (p=0.124 n=52+55)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/224                      12.0k ± 5%           12.0k ± 4%    ~           (p=0.467 n=57+55)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/3584                      294k ± 5%            292k ± 4%    ~           (p=0.188 n=56+57)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/57344                    6.40M ± 2%           6.39M ± 1%    ~           (p=0.381 n=57+56)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/917504                    199M ± 3%            199M ± 3%    ~           (p=0.977 n=57+57)
BM_MapInsertSeq<Map<llvm::StringRef, int>>/14680064                 4.56G ± 3%           4.55G ± 3%    ~           (p=0.129 n=55+56)
```
