### PR TITLE
Wrap lookup result in a new `ScopeLookupResult`

### DIFF
--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -78,10 +78,11 @@ auto HandleParseNode(Context& context, Parse::ExportDeclId node_id) -> bool {
   // diagnostic and so that cross-package imports can find it easily.
   auto entity_name = context.entity_names().Get(import_ref->entity_name_id);
   auto& parent_scope = context.name_scopes().Get(entity_name.parent_scope_id);
-  auto& scope_inst_id =
-      parent_scope.GetEntry(*parent_scope.Lookup(entity_name.name_id)).inst_id;
-  CARBON_CHECK(scope_inst_id == inst_id);
-  scope_inst_id = export_id;
+  auto& scope_result =
+      parent_scope.GetEntry(*parent_scope.Lookup(entity_name.name_id)).result;
+  CARBON_CHECK(scope_result.target_inst_id() == inst_id);
+  scope_result = SemIR::ScopeLookupResult::MakeFound(
+      export_id, scope_result.access_kind());
 
   return true;
 }

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -416,12 +416,13 @@ auto FinishImplWitness(Context& context, SemIR::Impl& impl) -> void {
           CARBON_FATAL("Unexpected type: {0}", type_inst);
         }
         auto& fn = context.functions().Get(fn_type->function_id);
