### PR TITLE
Fix rendering of https://docs.carbon-lang.dev/proposals/p2188.html

### DIFF
--- a/proposals/p2188.md
+++ b/proposals/p2188.md
@@ -1200,7 +1200,8 @@ David!
 
 <table>
 <tr><th>C++</th><th>P0095R1</th><th>This proposal</th></tr>
-<tr><td>
+<tr markdown="block">
+<td>
 
 ```c++
 struct set_score {
@@ -1255,7 +1256,7 @@ choice command {
 
 <table>
 <tr><th>C++</th><th>P0095R1</th><th>This proposal</th></tr>
-<tr><td>
+<tr markdown="block"><td>
 
 ```c++
 namespace {
@@ -1328,7 +1329,7 @@ impl command as Printable {
 
 <table>
 <tr><th>C++</th><th>P0095R1</th><th>This proposal</th></tr>
-<tr><td colspan=2>
+<tr markdown="block"><td colspan=2>
 
 ```c++
 enum color { red, yellow, green, blue };
@@ -1341,7 +1342,7 @@ choice color { red, yellow, green, blue }
 ```
 
 </td></tr>
-<tr><td>
+<tr markdown="block"><td>
 
 ```c++
 const Vec3 opengl_color = [&c] {
@@ -1398,7 +1399,7 @@ let opengl_color: Vec3 = GetOpenGLColor(c);
 
 <table>
 <tr><th>C++</th><th>P0095R1</th><th>This proposal</th></tr>
-<tr><td>
+<tr markdown="block"><td>
 
 ```c++
 struct expression;
@@ -1536,7 +1537,7 @@ fn simplify(exp: expression) -> expression {
 
 <table>
 <tr><th>C++</th><th>P0095R1</th><th>This proposal</th></tr>
-<tr><td colspan=2>
+<tr markdown="block"><td colspan=2>
 
 ```c++
 struct player {
@@ -1557,7 +1558,7 @@ class player {
 ```
 
 </td></tr>
-<tr><td>
+<tr markdown="block"><td>
 
 ```c++
 void takeDamage(player &p) {

--- a/proposals/p2188.md
+++ b/proposals/p2188.md
@@ -1200,8 +1200,7 @@ David!
 
 <table>
 <tr><th>C++</th><th>P0095R1</th><th>This proposal</th></tr>
-<tr markdown="block">
-<td>
+<tr markdown="block"><td>
 
 ```c++
 struct set_score {

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -23,3 +23,6 @@ mermaid:
 readme_index:
   remove_originals: true
   with_frontmatter: true
+
+kramdown:
+  parse_block_html: true


### PR DESCRIPTION
Per https://kramdown.gettalong.org/syntax.html#html-blocks, kramdown doesn't render markdown inside HTML tags by default. Enable this globally to get results more similar to Github-Flavored Markdown.