### PR TITLE
Website: exclude files that would cause problems for prebuild or jekyll

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -10,6 +10,13 @@ theme: just-the-docs
 
 favicon_ico: '/favicon.png'
 
+exclude:
+  - '.*'
+  - '**/node_modules'
+  - '**/dist'
+  - 'bazel-*'
+  - 'utils/vscode/images/icon.png'
+
 aux_links:
   Discord: https://discord.gg/ZjVdShJDAs
   GitHub: https://github.com/carbon-language/carbon-lang

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -85,8 +85,7 @@ def label_subdir(
     readme_content = readme.read_text()
 
     def include_child(md_file: Path) -> bool:
-        """Returns whether md_file is a child of this label.
-        """
+        """Returns whether md_file is a child of this label."""
         # The top-level README.md isn't a child.
         if md_file == readme:
             return False

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -10,6 +10,7 @@ import dataclasses
 import os
 from pathlib import Path
 import re
+import shutil
 from typing import Optional
 
 __copyright__ = """
@@ -88,7 +89,8 @@ def label_subdir(
     readme_titles = [readme_title]
     if parent_title:
         readme_titles.insert(0, parent_title)
-    children = [x for x in subdir.glob("**/*.md") if x != readme]
+    children = [x for x in subdir.glob("**/*.md")
+                    if x != readme and '/node_modules/' not in str(x) and '/dist/' not in str(x)]
     add_frontmatter(
         readme, readme_content, readme_titles, top_nav_order, bool(children)
     )
@@ -142,36 +144,9 @@ def label_root_file(
     add_frontmatter(f, f.read_text(), [title], top_nav_order, has_children)
 
 
-def unlink_dir(path: Path) -> None:
-    # TODO: Use path.walk once we require Python 3.12.
-    for root, dirs, files in os.walk(path, topdown=False):
-        root_path = Path(root)
-        for name in files:
-            (root_path / name).unlink()
-        for name in dirs:
-            (root_path / name).rmdir()
-
-
 def main() -> None:
     # Ensure this runs from the repo root.
     os.chdir(Path(__file__).parents[1])
-
-    # bazel-generated symlinks interfere with jekyll because they may contain
-    # broken symlinks.
-    Path("bazel-out").unlink(missing_ok=True)
-    Path("bazel-bin").unlink(missing_ok=True)
-    Path("bazel-genfiles").unlink(missing_ok=True)
-    # bazel-execroot interferes with jekyll because it's a broken symlink.
-    Path("bazel-execroot").unlink()
-    # This is a symlink to website/favicon.png, which is moved below.
-    # TODO: Consider moving the icon to a location which won't break.
-    Path("utils/vscode/images/icon.png").unlink()
-    # This may contain a README.md file that jekyll can't parse and that
-    # shouldn't appear in the navigation tree.
-    unlink_dir(Path("utils/vscode/node_modules"))
-    # This can cause a failure if jekyll has already been run prior to
-    # prebuild.
-    unlink_dir(Path("website/.jekyll-cache"))
 
     # The external symlink is created by scripts/create_compdb.py, and can
     # interfere with local execution.
@@ -181,7 +156,7 @@ def main() -> None:
 
     # Move files to the repo root.
     for f in Path("website").iterdir():
-        if f.name == "README.md":
+        if f.name in ["README.md", '.jekyll-cache', '_site']:
             continue
         f.rename(f.name)
 

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -10,7 +10,6 @@ import dataclasses
 import os
 from pathlib import Path
 import re
-import shutil
 from typing import Optional
 
 __copyright__ = """
@@ -89,8 +88,13 @@ def label_subdir(
     readme_titles = [readme_title]
     if parent_title:
         readme_titles.insert(0, parent_title)
-    children = [x for x in subdir.glob("**/*.md")
-                    if x != readme and '/node_modules/' not in str(x) and '/dist/' not in str(x)]
+    children = [
+        x
+        for x in subdir.glob("**/*.md")
+        if x != readme
+        and "/node_modules/" not in str(x)
+        and "/dist/" not in str(x)
+    ]
     add_frontmatter(
         readme, readme_content, readme_titles, top_nav_order, bool(children)
     )
@@ -156,7 +160,7 @@ def main() -> None:
 
     # Move files to the repo root.
     for f in Path("website").iterdir():
-        if f.name in ["README.md", '.jekyll-cache', '_site']:
+        if f.name in ["README.md", ".jekyll-cache", "_site"]:
             continue
         f.rename(f.name)
 

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -85,8 +85,7 @@ def label_subdir(
     readme_content = readme.read_text()
 
     def include_child(md_file: Path) -> bool:
-        """Determines whether a markdown file should be included in the
-        navigation tree as a child of this label.
+        """Returns whether md_file is a child of this label.
         """
         # The top-level README.md isn't a child.
         if md_file == readme:

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -84,17 +84,25 @@ def label_subdir(
     readme = subdir / "README.md"
     readme_content = readme.read_text()
 
+    def include_child(md_file: Path) -> bool:
+        """Determines whether a markdown file should be included in the
+        navigation tree as a child of this label.
+        """
+        # The top-level README.md isn't a child.
+        if md_file == readme:
+            return False
+        # Skip directories that aren't part of the repository.
+        if "/node_modules/" in str(md_file):
+            return False
+        if "/dist/" in str(md_file):
+            return False
+        return True
+
     readme_title = get_title(readme, readme_content)
     readme_titles = [readme_title]
     if parent_title:
         readme_titles.insert(0, parent_title)
-    children = [
-        x
-        for x in subdir.glob("**/*.md")
-        if x != readme
-        and "/node_modules/" not in str(x)
-        and "/dist/" not in str(x)
-    ]
+    children = [x for x in subdir.glob("**/*.md") if include_child(x)]
     add_frontmatter(
         readme, readme_content, readme_titles, top_nav_order, bool(children)
     )

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -142,15 +142,36 @@ def label_root_file(
     add_frontmatter(f, f.read_text(), [title], top_nav_order, has_children)
 
 
+def unlink_dir(path: Path) -> None:
+    # TODO: Use path.walk once we require Python 3.12.
+    for root, dirs, files in os.walk(path, topdown=False):
+        root_path = Path(root)
+        for name in files:
+            (root_path / name).unlink()
+        for name in dirs:
+            (root_path / name).rmdir()
+
+
 def main() -> None:
     # Ensure this runs from the repo root.
     os.chdir(Path(__file__).parents[1])
 
+    # bazel-generated symlinks interfere with jekyll because they may contain
+    # broken symlinks.
+    Path("bazel-out").unlink(missing_ok=True)
+    Path("bazel-bin").unlink(missing_ok=True)
+    Path("bazel-genfiles").unlink(missing_ok=True)
     # bazel-execroot interferes with jekyll because it's a broken symlink.
     Path("bazel-execroot").unlink()
     # This is a symlink to website/favicon.png, which is moved below.
     # TODO: Consider moving the icon to a location which won't break.
     Path("utils/vscode/images/icon.png").unlink()
+    # This may contain a README.md file that jekyll can't parse and that
+    # shouldn't appear in the navigation tree.
+    unlink_dir(Path("utils/vscode/node_modules"))
+    # This can cause a failure if jekyll has already been run prior to
+    # prebuild.
+    unlink_dir(Path("website/.jekyll-cache"))
 
     # The external symlink is created by scripts/create_compdb.py, and can
     # interfere with local execution.


### PR DESCRIPTION
Exclude some files from the website and prebuild steps that aren't part of the git repository, but may exist in a checkout, and if present will cause the website prebuild or build to misbehave or break.