### PR TITLE
Fix short option error

### DIFF
--- a/common/command_line.cpp
+++ b/common/command_line.cpp
@@ -1035,12 +1035,12 @@ auto Parser::ParseShortOptionSeq(llvm::StringRef unparsed_arg)
         unparsed_arg));
   }
 
-  for (char c : unparsed_arg) {
-    auto* arg_entry = (c < static_cast<ssize_t>(short_option_table_.size()))
-                          ? short_option_table_[c]
-                          : nullptr;
+  for (unsigned char c : unparsed_arg) {
+    auto* arg_entry =
+        (c < short_option_table_.size()) ? short_option_table_[c] : nullptr;
     if (!arg_entry) {
-      return Error(llvm::formatv("unknown short option `-{0}`", c));
+      return Error(
+          llvm::formatv("unknown short option `-{0}`", static_cast<char>(c)));
     }
     // Mark this argument as parsed.
     arg_entry->setInt(true);

--- a/common/command_line.cpp
+++ b/common/command_line.cpp
@@ -1035,11 +1035,12 @@ auto Parser::ParseShortOptionSeq(llvm::StringRef unparsed_arg)
         unparsed_arg));
   }
 
-  for (unsigned char c : unparsed_arg) {
-    auto* arg_entry =
-        (c < short_option_table_.size()) ? short_option_table_[c] : nullptr;
+  for (char c : unparsed_arg) {
+    auto* arg_entry = (c < static_cast<ssize_t>(short_option_table_.size()))
+                          ? short_option_table_[c]
+                          : nullptr;
     if (!arg_entry) {
-      return Error(llvm::formatv("unknown short option `{0}`", c));
+      return Error(llvm::formatv("unknown short option `-{0}`", c));
     }
     // Mark this argument as parsed.
     arg_entry->setInt(true);

--- a/common/command_line_test.cpp
+++ b/common/command_line_test.cpp
@@ -190,6 +190,7 @@ TEST(ArgParserTest, ShortArgs) {
   TestRawOstream os;
 
   EXPECT_THAT(parse({"-v"}, os), IsError(StrEq("unknown short option `-v`")));
+  EXPECT_THAT(parse({"-xvx"}, os), IsError(StrEq("unknown short option `-v`")));
 
   EXPECT_THAT(
       parse({"-xzf"}, os),

--- a/common/command_line_test.cpp
+++ b/common/command_line_test.cpp
@@ -188,6 +188,9 @@ TEST(ArgParserTest, ShortArgs) {
   EXPECT_THAT(integer_option, Eq(123));
 
   TestRawOstream os;
+
+  EXPECT_THAT(parse({"-v"}, os), IsError(StrEq("unknown short option `-v`")));
+
   EXPECT_THAT(
       parse({"-xzf"}, os),
       IsError(StrEq("option `-z` (short for `--option2`) requires a value to "


### PR DESCRIPTION
"unsigned char" prints as an integer, not a char