### PR TITLE
Add Support for #include in cpp files imported from Carbon

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,7 +117,7 @@ bazel_dep(name = "zstd", version = "1.5.6", repo_name = "llvm_zstd")
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
 # HEAD as of 2025-01-15.
-llvm_project_version = "6ca560a9092e29c9f9817db6d6da09edd5f0ded7"
+llvm_project_version = "6affc1837537a802531a5394535f1f0b7ca865cb"
 
 # Load a repository for the raw llvm-project, pre-overlay.
 http_archive(
@@ -128,7 +128,7 @@ http_archive(
         "@carbon//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",
         "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
     ],
-    sha256 = "1ee1e9baa236ac35c43b1a0878629f82b8ca0b85effe83aa697736a0b515923d",
+    sha256 = "bd6960ef96601a79fb12681b589d2567b9d4c85ca46458188e79856ac40cd060",
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,7 +117,7 @@ bazel_dep(name = "zstd", version = "1.5.6", repo_name = "llvm_zstd")
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
 # HEAD as of 2025-01-15.
-llvm_project_version = "6affc1837537a802531a5394535f1f0b7ca865cb"
+llvm_project_version = "6ca560a9092e29c9f9817db6d6da09edd5f0ded7"
 
 # Load a repository for the raw llvm-project, pre-overlay.
 http_archive(
@@ -128,7 +128,7 @@ http_archive(
         "@carbon//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",
         "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
     ],
-    sha256 = "bd6960ef96601a79fb12681b589d2567b9d4c85ca46458188e79856ac40cd060",
+    sha256 = "1ee1e9baa236ac35c43b1a0878629f82b8ca0b85effe83aa697736a0b515923d",
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],
 )

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -358,7 +358,7 @@ auto CheckUnit::ImportCppPackages() -> void {
     return;
   }
 
-  ImportCppFile(context_, import.node_id, source_buffer->filename(),
+  ImportCppFile(context_, import.node_id, fs_, source_buffer->filename(),
                 source_buffer->text());
 }
 

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -19,8 +19,9 @@
 
 namespace Carbon::Check {
 
-auto ImportCppFile(Context& context, SemIRLoc loc, llvm::StringRef file_path,
-                   llvm::StringRef code) -> void {
+auto ImportCppFile(Context& context, SemIRLoc loc,
+                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+                   llvm::StringRef file_path, llvm::StringRef code) -> void {
   std::string diagnostics_str;
   llvm::raw_string_ostream diagnostics_stream(diagnostics_str);
 
@@ -33,7 +34,7 @@ auto ImportCppFile(Context& context, SemIRLoc loc, llvm::StringRef file_path,
       code, {}, file_path, "clang-tool",
       std::make_shared<clang::PCHContainerOperations>(),
       clang::tooling::getClangStripDependencyFileAdjuster(),
-      clang::tooling::FileContentMappings(), &diagnostics_consumer);
+      clang::tooling::FileContentMappings(), &diagnostics_consumer, fs);
   // TODO: Implement and use a DynamicRecursiveASTVisitor to traverse the AST.
   int num_errors = diagnostics_consumer.getNumErrors();
   int num_warnings = diagnostics_consumer.getNumWarnings();

--- a/toolchain/check/import_cpp.h
+++ b/toolchain/check/import_cpp.h
@@ -12,8 +12,9 @@
 namespace Carbon::Check {
 
 // Parses the C++ code and report errors and warnings.
-auto ImportCppFile(Context& context, SemIRLoc loc, llvm::StringRef file_path,
-                   llvm::StringRef code) -> void;
+auto ImportCppFile(Context& context, SemIRLoc loc,
+                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+                   llvm::StringRef file_path, llvm::StringRef code) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/testdata/interop/cpp/no_prelude/include.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/include.carbon
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/no_prelude/include.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/no_prelude/include.carbon
+
+// --- included_file.h
+
+void foo();
+
+// --- including_file.h
+
+#include "included_file.h"
+
+// --- import_function_decl.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "including_file.h";
+
+// CHECK:STDOUT: --- import_function_decl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:


### PR DESCRIPTION
Propagate `FileSystem` to `buildASTFromCodeWithArgs`().
Part of #4666