### PR TITLE
Fix job name for clang tidy

### DIFF
--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  clang-tidy:
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
I think this will affect the name GH shows in some action UIs; this will more clearly disambiguate from tests.yaml actions.