### PR TITLE
Fix PR links in two proposals.

### DIFF
--- a/proposals/p0162.md
+++ b/proposals/p0162.md
@@ -6,7 +6,7 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-[Pull request](https://github.com/carbon-language/carbon-lang/pull/0162)
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/162)
 
 ## Table of contents
 

--- a/proposals/p1178.md
+++ b/proposals/p1178.md
@@ -6,7 +6,7 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-[Pull request](https://github.com/carbon-language/carbon-lang/pull/1178
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/1178)
 
 <!-- toc -->
 

--- a/proposals/p2022.md
+++ b/proposals/p2022.md
@@ -6,7 +6,7 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-[Pull request](https://github.com/carbon-language/carbon-lang/pull/2022
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2022)
 
 <!-- toc -->
 


### PR DESCRIPTION
Remove a leading 0 from another one for consistency with the rest of the three-digit proposals; the link works either way.
