### PR TITLE
Stop merging invalid impl redefinitions

### DIFF
--- a/toolchain/check/testdata/impl/fail_redefinition.carbon
+++ b/toolchain/check/testdata/impl/fail_redefinition.carbon
@@ -45,17 +45,18 @@ impl i32 as I {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [template] {} {
-// CHECK:STDOUT:     %int_32.loc13: Core.IntLiteral = int_value 32 [template = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc13: type = name_ref I, file.%I.decl [template = constants.%I.type]
+// CHECK:STDOUT:   impl_decl @impl.1 [template] {} {
+// CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
+// CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [template = constants.%impl_witness]
-// CHECK:STDOUT:   impl_decl @impl [template] {} {
-// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [template = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc21: type = name_ref I, file.%I.decl [template = constants.%I.type]
+// CHECK:STDOUT:   %impl_witness.loc13: <witness> = impl_witness () [template = constants.%impl_witness]
+// CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
+// CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
+// CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc21: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
@@ -66,8 +67,13 @@ impl i32 as I {}
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %i32.loc13 as %I.ref.loc13 {
+// CHECK:STDOUT: impl @impl.1: %i32 as %I.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness
+// CHECK:STDOUT:   witness = file.%impl_witness.loc13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.2: %i32 as %I.ref {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = file.%impl_witness.loc21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/fail_alias.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_alias.carbon
@@ -48,15 +48,16 @@ impl AC as AI {}
 // CHECK:STDOUT:   %AI: type = bind_alias AI, %I.decl [template = constants.%I.type]
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %AC: type = bind_alias AC, %C.decl [template = constants.%C]
-// CHECK:STDOUT:   impl_decl @impl [template] {} {
-// CHECK:STDOUT:     %AC.ref.loc17: type = name_ref AC, file.%AC [template = constants.%C]
-// CHECK:STDOUT:     %AI.ref.loc17: type = name_ref AI, file.%AI [template = constants.%I.type]
+// CHECK:STDOUT:   impl_decl @impl.1 [template] {} {
+// CHECK:STDOUT:     %AC.ref: type = name_ref AC, file.%AC [template = constants.%C]
+// CHECK:STDOUT:     %AI.ref: type = name_ref AI, file.%AI [template = constants.%I.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [template = constants.%impl_witness]
-// CHECK:STDOUT:   impl_decl @impl [template] {} {
-// CHECK:STDOUT:     %AC.ref.loc25: type = name_ref AC, file.%AC [template = constants.%C]
-// CHECK:STDOUT:     %AI.ref.loc25: type = name_ref AI, file.%AI [template = constants.%I.type]
+// CHECK:STDOUT:   %impl_witness.loc17: <witness> = impl_witness () [template = constants.%impl_witness]
+// CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
+// CHECK:STDOUT:     %AC.ref: type = name_ref AC, file.%AC [template = constants.%C]
+// CHECK:STDOUT:     %AI.ref: type = name_ref AI, file.%AI [template = constants.%I.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc25: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
@@ -67,9 +68,14 @@ impl AC as AI {}
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %AC.ref.loc17 as %AI.ref.loc17 {
+// CHECK:STDOUT: impl @impl.1: %AC.ref as %AI.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness
+// CHECK:STDOUT:   witness = file.%impl_witness.loc17
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.2: %AC.ref as %AI.ref {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = file.%impl_witness.loc25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {

--- a/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
@@ -72,10 +72,10 @@ impl forall [T:! type] T as I {
   fn A() {}
 }
 
-// CHECK:STDERR: regression_for_redefinition_regions.carbon:[[@LINE+6]]:1: error: redefinition of `impl T as I` [ImplRedefinition]
+// CHECK:STDERR: fail_redefinition_generic_regions.carbon:[[@LINE+6]]:1: error: redefinition of `impl T as I` [ImplRedefinition]
 // CHECK:STDERR: impl forall [T:! type] T as I {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: regression_for_redefinition_regions.carbon:[[@LINE-7]]:1: note: previous definition was here [ImplPreviousDefinition]
+// CHECK:STDERR: fail_redefinition_generic_regions.carbon:[[@LINE-7]]:1: note: previous definition was here [ImplPreviousDefinition]
 // CHECK:STDERR: impl forall [T:! type] T as I {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 impl forall [T:! type] T as I {
@@ -534,7 +534,7 @@ impl forall [T:! type] T as I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C;
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- regression_for_redefinition_regions.carbon
+// CHECK:STDOUT: --- fail_redefinition_generic_regions.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [template]

--- a/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
@@ -64,7 +64,7 @@ interface I {}
 impl C as I {}
 impl (C, C).0 as I {}
 
-// --- regression_for_redefinition_regions.carbon
+// --- fail_redefinition_generic_regions.carbon
 
 interface I {}
 

--- a/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
@@ -39,12 +39,13 @@ interface I {}
 interface J {}
 
 impl forall [T:! I] T as J {}
-// CHECK:STDERR: fail_same_self_and_interface_redefined.carbon:[[@LINE+6]]:1: error: redefinition of `impl T as J` [ImplRedefinition]
+// CHECK:STDERR: fail_same_self_and_interface_redefined.carbon:[[@LINE+7]]:1: error: redefinition of `impl T as J` [ImplRedefinition]
 // CHECK:STDERR: impl forall [T:! I] T as J {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_same_self_and_interface_redefined.carbon:[[@LINE-4]]:1: note: previous definition was here [ImplPreviousDefinition]
 // CHECK:STDERR: impl forall [T:! I] T as J {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 impl forall [T:! I] T as J {}
 
 // --- same_type_different_spelling.carbon
@@ -62,6 +63,30 @@ interface I {}
 // impl.
 impl C as I {}
 impl (C, C).0 as I {}
+
+// --- regression_for_redefinition_regions.carbon
+
+interface I {}
+
+impl forall [T:! type] T as I {
+  fn A() {}
+}
+
+// CHECK:STDERR: regression_for_redefinition_regions.carbon:[[@LINE+6]]:1: error: redefinition of `impl T as I` [ImplRedefinition]
+// CHECK:STDERR: impl forall [T:! type] T as I {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: regression_for_redefinition_regions.carbon:[[@LINE-7]]:1: note: previous definition was here [ImplPreviousDefinition]
+// CHECK:STDERR: impl forall [T:! type] T as I {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+impl forall [T:! type] T as I {
+  // Although not referenced, B has the same generic region index of A, and
+  // makes C a different index. We used to merge, and this was a crash.
+  fn B() {}
+  fn C() -> () { return (); }
+  fn D() -> () {
+    return C();
+  }
+}
 
 // CHECK:STDOUT: --- same_self_and_interface.carbon
 // CHECK:STDOUT:
@@ -351,7 +376,8 @@ impl (C, C).0 as I {}
 // CHECK:STDOUT:   %T: %I.type = bind_symbolic_name T, 0 [symbolic]
 // CHECK:STDOUT:   %T.patt: %I.type = symbolic_binding_pattern T, 0 [symbolic]
 // CHECK:STDOUT:   %T.as_type: type = facet_access_type %T [symbolic]
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl(%T) [symbolic]
+// CHECK:STDOUT:   %impl_witness.1896b7.1: <witness> = impl_witness (), @impl.1(%T) [symbolic]
+// CHECK:STDOUT:   %impl_witness.1896b7.2: <witness> = impl_witness (), @impl.2(%T) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -361,31 +387,32 @@ impl (C, C).0 as I {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
 // CHECK:STDOUT:   %J.decl: type = interface_decl @J [template = constants.%J.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [template] {
+// CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc7_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc7_14.1, runtime_param<invalid> [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref.loc7: %I.type = name_ref T, %T.loc7_14.1 [symbolic = %T.loc7_14.2 (constants.%T)]
-// CHECK:STDOUT:     %T.as_type.loc7_21.1: type = facet_access_type %T.ref.loc7 [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc7: type = converted %T.ref.loc7, %T.as_type.loc7_21.1 [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %J.ref.loc7: type = name_ref J, file.%J.decl [template = constants.%J.type]
-// CHECK:STDOUT:     %T.param.loc7: %I.type = value_param runtime_param<invalid>
-// CHECK:STDOUT:     %I.ref.loc7: type = name_ref I, file.%I.decl [template = constants.%I.type]
-// CHECK:STDOUT:     %T.loc7_14.1: %I.type = bind_symbolic_name T, 0, %T.param.loc7 [symbolic = %T.loc7_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.ref: %I.type = name_ref T, %T.loc7_14.1 [symbolic = %T.loc7_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.as_type.loc7_21.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc7: type = converted %T.ref, %T.as_type.loc7_21.1 [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
+// CHECK:STDOUT:     %T.param: %I.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
+// CHECK:STDOUT:     %T.loc7_14.1: %I.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]
-// CHECK:STDOUT:   impl_decl @impl [template] {
-// CHECK:STDOUT:     %T.patt.loc7_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc7_14.1, runtime_param<invalid> [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %impl_witness.loc7: <witness> = impl_witness (), @impl.1(constants.%T) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.1896b7.1)]
+// CHECK:STDOUT:   impl_decl @impl.2 [template] {
+// CHECK:STDOUT:     %T.patt.loc15_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc15_14.1, runtime_param<invalid> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref.loc14: %I.type = name_ref T, %T.loc14 [symbolic = constants.%T]
-// CHECK:STDOUT:     %T.as_type.loc14: type = facet_access_type %T.ref.loc14 [symbolic = constants.%T.as_type]
-// CHECK:STDOUT:     %.loc14: type = converted %T.ref.loc14, %T.as_type.loc14 [symbolic = constants.%T.as_type]
-// CHECK:STDOUT:     %J.ref.loc14: type = name_ref J, file.%J.decl [template = constants.%J.type]
-// CHECK:STDOUT:     %T.param.loc14: %I.type = value_param runtime_param<invalid>
-// CHECK:STDOUT:     %I.ref.loc14: type = name_ref I, file.%I.decl [template = constants.%I.type]
-// CHECK:STDOUT:     %T.loc14: %I.type = bind_symbolic_name T, 0, %T.param.loc14 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref: %I.type = name_ref T, %T.loc15_14.1 [symbolic = %T.loc15_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.as_type.loc15_21.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc15_21.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc15: type = converted %T.ref, %T.as_type.loc15_21.1 [symbolic = %T.as_type.loc15_21.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
+// CHECK:STDOUT:     %T.param: %I.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
+// CHECK:STDOUT:     %T.loc15_14.1: %I.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc15: <witness> = impl_witness (), @impl.2(constants.%T) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.1896b7.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
@@ -404,28 +431,51 @@ impl (C, C).0 as I {}
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @impl(%T.loc7_14.1: %I.type) {
+// CHECK:STDOUT: generic impl @impl.1(%T.loc7_14.1: %I.type) {
 // CHECK:STDOUT:   %T.loc7_14.2: %I.type = bind_symbolic_name T, 0 [symbolic = %T.loc7_14.2 (constants.%T)]
 // CHECK:STDOUT:   %T.patt.loc7_14.2: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   %T.as_type.loc7_21.2: type = facet_access_type %T.loc7_14.2 [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl(%T.loc7_14.2) [symbolic = %impl_witness (constants.%impl_witness)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl.1(%T.loc7_14.2) [symbolic = %impl_witness (constants.%impl_witness.1896b7.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: %.loc7 as %J.ref.loc7 {
+// CHECK:STDOUT:   impl: %.loc7 as %J.ref {
 // CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     witness = file.%impl_witness
+// CHECK:STDOUT:     witness = file.%impl_witness.loc7
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(constants.%T) {
+// CHECK:STDOUT: generic impl @impl.2(%T.loc15_14.1: %I.type) {
+// CHECK:STDOUT:   %T.loc15_14.2: %I.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_14.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc15_14.2: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %T.as_type.loc15_21.2: type = facet_access_type %T.loc15_14.2 [symbolic = %T.as_type.loc15_21.2 (constants.%T.as_type)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl.2(%T.loc15_14.2) [symbolic = %impl_witness (constants.%impl_witness.1896b7.2)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %.loc15 as %J.ref {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%impl_witness.loc15
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.1(constants.%T) {
 // CHECK:STDOUT:   %T.loc7_14.2 => constants.%T
 // CHECK:STDOUT:   %T.patt.loc7_14.2 => constants.%T
 // CHECK:STDOUT:   %T.as_type.loc7_21.2 => constants.%T.as_type
-// CHECK:STDOUT:   %impl_witness => constants.%impl_witness
+// CHECK:STDOUT:   %impl_witness => constants.%impl_witness.1896b7.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl(%T.loc7_14.2) {}
+// CHECK:STDOUT: specific @impl.1(%T.loc7_14.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(constants.%T) {
+// CHECK:STDOUT:   %T.loc15_14.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc15_14.2 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc15_21.2 => constants.%T.as_type
+// CHECK:STDOUT:   %impl_witness => constants.%impl_witness.1896b7.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(%T.loc15_14.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- same_type_different_spelling.carbon
 // CHECK:STDOUT:
@@ -483,4 +533,214 @@ impl (C, C).0 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- regression_for_redefinition_regions.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [template]
+// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [template]
+// CHECK:STDOUT:   %impl_witness.1f09a1.1: <witness> = impl_witness (), @impl.1(%T) [symbolic]
+// CHECK:STDOUT:   %A.type: type = fn_type @A, @impl.1(%T) [symbolic]
+// CHECK:STDOUT:   %A: %A.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %impl_witness.1f09a1.2: <witness> = impl_witness (), @impl.2(%T) [symbolic]
+// CHECK:STDOUT:   %B.type: type = fn_type @B, @impl.2(%T) [symbolic]
+// CHECK:STDOUT:   %B: %B.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %C.type: type = fn_type @C, @impl.2(%T) [symbolic]
+// CHECK:STDOUT:   %C: %C.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %D.type: type = fn_type @D, @impl.2(%T) [symbolic]
+// CHECK:STDOUT:   %D: %D.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [template]
+// CHECK:STDOUT:   %C.specific_fn: <specific function> = specific_function %C, @C(%T) [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
+// CHECK:STDOUT:   impl_decl @impl.1 [template] {
+// CHECK:STDOUT:     %T.patt.loc4_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_14.1, runtime_param<invalid> [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_14.1 [symbolic = %T.loc4_14.2 (constants.%T)]
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.loc4_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc4: <witness> = impl_witness (), @impl.1(constants.%T) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.1f09a1.1)]
+// CHECK:STDOUT:   impl_decl @impl.2 [template] {
+// CHECK:STDOUT:     %T.patt.loc14_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_14.1, runtime_param<invalid> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_14.1 [symbolic = %T.loc14_14.2 (constants.%T)]
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.loc14_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc14_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc14: <witness> = impl_witness (), @impl.2(constants.%T) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.1f09a1.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I {
+// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @impl.1(%T.loc4_14.1: type) {
+// CHECK:STDOUT:   %T.loc4_14.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_14.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_14.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl.1(%T.loc4_14.2) [symbolic = %impl_witness (constants.%impl_witness.1f09a1.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %A.type: type = fn_type @A, @impl.1(%T.loc4_14.2) [symbolic = %A.type (constants.%A.type)]
+// CHECK:STDOUT:   %A: @impl.1.%A.type (%A.type) = struct_value () [symbolic = %A (constants.%A)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %T.ref as %I.ref {
+// CHECK:STDOUT:     %A.decl: @impl.1.%A.type (%A.type) = fn_decl @A [symbolic = @impl.1.%A (constants.%A)] {} {}
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .A = %A.decl
+// CHECK:STDOUT:     witness = file.%impl_witness.loc4
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @impl.2(%T.loc14_14.1: type) {
+// CHECK:STDOUT:   %T.loc14_14.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_14.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc14_14.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl.2(%T.loc14_14.2) [symbolic = %impl_witness (constants.%impl_witness.1f09a1.2)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %B.type: type = fn_type @B, @impl.2(%T.loc14_14.2) [symbolic = %B.type (constants.%B.type)]
+// CHECK:STDOUT:   %B: @impl.2.%B.type (%B.type) = struct_value () [symbolic = %B (constants.%B)]
+// CHECK:STDOUT:   %C.type: type = fn_type @C, @impl.2(%T.loc14_14.2) [symbolic = %C.type (constants.%C.type)]
+// CHECK:STDOUT:   %C: @impl.2.%C.type (%C.type) = struct_value () [symbolic = %C (constants.%C)]
+// CHECK:STDOUT:   %D.type: type = fn_type @D, @impl.2(%T.loc14_14.2) [symbolic = %D.type (constants.%D.type)]
+// CHECK:STDOUT:   %D: @impl.2.%D.type (%D.type) = struct_value () [symbolic = %D (constants.%D)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %T.ref as %I.ref {
+// CHECK:STDOUT:     %B.decl: @impl.2.%B.type (%B.type) = fn_decl @B [symbolic = @impl.2.%B (constants.%B)] {} {}
+// CHECK:STDOUT:     %C.decl: @impl.2.%C.type (%C.type) = fn_decl @C [symbolic = @impl.2.%C (constants.%C)] {
+// CHECK:STDOUT:       %return.patt: %empty_tuple.type = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: %empty_tuple.type = out_param_pattern %return.patt, runtime_param0
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %.loc18_14.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:       %.loc18_14.2: type = converted %.loc18_14.1, constants.%empty_tuple.type [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:       %return.param: ref %empty_tuple.type = out_param runtime_param0
+// CHECK:STDOUT:       %return: ref %empty_tuple.type = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %D.decl: @impl.2.%D.type (%D.type) = fn_decl @D [symbolic = @impl.2.%D (constants.%D)] {
+// CHECK:STDOUT:       %return.patt: %empty_tuple.type = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: %empty_tuple.type = out_param_pattern %return.patt, runtime_param0
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %.loc19_14.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:       %.loc19_14.2: type = converted %.loc19_14.1, constants.%empty_tuple.type [template = constants.%empty_tuple.type]
+// CHECK:STDOUT:       %return.param: ref %empty_tuple.type = out_param runtime_param0
+// CHECK:STDOUT:       %return: ref %empty_tuple.type = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .D = %D.decl
+// CHECK:STDOUT:     witness = file.%impl_witness.loc14
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @A(@impl.1.%T.loc4_14.1: type) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @B(@impl.2.%T.loc14_14.1: type) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @C(@impl.2.%T.loc14_14.1: type) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() -> %empty_tuple.type {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %.loc18_26: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:     %empty_tuple: %empty_tuple.type = tuple_value () [template = constants.%empty_tuple]
+// CHECK:STDOUT:     %.loc18_27: %empty_tuple.type = converted %.loc18_26, %empty_tuple [template = constants.%empty_tuple]
+// CHECK:STDOUT:     return %.loc18_27
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @D(@impl.2.%T.loc14_14.1: type) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %C.type: type = fn_type @C, @impl.2(%T) [symbolic = %C.type (constants.%C.type)]
+// CHECK:STDOUT:   %C: @D.%C.type (%C.type) = struct_value () [symbolic = %C (constants.%C)]
+// CHECK:STDOUT:   %C.specific_fn.loc20_12.2: <specific function> = specific_function %C, @C(%T) [symbolic = %C.specific_fn.loc20_12.2 (constants.%C.specific_fn)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() -> %empty_tuple.type {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %.loc20_12: @D.%C.type (%C.type) = specific_constant @impl.2.%C.decl, @impl.2(constants.%T) [symbolic = %C (constants.%C)]
+// CHECK:STDOUT:     %C.ref: @D.%C.type (%C.type) = name_ref C, %.loc20_12 [symbolic = %C (constants.%C)]
+// CHECK:STDOUT:     %C.specific_fn.loc20_12.1: <specific function> = specific_function %C.ref, @C(constants.%T) [symbolic = %C.specific_fn.loc20_12.2 (constants.%C.specific_fn)]
+// CHECK:STDOUT:     %C.call: init %empty_tuple.type = call %C.specific_fn.loc20_12.1()
+// CHECK:STDOUT:     %.loc20_14.1: ref %empty_tuple.type = temporary_storage
+// CHECK:STDOUT:     %.loc20_14.2: ref %empty_tuple.type = temporary %.loc20_14.1, %C.call
+// CHECK:STDOUT:     %tuple: %empty_tuple.type = tuple_value () [template = constants.%empty_tuple]
+// CHECK:STDOUT:     %.loc20_15: %empty_tuple.type = converted %C.call, %tuple [template = constants.%empty_tuple]
+// CHECK:STDOUT:     return %.loc20_15
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.1(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_14.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_14.2 => constants.%T
+// CHECK:STDOUT:   %impl_witness => constants.%impl_witness.1f09a1.1
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %A.type => constants.%A.type
+// CHECK:STDOUT:   %A => constants.%A
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.1(%T.loc4_14.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @A(constants.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(constants.%T) {
+// CHECK:STDOUT:   %T.loc14_14.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc14_14.2 => constants.%T
+// CHECK:STDOUT:   %impl_witness => constants.%impl_witness.1f09a1.2
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %B.type => constants.%B.type
+// CHECK:STDOUT:   %B => constants.%B
+// CHECK:STDOUT:   %C.type => constants.%C.type
+// CHECK:STDOUT:   %C => constants.%C
+// CHECK:STDOUT:   %D.type => constants.%D.type
+// CHECK:STDOUT:   %D => constants.%D
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(%T.loc14_14.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @B(constants.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C(constants.%T) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @D(constants.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(@D.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C(@D.%T) {}
 // CHECK:STDOUT:


### PR DESCRIPTION
Fixes a crash, see the new regression test in toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon. Stopping merging seems like the most straightforward way to prevent references to generic regions with the incorrect block.