### PR TITLE
Fix clang-tidy to run on the merge queue

### DIFF
--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [trunk, action-test]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read # For actions/checkout.


### PR DESCRIPTION
Without this, the merge queue blocks on results but they never get triggered and show up. This will need to merge before we re-enable `clang-tidy` enforcement on the trunk branch.