### PR TITLE
Fix clang-tidy issues

### DIFF
--- a/common/raw_hashtable.h
+++ b/common/raw_hashtable.h
@@ -530,7 +530,7 @@ class BaseImpl {
   friend class TableImpl;
 
   static constexpr ssize_t Alignment = std::max<ssize_t>(
-      {alignof(MetadataGroup), alignof(StorageEntry<KeyT, ValueT>)});
+      alignof(MetadataGroup), alignof(StorageEntry<KeyT, ValueT>));
 
   // Implementation of inline small storage for the provided key type, value
   // type, and small size. Specialized for a zero small size to be an empty

--- a/toolchain/install/busybox_info_test.cpp
+++ b/toolchain/install/busybox_info_test.cpp
@@ -256,8 +256,8 @@ TEST_F(BusyboxInfoTest, StopSearchAtFirstSymlinkWithRelativeBusybox) {
 TEST_F(BusyboxInfoTest, RejectSymlinkInUnrelatedInstall) {
   // Add two installs of Carbon nested inside each other in a realistic
   // scenario: `/usr` and `/usr/local`.
-  auto usr_prefix = MakeInstallTree(dir_ / "usr");
-  auto usr_local_prefix = MakeInstallTree(dir_ / "usr/local");
+  MakeInstallTree(dir_ / "usr");
+  MakeInstallTree(dir_ / "usr/local");
 
   // Now add a stray symlink directly in `.../usr/local` to the local install.
   //


### PR DESCRIPTION
Both of these I noticed from testing #4785, but they occur at head.

```
(elided)/execroot/_main/common/raw_hashtable.h:532:40: error: do not use nested 'std::max' calls, use an initializer list instead [modernize-min-max-use-initializer-list,-warnings-as-errors]
  532 |   static constexpr ssize_t Alignment = std::max<ssize_t>(
      |                                        ^
  533 |       {alignof(MetadataGroup), alignof(StorageEntry<KeyT, ValueT>)});
      |        ~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |        static_cast<long>(alignof(MetadataGroup)) static_cast<long>(alignof(StorageEntry<KeyT, ValueT>))

(elided)/execroot/_main/toolchain/install/busybox_info_test.cpp:259:8: error: unused local variable 'usr_prefix' of type 'std::filesystem::path' [bugprone-unused-local-non-trivial-variable,-warnings-as-errors]
  259 |   auto usr_prefix = MakeInstallTree(dir_ / "usr");
      |        ^
(elided)/execroot/_main/toolchain/install/busybox_info_test.cpp:260:8: error: unused local variable 'usr_local_prefix' of type 'std::filesystem::path' [bugprone-unused-local-non-trivial-variable,-warnings-as-errors]
  260 |   auto usr_local_prefix = MakeInstallTree(dir_ / "usr/local");
      |        ^
```

The std::max diagnostic seems a little confused, but the initializer list seems like it can be dropped without any loss. The unused locals diagnostic is correct.

Neither of these seem like they should be newer than my last clang-tidy pass, maybe I just missed them in other sweeps.