### PR TITLE
Sink comment into implementation

### DIFF
--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -14,6 +14,12 @@ auto CheckFunctionTypeMatches(Context& context,
                               const SemIR::Function& prev_function,
                               SemIR::SpecificId prev_specific_id,
                               bool check_syntax) -> bool {
+  // TODO: When check_syntax is false, the functions should be allowed to have
+  // different signatures as long as we can synthesize a suitable thunk. i.e.,
+  // when there's an implicit conversion from the original parameter types to
+  // the overriding parameter types, and from the overriding return type to the
+  // original return type.
+  // Also, build that thunk.
   if (!CheckRedeclParamsMatch(context, DeclParams(new_function),
                               DeclParams(prev_function), prev_specific_id,
                               check_syntax)) {

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -129,11 +129,6 @@ static auto CheckAssociatedFunctionImplementation(
               .generic_id,
           self_type_id, witness_inst_id);
 
-  // TODO: The functions should be allowed to have different signatures as long
-  // as we can synthesize a suitable thunk. i.e., when there's an implicit
-  // conversion from the original parameter types to the overriding parameter
-  // types, and from the overriding return type to the original return type.
-  // Also, build that thunk.
   if (!CheckFunctionTypeMatches(
           context, context.functions().Get(impl_function_decl->function_id),
           context.functions().Get(interface_function_type.function_id),


### PR DESCRIPTION
This comment applies equally to any called passing `check_syntax=false`,
such as for virtual function impls, being tested in #4816
