### PR TITLE
Rename BoundMethod::function_id to function_decl_id

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1568,9 +1568,10 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
           eval_context, inst, &SemIR::AssociatedEntityType::interface_type_id,
           &SemIR::AssociatedEntityType::entity_type_id);
     case SemIR::BoundMethod::Kind:
-      return RebuildIfFieldsAreConstant(
-          eval_context, inst, &SemIR::BoundMethod::type_id,
-          &SemIR::BoundMethod::object_id, &SemIR::BoundMethod::function_id);
+      return RebuildIfFieldsAreConstant(eval_context, inst,
+                                        &SemIR::BoundMethod::type_id,
+                                        &SemIR::BoundMethod::object_id,
+                                        &SemIR::BoundMethod::function_decl_id);
     case SemIR::ClassType::Kind:
       return RebuildIfFieldsAreConstant(eval_context, inst,
                                         &SemIR::ClassType::specific_id);

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1452,7 +1452,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   CARBON_CHECK(resolver.import_types().GetInstId(inst.type_id) ==
                SemIR::BoundMethodType::SingletonInstId);
   auto object_id = GetLocalConstantInstId(resolver, inst.object_id);
-  auto function_id = GetLocalConstantInstId(resolver, inst.function_id);
+  auto function_decl_id =
+      GetLocalConstantInstId(resolver, inst.function_decl_id);
 
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
@@ -1462,7 +1463,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver, {.type_id = resolver.local_context().GetSingletonType(
                      SemIR::BoundMethodType::SingletonInstId),
                  .object_id = object_id,
-                 .function_id = function_id});
+                 .function_decl_id = function_decl_id});
 }
 
 static auto TryResolveTypedInst(ImportRefResolver& resolver, SemIR::Call inst)

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -380,7 +380,7 @@ static auto PerformInstanceBinding(Context& context, SemIR::LocId loc_id,
             loc_id, {.type_id = context.GetSingletonType(
                          SemIR::BoundMethodType::SingletonInstId),
                      .object_id = base_id,
-                     .function_id = member_id});
+                     .function_decl_id = member_id});
       }
       [[fallthrough]];
     }

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -167,7 +167,7 @@ static auto EmitAsConstant(ConstantContext& context, SemIR::BoundMethod inst)
     -> llvm::Constant* {
   // Propagate just the function; the object is separately provided to the
   // enclosing call as an implicit argument.
-  return context.GetConstant(inst.function_id);
+  return context.GetConstant(inst.function_decl_id);
 }
 
 static auto EmitAsConstant(ConstantContext& context,

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -109,7 +109,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::BoundMethod inst) -> void {
   // Propagate just the function; the object is separately provided to the
   // enclosing call as an implicit argument.
-  context.SetLocal(inst_id, context.GetValue(inst.function_id));
+  context.SetLocal(inst_id, context.GetValue(inst.function_decl_id));
 }
 
 auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -25,7 +25,7 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id) -> CalleeFunction {
 
   if (auto bound_method = sem_ir.insts().TryGetAs<BoundMethod>(callee_id)) {
     result.self_id = bound_method->object_id;
-    callee_id = bound_method->function_id;
+    callee_id = bound_method->function_decl_id;
   }
 
   // Identify the function we're calling.

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -523,7 +523,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
         continue;
       }
       case CARBON_KIND(BoundMethod inst): {
-        auto type_id = sem_ir_->insts().Get(inst.function_id).type_id();
+        auto type_id = sem_ir_->insts().Get(inst.function_decl_id).type_id();
         if (auto fn_ty = sem_ir_->types().TryGetAs<FunctionType>(type_id)) {
           add_inst_name_id(sem_ir_->functions().Get(fn_ty->function_id).name_id,
                            ".bound");
@@ -763,7 +763,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
       case CARBON_KIND(SpecificFunction inst): {
         InstId callee_id = inst.callee_id;
         if (auto method = sem_ir_->insts().TryGetAs<BoundMethod>(callee_id)) {
-          callee_id = method->function_id;
+          callee_id = method->function_decl_id;
         }
         auto type_id = sem_ir_->insts().Get(callee_id).type_id();
         if (auto fn_ty = sem_ir_->types().TryGetAs<FunctionType>(type_id)) {

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -398,7 +398,7 @@ struct BoundMethod {
   // self` parameter.
   InstId object_id;
   // The function being bound, whose type_id is always a `FunctionType`.
-  InstId function_id;
+  InstId function_decl_id;
 };
 
 // The type of bound method values.


### PR DESCRIPTION
The InstId in this field is to an instruction that declares the
function, rather than the function itself, so that diagnostics can print
where the function is coming from. The type of the function (the
FunctionType instruction) is the type (the type_id) of the
function_decl_id. So we rename the field to help make this distinction
more clear.

Followup to #4739