-        auto [impl_decl_id, _, is_poisoned] = context.LookupNameInExactScope(
+        auto lookup_result = context.LookupNameInExactScope(
             decl_id, fn.name_id, impl.scope_id, impl_scope);
-        if (impl_decl_id.has_value()) {
-          used_decl_ids.push_back(impl_decl_id);
+        if (lookup_result.is_found()) {
+          used_decl_ids.push_back(lookup_result.target_inst_id());
           witness_block[index] = CheckAssociatedFunctionImplementation(
-              context, *fn_type, impl_decl_id, self_type_id, impl.witness_id);
+              context, *fn_type, lookup_result.target_inst_id(), self_type_id,
+              impl.witness_id);
         } else {
           CARBON_DIAGNOSTIC(
               ImplMissingFunction, Error,

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1211,13 +1211,14 @@ static auto AddNameScopeImportRefs(ImportContext& context,
                                    const SemIR::NameScope& import_scope,
                                    SemIR::NameScope& new_scope) -> void {
   for (auto entry : import_scope.entries()) {
-    if (entry.is_poisoned) {
+    SemIR::ScopeLookupResult result = entry.result;
+    if (result.is_poisoned()) {
       continue;
     }
-    auto ref_id = AddImportRef(context, entry.inst_id);
+    auto ref_id = AddImportRef(context, result.target_inst_id());
     new_scope.AddRequired({.name_id = GetLocalNameId(context, entry.name_id),
-                           .inst_id = ref_id,
-                           .access_kind = entry.access_kind});
+                           .result = SemIR::ScopeLookupResult::MakeFound(
+                               ref_id, result.access_kind())});
   }
   for (auto scope_inst_id : import_scope.extended_scopes()) {
     new_scope.AddExtendedScope(AddImportRef(context, scope_inst_id));

--- a/toolchain/check/merge.cpp
+++ b/toolchain/check/merge.cpp
@@ -169,7 +169,9 @@ auto ReplacePrevInstForMerge(Context& context, SemIR::NameScopeId scope_id,
   auto& scope = context.name_scopes().Get(scope_id);
   auto entry_id = scope.Lookup(name_id);
   if (entry_id) {
-    scope.GetEntry(*entry_id).inst_id = new_inst_id;
+    auto& result = scope.GetEntry(*entry_id).result;
+    result = SemIR::ScopeLookupResult::MakeWrappedLookupResult(
+        new_inst_id, result.access_kind());
   }
 }
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -691,7 +691,7 @@ class FormatterImpl {
           break;
       }
       out_ << " = ";
-      FormatName(result.is_found() ? result.target_inst_id() : InstId::Invalid);
+      FormatName(result.is_found() ? result.target_inst_id() : InstId::None);
       out_ << "\n";
     }
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -672,15 +672,15 @@ class FormatterImpl {
       out_ << label;
     }
 
-    for (auto [name_id, inst_id, access_kind, is_poisoned] : scope.entries()) {
-      if (is_poisoned) {
+    for (auto [name_id, result] : scope.entries()) {
+      if (result.is_poisoned()) {
         // TODO: Add poisoned names.
         continue;
       }
       Indent();
       out_ << ".";
       FormatName(name_id);
-      switch (access_kind) {
+      switch (result.access_kind()) {
         case SemIR::AccessKind::Public:
           break;
         case SemIR::AccessKind::Protected:
@@ -691,7 +691,7 @@ class FormatterImpl {
           break;
       }
       out_ << " = ";
-      FormatName(inst_id);
+      FormatName(result.is_found() ? result.target_inst_id() : InstId::Invalid);
       out_ << "\n";
     }
 

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -22,33 +22,33 @@ enum class AccessKind : int8_t {
 //
 // Lookup results are constructed through the `Make()` factory functions. Each
 // result takes one of a few forms, depending on the function used:
-// - Found when the lookup was successful returning a valid `InstId`. Can be
-//   constructed using `MakeFound()` or `MakeWrappedLookupResult()` with a valid
-//   `inst_id`.
+// - Found when the lookup was successful returning an existing `InstId`. Can be
+//   constructed using `MakeFound()` or `MakeWrappedLookupResult()` with an
+//   existing `inst_id`.
 // - Not found when the name wasn't declared or nor poisoned. Can be constructed
-//   using `MakeNotFound()` or using `MakeWrappedLookupResult()` with an invalid
+//   using `MakeNotFound()` or using `MakeWrappedLookupResult()` with a `None`
 //   `inst_id`.
 // - Poisoned when the name wasn't declared but was poisoned and so also
 //   considered to not be found in that scope. Can be constructed using
 //   `MakePoisoned()`.
 // - Represent that an error has occurred during lookup. This is still
-//   considered found and the error `InstId` is considered valid. Can be
+//   considered found and the error `InstId` is considered existing. Can be
 //   constructed using `MakeError()` or using `MakeWrappedLookupResult()` with
 //   `ErrorInst::SingletonInstId`.
 class ScopeLookupResult {
  public:
   static auto MakeFound(InstId inst_id, AccessKind access_kind)
       -> ScopeLookupResult {
-    CARBON_CHECK(inst_id.is_valid());
+    CARBON_CHECK(inst_id.has_value());
     return MakeWrappedLookupResult(inst_id, access_kind);
   }
 
   static auto MakeNotFound() -> ScopeLookupResult {
-    return MakeWrappedLookupResult(InstId::Invalid, AccessKind::Public);
+    return MakeWrappedLookupResult(InstId::None, AccessKind::Public);
   }
 
   static auto MakePoisoned() -> ScopeLookupResult {
-    return ScopeLookupResult(InstId::Invalid, AccessKind::Public,
+    return ScopeLookupResult(InstId::None, AccessKind::Public,
                              /*is_poisoned=*/true);
   }
 
@@ -67,11 +67,11 @@ class ScopeLookupResult {
   // True when lookup was successful or resulted with an error. False for
   // poisoned or not found.
   auto is_found() const -> bool {
-    return !is_poisoned() && inst_id_.is_valid();
+    return !is_poisoned() && inst_id_.has_value();
   }
 
   // The `InstId` of the result of the lookup. Must only be called when lookup
-  // was successful e.g. `is_found()` returns true. Always returns a valid
+  // was successful e.g. `is_found()` returns true. Always returns an existing
   // `InstId`.
   auto target_inst_id() const -> InstId {
     CARBON_CHECK(is_found());

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -18,13 +18,95 @@ enum class AccessKind : int8_t {
   Private,
 };
 
+// Represents the result of a name lookup.
+//
+// Lookup results are constructed through the `Make()` factory functions. Each
+// result takes one of a few forms, depending on the function used:
+// - Found when the lookup was successful returning a valid `InstId`. Can be
+//   constructed using `MakeFound()` or `MakeWrappedLookupResult()` with a valid
+//   `inst_id`.
+// - Not found when the name wasn't declared or nor poisoned. Can be constructed
+//   using `MakeNotFound()` or using `MakeWrappedLookupResult()` with an invalid
+//   `inst_id`.
+// - Poisoned when the name wasn't declared but was poisoned and so also
+//   considered to not be found in that scope. Can be constructed using
+//   `MakePoisoned()`.
+// - Represent that an error has occurred during lookup. This is still
+//   considered found and the error `InstId` is considered valid. Can be
+//   constructed using `MakeError()` or using `MakeWrappedLookupResult()` with
+//   `ErrorInst::SingletonInstId`.
+class ScopeLookupResult {
+ public:
+  static auto MakeFound(InstId inst_id, AccessKind access_kind)
+      -> ScopeLookupResult {
+    CARBON_CHECK(inst_id.is_valid());
+    return MakeWrappedLookupResult(inst_id, access_kind);
+  }
+
+  static auto MakeNotFound() -> ScopeLookupResult {
+    return MakeWrappedLookupResult(InstId::Invalid, AccessKind::Public);
+  }
+
+  static auto MakePoisoned() -> ScopeLookupResult {
+    return ScopeLookupResult(InstId::Invalid, AccessKind::Public,
+                             /*is_poisoned=*/true);
+  }
+
+  static auto MakeError() -> ScopeLookupResult {
+    return MakeFound(ErrorInst::SingletonInstId, AccessKind::Public);
+  }
+
+  static auto MakeWrappedLookupResult(InstId inst_id, AccessKind access_kind)
+      -> ScopeLookupResult {
+    return ScopeLookupResult(inst_id, access_kind, /*is_poisoned=*/false);
+  }
+
+  // True iff CreatePoisoned() was used.
+  auto is_poisoned() const -> bool { return is_poisoned_; }
+
+  // True when lookup was successful or resulted with an error. False for
+  // poisoned or not found.
+  auto is_found() const -> bool {
+    return !is_poisoned() && inst_id_.is_valid();
+  }
+
+  // The `InstId` of the result of the lookup. Must only be called when lookup
+  // was successful e.g. `is_found()` returns true. Always returns a valid
+  // `InstId`.
+  auto target_inst_id() const -> InstId {
+    CARBON_CHECK(is_found());
+    return inst_id_;
+  }
+
+  auto access_kind() const -> AccessKind { return access_kind_; }
+
+  // Equality means either:
+  // - Both are not poisoned and have the same `InstId` and `AccessKind`.
+  // - Both are poisoned.
+  friend auto operator==(const ScopeLookupResult&, const ScopeLookupResult&)
+      -> bool = default;
+
+ private:
+  explicit ScopeLookupResult(InstId inst_id, AccessKind access_kind,
+                             bool is_poisoned)
+      : inst_id_(inst_id),
+        access_kind_(access_kind),
+        is_poisoned_(is_poisoned) {}
+
+  InstId inst_id_;
+  AccessKind access_kind_;
+  bool is_poisoned_;
+};
+static_assert(sizeof(ScopeLookupResult) == 8);
+
 class NameScope : public Printable<NameScope> {
  public:
   struct Entry {
     NameId name_id;
-    InstId inst_id;
-    AccessKind access_kind;
-    bool is_poisoned = false;
+    ScopeLookupResult result;
+
+    // Equality means they have the same `name_id` and equal `result`.
+    friend auto operator==(const Entry&, const Entry&) -> bool = default;
   };
   static_assert(sizeof(Entry) == 12);
 
@@ -185,9 +267,9 @@ class NameScopeStore {
   // The name must never conflict.
   auto AddRequiredName(NameScopeId scope_id, NameId name_id, InstId inst_id)
       -> void {
-    Get(scope_id).AddRequired({.name_id = name_id,
-                               .inst_id = inst_id,
-                               .access_kind = AccessKind::Public});
+    Get(scope_id).AddRequired(
+        {.name_id = name_id,
+         .result = ScopeLookupResult::MakeFound(inst_id, AccessKind::Public)});
   }
 
   // Returns the requested name scope.

--- a/toolchain/sem_ir/name_scope_test.cpp
+++ b/toolchain/sem_ir/name_scope_test.cpp
@@ -13,7 +13,7 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::Pair;
 
-TEST(ScopeLookupResult, MakeWrappedLookupResultUsingValidInstId) {
+TEST(ScopeLookupResult, MakeWrappedLookupResultUsingExistingInstId) {
   InstId inst_id(1);
   auto result = ScopeLookupResult::MakeWrappedLookupResult(
       inst_id, AccessKind::Protected);
@@ -24,9 +24,9 @@ TEST(ScopeLookupResult, MakeWrappedLookupResultUsingValidInstId) {
   EXPECT_EQ(result.access_kind(), AccessKind::Protected);
 }
 
-TEST(ScopeLookupResult, MakeWrappedLookupResultUsingInvalidInstId) {
+TEST(ScopeLookupResult, MakeWrappedLookupResultUsingNoneInstId) {
   auto result = ScopeLookupResult::MakeWrappedLookupResult(
-      InstId::Invalid, AccessKind::Protected);
+      InstId::None, AccessKind::Protected);
 
   EXPECT_FALSE(result.is_poisoned());
   EXPECT_FALSE(result.is_found());
@@ -44,7 +44,7 @@ TEST(ScopeLookupResult, MakeWrappedLookupResultUsingErrorInst) {
   EXPECT_EQ(result.access_kind(), AccessKind::Private);
 }
 
-TEST(ScopeLookupResult, MakeFoundValid) {
+TEST(ScopeLookupResult, MakeFoundExisting) {
   InstId inst_id(1);
   auto result = ScopeLookupResult::MakeFound(inst_id, AccessKind::Protected);
 
@@ -54,10 +54,10 @@ TEST(ScopeLookupResult, MakeFoundValid) {
   EXPECT_EQ(result.access_kind(), AccessKind::Protected);
 }
 
-TEST(ScopeLookupResult, MakeFoundInvalid) {
+TEST(ScopeLookupResult, MakeFoundNone) {
   EXPECT_DEATH(
-      ScopeLookupResult::MakeFound(InstId::Invalid, AccessKind::Protected),
-      "is_valid");
+      ScopeLookupResult::MakeFound(InstId::None, AccessKind::Protected),
+      "has_value");
 }
 
 TEST(ScopeLookupResult, MakeNotFound) {

--- a/toolchain/sem_ir/name_scope_test.cpp
+++ b/toolchain/sem_ir/name_scope_test.cpp
@@ -11,17 +11,80 @@ namespace Carbon::SemIR {
 namespace {
 
 using ::testing::ElementsAre;
-using ::testing::Field;
 using ::testing::Pair;
 
-// NOLINTNEXTLINE(modernize-use-trailing-return-type): From the macro.
-MATCHER_P(NameScopeEntryEquals, entry, "") {
-  return ExplainMatchResult(
-      AllOf(Field("name_id", &NameScope::Entry::name_id, entry.name_id),
-            Field("inst_id", &NameScope::Entry::inst_id, entry.inst_id),
-            Field("access_kind", &NameScope::Entry::access_kind,
-                  entry.access_kind)),
-      arg, result_listener);
+TEST(ScopeLookupResult, MakeWrappedLookupResultUsingValidInstId) {
+  InstId inst_id(1);
+  auto result = ScopeLookupResult::MakeWrappedLookupResult(
+      inst_id, AccessKind::Protected);
+
+  EXPECT_FALSE(result.is_poisoned());
+  EXPECT_TRUE(result.is_found());
+  EXPECT_EQ(result.target_inst_id(), inst_id);
+  EXPECT_EQ(result.access_kind(), AccessKind::Protected);
+}
+
+TEST(ScopeLookupResult, MakeWrappedLookupResultUsingInvalidInstId) {
+  auto result = ScopeLookupResult::MakeWrappedLookupResult(
+      InstId::Invalid, AccessKind::Protected);
+
+  EXPECT_FALSE(result.is_poisoned());
+  EXPECT_FALSE(result.is_found());
+  EXPECT_DEATH(result.target_inst_id(), "is_found");
+  EXPECT_EQ(result.access_kind(), AccessKind::Protected);
+}
+
+TEST(ScopeLookupResult, MakeWrappedLookupResultUsingErrorInst) {
+  auto result = ScopeLookupResult::MakeWrappedLookupResult(
+      ErrorInst::SingletonInstId, AccessKind::Private);
+
+  EXPECT_FALSE(result.is_poisoned());
+  EXPECT_TRUE(result.is_found());
+  EXPECT_EQ(result.target_inst_id(), ErrorInst::SingletonInstId);
+  EXPECT_EQ(result.access_kind(), AccessKind::Private);
+}
+
+TEST(ScopeLookupResult, MakeFoundValid) {
+  InstId inst_id(1);
+  auto result = ScopeLookupResult::MakeFound(inst_id, AccessKind::Protected);
+
+  EXPECT_FALSE(result.is_poisoned());
+  EXPECT_TRUE(result.is_found());
+  EXPECT_EQ(result.target_inst_id(), inst_id);
+  EXPECT_EQ(result.access_kind(), AccessKind::Protected);
+}
+
+TEST(ScopeLookupResult, MakeFoundInvalid) {
+  EXPECT_DEATH(
+      ScopeLookupResult::MakeFound(InstId::Invalid, AccessKind::Protected),
+      "is_valid");
+}
+
+TEST(ScopeLookupResult, MakeNotFound) {
+  auto result = ScopeLookupResult::MakeNotFound();
+
+  EXPECT_FALSE(result.is_poisoned());
+  EXPECT_FALSE(result.is_found());
+  EXPECT_DEATH(result.target_inst_id(), "is_found");
+  EXPECT_EQ(result.access_kind(), AccessKind::Public);
+}
+
+TEST(ScopeLookupResult, MakePoisoned) {
+  auto result = ScopeLookupResult::MakePoisoned();
+
+  EXPECT_TRUE(result.is_poisoned());
+  EXPECT_FALSE(result.is_found());
+  EXPECT_DEATH(result.target_inst_id(), "is_found");
+  EXPECT_EQ(result.access_kind(), AccessKind::Public);
+}
+
+TEST(ScopeLookupResult, MakeError) {
+  auto result = ScopeLookupResult::MakeError();
+
+  EXPECT_FALSE(result.is_poisoned());
+  EXPECT_TRUE(result.is_found());
+  EXPECT_EQ(result.target_inst_id(), ErrorInst::SingletonInstId);
+  EXPECT_EQ(result.access_kind(), AccessKind::Public);
 }
 
 TEST(NameScope, Empty) {
@@ -51,35 +114,34 @@ TEST(NameScope, Lookup) {
   NameScopeId parent_scope_id(++id);
   NameScope name_scope(scope_inst_id, scope_name_id, parent_scope_id);
 
-  NameScope::Entry entry1 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Public};
+  NameScope::Entry entry1 = {
+      .name_id = NameId(++id),
+      .result = ScopeLookupResult::MakeFound(InstId(++id), AccessKind::Public)};
   name_scope.AddRequired(entry1);
 
   NameScope::Entry entry2 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Protected};
+                             .result = ScopeLookupResult::MakeFound(
+                                 InstId(++id), AccessKind::Protected)};
   name_scope.AddRequired(entry2);
 
   NameScope::Entry entry3 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Private};
+                             .result = ScopeLookupResult::MakeFound(
+                                 InstId(++id), AccessKind::Private)};
   name_scope.AddRequired(entry3);
 
   auto lookup = name_scope.Lookup(entry1.name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(static_cast<NameScope&>(name_scope).GetEntry(*lookup),
-              NameScopeEntryEquals(entry1));
-  EXPECT_THAT(static_cast<const NameScope&>(name_scope).GetEntry(*lookup),
-              NameScopeEntryEquals(entry1));
+  EXPECT_EQ(static_cast<NameScope&>(name_scope).GetEntry(*lookup), entry1);
+  EXPECT_EQ(static_cast<const NameScope&>(name_scope).GetEntry(*lookup),
+            entry1);
 
   lookup = name_scope.Lookup(entry2.name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(name_scope.GetEntry(*lookup), NameScopeEntryEquals(entry2));
+  EXPECT_EQ(name_scope.GetEntry(*lookup), entry2);
 
   lookup = name_scope.Lookup(entry3.name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(name_scope.GetEntry(*lookup), NameScopeEntryEquals(entry3));
+  EXPECT_EQ(name_scope.GetEntry(*lookup), entry3);
 
   NameId unknown_name_id(++id);
   lookup = name_scope.Lookup(unknown_name_id);
@@ -94,35 +156,34 @@ TEST(NameScope, LookupOrPoison) {
   NameScopeId parent_scope_id(++id);
   NameScope name_scope(scope_inst_id, scope_name_id, parent_scope_id);
 
-  NameScope::Entry entry1 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Public};
+  NameScope::Entry entry1 = {
+      .name_id = NameId(++id),
+      .result = ScopeLookupResult::MakeFound(InstId(++id), AccessKind::Public)};
   name_scope.AddRequired(entry1);
 
   NameScope::Entry entry2 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Protected};
+                             .result = ScopeLookupResult::MakeFound(
+                                 InstId(++id), AccessKind::Protected)};
   name_scope.AddRequired(entry2);
 
   NameScope::Entry entry3 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Private};
+                             .result = ScopeLookupResult::MakeFound(
+                                 InstId(++id), AccessKind::Private)};
   name_scope.AddRequired(entry3);
 
   auto lookup = name_scope.LookupOrPoison(entry1.name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(static_cast<NameScope&>(name_scope).GetEntry(*lookup),
-              NameScopeEntryEquals(entry1));
-  EXPECT_THAT(static_cast<const NameScope&>(name_scope).GetEntry(*lookup),
-              NameScopeEntryEquals(entry1));
+  EXPECT_EQ(static_cast<NameScope&>(name_scope).GetEntry(*lookup), entry1);
+  EXPECT_EQ(static_cast<const NameScope&>(name_scope).GetEntry(*lookup),
+            entry1);
 
   lookup = name_scope.LookupOrPoison(entry2.name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(name_scope.GetEntry(*lookup), NameScopeEntryEquals(entry2));
+  EXPECT_EQ(name_scope.GetEntry(*lookup), entry2);
 
   lookup = name_scope.LookupOrPoison(entry3.name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(name_scope.GetEntry(*lookup), NameScopeEntryEquals(entry3));
+  EXPECT_EQ(name_scope.GetEntry(*lookup), entry3);
 
   NameId unknown_name_id(++id);
   lookup = name_scope.LookupOrPoison(unknown_name_id);
@@ -137,55 +198,61 @@ TEST(NameScope, LookupOrAdd) {
   NameScopeId parent_scope_id(++id);
   NameScope name_scope(scope_inst_id, scope_name_id, parent_scope_id);
 
-  NameScope::Entry entry1 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Public};
+  NameScope::Entry entry1 = {
+      .name_id = NameId(++id),
+      .result = ScopeLookupResult::MakeFound(InstId(++id), AccessKind::Public)};
   {
-    auto [added, entry_id] = name_scope.LookupOrAdd(
-        entry1.name_id, entry1.inst_id, entry1.access_kind);
+    auto [added, entry_id] =
+        name_scope.LookupOrAdd(entry1.name_id, entry1.result.target_inst_id(),
+                               entry1.result.access_kind());
     EXPECT_TRUE(added);
-    EXPECT_THAT(name_scope.GetEntry(entry_id), NameScopeEntryEquals(entry1));
+    EXPECT_EQ(name_scope.GetEntry(entry_id), entry1);
   }
 
   NameScope::Entry entry2 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Protected};
+                             .result = ScopeLookupResult::MakeFound(
+                                 InstId(++id), AccessKind::Protected)};
   {
-    auto [added, entry_id] = name_scope.LookupOrAdd(
-        entry2.name_id, entry2.inst_id, entry2.access_kind);
+    auto [added, entry_id] =
+        name_scope.LookupOrAdd(entry2.name_id, entry2.result.target_inst_id(),
+                               entry2.result.access_kind());
     EXPECT_TRUE(added);
-    EXPECT_THAT(name_scope.GetEntry(entry_id), NameScopeEntryEquals(entry2));
+    EXPECT_EQ(name_scope.GetEntry(entry_id), entry2);
   }
 
   NameScope::Entry entry3 = {.name_id = NameId(++id),
-                             .inst_id = InstId(++id),
-                             .access_kind = AccessKind::Private};
+                             .result = ScopeLookupResult::MakeFound(
+                                 InstId(++id), AccessKind::Private)};
   {
-    auto [added, entry_id] = name_scope.LookupOrAdd(
-        entry3.name_id, entry3.inst_id, entry3.access_kind);
+    auto [added, entry_id] =
+        name_scope.LookupOrAdd(entry3.name_id, entry3.result.target_inst_id(),
+                               entry3.result.access_kind());
     EXPECT_TRUE(added);
-    EXPECT_THAT(name_scope.GetEntry(entry_id), NameScopeEntryEquals(entry3));
+    EXPECT_EQ(name_scope.GetEntry(entry_id), entry3);
   }
 
   {
-    auto [added, entry_id] = name_scope.LookupOrAdd(
-        entry1.name_id, entry1.inst_id, entry1.access_kind);
+    auto [added, entry_id] =
+        name_scope.LookupOrAdd(entry1.name_id, entry1.result.target_inst_id(),
+                               entry1.result.access_kind());
     EXPECT_FALSE(added);
-    EXPECT_THAT(name_scope.GetEntry(entry_id), NameScopeEntryEquals(entry1));
+    EXPECT_EQ(name_scope.GetEntry(entry_id), entry1);
   }
 
   {
-    auto [added, entry_id] = name_scope.LookupOrAdd(
-        entry2.name_id, entry2.inst_id, entry2.access_kind);
+    auto [added, entry_id] =
+        name_scope.LookupOrAdd(entry2.name_id, entry2.result.target_inst_id(),
+                               entry2.result.access_kind());
     EXPECT_FALSE(added);
-    EXPECT_THAT(name_scope.GetEntry(entry_id), NameScopeEntryEquals(entry2));
+    EXPECT_EQ(name_scope.GetEntry(entry_id), entry2);
   }
 
   {
-    auto [added, entry_id] = name_scope.LookupOrAdd(
-        entry3.name_id, entry3.inst_id, entry3.access_kind);
+    auto [added, entry_id] =
+        name_scope.LookupOrAdd(entry3.name_id, entry3.result.target_inst_id(),
+                               entry3.result.access_kind());
     EXPECT_FALSE(added);
-    EXPECT_THAT(name_scope.GetEntry(entry_id), NameScopeEntryEquals(entry3));
+    EXPECT_EQ(name_scope.GetEntry(entry_id), entry3);
   }
 }
 
@@ -199,35 +266,26 @@ TEST(NameScope, Poison) {
 
   NameId poison1(++id);
   EXPECT_EQ(name_scope.LookupOrPoison(poison1), std::nullopt);
-  EXPECT_THAT(name_scope.entries(),
-              ElementsAre(NameScopeEntryEquals(
-                  NameScope::Entry({.name_id = poison1,
-                                    .inst_id = InstId::None,
-                                    .access_kind = AccessKind::Public,
-                                    .is_poisoned = true}))));
+  EXPECT_THAT(
+      name_scope.entries(),
+      ElementsAre(NameScope::Entry(
+          {.name_id = poison1, .result = ScopeLookupResult::MakePoisoned()})));
 
   NameId poison2(++id);
   EXPECT_EQ(name_scope.LookupOrPoison(poison2), std::nullopt);
-  EXPECT_THAT(name_scope.entries(),
-              ElementsAre(NameScopeEntryEquals(NameScope::Entry(
-                              {.name_id = poison1,
-                               .inst_id = InstId::None,
-                               .access_kind = AccessKind::Public,
-                               .is_poisoned = true})),
-                          NameScopeEntryEquals(NameScope::Entry(
-                              {.name_id = poison2,
-                               .inst_id = InstId::None,
-                               .access_kind = AccessKind::Public,
-                               .is_poisoned = true}))));
+  EXPECT_THAT(
+      name_scope.entries(),
+      ElementsAre(
+          NameScope::Entry({.name_id = poison1,
+                            .result = ScopeLookupResult::MakePoisoned()}),
+          NameScope::Entry({.name_id = poison2,
+                            .result = ScopeLookupResult::MakePoisoned()})));
 
   auto lookup = name_scope.Lookup(poison1);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(
-      name_scope.GetEntry(*lookup),
-      NameScopeEntryEquals(NameScope::Entry({.name_id = poison1,
-                                             .inst_id = InstId::None,
-                                             .access_kind = AccessKind::Public,
-                                             .is_poisoned = true})));
+  EXPECT_THAT(name_scope.GetEntry(*lookup),
+              NameScope::Entry({.name_id = poison1,
+                                .result = ScopeLookupResult::MakePoisoned()}));
 }
 
 TEST(NameScope, AddRequiredAfterPoison) {
@@ -242,26 +300,22 @@ TEST(NameScope, AddRequiredAfterPoison) {
   InstId inst_id(++id);
 
   EXPECT_EQ(name_scope.LookupOrPoison(name_id), std::nullopt);
-  EXPECT_THAT(name_scope.entries(),
-              ElementsAre(NameScopeEntryEquals(
-                  NameScope::Entry({.name_id = name_id,
-                                    .inst_id = InstId::None,
-                                    .access_kind = AccessKind::Public,
-                                    .is_poisoned = true}))));
+  EXPECT_THAT(
+      name_scope.entries(),
+      ElementsAre(NameScope::Entry(
+          {.name_id = name_id, .result = ScopeLookupResult::MakePoisoned()})));
 
-  NameScope::Entry entry = {.name_id = name_id,
-                            .inst_id = inst_id,
-                            .access_kind = AccessKind::Private};
+  NameScope::Entry entry = {
+      .name_id = name_id,
+      .result = ScopeLookupResult::MakeFound(inst_id, AccessKind::Private)};
   name_scope.AddRequired(entry);
 
   auto lookup = name_scope.LookupOrPoison(name_id);
   ASSERT_NE(lookup, std::nullopt);
-  EXPECT_THAT(
-      name_scope.GetEntry(*lookup),
-      NameScopeEntryEquals(NameScope::Entry({.name_id = name_id,
-                                             .inst_id = inst_id,
-                                             .access_kind = AccessKind::Private,
-                                             .is_poisoned = false})));
+  EXPECT_EQ(name_scope.GetEntry(*lookup),
+            NameScope::Entry({.name_id = name_id,
+                              .result = ScopeLookupResult::MakeFound(
+                                  inst_id, AccessKind::Private)}));
 }
 
 TEST(NameScope, ExtendedScopes) {


### PR DESCRIPTION
Benefits:
* Provide a proper API for accessing lookup information.
* Make assumptions on whether the result is poisoned or not and how we can use `InstId` explicit.
* Allow safely reusing the `InstId` value for pointing to the poisoning entity for poisoned results (in a future PR).
* Consolidate `LookupNameInExactScopeResult`, `std::pair<SemIR::InstId, bool>` and part of `LookupResult`.
Part of #4622.