### PR TITLE
Add stdin to driver's streams, and refactor stream passing

### DIFF
--- a/testing/base/source_gen_test.cpp
+++ b/testing/base/source_gen_test.cpp
@@ -147,7 +147,11 @@ auto TestCompile(llvm::StringRef source) -> bool {
       new llvm::vfs::InMemoryFileSystem;
   InstallPaths installation(
       InstallPaths::MakeForBazelRunfiles(Testing::GetExePath()));
-  Driver driver(fs, &installation, llvm::outs(), llvm::errs());
+  Driver driver({.fs = fs,
+                 .installation = &installation,
+                 .input_stream = nullptr,
+                 .output_stream = &llvm::outs(),
+                 .error_stream = &llvm::errs()});
 
   AddPreludeFilesToVfs(installation, fs);
 

--- a/toolchain/check/check_fuzzer.cpp
+++ b/toolchain/check/check_fuzzer.cpp
@@ -39,7 +39,12 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
                                        /*RequiresNullTerminator=*/false)));
 
   llvm::raw_null_ostream null_ostream;
-  Driver driver(fs, install_paths, null_ostream, null_ostream);
+  Driver driver({.fs = fs,
+                 .installation = install_paths,
+                 .input_stream = nullptr,
+                 .output_stream = &null_ostream,
+                 .error_stream = &null_ostream,
+                 .fuzzing = true});
 
   // TODO: Get checking to a point where it can handle invalid parse trees
   // without crashing.

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -114,6 +114,7 @@ cc_library(
     deps = [
         ":clang_runner",
         "//common:command_line",
+        "//common:error",
         "//common:ostream",
         "//common:raw_string_ostream",
         "//common:version",

--- a/toolchain/driver/clang_subcommand.cpp
+++ b/toolchain/driver/clang_subcommand.cpp
@@ -51,7 +51,7 @@ auto ClangSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   // Don't run Clang when fuzzing, it is known to not be reliable under fuzzing
   // due to many unfixed issues.
   if (driver_env.fuzzing) {
-    driver_env.error_stream
+    *driver_env.error_stream
         << "error: cannot run `clang` subcommand productively when fuzzing\n";
     return {.success = false};
   }

--- a/toolchain/driver/compile_benchmark.cpp
+++ b/toolchain/driver/compile_benchmark.cpp
@@ -23,7 +23,11 @@ class CompileBenchmark {
  public:
   CompileBenchmark()
       : installation_(InstallPaths::MakeForBazelRunfiles(GetExePath())),
-        driver_(fs_, &installation_, llvm::outs(), llvm::errs()) {
+        driver_({.fs = fs_,
+                 .installation = &installation_,
+                 .input_stream = nullptr,
+                 .output_stream = &llvm::outs(),
+                 .error_stream = &llvm::errs()}) {
     AddPreludeFilesToVfs(installation_, fs_);
   }
 

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_DRIVER_COMPILE_SUBCOMMAND_H_
 
 #include "common/command_line.h"
+#include "common/error.h"
 #include "common/ostream.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -75,7 +76,7 @@ class CompileSubcommand : public DriverSubcommand {
  private:
   // Does custom validation of the compile-subcommand options structure beyond
   // what the command line parsing library supports.
-  auto ValidateOptions(DriverEnv& driver_env) const -> bool;
+  auto ValidateOptions() const -> ErrorOr<Success>;
 
   CompileOptions options_;
 };

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -20,16 +20,8 @@ namespace Carbon {
 // with the language.
 class Driver {
  public:
-  // Constructs a driver with any error or informational output directed to a
-  // specified stream.
-  Driver(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-         const InstallPaths* installation,
-         llvm::raw_pwrite_stream& output_stream,
-         llvm::raw_pwrite_stream& error_stream)
-      : driver_env_{.fs = fs,
-                    .installation = installation,
-                    .output_stream = output_stream,
-                    .error_stream = error_stream} {}
+  // Constructs a driver with the provided environment.
+  explicit Driver(DriverEnv env) : driver_env_(std::move(env)) {}
 
   // Parses the given arguments into both a subcommand to select the operation
   // to perform and any arguments to that subcommand.
@@ -38,10 +30,6 @@ class Driver {
   // false and any information about the failure is printed to the registered
   // error stream (stderr by default).
   auto RunCommand(llvm::ArrayRef<llvm::StringRef> args) -> DriverResult;
-
-  // Configure the driver for fuzzing. This allows specific commands to error
-  // rather than perform operations that aren't well behaved during fuzzing.
-  auto SetFuzzing() -> void;
 
  private:
   DriverEnv driver_env_;

--- a/toolchain/driver/driver_env.h
+++ b/toolchain/driver/driver_env.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_ENV_H_
 #define CARBON_TOOLCHAIN_DRIVER_DRIVER_ENV_H_
 
+#include <cstdio>
+
 #include "common/ostream.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "toolchain/install/install_paths.h"
@@ -18,15 +20,19 @@ struct DriverEnv {
   // Helper to locate the toolchain installation's files.
   const InstallPaths* installation;
 
+  // Standard input; stdin. May be null, to prevent accidental use.
+  FILE* input_stream;
   // Standard output; stdout.
-  llvm::raw_pwrite_stream& output_stream;
+  llvm::raw_pwrite_stream* output_stream;
   // Error output; stderr.
-  llvm::raw_pwrite_stream& error_stream;
+  llvm::raw_pwrite_stream* error_stream;
 
   // For CARBON_VLOG.
   llvm::raw_pwrite_stream* vlog_stream = nullptr;
 
-  // Tracks when the driver is being fuzzed.
+  // Tracks when the driver is being fuzzed. This allows specific commands to
+  // error rather than perform operations that aren't well behaved during
+  // fuzzing.
   bool fuzzing = false;
 };
 

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -43,7 +43,11 @@ class DriverTest : public testing::Test {
   DriverTest()
       : installation_(
             InstallPaths::MakeForBazelRunfiles(Testing::GetExePath())),
-        driver_(fs_, &installation_, test_output_stream_, test_error_stream_) {
+        driver_({.fs = fs_,
+                 .installation = &installation_,
+                 .input_stream = nullptr,
+                 .output_stream = &test_output_stream_,
+                 .error_stream = &test_error_stream_}) {
     char* tmpdir_env = getenv("TEST_TMPDIR");
     CARBON_CHECK(tmpdir_env != nullptr);
     test_tmpdir_ = tmpdir_env;

--- a/toolchain/driver/format_subcommand.cpp
+++ b/toolchain/driver/format_subcommand.cpp
@@ -56,8 +56,9 @@ auto FormatSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   DriverResult result = {.success = true};
   if (options_.input_filenames.size() > 1 &&
       !options_.output_filename.empty()) {
-    driver_env.error_stream << "error: cannot format multiple input files when "
-                               "--output is set\n";
+    *driver_env.error_stream
+        << "error: cannot format multiple input files when "
+           "--output is set\n";
     result.success = false;
     return result;
   }
@@ -67,7 +68,7 @@ auto FormatSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
     result.per_file_success.back().second = false;
   };
 
-  StreamDiagnosticConsumer consumer(driver_env.error_stream,
+  StreamDiagnosticConsumer consumer(*driver_env.error_stream,
                                     /*include_diagnostic_kind=*/false);
   for (auto& f : options_.input_filenames) {
     // Push a result, which we'll update on failure.
@@ -89,11 +90,11 @@ auto FormatSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
       // TODO: Figure out a multi-file output setup that supports good
       // multi-file testing.
       // TODO: Use --output values (and default to overwrite).
-      driver_env.output_stream << buffer.TakeStr();
+      *driver_env.output_stream << buffer.TakeStr();
     } else {
       buffer.clear();
       mark_per_file_error();
-      driver_env.output_stream << source->text();
+      *driver_env.output_stream << source->text();
     }
   }
 

--- a/toolchain/driver/language_server_subcommand.cpp
+++ b/toolchain/driver/language_server_subcommand.cpp
@@ -25,8 +25,8 @@ auto LanguageServerSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   }
 
   auto err =
-      LanguageServer::Run(driver_env.input_stream, driver_env.output_stream,
-                          driver_env.error_stream);
+      LanguageServer::Run(driver_env.input_stream, *driver_env.output_stream,
+                          *driver_env.error_stream);
   if (!err.ok()) {
     *driver_env.error_stream << "error: " << err.error() << "\n";
   }

--- a/toolchain/driver/language_server_subcommand.cpp
+++ b/toolchain/driver/language_server_subcommand.cpp
@@ -19,11 +19,16 @@ LanguageServerSubcommand::LanguageServerSubcommand()
     : DriverSubcommand(SubcommandInfo) {}
 
 auto LanguageServerSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
-  // TODO: Consider a way to override stdin, but it's a `FILE*` so less
-  // convenient to work with.
-  auto err = LanguageServer::Run(stdin, driver_env.output_stream);
+  if (!driver_env.input_stream) {
+    *driver_env.error_stream
+        << "error: language-server requires input_stream\n";
+  }
+
+  auto err =
+      LanguageServer::Run(driver_env.input_stream, driver_env.output_stream,
+                          driver_env.error_stream);
   if (!err.ok()) {
-    driver_env.error_stream << "error: " << err.error() << "\n";
+    *driver_env.error_stream << "error: " << err.error() << "\n";
   }
   return {.success = err.ok()};
 }

--- a/toolchain/install/busybox_main.cpp
+++ b/toolchain/install/busybox_main.cpp
@@ -45,7 +45,11 @@ static auto Main(int argc, char** argv) -> ErrorOr<int> {
   }
   args.append(argv + 1, argv + argc);
 
-  Driver driver(fs, &install_paths, llvm::outs(), llvm::errs());
+  Driver driver({.fs = fs,
+                 .installation = &install_paths,
+                 .input_stream = stdin,
+                 .output_stream = &llvm::outs(),
+                 .error_stream = &llvm::errs()});
   bool success = driver.RunCommand(args).success;
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/toolchain/language_server/language_server.cpp
+++ b/toolchain/language_server/language_server.cpp
@@ -13,14 +13,17 @@
 
 namespace Carbon::LanguageServer {
 
-auto Run(std::FILE* input_stream, llvm::raw_ostream& output_stream)
-    -> ErrorOr<Success> {
+auto Run(std::FILE* input_stream, llvm::raw_ostream* output_stream,
+         llvm::raw_ostream* error_stream) -> ErrorOr<Success> {
+  CARBON_CHECK(input_stream && output_stream && error_stream);
+
   // Set up the connection.
   std::unique_ptr<clang::clangd::Transport> transport(
-      clang::clangd::newJSONTransport(input_stream, output_stream,
+      clang::clangd::newJSONTransport(input_stream, *output_stream,
                                       /*InMirror=*/nullptr,
                                       /*Pretty=*/true));
   Context context;
+  // TODO: Use error_stream in IncomingMessages to report dropped errors.
   IncomingMessages incoming(transport.get(), &context);
   OutgoingMessages outgoing(transport.get());
 

--- a/toolchain/language_server/language_server.cpp
+++ b/toolchain/language_server/language_server.cpp
@@ -13,13 +13,11 @@
 
 namespace Carbon::LanguageServer {
 
-auto Run(std::FILE* input_stream, llvm::raw_ostream* output_stream,
-         llvm::raw_ostream* error_stream) -> ErrorOr<Success> {
-  CARBON_CHECK(input_stream && output_stream && error_stream);
-
+auto Run(FILE* input_stream, llvm::raw_ostream& output_stream,
+         llvm::raw_ostream& /*error_stream*/) -> ErrorOr<Success> {
   // Set up the connection.
   std::unique_ptr<clang::clangd::Transport> transport(
-      clang::clangd::newJSONTransport(input_stream, *output_stream,
+      clang::clangd::newJSONTransport(input_stream, output_stream,
                                       /*InMirror=*/nullptr,
                                       /*Pretty=*/true));
   Context context;

--- a/toolchain/language_server/language_server.h
+++ b/toolchain/language_server/language_server.h
@@ -12,8 +12,8 @@ namespace Carbon::LanguageServer {
 
 // Start the language server. input_stream and output_stream are used by LSP;
 // error_stream is primarily for errors that don't fit into LSP.
-auto Run(std::FILE* input_stream, llvm::raw_ostream* output_stream,
-         llvm::raw_ostream* error_stream) -> ErrorOr<Success>;
+auto Run(FILE* input_stream, llvm::raw_ostream& output_stream,
+         llvm::raw_ostream& error_stream) -> ErrorOr<Success>;
 
 }  // namespace Carbon::LanguageServer
 

--- a/toolchain/language_server/language_server.h
+++ b/toolchain/language_server/language_server.h
@@ -10,9 +10,10 @@
 
 namespace Carbon::LanguageServer {
 
-// Start the language server.
-auto Run(std::FILE* input_stream, llvm::raw_ostream& output_stream)
-    -> ErrorOr<Success>;
+// Start the language server. input_stream and output_stream are used by LSP;
+// error_stream is primarily for errors that don't fit into LSP.
+auto Run(std::FILE* input_stream, llvm::raw_ostream* output_stream,
+         llvm::raw_ostream* error_stream) -> ErrorOr<Success>;
 
 }  // namespace Carbon::LanguageServer
 

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -38,10 +38,14 @@ TEST(SemIRTest, YAML) {
   const auto install_paths =
       InstallPaths::MakeForBazelRunfiles(Testing::GetExePath());
   RawStringOstream print_stream;
-  Driver d(fs, &install_paths, print_stream, llvm::errs());
+  Driver driver({.fs = fs,
+                 .installation = &install_paths,
+                 .input_stream = nullptr,
+                 .output_stream = &print_stream,
+                 .error_stream = &llvm::errs()});
   auto run_result =
-      d.RunCommand({"compile", "--no-prelude-import", "--phase=check",
-                    "--dump-raw-sem-ir", "test.carbon"});
+      driver.RunCommand({"compile", "--no-prelude-import", "--phase=check",
+                         "--dump-raw-sem-ir", "test.carbon"});
   EXPECT_TRUE(run_result.success);
 
   // Matches the ID of an instruction. Instruction counts may change as various

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -44,7 +44,11 @@ class ToolchainFileTest : public FileTestBase {
       }
     }
 
-    Driver driver(fs, &installation_, stdout, stderr);
+    Driver driver({.fs = fs,
+                   .installation = &installation_,
+                   .input_stream = nullptr,
+                   .output_stream = &stdout,
+                   .error_stream = &stderr});
     auto driver_result = driver.RunCommand(test_args);
     // If any diagnostics have been produced, add a trailing newline to make the
     // last diagnostic match intermediate diagnostics (that have a newline


### PR DESCRIPTION
The language server needs stdin, and for tests we should be passing it around. My intent is to pass in a faux stdin to Driver for language server tests.

As long as I'm adding a new parameter, I was looking at also changing the way streams are passed in to Driver for style (pointers since they're held past construction lifetime). Since these are all stored in DriverEnv, I thought it might be a net improvement to use the struct directly, getting more explicit parameter names and also removing the need for `SetFuzzing`.

I'm trying here to avoid functional changes, but there are a couple additional fixes like removing an obsolete `find_insensitive` and refactoring how `ValidateOptions` handles errors (because it reduces the number of spots that operate on error_stream).