### PR TITLE
When adding a namespace, explicitly unpoison an optimistically poisoned name

### DIFF
--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -153,7 +153,9 @@ static auto AddNamespace(Context& context, SemIR::TypeId namespace_type_id,
   // poisoned optimistically by name lookup before checking for imports, so we
   // may be overwriting a poisoned entry here.
   auto& entry = parent_scope->GetEntry(entry_id);
-  if (!inserted && !entry.is_poisoned) {
+  if (entry.is_poisoned) {
+    entry.is_poisoned = false;
+  } else if (!inserted) {
     context.DiagnoseDuplicateName(namespace_id, entry.inst_id);
     entry.access_kind = SemIR::AccessKind::Public;
   }

--- a/toolchain/check/testdata/namespace/merging_with_indirections.carbon
+++ b/toolchain/check/testdata/namespace/merging_with_indirections.carbon
@@ -159,6 +159,7 @@ fn Run() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace file.%Other.import, [template] {
 // CHECK:STDOUT:     .F = %import_ref.f04
+// CHECK:STDOUT:     .NS1 = %NS1
 // CHECK:STDOUT:     import Other//b
 // CHECK:STDOUT:     import Other//a
 // CHECK:STDOUT:   }


### PR DESCRIPTION
Part of #4622