### PR TITLE
Remove clangd Function.h include, fix Protocol.h location

### DIFF
--- a/toolchain/language_server/BUILD
+++ b/toolchain/language_server/BUILD
@@ -25,7 +25,6 @@ cc_library(
     hdrs = ["context.h"],
     deps = [
         "//common:map",
-        "@llvm-project//clang-tools-extra/clangd:ClangDaemon",
     ],
 )
 
@@ -42,6 +41,7 @@ cc_library(
         "//toolchain/parse:node_kind",
         "//toolchain/parse:tree",
         "//toolchain/source:source_buffer",
+        "@llvm-project//clang-tools-extra/clangd:ClangDaemon",
     ],
 )
 

--- a/toolchain/language_server/context.h
+++ b/toolchain/language_server/context.h
@@ -5,8 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_LANGUAGE_SERVER_CONTEXT_H_
 #define CARBON_TOOLCHAIN_LANGUAGE_SERVER_CONTEXT_H_
 
-#include "clang-tools-extra/clangd/Protocol.h"
-#include "clang-tools-extra/clangd/support/Function.h"
+#include <string>
+
 #include "common/map.h"
 
 namespace Carbon::LanguageServer {

--- a/toolchain/language_server/handle.h
+++ b/toolchain/language_server/handle.h
@@ -5,6 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_LANGUAGE_SERVER_HANDLE_H_
 #define CARBON_TOOLCHAIN_LANGUAGE_SERVER_HANDLE_H_
 
+#include "clang-tools-extra/clangd/Protocol.h"
 #include "toolchain/language_server/context.h"
 
 namespace Carbon::LanguageServer {


### PR DESCRIPTION
The Function.h include was simply unused, I was partly dropping the bits that would've depended on it. Protocol.h is used, but it should really be included from handle.h.