### PR TITLE
Id::Invalid -> Id::None

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -53,7 +53,7 @@ struct IdBase : public AnyIdBase, public Printable<IdT> {
     if (is_valid()) {
       out << index;
     } else {
-      out << "<invalid>";
+      out << "<none>";
     }
   }
 

--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -20,12 +20,12 @@ class DataIterator;
 
 // Non-templated portions of `IdBase`.
 struct AnyIdBase {
-  static constexpr int32_t InvalidIndex = -1;
+  static constexpr int32_t NoneIndex = -1;
 
   AnyIdBase() = delete;
   constexpr explicit AnyIdBase(int index) : index(index) {}
 
-  constexpr auto is_valid() const -> bool { return index != InvalidIndex; }
+  constexpr auto has_value() const -> bool { return index != NoneIndex; }
 
   int32_t index;
 };
@@ -50,7 +50,7 @@ struct IdBase : public AnyIdBase, public Printable<IdT> {
 
   auto Print(llvm::raw_ostream& out) const -> void {
     out << IdT::Label;
-    if (is_valid()) {
+    if (has_value()) {
       out << index;
     } else {
       out << "<none>";

--- a/toolchain/base/int.cpp
+++ b/toolchain/base/int.cpp
@@ -30,28 +30,28 @@ auto IntStore::CanonicalizeUnsigned(llvm::APInt value) -> llvm::APInt {
 auto IntStore::AddLarge(int64_t value) -> IntId {
   auto ap_id =
       values_.Add(llvm::APInt(CanonicalBitWidth(64), value, /*isSigned=*/true));
-  return MakeIndexOrInvalid(ap_id.index);
+  return MakeIndexOrNone(ap_id.index);
 }
 
 auto IntStore::AddSignedLarge(llvm::APInt value) -> IntId {
   auto ap_id = values_.Add(CanonicalizeSigned(value));
-  return MakeIndexOrInvalid(ap_id.index);
+  return MakeIndexOrNone(ap_id.index);
 }
 
 auto IntStore::AddUnsignedLarge(llvm::APInt value) -> IntId {
   auto ap_id = values_.Add(CanonicalizeUnsigned(value));
-  return MakeIndexOrInvalid(ap_id.index);
+  return MakeIndexOrNone(ap_id.index);
 }
 
 auto IntStore::LookupLarge(int64_t value) const -> IntId {
   auto ap_id = values_.Lookup(
       llvm::APInt(CanonicalBitWidth(64), value, /*isSigned=*/true));
-  return MakeIndexOrInvalid(ap_id.index);
+  return MakeIndexOrNone(ap_id.index);
 }
 
 auto IntStore::LookupSignedLarge(llvm::APInt value) const -> IntId {
   auto ap_id = values_.Lookup(CanonicalizeSigned(value));
-  return MakeIndexOrInvalid(ap_id.index);
+  return MakeIndexOrNone(ap_id.index);
 }
 
 auto IntStore::OutputYaml() const -> Yaml::OutputMapping {

--- a/toolchain/base/int.h
+++ b/toolchain/base/int.h
@@ -47,9 +47,9 @@ struct IntStoreTestPeer;
 // to the 32-bit signed integer minimum, supporting approximately 1.998 billion
 // unique larger integers.
 //
-// Note that the invalid ID can't be used with a token. This is OK as we
-// expect invalid tokens to be *error* tokens and not need to represent an
-// invalid integer.
+// Note the `None` ID can't be used with a token. This is OK as we expect
+// invalid tokens to be *error* tokens and not need to represent an invalid
+// integer.
 class IntId : public Printable<IntId> {
  public:
   static constexpr llvm::StringLiteral Label = "int";
@@ -79,33 +79,34 @@ class IntId : public Printable<IntId> {
     return IntId(raw_id);
   }
 
-  // Tests whether the ID is a value ID.
+  // Tests whether the ID is an embedded value ID.
   //
-  // Only *valid* IDs can have an embedded value, so when true this also implies
-  // the ID is valid.
-  constexpr auto is_value() const -> bool { return id_ > ZeroIndexId; }
+  // Note `None` is not an embedded value, so this implies `has_value()` is
+  // true.
+  constexpr auto is_embedded_value() const -> bool { return id_ > ZeroIndexId; }
 
   // Tests whether the ID is an index ID.
   //
-  // Note that an invalid ID is represented as an index ID, so this is *not*
-  // sufficient to test whether an ID is valid.
+  // Note `None` is represented as an index ID, so this is *not* sufficient to
+  // test `has_value()`.
   constexpr auto is_index() const -> bool { return id_ <= ZeroIndexId; }
 
-  // Test whether an ID is valid.
+  // Test whether a value is present.
   //
-  // This does not distinguish between value and index IDs, only whether valid.
-  constexpr auto is_valid() const -> bool { return id_ != InvalidId; }
+  // This does not distinguish between embedded values and index IDs, only
+  // whether some value is present.
+  constexpr auto has_value() const -> bool { return id_ != NoneId; }
 
-  // Converts an ID to the embedded value. Requires that `is_value()` is true.
+  // Converts an ID to the embedded value. Requires that `is_embedded_value()`
+  // is true.
   constexpr auto AsValue() const -> int {
-    CARBON_DCHECK(is_value());
+    CARBON_DCHECK(is_embedded_value());
     return id_;
   }
 
   // Converts an ID to an index. Requires that `is_index()` is true.
   //
-  // Note that this does *not* require that the ID is valid. An invalid ID will
-  // turn into an invalid index.
+  // Note `None` is represented as an index ID, and can be converted here.
   constexpr auto AsIndex() const -> int {
     CARBON_DCHECK(is_index());
     return ZeroIndexId - id_;
@@ -123,12 +124,12 @@ class IntId : public Printable<IntId> {
 
   auto Print(llvm::raw_ostream& out) const -> void {
     out << Label << "(";
-    if (is_value()) {
+    if (is_embedded_value()) {
       out << "value: " << AsValue();
     } else if (is_index()) {
       out << "index: " << AsIndex();
     } else {
-      CARBON_CHECK(!is_valid());
+      CARBON_CHECK(!has_value());
       out << "<none>";
     }
     out << ")";
@@ -173,17 +174,17 @@ class IntId : public Printable<IntId> {
   // The minimum embedded value in an ID.
   static constexpr int32_t MinValue = ZeroIndexId + 1;
 
-  // The invalid ID, which needs to be placed after the largest index, which
+  // The `None` ID, which needs to be placed after the largest index, which
   // count downwards as IDs so below the smallest index ID, in order to optimize
   // the code sequence needed to distinguish between integer and value IDs and
   // to convert index IDs into actual indices small.
-  static constexpr int32_t InvalidId = std::numeric_limits<int32_t>::min();
+  static constexpr int32_t NoneId = std::numeric_limits<int32_t>::min();
 
-  // The invalid index. This is the result of converting an invalid ID into an
+  // The `None` index. This is the result of converting a `None` ID into an
   // index. We ensure that conversion can be done so that we can simplify the
   // code that first tries to use an embedded value, then converts to an index
-  // and checks that the index is valid.
-  static const int32_t InvalidIndex;
+  // and checks that the index is still `None`.
+  static const int32_t NoneIndex;
 
   // Document the specific values of some of these constants to help visualize
   // how the bit patterns map from the above computations.
@@ -197,7 +198,7 @@ class IntId : public Printable<IntId> {
   static_assert(MaxValue    == 0b0000'0000'0011'1111'1111'1111'1111'1111);
   static_assert(ZeroIndexId == 0b1111'1111'1110'0000'0000'0000'0000'0000);
   static_assert(MinValue    == 0b1111'1111'1110'0000'0000'0000'0000'0001);
-  static_assert(InvalidId   == 0b1000'0000'0000'0000'0000'0000'0000'0000);
+  static_assert(NoneId      == 0b1000'0000'0000'0000'0000'0000'0000'0000);
   // clang-format on
 
   constexpr explicit IntId(int32_t id) : id_(id) {}
@@ -205,12 +206,12 @@ class IntId : public Printable<IntId> {
   int32_t id_;
 };
 
-constexpr IntId IntId::None(IntId::InvalidId);
+constexpr IntId IntId::None(IntId::NoneId);
 
-// Note that we initialize the invalid index in a constexpr context which
+// Note that we initialize the `None` index in a constexpr context which
 // ensures there is no UB in forming it. This helps ensure all the ID -> index
-// conversions are correct because the invalid ID is at the limit of that range.
-constexpr int32_t IntId::NoneIndex = Invalid.AsIndex();
+// conversions are correct because the `None` ID is at the limit of that range.
+constexpr int32_t IntId::NoneIndex = None.AsIndex();
 
 // A canonicalizing value store with deep optimizations for integers.
 //
@@ -246,7 +247,7 @@ class IntStore {
   // necessary to represent it.
   auto Add(int64_t value) -> IntId {
     // First try directly making this into an ID.
-    if (IntId id = TryMakeValue(value); id.is_valid()) [[likely]] {
+    if (IntId id = TryMakeValue(value); id.has_value()) [[likely]] {
       return id;
     }
 
@@ -258,7 +259,7 @@ class IntStore {
   // `APInt` if necessary to represent it.
   auto AddSigned(llvm::APInt value) -> IntId {
     // First try directly making this into an ID.
-    if (IntId id = TryMakeSignedValue(value); id.is_valid()) [[likely]] {
+    if (IntId id = TryMakeSignedValue(value); id.has_value()) [[likely]] {
       return id;
     }
 
@@ -271,7 +272,7 @@ class IntStore {
   // represent it.
   auto AddUnsigned(llvm::APInt value) -> IntId {
     // First try directly making this into an ID.
-    if (IntId id = TryMakeUnsignedValue(value); id.is_valid()) [[likely]] {
+    if (IntId id = TryMakeUnsignedValue(value); id.has_value()) [[likely]] {
       return id;
     }
 
@@ -284,7 +285,7 @@ class IntStore {
   // This will always be a signed `APInt` with a canonical bit width for the
   // specific integer value in question.
   auto Get(IntId id) const -> llvm::APInt {
-    if (id.is_value()) [[likely]] {
+    if (id.is_embedded_value()) [[likely]] {
       return llvm::APInt(MinAPWidth, id.AsValue(), /*isSigned=*/true);
     }
     return values_.Get(APIntId(id.AsIndex()));
@@ -319,9 +320,9 @@ class IntStore {
 
   // Accepts a signed `int64_t` and uses the mathematical signed integer value
   // of it as the integer value to lookup. Returns the canonical ID for that
-  // value or returns invalid if not in the store.
+  // value or returns `None` if not in the store.
   auto Lookup(int64_t value) const -> IntId {
-    if (IntId id = TryMakeValue(value); id.is_valid()) [[likely]] {
+    if (IntId id = TryMakeValue(value); id.has_value()) [[likely]] {
       return id;
     }
 
@@ -329,10 +330,10 @@ class IntStore {
     return LookupLarge(value);
   }
 
-  // Looks up the canonical ID for this signed integer value, or returns invalid
+  // Looks up the canonical ID for this signed integer value, or returns `None`
   // if not in the store.
   auto LookupSigned(llvm::APInt value) const -> IntId {
-    if (IntId id = TryMakeSignedValue(value); id.is_valid()) [[likely]] {
+    if (IntId id = TryMakeSignedValue(value); id.has_value()) [[likely]] {
       return id;
     }
 
@@ -367,13 +368,13 @@ class IntStore {
 
   static constexpr int MinAPWidth = 64;
 
-  static auto MakeIndexOrInvalid(int index) -> IntId {
+  static auto MakeIndexOrNone(int index) -> IntId {
     CARBON_DCHECK(index >= 0 && index <= IntId::NoneIndex);
     return IntId(IntId::ZeroIndexId - index);
   }
 
   // Tries to make a signed 64-bit integer into an embedded value in the ID, and
-  // if unable to do that returns the `Invalid` ID.
+  // if unable to do that returns the `None` ID.
   static auto TryMakeValue(int64_t value) -> IntId {
     if (IntId::MinValue <= value && value <= IntId::MaxValue) {
       return IntId(value);
@@ -383,7 +384,7 @@ class IntStore {
   }
 
   // Tries to make a signed APInt into an embedded value in the ID, and if
-  // unable to do that returns the `Invalid` ID.
+  // unable to do that returns the `None` ID.
   static auto TryMakeSignedValue(llvm::APInt value) -> IntId {
     if (value.sge(IntId::MinValue) && value.sle(IntId::MaxValue)) {
       return IntId(value.getSExtValue());
@@ -393,7 +394,7 @@ class IntStore {
   }
 
   // Tries to make an unsigned APInt into an embedded value in the ID, and if
-  // unable to do that returns the `Invalid` ID.
+  // unable to do that returns the `None` ID.
   static auto TryMakeUnsignedValue(llvm::APInt value) -> IntId {
     if (value.ule(IntId::MaxValue)) {
       return IntId(value.getZExtValue());

--- a/toolchain/base/int.h
+++ b/toolchain/base/int.h
@@ -65,7 +65,7 @@ class IntId : public Printable<IntId> {
   // tokens or computed after lexing outside of this range.
   static constexpr int TokenIdBits = 23;
 
-  static const IntId Invalid;
+  static const IntId None;
 
   static auto MakeFromTokenPayload(uint32_t payload) -> IntId {
     // Token-associated IDs are signed `TokenIdBits` integers, so force sign
@@ -129,7 +129,7 @@ class IntId : public Printable<IntId> {
       out << "index: " << AsIndex();
     } else {
       CARBON_CHECK(!is_valid());
-      out << "<invalid>";
+      out << "<none>";
     }
     out << ")";
   }
@@ -205,12 +205,12 @@ class IntId : public Printable<IntId> {
   int32_t id_;
 };
 
-constexpr IntId IntId::Invalid(IntId::InvalidId);
+constexpr IntId IntId::None(IntId::InvalidId);
 
 // Note that we initialize the invalid index in a constexpr context which
 // ensures there is no UB in forming it. This helps ensure all the ID -> index
 // conversions are correct because the invalid ID is at the limit of that range.
-constexpr int32_t IntId::InvalidIndex = Invalid.AsIndex();
+constexpr int32_t IntId::NoneIndex = Invalid.AsIndex();
 
 // A canonicalizing value store with deep optimizations for integers.
 //
@@ -361,14 +361,14 @@ class IntStore {
   struct APIntId : IdBase<APIntId> {
     static constexpr llvm::StringLiteral Label = "ap_int";
     using ValueType = llvm::APInt;
-    static const APIntId Invalid;
+    static const APIntId None;
     using IdBase::IdBase;
   };
 
   static constexpr int MinAPWidth = 64;
 
   static auto MakeIndexOrInvalid(int index) -> IntId {
-    CARBON_DCHECK(index >= 0 && index <= IntId::InvalidIndex);
+    CARBON_DCHECK(index >= 0 && index <= IntId::NoneIndex);
     return IntId(IntId::ZeroIndexId - index);
   }
 
@@ -379,7 +379,7 @@ class IntStore {
       return IntId(value);
     }
 
-    return IntId::Invalid;
+    return IntId::None;
   }
 
   // Tries to make a signed APInt into an embedded value in the ID, and if
@@ -389,7 +389,7 @@ class IntStore {
       return IntId(value.getSExtValue());
     }
 
-    return IntId::Invalid;
+    return IntId::None;
   }
 
   // Tries to make an unsigned APInt into an embedded value in the ID, and if
@@ -399,7 +399,7 @@ class IntStore {
       return IntId(value.getZExtValue());
     }
 
-    return IntId::Invalid;
+    return IntId::None;
   }
 
   // Canonicalize an incoming signed APInt to the correct bit width.
@@ -423,8 +423,7 @@ class IntStore {
   CanonicalValueStore<APIntId> values_;
 };
 
-constexpr IntStore::APIntId IntStore::APIntId::Invalid(
-    IntId::Invalid.AsIndex());
+constexpr IntStore::APIntId IntStore::APIntId::None(IntId::None.AsIndex());
 
 }  // namespace Carbon
 

--- a/toolchain/base/int_test.cpp
+++ b/toolchain/base/int_test.cpp
@@ -43,7 +43,7 @@ TEST(IntStore, Basic) {
 
   for (IntId id :
        {id_0, id_1, id_2, id_42, id_n1, id_n42, id_nines, id_max64, id_min64}) {
-    ASSERT_TRUE(id.is_valid());
+    ASSERT_TRUE(id.has_value());
   }
 
   // Small values should be embedded.
@@ -55,11 +55,11 @@ TEST(IntStore, Basic) {
   EXPECT_THAT(id_n42.AsValue(), Eq(-42));
 
   // Rest should be indices as they don't fit as embedded values.
-  EXPECT_TRUE(!id_nines.is_value());
+  EXPECT_TRUE(!id_nines.is_embedded_value());
   EXPECT_TRUE(id_nines.is_index());
-  EXPECT_TRUE(!id_max64.is_value());
+  EXPECT_TRUE(!id_max64.is_embedded_value());
   EXPECT_TRUE(id_max64.is_index());
-  EXPECT_TRUE(!id_min64.is_value());
+  EXPECT_TRUE(!id_min64.is_embedded_value());
   EXPECT_TRUE(id_min64.is_index());
 
   // And round tripping all the way through the store should work.
@@ -107,7 +107,7 @@ TEST(IntStore, APSigned) {
   };
   for (auto& [ap, id] : ap_and_ids) {
     id = ints.AddSigned(ap);
-    ASSERT_TRUE(id.is_valid()) << ap;
+    ASSERT_TRUE(id.has_value()) << ap;
   }
 
   for (const auto& [ap, id] : ap_and_ids) {
@@ -139,7 +139,7 @@ TEST(IntStore, APUnsigned) {
   };
   for (auto& [ap, id] : ap_and_ids) {
     id = ints.AddUnsigned(ap);
-    ASSERT_TRUE(id.is_valid()) << ap;
+    ASSERT_TRUE(id.has_value()) << ap;
   }
 
   for (const auto& [ap, id] : ap_and_ids) {

--- a/toolchain/base/int_test.cpp
+++ b/toolchain/base/int_test.cpp
@@ -77,7 +77,7 @@ TEST(IntStore, Basic) {
 // Helper struct to hold test values and the resulting IDs.
 struct APAndId {
   llvm::APInt ap;
-  IntId id = IntId::Invalid;
+  IntId id = IntId::None;
 };
 
 TEST(IntStore, APSigned) {

--- a/toolchain/base/value_ids.h
+++ b/toolchain/base/value_ids.h
@@ -61,7 +61,7 @@ constexpr RealId RealId::None(RealId::NoneIndex);
 
 // Corresponds to StringRefs for identifiers.
 //
-// `NameId` relies on the values of this type other than `Invalid` all being
+// `NameId` relies on the values of this type other than `None` all being
 // non-negative.
 struct IdentifierId : public IdBase<IdentifierId> {
   static constexpr llvm::StringLiteral Label = "identifier";

--- a/toolchain/base/value_ids.h
+++ b/toolchain/base/value_ids.h
@@ -45,19 +45,19 @@ struct Real : public Printable<Real> {
 struct FloatId : public IdBase<FloatId> {
   static constexpr llvm::StringLiteral Label = "float";
   using ValueType = llvm::APFloat;
-  static const FloatId Invalid;
+  static const FloatId None;
   using IdBase::IdBase;
 };
-constexpr FloatId FloatId::Invalid(FloatId::InvalidIndex);
+constexpr FloatId FloatId::None(FloatId::NoneIndex);
 
 // Corresponds to a Real value.
 struct RealId : public IdBase<RealId> {
   static constexpr llvm::StringLiteral Label = "real";
   using ValueType = Real;
-  static const RealId Invalid;
+  static const RealId None;
   using IdBase::IdBase;
 };
-constexpr RealId RealId::Invalid(RealId::InvalidIndex);
+constexpr RealId RealId::None(RealId::NoneIndex);
 
 // Corresponds to StringRefs for identifiers.
 //
@@ -66,20 +66,20 @@ constexpr RealId RealId::Invalid(RealId::InvalidIndex);
 struct IdentifierId : public IdBase<IdentifierId> {
   static constexpr llvm::StringLiteral Label = "identifier";
   using ValueType = llvm::StringRef;
-  static const IdentifierId Invalid;
+  static const IdentifierId None;
   using IdBase::IdBase;
 };
-constexpr IdentifierId IdentifierId::Invalid(IdentifierId::InvalidIndex);
+constexpr IdentifierId IdentifierId::None(IdentifierId::NoneIndex);
 
 // Corresponds to StringRefs for string literals.
 struct StringLiteralValueId : public IdBase<StringLiteralValueId> {
   static constexpr llvm::StringLiteral Label = "string";
   using ValueType = llvm::StringRef;
-  static const StringLiteralValueId Invalid;
+  static const StringLiteralValueId None;
   using IdBase::IdBase;
 };
-constexpr StringLiteralValueId StringLiteralValueId::Invalid(
-    StringLiteralValueId::InvalidIndex);
+constexpr StringLiteralValueId StringLiteralValueId::None(
+    StringLiteralValueId::NoneIndex);
 
 }  // namespace Carbon
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -123,7 +123,7 @@ class CanonicalValueStore {
   // Returns the value for an ID.
   auto Get(IdT id) const -> ConstRefType { return values_.Get(id); }
 
-  // Looks up the canonical ID for a value, or returns invalid if not in the
+  // Looks up the canonical ID for a value, or returns `None` if not in the
   // store.
   auto Lookup(ValueType value) const -> IdT;
 
@@ -183,7 +183,7 @@ auto CanonicalValueStore<IdT>::Lookup(ValueType value) const -> IdT {
   if (auto result = set_.Lookup(value, KeyContext(values_.array_ref()))) {
     return result.key();
   }
-  return IdT::Invalid;
+  return IdT::None;
 }
 
 template <typename IdT>

--- a/toolchain/base/value_store_test.cpp
+++ b/toolchain/base/value_store_test.cpp
@@ -77,7 +77,7 @@ TEST(ValueStore, Identifiers) {
   EXPECT_THAT(identifiers.Get(b_id), Eq(b));
 
   EXPECT_THAT(identifiers.Lookup(a), Eq(a_id));
-  EXPECT_THAT(identifiers.Lookup("c"), Eq(IdentifierId::Invalid));
+  EXPECT_THAT(identifiers.Lookup("c"), Eq(IdentifierId::None));
 }
 
 TEST(ValueStore, StringLiterals) {
@@ -96,7 +96,7 @@ TEST(ValueStore, StringLiterals) {
   EXPECT_THAT(string_literals.Get(b_id), Eq(b));
 
   EXPECT_THAT(string_literals.Lookup(a), Eq(a_id));
-  EXPECT_THAT(string_literals.Lookup("c"), Eq(StringLiteralValueId::Invalid));
+  EXPECT_THAT(string_literals.Lookup("c"), Eq(StringLiteralValueId::None));
 }
 
 }  // namespace

--- a/toolchain/base/value_store_test.cpp
+++ b/toolchain/base/value_store_test.cpp
@@ -27,8 +27,8 @@ TEST(ValueStore, Real) {
   RealId id1 = reals.Add(real1);
   RealId id2 = reals.Add(real2);
 
-  ASSERT_TRUE(id1.is_valid());
-  ASSERT_TRUE(id2.is_valid());
+  ASSERT_TRUE(id1.has_value());
+  ASSERT_TRUE(id2.has_value());
   EXPECT_THAT(id1, Not(Eq(id2)));
 
   const auto& real1_copy = reals.Get(id1);
@@ -50,8 +50,8 @@ TEST(ValueStore, Float) {
   FloatId id1 = floats.Add(float1);
   FloatId id2 = floats.Add(float2);
 
-  ASSERT_TRUE(id1.is_valid());
-  ASSERT_TRUE(id2.is_valid());
+  ASSERT_TRUE(id1.has_value());
+  ASSERT_TRUE(id2.has_value());
   EXPECT_THAT(id1, Not(Eq(id2)));
 
   EXPECT_THAT(floats.Get(id1).compare(float1), Eq(llvm::APFloatBase::cmpEqual));
@@ -69,8 +69,8 @@ TEST(ValueStore, Identifiers) {
   auto a_id = identifiers.Add(a);
   auto b_id = identifiers.Add(b);
 
-  ASSERT_TRUE(a_id.is_valid());
-  ASSERT_TRUE(b_id.is_valid());
+  ASSERT_TRUE(a_id.has_value());
+  ASSERT_TRUE(b_id.has_value());
   EXPECT_THAT(a_id, Not(Eq(b_id)));
 
   EXPECT_THAT(identifiers.Get(a_id), Eq(a));
@@ -88,8 +88,8 @@ TEST(ValueStore, StringLiterals) {
   auto a_id = string_literals.Add(a);
   auto b_id = string_literals.Add(b);
 
-  ASSERT_TRUE(a_id.is_valid());
-  ASSERT_TRUE(b_id.is_valid());
+  ASSERT_TRUE(a_id.has_value());
+  ASSERT_TRUE(b_id.has_value());
   EXPECT_THAT(a_id, Not(Eq(b_id)));
 
   EXPECT_THAT(string_literals.Get(a_id), Eq(a));

--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -35,7 +35,7 @@ enum class EntityKind : uint8_t {
 // `self_id` and `arg_ids` are the self argument and explicit arguments in the
 // call.
 //
-// Returns a `SpecificId` for the specific callee, `SpecificId::Invalid` if the
+// Returns a `SpecificId` for the specific callee, `SpecificId::None` if the
 // callee is not generic, or `nullopt` if an error has been diagnosed.
 static auto ResolveCalleeInCall(Context& context, SemIR::LocId loc_id,
                                 const SemIR::EntityWithParamsBase& entity,
@@ -67,7 +67,7 @@ static auto ResolveCalleeInCall(Context& context, SemIR::LocId loc_id,
   }
 
   // Perform argument deduction.
-  auto specific_id = SemIR::SpecificId::Invalid;
+  auto specific_id = SemIR::SpecificId::None;
   if (entity.generic_id.is_valid()) {
     specific_id = DeduceGenericCallArguments(
         context, loc_id, entity.generic_id, enclosing_specific_id,
@@ -91,7 +91,7 @@ static auto PerformCallToGenericClass(Context& context, SemIR::LocId loc_id,
   auto callee_specific_id =
       ResolveCalleeInCall(context, loc_id, generic_class,
                           EntityKind::GenericClass, enclosing_specific_id,
-                          /*self_id=*/SemIR::InstId::Invalid, arg_ids);
+                          /*self_id=*/SemIR::InstId::None, arg_ids);
   if (!callee_specific_id) {
     return SemIR::ErrorInst::SingletonInstId;
   }
@@ -111,7 +111,7 @@ static auto PerformCallToGenericInterface(
   auto callee_specific_id =
       ResolveCalleeInCall(context, loc_id, interface,
                           EntityKind::GenericInterface, enclosing_specific_id,
-                          /*self_id=*/SemIR::InstId::Invalid, arg_ids);
+                          /*self_id=*/SemIR::InstId::None, arg_ids);
   if (!callee_specific_id) {
     return SemIR::ErrorInst::SingletonInstId;
   }
@@ -169,7 +169,7 @@ auto PerformCall(Context& context, SemIR::LocId loc_id, SemIR::InstId callee_id,
   }
 
   // If there is a return slot, build storage for the result.
-  SemIR::InstId return_slot_arg_id = SemIR::InstId::Invalid;
+  SemIR::InstId return_slot_arg_id = SemIR::InstId::None;
   SemIR::ReturnTypeInfo return_info = [&] {
     auto& function = context.functions().Get(callee_function.function_id);
     DiagnosticAnnotationScope annotate_diagnostics(

--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -68,12 +68,12 @@ static auto ResolveCalleeInCall(Context& context, SemIR::LocId loc_id,
 
   // Perform argument deduction.
   auto specific_id = SemIR::SpecificId::None;
-  if (entity.generic_id.is_valid()) {
+  if (entity.generic_id.has_value()) {
     specific_id = DeduceGenericCallArguments(
         context, loc_id, entity.generic_id, enclosing_specific_id,
         entity.implicit_param_patterns_id, entity.param_patterns_id, self_id,
         arg_ids);
-    if (!specific_id.is_valid()) {
+    if (!specific_id.has_value()) {
       return std::nullopt;
     }
   }
@@ -123,7 +123,7 @@ auto PerformCall(Context& context, SemIR::LocId loc_id, SemIR::InstId callee_id,
                  llvm::ArrayRef<SemIR::InstId> arg_ids) -> SemIR::InstId {
   // Identify the function we're calling.
   auto callee_function = GetCalleeFunction(context.sem_ir(), callee_id);
-  if (!callee_function.function_id.is_valid()) {
+  if (!callee_function.function_id.has_value()) {
     auto type_inst =
         context.types().GetAsInst(context.insts().Get(callee_id).type_id());
     CARBON_KIND_SWITCH(type_inst) {
@@ -157,7 +157,7 @@ auto PerformCall(Context& context, SemIR::LocId loc_id, SemIR::InstId callee_id,
   if (!callee_specific_id) {
     return SemIR::ErrorInst::SingletonInstId;
   }
-  if (callee_specific_id->is_valid()) {
+  if (callee_specific_id->has_value()) {
     callee_id = context.GetOrAddInst(
         context.insts().GetLocId(callee_id),
         SemIR::SpecificFunction{
@@ -192,7 +192,7 @@ auto PerformCall(Context& context, SemIR::LocId loc_id, SemIR::InstId callee_id,
     case SemIR::InitRepr::None:
       // For functions with an implicit return type, the return type is the
       // empty tuple type.
-      if (!return_info.type_id.is_valid()) {
+      if (!return_info.type_id.has_value()) {
         return_info.type_id = context.GetTupleType({});
       }
       break;

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -31,11 +31,11 @@ static auto GetImportKey(UnitAndImports& unit_info,
                          Parse::Tree::PackagingNames names) -> ImportKey {
   auto* stores = unit_info.unit->value_stores;
   llvm::StringRef package_name =
-      names.package_id.is_valid()  ? stores->identifiers().Get(names.package_id)
-      : file_package_id.is_valid() ? stores->identifiers().Get(file_package_id)
-                                   : "";
+      names.package_id.has_value() ? stores->identifiers().Get(names.package_id)
+      : file_package_id.has_value() ? stores->identifiers().Get(file_package_id)
+                                    : "";
   llvm::StringRef library_name =
-      names.library_id.is_valid()
+      names.library_id.has_value()
           ? stores->string_literal_values().Get(names.library_id)
           : "";
   return {package_name, library_name};
@@ -112,12 +112,12 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
     // True if the file's package is implicitly `Main` (by omitting an explicit
     // package name).
     bool is_file_implicit_main =
-        !packaging || !packaging->names.package_id.is_valid();
+        !packaging || !packaging->names.package_id.has_value();
     // True if the import is using implicit "current package" syntax (by
     // omitting an explicit package name).
-    bool is_import_implicit_current_package = !import.package_id.is_valid();
+    bool is_import_implicit_current_package = !import.package_id.has_value();
     // True if the import is using `default` library syntax.
-    bool is_import_default_library = !import.library_id.is_valid();
+    bool is_import_default_library = !import.library_id.has_value();
     // True if the import and file point at the same package, even by
     // incorrectly specifying the current package name to `import`.
     bool is_same_package = is_import_implicit_current_package ||

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -66,7 +66,7 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
   const auto& packaging = unit_info.parse_tree().packaging_decl();
 
   IdentifierId file_package_id =
-      packaging ? packaging->names.package_id : IdentifierId::Invalid;
+      packaging ? packaging->names.package_id : IdentifierId::None;
   const auto import_key = GetImportKey(unit_info, file_package_id, import);
   const auto& [import_package_name, import_library_name] = import_key;
 
@@ -232,7 +232,7 @@ static auto BuildApiMapAndDiagnosePackaging(
     const auto& packaging = unit_info.parse_tree().packaging_decl();
     // An import key formed from the `package` or `library` declaration. Or, for
     // Main//default, a placeholder key.
-    auto import_key = packaging ? GetImportKey(unit_info, IdentifierId::Invalid,
+    auto import_key = packaging ? GetImportKey(unit_info, IdentifierId::None,
                                                packaging->names)
                                 // Construct a boring key for Main//default.
                                 : ImportKey{"", ""};
@@ -278,7 +278,7 @@ static auto BuildApiMapAndDiagnosePackaging(
                             "`Main//default` previously provided by `{0}`",
                             std::string);
           // Use the invalid node because there's no node to associate with.
-          unit_info.emitter.Emit(Parse::NodeId::Invalid, DuplicateMainApi,
+          unit_info.emitter.Emit(Parse::NodeId::None, DuplicateMainApi,
                                  prev_filename.str());
         }
       }
@@ -299,13 +299,13 @@ static auto BuildApiMapAndDiagnosePackaging(
             "file extension of `{0:.impl|}.carbon` required for {0:`impl`|api}",
             BoolAsSelect);
         auto diag = unit_info.emitter.Build(
-            packaging ? packaging->names.node_id : Parse::NodeId::Invalid,
+            packaging ? packaging->names.node_id : Parse::NodeId::None,
             IncorrectExtension, is_impl);
         if (is_api_with_impl_ext) {
           CARBON_DIAGNOSTIC(
               IncorrectExtensionImplNote, Note,
               "file extension of `.impl.carbon` only allowed for `impl`");
-          diag.Note(Parse::NodeId::Invalid, IncorrectExtensionImplNote);
+          diag.Note(Parse::NodeId::None, IncorrectExtensionImplNote);
         }
         diag.Emit();
       }
@@ -336,7 +336,7 @@ auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
     if (packaging && packaging->is_impl) {
       // An `impl` has an implicit import of its `api`.
       auto implicit_names = packaging->names;
-      implicit_names.package_id = IdentifierId::Invalid;
+      implicit_names.package_id = IdentifierId::None;
       TrackImport(api_map, nullptr, unit_info, implicit_names, fuzzing);
     }
 
@@ -351,7 +351,7 @@ auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
       auto prelude_id =
           unit_info.unit->value_stores->string_literal_values().Add("prelude");
       TrackImport(api_map, &explicit_import_map, unit_info,
-                  {.node_id = Parse::InvalidNodeId(),
+                  {.node_id = Parse::NoneNodeId(),
                    .package_id = core_ident_id,
                    .library_id = prelude_id},
                   fuzzing);

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -96,13 +96,13 @@ auto CheckUnit::InitPackageScopeAndImports() -> void {
   // reference.
   auto package_scope_id = context_.name_scopes().Add(
       SemIR::Namespace::PackageInstId, SemIR::NameId::PackageNamespace,
-      SemIR::NameScopeId::Invalid);
+      SemIR::NameScopeId::None);
   CARBON_CHECK(package_scope_id == SemIR::NameScopeId::Package);
 
   auto package_inst_id = context_.AddInst<SemIR::Namespace>(
-      Parse::NodeId::Invalid, {.type_id = namespace_type_id,
-                               .name_scope_id = SemIR::NameScopeId::Package,
-                               .import_id = SemIR::InstId::Invalid});
+      Parse::NodeId::None, {.type_id = namespace_type_id,
+                            .name_scope_id = SemIR::NameScopeId::Package,
+                            .import_id = SemIR::InstId::None});
   CARBON_CHECK(package_inst_id == SemIR::Namespace::PackageInstId);
 
   // If there is an implicit `api` import, set it first so that it uses the
@@ -118,7 +118,7 @@ auto CheckUnit::InitPackageScopeAndImports() -> void {
                     .sem_ir = unit_and_imports_->api_for_impl->unit->sem_ir});
   } else {
     SetApiImportIR(context_,
-                   {.decl_id = SemIR::InstId::Invalid, .sem_ir = nullptr});
+                   {.decl_id = SemIR::InstId::None, .sem_ir = nullptr});
   }
 
   // Add import instructions for everything directly imported. Implicit imports
@@ -221,7 +221,7 @@ auto CheckUnit::ImportCurrentPackage(SemIR::InstId package_inst_id,
                                      SemIR::TypeId namespace_type_id) -> void {
   // Add imports from the current package.
   auto import_map_lookup =
-      unit_and_imports_->package_imports_map.Lookup(IdentifierId::Invalid);
+      unit_and_imports_->package_imports_map.Lookup(IdentifierId::None);
   if (!import_map_lookup) {
     // Push the scope; there are no names to add.
     context_.scope_stack().Push(package_inst_id, SemIR::NameScopeId::Package);
@@ -240,7 +240,7 @@ auto CheckUnit::ImportCurrentPackage(SemIR::InstId package_inst_id,
                                /*api_imports=*/nullptr));
 
   context_.scope_stack().Push(
-      package_inst_id, SemIR::NameScopeId::Package, SemIR::SpecificId::Invalid,
+      package_inst_id, SemIR::NameScopeId::Package, SemIR::SpecificId::None,
       context_.name_scopes().Get(SemIR::NameScopeId::Package).has_error());
 }
 
@@ -255,7 +255,7 @@ auto CheckUnit::ImportOtherPackages(SemIR::TypeId namespace_type_id) -> void {
   // {Invalid, -1} state remains.
   llvm::SmallVector<std::pair<IdentifierId, int32_t>> api_imports_list;
   api_imports_list.resize(unit_and_imports_->package_imports.size(),
-                          {IdentifierId::Invalid, -1});
+                          {IdentifierId::None, -1});
 
   // When there's an API file, add the mapping to api_imports_list.
   if (unit_and_imports_->api_for_impl) {
@@ -287,8 +287,8 @@ auto CheckUnit::ImportOtherPackages(SemIR::TypeId namespace_type_id) -> void {
 
   for (auto [i, api_imports_entry] : llvm::enumerate(api_imports_list)) {
     // These variables are updated after figuring out which imports are present.
-    auto import_decl_id = SemIR::InstId::Invalid;
-    IdentifierId package_id = IdentifierId::Invalid;
+    auto import_decl_id = SemIR::InstId::None;
+    IdentifierId package_id = IdentifierId::None;
     bool has_load_error = false;
 
     // Identify the local package imports if present.
@@ -359,7 +359,7 @@ auto CheckUnit::ImportCppPackages() -> void {
 auto CheckUnit::ProcessNodeIds() -> bool {
   NodeIdTraversal traversal(context_, vlog_stream_);
 
-  Parse::NodeId node_id = Parse::NodeId::Invalid;
+  Parse::NodeId node_id = Parse::NodeId::None;
 
   // On crash, report which token we were handling.
   PrettyStackTraceFunction node_dumper([&](llvm::raw_ostream& output) {
@@ -421,7 +421,7 @@ auto CheckUnit::CheckRequiredDefinitions() -> void {
       }
       case CARBON_KIND(SemIR::FunctionDecl function_decl): {
         if (context_.functions().Get(function_decl.function_id).definition_id ==
-            SemIR::InstId::Invalid) {
+            SemIR::InstId::None) {
           emitter_.Emit(decl_inst_id, MissingDefinitionInImpl);
         }
         break;

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -124,7 +124,7 @@ auto CheckUnit::InitPackageScopeAndImports() -> void {
   // Add import instructions for everything directly imported. Implicit imports
   // are handled separately.
   for (auto& package_imports : unit_and_imports_->package_imports) {
-    CARBON_CHECK(!package_imports.import_decl_id.is_valid());
+    CARBON_CHECK(!package_imports.import_decl_id.has_value());
     package_imports.import_decl_id = context_.AddInst<SemIR::ImportDecl>(
         package_imports.node_id, {.package_id = SemIR::NameId::ForIdentifier(
                                       package_imports.package_id)});
@@ -267,7 +267,7 @@ auto CheckUnit::ImportOtherPackages(SemIR::TypeId namespace_type_id) -> void {
     for (auto [api_imports_index, api_imports] :
          llvm::enumerate(unit_and_imports_->api_for_impl->package_imports)) {
       // Skip the current package.
-      if (!api_imports.package_id.is_valid()) {
+      if (!api_imports.package_id.has_value()) {
         continue;
       }
       // Translate the package ID from the API file to the implementation file.
@@ -295,7 +295,7 @@ auto CheckUnit::ImportOtherPackages(SemIR::TypeId namespace_type_id) -> void {
     PackageImports* local_imports = nullptr;
     if (i < unit_and_imports_->package_imports.size()) {
       local_imports = &unit_and_imports_->package_imports[i];
-      if (!local_imports->package_id.is_valid()) {
+      if (!local_imports->package_id.has_value()) {
         // Skip the current package.
         continue;
       }

--- a/toolchain/check/check_unit.h
+++ b/toolchain/check/check_unit.h
@@ -37,7 +37,7 @@ struct PackageImports {
   // not specific to a single import.
   Parse::ImportDeclId node_id;
   // The associated `import` instruction. Only valid once a file is checked.
-  SemIR::InstId import_decl_id = SemIR::InstId::Invalid;
+  SemIR::InstId import_decl_id = SemIR::InstId::None;
   // Whether there's an import that failed to load.
   bool has_load_error = false;
   // The list of valid imports.

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -102,7 +102,7 @@ auto Context::GetOrAddInst(SemIR::LocIdAndInst loc_id_and_inst)
   if (loc_id_and_inst.loc_id.is_implicit()) {
     auto const_id =
         TryEvalInst(*this, SemIR::InstId::None, loc_id_and_inst.inst);
-    if (const_id.is_valid()) {
+    if (const_id.has_value()) {
       CARBON_VLOG("GetOrAddInst: constant: {0}\n", loc_id_and_inst.inst);
       return constant_values().GetInstId(const_id);
     }
@@ -245,10 +245,10 @@ auto Context::DiagnoseMemberNameNotFound(
     SemIRLoc loc, SemIR::NameId name_id,
     llvm::ArrayRef<LookupScope> lookup_scopes) -> void {
   if (lookup_scopes.size() == 1 &&
-      lookup_scopes.front().name_scope_id.is_valid()) {
+      lookup_scopes.front().name_scope_id.has_value()) {
     auto specific_id = lookup_scopes.front().specific_id;
     auto scope_inst_id =
-        specific_id.is_valid()
+        specific_id.has_value()
             ? GetInstForSpecific(*this, specific_id)
             : name_scopes().Get(lookup_scopes.front().name_scope_id).inst_id();
     CARBON_DIAGNOSTIC(MemberNameNotFoundInScope, Error,
@@ -309,7 +309,7 @@ auto Context::AddNameToLookup(SemIR::NameId name_id, SemIR::InstId target_id,
                               ScopeIndex scope_index) -> void {
   if (auto existing =
           scope_stack().LookupOrAddName(name_id, target_id, scope_index);
-      existing.is_valid()) {
+      existing.has_value()) {
     DiagnoseDuplicateName(target_id, existing);
   }
 }
@@ -318,7 +318,7 @@ auto Context::LookupNameInDecl(SemIR::LocId loc_id, SemIR::NameId name_id,
                                SemIR::NameScopeId scope_id,
                                ScopeIndex scope_index)
     -> std::pair<SemIR::InstId, bool> {
-  if (!scope_id.is_valid()) {
+  if (!scope_id.has_value()) {
     // Look for a name in the specified scope or a scope nested within it only.
     // There are two cases where the name would be in an outer scope:
     //
@@ -390,7 +390,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
                                 LookupScope{.name_scope_id = lookup_scope_id,
                                             .specific_id = specific_id},
                                 /*required=*/false);
-        non_lexical_result.inst_id.is_valid()) {
+        non_lexical_result.inst_id.has_value()) {
       return non_lexical_result;
     }
   }
@@ -403,7 +403,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
             .inst_id = SemIR::ErrorInst::SingletonInstId};
   }
 
-  if (lexical_result.is_valid()) {
+  if (lexical_result.has_value()) {
     // A lexical scope never needs an associated specific. If there's a
     // lexically enclosing generic, then it also encloses the point of use of
     // the name.
@@ -465,11 +465,11 @@ static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
   if (access_kind == SemIR::AccessKind::Private && is_parent_access) {
     if (auto base_type_id =
             class_info.GetBaseType(context.sem_ir(), class_type->specific_id);
-        base_type_id.is_valid()) {
+        base_type_id.has_value()) {
       parent_type_id = base_type_id;
     } else if (auto adapted_type_id = class_info.GetAdaptedType(
                    context.sem_ir(), class_type->specific_id);
-               adapted_type_id.is_valid()) {
+               adapted_type_id.has_value()) {
       parent_type_id = adapted_type_id;
     } else {
       CARBON_FATAL("Expected parent for parent access");
@@ -591,7 +591,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
   // Walk this scope and, if nothing is found here, the scopes it extends.
   while (!scopes.empty()) {
     auto [scope_id, specific_id] = scopes.pop_back_val();
-    if (!scope_id.is_valid()) {
+    if (!scope_id.has_value()) {
       has_error = true;
       continue;
     }
@@ -614,7 +614,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
       });
     }
 
-    if (!scope_result_id.is_valid() || is_access_prohibited) {
+    if (!scope_result_id.has_value() || is_access_prohibited) {
       // If nothing is found in this scope or if we encountered an invalid
       // access, look in its extended scopes.
       const auto& extended = name_scope.extended_scopes();
@@ -622,7 +622,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
       for (auto extended_id : llvm::reverse(extended)) {
         // Substitute into the constant describing the extended scope to
         // determine its corresponding specific.
-        CARBON_CHECK(extended_id.is_valid());
+        CARBON_CHECK(extended_id.has_value());
         LoadImportRef(*this, extended_id);
         SemIR::ConstantId const_id =
             GetConstantValueInSpecific(sem_ir(), specific_id, extended_id);
@@ -643,7 +643,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
     }
 
     // If this is our second lookup result, diagnose an ambiguity.
-    if (result.inst_id.is_valid()) {
+    if (result.inst_id.has_value()) {
       CARBON_DIAGNOSTIC(
           NameAmbiguousDueToExtend, Error,
           "ambiguous use of name `{0}` found in multiple extended scopes",
@@ -659,7 +659,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
     result.is_poisoned = is_poisoned;
   }
 
-  if (required && !result.inst_id.is_valid()) {
+  if (required && !result.inst_id.has_value()) {
     if (!has_error) {
       if (prohibited_accesses.empty()) {
         DiagnoseMemberNameNotFound(loc_id, name_id, lookup_scopes);
@@ -702,7 +702,7 @@ static auto GetCorePackage(Context& context, SemIRLoc loc, llvm::StringRef name)
   auto [core_inst_id, _, is_poisoned] = context.LookupNameInExactScope(
       loc, core_name_id, SemIR::NameScopeId::Package,
       context.name_scopes().Get(SemIR::NameScopeId::Package));
-  if (core_inst_id.is_valid()) {
+  if (core_inst_id.has_value()) {
     // We expect it to be a namespace.
     if (auto namespace_inst =
             context.insts().TryGetAs<SemIR::Namespace>(core_inst_id)) {
@@ -722,14 +722,14 @@ static auto GetCorePackage(Context& context, SemIRLoc loc, llvm::StringRef name)
 auto Context::LookupNameInCore(SemIRLoc loc, llvm::StringRef name)
     -> SemIR::InstId {
   auto core_package_id = GetCorePackage(*this, loc, name);
-  if (!core_package_id.is_valid()) {
+  if (!core_package_id.has_value()) {
     return SemIR::ErrorInst::SingletonInstId;
   }
 
   auto name_id = SemIR::NameId::ForIdentifier(identifiers().Add(name));
   auto [inst_id, _, is_poisoned] = LookupNameInExactScope(
       loc, name_id, core_package_id, name_scopes().Get(core_package_id));
-  if (!inst_id.is_valid()) {
+  if (!inst_id.has_value()) {
     CARBON_DIAGNOSTIC(
         CoreNameNotFound, Error,
         "name `Core.{0}` implicitly referenced here, but not found",
@@ -783,7 +783,7 @@ auto Context::AddConvergenceBlockAndPush(Parse::NodeId node_id, int num_blocks)
       if (new_block_id == SemIR::InstBlockId::Unreachable) {
         new_block_id = inst_blocks().AddDefaultValue();
       }
-      CARBON_CHECK(node_id.is_valid());
+      CARBON_CHECK(node_id.has_value());
       AddInst<SemIR::Branch>(node_id, {.target_id = new_block_id});
     }
     inst_block_stack().Pop();
@@ -1091,12 +1091,12 @@ class TypeCompleter {
           }
           return false;
         }
-        if (inst.specific_id.is_valid()) {
+        if (inst.specific_id.has_value()) {
           ResolveSpecificDefinition(context_, loc_, inst.specific_id);
         }
         if (auto adapted_type_id =
                 class_info.GetAdaptedType(context_.sem_ir(), inst.specific_id);
-            adapted_type_id.is_valid()) {
+            adapted_type_id.has_value()) {
           Push(adapted_type_id);
         } else {
           Push(class_info.GetObjectRepr(context_.sem_ir(), inst.specific_id));
@@ -1274,7 +1274,7 @@ class TypeCompleter {
     // its adapted type.
     if (auto adapted_type_id =
             class_info.GetAdaptedType(context_.sem_ir(), inst.specific_id);
-        adapted_type_id.is_valid()) {
+        adapted_type_id.has_value()) {
       return GetNestedValueRepr(adapted_type_id);
     }
     // Otherwise, the value representation for a class is a pointer to the
@@ -1449,7 +1449,7 @@ auto Context::RequireDefinedType(SemIR::TypeId type_id, SemIR::LocId loc_id,
         return false;
       }
 
-      if (interface.specific_id.is_valid()) {
+      if (interface.specific_id.has_value()) {
         ResolveSpecificDefinition(*this, loc_id, interface.specific_id);
       }
     }

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -59,7 +59,7 @@ Context::Context(DiagnosticEmitter* emitter,
   // Prepare fields which relate to the number of IRs available for import.
   import_irs().Reserve(imported_ir_count);
   import_ir_constant_values_.reserve(imported_ir_count);
-  check_ir_map_.resize(total_ir_count, SemIR::ImportIRId::Invalid);
+  check_ir_map_.resize(total_ir_count, SemIR::ImportIRId::None);
 
   // Map the builtin `<error>` and `type` type constants to their corresponding
   // special `TypeId` values.
@@ -101,7 +101,7 @@ auto Context::GetOrAddInst(SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::InstId {
   if (loc_id_and_inst.loc_id.is_implicit()) {
     auto const_id =
-        TryEvalInst(*this, SemIR::InstId::Invalid, loc_id_and_inst.inst);
+        TryEvalInst(*this, SemIR::InstId::None, loc_id_and_inst.inst);
     if (const_id.is_valid()) {
       CARBON_VLOG("GetOrAddInst: constant: {0}\n", loc_id_and_inst.inst);
       return constant_values().GetInstId(const_id);
@@ -179,7 +179,7 @@ auto Context::AddPlaceholderInstInNoBlock(SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::InstId {
   auto inst_id = sem_ir().insts().AddInNoBlock(loc_id_and_inst);
   CARBON_VLOG("AddPlaceholderInst: {0}\n", loc_id_and_inst.inst);
-  constant_values().Set(inst_id, SemIR::ConstantId::Invalid);
+  constant_values().Set(inst_id, SemIR::ConstantId::None);
   return inst_id;
 }
 
@@ -224,13 +224,13 @@ auto Context::DiagnoseDuplicateName(SemIRLoc dup_def, SemIRLoc prev_def)
 }
 
 auto Context::DiagnosePoisonedName(SemIRLoc loc) -> void {
-  // TODO: Improve the diagnostic to replace NodeId::Invalid with the location
+  // TODO: Improve the diagnostic to replace NodeId::None with the location
   // where the name was poisoned. See discussion in
   // https://github.com/carbon-language/carbon-lang/pull/4654#discussion_r1876607172
   CARBON_DIAGNOSTIC(NameUseBeforeDecl, Error,
                     "name used before it was declared");
   CARBON_DIAGNOSTIC(NameUseBeforeDeclNote, Note, "declared here");
-  emitter_->Build(SemIR::LocId::Invalid, NameUseBeforeDecl)
+  emitter_->Build(SemIR::LocId::None, NameUseBeforeDecl)
       .Note(loc, NameUseBeforeDeclNote)
       .Emit();
 }
@@ -399,7 +399,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
     CARBON_DIAGNOSTIC(UsedBeforeInitialization, Error,
                       "`{0}` used before initialization", SemIR::NameId);
     emitter_->Emit(node_id, UsedBeforeInitialization, name_id);
-    return {.specific_id = SemIR::SpecificId::Invalid,
+    return {.specific_id = SemIR::SpecificId::None,
             .inst_id = SemIR::ErrorInst::SingletonInstId};
   }
 
@@ -407,8 +407,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
     // A lexical scope never needs an associated specific. If there's a
     // lexically enclosing generic, then it also encloses the point of use of
     // the name.
-    return {.specific_id = SemIR::SpecificId::Invalid,
-            .inst_id = lexical_result};
+    return {.specific_id = SemIR::SpecificId::None, .inst_id = lexical_result};
   }
 
   // We didn't find anything at all.
@@ -416,7 +415,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
     DiagnoseNameNotFound(node_id, name_id);
   }
 
-  return {.specific_id = SemIR::SpecificId::Invalid,
+  return {.specific_id = SemIR::SpecificId::None,
           .inst_id = SemIR::ErrorInst::SingletonInstId};
 }
 
@@ -431,7 +430,7 @@ auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
     if (!entry.is_poisoned) {
       LoadImportRef(*this, entry.inst_id);
     } else if (is_being_declared) {
-      entry.inst_id = SemIR::InstId::Invalid;
+      entry.inst_id = SemIR::InstId::None;
     }
     return {entry.inst_id, entry.access_kind, entry.is_poisoned};
   }
@@ -442,7 +441,7 @@ auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
                                        scope.import_ir_scopes(), name_id),
             SemIR::AccessKind::Public};
   }
-  return {SemIR::InstId::Invalid, SemIR::AccessKind::Public};
+  return {SemIR::InstId::None, SemIR::AccessKind::Public};
 }
 
 // Prints diagnostics on invalid qualified name access.
@@ -528,7 +527,7 @@ auto Context::AppendLookupScopesForConstant(
   if (auto base_as_namespace = base.TryAs<SemIR::Namespace>()) {
     scopes->push_back(
         LookupScope{.name_scope_id = base_as_namespace->name_scope_id,
-                    .specific_id = SemIR::SpecificId::Invalid});
+                    .specific_id = SemIR::SpecificId::None});
     return true;
   }
   if (auto base_as_class = base.TryAs<SemIR::ClassType>()) {
@@ -563,8 +562,8 @@ auto Context::AppendLookupScopesForConstant(
   }
   if (base_const_id == SemIR::ErrorInst::SingletonConstantId) {
     // Lookup into this scope should fail without producing an error.
-    scopes->push_back(LookupScope{.name_scope_id = SemIR::NameScopeId::Invalid,
-                                  .specific_id = SemIR::SpecificId::Invalid});
+    scopes->push_back(LookupScope{.name_scope_id = SemIR::NameScopeId::None,
+                                  .specific_id = SemIR::SpecificId::None});
     return true;
   }
   // TODO: Per the design, if `base_id` is any kind of type, then lookup should
@@ -584,8 +583,8 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
   // TODO: Support reporting of multiple prohibited access.
   llvm::SmallVector<ProhibitedAccessInfo> prohibited_accesses;
 
-  LookupResult result = {.specific_id = SemIR::SpecificId::Invalid,
-                         .inst_id = SemIR::InstId::Invalid};
+  LookupResult result = {.specific_id = SemIR::SpecificId::None,
+                         .inst_id = SemIR::InstId::None};
   bool has_error = false;
   bool is_parent_access = false;
 
@@ -651,7 +650,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
           SemIR::NameId);
       emitter_->Emit(loc_id, NameAmbiguousDueToExtend, name_id);
       // TODO: Add notes pointing to the scopes.
-      return {.specific_id = SemIR::SpecificId::Invalid,
+      return {.specific_id = SemIR::SpecificId::None,
               .inst_id = SemIR::ErrorInst::SingletonInstId};
     }
 
@@ -678,7 +677,7 @@ auto Context::LookupQualifiedName(SemIR::LocId loc_id, SemIR::NameId name_id,
       }
     }
 
-    return {.specific_id = SemIR::SpecificId::Invalid,
+    return {.specific_id = SemIR::SpecificId::None,
             .inst_id = SemIR::ErrorInst::SingletonInstId,
             .is_poisoned = result.is_poisoned};
   }
@@ -717,7 +716,7 @@ static auto GetCorePackage(Context& context, SemIRLoc loc, llvm::StringRef name)
       "`Core.{0}` implicitly referenced here, but package `Core` not found",
       std::string);
   context.emitter().Emit(loc, CoreNotFound, name.str());
-  return SemIR::NameScopeId::Invalid;
+  return SemIR::NameScopeId::None;
 }
 
 auto Context::LookupNameInCore(SemIRLoc loc, llvm::StringRef name)
@@ -1377,7 +1376,7 @@ auto Context::TryToCompleteType(SemIR::TypeId type_id, SemIRLoc loc,
 
 auto Context::CompleteTypeOrCheckFail(SemIR::TypeId type_id) -> void {
   bool complete =
-      TypeCompleter(*this, SemIR::LocId::Invalid, nullptr).Complete(type_id);
+      TypeCompleter(*this, SemIR::LocId::None, nullptr).Complete(type_id);
   CARBON_CHECK(complete, "Expected {0} to be a complete type",
                types().GetAsInst(type_id));
 }
@@ -1492,7 +1491,7 @@ static auto GetTypeImpl(Context& context, EachArgT... each_arg)
   // TODO: Remove inst_id parameter from TryEvalInst.
   InstT inst = {SemIR::TypeType::SingletonTypeId, each_arg...};
   return context.GetTypeIdForTypeConstant(
-      TryEvalInst(context, SemIR::InstId::Invalid, inst));
+      TryEvalInst(context, SemIR::InstId::None, inst));
 }
 
 // Gets or forms a type_id for a type, given the instruction kind and arguments,

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -225,7 +225,7 @@ class Context {
   // specified, `scope_index` specifies which lexical scope the name is inserted
   // into, otherwise the name is inserted into the current scope.
   auto AddNameToLookup(SemIR::NameId name_id, SemIR::InstId target_id,
-                       ScopeIndex scope_index = ScopeIndex::Invalid) -> void;
+                       ScopeIndex scope_index = ScopeIndex::None) -> void;
 
   // Performs name lookup in a specified scope for a name appearing in a
   // declaration. If scope_id is invalid, performs lookup into the lexical scope

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -35,14 +35,14 @@ namespace Carbon::Check {
 struct LookupScope {
   // The name scope in which names are searched.
   SemIR::NameScopeId name_scope_id;
-  // The specific for the name scope, or `Invalid` if the name scope is not
+  // The specific for the name scope, or `None` if the name scope is not
   // defined by a generic or we should perform lookup into the generic itself.
   SemIR::SpecificId specific_id;
 };
 
 // A result produced by name lookup.
 struct LookupResult {
-  // The specific in which the lookup result was found. `Invalid` if the result
+  // The specific in which the lookup result was found. `None` if the result
   // was not found in a specific.
   SemIR::SpecificId specific_id;
   // The declaration that was found by name lookup.
@@ -75,7 +75,7 @@ class Context {
       llvm::function_ref<auto()->Context::DiagnosticBuilder>;
 
   struct LookupNameInExactScopeResult {
-    // The matching entity if found, or invalid if poisoned or not found.
+    // The matching entity if found, or `None` if poisoned or not found.
     SemIR::InstId inst_id;
 
     // The access level required to use inst_id, if it's valid.
@@ -228,9 +228,9 @@ class Context {
                        ScopeIndex scope_index = ScopeIndex::None) -> void;
 
   // Performs name lookup in a specified scope for a name appearing in a
-  // declaration. If scope_id is invalid, performs lookup into the lexical scope
+  // declaration. If scope_id is `None`, performs lookup into the lexical scope
   // specified by scope_index instead. If found, returns the referenced
-  // instruction and false. If poisoned, returns an invalid instruction and
+  // instruction and false. If poisoned, returns an `None` instruction and
   // true.
   // TODO: For poisoned names, return the poisoning instruction.
   auto LookupNameInDecl(SemIR::LocId loc_id, SemIR::NameId name_id,
@@ -242,7 +242,7 @@ class Context {
                              bool required = true) -> LookupResult;
 
   // Performs a name lookup in a specified scope, returning the referenced
-  // instruction. Does not look into extended scopes. Returns an invalid
+  // instruction. Does not look into extended scopes. Returns a `None`
   // instruction if the name is not found.
   //
   // If `is_being_declared` is false, then this is a regular name lookup, and
@@ -521,7 +521,7 @@ class Context {
 
   auto Finalize() -> void;
 
-  // Returns the imported IR ID for an IR, or invalid if not imported.
+  // Returns the imported IR ID for an IR, or `None` if not imported.
   auto GetImportIRId(const SemIR::File& sem_ir) -> SemIR::ImportIRId& {
     return check_ir_map_[sem_ir.check_ir_id().index];
   }

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -64,11 +64,11 @@ static auto FindReturnSlotArgForInitializer(SemIR::File& sem_ir,
       case CARBON_KIND(SemIR::Call call): {
         if (!SemIR::ReturnTypeInfo::ForType(sem_ir, call.type_id)
                  .has_return_slot()) {
-          return SemIR::InstId::Invalid;
+          return SemIR::InstId::None;
         }
         if (!call.args_id.is_valid()) {
           // Argument initialization failed, so we have no return slot.
-          return SemIR::InstId::Invalid;
+          return SemIR::InstId::None;
         }
         return sem_ir.inst_blocks().Get(call.args_id).back();
       }
@@ -98,7 +98,7 @@ static auto MarkInitializerFor(SemIR::File& sem_ir, SemIR::InstId init_id,
 // expression described by `init_id`, and returns the location of the
 // temporary. If `discarded` is `true`, the result is discarded, and no
 // temporary will be created if possible; if no temporary is created, the
-// return value will be `SemIR::InstId::Invalid`.
+// return value will be `SemIR::InstId::None`.
 static auto FinalizeTemporary(Context& context, SemIR::InstId init_id,
                               bool discarded) -> SemIR::InstId {
   auto& sem_ir = context.sem_ir();
@@ -119,7 +119,7 @@ static auto FinalizeTemporary(Context& context, SemIR::InstId init_id,
 
   if (discarded) {
     // Don't invent a temporary that we're going to discard.
-    return SemIR::InstId::Invalid;
+    return SemIR::InstId::None;
   }
 
   // The initializer has no return slot, but we want to produce a temporary
@@ -325,7 +325,7 @@ static auto ConvertTupleToTuple(Context& context, SemIR::TupleType src_type,
   // directly. Otherwise, materialize a temporary if needed and index into the
   // result.
   llvm::ArrayRef<SemIR::InstId> literal_elems;
-  auto literal_elems_id = SemIR::InstBlockId::Invalid;
+  auto literal_elems_id = SemIR::InstBlockId::None;
   if (auto tuple_literal = value.TryAs<SemIR::TupleLiteral>()) {
     literal_elems_id = tuple_literal->elements_id;
     literal_elems = sem_ir.inst_blocks().Get(literal_elems_id);
@@ -420,7 +420,7 @@ static auto ConvertStructToStructOrClass(Context& context,
   // directly. Otherwise, materialize a temporary if needed and index into the
   // result.
   llvm::ArrayRef<SemIR::InstId> literal_elems;
-  auto literal_elems_id = SemIR::InstBlockId::Invalid;
+  auto literal_elems_id = SemIR::InstBlockId::None;
   if (auto struct_literal = value.TryAs<SemIR::StructLiteral>()) {
     literal_elems_id = struct_literal->elements_id;
     literal_elems = sem_ir.inst_blocks().Get(literal_elems_id);
@@ -827,7 +827,7 @@ static auto PerformBuiltinConversion(Context& context, SemIR::LocId loc_id,
           loc_id, {.type_id = foundation_type_id, .source_id = value_id});
 
       auto foundation_init_id = target.init_id;
-      if (foundation_init_id != SemIR::InstId::Invalid) {
+      if (foundation_init_id != SemIR::InstId::None) {
         foundation_init_id = target.init_block->AddInst<SemIR::AsCompatible>(
             loc_id,
             {.type_id = foundation_type_id, .source_id = target.init_id});
@@ -1270,7 +1270,7 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
 
   // Find self parameter pattern.
   // TODO: Do this during initial traversal of implicit params.
-  auto self_param_id = SemIR::InstId::Invalid;
+  auto self_param_id = SemIR::InstId::None;
   for (auto implicit_param_id : implicit_param_patterns) {
     if (SemIR::Function::GetNameFromPatternId(
             context.sem_ir(), implicit_param_id) == SemIR::NameId::SelfValue) {

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -30,7 +30,7 @@
 namespace Carbon::Check {
 
 // Given an initializing expression, find its return slot argument. Returns
-// `Invalid` if there is no return slot, because the initialization is not
+// `None` if there is no return slot, because the initialization is not
 // performed in place.
 static auto FindReturnSlotArgForInitializer(SemIR::File& sem_ir,
                                             SemIR::InstId init_id)

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -66,7 +66,7 @@ static auto FindReturnSlotArgForInitializer(SemIR::File& sem_ir,
                  .has_return_slot()) {
           return SemIR::InstId::None;
         }
-        if (!call.args_id.is_valid()) {
+        if (!call.args_id.has_value()) {
           // Argument initialization failed, so we have no return slot.
           return SemIR::InstId::None;
         }
@@ -83,7 +83,7 @@ static auto MarkInitializerFor(SemIR::File& sem_ir, SemIR::InstId init_id,
                                SemIR::InstId target_id,
                                PendingBlock& target_block) -> void {
   auto return_slot_arg_id = FindReturnSlotArgForInitializer(sem_ir, init_id);
-  if (return_slot_arg_id.is_valid()) {
+  if (return_slot_arg_id.has_value()) {
     // Replace the temporary in the return slot with a reference to our target.
     CARBON_CHECK(sem_ir.insts().Get(return_slot_arg_id).kind() ==
                      SemIR::TemporaryStorage::Kind,
@@ -103,7 +103,7 @@ static auto FinalizeTemporary(Context& context, SemIR::InstId init_id,
                               bool discarded) -> SemIR::InstId {
   auto& sem_ir = context.sem_ir();
   auto return_slot_arg_id = FindReturnSlotArgForInitializer(sem_ir, init_id);
-  if (return_slot_arg_id.is_valid()) {
+  if (return_slot_arg_id.has_value()) {
     // The return slot should already have a materialized temporary in it.
     CARBON_CHECK(sem_ir.insts().Get(return_slot_arg_id).kind() ==
                      SemIR::TemporaryStorage::Kind,
@@ -273,7 +273,7 @@ static auto ConvertTupleToArray(Context& context, SemIR::TupleType tuple_type,
   // Arrays are always initialized in-place. Allocate a temporary as the
   // destination for the array initialization if we weren't given one.
   SemIR::InstId return_slot_arg_id = target.init_id;
-  if (!target.init_id.is_valid()) {
+  if (!target.init_id.has_value()) {
     return_slot_arg_id = target_block->AddInst<SemIR::TemporaryStorage>(
         value_loc_id, {.type_id = target.type_id});
   }
@@ -360,7 +360,7 @@ static auto ConvertTupleToTuple(Context& context, SemIR::TupleType src_type,
   // of the source.
   // TODO: Annotate diagnostics coming from here with the element index.
   auto new_block =
-      literal_elems_id.is_valid()
+      literal_elems_id.has_value()
           ? SemIR::CopyOnWriteInstBlock(sem_ir, literal_elems_id)
           : SemIR::CopyOnWriteInstBlock(
                 sem_ir, SemIR::CopyOnWriteInstBlock::UninitializedBlock{
@@ -468,7 +468,7 @@ static auto ConvertStructToStructOrClass(Context& context,
   // of the source.
   // TODO: Annotate diagnostics coming from here with the element index.
   auto new_block =
-      literal_elems_id.is_valid() && !dest_has_vptr
+      literal_elems_id.has_value() && !dest_has_vptr
           ? SemIR::CopyOnWriteInstBlock(sem_ir, literal_elems_id)
           : SemIR::CopyOnWriteInstBlock(
                 sem_ir, SemIR::CopyOnWriteInstBlock::UninitializedBlock{
@@ -496,7 +496,7 @@ static auto ConvertStructToStructOrClass(Context& context,
       if (auto lookup = src_field_indexes.Lookup(dest_field.name_id)) {
         src_field_index = lookup.value();
       } else {
-        if (literal_elems_id.is_valid()) {
+        if (literal_elems_id.has_value()) {
           CARBON_DIAGNOSTIC(
               StructInitMissingFieldInLiteral, Error,
               "missing value for field `{0}` in struct initialization",
@@ -634,7 +634,7 @@ static auto ComputeInheritancePath(Context& context, SemIRLoc loc,
     auto& derived_class = context.classes().Get(derived_class_type->class_id);
     auto base_type_id = derived_class.GetBaseType(
         context.sem_ir(), derived_class_type->specific_id);
-    if (!base_type_id.is_valid()) {
+    if (!base_type_id.has_value()) {
       result = std::nullopt;
       break;
     }
@@ -741,7 +741,7 @@ static auto GetTransitiveAdaptedType(Context& context, SemIR::TypeId type_id)
     auto& class_info = context.classes().Get(class_type->class_id);
     auto adapted_type_id =
         class_info.GetAdaptedType(context.sem_ir(), class_type->specific_id);
-    if (!adapted_type_id.is_valid()) {
+    if (!adapted_type_id.has_value()) {
       break;
     }
     type_id = adapted_type_id;
@@ -923,7 +923,7 @@ static auto PerformBuiltinConversion(Context& context, SemIR::LocId loc_id,
             sem_ir.types().TryGetAs<SemIR::StructType>(value_type_id)) {
       if (!context.classes()
                .Get(target_class_type->class_id)
-               .adapt_id.is_valid()) {
+               .adapt_id.has_value()) {
         return ConvertStructToClass(context, *src_struct_type,
                                     *target_class_type, value_id, target);
       }
@@ -1274,12 +1274,12 @@ auto ConvertCallArgs(Context& context, SemIR::LocId call_loc_id,
   for (auto implicit_param_id : implicit_param_patterns) {
     if (SemIR::Function::GetNameFromPatternId(
             context.sem_ir(), implicit_param_id) == SemIR::NameId::SelfValue) {
-      CARBON_CHECK(!self_param_id.is_valid());
+      CARBON_CHECK(!self_param_id.has_value());
       self_param_id = implicit_param_id;
     }
   }
 
-  if (self_param_id.is_valid() && !self_id.is_valid()) {
+  if (self_param_id.has_value() && !self_id.has_value()) {
     CARBON_DIAGNOSTIC(MissingObjectInMethodCall, Error,
                       "missing object argument in method call");
     CARBON_DIAGNOSTIC(InCallToFunction, Note, "calling function declared here");

--- a/toolchain/check/convert.h
+++ b/toolchain/check/convert.h
@@ -38,7 +38,7 @@ struct ConversionTarget {
   // The target type for the conversion.
   SemIR::TypeId type_id;
   // For an initializer, the object being initialized.
-  SemIR::InstId init_id = SemIR::InstId::Invalid;
+  SemIR::InstId init_id = SemIR::InstId::None;
   // For an initializer, a block of pending instructions that are needed to
   // form the value of `init_id`, and that can be discarded if no
   // initialization is needed.

--- a/toolchain/check/decl_introducer_state.h
+++ b/toolchain/check/decl_introducer_state.h
@@ -26,7 +26,7 @@ struct DeclIntroducerState {
   // The token kind of the introducer.
   Lex::TokenKind kind;
 
-  // Nodes of modifiers on this declaration, in expected order. `Invalid` if no
+  // Nodes of modifiers on this declaration, in expected order. `None` if no
   // modifier of that kind is present.
   Parse::NodeId
       ordered_modifier_node_ids[static_cast<int8_t>(ModifierOrder::Decl) + 1] =

--- a/toolchain/check/decl_introducer_state.h
+++ b/toolchain/check/decl_introducer_state.h
@@ -30,14 +30,13 @@ struct DeclIntroducerState {
   // modifier of that kind is present.
   Parse::NodeId
       ordered_modifier_node_ids[static_cast<int8_t>(ModifierOrder::Decl) + 1] =
-          {Parse::NodeId::Invalid, Parse::NodeId::Invalid,
-           Parse::NodeId::Invalid};
+          {Parse::NodeId::None, Parse::NodeId::None, Parse::NodeId::None};
 
   // Invariant: contains just the modifiers represented by `saw_*_modifier`.
   KeywordModifierSet modifier_set = KeywordModifierSet();
 
   // If there's an `extern library` in use, the library name.
-  SemIR::LibraryNameId extern_library = SemIR::LibraryNameId::Invalid;
+  SemIR::LibraryNameId extern_library = SemIR::LibraryNameId::None;
 };
 
 // Stack of `DeclIntroducerState` values, representing all the declaration

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -20,7 +20,7 @@ auto DeclNameStack::NameContext::prev_inst_id() -> SemIR::InstId {
   switch (state) {
     case NameContext::State::Error:
       // The name is invalid and a diagnostic has already been emitted.
-      return SemIR::InstId::Invalid;
+      return SemIR::InstId::None;
 
     case NameContext::State::Empty:
       CARBON_FATAL(
@@ -31,7 +31,7 @@ auto DeclNameStack::NameContext::prev_inst_id() -> SemIR::InstId {
       return resolved_inst_id;
 
     case NameContext::State::Unresolved:
-      return SemIR::InstId::Invalid;
+      return SemIR::InstId::None;
 
     case NameContext::State::Poisoned:
       CARBON_FATAL("Poisoned state should not call prev_inst_id()");
@@ -188,13 +188,13 @@ auto DeclNameStack::LookupOrAddName(NameContext name_context,
                                     SemIR::AccessKind access_kind)
     -> std::pair<SemIR::InstId, bool> {
   if (name_context.state == NameContext::State::Poisoned) {
-    return {SemIR::InstId::Invalid, true};
+    return {SemIR::InstId::None, true};
   }
   if (auto id = name_context.prev_inst_id(); id.is_valid()) {
     return {id, false};
   }
   AddName(name_context, target_id, access_kind);
-  return {SemIR::InstId::Invalid, false};
+  return {SemIR::InstId::None, false};
 }
 
 // Push a scope corresponding to a name qualifier. For example, for
@@ -374,7 +374,7 @@ auto DeclNameStack::ResolveAsScope(const NameContext& name_context,
                                    const NameComponent& name) const
     -> std::pair<SemIR::NameScopeId, SemIR::SpecificId> {
   constexpr std::pair<SemIR::NameScopeId, SemIR::SpecificId> InvalidResult = {
-      SemIR::NameScopeId::Invalid, SemIR::SpecificId::Invalid};
+      SemIR::NameScopeId::None, SemIR::SpecificId::None};
 
   if (!CheckQualifierIsResolved(*context_, name_context)) {
     return InvalidResult;
@@ -429,9 +429,9 @@ auto DeclNameStack::ResolveAsScope(const NameContext& name_context,
       // This is specifically for qualified name handling.
       if (!CheckRedeclParamsMatch(
               *context_, new_params,
-              DeclParams(name_context.resolved_inst_id, Parse::NodeId::Invalid,
-                         Parse::NodeId::Invalid, SemIR::InstBlockId::Invalid,
-                         SemIR::InstBlockId::Invalid))) {
+              DeclParams(name_context.resolved_inst_id, Parse::NodeId::None,
+                         Parse::NodeId::None, SemIR::InstBlockId::None,
+                         SemIR::InstBlockId::None))) {
         return InvalidResult;
       }
       if (scope.is_closed_import()) {
@@ -441,7 +441,7 @@ auto DeclNameStack::ResolveAsScope(const NameContext& name_context,
         // be used as a name qualifier.
         scope.set_is_closed_import(false);
       }
-      return {scope_id, SemIR::SpecificId::Invalid};
+      return {scope_id, SemIR::SpecificId::None};
     }
     default: {
       DiagnoseQualifiedDeclInNonScope(*context_, name_context.loc_id,

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -117,7 +117,7 @@ auto DeclNameStack::Restore(SuspendedName sus) -> void {
   for (auto& suspended_scope : llvm::reverse(sus.scopes)) {
     // Reattempt to resolve the definition of the specific. The generic might
     // have been defined after we suspended this scope.
-    if (suspended_scope.entry.specific_id.is_valid()) {
+    if (suspended_scope.entry.specific_id.has_value()) {
       ResolveSpecificDefinition(*context_, sus.name_context.loc_id,
                                 suspended_scope.entry.specific_id);
     }
@@ -133,7 +133,7 @@ auto DeclNameStack::AddName(NameContext name_context, SemIR::InstId target_id,
       return;
 
     case NameContext::State::Unresolved:
-      if (!name_context.parent_scope_id.is_valid()) {
+      if (!name_context.parent_scope_id.has_value()) {
         context_->AddNameToLookup(name_context.unresolved_name_id, target_id,
                                   name_context.initial_scope_index);
       } else {
@@ -176,7 +176,7 @@ auto DeclNameStack::AddNameOrDiagnose(NameContext name_context,
                                       SemIR::AccessKind access_kind) -> void {
   if (name_context.state == DeclNameStack::NameContext::State::Poisoned) {
     context_->DiagnosePoisonedName(target_id);
-  } else if (auto id = name_context.prev_inst_id(); id.is_valid()) {
+  } else if (auto id = name_context.prev_inst_id(); id.has_value()) {
     context_->DiagnoseDuplicateName(target_id, id);
   } else {
     AddName(name_context, target_id, access_kind);
@@ -190,7 +190,7 @@ auto DeclNameStack::LookupOrAddName(NameContext name_context,
   if (name_context.state == NameContext::State::Poisoned) {
     return {SemIR::InstId::None, true};
   }
-  if (auto id = name_context.prev_inst_id(); id.is_valid()) {
+  if (auto id = name_context.prev_inst_id(); id.has_value()) {
     return {id, false};
   }
   AddName(name_context, target_id, access_kind);
@@ -211,7 +211,7 @@ static auto PushNameQualifierScope(Context& context, SemIRLoc loc,
   context.scope_stack().PopIfEmpty();
 
   // When declaring a member of a generic, resolve the self specific.
-  if (specific_id.is_valid()) {
+  if (specific_id.has_value()) {
     ResolveSpecificDefinition(context, loc, specific_id);
   }
 
@@ -237,7 +237,7 @@ auto DeclNameStack::ApplyNameQualifier(const NameComponent& name) -> void {
 
   // Resolve the qualifier as a scope and enter the new scope.
   auto [scope_id, specific_id] = ResolveAsScope(name_context, name);
-  if (scope_id.is_valid()) {
+  if (scope_id.has_value()) {
     PushNameQualifierScope(*context_, name_context.loc_id,
                            name_context.resolved_inst_id, scope_id, specific_id,
                            context_->name_scopes().Get(scope_id).has_error());
@@ -268,7 +268,7 @@ auto DeclNameStack::ApplyAndLookupName(NameContext& name_context,
   if (is_poisoned) {
     name_context.unresolved_name_id = name_id;
     name_context.state = NameContext::State::Poisoned;
-  } else if (!resolved_inst_id.is_valid()) {
+  } else if (!resolved_inst_id.has_value()) {
     // Invalid indicates an unresolved name. Store it and return.
     name_context.unresolved_name_id = name_id;
     name_context.state = NameContext::State::Unresolved;

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -100,7 +100,7 @@ class DeclNameStack {
       return {
           .name_id = name_id_for_new_inst(),
           .parent_scope_id = parent_scope_id,
-          .generic_id = SemIR::GenericId::Invalid,
+          .generic_id = SemIR::GenericId::None,
           .first_param_node_id = name.first_param_node_id,
           .last_param_node_id = name.last_param_node_id,
           .pattern_block_id = name.pattern_block_id,
@@ -110,9 +110,9 @@ class DeclNameStack {
           .is_extern = is_extern,
           .extern_library_id = extern_library,
           .non_owning_decl_id =
-              extern_library.is_valid() ? decl_id : SemIR::InstId::Invalid,
+              extern_library.is_valid() ? decl_id : SemIR::InstId::None,
           .first_owning_decl_id =
-              extern_library.is_valid() ? SemIR::InstId::Invalid : decl_id,
+              extern_library.is_valid() ? SemIR::InstId::None : decl_id,
       };
     }
 
@@ -123,7 +123,7 @@ class DeclNameStack {
     // resolved.
     auto name_id_for_new_inst() -> SemIR::NameId {
       return state == State::Unresolved ? unresolved_name_id
-                                        : SemIR::NameId::Invalid;
+                                        : SemIR::NameId::None;
     }
 
     // The current scope when this name began. This is the scope that we will
@@ -141,7 +141,7 @@ class DeclNameStack {
     SemIR::NameScopeId parent_scope_id;
 
     // The last location ID used.
-    SemIR::LocId loc_id = SemIR::LocId::Invalid;
+    SemIR::LocId loc_id = SemIR::LocId::None;
 
     union {
       // The ID of a resolved qualifier, including both identifiers and
@@ -149,7 +149,7 @@ class DeclNameStack {
       SemIR::InstId resolved_inst_id;
 
       // The ID of an unresolved identifier.
-      SemIR::NameId unresolved_name_id = SemIR::NameId::Invalid;
+      SemIR::NameId unresolved_name_id = SemIR::NameId::None;
     };
   };
 

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -110,9 +110,9 @@ class DeclNameStack {
           .is_extern = is_extern,
           .extern_library_id = extern_library,
           .non_owning_decl_id =
-              extern_library.is_valid() ? decl_id : SemIR::InstId::None,
+              extern_library.has_value() ? decl_id : SemIR::InstId::None,
           .first_owning_decl_id =
-              extern_library.is_valid() ? SemIR::InstId::None : decl_id,
+              extern_library.has_value() ? SemIR::InstId::None : decl_id,
       };
     }
 

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -531,7 +531,7 @@ auto DeduceGenericCallArguments(
 }
 
 // Deduces the impl arguments to use in a use of a parameterized impl. Returns
-// `Invalid` if deduction fails.
+// `None` if deduction fails.
 auto DeduceImplArguments(Context& context, SemIR::LocId loc_id,
                          const SemIR::Impl& impl, SemIR::ConstantId self_id,
                          SemIR::ConstantId constraint_id) -> SemIR::SpecificId {

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -265,7 +265,7 @@ DeductionContext::DeductionContext(Context& context, SemIR::LocId loc_id,
       context.inst_blocks()
           .Get(context.generics().Get(generic_id_).bindings_id)
           .size(),
-      SemIR::InstId::Invalid);
+      SemIR::InstId::None);
 
   if (enclosing_specific_id.is_valid()) {
     // Copy any outer generic arguments from the specified instance and prepare
@@ -524,7 +524,7 @@ auto DeduceGenericCallArguments(
   deduction.AddAll(params_id, arg_ids, /*needs_substitution=*/true);
 
   if (!deduction.Deduce() || !deduction.CheckDeductionIsComplete()) {
-    return SemIR::SpecificId::Invalid;
+    return SemIR::SpecificId::None;
   }
 
   return deduction.MakeSpecific();
@@ -535,10 +535,9 @@ auto DeduceGenericCallArguments(
 auto DeduceImplArguments(Context& context, SemIR::LocId loc_id,
                          const SemIR::Impl& impl, SemIR::ConstantId self_id,
                          SemIR::ConstantId constraint_id) -> SemIR::SpecificId {
-  DeductionContext deduction(
-      context, loc_id, impl.generic_id,
-      /*enclosing_specific_id=*/SemIR::SpecificId::Invalid,
-      /*diagnose=*/false);
+  DeductionContext deduction(context, loc_id, impl.generic_id,
+                             /*enclosing_specific_id=*/SemIR::SpecificId::None,
+                             /*diagnose=*/false);
 
   // Prepare to perform deduction of the type and interface.
   deduction.Add(impl.self_id, context.constant_values().GetInstId(self_id),
@@ -548,7 +547,7 @@ auto DeduceImplArguments(Context& context, SemIR::LocId loc_id,
                 /*needs_substitution=*/false);
 
   if (!deduction.Deduce() || !deduction.CheckDeductionIsComplete()) {
-    return SemIR::SpecificId::Invalid;
+    return SemIR::SpecificId::None;
   }
 
   return deduction.MakeSpecific();

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -50,7 +50,7 @@ class DeductionWorklist {
   // Adds a single (param, arg) deduction of a specific.
   auto Add(SemIR::SpecificId param, SemIR::SpecificId arg,
            bool needs_substitution) -> void {
-    if (!param.is_valid() || !arg.is_valid()) {
+    if (!param.has_value() || !arg.has_value()) {
       return;
     }
     auto& param_specific = context_.specifics().Get(param);
@@ -257,7 +257,7 @@ DeductionContext::DeductionContext(Context& context, SemIR::LocId loc_id,
       diagnose_(diagnose),
       worklist_(context),
       first_deduced_index_(0) {
-  CARBON_CHECK(generic_id.is_valid(),
+  CARBON_CHECK(generic_id.has_value(),
                "Performing deduction for non-generic entity");
 
   // Initialize the deduced arguments to Invalid.
@@ -267,7 +267,7 @@ DeductionContext::DeductionContext(Context& context, SemIR::LocId loc_id,
           .size(),
       SemIR::InstId::None);
 
-  if (enclosing_specific_id.is_valid()) {
+  if (enclosing_specific_id.has_value()) {
     // Copy any outer generic arguments from the specified instance and prepare
     // to substitute them into the function declaration.
     auto args = context.inst_blocks().Get(
@@ -343,7 +343,7 @@ auto DeductionContext::Deduce() -> bool {
       case CARBON_KIND(SemIR::SymbolicBindingPattern bind): {
         auto& entity_name = context().entity_names().Get(bind.entity_name_id);
         auto index = entity_name.bind_index;
-        if (!index.is_valid()) {
+        if (!index.has_value()) {
           break;
         }
         CARBON_CHECK(
@@ -352,12 +352,12 @@ auto DeductionContext::Deduce() -> bool {
             "Unexpected index {0} for symbolic binding pattern; "
             "expected to be in range [{1}, {2})",
             index.index, first_deduced_index_.index, result_arg_ids_.size());
-        CARBON_CHECK(!result_arg_ids_[index.index].is_valid(),
+        CARBON_CHECK(!result_arg_ids_[index.index].has_value(),
                      "Deduced a value for parameter prior to its declaration");
 
         auto arg_const_inst_id =
             context().constant_values().GetConstantInstId(arg_id);
-        if (!arg_const_inst_id.is_valid()) {
+        if (!arg_const_inst_id.has_value()) {
           if (diagnose_) {
             CARBON_DIAGNOSTIC(CompTimeArgumentNotConstant, Error,
                               "argument for generic parameter is not a "
@@ -382,7 +382,7 @@ auto DeductionContext::Deduce() -> bool {
       case CARBON_KIND(SemIR::BindSymbolicName bind): {
         auto& entity_name = context().entity_names().Get(bind.entity_name_id);
         auto index = entity_name.bind_index;
-        if (!index.is_valid() || index < first_deduced_index_ ||
+        if (!index.has_value() || index < first_deduced_index_ ||
             non_deduced_indexes_[index.index - first_deduced_index_.index]) {
           break;
         }
@@ -393,8 +393,8 @@ auto DeductionContext::Deduce() -> bool {
                      index, result_arg_ids_.size());
         auto arg_const_inst_id =
             context().constant_values().GetConstantInstId(arg_id);
-        if (arg_const_inst_id.is_valid()) {
-          if (result_arg_ids_[index.index].is_valid() &&
+        if (arg_const_inst_id.has_value()) {
+          if (result_arg_ids_[index.index].has_value() &&
               result_arg_ids_[index.index] != arg_const_inst_id) {
             if (diagnose_) {
               // TODO: Include the two different deduced values.
@@ -446,7 +446,7 @@ auto DeductionContext::Deduce() -> bool {
     // We didn't manage to deduce against the syntactic form of the parameter.
     // Convert it to a canonical constant value and try deducing against that.
     auto param_const_id = context().constant_values().Get(param_id);
-    if (!param_const_id.is_valid() || !param_const_id.is_symbolic()) {
+    if (!param_const_id.has_value() || !param_const_id.is_symbolic()) {
       // It's not a symbolic constant. There's nothing here to deduce.
       continue;
     }
@@ -460,7 +460,7 @@ auto DeductionContext::Deduce() -> bool {
     // If we've not yet substituted into the parameter, do so now and try again.
     if (needs_substitution) {
       param_const_id = SubstConstant(context(), param_const_id, substitutions_);
-      if (!param_const_id.is_valid() || !param_const_id.is_symbolic()) {
+      if (!param_const_id.has_value() || !param_const_id.is_symbolic()) {
         continue;
       }
       Add(context().constant_values().GetInstId(param_const_id), arg_id,
@@ -476,7 +476,7 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
   for (auto [i, deduced_arg_id] :
        llvm::enumerate(llvm::ArrayRef(result_arg_ids_)
                            .drop_front(first_deduced_index_.index))) {
-    if (!deduced_arg_id.is_valid()) {
+    if (!deduced_arg_id.has_value()) {
       if (diagnose_) {
         auto binding_index = first_deduced_index_.index + i;
         auto binding_id = context().inst_blocks().Get(

--- a/toolchain/check/deduce.h
+++ b/toolchain/check/deduce.h
@@ -21,7 +21,7 @@ auto DeduceGenericCallArguments(Context& context, SemIR::LocId loc_id,
     -> SemIR::SpecificId;
 
 // Deduces the impl arguments to use in a use of a parameterized impl. Returns
-// `Invalid` if deduction fails.
+// `None` if deduction fails.
 auto DeduceImplArguments(Context& context, SemIR::LocId loc_id,
                          const SemIR::Impl& impl, SemIR::ConstantId self_id,
                          SemIR::ConstantId constraint_id) -> SemIR::SpecificId;

--- a/toolchain/check/dump.cpp
+++ b/toolchain/check/dump.cpp
@@ -30,7 +30,7 @@
 namespace Carbon::Check {
 
 static auto DumpNoNewline(const Context& context, SemIR::LocId loc_id) -> void {
-  if (!loc_id.is_valid()) {
+  if (!loc_id.has_value()) {
     llvm::errs() << "LocId(invalid)";
     return;
   }

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -33,7 +33,7 @@ class EvalContext {
  public:
   explicit EvalContext(
       Context& context, SemIRLoc fallback_loc,
-      SemIR::SpecificId specific_id = SemIR::SpecificId::Invalid,
+      SemIR::SpecificId specific_id = SemIR::SpecificId::None,
       std::optional<SpecificEvalInfo> specific_eval_info = std::nullopt)
       : context_(context),
         fallback_loc_(fallback_loc),
@@ -62,8 +62,8 @@ class EvalContext {
   // Returns `Invalid` if the value is not fixed in this context.
   auto GetCompileTimeBindValue(SemIR::CompileTimeBindIndex bind_index)
       -> SemIR::ConstantId {
-    if (!bind_index.is_valid() || !specific_id_.is_valid()) {
-      return SemIR::ConstantId::Invalid;
+    if (!bind_index.is_valid() || !specific_id_.has_value()) {
+      return SemIR::ConstantId::None;
     }
 
     const auto& specific = specifics().Get(specific_id_);
@@ -72,7 +72,7 @@ class EvalContext {
     // Bindings past the ones with known arguments can appear as local
     // bindings of entities declared within this generic.
     if (static_cast<size_t>(bind_index.index) >= args.size()) {
-      return SemIR::ConstantId::Invalid;
+      return SemIR::ConstantId::None;
     }
     return constant_values().Get(args[bind_index.index]);
   }
@@ -339,14 +339,14 @@ static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::InstBlockId inst_block_id, Phase* phase)
     -> SemIR::InstBlockId {
   if (!inst_block_id.is_valid()) {
-    return SemIR::InstBlockId::Invalid;
+    return SemIR::InstBlockId::None;
   }
   auto insts = eval_context.inst_blocks().Get(inst_block_id);
   llvm::SmallVector<SemIR::InstId> const_insts;
   for (auto inst_id : insts) {
     auto const_inst_id = GetConstantValue(eval_context, inst_id, phase);
     if (!const_inst_id.is_valid()) {
-      return SemIR::InstBlockId::Invalid;
+      return SemIR::InstBlockId::None;
     }
 
     // Once we leave the small buffer, we know the first few elements are all
@@ -369,14 +369,14 @@ static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::StructTypeFieldsId fields_id, Phase* phase)
     -> SemIR::StructTypeFieldsId {
   if (!fields_id.is_valid()) {
-    return SemIR::StructTypeFieldsId::Invalid;
+    return SemIR::StructTypeFieldsId::None;
   }
   auto fields = eval_context.context().struct_type_fields().Get(fields_id);
   llvm::SmallVector<SemIR::StructTypeField> new_fields;
   for (auto field : fields) {
     auto new_type_id = GetConstantValue(eval_context, field.type_id, phase);
     if (!new_type_id.is_valid()) {
-      return SemIR::StructTypeFieldsId::Invalid;
+      return SemIR::StructTypeFieldsId::None;
     }
 
     // Once we leave the small buffer, we know the first few elements are all
@@ -399,14 +399,14 @@ static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::TypeBlockId type_block_id, Phase* phase)
     -> SemIR::TypeBlockId {
   if (!type_block_id.is_valid()) {
-    return SemIR::TypeBlockId::Invalid;
+    return SemIR::TypeBlockId::None;
   }
   auto types = eval_context.type_blocks().Get(type_block_id);
   llvm::SmallVector<SemIR::TypeId> new_types;
   for (auto type_id : types) {
     auto new_type_id = GetConstantValue(eval_context, type_id, phase);
     if (!new_type_id.is_valid()) {
-      return SemIR::TypeBlockId::Invalid;
+      return SemIR::TypeBlockId::None;
     }
 
     // Once we leave the small buffer, we know the first few elements are all
@@ -429,13 +429,13 @@ static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::SpecificId specific_id, Phase* phase)
     -> SemIR::SpecificId {
   if (!specific_id.is_valid()) {
-    return SemIR::SpecificId::Invalid;
+    return SemIR::SpecificId::None;
   }
 
   const auto& specific = eval_context.specifics().Get(specific_id);
   auto args_id = GetConstantValue(eval_context, specific.args_id, phase);
   if (!args_id.is_valid()) {
-    return SemIR::SpecificId::Invalid;
+    return SemIR::SpecificId::None;
   }
 
   if (args_id == specific.args_id) {
@@ -1430,7 +1430,7 @@ static auto MakeConstantForCall(EvalContext& eval_context, SemIRLoc loc,
   // call.
   //
   // TODO: Use a better representation for this.
-  if (call.args_id == SemIR::InstBlockId::Invalid) {
+  if (call.args_id == SemIR::InstBlockId::None) {
     return SemIR::ErrorInst::SingletonConstantId;
   }
 
@@ -1710,7 +1710,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
           eval_context.context(),
           SemIR::ClassType{.type_id = SemIR::TypeType::SingletonTypeId,
                            .class_id = class_decl.class_id,
-                           .specific_id = SemIR::SpecificId::Invalid},
+                           .specific_id = SemIR::SpecificId::None},
           Phase::Template);
     }
 
@@ -1742,7 +1742,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
       return MakeConstantResult(
           eval_context.context(),
           eval_context.context().FacetTypeFromInterface(
-              interface_decl.interface_id, SemIR::SpecificId::Invalid),
+              interface_decl.interface_id, SemIR::SpecificId::None),
           Phase::Template);
     }
 
@@ -1885,7 +1885,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
       // original, with no equivalent value.
       bind.entity_name_id =
           eval_context.entity_names().MakeCanonical(bind.entity_name_id);
-      bind.value_id = SemIR::InstId::Invalid;
+      bind.value_id = SemIR::InstId::None;
       if (!ReplaceFieldWithConstantValue(
               eval_context, &bind, &SemIR::BindSymbolicName::type_id, &phase)) {
         return MakeNonConstantResult(phase);
@@ -2114,7 +2114,7 @@ auto TryEvalBlockForSpecific(Context& context, SemIRLoc loc,
   auto eval_block = context.inst_blocks().Get(eval_block_id);
 
   llvm::SmallVector<SemIR::InstId> result;
-  result.resize(eval_block.size(), SemIR::InstId::Invalid);
+  result.resize(eval_block.size(), SemIR::InstId::None);
 
   EvalContext eval_context(context, loc, specific_id,
                            SpecificEvalInfo{

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -60,7 +60,7 @@ class EvalContext {
   }
 
   // Gets the value of the specified compile-time binding in this context.
-  // Returns `Invalid` if the value is not fixed in this context.
+  // Returns `None` if the value is not fixed in this context.
   auto GetCompileTimeBindValue(SemIR::CompileTimeBindIndex bind_index)
       -> SemIR::ConstantId {
     if (!bind_index.has_value() || !specific_id_.has_value()) {

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -51,7 +51,8 @@ class EvalContext {
   // is one, and otherwise the fallback location.
   auto GetDiagnosticLoc(llvm::ArrayRef<SemIR::InstId> inst_ids) -> SemIRLoc {
     for (auto inst_id : inst_ids) {
-      if (inst_id.is_valid() && context_.insts().GetLocId(inst_id).is_valid()) {
+      if (inst_id.has_value() &&
+          context_.insts().GetLocId(inst_id).has_value()) {
         return inst_id;
       }
     }
@@ -62,7 +63,7 @@ class EvalContext {
   // Returns `Invalid` if the value is not fixed in this context.
   auto GetCompileTimeBindValue(SemIR::CompileTimeBindIndex bind_index)
       -> SemIR::ConstantId {
-    if (!bind_index.is_valid() || !specific_id_.has_value()) {
+    if (!bind_index.has_value() || !specific_id_.has_value()) {
       return SemIR::ConstantId::None;
     }
 
@@ -93,12 +94,12 @@ class EvalContext {
     if (specific_eval_info_) {
       const auto& symbolic_info =
           constant_values().GetSymbolicConstant(const_id);
-      if (symbolic_info.index.is_valid() &&
+      if (symbolic_info.index.has_value() &&
           symbolic_info.generic_id ==
               specifics().Get(specific_id_).generic_id &&
           symbolic_info.index.region() == specific_eval_info_->region) {
         auto inst_id = specific_eval_info_->values[symbolic_info.index.index()];
-        CARBON_CHECK(inst_id.is_valid(),
+        CARBON_CHECK(inst_id.has_value(),
                      "Forward reference in eval block: index {0} referenced "
                      "before evaluation",
                      symbolic_info.index.index());
@@ -338,14 +339,14 @@ static auto GetConstantValue(EvalContext& eval_context, SemIR::TypeId type_id,
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::InstBlockId inst_block_id, Phase* phase)
     -> SemIR::InstBlockId {
-  if (!inst_block_id.is_valid()) {
+  if (!inst_block_id.has_value()) {
     return SemIR::InstBlockId::None;
   }
   auto insts = eval_context.inst_blocks().Get(inst_block_id);
   llvm::SmallVector<SemIR::InstId> const_insts;
   for (auto inst_id : insts) {
     auto const_inst_id = GetConstantValue(eval_context, inst_id, phase);
-    if (!const_inst_id.is_valid()) {
+    if (!const_inst_id.has_value()) {
       return SemIR::InstBlockId::None;
     }
 
@@ -368,14 +369,14 @@ static auto GetConstantValue(EvalContext& eval_context,
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::StructTypeFieldsId fields_id, Phase* phase)
     -> SemIR::StructTypeFieldsId {
-  if (!fields_id.is_valid()) {
+  if (!fields_id.has_value()) {
     return SemIR::StructTypeFieldsId::None;
   }
   auto fields = eval_context.context().struct_type_fields().Get(fields_id);
   llvm::SmallVector<SemIR::StructTypeField> new_fields;
   for (auto field : fields) {
     auto new_type_id = GetConstantValue(eval_context, field.type_id, phase);
-    if (!new_type_id.is_valid()) {
+    if (!new_type_id.has_value()) {
       return SemIR::StructTypeFieldsId::None;
     }
 
@@ -398,14 +399,14 @@ static auto GetConstantValue(EvalContext& eval_context,
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::TypeBlockId type_block_id, Phase* phase)
     -> SemIR::TypeBlockId {
-  if (!type_block_id.is_valid()) {
+  if (!type_block_id.has_value()) {
     return SemIR::TypeBlockId::None;
   }
   auto types = eval_context.type_blocks().Get(type_block_id);
   llvm::SmallVector<SemIR::TypeId> new_types;
   for (auto type_id : types) {
     auto new_type_id = GetConstantValue(eval_context, type_id, phase);
-    if (!new_type_id.is_valid()) {
+    if (!new_type_id.has_value()) {
       return SemIR::TypeBlockId::None;
     }
 
@@ -428,13 +429,13 @@ static auto GetConstantValue(EvalContext& eval_context,
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::SpecificId specific_id, Phase* phase)
     -> SemIR::SpecificId {
-  if (!specific_id.is_valid()) {
+  if (!specific_id.has_value()) {
     return SemIR::SpecificId::None;
   }
 
   const auto& specific = eval_context.specifics().Get(specific_id);
   auto args_id = GetConstantValue(eval_context, specific.args_id, phase);
-  if (!args_id.is_valid()) {
+  if (!args_id.has_value()) {
     return SemIR::SpecificId::None;
   }
 
@@ -474,7 +475,7 @@ static auto ReplaceFieldWithConstantValue(EvalContext& eval_context,
                                           InstT* inst, FieldIdT InstT::*field,
                                           Phase* phase) -> bool {
   auto unwrapped = GetConstantValue(eval_context, inst->*field, phase);
-  if (!unwrapped.is_valid() && (inst->*field).is_valid()) {
+  if (!unwrapped.has_value() && (inst->*field).has_value()) {
     return false;
   }
   inst->*field = unwrapped;
@@ -596,7 +597,7 @@ static auto PerformArrayIndex(EvalContext& eval_context, SemIR::ArrayIndex inst)
   Phase phase = Phase::Template;
   auto index_id = GetConstantValue(eval_context, inst.index_id, &phase);
 
-  if (!index_id.is_valid()) {
+  if (!index_id.has_value()) {
     return MakeNonConstantResult(phase);
   }
   auto index = eval_context.insts().TryGetAs<SemIR::IntValue>(index_id);
@@ -633,7 +634,7 @@ static auto PerformArrayIndex(EvalContext& eval_context, SemIR::ArrayIndex inst)
   }
 
   auto aggregate_id = GetConstantValue(eval_context, inst.array_id, &phase);
-  if (!aggregate_id.is_valid()) {
+  if (!aggregate_id.has_value()) {
     return MakeNonConstantResult(phase);
   }
   auto aggregate =
@@ -729,7 +730,7 @@ static auto PerformIntConvert(Context& context, SemIR::InstId arg_id,
       context.ints().Get(context.insts().GetAs<SemIR::IntValue>(arg_id).int_id);
   auto [dest_is_signed, bit_width_id] =
       context.sem_ir().types().GetIntTypeInfo(dest_type_id);
-  if (bit_width_id.is_valid()) {
+  if (bit_width_id.has_value()) {
     // TODO: If the value fits in the destination type, reuse the existing
     // int_id rather than recomputing it. This is probably the most common case.
     bool src_is_signed = context.sem_ir().types().IsSignedInt(
@@ -752,7 +753,7 @@ static auto PerformCheckedIntConvert(Context& context, SemIRLoc loc,
 
   auto [is_signed, bit_width_id] =
       context.sem_ir().types().GetIntTypeInfo(dest_type_id);
-  auto width = bit_width_id.is_valid()
+  auto width = bit_width_id.has_value()
                    ? context.ints().Get(bit_width_id).getZExtValue()
                    : arg_val.getBitWidth();
 
@@ -791,7 +792,7 @@ static auto DiagnoseDivisionByZero(Context& context, SemIRLoc loc) -> void {
 // or the canonical width from the value store if not.
 static auto GetIntAtSuitableWidth(Context& context, IntId int_id,
                                   IntId bit_width_id) -> llvm::APInt {
-  return bit_width_id.is_valid()
+  return bit_width_id.has_value()
              ? context.ints().GetAtWidth(int_id, bit_width_id)
              : context.ints().Get(int_id);
 }
@@ -809,7 +810,7 @@ static auto PerformBuiltinUnaryIntOp(Context& context, SemIRLoc loc,
   switch (builtin_kind) {
     case SemIR::BuiltinFunctionKind::IntSNegate:
       if (op_val.isMinSignedValue()) {
-        if (bit_width_id.is_valid()) {
+        if (bit_width_id.has_value()) {
           CARBON_DIAGNOSTIC(CompileTimeIntegerNegateOverflow, Error,
                             "integer overflow in negation of {0}", TypedInt);
           context.emitter().Emit(loc, CompileTimeIntegerNegateOverflow,
@@ -823,7 +824,7 @@ static auto PerformBuiltinUnaryIntOp(Context& context, SemIRLoc loc,
       op_val.negate();
       break;
     case SemIR::BuiltinFunctionKind::IntUNegate:
-      CARBON_CHECK(bit_width_id.is_valid(), "Unsigned negate on unsized int");
+      CARBON_CHECK(bit_width_id.has_value(), "Unsigned negate on unsized int");
       op_val.negate();
       break;
     case SemIR::BuiltinFunctionKind::IntComplement:
@@ -856,7 +857,7 @@ struct APIntBinaryOperands {
 static auto GetIntsAtSuitableWidth(Context& context, IntId lhs_id, IntId rhs_id,
                                    IntId bit_width_id) -> APIntBinaryOperands {
   // Unsized operands: take the wider of the bit widths.
-  if (!bit_width_id.is_valid()) {
+  if (!bit_width_id.has_value()) {
     APIntBinaryOperands result = {.lhs = context.ints().Get(lhs_id),
                                   .rhs = context.ints().Get(rhs_id)};
     if (result.lhs.getBitWidth() != result.rhs.getBitWidth()) {
@@ -977,7 +978,7 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIRLoc loc,
   llvm::APInt lhs_val =
       GetIntAtSuitableWidth(context, lhs.int_id, lhs_bit_width_id);
   const auto& rhs_orig_val = context.ints().Get(rhs.int_id);
-  if (lhs_bit_width_id.is_valid() && rhs_orig_val.uge(lhs_val.getBitWidth())) {
+  if (lhs_bit_width_id.has_value() && rhs_orig_val.uge(lhs_val.getBitWidth())) {
     CARBON_DIAGNOSTIC(
         CompileTimeShiftOutOfRange, Error,
         "shift distance >= type width of {0} in `{1} {2:<<|>>} {3}`", unsigned,
@@ -1006,7 +1007,7 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIRLoc loc,
 
   llvm::APInt result_val;
   if (builtin_kind == SemIR::BuiltinFunctionKind::IntLeftShift) {
-    if (!lhs_bit_width_id.is_valid() && !lhs_val.isZero()) {
+    if (!lhs_bit_width_id.has_value() && !lhs_val.isZero()) {
       // Ensure we don't generate a ridiculously large integer through a bit
       // shift.
       auto width = rhs_orig_val.trySExtValue();
@@ -1032,7 +1033,7 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIRLoc loc,
     result_val =
         lhs_val.ashr(rhs_orig_val.getLimitedValue(lhs_val.getBitWidth()));
   } else {
-    CARBON_CHECK(lhs_bit_width_id.is_valid(), "Logical shift on unsized int");
+    CARBON_CHECK(lhs_bit_width_id.has_value(), "Logical shift on unsized int");
     result_val =
         lhs_val.lshr(rhs_orig_val.getLimitedValue(lhs_val.getBitWidth()));
   }
@@ -1074,7 +1075,7 @@ static auto PerformBuiltinBinaryIntOp(Context& context, SemIRLoc loc,
   BinaryIntOpResult result =
       ComputeBinaryIntOpResult(builtin_kind, lhs_val, rhs_val);
 
-  if (result.overflow && !bit_width_id.is_valid()) {
+  if (result.overflow && !bit_width_id.has_value()) {
     // Retry with a larger bit width. Most operations can only overflow by one
     // bit, but signed n-bit multiplication can overflow to 2n-1 bits. We don't
     // need to handle unsigned multiplication here because it's not permitted
@@ -1441,7 +1442,7 @@ static auto MakeConstantForCall(EvalContext& eval_context, SemIRLoc loc,
   auto callee_function =
       SemIR::GetCalleeFunction(eval_context.sem_ir(), call.callee_id);
   auto builtin_kind = SemIR::BuiltinFunctionKind::None;
-  if (callee_function.function_id.is_valid()) {
+  if (callee_function.function_id.has_value()) {
     // Calls to builtins might be constant.
     builtin_kind = eval_context.functions()
                        .Get(callee_function.function_id)
@@ -1799,7 +1800,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
           // contains a symbolic context.
 
           auto element = elements[index];
-          if (!element.is_valid()) {
+          if (!element.has_value()) {
             // TODO: Perhaps this should be a `{}` value with incomplete type?
             CARBON_DIAGNOSTIC(ImplAccessMemberBeforeComplete, Error,
                               "accessing member from impl before the end of "
@@ -1853,7 +1854,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
       // argument value.
       if (auto value =
               eval_context.GetCompileTimeBindValue(bind_name.bind_index);
-          value.is_valid()) {
+          value.has_value()) {
         return value;
       }
 
@@ -1876,7 +1877,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
         // argument value.
         if (auto value =
                 eval_context.GetCompileTimeBindValue(bind_name.bind_index);
-            value.is_valid()) {
+            value.has_value()) {
           return value;
         }
         phase = Phase::Symbolic;
@@ -1971,7 +1972,7 @@ static auto TryEvalInstInContext(EvalContext& eval_context,
                      "Unexpected type_id: {0}, inst: {1}", base_facet_type_id,
                      base_facet_inst);
       }
-      if (typed_inst.requirements_id.is_valid()) {
+      if (typed_inst.requirements_id.has_value()) {
         auto insts = eval_context.inst_blocks().Get(typed_inst.requirements_id);
         for (auto inst_id : insts) {
           if (auto rewrite =
@@ -2126,7 +2127,7 @@ auto TryEvalBlockForSpecific(Context& context, SemIRLoc loc,
       &context.emitter(), [&](auto& builder) {
         CARBON_DIAGNOSTIC(ResolvingSpecificHere, Note, "in {0} used here",
                           InstIdAsType);
-        if (loc.is_inst_id && !loc.inst_id.is_valid()) {
+        if (loc.is_inst_id && !loc.inst_id.has_value()) {
           return;
         }
         builder.Note(loc, ResolvingSpecificHere,
@@ -2137,7 +2138,7 @@ auto TryEvalBlockForSpecific(Context& context, SemIRLoc loc,
     auto const_id = TryEvalInstInContext(eval_context, inst_id,
                                          context.insts().Get(inst_id));
     result[i] = context.constant_values().GetInstId(const_id);
-    CARBON_CHECK(result[i].is_valid());
+    CARBON_CHECK(result[i].has_value());
   }
 
   return context.inst_blocks().Add(result);

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -40,13 +40,13 @@ auto CheckFunctionTypeMatches(Context& context,
         FunctionRedeclReturnTypeDiffersNoReturn, Error,
         "function redeclaration differs because no return type is provided");
     auto diag =
-        new_return_type_id.is_valid()
+        new_return_type_id.has_value()
             ? context.emitter().Build(new_function.latest_decl_id(),
                                       FunctionRedeclReturnTypeDiffers,
                                       new_return_type_id)
             : context.emitter().Build(new_function.latest_decl_id(),
                                       FunctionRedeclReturnTypeDiffersNoReturn);
-    if (prev_return_type_id.is_valid()) {
+    if (prev_return_type_id.has_value()) {
       CARBON_DIAGNOSTIC(FunctionRedeclReturnTypePrevious, Note,
                         "previously declared with return type {0}",
                         SemIR::TypeId);

--- a/toolchain/check/function.h
+++ b/toolchain/check/function.h
@@ -32,7 +32,7 @@ struct SuspendedFunction {
 auto CheckFunctionTypeMatches(
     Context& context, const SemIR::Function& new_function,
     const SemIR::Function& prev_function,
-    SemIR::SpecificId prev_specific_id = SemIR::SpecificId::Invalid,
+    SemIR::SpecificId prev_specific_id = SemIR::SpecificId::None,
     bool check_syntax = true) -> bool;
 
 // Checks that the return type of the specified function is complete, issuing an

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -79,7 +79,7 @@ class RebuildGenericConstantInEvalBlockCallbacks final
   // block, and substitute them for the instructions in the eval block.
   auto Subst(SemIR::InstId& inst_id) const -> bool override {
     auto const_id = context_.constant_values().Get(inst_id);
-    if (!const_id.is_valid()) {
+    if (!const_id.has_value()) {
       // An unloaded import ref should never contain anything we need to
       // substitute into. Don't trigger loading it here.
       CARBON_CHECK(
@@ -103,7 +103,7 @@ class RebuildGenericConstantInEvalBlockCallbacks final
       if (const_id != context_.constant_values().Get(result.value())) {
         inst_id = result.value();
       }
-      CARBON_CHECK(inst_id.is_valid());
+      CARBON_CHECK(inst_id.has_value());
       return true;
     }
 
@@ -113,7 +113,7 @@ class RebuildGenericConstantInEvalBlockCallbacks final
             context_.insts().TryGetAs<SemIR::BindSymbolicName>(inst_id)) {
       if (context_.entity_names()
               .Get(binding->entity_name_id)
-              .bind_index.is_valid()) {
+              .bind_index.has_value()) {
         inst_id = Rebuild(inst_id, *binding);
         return true;
       }
@@ -356,7 +356,7 @@ auto BuildGeneric(Context& context, SemIR::InstId decl_id) -> SemIR::GenericId {
 
 auto FinishGenericDecl(Context& context, SemIRLoc loc,
                        SemIR::GenericId generic_id) -> void {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     return;
   }
   auto decl_block_id = MakeGenericEvalBlock(
@@ -371,7 +371,7 @@ auto FinishGenericDecl(Context& context, SemIRLoc loc,
 auto BuildGenericDecl(Context& context, SemIR::InstId decl_id)
     -> SemIR::GenericId {
   SemIR::GenericId generic_id = BuildGeneric(context, decl_id);
-  if (generic_id.is_valid()) {
+  if (generic_id.has_value()) {
     FinishGenericDecl(context, decl_id, generic_id);
   }
   return generic_id;
@@ -386,7 +386,7 @@ auto FinishGenericRedecl(Context& context, SemIR::InstId /*decl_id*/,
 
 auto FinishGenericDefinition(Context& context, SemIR::GenericId generic_id)
     -> void {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     // TODO: We can have symbolic constants in a context that had a non-generic
     // declaration, for example if there's a local generic let binding in a
     // function definition. Handle this case somehow -- perhaps by forming
@@ -406,7 +406,7 @@ static auto ResolveSpecificDeclaration(Context& context, SemIRLoc loc,
                                        SemIR::SpecificId specific_id) -> void {
   // If this is the first time we've formed this specific, evaluate its decl
   // block to form information about the specific.
-  if (!context.specifics().Get(specific_id).decl_block_id.is_valid()) {
+  if (!context.specifics().Get(specific_id).decl_block_id.has_value()) {
     // Set a placeholder value as the decl block ID so we won't attempt to
     // recursively resolve the same specific.
     context.specifics().Get(specific_id).decl_block_id =
@@ -430,7 +430,7 @@ auto MakeSpecific(Context& context, SemIRLoc loc, SemIR::GenericId generic_id,
 
 static auto MakeSelfSpecificId(Context& context, SemIR::GenericId generic_id)
     -> SemIR::SpecificId {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     return SemIR::SpecificId::None;
   }
 
@@ -463,12 +463,12 @@ auto ResolveSpecificDefinition(Context& context, SemIRLoc loc,
   // TODO: Handle recursive resolution of the same generic definition.
   auto& specific = context.specifics().Get(specific_id);
   auto generic_id = specific.generic_id;
-  CARBON_CHECK(generic_id.is_valid(), "Specific with no generic ID");
+  CARBON_CHECK(generic_id.has_value(), "Specific with no generic ID");
 
-  if (!specific.definition_block_id.is_valid()) {
+  if (!specific.definition_block_id.has_value()) {
     // Evaluate the eval block for the definition of the generic.
     auto& generic = context.generics().Get(generic_id);
-    if (!generic.definition_block_id.is_valid()) {
+    if (!generic.definition_block_id.has_value()) {
       // The generic is not defined yet.
       return false;
     }
@@ -484,7 +484,7 @@ auto ResolveSpecificDefinition(Context& context, SemIRLoc loc,
 
 auto GetInstForSpecific(Context& context, SemIR::SpecificId specific_id)
     -> SemIR::InstId {
-  CARBON_CHECK(specific_id.is_valid());
+  CARBON_CHECK(specific_id.has_value());
   const auto& specific = context.specifics().Get(specific_id);
   const auto& generic = context.generics().Get(specific.generic_id);
   auto decl = context.insts().Get(generic.decl_id);

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -334,7 +334,7 @@ auto BuildGeneric(Context& context, SemIR::InstId decl_id) -> SemIR::GenericId {
                                          .inst_id),
                  context.insts().Get(decl_id));
     context.generic_region_stack().Pop();
-    return SemIR::GenericId::Invalid;
+    return SemIR::GenericId::None;
   }
 
   // Build the new Generic object. Note that we intentionally do not hold a
@@ -346,7 +346,7 @@ auto BuildGeneric(Context& context, SemIR::InstId decl_id) -> SemIR::GenericId {
   SemIR::GenericId generic_id = context.generics().Add(
       SemIR::Generic{.decl_id = decl_id,
                      .bindings_id = bindings_id,
-                     .self_specific_id = SemIR::SpecificId::Invalid});
+                     .self_specific_id = SemIR::SpecificId::None});
   // MakeSelfSpecificId could cause something to be imported, which would
   // invalidate the return value of `context.generics().Get(generic_id)`.
   auto self_specific_id = MakeSelfSpecificId(context, generic_id);
@@ -431,7 +431,7 @@ auto MakeSpecific(Context& context, SemIRLoc loc, SemIR::GenericId generic_id,
 static auto MakeSelfSpecificId(Context& context, SemIR::GenericId generic_id)
     -> SemIR::SpecificId {
   if (!generic_id.is_valid()) {
-    return SemIR::SpecificId::Invalid;
+    return SemIR::SpecificId::None;
   }
 
   auto& generic = context.generics().Get(generic_id);
@@ -499,7 +499,7 @@ auto GetInstForSpecific(Context& context, SemIR::SpecificId specific_id)
     }
     case SemIR::FunctionDecl::Kind: {
       return context.constant_values().GetInstId(
-          TryEvalInst(context, SemIR::InstId::Invalid,
+          TryEvalInst(context, SemIR::InstId::None,
                       SemIR::SpecificFunction{
                           .type_id = context.GetSingletonType(
                               SemIR::SpecificFunctionType::SingletonInstId),

--- a/toolchain/check/generic.h
+++ b/toolchain/check/generic.h
@@ -66,8 +66,9 @@ inline auto MakeSpecificIfGeneric(Context& context, SemIRLoc loc,
                                   SemIR::GenericId generic_id,
                                   SemIR::InstBlockId args_id)
     -> SemIR::SpecificId {
-  return generic_id.is_valid() ? MakeSpecific(context, loc, generic_id, args_id)
-                               : SemIR::SpecificId::None;
+  return generic_id.has_value()
+             ? MakeSpecific(context, loc, generic_id, args_id)
+             : SemIR::SpecificId::None;
 }
 
 // Builds the specific that describes how the generic should refer to itself.

--- a/toolchain/check/generic.h
+++ b/toolchain/check/generic.h
@@ -22,7 +22,7 @@ auto StartGenericDefinition(Context& context) -> void;
 auto DiscardGenericDecl(Context& context) -> void;
 
 // Finish processing a potentially generic declaration and produce a
-// corresponding generic object. Returns SemIR::GenericId::Invalid if this
+// corresponding generic object. Returns SemIR::GenericId::None if this
 // declaration is not actually generic.
 auto BuildGeneric(Context& context, SemIR::InstId decl_id) -> SemIR::GenericId;
 
@@ -67,7 +67,7 @@ inline auto MakeSpecificIfGeneric(Context& context, SemIRLoc loc,
                                   SemIR::InstBlockId args_id)
     -> SemIR::SpecificId {
   return generic_id.is_valid() ? MakeSpecific(context, loc, generic_id, args_id)
-                               : SemIR::SpecificId::Invalid;
+                               : SemIR::SpecificId::None;
 }
 
 // Builds the specific that describes how the generic should refer to itself.

--- a/toolchain/check/global_init.cpp
+++ b/toolchain/check/global_init.cpp
@@ -29,7 +29,7 @@ auto GlobalInit::Finalize() -> void {
   }
 
   Resume();
-  context_->AddInst<SemIR::Return>(Parse::NodeId::Invalid, {});
+  context_->AddInst<SemIR::Return>(Parse::NodeId::None, {});
   // Pop the GlobalInit block here to finalize it.
   context_->inst_block_stack().Pop();
 
@@ -37,18 +37,18 @@ auto GlobalInit::Finalize() -> void {
   context_->sem_ir().set_global_ctor_id(context_->sem_ir().functions().Add(
       {{.name_id = SemIR::NameId::ForIdentifier(name_id),
         .parent_scope_id = SemIR::NameScopeId::Package,
-        .generic_id = SemIR::GenericId::Invalid,
-        .first_param_node_id = Parse::NodeId::Invalid,
-        .last_param_node_id = Parse::NodeId::Invalid,
+        .generic_id = SemIR::GenericId::None,
+        .first_param_node_id = Parse::NodeId::None,
+        .last_param_node_id = Parse::NodeId::None,
         .pattern_block_id = SemIR::InstBlockId::Empty,
-        .implicit_param_patterns_id = SemIR::InstBlockId::Invalid,
+        .implicit_param_patterns_id = SemIR::InstBlockId::None,
         .param_patterns_id = SemIR::InstBlockId::Empty,
         .call_params_id = SemIR::InstBlockId::Empty,
         .is_extern = false,
-        .extern_library_id = SemIR::LibraryNameId::Invalid,
-        .non_owning_decl_id = SemIR::InstId::Invalid,
-        .first_owning_decl_id = SemIR::InstId::Invalid},
-       {.return_slot_pattern_id = SemIR::InstId::Invalid,
+        .extern_library_id = SemIR::LibraryNameId::None,
+        .non_owning_decl_id = SemIR::InstId::None,
+        .first_owning_decl_id = SemIR::InstId::None},
+       {.return_slot_pattern_id = SemIR::InstId::None,
         .body_block_ids = {SemIR::InstBlockId::GlobalInit}}}));
 }
 

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -37,10 +37,10 @@ auto HandleParseNode(Context& context, Parse::AliasId /*node_id*/) -> bool {
   auto entity_name_id = context.entity_names().Add(
       {.name_id = name_context.name_id_for_new_inst(),
        .parent_scope_id = name_context.parent_scope_id,
-       .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+       .bind_index = SemIR::CompileTimeBindIndex::None});
 
-  auto alias_type_id = SemIR::TypeId::Invalid;
-  auto alias_value_id = SemIR::InstId::Invalid;
+  auto alias_type_id = SemIR::TypeId::None;
+  auto alias_value_id = SemIR::InstId::None;
   if (SemIR::IsSingletonInstId(expr_id)) {
     // Type (`bool`) and value (`false`) literals provided by the builtin
     // structure should be turned into name references.

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -36,8 +36,8 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   bool is_generic = node_kind == Parse::NodeKind::CompileTimeBindingPattern;
   if (is_generic) {
     auto inst_id = context.scope_stack().PeekInstId();
-    is_associated_constant =
-        inst_id.is_valid() && context.insts().Is<SemIR::InterfaceDecl>(inst_id);
+    is_associated_constant = inst_id.has_value() &&
+                             context.insts().Is<SemIR::InterfaceDecl>(inst_id);
   }
 
   bool needs_compile_time_binding = is_generic && !is_associated_constant;
@@ -325,7 +325,7 @@ auto HandleParseNode(Context& context,
     // can represent a block scope, but is also used for other kinds of scopes
     // that aren't necessarily part of an interface or function decl.
     auto scope_inst_id = context.scope_stack().PeekInstId();
-    if (scope_inst_id.is_valid()) {
+    if (scope_inst_id.has_value()) {
       auto scope_inst = context.insts().Get(scope_inst_id);
       if (!scope_inst.Is<SemIR::InterfaceDecl>() &&
           !scope_inst.Is<SemIR::FunctionDecl>()) {

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -46,8 +46,8 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
       context.decl_introducer_state_stack().innermost();
 
   auto make_binding_pattern = [&]() -> SemIR::InstId {
-    auto bind_id = SemIR::InstId::Invalid;
-    auto binding_pattern_id = SemIR::InstId::Invalid;
+    auto bind_id = SemIR::InstId::None;
+    auto binding_pattern_id = SemIR::InstId::None;
     // TODO: Eventually the name will need to support associations with other
     // scopes, but right now we don't support qualified names here.
     auto entity_name_id = context.entity_names().Add(
@@ -57,14 +57,13 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
          // constant declaration.
          .bind_index = needs_compile_time_binding
                            ? context.scope_stack().AddCompileTimeBinding()
-                           : SemIR::CompileTimeBindIndex::Invalid});
+                           : SemIR::CompileTimeBindIndex::None});
     if (is_generic) {
       // TODO: Create a `BindTemplateName` instead inside a `template` pattern.
       bind_id = context.AddInstInNoBlock(SemIR::LocIdAndInst(
-          name_node,
-          SemIR::BindSymbolicName{.type_id = cast_type_id,
-                                  .entity_name_id = entity_name_id,
-                                  .value_id = SemIR::InstId::Invalid}));
+          name_node, SemIR::BindSymbolicName{.type_id = cast_type_id,
+                                             .entity_name_id = entity_name_id,
+                                             .value_id = SemIR::InstId::None}));
       binding_pattern_id =
           context.AddPatternInst<SemIR::SymbolicBindingPattern>(
               name_node,
@@ -73,7 +72,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
       bind_id = context.AddInstInNoBlock(SemIR::LocIdAndInst(
           name_node, SemIR::BindName{.type_id = cast_type_id,
                                      .entity_name_id = entity_name_id,
-                                     .value_id = SemIR::InstId::Invalid}));
+                                     .value_id = SemIR::InstId::None}));
       binding_pattern_id = context.AddPatternInst<SemIR::BindingPattern>(
           name_node,
           {.type_id = cast_type_id, .entity_name_id = entity_name_id});
@@ -133,7 +132,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
         });
     auto binding_id =
         is_generic
-            ? Parse::NodeId::Invalid
+            ? Parse::NodeId::None
             : context.parse_tree().As<Parse::VarBindingPatternId>(node_id);
     auto& class_info = context.classes().Get(parent_class_decl->class_id);
     auto field_type_id =
@@ -141,7 +140,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
     auto field_id = context.AddInst<SemIR::FieldDecl>(
         binding_id, {.type_id = field_type_id,
                      .name_id = name_id,
-                     .index = SemIR::ElementIndex::Invalid});
+                     .index = SemIR::ElementIndex::None});
     context.field_decls_stack().AppendToTop(field_id);
 
     context.node_stack().Push(node_id, field_id);
@@ -167,7 +166,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
     context.entity_names().Add(
         {.name_id = name_id,
          .parent_scope_id = context.scope_stack().PeekNameScopeId(),
-         .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+         .bind_index = SemIR::CompileTimeBindIndex::None});
 
     SemIR::InstId decl_id = context.AddInst<SemIR::AssociatedConstantDecl>(
         context.parse_tree().As<Parse::CompileTimeBindingPatternId>(node_id),
@@ -228,7 +227,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
       // in a function definition. We don't know which kind we have here.
       // TODO: A tuple pattern can appear in other places than function
       // parameters.
-      auto param_pattern_id = SemIR::InstId::Invalid;
+      auto param_pattern_id = SemIR::InstId::None;
       bool had_error = false;
       switch (introducer.kind) {
         case Lex::TokenKind::Fn: {
@@ -273,7 +272,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
             {
                 .type_id = context.insts().Get(pattern_inst_id).type_id(),
                 .subpattern_id = pattern_inst_id,
-                .runtime_index = is_generic ? SemIR::RuntimeParamIndex::Invalid
+                .runtime_index = is_generic ? SemIR::RuntimeParamIndex::None
                                             : SemIR::RuntimeParamIndex::Unknown,
             });
       }

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -117,8 +117,8 @@ static auto MergeOrAddName(Context& context, Parse::AnyClassDeclId node_id,
     return;
   }
 
-  auto prev_class_id = SemIR::ClassId::Invalid;
-  auto prev_import_ir_id = SemIR::ImportIRId::Invalid;
+  auto prev_class_id = SemIR::ClassId::None;
+  auto prev_import_ir_id = SemIR::ImportIRId::None;
   auto prev = context.insts().Get(prev_id);
   CARBON_KIND_SWITCH(prev) {
     case CARBON_KIND(SemIR::ClassDecl class_decl): {
@@ -212,7 +212,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
   // Add the class declaration.
   auto class_decl =
       SemIR::ClassDecl{.type_id = SemIR::TypeType::SingletonTypeId,
-                       .class_id = SemIR::ClassId::Invalid,
+                       .class_id = SemIR::ClassId::None,
                        .decl_block_id = decl_block_id};
   auto class_decl_id =
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, class_decl));
@@ -220,9 +220,9 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
   // TODO: Store state regarding is_extern.
   SemIR::Class class_info = {
       name_context.MakeEntityWithParamsBase(name, class_decl_id, is_extern,
-                                            SemIR::LibraryNameId::Invalid),
+                                            SemIR::LibraryNameId::None),
       {// `.self_type_id` depends on the ClassType, so is set below.
-       .self_type_id = SemIR::TypeId::Invalid,
+       .self_type_id = SemIR::TypeId::None,
        .inheritance_kind = inheritance_kind}};
 
   MergeOrAddName(context, node_id, name_context, class_decl_id, class_decl,
@@ -256,7 +256,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
     auto specific_id =
         context.generics().GetSelfSpecific(class_info.generic_id);
     class_info.self_type_id = context.GetTypeIdForTypeConstant(TryEvalInst(
-        context, SemIR::InstId::Invalid,
+        context, SemIR::InstId::None,
         SemIR::ClassType{.type_id = SemIR::TypeType::SingletonTypeId,
                          .class_id = class_decl.class_id,
                          .specific_id = specific_id}));
@@ -285,7 +285,7 @@ auto HandleParseNode(Context& context, Parse::ClassDefinitionStartId node_id)
   CARBON_CHECK(!class_info.has_definition_started());
   class_info.definition_id = class_decl_id;
   class_info.scope_id = context.name_scopes().Add(
-      class_decl_id, SemIR::NameId::Invalid, class_info.parent_scope_id);
+      class_decl_id, SemIR::NameId::None, class_info.parent_scope_id);
 
   // Enter the class scope.
   context.scope_stack().Push(
@@ -442,7 +442,7 @@ struct BaseInfo {
 };
 constexpr BaseInfo BaseInfo::Error = {
     .type_id = SemIR::ErrorInst::SingletonTypeId,
-    .scope_id = SemIR::NameScopeId::Invalid,
+    .scope_id = SemIR::NameScopeId::None,
     .inst_id = SemIR::ErrorInst::SingletonInstId};
 }  // namespace
 
@@ -541,7 +541,7 @@ auto HandleParseNode(Context& context, Parse::BaseDeclId node_id) -> bool {
   class_info.base_id = context.AddInst<SemIR::BaseDecl>(
       node_id, {.type_id = field_type_id,
                 .base_type_inst_id = base_info.inst_id,
-                .index = SemIR::ElementIndex::Invalid});
+                .index = SemIR::ElementIndex::None});
 
   if (base_info.type_id != SemIR::ErrorInst::SingletonTypeId) {
     auto base_class_info = context.classes().Get(
@@ -618,7 +618,7 @@ static auto CheckCompleteAdapterClassType(Context& context,
   // The object representation of the adapter is the object representation
   // of the adapted type.
   auto adapted_type_id =
-      class_info.GetAdaptedType(context.sem_ir(), SemIR::SpecificId::Invalid);
+      class_info.GetAdaptedType(context.sem_ir(), SemIR::SpecificId::None);
   auto object_repr_id = context.types().GetObjectRepr(adapted_type_id);
 
   return context.AddInst<SemIR::CompleteTypeWitness>(
@@ -665,7 +665,7 @@ static auto CheckCompleteClassType(Context& context, Parse::NodeId node_id,
 
   bool defining_vptr = class_info.is_dynamic;
   auto base_type_id =
-      class_info.GetBaseType(context.sem_ir(), SemIR::SpecificId::Invalid);
+      class_info.GetBaseType(context.sem_ir(), SemIR::SpecificId::None);
   SemIR::Class* base_class_info = nullptr;
   if (base_type_id.is_valid()) {
     // TODO: If the base class is template dependent, we will need to decide

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -87,7 +87,7 @@ static auto MergeClassRedecl(Context& context, SemIRLoc new_loc,
     prev_class.complete_type_witness_id = new_class.complete_type_witness_id;
   }
 
-  if ((prev_import_ir_id.is_valid() && !new_is_import) ||
+  if ((prev_import_ir_id.has_value() && !new_is_import) ||
       (prev_class.is_extern && !new_class.is_extern)) {
     prev_class.first_owning_decl_id = new_class.first_owning_decl_id;
     ReplacePrevInstForMerge(
@@ -113,7 +113,7 @@ static auto MergeOrAddName(Context& context, Parse::AnyClassDeclId node_id,
     return;
   }
 
-  if (!prev_id.is_valid()) {
+  if (!prev_id.has_value()) {
     return;
   }
 
@@ -154,7 +154,7 @@ static auto MergeOrAddName(Context& context, Parse::AnyClassDeclId node_id,
       break;
   }
 
-  if (!prev_class_id.is_valid()) {
+  if (!prev_class_id.has_value()) {
     // This is a redeclaration of something other than a class.
     context.DiagnoseDuplicateName(class_decl_id, prev_id);
     return;
@@ -198,7 +198,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
                                is_definition);
 
   bool is_extern = introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extern);
-  if (introducer.extern_library.is_valid()) {
+  if (introducer.extern_library.has_value()) {
     context.TODO(node_id, "extern library");
   }
   auto inheritance_kind =
@@ -230,7 +230,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
                  introducer.modifier_set.GetAccessKind());
 
   // Create a new class if this isn't a valid redeclaration.
-  bool is_new_class = !class_decl.class_id.is_valid();
+  bool is_new_class = !class_decl.class_id.has_value();
   if (is_new_class) {
     // TODO: If this is an invalid redeclaration of a non-class entity or there
     // was an error in the qualifier, we will have lost track of the class name
@@ -380,7 +380,7 @@ auto HandleParseNode(Context& context, Parse::AdaptDeclId node_id) -> bool {
   }
 
   auto& class_info = context.classes().Get(parent_class_decl->class_id);
-  if (class_info.adapt_id.is_valid()) {
+  if (class_info.adapt_id.has_value()) {
     DiagnoseClassSpecificDeclRepeated(context, node_id, class_info.adapt_id,
                                       Lex::TokenKind::Adapt);
     return true;
@@ -487,7 +487,7 @@ static auto CheckBaseType(Context& context, Parse::NodeId node_id,
     DiagnoseBaseIsFinal(context, node_id, base_type_inst_id);
   }
 
-  CARBON_CHECK(base_class_info->scope_id.is_valid(),
+  CARBON_CHECK(base_class_info->scope_id.has_value(),
                "Complete class should have a scope");
   return {.type_id = base_type_id,
           .scope_id = base_class_info->scope_id,
@@ -515,7 +515,7 @@ auto HandleParseNode(Context& context, Parse::BaseDeclId node_id) -> bool {
   }
 
   auto& class_info = context.classes().Get(parent_class_decl->class_id);
-  if (class_info.base_id.is_valid()) {
+  if (class_info.base_id.has_value()) {
     DiagnoseClassSpecificDeclRepeated(context, node_id, class_info.base_id,
                                       Lex::TokenKind::Base);
     return true;
@@ -558,7 +558,7 @@ auto HandleParseNode(Context& context, Parse::BaseDeclId node_id) -> bool {
   // Extend the class scope with the base class.
   if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extend)) {
     auto& class_scope = context.name_scopes().Get(class_info.scope_id);
-    if (base_info.scope_id.is_valid()) {
+    if (base_info.scope_id.has_value()) {
       class_scope.AddExtendedScope(base_info.inst_id);
     } else {
       class_scope.set_has_error();
@@ -574,7 +574,7 @@ static auto CheckCompleteAdapterClassType(Context& context,
                                           SemIR::ClassId class_id)
     -> SemIR::InstId {
   const auto& class_info = context.classes().Get(class_id);
-  if (class_info.base_id.is_valid()) {
+  if (class_info.base_id.has_value()) {
     CARBON_DIAGNOSTIC(AdaptWithBase, Error, "adapter with base class");
     CARBON_DIAGNOSTIC(AdaptWithBaseHere, Note, "`base` declaration is here");
     context.emitter()
@@ -659,7 +659,7 @@ static auto AddStructTypeFields(
 static auto CheckCompleteClassType(Context& context, Parse::NodeId node_id,
                                    SemIR::ClassId class_id) -> SemIR::InstId {
   auto& class_info = context.classes().Get(class_id);
-  if (class_info.adapt_id.is_valid()) {
+  if (class_info.adapt_id.has_value()) {
     return CheckCompleteAdapterClassType(context, node_id, class_id);
   }
 
@@ -667,7 +667,7 @@ static auto CheckCompleteClassType(Context& context, Parse::NodeId node_id,
   auto base_type_id =
       class_info.GetBaseType(context.sem_ir(), SemIR::SpecificId::None);
   SemIR::Class* base_class_info = nullptr;
-  if (base_type_id.is_valid()) {
+  if (base_type_id.has_value()) {
     // TODO: If the base class is template dependent, we will need to decide
     // whether to add a vptr as part of instantiation.
     base_class_info = TryGetAsClass(context, base_type_id);
@@ -678,7 +678,7 @@ static auto CheckCompleteClassType(Context& context, Parse::NodeId node_id,
 
   auto field_decls = context.field_decls_stack().PeekArray();
   llvm::SmallVector<SemIR::StructTypeField> struct_type_fields;
-  struct_type_fields.reserve(defining_vptr + class_info.base_id.is_valid() +
+  struct_type_fields.reserve(defining_vptr + class_info.base_id.has_value() +
                              field_decls.size());
   if (defining_vptr) {
     struct_type_fields.push_back(
@@ -686,7 +686,7 @@ static auto CheckCompleteClassType(Context& context, Parse::NodeId node_id,
          .type_id = context.GetPointerType(
              context.GetSingletonType(SemIR::VtableType::SingletonInstId))});
   }
-  if (base_type_id.is_valid()) {
+  if (base_type_id.has_value()) {
     auto base_decl = context.insts().GetAs<SemIR::BaseDecl>(class_info.base_id);
     base_decl.index =
         SemIR::ElementIndex{static_cast<int>(struct_type_fields.size())};

--- a/toolchain/check/handle_export.cpp
+++ b/toolchain/check/handle_export.cpp
@@ -36,7 +36,7 @@ auto HandleParseNode(Context& context, Parse::ExportDeclId node_id) -> bool {
   }
 
   auto inst_id = name_context.prev_inst_id();
-  if (!inst_id.is_valid()) {
+  if (!inst_id.has_value()) {
     context.DiagnoseNameNotFound(node_id, name_context.name_id_for_new_inst());
     return true;
   }

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -125,8 +125,8 @@ static auto TryMergeRedecl(Context& context, Parse::AnyFunctionDeclId node_id,
     return;
   }
 
-  auto prev_function_id = SemIR::FunctionId::Invalid;
-  auto prev_import_ir_id = SemIR::ImportIRId::Invalid;
+  auto prev_function_id = SemIR::FunctionId::None;
+  auto prev_import_ir_id = SemIR::ImportIRId::None;
   CARBON_KIND_SWITCH(context.insts().Get(prev_id)) {
     case CARBON_KIND(SemIR::FunctionDecl function_decl): {
       prev_function_id = function_decl.function_id;
@@ -177,7 +177,7 @@ static auto BuildFunctionDecl(Context& context,
                               Parse::AnyFunctionDeclId node_id,
                               bool is_definition)
     -> std::pair<SemIR::FunctionId, SemIR::InstId> {
-  auto return_slot_pattern_id = SemIR::InstId::Invalid;
+  auto return_slot_pattern_id = SemIR::InstId::None;
   if (auto [return_node, maybe_return_slot_pattern_id] =
           context.node_stack().PopWithNodeIdIf<Parse::NodeKind::ReturnType>();
       maybe_return_slot_pattern_id) {
@@ -236,7 +236,7 @@ static auto BuildFunctionDecl(Context& context,
   // Add the function declaration.
   auto decl_block_id = context.inst_block_stack().Pop();
   auto function_decl = SemIR::FunctionDecl{
-      SemIR::TypeId::Invalid, SemIR::FunctionId::Invalid, decl_block_id};
+      SemIR::TypeId::None, SemIR::FunctionId::None, decl_block_id};
   auto decl_id =
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, function_decl));
 
@@ -291,7 +291,7 @@ static auto BuildFunctionDecl(Context& context,
   // Check if we need to add this to name lookup, now that the function decl is
   // done.
   if (name_context.state != DeclNameStack::NameContext::State::Poisoned &&
-      !name_context.prev_inst_id().is_valid()) {
+      !name_context.prev_inst_id().has_value()) {
     // At interface scope, a function declaration introduces an associated
     // function.
     auto lookup_result_id = decl_id;
@@ -349,7 +349,7 @@ static auto CheckFunctionDefinitionSignature(Context& context,
   if (function.return_slot_pattern_id.is_valid()) {
     CheckFunctionReturnType(
         context, context.insts().GetLocId(function.return_slot_pattern_id),
-        function, SemIR::SpecificId::Invalid);
+        function, SemIR::SpecificId::None);
     params_to_complete = params_to_complete.drop_back();
   }
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -98,7 +98,7 @@ static auto MergeFunctionRedecl(Context& context, SemIRLoc new_loc,
     return false;
   }
 
-  if (!prev_function.first_owning_decl_id.is_valid()) {
+  if (!prev_function.first_owning_decl_id.has_value()) {
     prev_function.first_owning_decl_id = new_function.first_owning_decl_id;
   }
   if (new_is_definition) {
@@ -107,7 +107,7 @@ static auto MergeFunctionRedecl(Context& context, SemIRLoc new_loc,
     prev_function.MergeDefinition(new_function);
     prev_function.return_slot_pattern_id = new_function.return_slot_pattern_id;
   }
-  if ((prev_import_ir_id.is_valid() && !new_is_import)) {
+  if ((prev_import_ir_id.has_value() && !new_is_import)) {
     ReplacePrevInstForMerge(context, new_function.parent_scope_id,
                             prev_function.name_id,
                             new_function.first_owning_decl_id);
@@ -121,7 +121,7 @@ static auto TryMergeRedecl(Context& context, Parse::AnyFunctionDeclId node_id,
                            SemIR::FunctionDecl& function_decl,
                            SemIR::Function& function_info, bool is_definition)
     -> void {
-  if (!prev_id.is_valid()) {
+  if (!prev_id.has_value()) {
     return;
   }
 
@@ -157,7 +157,7 @@ static auto TryMergeRedecl(Context& context, Parse::AnyFunctionDeclId node_id,
       break;
   }
 
-  if (!prev_function_id.is_valid()) {
+  if (!prev_function_id.has_value()) {
     context.DiagnoseDuplicateName(function_info.latest_decl_id(), prev_id);
     return;
   }
@@ -185,7 +185,7 @@ static auto BuildFunctionDecl(Context& context,
   }
 
   auto name = PopNameComponent(context, return_slot_pattern_id);
-  if (!name.param_patterns_id.is_valid()) {
+  if (!name.param_patterns_id.has_value()) {
     context.TODO(node_id, "function with positional parameters");
     name.param_patterns_id = SemIR::InstBlockId::Empty;
   }
@@ -217,7 +217,7 @@ static auto BuildFunctionDecl(Context& context,
     if (auto class_decl = parent_scope_inst->TryAs<SemIR::ClassDecl>()) {
       virtual_class_info = &context.classes().Get(class_decl->class_id);
       if (virtual_modifier == SemIR::Function::VirtualModifier::Impl &&
-          !virtual_class_info->base_id.is_valid()) {
+          !virtual_class_info->base_id.has_value()) {
         CARBON_DIAGNOSTIC(ImplWithoutBase, Error, "impl without base class");
         context.emitter().Build(node_id, ImplWithoutBase).Emit();
       }
@@ -262,7 +262,7 @@ static auto BuildFunctionDecl(Context& context,
   }
 
   // Create a new function if this isn't a valid redeclaration.
-  if (!function_decl.function_id.is_valid()) {
+  if (!function_decl.function_id.has_value()) {
     if (function_info.is_extern && context.IsImplFile()) {
       DiagnoseExternRequiresDeclInApiFile(context, node_id);
     }
@@ -310,10 +310,10 @@ static auto BuildFunctionDecl(Context& context,
   if (SemIR::IsEntryPoint(context.sem_ir(), function_decl.function_id)) {
     auto return_type_id = function_info.GetDeclaredReturnType(context.sem_ir());
     // TODO: Update this once valid signatures for the entry point are decided.
-    if (function_info.implicit_param_patterns_id.is_valid() ||
-        !function_info.param_patterns_id.is_valid() ||
+    if (function_info.implicit_param_patterns_id.has_value() ||
+        !function_info.param_patterns_id.has_value() ||
         !context.inst_blocks().Get(function_info.param_patterns_id).empty() ||
-        (return_type_id.is_valid() &&
+        (return_type_id.has_value() &&
          return_type_id != context.GetTupleType({}) &&
          // TODO: Decide on valid return types for `Main.Run`. Perhaps we should
          // have an interface for this.
@@ -346,7 +346,7 @@ static auto CheckFunctionDefinitionSignature(Context& context,
       context.inst_blocks().GetOrEmpty(function.call_params_id);
 
   // Check the return type is complete.
-  if (function.return_slot_pattern_id.is_valid()) {
+  if (function.return_slot_pattern_id.has_value()) {
     CheckFunctionReturnType(
         context, context.insts().GetLocId(function.return_slot_pattern_id),
         function, SemIR::SpecificId::None);
@@ -432,7 +432,7 @@ auto HandleParseNode(Context& context, Parse::FunctionDefinitionId node_id)
   if (context.is_current_position_reachable()) {
     if (context.functions()
             .Get(function_id)
-            .return_slot_pattern_id.is_valid()) {
+            .return_slot_pattern_id.has_value()) {
       CARBON_DIAGNOSTIC(
           MissingReturnStatement, Error,
           "missing `return` at end of function with declared return type");
@@ -510,7 +510,7 @@ static auto IsValidBuiltinDeclaration(Context& context,
 
   // Get the return type. This is `()` if none was specified.
   auto return_type_id = function.GetDeclaredReturnType(context.sem_ir());
-  if (!return_type_id.is_valid()) {
+  if (!return_type_id.has_value()) {
     return_type_id = context.GetTupleType({});
   }
 

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -73,7 +73,7 @@ auto HandleParseNode(Context& context, Parse::TypeImplAsId node_id) -> bool {
 // TODO: Should this be somewhere more central?
 static auto TryAsClassScope(Context& context, SemIR::NameScopeId scope_id)
     -> std::optional<SemIR::ClassDecl> {
-  if (!scope_id.is_valid()) {
+  if (!scope_id.has_value()) {
     return std::nullopt;
   }
   auto& scope = context.name_scopes().Get(scope_id);
@@ -98,7 +98,7 @@ static auto GetDefaultSelfType(Context& context) -> SemIR::TypeId {
 auto HandleParseNode(Context& context, Parse::DefaultSelfImplAsId node_id)
     -> bool {
   auto self_type_id = GetDefaultSelfType(context);
-  if (!self_type_id.is_valid()) {
+  if (!self_type_id.has_value()) {
     CARBON_DIAGNOSTIC(ImplAsOutsideClass, Error,
                       "`impl as` can only be used in a class");
     context.emitter().Emit(node_id, ImplAsOutsideClass);
@@ -143,7 +143,7 @@ static auto ExtendImpl(Context& context, Parse::NodeId extend_node,
     return;
   }
 
-  if (params_node.is_valid()) {
+  if (params_node.has_value()) {
     CARBON_DIAGNOSTIC(ExtendImplForall, Error,
                       "cannot `extend` a parameterized `impl`");
     context.emitter().Emit(extend_node, ExtendImplForall);
@@ -388,7 +388,7 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
   }
 
   // Create a new impl if this isn't a valid redeclaration.
-  if (!impl_decl.impl_id.is_valid()) {
+  if (!impl_decl.impl_id.has_value()) {
     impl_info.generic_id = BuildGeneric(context, impl_decl_id);
     impl_info.witness_id = ImplWitnessForDeclaration(context, impl_info);
     AddConstantsToImplWitnessFromConstraint(
@@ -409,7 +409,7 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
   // For an `extend impl` declaration, mark the impl as extending this `impl`.
   if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Extend)) {
     auto extend_node = introducer.modifier_node_id(ModifierOrder::Decl);
-    if (impl_info.generic_id.is_valid()) {
+    if (impl_info.generic_id.has_value()) {
       SemIR::TypeId type_id = context.insts().Get(constraint_inst_id).type_id();
       constraint_inst_id = context.AddInst<SemIR::SpecificConstant>(
           context.insts().GetLocId(constraint_inst_id),

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -77,7 +77,7 @@ static auto TryAsClassScope(Context& context, SemIR::NameScopeId scope_id)
     return std::nullopt;
   }
   auto& scope = context.name_scopes().Get(scope_id);
-  if (!scope.inst_id().is_valid()) {
+  if (!scope.inst_id().has_value()) {
     return std::nullopt;
   }
   return context.insts().TryGetAs<SemIR::ClassDecl>(scope.inst_id());
@@ -92,7 +92,7 @@ static auto GetDefaultSelfType(Context& context) -> SemIR::TypeId {
 
   // TODO: This is also valid in a mixin.
 
-  return SemIR::TypeId::Invalid;
+  return SemIR::TypeId::None;
 }
 
 auto HandleParseNode(Context& context, Parse::DefaultSelfImplAsId node_id)
@@ -202,7 +202,7 @@ static auto PopImplIntroducerAndParamsAsNameComponent(
     // because `impl`s are never actually called at runtime.
     auto call_params_id =
         CalleePatternMatch(context, *implicit_param_patterns_id,
-                           SemIR::InstBlockId::Invalid, SemIR::InstId::Invalid);
+                           SemIR::InstBlockId::None, SemIR::InstId::None);
     CARBON_CHECK(call_params_id == SemIR::InstBlockId::Empty ||
                  llvm::all_of(context.inst_blocks().Get(call_params_id),
                               [](SemIR::InstId inst_id) {
@@ -248,17 +248,17 @@ static auto PopImplIntroducerAndParamsAsNameComponent(
   }
 
   return {
-      .name_loc_id = Parse::NodeId::Invalid,
-      .name_id = SemIR::NameId::Invalid,
+      .name_loc_id = Parse::NodeId::None,
+      .name_id = SemIR::NameId::None,
       .first_param_node_id = first_param_node_id,
       .last_param_node_id = *last_param_iter,
       .implicit_params_loc_id = implicit_params_loc_id,
       .implicit_param_patterns_id =
-          implicit_param_patterns_id.value_or(SemIR::InstBlockId::Invalid),
-      .params_loc_id = Parse::NodeId::Invalid,
-      .param_patterns_id = SemIR::InstBlockId::Invalid,
-      .call_params_id = SemIR::InstBlockId::Invalid,
-      .return_slot_pattern_id = SemIR::InstId::Invalid,
+          implicit_param_patterns_id.value_or(SemIR::InstBlockId::None),
+      .params_loc_id = Parse::NodeId::None,
+      .param_patterns_id = SemIR::InstBlockId::None,
+      .call_params_id = SemIR::InstBlockId::None,
+      .return_slot_pattern_id = SemIR::InstId::None,
       .pattern_block_id = context.pattern_block_stack().Pop(),
   };
 }
@@ -270,7 +270,7 @@ static auto MergeImplRedecl(Context& context, SemIR::Impl& new_impl,
   // If the parameters aren't the same, then this is not a redeclaration of this
   // `impl`. Keep looking for a prior declaration without issuing a diagnostic.
   if (!CheckRedeclParamsMatch(context, DeclParams(new_impl),
-                              DeclParams(prev_impl), SemIR::SpecificId::Invalid,
+                              DeclParams(prev_impl), SemIR::SpecificId::None,
                               /*check_syntax=*/true, /*diagnose=*/false)) {
     // NOLINTNEXTLINE(readability-simplify-boolean-expr)
     return false;
@@ -360,7 +360,7 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
   // TODO: Check for an orphan `impl`.
 
   // Add the impl declaration.
-  SemIR::ImplDecl impl_decl = {.impl_id = SemIR::ImplId::Invalid,
+  SemIR::ImplDecl impl_decl = {.impl_id = SemIR::ImplId::None,
                                .decl_block_id = decl_block_id};
   auto impl_decl_id =
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, impl_decl));
@@ -368,7 +368,7 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
   SemIR::Impl impl_info = {
       name_context.MakeEntityWithParamsBase(name, impl_decl_id,
                                             /*is_extern=*/false,
-                                            SemIR::LibraryNameId::Invalid),
+                                            SemIR::LibraryNameId::None),
       {.self_id = self_inst_id, .constraint_id = constraint_inst_id}};
 
   // Add the impl declaration.
@@ -447,7 +447,7 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionStartId node_id)
   CARBON_CHECK(!impl_info.has_definition_started());
   impl_info.definition_id = impl_decl_id;
   impl_info.scope_id =
-      context.name_scopes().Add(impl_decl_id, SemIR::NameId::Invalid,
+      context.name_scopes().Add(impl_decl_id, SemIR::NameId::None,
                                 context.decl_name_stack().PeekParentScopeId());
 
   context.scope_stack().Push(

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -50,13 +50,13 @@ static auto BuildInterfaceDecl(Context& context,
   // Add the interface declaration.
   auto interface_decl =
       SemIR::InterfaceDecl{SemIR::TypeType::SingletonTypeId,
-                           SemIR::InterfaceId::Invalid, decl_block_id};
+                           SemIR::InterfaceId::None, decl_block_id};
   auto interface_decl_id =
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, interface_decl));
 
   SemIR::Interface interface_info = {name_context.MakeEntityWithParamsBase(
       name, interface_decl_id, /*is_extern=*/false,
-      SemIR::LibraryNameId::Invalid)};
+      SemIR::LibraryNameId::None)};
 
   // Check whether this is a redeclaration.
   auto [existing_id, is_poisoned] = context.decl_name_stack().LookupOrAddName(
@@ -84,7 +84,7 @@ static auto BuildInterfaceDecl(Context& context,
             RedeclInfo(interface_info, node_id, is_definition),
             RedeclInfo(existing_interface, existing_interface.latest_decl_id(),
                        existing_interface.has_definition_started()),
-            /*prev_import_ir_id=*/SemIR::ImportIRId::Invalid);
+            /*prev_import_ir_id=*/SemIR::ImportIRId::None);
 
         // Can't merge interface definitions due to the generic requirements.
         if (!is_definition || !existing_interface.has_definition_started()) {
@@ -142,9 +142,8 @@ auto HandleParseNode(Context& context,
   CARBON_CHECK(!interface_info.has_definition_started(),
                "Can't merge with defined interfaces.");
   interface_info.definition_id = interface_decl_id;
-  interface_info.scope_id =
-      context.name_scopes().Add(interface_decl_id, SemIR::NameId::Invalid,
-                                interface_info.parent_scope_id);
+  interface_info.scope_id = context.name_scopes().Add(
+      interface_decl_id, SemIR::NameId::None, interface_info.parent_scope_id);
 
   auto self_specific_id =
       context.generics().GetSelfSpecific(interface_info.generic_id);
@@ -161,7 +160,7 @@ auto HandleParseNode(Context& context,
   SemIR::FacetType facet_type =
       context.FacetTypeFromInterface(interface_id, self_specific_id);
   SemIR::TypeId self_type_id = context.GetTypeIdForTypeConstant(
-      TryEvalInst(context, SemIR::InstId::Invalid, facet_type));
+      TryEvalInst(context, SemIR::InstId::None, facet_type));
 
   // We model `Self` as a symbolic binding whose type is the interface.
   // Because there is no equivalent non-symbolic value, we use `Invalid` as
@@ -174,7 +173,7 @@ auto HandleParseNode(Context& context,
       context.AddInst(SemIR::LocIdAndInst::NoLoc<SemIR::BindSymbolicName>(
           {.type_id = self_type_id,
            .entity_name_id = entity_name_id,
-           .value_id = SemIR::InstId::Invalid}));
+           .value_id = SemIR::InstId::None}));
   context.scope_stack().PushCompileTimeBinding(interface_info.self_param_id);
   context.name_scopes().AddRequiredName(interface_info.scope_id,
                                         SemIR::NameId::SelfType,

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -163,7 +163,7 @@ auto HandleParseNode(Context& context,
       TryEvalInst(context, SemIR::InstId::None, facet_type));
 
   // We model `Self` as a symbolic binding whose type is the interface.
-  // Because there is no equivalent non-symbolic value, we use `Invalid` as
+  // Because there is no equivalent non-symbolic value, we use `None` as
   // the `value_id` on the `BindSymbolicName`.
   auto entity_name_id = context.entity_names().Add(
       {.name_id = SemIR::NameId::SelfType,

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -64,7 +64,7 @@ static auto BuildInterfaceDecl(Context& context,
   if (is_poisoned) {
     // This is a declaration of a poisoned name.
     context.DiagnosePoisonedName(interface_decl_id);
-  } else if (existing_id.is_valid()) {
+  } else if (existing_id.has_value()) {
     if (auto existing_interface_decl =
             context.insts().Get(existing_id).TryAs<SemIR::InterfaceDecl>()) {
       auto existing_interface =
@@ -103,7 +103,7 @@ static auto BuildInterfaceDecl(Context& context,
   }
 
   // Create a new interface if this isn't a valid redeclaration.
-  if (!interface_decl.interface_id.is_valid()) {
+  if (!interface_decl.interface_id.has_value()) {
     // TODO: If this is an invalid redeclaration of a non-interface entity or
     // there was an error in the qualifier, we will have lost track of the
     // interface name here. We should keep track of it even if the name is
@@ -205,7 +205,7 @@ auto HandleParseNode(Context& context, Parse::InterfaceDefinitionId /*node_id*/)
 
   // The interface type is now fully defined.
   auto& interface_info = context.interfaces().Get(interface_id);
-  if (!interface_info.associated_entities_id.is_valid()) {
+  if (!interface_info.associated_entities_id.has_value()) {
     interface_info.associated_entities_id = associated_entities_id;
   }
 

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -57,7 +57,7 @@ static auto GetOrAddStorage(Context& context, SemIR::InstId pattern_id)
       context.insts().Get(pattern.inst.As<SemIR::VarPattern>().subpattern_id);
 
   // Try to populate name_id on a best-effort basis.
-  auto name_id = SemIR::NameId::Invalid;
+  auto name_id = SemIR::NameId::None;
   if (auto binding_pattern = subpattern.TryAs<SemIR::BindingPattern>()) {
     name_id =
         context.entity_names().Get(binding_pattern->entity_name_id).name_id;
@@ -69,7 +69,7 @@ static auto GetOrAddStorage(Context& context, SemIR::InstId pattern_id)
 
 auto HandleParseNode(Context& context, Parse::VariablePatternId node_id)
     -> bool {
-  auto subpattern_id = SemIR::InstId::Invalid;
+  auto subpattern_id = SemIR::InstId::None;
   if (context.node_stack().PeekIs(Parse::NodeKind::TuplePattern)) {
     context.node_stack().PopAndIgnore();
     CARBON_CHECK(
@@ -141,7 +141,7 @@ namespace {
 struct DeclInfo {
   // The optional initializer.
   std::optional<SemIR::InstId> init_id = std::nullopt;
-  SemIR::InstId pattern_id = SemIR::InstId::Invalid;
+  SemIR::InstId pattern_id = SemIR::InstId::None;
   std::optional<SemIR::Inst> parent_scope_inst = std::nullopt;
   DeclIntroducerState introducer = DeclIntroducerState();
 };
@@ -287,7 +287,7 @@ auto HandleParseNode(Context& context, Parse::VariableDeclId node_id) -> bool {
     return true;
   }
   LocalPatternMatch(context, decl_info->pattern_id,
-                    decl_info->init_id.value_or(SemIR::InstId::Invalid));
+                    decl_info->init_id.value_or(SemIR::InstId::None));
 
   return true;
 }

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -67,7 +67,7 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
   if (auto later_modifier_set = s.modifier_set & later_modifiers;
       !later_modifier_set.empty()) {
     // At least one later modifier is present. Diagnose using the closest.
-    Parse::NodeId closest_later_modifier = Parse::NodeId::Invalid;
+    Parse::NodeId closest_later_modifier = Parse::NodeId::None;
     for (auto later_order = static_cast<int8_t>(order) + 1;
          later_order <= static_cast<int8_t>(ModifierOrder::Last);
          ++later_order) {

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -60,7 +60,7 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
     DiagnoseRepeated(context, current_modifier_node_id, node_id);
     return false;
   }
-  if (current_modifier_node_id.is_valid()) {
+  if (current_modifier_node_id.has_value()) {
     DiagnoseNotAllowedWith(context, current_modifier_node_id, node_id);
     return false;
   }
@@ -71,12 +71,12 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
     for (auto later_order = static_cast<int8_t>(order) + 1;
          later_order <= static_cast<int8_t>(ModifierOrder::Last);
          ++later_order) {
-      if (s.ordered_modifier_node_ids[later_order].is_valid()) {
+      if (s.ordered_modifier_node_ids[later_order].has_value()) {
         closest_later_modifier = s.ordered_modifier_node_ids[later_order];
         break;
       }
     }
-    CARBON_CHECK(closest_later_modifier.is_valid());
+    CARBON_CHECK(closest_later_modifier.has_value());
 
     CARBON_DIAGNOSTIC(ModifierMustAppearBefore, Error,
                       "`{0}` must appear before `{1}`", Lex::TokenKind,

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -106,11 +106,11 @@ static auto HandleNameAsExpr(Context& context, Parse::NodeId node_id,
   auto value = context.insts().Get(result.inst_id);
   auto type_id = SemIR::GetTypeInSpecific(context.sem_ir(), result.specific_id,
                                           value.type_id());
-  CARBON_CHECK(type_id.is_valid(), "Missing type for {0}", value);
+  CARBON_CHECK(type_id.has_value(), "Missing type for {0}", value);
 
   // If the named entity has a constant value that depends on its specific,
   // store the specific too.
-  if (result.specific_id.is_valid() &&
+  if (result.specific_id.has_value() &&
       context.constant_values().Get(result.inst_id).is_symbolic()) {
     result.inst_id = context.AddInst<SemIR::SpecificConstant>(
         node_id, {.type_id = type_id,

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -210,7 +210,7 @@ auto HandleParseNode(Context& context, Parse::DesignatorExprId node_id)
   } else {
     // Otherwise this is `.Member`, so look up `.Self` and then `Member` in
     // `.Self`.
-    SemIR::InstId period_self_id = SemIR::InstId::Invalid;
+    SemIR::InstId period_self_id = SemIR::InstId::None;
     {
       // TODO: Instead of annotating the diagnostic, should change
       // `HandleNameAsExpr` to optionally allow us to produce the diagnostic
@@ -222,7 +222,7 @@ auto HandleParseNode(Context& context, Parse::DesignatorExprId node_id)
             CARBON_DIAGNOSTIC(
                 NoPeriodSelfForDesignator, Note,
                 "designator may only be used when `.Self` is in scope");
-            builder.Note(SemIR::LocId::Invalid, NoPeriodSelfForDesignator);
+            builder.Note(SemIR::LocId::None, NoPeriodSelfForDesignator);
           });
       period_self_id =
           HandleNameAsExpr(context, node_id, SemIR::NameId::PeriodSelf);

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -47,7 +47,7 @@ auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
                                                 SemIR::AccessKind::Public);
   if (is_poisoned) {
     context.DiagnosePoisonedName(namespace_id);
-  } else if (existing_inst_id.is_valid()) {
+  } else if (existing_inst_id.has_value()) {
     if (auto existing =
             context.insts().TryGetAs<SemIR::Namespace>(existing_inst_id)) {
       // If there's a name conflict with a namespace, "merge" by using the
@@ -67,8 +67,8 @@ auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
         context.name_scopes()
             .Get(existing->name_scope_id)
             .set_is_closed_import(false);
-      } else if (existing->import_id.is_valid() &&
-                 !context.insts().GetLocId(existing_inst_id).is_valid()) {
+      } else if (existing->import_id.has_value() &&
+                 !context.insts().GetLocId(existing_inst_id).has_value()) {
         // When the name conflict is an imported namespace, fill the location ID
         // so that future diagnostics point at this declaration.
         context.SetNamespaceNodeId(existing_inst_id, node_id);
@@ -81,7 +81,7 @@ auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
   // If we weren't able to merge namespaces, add a new name scope. Note this
   // occurs even for duplicates where we discard the namespace, because we want
   // to produce a valid constant.
-  if (!namespace_inst.name_scope_id.is_valid()) {
+  if (!namespace_inst.name_scope_id.has_value()) {
     namespace_inst.name_scope_id = context.name_scopes().Add(
         namespace_id, name_context.name_id_for_new_inst(),
         name_context.parent_scope_id);

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -38,7 +38,7 @@ auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
 
   auto namespace_inst = SemIR::Namespace{
       context.GetSingletonType(SemIR::NamespaceType::SingletonInstId),
-      SemIR::NameScopeId::Invalid, SemIR::InstId::Invalid};
+      SemIR::NameScopeId::None, SemIR::InstId::None};
   auto namespace_id =
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, namespace_inst));
 

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -108,7 +108,7 @@ static auto PopFieldNameNodes(Context& context, size_t field_count)
   while (true) {
     auto [name_node, _] =
         context.node_stack().PopWithNodeIdIf<Parse::NodeCategory::MemberName>();
-    if (name_node.is_valid()) {
+    if (name_node.has_value()) {
       nodes.push_back(name_node);
     } else {
       break;

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -33,13 +33,13 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
       {.name_id = SemIR::NameId::PeriodSelf,
        .parent_scope_id = context.scope_stack().PeekNameScopeId(),
        // Invalid because this is not the parameter of a generic.
-       .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+       .bind_index = SemIR::CompileTimeBindIndex::None});
   auto inst_id =
       context.AddInst(SemIR::LocIdAndInst::NoLoc<SemIR::BindSymbolicName>(
           {.type_id = self_type_id,
            .entity_name_id = entity_name_id,
            // Invalid because there is no equivalent non-symbolic value.
-           .value_id = SemIR::InstId::Invalid}));
+           .value_id = SemIR::InstId::None}));
   auto existing =
       context.scope_stack().LookupOrAddName(SemIR::NameId::PeriodSelf, inst_id);
   // Shouldn't have any names in newly created scope.

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -43,7 +43,7 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
   auto existing =
       context.scope_stack().LookupOrAddName(SemIR::NameId::PeriodSelf, inst_id);
   // Shouldn't have any names in newly created scope.
-  CARBON_CHECK(!existing.is_valid());
+  CARBON_CHECK(!existing.has_value());
 
   // Save the `.Self` symbolic binding on the node stack. It will become the
   // first argument to the `WhereExpr` instruction.

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -75,7 +75,7 @@ static auto GetSelfSpecificForInterfaceMemberWithSelfType(
   // since we haven't finished defining the implementation here.
   auto type_inst_id = context.types().GetInstId(self_type_id);
   auto facet_value_const_id =
-      TryEvalInst(context, SemIR::InstId::Invalid,
+      TryEvalInst(context, SemIR::InstId::None,
                   SemIR::FacetValue{.type_id = self_binding.type_id,
                                     .type_inst_id = type_inst_id,
                                     .witness_inst_id = witness_inst_id});
@@ -192,7 +192,7 @@ auto ImplWitnessForDeclaration(Context& context, const SemIR::Impl& impl)
   }
 
   llvm::SmallVector<SemIR::InstId> table(assoc_entities.size(),
-                                         SemIR::InstId::Invalid);
+                                         SemIR::InstId::None);
   auto table_id = context.inst_blocks().Add(table);
   return context.AddInst<SemIR::ImplWitness>(
       context.insts().GetLocId(impl.latest_decl_id()),
@@ -245,8 +245,8 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
 
   // Scan through rewrites, produce map from element index to constant value.
   // TODO: Perhaps move this into facet type resolution?
-  llvm::SmallVector<SemIR::ConstantId> rewrite_values(
-      assoc_entities.size(), SemIR::ConstantId::Invalid);
+  llvm::SmallVector<SemIR::ConstantId> rewrite_values(assoc_entities.size(),
+                                                      SemIR::ConstantId::None);
   for (auto rewrite : facet_type_info.rewrite_constraints) {
     auto inst_id = context.constant_values().GetInstId(rewrite.lhs_const_id);
     auto access = context.insts().GetAs<SemIR::ImplWitnessAccess>(inst_id);

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -53,7 +53,7 @@ static auto GetSelfSpecificForInterfaceMemberWithSelfType(
   arg_ids.reserve(bindings.size());
 
   // Start with the enclosing arguments.
-  if (enclosing_specific_id.is_valid()) {
+  if (enclosing_specific_id.has_value()) {
     auto enclosing_specific_args_id =
         context.specifics().Get(enclosing_specific_id).args_id;
     auto enclosing_specific_args =
@@ -222,7 +222,7 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
                                              SemIR::ImplId prev_decl_id)
     -> void {
   CARBON_CHECK(!impl.has_definition_started());
-  CARBON_CHECK(witness_id.is_valid());
+  CARBON_CHECK(witness_id.has_value());
   if (witness_id == SemIR::ErrorInst::SingletonInstId) {
     return;
   }
@@ -260,7 +260,7 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
     CARBON_CHECK(access.index.index <
                  static_cast<int32_t>(rewrite_values.size()));
     auto& rewrite_value = rewrite_values[access.index.index];
-    if (rewrite_value.is_valid() &&
+    if (rewrite_value.has_value() &&
         rewrite_value != SemIR::ErrorInst::SingletonConstantId) {
       if (rewrite_value != rewrite.rhs_const_id &&
           rewrite.rhs_const_id != SemIR::ErrorInst::SingletonConstantId) {
@@ -276,7 +276,7 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
         decl_id = context.constant_values().GetInstId(
             SemIR::GetConstantValueInSpecific(
                 context.sem_ir(), interface_type->specific_id, decl_id));
-        CARBON_CHECK(decl_id.is_valid(), "Non-constant associated entity");
+        CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
         auto decl =
             context.insts().GetAs<SemIR::AssociatedConstantDecl>(decl_id);
         context.emitter().Emit(impl.constraint_id,
@@ -294,16 +294,16 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
     decl_id =
         context.constant_values().GetInstId(SemIR::GetConstantValueInSpecific(
             context.sem_ir(), interface_type->specific_id, decl_id));
-    CARBON_CHECK(decl_id.is_valid(), "Non-constant associated entity");
+    CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
     if (auto decl =
             context.insts().TryGetAs<SemIR::AssociatedConstantDecl>(decl_id)) {
       auto& witness_value = witness_block[index];
       auto rewrite_value = rewrite_values[index];
-      if (witness_value.is_valid() &&
+      if (witness_value.has_value() &&
           witness_value != SemIR::ErrorInst::SingletonInstId) {
         // TODO: Support just using the witness values if the redeclaration uses
         // `where _`, per proposal #1084.
-        if (!rewrite_value.is_valid()) {
+        if (!rewrite_value.has_value()) {
           CARBON_DIAGNOSTIC(AssociatedConstantMissingInRedecl, Error,
                             "associated constant {0} given value in "
                             "declaration but not redeclaration",
@@ -330,7 +330,7 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
           builder.Emit();
           continue;
         }
-      } else if (rewrite_value.is_valid()) {
+      } else if (rewrite_value.has_value()) {
         witness_value = context.constant_values().GetInstId(rewrite_value);
       }
     }
@@ -339,7 +339,7 @@ auto AddConstantsToImplWitnessFromConstraint(Context& context,
 
 auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
   CARBON_CHECK(impl.is_being_defined());
-  CARBON_CHECK(impl.witness_id.is_valid());
+  CARBON_CHECK(impl.witness_id.has_value());
   if (impl.witness_id == SemIR::ErrorInst::SingletonInstId) {
     return;
   }
@@ -368,11 +368,11 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
     decl_id =
         context.constant_values().GetInstId(SemIR::GetConstantValueInSpecific(
             context.sem_ir(), interface_type->specific_id, decl_id));
-    CARBON_CHECK(decl_id.is_valid(), "Non-constant associated entity");
+    CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
     if (auto decl =
             context.insts().TryGetAs<SemIR::AssociatedConstantDecl>(decl_id)) {
       auto& witness_value = witness_block[index];
-      if (!witness_value.is_valid()) {
+      if (!witness_value.has_value()) {
         CARBON_DIAGNOSTIC(ImplAssociatedConstantNeedsValue, Error,
                           "associated constant {0} not given a value in impl "
                           "of interface {1}",
@@ -396,7 +396,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
 // interface.
 auto FinishImplWitness(Context& context, SemIR::Impl& impl) -> void {
   CARBON_CHECK(impl.is_being_defined());
-  CARBON_CHECK(impl.witness_id.is_valid());
+  CARBON_CHECK(impl.witness_id.has_value());
   if (impl.witness_id == SemIR::ErrorInst::SingletonInstId) {
     return;
   }
@@ -425,7 +425,7 @@ auto FinishImplWitness(Context& context, SemIR::Impl& impl) -> void {
     decl_id =
         context.constant_values().GetInstId(SemIR::GetConstantValueInSpecific(
             context.sem_ir(), interface_type->specific_id, decl_id));
-    CARBON_CHECK(decl_id.is_valid(), "Non-constant associated entity");
+    CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
     auto decl = context.insts().Get(decl_id);
     CARBON_KIND_SWITCH(decl) {
       case CARBON_KIND(SemIR::StructValue struct_value): {
@@ -441,7 +441,7 @@ auto FinishImplWitness(Context& context, SemIR::Impl& impl) -> void {
         auto& fn = context.functions().Get(fn_type->function_id);
         auto [impl_decl_id, _, is_poisoned] = context.LookupNameInExactScope(
             decl_id, fn.name_id, impl.scope_id, impl_scope);
-        if (impl_decl_id.is_valid()) {
+        if (impl_decl_id.has_value()) {
           used_decl_ids.push_back(impl_decl_id);
           witness_block[index] = CheckAssociatedFunctionImplementation(
               context, *fn_type, impl_decl_id, self_type_id, impl.witness_id);
@@ -476,12 +476,12 @@ auto FinishImplWitness(Context& context, SemIR::Impl& impl) -> void {
 }
 
 auto FillImplWitnessWithErrors(Context& context, SemIR::Impl& impl) -> void {
-  if (impl.witness_id.is_valid() &&
+  if (impl.witness_id.has_value() &&
       impl.witness_id != SemIR::ErrorInst::SingletonInstId) {
     auto witness = context.insts().GetAs<SemIR::ImplWitness>(impl.witness_id);
     auto witness_block = context.inst_blocks().GetMutable(witness.elements_id);
     for (auto& elem : witness_block) {
-      if (!elem.is_valid()) {
+      if (!elem.has_value()) {
         elem = SemIR::ErrorInst::SingletonInstId;
       }
     }

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -134,7 +134,7 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
   // considering impls that are for the same interface we're querying. We can
   // also skip impls that mention any types that aren't part of our impl query.
   for (const auto& impl : context.impls().array_ref()) {
-    auto specific_id = SemIR::SpecificId::Invalid;
+    auto specific_id = SemIR::SpecificId::None;
     if (impl.generic_id.is_valid()) {
       specific_id = DeduceImplArguments(context, loc_id, impl, type_const_id,
                                         interface_const_id);
@@ -158,7 +158,7 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
     }
     if (!impl.witness_id.is_valid()) {
       // TODO: Diagnose if the impl isn't defined yet?
-      return SemIR::InstId::Invalid;
+      return SemIR::InstId::None;
     }
     LoadImportRef(context, impl.witness_id);
     if (specific_id.is_valid()) {
@@ -170,7 +170,7 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
         SemIR::GetConstantValueInSpecific(context.sem_ir(), specific_id,
                                           impl.witness_id));
   }
-  return SemIR::InstId::Invalid;
+  return SemIR::InstId::None;
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -23,11 +23,11 @@ static auto FindAssociatedImportIRs(Context& context,
     // We will look for impls in the import IR associated with the first owning
     // declaration.
     auto decl_id = entity.first_owning_decl_id;
-    if (!decl_id.is_valid()) {
+    if (!decl_id.has_value()) {
       return;
     }
     if (auto ir_id = GetCanonicalImportIRInst(context, decl_id).ir_id;
-        ir_id.is_valid()) {
+        ir_id.has_value()) {
       result.push_back(ir_id);
     }
   };
@@ -38,14 +38,14 @@ static auto FindAssociatedImportIRs(Context& context,
 
   // Push the contents of an instruction block onto our worklist.
   auto push_block = [&](SemIR::InstBlockId block_id) {
-    if (block_id.is_valid()) {
+    if (block_id.has_value()) {
       llvm::append_range(worklist, context.inst_blocks().Get(block_id));
     }
   };
 
   // Add the arguments of a specific to the worklist.
   auto push_args = [&](SemIR::SpecificId specific_id) {
-    if (specific_id.is_valid()) {
+    if (specific_id.has_value()) {
       push_block(context.specifics().Get(specific_id).args_id);
     }
   };
@@ -60,7 +60,7 @@ static auto FindAssociatedImportIRs(Context& context,
          {std::pair{inst.arg0(), arg0_kind}, {inst.arg1(), arg1_kind}}) {
       switch (kind) {
         case SemIR::IdKind::For<SemIR::InstId>: {
-          if (auto id = SemIR::InstId(arg); id.is_valid()) {
+          if (auto id = SemIR::InstId(arg); id.has_value()) {
             worklist.push_back(id);
           }
           break;
@@ -135,10 +135,10 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
   // also skip impls that mention any types that aren't part of our impl query.
   for (const auto& impl : context.impls().array_ref()) {
     auto specific_id = SemIR::SpecificId::None;
-    if (impl.generic_id.is_valid()) {
+    if (impl.generic_id.has_value()) {
       specific_id = DeduceImplArguments(context, loc_id, impl, type_const_id,
                                         interface_const_id);
-      if (!specific_id.is_valid()) {
+      if (!specific_id.has_value()) {
         continue;
       }
     }
@@ -156,12 +156,12 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
       // the constraint's interfaces.
       continue;
     }
-    if (!impl.witness_id.is_valid()) {
+    if (!impl.witness_id.has_value()) {
       // TODO: Diagnose if the impl isn't defined yet?
       return SemIR::InstId::None;
     }
     LoadImportRef(context, impl.witness_id);
-    if (specific_id.is_valid()) {
+    if (specific_id.has_value()) {
       // We need a definition of the specific `impl` so we can access its
       // witness.
       ResolveSpecificDefinition(context, loc_id, specific_id);

--- a/toolchain/check/impl_lookup.h
+++ b/toolchain/check/impl_lookup.h
@@ -11,7 +11,7 @@
 namespace Carbon::Check {
 
 // Looks up the witness to use for a particular type and interface. Returns the
-// witness, or `InstId::Invalid` if the type is not known to implement the
+// witness, or `InstId::None` if the type is not known to implement the
 // interface.
 auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
                        SemIR::ConstantId type_const_id,

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -107,7 +107,7 @@ static auto AddNamespace(Context& context, SemIR::TypeId namespace_type_id,
   auto [inserted, entry_id] = parent_scope->LookupOrAdd(
       name_id,
       // This InstId is temporary and would be overridden if used.
-      SemIR::InstId::Invalid, SemIR::AccessKind::Public);
+      SemIR::InstId::None, SemIR::AccessKind::Public);
   if (!inserted) {
     const auto& prev_entry = parent_scope->GetEntry(entry_id);
     if (!prev_entry.is_poisoned) {
@@ -128,8 +128,8 @@ static auto AddNamespace(Context& context, SemIR::TypeId namespace_type_id,
   CARBON_CHECK(import_id.is_valid());
   auto import_loc_id = context.insts().GetLocId(import_id);
 
-  auto namespace_inst = SemIR::Namespace{
-      namespace_type_id, SemIR::NameScopeId::Invalid, import_id};
+  auto namespace_inst =
+      SemIR::Namespace{namespace_type_id, SemIR::NameScopeId::None, import_id};
   auto namespace_inst_and_loc =
       import_loc_id.is_import_ir_inst_id()
           ? context.MakeImportedLocAndInst(import_loc_id.import_ir_inst_id(),
@@ -189,7 +189,7 @@ static auto CopySingleNameScopeFromImportIR(
     auto entity_name_id = context.entity_names().Add(
         {.name_id = name_id,
          .parent_scope_id = parent_scope_id,
-         .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+         .bind_index = SemIR::CompileTimeBindIndex::None});
     auto import_ir_inst_id = context.import_ir_insts().Add(
         {.ir_id = ir_id, .inst_id = import_inst_id});
     auto inst_id = context.AddInstInNoBlock(
@@ -277,13 +277,13 @@ static auto AddImportRefOrMerge(Context& context, SemIR::ImportIRId ir_id,
   auto [inserted, entry_id] = parent_scope.LookupOrAdd(
       name_id,
       // This InstId is temporary and would be overridden if used.
-      SemIR::InstId::Invalid, SemIR::AccessKind::Public);
+      SemIR::InstId::None, SemIR::AccessKind::Public);
   auto& entry = parent_scope.GetEntry(entry_id);
   if (inserted) {
     auto entity_name_id = context.entity_names().Add(
         {.name_id = name_id,
          .parent_scope_id = parent_scope_id,
-         .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+         .bind_index = SemIR::CompileTimeBindIndex::None});
     entry.inst_id = AddImportRef(
         context, {.ir_id = ir_id, .inst_id = import_inst_id}, entity_name_id);
     return;
@@ -321,7 +321,7 @@ static auto AddScopedImportRef(Context& context,
   auto impl_entity_name_id = context.entity_names().Add(
       {.name_id = name_id,
        .parent_scope_id = parent_scope_id,
-       .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+       .bind_index = SemIR::CompileTimeBindIndex::None});
   auto import_ref_id = AddImportRef(context, import_inst, impl_entity_name_id);
   parent_scope.AddRequired({.name_id = name_id,
                             .inst_id = import_ref_id,
@@ -553,7 +553,7 @@ auto ImportNameFromOtherPackage(
 
   // Although we track the result here and look in each IR, we pretty much use
   // the first result.
-  auto result_id = SemIR::InstId::Invalid;
+  auto result_id = SemIR::InstId::None;
   // The canonical IR and inst_id for where `result_id` came from, which may be
   // indirectly imported. This is only resolved on a conflict, when it can be
   // used to determine the conflict is actually the same instruction.

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -78,7 +78,7 @@ static auto CopyNameFromImportIR(Context& context,
                                  const SemIR::File& import_sem_ir,
                                  SemIR::NameId import_name_id) {
   if (auto import_identifier_id = import_name_id.AsIdentifierId();
-      import_identifier_id.is_valid()) {
+      import_identifier_id.has_value()) {
     auto name = import_sem_ir.identifiers().Get(import_identifier_id);
     return SemIR::NameId::ForIdentifier(context.identifiers().Add(name));
   }
@@ -116,7 +116,7 @@ static auto AddNamespace(Context& context, SemIR::TypeId namespace_type_id,
               context.insts().TryGetAs<SemIR::Namespace>(prev_inst_id)) {
         if (diagnose_duplicate_namespace) {
           auto import_id = make_import_id();
-          CARBON_CHECK(import_id.is_valid());
+          CARBON_CHECK(import_id.has_value());
           context.DiagnoseDuplicateName(import_id, prev_inst_id);
         }
         return {namespace_inst->name_scope_id, prev_inst_id, true};
@@ -125,7 +125,7 @@ static auto AddNamespace(Context& context, SemIR::TypeId namespace_type_id,
   }
 
   auto import_id = make_import_id();
-  CARBON_CHECK(import_id.is_valid());
+  CARBON_CHECK(import_id.has_value());
   auto import_loc_id = context.insts().GetLocId(import_id);
 
   auto namespace_inst =
@@ -484,7 +484,7 @@ static auto LookupNameInImport(const SemIR::File& import_ir,
   SemIR::NameId import_name_id = name_id;
   if (!identifier.empty()) {
     auto import_identifier_id = import_ir.identifiers().Lookup(identifier);
-    if (!import_identifier_id.is_valid()) {
+    if (!import_identifier_id.has_value()) {
       // Name doesn't exist in the import IR.
       return nullptr;
     }
@@ -538,7 +538,8 @@ auto ImportNameFromOtherPackage(
   // If the name is an identifier, get the string first so that it can be shared
   // when there are multiple IRs.
   llvm::StringRef identifier;
-  if (auto identifier_id = name_id.AsIdentifierId(); identifier_id.is_valid()) {
+  if (auto identifier_id = name_id.AsIdentifierId();
+      identifier_id.has_value()) {
     identifier = context.identifiers().Get(identifier_id);
     CARBON_CHECK(!identifier.empty());
   }
@@ -576,7 +577,7 @@ auto ImportNameFromOtherPackage(
     }
 
     // Add the first result found.
-    if (!result_id.is_valid()) {
+    if (!result_id.has_value()) {
       // If the imported instruction is a namespace, we add it directly instead
       // of as an ImportRef.
       if (auto import_ns = import_inst.TryAs<SemIR::Namespace>()) {

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -815,7 +815,7 @@ static auto SetGenericData(ImportContext& context,
 }
 
 // Gets a local constant value corresponding to an imported generic ID. May
-// add work to the work stack and return `Invalid`.
+// add work to the work stack and return `None`.
 static auto GetLocalConstantId(ImportRefResolver& resolver,
                                SemIR::GenericId generic_id)
     -> SemIR::ConstantId {

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -44,7 +44,7 @@ auto SetApiImportIR(Context& context, SemIR::ImportIR import_ir) -> void {
 auto AddImportIR(Context& context, SemIR::ImportIR import_ir)
     -> SemIR::ImportIRId {
   auto& ir_id = context.GetImportIRId(*import_ir.sem_ir);
-  if (!ir_id.is_valid()) {
+  if (!ir_id.has_value()) {
     // Note this updates check_ir_map.
     ir_id = InternalAddImportIR(context, import_ir);
   } else if (import_ir.is_export) {
@@ -154,7 +154,7 @@ auto VerifySameCanonicalImportIRInst(Context& context, SemIR::InstId prev_id,
 static auto GetInstWithConstantValue(const SemIR::File& file,
                                      SemIR::ConstantId const_id)
     -> SemIR::InstId {
-  if (!const_id.is_valid()) {
+  if (!const_id.has_value()) {
     return SemIR::InstId::None;
   }
 
@@ -168,7 +168,7 @@ static auto GetInstWithConstantValue(const SemIR::File& file,
   // desired constant value.
   const auto& symbolic_const =
       file.constant_values().GetSymbolicConstant(const_id);
-  if (!symbolic_const.generic_id.is_valid()) {
+  if (!symbolic_const.generic_id.has_value()) {
     return file.constant_values().GetInstId(const_id);
   }
 
@@ -448,11 +448,11 @@ class ImportRefResolver : public ImportContext {
     work_stack_.push_back({.inst_id = inst_id});
     while (!work_stack_.empty()) {
       auto work = work_stack_.back();
-      CARBON_CHECK(work.inst_id.is_valid());
+      CARBON_CHECK(work.inst_id.has_value());
 
       // Step 1: check for a constant value.
       auto existing = FindResolvedConstId(work.inst_id);
-      if (existing.const_id.is_valid() && !work.retry_with_constant_value) {
+      if (existing.const_id.has_value() && !work.retry_with_constant_value) {
         work_stack_.pop_back();
         continue;
       }
@@ -464,22 +464,22 @@ class ImportRefResolver : public ImportContext {
       CARBON_CHECK(!HasNewWork() || retry);
 
       CARBON_CHECK(
-          !existing.const_id.is_valid() || existing.const_id == new_const_id,
+          !existing.const_id.has_value() || existing.const_id == new_const_id,
           "Constant value changed in third phase.");
-      if (!existing.const_id.is_valid()) {
+      if (!existing.const_id.has_value()) {
         SetResolvedConstId(work.inst_id, existing.indirect_insts, new_const_id);
       }
 
       // Step 3: pop or retry.
       if (retry) {
         work_stack_[initial_work_ - 1].retry_with_constant_value =
-            new_const_id.is_valid();
+            new_const_id.has_value();
       } else {
         work_stack_.pop_back();
       }
     }
     auto constant_id = local_constant_values_for_import_insts().Get(inst_id);
-    CARBON_CHECK(constant_id.is_valid());
+    CARBON_CHECK(constant_id.has_value());
     return constant_id;
   }
 
@@ -498,13 +498,13 @@ class ImportRefResolver : public ImportContext {
 
   // Wraps constant evaluation with logic to handle types.
   auto ResolveType(SemIR::TypeId import_type_id) -> SemIR::TypeId {
-    if (!import_type_id.is_valid()) {
+    if (!import_type_id.has_value()) {
       return import_type_id;
     }
 
     auto import_type_const_id =
         import_ir().types().GetConstantId(import_type_id);
-    CARBON_CHECK(import_type_const_id.is_valid());
+    CARBON_CHECK(import_type_const_id.has_value());
 
     if (auto import_type_inst_id =
             import_ir().constant_values().GetInstId(import_type_const_id);
@@ -529,7 +529,7 @@ class ImportRefResolver : public ImportContext {
   // work_stack_.
   auto GetLocalConstantValueOrPush(SemIR::InstId inst_id) -> SemIR::ConstantId {
     auto const_id = local_constant_values_for_import_insts().Get(inst_id);
-    if (!const_id.is_valid()) {
+    if (!const_id.has_value()) {
       work_stack_.push_back({.inst_id = inst_id});
     }
     return const_id;
@@ -565,7 +565,7 @@ class ImportRefResolver : public ImportContext {
 
     if (auto existing_const_id =
             local_constant_values_for_import_insts().Get(inst_id);
-        existing_const_id.is_valid()) {
+        existing_const_id.has_value()) {
       result.const_id = existing_const_id;
       return result;
     }
@@ -587,7 +587,7 @@ class ImportRefResolver : public ImportContext {
 
       cursor_ir = cursor_ir->import_irs().Get(ir_inst.ir_id).sem_ir;
       cursor_ir_id = local_context().GetImportIRId(*cursor_ir);
-      if (!cursor_ir_id.is_valid()) {
+      if (!cursor_ir_id.has_value()) {
         // TODO: Should we figure out a location to assign here?
         cursor_ir_id =
             AddImportIR(local_context(), {.decl_id = SemIR::InstId::None,
@@ -602,7 +602,7 @@ class ImportRefResolver : public ImportContext {
       if (auto const_id = local_context()
                               .import_ir_constant_values()[cursor_ir_id.index]
                               .Get(cursor_inst_id);
-          const_id.is_valid()) {
+          const_id.has_value()) {
         SetResolvedConstId(inst_id, result.indirect_insts, const_id);
         result.const_id = const_id;
         result.indirect_insts.clear();
@@ -694,7 +694,7 @@ static auto GetLocalConstantIdChecked(ImportContext& context,
     -> SemIR::ConstantId {
   auto result_id =
       context.local_constant_values_for_import_insts().Get(inst_id);
-  CARBON_CHECK(result_id.is_valid());
+  CARBON_CHECK(result_id.has_value());
   return result_id;
 }
 
@@ -719,7 +719,7 @@ static auto GetLocalConstantIdChecked(ImportContext& context,
 // Translates a NameId from the import IR to a local NameId.
 static auto GetLocalNameId(ImportContext& context, SemIR::NameId import_name_id)
     -> SemIR::NameId {
-  if (auto ident_id = import_name_id.AsIdentifierId(); ident_id.is_valid()) {
+  if (auto ident_id = import_name_id.AsIdentifierId(); ident_id.has_value()) {
     return SemIR::NameId::ForIdentifier(context.local_identifiers().Add(
         context.import_identifiers().Get(ident_id)));
   }
@@ -731,7 +731,7 @@ static auto GetLocalInstBlockContents(ImportRefResolver& resolver,
                                       SemIR::InstBlockId import_block_id)
     -> llvm::SmallVector<SemIR::InstId> {
   llvm::SmallVector<SemIR::InstId> inst_ids;
-  if (!import_block_id.is_valid() ||
+  if (!import_block_id.has_value() ||
       import_block_id == SemIR::InstBlockId::Empty) {
     return inst_ids;
   }
@@ -755,7 +755,7 @@ static auto GetLocalCanonicalInstBlockId(ImportContext& context,
                                          SemIR::InstBlockId import_block_id,
                                          llvm::ArrayRef<SemIR::InstId> contents)
     -> SemIR::InstBlockId {
-  if (!import_block_id.is_valid()) {
+  if (!import_block_id.has_value()) {
     return SemIR::InstBlockId::None;
   }
   return context.local_inst_blocks().AddCanonical(contents);
@@ -766,7 +766,7 @@ static auto GetLocalCanonicalInstBlockId(ImportContext& context,
 static auto MakeIncompleteGeneric(ImportContext& context, SemIR::InstId decl_id,
                                   SemIR::GenericId generic_id)
     -> SemIR::GenericId {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     return SemIR::GenericId::None;
   }
 
@@ -786,7 +786,7 @@ struct GenericData {
 // Gets a local version of the data associated with a generic.
 static auto GetLocalGenericData(ImportRefResolver& resolver,
                                 SemIR::GenericId generic_id) -> GenericData {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     return GenericData();
   }
 
@@ -799,7 +799,7 @@ static auto SetGenericData(ImportContext& context,
                            SemIR::GenericId import_generic_id,
                            SemIR::GenericId new_generic_id,
                            const GenericData& generic_data) -> void {
-  if (!import_generic_id.is_valid()) {
+  if (!import_generic_id.has_value()) {
     return;
   }
 
@@ -819,7 +819,7 @@ static auto SetGenericData(ImportContext& context,
 static auto GetLocalConstantId(ImportRefResolver& resolver,
                                SemIR::GenericId generic_id)
     -> SemIR::ConstantId {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     return SemIR::ConstantId::None;
   }
   auto import_decl_inst_id = resolver.import_generics().Get(generic_id).decl_id;
@@ -839,7 +839,7 @@ static auto GetLocalConstantId(ImportRefResolver& resolver,
 static auto GetLocalGenericId(ImportContext& context,
                               SemIR::ConstantId local_const_id)
     -> SemIR::GenericId {
-  if (!local_const_id.is_valid()) {
+  if (!local_const_id.has_value()) {
     return SemIR::GenericId::None;
   }
   auto inst = context.local_insts().Get(
@@ -877,7 +877,7 @@ struct SpecificData {
 static auto GetLocalSpecificData(ImportRefResolver& resolver,
                                  SemIR::SpecificId specific_id)
     -> SpecificData {
-  if (!specific_id.is_valid()) {
+  if (!specific_id.has_value()) {
     return {.generic_const_id = SemIR::ConstantId::None, .args = {}};
   }
 
@@ -894,7 +894,7 @@ static auto GetOrAddLocalSpecific(ImportContext& context,
                                   SemIR::SpecificId import_specific_id,
                                   const SpecificData& data)
     -> SemIR::SpecificId {
-  if (!import_specific_id.is_valid()) {
+  if (!import_specific_id.has_value()) {
     return SemIR::SpecificId::None;
   }
 
@@ -910,9 +910,9 @@ static auto GetOrAddLocalSpecific(ImportContext& context,
 
   // Fill in the remaining information in FinishPendingSpecific, if necessary.
   auto& specific = context.local_specifics().Get(specific_id);
-  if (!specific.decl_block_id.is_valid() ||
-      (import_specific.definition_block_id.is_valid() &&
-       !specific.definition_block_id.is_valid())) {
+  if (!specific.decl_block_id.has_value() ||
+      (import_specific.definition_block_id.has_value() &&
+       !specific.definition_block_id.has_value())) {
     context.AddPendingSpecific(
         {.import_id = import_specific_id, .local_id = specific_id});
   }
@@ -924,7 +924,7 @@ static auto GetOrAddLocalSpecific(ImportContext& context,
 static auto LoadLocalPatternConstantIds(ImportRefResolver& resolver,
                                         SemIR::InstBlockId param_patterns_id)
     -> void {
-  if (!param_patterns_id.is_valid() ||
+  if (!param_patterns_id.has_value() ||
       param_patterns_id == SemIR::InstBlockId::Empty) {
     return;
   }
@@ -967,7 +967,7 @@ static auto LoadLocalPatternConstantIds(ImportRefResolver& resolver,
 static auto GetLocalParamPatternsId(ImportContext& context,
                                     SemIR::InstBlockId param_patterns_id)
     -> SemIR::InstBlockId {
-  if (!param_patterns_id.is_valid() ||
+  if (!param_patterns_id.has_value() ||
       param_patterns_id == SemIR::InstBlockId::Empty) {
     return param_patterns_id;
   }
@@ -1054,7 +1054,7 @@ static auto GetLocalParamPatternsId(ImportContext& context,
 static auto GetLocalReturnSlotPatternId(
     ImportContext& context, SemIR::InstId import_return_slot_pattern_id)
     -> SemIR::InstId {
-  if (!import_return_slot_pattern_id.is_valid()) {
+  if (!import_return_slot_pattern_id.has_value()) {
     return SemIR::InstId::None;
   }
 
@@ -1095,7 +1095,7 @@ static auto GetLocalNameScopeId(ImportRefResolver& resolver,
 
   // Get the constant value for the scope.
   auto const_id = GetLocalConstantId(resolver, inst_id);
-  if (!const_id.is_valid()) {
+  if (!const_id.has_value()) {
     return SemIR::NameScopeId::None;
   }
 
@@ -1162,7 +1162,7 @@ static auto GetIncompleteLocalEntityBase(
     -> SemIR::EntityWithParamsBase {
   // Translate the extern_library_id if present.
   auto extern_library_id = SemIR::LibraryNameId::None;
-  if (import_base.extern_library_id.is_valid()) {
+  if (import_base.extern_library_id.has_value()) {
     if (import_base.extern_library_id.index >= 0) {
       auto val = context.import_string_literal_values().Get(
           import_base.extern_library_id.AsStringLiteralValueId());
@@ -1182,19 +1182,19 @@ static auto GetIncompleteLocalEntityBase(
       .last_param_node_id = Parse::NodeId::None,
       .pattern_block_id = SemIR::InstBlockId::None,
       .implicit_param_patterns_id =
-          import_base.implicit_param_patterns_id.is_valid()
+          import_base.implicit_param_patterns_id.has_value()
               ? SemIR::InstBlockId::Empty
               : SemIR::InstBlockId::None,
-      .param_patterns_id = import_base.param_patterns_id.is_valid()
+      .param_patterns_id = import_base.param_patterns_id.has_value()
                                ? SemIR::InstBlockId::Empty
                                : SemIR::InstBlockId::None,
       .call_params_id = SemIR::InstBlockId::None,
       .is_extern = import_base.is_extern,
       .extern_library_id = extern_library_id,
-      .non_owning_decl_id = import_base.non_owning_decl_id.is_valid()
+      .non_owning_decl_id = import_base.non_owning_decl_id.has_value()
                                 ? decl_id
                                 : SemIR::InstId::None,
-      .first_owning_decl_id = import_base.first_owning_decl_id.is_valid()
+      .first_owning_decl_id = import_base.first_owning_decl_id.has_value()
                                   ? decl_id
                                   : SemIR::InstId::None,
   };
@@ -1577,13 +1577,13 @@ static auto AddClassDefinition(ImportContext& context,
   AddNameScopeImportRefs(context, import_scope, new_scope);
   new_class.body_block_id = context.local_context().inst_block_stack().Pop();
 
-  if (import_class.base_id.is_valid()) {
+  if (import_class.base_id.has_value()) {
     new_class.base_id = base_id;
   }
-  if (import_class.adapt_id.is_valid()) {
+  if (import_class.adapt_id.has_value()) {
     new_class.adapt_id = adapt_id;
   }
-  if (import_class.vtable_id.is_valid()) {
+  if (import_class.vtable_id.has_value()) {
     new_class.vtable_id = vtable_id;
   }
 }
@@ -1598,7 +1598,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   const auto& import_class = resolver.import_classes().Get(inst.class_id);
 
   SemIR::ClassId class_id = SemIR::ClassId::None;
-  if (!class_const_id.is_valid()) {
+  if (!class_const_id.has_value()) {
     auto import_specific_id = SemIR::SpecificId::None;
     if (auto import_generic_class_type =
             resolver.import_types().TryGetAs<SemIR::GenericClassType>(
@@ -1642,13 +1642,13 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto generic_data = GetLocalGenericData(resolver, import_class.generic_id);
   auto self_const_id = GetLocalConstantId(resolver, import_class.self_type_id);
   auto complete_type_witness_const_id =
-      import_class.complete_type_witness_id.is_valid()
+      import_class.complete_type_witness_id.has_value()
           ? GetLocalConstantId(resolver, import_class.complete_type_witness_id)
           : SemIR::ConstantId::None;
-  auto base_id = import_class.base_id.is_valid()
+  auto base_id = import_class.base_id.has_value()
                      ? GetLocalConstantInstId(resolver, import_class.base_id)
                      : SemIR::InstId::None;
-  auto adapt_id = import_class.adapt_id.is_valid()
+  auto adapt_id = import_class.adapt_id.has_value()
                       ? GetLocalConstantInstId(resolver, import_class.adapt_id)
                       : SemIR::InstId::None;
   auto& new_class = resolver.local_classes().Get(class_id);
@@ -1657,7 +1657,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry(class_const_id, new_class.first_decl_id());
   }
 
-  auto vtable_id = import_class.vtable_id.is_valid()
+  auto vtable_id = import_class.vtable_id.has_value()
                        ? AddImportRef(resolver, import_class.vtable_id)
                        : SemIR::InstId::None;
 
@@ -1809,7 +1809,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver.import_functions().Get(inst.function_id);
 
   SemIR::FunctionId function_id = SemIR::FunctionId::None;
-  if (!function_const_id.is_valid()) {
+  if (!function_const_id.has_value()) {
     auto import_specific_id = resolver.import_types()
                                   .GetAs<SemIR::FunctionType>(inst.type_id)
                                   .specific_id;
@@ -1836,7 +1836,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   }
 
   auto return_type_const_id = SemIR::ConstantId::None;
-  if (import_function.return_slot_pattern_id.is_valid()) {
+  if (import_function.return_slot_pattern_id.has_value()) {
     return_type_const_id = GetLocalConstantId(
         resolver, resolver.import_insts()
                       .Get(import_function.return_slot_pattern_id)
@@ -1866,7 +1866,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   SetGenericData(resolver, import_function.generic_id, new_function.generic_id,
                  generic_data);
 
-  if (import_function.definition_id.is_valid()) {
+  if (import_function.definition_id.has_value()) {
     new_function.definition_id = new_function.first_owning_decl_id;
   }
 
@@ -1955,7 +1955,7 @@ static auto AddImplDefinition(ImportContext& context,
   new_impl.definition_id = new_impl.first_owning_decl_id;
   new_impl.defined = true;
 
-  if (import_impl.scope_id.is_valid()) {
+  if (import_impl.scope_id.has_value()) {
     new_impl.scope_id = context.local_name_scopes().Add(
         new_impl.first_owning_decl_id, SemIR::NameId::None,
         new_impl.parent_scope_id);
@@ -1988,7 +1988,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   const auto& import_impl = resolver.import_impls().Get(inst.impl_id);
 
   SemIR::ImplId impl_id = SemIR::ImplId::None;
-  if (!impl_const_id.is_valid()) {
+  if (!impl_const_id.has_value()) {
     if (resolver.HasNewWork()) {
       // This is the end of the first phase. Don't make a new impl yet if we
       // already have new work.
@@ -2058,7 +2058,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::InstId inst_id) -> ResolveResult {
   // Return the constant for the instruction of the imported constant.
   auto constant_id = resolver.import_constant_values().Get(inst_id);
-  if (!constant_id.is_valid()) {
+  if (!constant_id.has_value()) {
     return ResolveResult::Done(SemIR::ErrorInst::SingletonConstantId);
   }
   if (!constant_id.is_constant()) {
@@ -2139,7 +2139,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver.import_interfaces().Get(inst.interface_id);
 
   SemIR::InterfaceId interface_id = SemIR::InterfaceId::None;
-  if (!interface_const_id.is_valid()) {
+  if (!interface_const_id.has_value()) {
     auto import_specific_id = SemIR::SpecificId::None;
     if (auto import_generic_interface_type =
             resolver.import_types().TryGetAs<SemIR::GenericInterfaceType>(
@@ -2371,7 +2371,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   // We can directly reuse the value IDs across file IRs. Otherwise, we need
   // to add a new canonical int in this IR.
-  auto int_id = inst.int_id.is_value()
+  auto int_id = inst.int_id.is_embedded_value()
                     ? inst.int_id
                     : resolver.local_ints().AddSigned(
                           resolver.import_ints().Get(inst.int_id));
@@ -2606,7 +2606,7 @@ static auto TryResolveInstCanonical(ImportRefResolver& resolver,
                                     SemIR::ConstantId const_id)
     -> ResolveResult {
   if (SemIR::IsSingletonInstId(inst_id)) {
-    CARBON_CHECK(!const_id.is_valid());
+    CARBON_CHECK(!const_id.has_value());
     // Constants for builtins can be directly copied.
     return ResolveResult::Done(resolver.local_constant_values().Get(inst_id));
   }
@@ -2775,7 +2775,7 @@ static auto TryResolveInstCanonical(ImportRefResolver& resolver,
 static auto TryResolveInst(ImportRefResolver& resolver, SemIR::InstId inst_id,
                            SemIR::ConstantId const_id) -> ResolveResult {
   auto inst_const_id = resolver.import_constant_values().Get(inst_id);
-  if (!inst_const_id.is_valid() || !inst_const_id.is_symbolic()) {
+  if (!inst_const_id.has_value() || !inst_const_id.is_symbolic()) {
     return TryResolveInstCanonical(resolver, inst_id, const_id);
   }
 
@@ -2786,7 +2786,7 @@ static auto TryResolveInst(ImportRefResolver& resolver, SemIR::InstId inst_id,
       GetLocalConstantId(resolver, symbolic_const.generic_id);
 
   auto inner_const_id = SemIR::ConstantId::None;
-  if (const_id.is_valid()) {
+  if (const_id.has_value()) {
     // For the third phase, extract the constant value that
     // TryResolveInstCanonical produced previously.
     inner_const_id = resolver.local_constant_values().Get(
@@ -2795,21 +2795,21 @@ static auto TryResolveInst(ImportRefResolver& resolver, SemIR::InstId inst_id,
 
   // Import the constant and rebuild the symbolic constant data.
   auto result = TryResolveInstCanonical(resolver, inst_id, inner_const_id);
-  if (!result.const_id.is_valid()) {
+  if (!result.const_id.has_value()) {
     // First phase: TryResolveInstCanoncial needs a retry.
     return result;
   }
 
-  if (!const_id.is_valid()) {
+  if (!const_id.has_value()) {
     // Second phase: we have created an abstract constant. Create a
     // corresponding generic constant.
-    if (symbolic_const.generic_id.is_valid()) {
+    if (symbolic_const.generic_id.has_value()) {
       result.const_id = resolver.local_constant_values().AddSymbolicConstant(
           {.inst_id =
                resolver.local_constant_values().GetInstId(result.const_id),
            .generic_id = GetLocalGenericId(resolver, generic_const_id),
            .index = symbolic_const.index});
-      if (result.decl_id.is_valid()) {
+      if (result.decl_id.has_value()) {
         // Overwrite the abstract symbolic constant given initially to the
         // declaration with its final concrete symbolic value.
         resolver.local_constant_values().Set(result.decl_id, result.const_id);
@@ -2850,7 +2850,7 @@ static auto ResolveLocalEvalBlock(ImportRefResolver& resolver,
                                   SemIR::GenericInstIndex::Region region)
     -> SemIR::InstBlockId {
   auto import_block_id = import_generic.GetEvalBlock(region);
-  if (!import_block_id.is_valid()) {
+  if (!import_block_id.has_value()) {
     return SemIR::InstBlockId::None;
   }
 
@@ -2894,7 +2894,7 @@ static auto FinishPendingGeneric(ImportRefResolver& resolver,
 static auto ResolveLocalInstBlock(ImportRefResolver& resolver,
                                   SemIR::InstBlockId import_block_id)
     -> SemIR::InstBlockId {
-  if (!import_block_id.is_valid()) {
+  if (!import_block_id.has_value()) {
     return SemIR::InstBlockId::None;
   }
 
@@ -2914,7 +2914,7 @@ static auto FinishPendingSpecific(ImportRefResolver& resolver,
 
   if (!resolver.local_specifics()
            .Get(pending.local_id)
-           .decl_block_id.is_valid()) {
+           .decl_block_id.has_value()) {
     auto decl_block_id =
         ResolveLocalInstBlock(resolver, import_specific.decl_block_id);
     resolver.local_specifics().Get(pending.local_id).decl_block_id =
@@ -2923,8 +2923,8 @@ static auto FinishPendingSpecific(ImportRefResolver& resolver,
 
   if (!resolver.local_specifics()
            .Get(pending.local_id)
-           .definition_block_id.is_valid() &&
-      import_specific.definition_block_id.is_valid()) {
+           .definition_block_id.has_value() &&
+      import_specific.definition_block_id.has_value()) {
     auto definition_block_id =
         ResolveLocalInstBlock(resolver, import_specific.definition_block_id);
     resolver.local_specifics().Get(pending.local_id).definition_block_id =

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -25,12 +25,12 @@ namespace Carbon::Check {
 static auto InternalAddImportIR(Context& context, SemIR::ImportIR import_ir)
     -> SemIR::ImportIRId {
   context.import_ir_constant_values().push_back(
-      SemIR::ConstantValueStore(SemIR::ConstantId::Invalid));
+      SemIR::ConstantValueStore(SemIR::ConstantId::None));
   return context.import_irs().Add(import_ir);
 }
 
 auto SetApiImportIR(Context& context, SemIR::ImportIR import_ir) -> void {
-  auto ir_id = SemIR::ImportIRId::Invalid;
+  auto ir_id = SemIR::ImportIRId::None;
   if (import_ir.sem_ir != nullptr) {
     ir_id = AddImportIR(context, import_ir);
   } else {
@@ -57,7 +57,7 @@ auto AddImportIR(Context& context, SemIR::ImportIR import_ir)
 
 auto AddImportRef(Context& context, SemIR::ImportIRInst import_ir_inst,
                   SemIR::EntityNameId entity_name_id =
-                      SemIR::EntityNameId::Invalid) -> SemIR::InstId {
+                      SemIR::EntityNameId::None) -> SemIR::InstId {
   auto import_ir_inst_id = context.import_ir_insts().Add(import_ir_inst);
   SemIR::ImportRefUnloaded inst = {.import_ir_inst_id = import_ir_inst_id,
                                    .entity_name_id = entity_name_id};
@@ -79,10 +79,9 @@ static auto AddLoadedImportRef(Context& context, SemIR::TypeId type_id,
                                SemIR::ImportIRInst import_ir_inst,
                                SemIR::ConstantId const_id) -> SemIR::InstId {
   auto import_ir_inst_id = context.import_ir_insts().Add(import_ir_inst);
-  SemIR::ImportRefLoaded inst = {
-      .type_id = type_id,
-      .import_ir_inst_id = import_ir_inst_id,
-      .entity_name_id = SemIR::EntityNameId::Invalid};
+  SemIR::ImportRefLoaded inst = {.type_id = type_id,
+                                 .import_ir_inst_id = import_ir_inst_id,
+                                 .entity_name_id = SemIR::EntityNameId::None};
   auto inst_id = context.AddPlaceholderInstInNoBlock(
       context.MakeImportedLocAndInst(import_ir_inst_id, inst));
   context.import_ref_ids().push_back(inst_id);
@@ -120,11 +119,11 @@ static auto GetCanonicalImportIRInst(Context& context,
     break;
   }
 
-  auto ir_id = SemIR::ImportIRId::Invalid;
+  auto ir_id = SemIR::ImportIRId::None;
   if (cursor_ir != &context.sem_ir()) {
     // This uses AddImportIR in case it was indirectly found, which can
     // happen with two or more steps of exports.
-    ir_id = AddImportIR(context, {.decl_id = SemIR::InstId::Invalid,
+    ir_id = AddImportIR(context, {.decl_id = SemIR::InstId::None,
                                   .is_export = false,
                                   .sem_ir = cursor_ir});
   }
@@ -156,7 +155,7 @@ static auto GetInstWithConstantValue(const SemIR::File& file,
                                      SemIR::ConstantId const_id)
     -> SemIR::InstId {
   if (!const_id.is_valid()) {
-    return SemIR::InstId::Invalid;
+    return SemIR::InstId::None;
   }
 
   // For template constants, the corresponding instruction has the desired
@@ -188,7 +187,7 @@ struct ResolveResult {
   // The new constant value, if known.
   SemIR::ConstantId const_id;
   // Newly created declaration whose value is being resolved, if any.
-  SemIR::InstId decl_id = SemIR::InstId::Invalid;
+  SemIR::InstId decl_id = SemIR::InstId::None;
   // Whether resolution has been attempted once and needs to be retried.
   bool retry = false;
 
@@ -196,8 +195,8 @@ struct ResolveResult {
   // `const_id` is specified, then this is the end of the second phase, and the
   // constant value will be passed to the next resolution attempt. Otherwise,
   // this is the end of the first phase.
-  static auto Retry(SemIR::ConstantId const_id = SemIR::ConstantId::Invalid,
-                    SemIR::InstId decl_id = SemIR::InstId::Invalid)
+  static auto Retry(SemIR::ConstantId const_id = SemIR::ConstantId::None,
+                    SemIR::InstId decl_id = SemIR::InstId::None)
       -> ResolveResult {
     return {.const_id = const_id, .decl_id = decl_id, .retry = true};
   }
@@ -205,7 +204,7 @@ struct ResolveResult {
   // Produces a resolve result that provides the given constant value. Requires
   // that there is no new work.
   static auto Done(SemIR::ConstantId const_id,
-                   SemIR::InstId decl_id = SemIR::InstId::Invalid)
+                   SemIR::InstId decl_id = SemIR::InstId::None)
       -> ResolveResult {
     return {.const_id = const_id, .decl_id = decl_id};
   }
@@ -549,7 +548,7 @@ class ImportRefResolver : public ImportContext {
   // The constant found by FindResolvedConstId.
   struct ResolvedConstId {
     // The constant for the instruction. Invalid if not yet resolved.
-    SemIR::ConstantId const_id = SemIR::ConstantId::Invalid;
+    SemIR::ConstantId const_id = SemIR::ConstantId::None;
 
     // Instructions which are indirect but equivalent to the current instruction
     // being resolved, and should have their constant set to the same. Empty
@@ -572,7 +571,7 @@ class ImportRefResolver : public ImportContext {
     }
 
     const auto* cursor_ir = &import_ir();
-    auto cursor_ir_id = SemIR::ImportIRId::Invalid;
+    auto cursor_ir_id = SemIR::ImportIRId::None;
     auto cursor_inst_id = inst_id;
 
     while (true) {
@@ -591,7 +590,7 @@ class ImportRefResolver : public ImportContext {
       if (!cursor_ir_id.is_valid()) {
         // TODO: Should we figure out a location to assign here?
         cursor_ir_id =
-            AddImportIR(local_context(), {.decl_id = SemIR::InstId::Invalid,
+            AddImportIR(local_context(), {.decl_id = SemIR::InstId::None,
                                           .is_export = false,
                                           .sem_ir = cursor_ir});
       }
@@ -637,7 +636,7 @@ class ImportRefResolver : public ImportContext {
 
 static auto AddImportRef(ImportContext& context, SemIR::InstId inst_id,
                          SemIR::EntityNameId entity_name_id =
-                             SemIR::EntityNameId::Invalid) -> SemIR::InstId {
+                             SemIR::EntityNameId::None) -> SemIR::InstId {
   return AddImportRef(context.local_context(),
                       {.ir_id = context.import_ir_id(), .inst_id = inst_id},
                       entity_name_id);
@@ -757,7 +756,7 @@ static auto GetLocalCanonicalInstBlockId(ImportContext& context,
                                          llvm::ArrayRef<SemIR::InstId> contents)
     -> SemIR::InstBlockId {
   if (!import_block_id.is_valid()) {
-    return SemIR::InstBlockId::Invalid;
+    return SemIR::InstBlockId::None;
   }
   return context.local_inst_blocks().AddCanonical(contents);
 }
@@ -768,13 +767,13 @@ static auto MakeIncompleteGeneric(ImportContext& context, SemIR::InstId decl_id,
                                   SemIR::GenericId generic_id)
     -> SemIR::GenericId {
   if (!generic_id.is_valid()) {
-    return SemIR::GenericId::Invalid;
+    return SemIR::GenericId::None;
   }
 
   return context.local_generics().Add(
       {.decl_id = decl_id,
-       .bindings_id = SemIR::InstBlockId::Invalid,
-       .self_specific_id = SemIR::SpecificId::Invalid});
+       .bindings_id = SemIR::InstBlockId::None,
+       .self_specific_id = SemIR::SpecificId::None});
 }
 
 namespace {
@@ -821,7 +820,7 @@ static auto GetLocalConstantId(ImportRefResolver& resolver,
                                SemIR::GenericId generic_id)
     -> SemIR::ConstantId {
   if (!generic_id.is_valid()) {
-    return SemIR::ConstantId::Invalid;
+    return SemIR::ConstantId::None;
   }
   auto import_decl_inst_id = resolver.import_generics().Get(generic_id).decl_id;
   auto import_decl_inst = resolver.import_insts().Get(import_decl_inst_id);
@@ -841,7 +840,7 @@ static auto GetLocalGenericId(ImportContext& context,
                               SemIR::ConstantId local_const_id)
     -> SemIR::GenericId {
   if (!local_const_id.is_valid()) {
-    return SemIR::GenericId::Invalid;
+    return SemIR::GenericId::None;
   }
   auto inst = context.local_insts().Get(
       context.local_constant_values().GetInstId(local_const_id));
@@ -879,7 +878,7 @@ static auto GetLocalSpecificData(ImportRefResolver& resolver,
                                  SemIR::SpecificId specific_id)
     -> SpecificData {
   if (!specific_id.is_valid()) {
-    return {.generic_const_id = SemIR::ConstantId::Invalid, .args = {}};
+    return {.generic_const_id = SemIR::ConstantId::None, .args = {}};
   }
 
   const auto& specific = resolver.import_specifics().Get(specific_id);
@@ -896,7 +895,7 @@ static auto GetOrAddLocalSpecific(ImportContext& context,
                                   const SpecificData& data)
     -> SemIR::SpecificId {
   if (!import_specific_id.is_valid()) {
-    return SemIR::SpecificId::Invalid;
+    return SemIR::SpecificId::None;
   }
 
   // Form a corresponding local specific ID.
@@ -1000,13 +999,13 @@ static auto GetLocalParamPatternsId(ImportContext& context,
     auto type_id = context.local_context().GetTypeIdForTypeConstant(
         GetLocalConstantIdChecked(context, binding.type_id));
 
-    auto new_param_id = SemIR::InstId::Invalid;
+    auto new_param_id = SemIR::InstId::None;
     switch (binding.kind) {
       case SemIR::BindingPattern::Kind: {
         auto entity_name_id = context.local_entity_names().Add(
             {.name_id = name_id,
-             .parent_scope_id = SemIR::NameScopeId::Invalid,
-             .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+             .parent_scope_id = SemIR::NameScopeId::None,
+             .bind_index = SemIR::CompileTimeBindIndex::None});
         new_param_id =
             context.local_context().AddInstInNoBlock<SemIR::BindingPattern>(
                 AddImportIRInst(context, binding_id),
@@ -1056,7 +1055,7 @@ static auto GetLocalReturnSlotPatternId(
     ImportContext& context, SemIR::InstId import_return_slot_pattern_id)
     -> SemIR::InstId {
   if (!import_return_slot_pattern_id.is_valid()) {
-    return SemIR::InstId::Invalid;
+    return SemIR::InstId::None;
   }
 
   auto param_pattern = context.import_insts().GetAs<SemIR::OutParamPattern>(
@@ -1070,7 +1069,7 @@ static auto GetLocalReturnSlotPatternId(
   auto new_return_slot_pattern_id = context.local_context().AddInstInNoBlock(
       context.local_context().MakeImportedLocAndInst<SemIR::ReturnSlotPattern>(
           AddImportIRInst(context, param_pattern.subpattern_id),
-          {.type_id = type_id, .type_inst_id = SemIR::InstId::Invalid}));
+          {.type_id = type_id, .type_inst_id = SemIR::InstId::None}));
   return context.local_context().AddInstInNoBlock(
       context.local_context().MakeImportedLocAndInst<SemIR::OutParamPattern>(
           AddImportIRInst(context, import_return_slot_pattern_id),
@@ -1091,13 +1090,13 @@ static auto GetLocalNameScopeId(ImportRefResolver& resolver,
     // Map scopes that aren't associated with an instruction to invalid
     // scopes. For now, such scopes aren't used, and we don't have a good way
     // to remap them.
-    return SemIR::NameScopeId::Invalid;
+    return SemIR::NameScopeId::None;
   }
 
   // Get the constant value for the scope.
   auto const_id = GetLocalConstantId(resolver, inst_id);
   if (!const_id.is_valid()) {
-    return SemIR::NameScopeId::Invalid;
+    return SemIR::NameScopeId::None;
   }
 
   auto const_inst_id = resolver.local_constant_values().GetInstId(const_id);
@@ -1141,7 +1140,7 @@ static auto GetLocalNameScopeId(ImportRefResolver& resolver,
     }
     default: {
       if (const_inst_id == SemIR::ErrorInst::SingletonInstId) {
-        return SemIR::NameScopeId::Invalid;
+        return SemIR::NameScopeId::None;
       }
       break;
     }
@@ -1162,7 +1161,7 @@ static auto GetIncompleteLocalEntityBase(
     const SemIR::EntityWithParamsBase& import_base)
     -> SemIR::EntityWithParamsBase {
   // Translate the extern_library_id if present.
-  auto extern_library_id = SemIR::LibraryNameId::Invalid;
+  auto extern_library_id = SemIR::LibraryNameId::None;
   if (import_base.extern_library_id.is_valid()) {
     if (import_base.extern_library_id.index >= 0) {
       auto val = context.import_string_literal_values().Get(
@@ -1176,28 +1175,28 @@ static auto GetIncompleteLocalEntityBase(
 
   return {
       .name_id = GetLocalNameId(context, import_base.name_id),
-      .parent_scope_id = SemIR::NameScopeId::Invalid,
+      .parent_scope_id = SemIR::NameScopeId::None,
       .generic_id =
           MakeIncompleteGeneric(context, decl_id, import_base.generic_id),
-      .first_param_node_id = Parse::NodeId::Invalid,
-      .last_param_node_id = Parse::NodeId::Invalid,
-      .pattern_block_id = SemIR::InstBlockId::Invalid,
+      .first_param_node_id = Parse::NodeId::None,
+      .last_param_node_id = Parse::NodeId::None,
+      .pattern_block_id = SemIR::InstBlockId::None,
       .implicit_param_patterns_id =
           import_base.implicit_param_patterns_id.is_valid()
               ? SemIR::InstBlockId::Empty
-              : SemIR::InstBlockId::Invalid,
+              : SemIR::InstBlockId::None,
       .param_patterns_id = import_base.param_patterns_id.is_valid()
                                ? SemIR::InstBlockId::Empty
-                               : SemIR::InstBlockId::Invalid,
-      .call_params_id = SemIR::InstBlockId::Invalid,
+                               : SemIR::InstBlockId::None,
+      .call_params_id = SemIR::InstBlockId::None,
       .is_extern = import_base.is_extern,
       .extern_library_id = extern_library_id,
       .non_owning_decl_id = import_base.non_owning_decl_id.is_valid()
                                 ? decl_id
-                                : SemIR::InstId::Invalid,
+                                : SemIR::InstId::None,
       .first_owning_decl_id = import_base.first_owning_decl_id.is_valid()
                                   ? decl_id
-                                  : SemIR::InstId::Invalid,
+                                  : SemIR::InstId::None,
   };
 }
 
@@ -1235,7 +1234,7 @@ static auto AddAssociatedEntities(ImportContext& context,
   new_associated_entities.reserve(associated_entities.size());
   for (auto inst_id : associated_entities) {
     // Determine the name of the associated entity, by switching on its kind.
-    SemIR::NameId import_name_id = SemIR::NameId::Invalid;
+    SemIR::NameId import_name_id = SemIR::NameId::None;
     if (auto associated_const =
             context.import_insts().TryGetAs<SemIR::AssociatedConstantDecl>(
                 inst_id)) {
@@ -1259,7 +1258,7 @@ static auto AddAssociatedEntities(ImportContext& context,
     auto entity_name_id = context.local_entity_names().Add(
         {.name_id = name_id,
          .parent_scope_id = local_name_scope_id,
-         .bind_index = SemIR::CompileTimeBindIndex::Invalid});
+         .bind_index = SemIR::CompileTimeBindIndex::None});
     new_associated_entities.push_back(
         AddImportRef(context, inst_id, entity_name_id));
   }
@@ -1283,8 +1282,7 @@ static auto RetryOrDone(ImportRefResolver& resolver, SemIR::ConstantId const_id)
 // that there is no new work.
 static auto ResolveAsUntyped(ImportContext& context, SemIR::Inst inst)
     -> ResolveResult {
-  auto result =
-      TryEvalInst(context.local_context(), SemIR::InstId::Invalid, inst);
+  auto result = TryEvalInst(context.local_context(), SemIR::InstId::None, inst);
   CARBON_CHECK(result.is_constant(), "{0} is not constant", inst);
   return ResolveResult::Done(result);
 }
@@ -1457,13 +1455,13 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto name_id = GetLocalNameId(resolver, import_entity_name.name_id);
   auto entity_name_id = resolver.local_entity_names().Add(
       {.name_id = name_id,
-       .parent_scope_id = SemIR::NameScopeId::Invalid,
+       .parent_scope_id = SemIR::NameScopeId::None,
        .bind_index = import_entity_name.bind_index});
   return ResolveAs<SemIR::BindSymbolicName>(
       resolver,
       {.type_id = resolver.local_context().GetTypeIdForTypeConstant(type_id),
        .entity_name_id = entity_name_id,
-       .value_id = SemIR::InstId::Invalid});
+       .value_id = SemIR::InstId::None});
 }
 
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
@@ -1479,7 +1477,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto name_id = GetLocalNameId(resolver, import_entity_name.name_id);
   auto entity_name_id = resolver.local_entity_names().Add(
       {.name_id = name_id,
-       .parent_scope_id = SemIR::NameScopeId::Invalid,
+       .parent_scope_id = SemIR::NameScopeId::None,
        .bind_index = import_entity_name.bind_index});
   return ResolveAs<SemIR::SymbolicBindingPattern>(
       resolver,
@@ -1531,7 +1529,7 @@ static auto MakeIncompleteClass(ImportContext& context,
                                 SemIR::SpecificId enclosing_specific_id)
     -> std::pair<SemIR::ClassId, SemIR::ConstantId> {
   SemIR::ClassDecl class_decl = {.type_id = SemIR::TypeType::SingletonTypeId,
-                                 .class_id = SemIR::ClassId::Invalid,
+                                 .class_id = SemIR::ClassId::None,
                                  .decl_block_id = SemIR::InstBlockId::Empty};
   auto class_decl_id = context.local_context().AddPlaceholderInstInNoBlock(
       context.local_context().MakeImportedLocAndInst(
@@ -1540,7 +1538,7 @@ static auto MakeIncompleteClass(ImportContext& context,
   // incomplete type so that any references have something to point at.
   class_decl.class_id = context.local_classes().Add(
       {GetIncompleteLocalEntityBase(context, class_decl_id, import_class),
-       {.self_type_id = SemIR::TypeId::Invalid,
+       {.self_type_id = SemIR::TypeId::None,
         .inheritance_kind = import_class.inheritance_kind,
         .is_dynamic = import_class.is_dynamic}});
 
@@ -1568,7 +1566,7 @@ static auto AddClassDefinition(ImportContext& context,
   new_class.complete_type_witness_id = complete_type_witness_id;
 
   new_class.scope_id = context.local_name_scopes().Add(
-      new_class.first_owning_decl_id, SemIR::NameId::Invalid,
+      new_class.first_owning_decl_id, SemIR::NameId::None,
       new_class.parent_scope_id);
   auto& new_scope = context.local_name_scopes().Get(new_class.scope_id);
   const auto& import_scope =
@@ -1599,9 +1597,9 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   // choice types. Factor out some of this functionality.
   const auto& import_class = resolver.import_classes().Get(inst.class_id);
 
-  SemIR::ClassId class_id = SemIR::ClassId::Invalid;
+  SemIR::ClassId class_id = SemIR::ClassId::None;
   if (!class_const_id.is_valid()) {
-    auto import_specific_id = SemIR::SpecificId::Invalid;
+    auto import_specific_id = SemIR::SpecificId::None;
     if (auto import_generic_class_type =
             resolver.import_types().TryGetAs<SemIR::GenericClassType>(
                 inst.type_id)) {
@@ -1646,13 +1644,13 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto complete_type_witness_const_id =
       import_class.complete_type_witness_id.is_valid()
           ? GetLocalConstantId(resolver, import_class.complete_type_witness_id)
-          : SemIR::ConstantId::Invalid;
+          : SemIR::ConstantId::None;
   auto base_id = import_class.base_id.is_valid()
                      ? GetLocalConstantInstId(resolver, import_class.base_id)
-                     : SemIR::InstId::Invalid;
+                     : SemIR::InstId::None;
   auto adapt_id = import_class.adapt_id.is_valid()
                       ? GetLocalConstantInstId(resolver, import_class.adapt_id)
-                      : SemIR::InstId::Invalid;
+                      : SemIR::InstId::None;
   auto& new_class = resolver.local_classes().Get(class_id);
 
   if (resolver.HasNewWork()) {
@@ -1661,7 +1659,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   auto vtable_id = import_class.vtable_id.is_valid()
                        ? AddImportRef(resolver, import_class.vtable_id)
-                       : SemIR::InstId::Invalid;
+                       : SemIR::InstId::None;
 
   new_class.parent_scope_id = parent_scope_id;
   new_class.implicit_param_patterns_id = GetLocalParamPatternsId(
@@ -1779,8 +1777,8 @@ static auto MakeFunctionDecl(ImportContext& context,
                              SemIR::SpecificId specific_id)
     -> std::pair<SemIR::FunctionId, SemIR::ConstantId> {
   SemIR::FunctionDecl function_decl = {
-      .type_id = SemIR::TypeId::Invalid,
-      .function_id = SemIR::FunctionId::Invalid,
+      .type_id = SemIR::TypeId::None,
+      .function_id = SemIR::FunctionId::None,
       .decl_block_id = SemIR::InstBlockId::Empty};
   auto function_decl_id = context.local_context().AddPlaceholderInstInNoBlock(
       context.local_context().MakeImportedLocAndInst(
@@ -1790,7 +1788,7 @@ static auto MakeFunctionDecl(ImportContext& context,
   // Start with an incomplete function.
   function_decl.function_id = context.local_functions().Add(
       {GetIncompleteLocalEntityBase(context, function_decl_id, import_function),
-       {.return_slot_pattern_id = SemIR::InstId::Invalid,
+       {.return_slot_pattern_id = SemIR::InstId::None,
         .builtin_function_kind = import_function.builtin_function_kind}});
 
   function_decl.type_id = context.local_context().GetFunctionType(
@@ -1810,7 +1808,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   const auto& import_function =
       resolver.import_functions().Get(inst.function_id);
 
-  SemIR::FunctionId function_id = SemIR::FunctionId::Invalid;
+  SemIR::FunctionId function_id = SemIR::FunctionId::None;
   if (!function_const_id.is_valid()) {
     auto import_specific_id = resolver.import_types()
                                   .GetAs<SemIR::FunctionType>(inst.type_id)
@@ -1837,7 +1835,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     function_id = function_type.function_id;
   }
 
-  auto return_type_const_id = SemIR::ConstantId::Invalid;
+  auto return_type_const_id = SemIR::ConstantId::None;
   if (import_function.return_slot_pattern_id.is_valid()) {
     return_type_const_id = GetLocalConstantId(
         resolver, resolver.import_insts()
@@ -1934,15 +1932,15 @@ static auto MakeImplDeclaration(ImportContext& context,
                                 const SemIR::Impl& import_impl,
                                 SemIR::InstId witness_id)
     -> std::pair<SemIR::ImplId, SemIR::ConstantId> {
-  SemIR::ImplDecl impl_decl = {.impl_id = SemIR::ImplId::Invalid,
+  SemIR::ImplDecl impl_decl = {.impl_id = SemIR::ImplId::None,
                                .decl_block_id = SemIR::InstBlockId::Empty};
   auto impl_decl_id = context.local_context().AddPlaceholderInstInNoBlock(
       context.local_context().MakeImportedLocAndInst(
           AddImportIRInst(context, import_impl.latest_decl_id()), impl_decl));
   impl_decl.impl_id = context.local_impls().Add(
       {GetIncompleteLocalEntityBase(context, impl_decl_id, import_impl),
-       {.self_id = SemIR::InstId::Invalid,
-        .constraint_id = SemIR::InstId::Invalid,
+       {.self_id = SemIR::InstId::None,
+        .constraint_id = SemIR::InstId::None,
         .witness_id = witness_id}});
 
   // Write the impl ID into the ImplDecl.
@@ -1959,7 +1957,7 @@ static auto AddImplDefinition(ImportContext& context,
 
   if (import_impl.scope_id.is_valid()) {
     new_impl.scope_id = context.local_name_scopes().Add(
-        new_impl.first_owning_decl_id, SemIR::NameId::Invalid,
+        new_impl.first_owning_decl_id, SemIR::NameId::None,
         new_impl.parent_scope_id);
     // Import the contents of the definition scope, if we might need it. Name
     // lookup is never performed into this scope by a user of the impl, so
@@ -1989,7 +1987,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   // functions. Factor out the commonality.
   const auto& import_impl = resolver.import_impls().Get(inst.impl_id);
 
-  SemIR::ImplId impl_id = SemIR::ImplId::Invalid;
+  SemIR::ImplId impl_id = SemIR::ImplId::None;
   if (!impl_const_id.is_valid()) {
     if (resolver.HasNewWork()) {
       // This is the end of the first phase. Don't make a new impl yet if we
@@ -2082,7 +2080,7 @@ static auto MakeInterfaceDecl(ImportContext& context,
     -> std::pair<SemIR::InterfaceId, SemIR::ConstantId> {
   SemIR::InterfaceDecl interface_decl = {
       .type_id = SemIR::TypeType::SingletonTypeId,
-      .interface_id = SemIR::InterfaceId::Invalid,
+      .interface_id = SemIR::InterfaceId::None,
       .decl_block_id = SemIR::InstBlockId::Empty};
   auto interface_decl_id = context.local_context().AddPlaceholderInstInNoBlock(
       context.local_context().MakeImportedLocAndInst(
@@ -2114,7 +2112,7 @@ static auto AddInterfaceDefinition(ImportContext& context,
                                    SemIR::Interface& new_interface,
                                    SemIR::InstId self_param_id) -> void {
   new_interface.scope_id = context.local_name_scopes().Add(
-      new_interface.first_owning_decl_id, SemIR::NameId::Invalid,
+      new_interface.first_owning_decl_id, SemIR::NameId::None,
       new_interface.parent_scope_id);
   auto& new_scope = context.local_name_scopes().Get(new_interface.scope_id);
   const auto& import_scope =
@@ -2140,9 +2138,9 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   const auto& import_interface =
       resolver.import_interfaces().Get(inst.interface_id);
 
-  SemIR::InterfaceId interface_id = SemIR::InterfaceId::Invalid;
+  SemIR::InterfaceId interface_id = SemIR::InterfaceId::None;
   if (!interface_const_id.is_valid()) {
-    auto import_specific_id = SemIR::SpecificId::Invalid;
+    auto import_specific_id = SemIR::SpecificId::None;
     if (auto import_generic_interface_type =
             resolver.import_types().TryGetAs<SemIR::GenericInterfaceType>(
                 inst.type_id)) {
@@ -2418,8 +2416,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       SemIR::NamespaceType::SingletonInstId);
   auto namespace_decl =
       SemIR::Namespace{.type_id = namespace_type_id,
-                       .name_scope_id = SemIR::NameScopeId::Invalid,
-                       .import_id = SemIR::AbsoluteInstId::Invalid};
+                       .name_scope_id = SemIR::NameScopeId::None,
+                       .import_id = SemIR::AbsoluteInstId::None};
   auto inst_id = resolver.local_context().AddPlaceholderInstInNoBlock(
       resolver.local_context().MakeImportedLocAndInst(
           AddImportIRInst(resolver, import_inst_id), namespace_decl));
@@ -2787,7 +2785,7 @@ static auto TryResolveInst(ImportRefResolver& resolver, SemIR::InstId inst_id,
   auto generic_const_id =
       GetLocalConstantId(resolver, symbolic_const.generic_id);
 
-  auto inner_const_id = SemIR::ConstantId::Invalid;
+  auto inner_const_id = SemIR::ConstantId::None;
   if (const_id.is_valid()) {
     // For the third phase, extract the constant value that
     // TryResolveInstCanonical produced previously.
@@ -2853,7 +2851,7 @@ static auto ResolveLocalEvalBlock(ImportRefResolver& resolver,
     -> SemIR::InstBlockId {
   auto import_block_id = import_generic.GetEvalBlock(region);
   if (!import_block_id.is_valid()) {
-    return SemIR::InstBlockId::Invalid;
+    return SemIR::InstBlockId::None;
   }
 
   auto inst_ids = ResolveLocalInstBlockContents(resolver, import_block_id);
@@ -2897,7 +2895,7 @@ static auto ResolveLocalInstBlock(ImportRefResolver& resolver,
                                   SemIR::InstBlockId import_block_id)
     -> SemIR::InstBlockId {
   if (!import_block_id.is_valid()) {
-    return SemIR::InstBlockId::Invalid;
+    return SemIR::InstBlockId::None;
   }
 
   auto inst_ids = ResolveLocalInstBlockContents(resolver, import_block_id);
@@ -2968,7 +2966,7 @@ static auto GetInstForLoad(Context& context,
                            SemIR::ImportIRInstId import_ir_inst_id)
     -> std::pair<llvm::SmallVector<SemIR::ImportIRInst>, SemIR::TypeId> {
   std::pair<llvm::SmallVector<SemIR::ImportIRInst>, SemIR::TypeId> result = {
-      {}, SemIR::TypeId::Invalid};
+      {}, SemIR::TypeId::None};
   auto& [import_ir_insts, type_id] = result;
 
   auto import_ir_inst = context.import_ir_insts().Get(import_ir_inst_id);
@@ -2990,7 +2988,7 @@ static auto GetInstForLoad(Context& context,
         cursor_ir->import_ir_insts().Get(import_ref->import_ir_inst_id);
     cursor_ir = cursor_ir->import_irs().Get(import_ir_inst.ir_id).sem_ir;
     import_ir_insts.push_back(
-        {.ir_id = AddImportIR(context, {.decl_id = SemIR::InstId::Invalid,
+        {.ir_id = AddImportIR(context, {.decl_id = SemIR::InstId::None,
                                         .is_export = false,
                                         .sem_ir = cursor_ir}),
          .inst_id = import_ir_inst.inst_id});

--- a/toolchain/check/inst_block_stack.cpp
+++ b/toolchain/check/inst_block_stack.cpp
@@ -28,7 +28,7 @@ auto InstBlockStack::PeekOrAdd(int depth) -> SemIR::InstBlockId {
   CARBON_CHECK(static_cast<int>(id_stack_.size()) > depth, "no such block");
   int index = id_stack_.size() - depth - 1;
   auto& slot = id_stack_[index];
-  if (!slot.is_valid()) {
+  if (!slot.has_value()) {
     slot = sem_ir_->inst_blocks().AddDefaultValue();
   }
   return slot;
@@ -41,7 +41,7 @@ auto InstBlockStack::Pop() -> SemIR::InstBlockId {
 
   // Finalize the block.
   if (!insts.empty() && id != SemIR::InstBlockId::Unreachable) {
-    if (id.is_valid()) {
+    if (id.has_value()) {
       sem_ir_->inst_blocks().Set(id, insts);
     } else {
       id = sem_ir_->inst_blocks().Add(insts);
@@ -51,7 +51,7 @@ auto InstBlockStack::Pop() -> SemIR::InstBlockId {
   insts_stack_.PopArray();
 
   CARBON_VLOG("{0} Pop {1}: {2}\n", name_, id_stack_.size(), id);
-  return id.is_valid() ? id : SemIR::InstBlockId::Empty;
+  return id.has_value() ? id : SemIR::InstBlockId::Empty;
 }
 
 auto InstBlockStack::PopAndDiscard() -> void {

--- a/toolchain/check/inst_block_stack.h
+++ b/toolchain/check/inst_block_stack.h
@@ -33,7 +33,7 @@ class InstBlockStack {
 
   // Pushes a new instruction block. It will be invalid unless PeekOrAdd is
   // called in order to support lazy allocation.
-  auto Push() -> void { Push(SemIR::InstBlockId::Invalid); }
+  auto Push() -> void { Push(SemIR::InstBlockId::None); }
 
   // Pushes a new unreachable code block.
   auto PushUnreachable() -> void { Push(SemIR::InstBlockId::Unreachable); }

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -58,7 +58,7 @@ static auto GetHighestAllowedAccess(Context& context, SemIR::LocId loc_id,
   auto [_, self_type_inst_id, is_poisoned] = context.LookupUnqualifiedName(
       loc_id.node_id(), SemIR::NameId::SelfType, /*required=*/false);
   CARBON_CHECK(!is_poisoned);
-  if (!self_type_inst_id.is_valid()) {
+  if (!self_type_inst_id.has_value()) {
     return SemIR::AccessKind::Public;
   }
 
@@ -84,14 +84,14 @@ static auto GetHighestAllowedAccess(Context& context, SemIR::LocId loc_id,
     // accessing, try checking if this class is of the parent type of `Self`.
     if (auto base_type_id = self_class_info.GetBaseType(
             context.sem_ir(), self_class_type->specific_id);
-        base_type_id.is_valid()) {
+        base_type_id.has_value()) {
       if (context.types().GetConstantId(base_type_id) == name_scope_const_id) {
         return SemIR::AccessKind::Protected;
       }
       // TODO: Also check whether this base class has a base class of its own.
     } else if (auto adapt_type_id = self_class_info.GetAdaptedType(
                    context.sem_ir(), self_class_type->specific_id);
-               adapt_type_id.is_valid()) {
+               adapt_type_id.has_value()) {
       if (context.types().GetConstantId(adapt_type_id) == name_scope_const_id) {
         // TODO: Should we be allowed to access protected fields of a type we
         // are adapting? The design doesn't allow this.
@@ -110,7 +110,7 @@ static auto ScopeNeedsImplLookup(Context& context,
     -> bool {
   SemIR::InstId inst_id =
       context.constant_values().GetInstId(name_scope_const_id);
-  CARBON_CHECK(inst_id.is_valid());
+  CARBON_CHECK(inst_id.has_value());
   SemIR::Inst inst = context.insts().Get(inst_id);
 
   if (inst.Is<SemIR::FacetType>()) {
@@ -144,7 +144,7 @@ static auto AccessMemberOfImplWitness(Context& context, SemIR::LocId loc_id,
                                       SemIR::InstId member_id)
     -> SemIR::InstId {
   auto member_value_id = context.constant_values().GetConstantInstId(member_id);
-  if (!member_value_id.is_valid()) {
+  if (!member_value_id.has_value()) {
     if (member_value_id != SemIR::ErrorInst::SingletonInstId) {
       context.TODO(member_id, "non-constant associated entity");
     }
@@ -189,7 +189,7 @@ static auto PerformImplLookup(
   auto witness_id =
       LookupImplWitness(context, loc_id, type_const_id,
                         assoc_type.interface_type_id.AsConstantId());
-  if (!witness_id.is_valid()) {
+  if (!witness_id.has_value()) {
     auto interface_type_id = context.GetInterfaceType(
         interface_type->interface_id, interface_type->specific_id);
     if (missing_impl_diagnoser) {
@@ -237,7 +237,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
       context.LookupQualifiedName(loc_id, name_id, lookup_scopes,
                                   /*required=*/true, access_info);
 
-  if (!result.inst_id.is_valid()) {
+  if (!result.inst_id.has_value()) {
     return SemIR::ErrorInst::SingletonInstId;
   }
 
@@ -245,11 +245,11 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
   auto inst = context.insts().Get(result.inst_id);
   auto type_id = SemIR::GetTypeInSpecific(context.sem_ir(), result.specific_id,
                                           inst.type_id());
-  CARBON_CHECK(type_id.is_valid(), "Missing type for member {0}", inst);
+  CARBON_CHECK(type_id.has_value(), "Missing type for member {0}", inst);
 
   // If the named entity has a constant value that depends on its specific,
   // store the specific too.
-  if (result.specific_id.is_valid() &&
+  if (result.specific_id.has_value() &&
       context.constant_values().Get(result.inst_id).is_symbolic()) {
     result.inst_id = context.GetOrAddInst<SemIR::SpecificConstant>(
         loc_id, {.type_id = type_id,
@@ -308,7 +308,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
         }
         // TODO: If that fails, would need to do impl lookup to see if the facet
         // value implements the interface of `*assoc_type`.
-        if (!witness_inst_id.is_valid()) {
+        if (!witness_inst_id.has_value()) {
           context.TODO(member_id,
                        "associated entity not found in facet type, need to do "
                        "impl lookup");
@@ -353,7 +353,7 @@ static auto PerformInstanceBinding(Context& context, SemIR::LocId loc_id,
       // Find the specified element, which could be either a field or a base
       // class, and build an element access expression.
       auto element_id = context.constant_values().GetConstantInstId(member_id);
-      CARBON_CHECK(element_id.is_valid(),
+      CARBON_CHECK(element_id.has_value(),
                    "Non-constant value {0} of unbound element type",
                    context.insts().Get(member_id));
       auto index = GetClassElementIndex(context, element_id);

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -290,7 +290,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
         const auto& facet_type_info =
             context.facet_types().Get(facet_type.facet_type_id);
         // Witness that `T` implements the `*assoc_interface`.
-        SemIR::InstId witness_inst_id = SemIR::InstId::Invalid;
+        SemIR::InstId witness_inst_id = SemIR::InstId::None;
         for (auto base_interface : facet_type_info.impls_constraints) {
           // Get the witness that `T` implements `base_type_id`.
           if (base_interface == *assoc_interface) {

--- a/toolchain/check/merge.cpp
+++ b/toolchain/check/merge.cpp
@@ -95,7 +95,7 @@ auto DiagnoseIfInvalidRedecl(Context& context, Lex::TokenKind decl_kind,
                              SemIR::NameId name_id, RedeclInfo new_decl,
                              RedeclInfo prev_decl,
                              SemIR::ImportIRId import_ir_id) -> void {
-  if (!import_ir_id.is_valid()) {
+  if (!import_ir_id.has_value()) {
     // Check for disallowed redeclarations in the same file.
     if (!new_decl.is_definition) {
       DiagnoseRedundant(context, decl_kind, name_id, new_decl.loc,
@@ -146,8 +146,8 @@ auto DiagnoseIfInvalidRedecl(Context& context, Lex::TokenKind decl_kind,
                            prev_decl.loc);
     return;
   }
-  if (!prev_decl.extern_library_id.is_valid()) {
-    if (new_decl.extern_library_id.is_valid()) {
+  if (!prev_decl.extern_library_id.has_value()) {
+    if (new_decl.extern_library_id.has_value()) {
       DiagnoseExternLibraryInImporter(context, decl_kind, name_id, new_decl.loc,
                                       prev_decl.loc);
     } else {
@@ -179,7 +179,7 @@ static auto EntityHasParamError(Context& context, const DeclParams& info)
     -> bool {
   for (auto param_patterns_id :
        {info.implicit_param_patterns_id, info.param_patterns_id}) {
-    if (param_patterns_id.is_valid() &&
+    if (param_patterns_id.has_value() &&
         param_patterns_id != SemIR::InstBlockId::Empty) {
       for (auto param_id : context.inst_blocks().Get(param_patterns_id)) {
         if (context.insts().Get(param_id).type_id() ==
@@ -293,7 +293,7 @@ static auto CheckRedeclParams(Context& context, SemIRLoc new_decl_loc,
   }
 
   // If exactly one of the parameter lists was present, they differ.
-  if (new_param_patterns_id.is_valid() != prev_param_patterns_id.is_valid()) {
+  if (new_param_patterns_id.has_value() != prev_param_patterns_id.has_value()) {
     if (!diagnose) {
       return false;
     }
@@ -307,15 +307,15 @@ static auto CheckRedeclParams(Context& context, SemIRLoc new_decl_loc,
                       BoolAsSelect, BoolAsSelect);
     context.emitter()
         .Build(new_decl_loc, RedeclParamListDiffers, is_implicit_param,
-               new_param_patterns_id.is_valid())
+               new_param_patterns_id.has_value())
         .Note(prev_decl_loc, RedeclParamListPrevious, is_implicit_param,
-              prev_param_patterns_id.is_valid())
+              prev_param_patterns_id.has_value())
         .Emit();
     return false;
   }
 
-  CARBON_CHECK(new_param_patterns_id.is_valid() &&
-               prev_param_patterns_id.is_valid());
+  CARBON_CHECK(new_param_patterns_id.has_value() &&
+               prev_param_patterns_id.has_value());
   const auto new_param_pattern_ids =
       context.inst_blocks().Get(new_param_patterns_id);
   const auto prev_param_pattern_ids =
@@ -382,16 +382,16 @@ static auto CheckRedeclParamSyntax(Context& context,
   // TODO: Support cross-file syntax checks. Right now imports provide invalid
   // nodes, and we'll need to follow the declaration to its original file to
   // get the parse tree.
-  if (!new_first_param_node_id.is_valid() ||
-      !prev_first_param_node_id.is_valid()) {
+  if (!new_first_param_node_id.has_value() ||
+      !prev_first_param_node_id.has_value()) {
     return true;
   }
-  CARBON_CHECK(new_last_param_node_id.is_valid(),
-               "new_last_param_node_id.is_valid should match "
-               "new_first_param_node_id.is_valid");
-  CARBON_CHECK(prev_last_param_node_id.is_valid(),
-               "prev_last_param_node_id.is_valid should match "
-               "prev_first_param_node_id.is_valid");
+  CARBON_CHECK(new_last_param_node_id.has_value(),
+               "new_last_param_node_id.has_value should match "
+               "new_first_param_node_id.has_value");
+  CARBON_CHECK(prev_last_param_node_id.has_value(),
+               "prev_last_param_node_id.has_value should match "
+               "prev_first_param_node_id.has_value");
   Parse::Tree::PostorderIterator new_iter(new_first_param_node_id);
   Parse::Tree::PostorderIterator new_end(new_last_param_node_id);
   Parse::Tree::PostorderIterator prev_iter(prev_first_param_node_id);

--- a/toolchain/check/merge.h
+++ b/toolchain/check/merge.h
@@ -99,7 +99,7 @@ struct DeclParams {
 auto CheckRedeclParamsMatch(
     Context& context, const DeclParams& new_entity,
     const DeclParams& prev_entity,
-    SemIR::SpecificId prev_specific_id = SemIR::SpecificId::Invalid,
+    SemIR::SpecificId prev_specific_id = SemIR::SpecificId::None,
     bool check_syntax = true, bool diagnose = true) -> bool;
 
 }  // namespace Carbon::Check

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -67,7 +67,7 @@ template <typename DiagnosticBaseT>
 static auto ForbidModifiersOnDecl(
     Context& context, const DiagnosticBaseT& diagnostic_base,
     DeclIntroducerState& introducer, KeywordModifierSet forbidden,
-    SemIR::LocId context_loc_id = SemIR::LocId::Invalid) -> void {
+    SemIR::LocId context_loc_id = SemIR::LocId::None) -> void {
   auto not_allowed = introducer.modifier_set & forbidden;
   if (not_allowed.empty()) {
     return;
@@ -80,7 +80,7 @@ static auto ForbidModifiersOnDecl(
       DiagnoseNotAllowed(context, diagnostic_base,
                          introducer.modifier_node_id(order), introducer.kind,
                          context_loc_id);
-      introducer.set_modifier_node_id(order, Parse::NodeId::Invalid);
+      introducer.set_modifier_node_id(order, Parse::NodeId::None);
     }
   }
 
@@ -189,7 +189,7 @@ auto RestrictExternModifierOnDecl(Context& context,
     ForbidModifiersOnDecl(context, ModifierExternNotAllowed, introducer,
                           KeywordModifierSet::Extern);
     // Treat as unset.
-    introducer.extern_library = SemIR::LibraryNameId::Invalid;
+    introducer.extern_library = SemIR::LibraryNameId::None;
     return;
   }
 

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -39,7 +39,7 @@ static auto DiagnoseNotAllowed(
     SemIR::LocId context_loc_id) -> void {
   auto diag = StartDiagnoseNotAllowed(context, diagnostic_base, modifier_node,
                                       decl_kind);
-  if (context_loc_id.is_valid()) {
+  if (context_loc_id.has_value()) {
     CARBON_DIAGNOSTIC(ModifierNotInContext, Note, "containing definition here");
     diag.Note(context_loc_id, ModifierNotInContext);
   }
@@ -204,7 +204,7 @@ auto RestrictExternModifierOnDecl(Context& context,
     // Right now this can produce both this and the below diagnostic.
   }
 
-  if (is_definition && introducer.extern_library.is_valid()) {
+  if (is_definition && introducer.extern_library.has_value()) {
     CARBON_DIAGNOSTIC(ExternLibraryOnDefinition, Error,
                       "a library cannot be provided for an `extern` modifier "
                       "on a definition");

--- a/toolchain/check/name_component.cpp
+++ b/toolchain/check/name_component.cpp
@@ -11,8 +11,8 @@ namespace Carbon::Check {
 
 auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
     -> NameComponent {
-  Parse::NodeId first_param_node_id = Parse::InvalidNodeId();
-  Parse::NodeId last_param_node_id = Parse::InvalidNodeId();
+  Parse::NodeId first_param_node_id = Parse::NoneNodeId();
+  Parse::NodeId last_param_node_id = Parse::NoneNodeId();
 
   // Explicit params.
   auto [params_loc_id, param_patterns_id] =
@@ -23,7 +23,7 @@ auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
             .PopForSoloNodeId<Parse::NodeKind::TuplePatternStart>();
     last_param_node_id = params_loc_id;
   } else {
-    param_patterns_id = SemIR::InstBlockId::Invalid;
+    param_patterns_id = SemIR::InstBlockId::None;
   }
 
   // Implicit params.
@@ -40,11 +40,11 @@ auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
       last_param_node_id = params_loc_id;
     }
   } else {
-    implicit_param_patterns_id = SemIR::InstBlockId::Invalid;
+    implicit_param_patterns_id = SemIR::InstBlockId::None;
   }
 
-  auto call_params_id = SemIR::InstBlockId::Invalid;
-  auto pattern_block_id = SemIR::InstBlockId::Invalid;
+  auto call_params_id = SemIR::InstBlockId::None;
+  auto pattern_block_id = SemIR::InstBlockId::None;
   if (param_patterns_id->is_valid() || implicit_param_patterns_id->is_valid()) {
     call_params_id =
         CalleePatternMatch(context, *implicit_param_patterns_id,
@@ -87,7 +87,7 @@ auto PopNameComponentWithoutParams(Context& context, Lex::TokenKind introducer)
                                : name.params_loc_id,
                            UnexpectedDeclNameParams, introducer);
 
-    name.call_params_id = SemIR::InstBlockId::Invalid;
+    name.call_params_id = SemIR::InstBlockId::None;
   }
   return name;
 }

--- a/toolchain/check/name_component.cpp
+++ b/toolchain/check/name_component.cpp
@@ -36,7 +36,7 @@ auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
         context.node_stack()
             .PopForSoloNodeId<Parse::NodeKind::ImplicitParamListStart>();
     // Only use the end of implicit params if there weren't explicit params.
-    if (last_param_node_id.is_valid()) {
+    if (last_param_node_id.has_value()) {
       last_param_node_id = params_loc_id;
     }
   } else {
@@ -45,7 +45,8 @@ auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
 
   auto call_params_id = SemIR::InstBlockId::None;
   auto pattern_block_id = SemIR::InstBlockId::None;
-  if (param_patterns_id->is_valid() || implicit_param_patterns_id->is_valid()) {
+  if (param_patterns_id->has_value() ||
+      implicit_param_patterns_id->has_value()) {
     call_params_id =
         CalleePatternMatch(context, *implicit_param_patterns_id,
                            *param_patterns_id, return_slot_pattern_id);
@@ -77,12 +78,12 @@ auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
 auto PopNameComponentWithoutParams(Context& context, Lex::TokenKind introducer)
     -> NameComponent {
   NameComponent name = PopNameComponent(context);
-  if (name.call_params_id.is_valid()) {
+  if (name.call_params_id.has_value()) {
     CARBON_DIAGNOSTIC(UnexpectedDeclNameParams, Error,
                       "`{0}` declaration cannot have parameters",
                       Lex::TokenKind);
     // Point to the lexically first parameter list in the diagnostic.
-    context.emitter().Emit(name.implicit_param_patterns_id.is_valid()
+    context.emitter().Emit(name.implicit_param_patterns_id.has_value()
                                ? name.implicit_params_loc_id
                                : name.params_loc_id,
                            UnexpectedDeclNameParams, introducer);

--- a/toolchain/check/name_component.h
+++ b/toolchain/check/name_component.h
@@ -52,7 +52,7 @@ struct NameComponent {
 // Pops a name component from the node stack (and pattern block stack, if it has
 // parameters).
 auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id =
-                                            SemIR::InstId::Invalid)
+                                            SemIR::InstId::None)
     -> NameComponent;
 
 // Equivalent to PopNameComponent, but also diagnoses if the name component has

--- a/toolchain/check/node_id_traversal.cpp
+++ b/toolchain/check/node_id_traversal.cpp
@@ -14,10 +14,9 @@ NodeIdTraversal::NodeIdTraversal(Context& context,
       next_deferred_definition_(&context.parse_tree()),
       worklist_(vlog_stream) {
   auto range = context.parse_tree().postorder();
-  chunks_.push_back(
-      {.it = range.begin(),
-       .end = range.end(),
-       .next_definition = Parse::DeferredDefinitionIndex::Invalid});
+  chunks_.push_back({.it = range.begin(),
+                     .end = range.end(),
+                     .next_definition = Parse::DeferredDefinitionIndex::None});
 }
 
 auto NodeIdTraversal::Next() -> std::optional<Parse::NodeId> {
@@ -166,7 +165,7 @@ auto NodeIdTraversal::NextDeferredDefinitionCache::SkipTo(
   index_ = next_index;
   if (static_cast<size_t>(index_.index) ==
       tree_->deferred_definitions().size()) {
-    start_id_ = Parse::NodeId::Invalid;
+    start_id_ = Parse::NodeId::None;
   } else {
     start_id_ = tree_->deferred_definitions().Get(index_).start_id;
   }

--- a/toolchain/check/node_id_traversal.h
+++ b/toolchain/check/node_id_traversal.h
@@ -46,8 +46,8 @@ class NodeIdTraversal {
    private:
     const Parse::Tree* tree_;
     Parse::DeferredDefinitionIndex index_ =
-        Parse::DeferredDefinitionIndex::Invalid;
-    Parse::NodeId start_id_ = Parse::NodeId::Invalid;
+        Parse::DeferredDefinitionIndex::None;
+    Parse::NodeId start_id_ = Parse::NodeId::None;
   };
 
   // A chunk of the parse tree that we need to type-check.

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -41,7 +41,7 @@ class IdUnion {
     return As<SemIR::IdKind::TypeFor<K>>();
   }
 
-  // Translates an ID type to the enum ID kind. Returns Invalid if `IdT` isn't
+  // Translates an ID type to the enum ID kind. Returns `None` if `IdT` isn't
   // a type that can be stored in this union.
   template <typename IdT>
   static constexpr auto KindFor() -> Kind {
@@ -92,7 +92,7 @@ class NodeStack {
     auto kind = parse_tree_->node_kind(node_id);
     CARBON_CHECK(NodeKindToIdKind(kind) == Id::KindFor<IdT>(),
                  "Parse kind expected a different IdT: {0} -> {1}\n", kind, id);
-    CARBON_CHECK(id.has_value(), "Push called with invalid id: {0}",
+    CARBON_CHECK(id.has_value(), "Push called with `None` id: {0}",
                  parse_tree_->node_kind(node_id));
     CARBON_VLOG("Node Push {0}: {1} -> {2}\n", stack_.size(), kind, id);
     CARBON_CHECK(stack_.size() < (1 << 20),

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -20,7 +20,7 @@ namespace Carbon::Check {
 class IdUnion {
  public:
   // The default constructor forms an invalid ID.
-  explicit constexpr IdUnion() : index(AnyIdBase::InvalidIndex) {}
+  explicit constexpr IdUnion() : index(AnyIdBase::NoneIndex) {}
 
   template <typename IdT>
     requires SemIR::IdKind::Contains<IdT>
@@ -271,7 +271,7 @@ class NodeStack {
   auto PopWithNodeIdIf() -> std::pair<Parse::NodeIdForKind<RequiredParseKind>,
                                       decltype(PopIf<RequiredParseKind>())> {
     if (!PeekIs(RequiredParseKind)) {
-      return {Parse::NodeId::Invalid, std::nullopt};
+      return {Parse::NodeId::None, std::nullopt};
     }
     return PopWithNodeId<RequiredParseKind>();
   }
@@ -283,7 +283,7 @@ class NodeStack {
       -> std::pair<Parse::NodeIdInCategory<RequiredParseCategory>,
                    decltype(PopIf<RequiredParseCategory>())> {
     if (!PeekIs(RequiredParseCategory)) {
-      return {Parse::NodeId::Invalid, std::nullopt};
+      return {Parse::NodeId::None, std::nullopt};
     }
     return PopWithNodeId<RequiredParseCategory>();
   }

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -92,7 +92,7 @@ class NodeStack {
     auto kind = parse_tree_->node_kind(node_id);
     CARBON_CHECK(NodeKindToIdKind(kind) == Id::KindFor<IdT>(),
                  "Parse kind expected a different IdT: {0} -> {1}\n", kind, id);
-    CARBON_CHECK(id.is_valid(), "Push called with invalid id: {0}",
+    CARBON_CHECK(id.has_value(), "Push called with invalid id: {0}",
                  parse_tree_->node_kind(node_id));
     CARBON_VLOG("Node Push {0}: {1} -> {2}\n", stack_.size(), kind, id);
     CARBON_CHECK(stack_.size() < (1 << 20),

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -161,7 +161,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
         case MatchKind::Callee: {
           if (context.insts()
                   .GetAs<SemIR::AnyParam>(value_id)
-                  .runtime_index.is_valid()) {
+                  .runtime_index.has_value()) {
             results_.push_back(value_id);
           }
           break;
@@ -170,7 +170,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
           CARBON_FATAL("Found binding pattern during caller pattern match");
       }
       auto bind_name = context.insts().GetAs<SemIR::AnyBindName>(bind_name_id);
-      CARBON_CHECK(!bind_name.value_id.is_valid());
+      CARBON_CHECK(!bind_name.value_id.has_value());
       bind_name.value_id = value_id;
       context.ReplaceInstBeforeConstantUse(bind_name_id, bind_name);
       context.inst_block_stack().AddInstId(bind_name_id);
@@ -186,7 +186,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
                  .scrutinee_id = SemIR::InstId::None});
         break;
       }
-      CARBON_CHECK(entry.scrutinee_id.is_valid());
+      CARBON_CHECK(entry.scrutinee_id.has_value());
       auto scrutinee_ref_id =
           ConvertToValueOrRefExpr(context, entry.scrutinee_id);
       switch (SemIR::GetExprCategory(context.sem_ir(), scrutinee_ref_id)) {
@@ -220,7 +220,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
                    results_.size(), param_pattern.runtime_index.index);
       switch (kind_) {
         case MatchKind::Caller: {
-          CARBON_CHECK(entry.scrutinee_id.is_valid());
+          CARBON_CHECK(entry.scrutinee_id.has_value());
           if (entry.scrutinee_id == SemIR::ErrorInst::SingletonInstId) {
             results_.push_back(SemIR::ErrorInst::SingletonInstId);
           } else {
@@ -259,7 +259,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
     case CARBON_KIND(SemIR::OutParamPattern param_pattern): {
       switch (kind_) {
         case MatchKind::Caller: {
-          CARBON_CHECK(entry.scrutinee_id.is_valid());
+          CARBON_CHECK(entry.scrutinee_id.has_value());
           CARBON_CHECK(context.insts().Get(entry.scrutinee_id).type_id() ==
                        SemIR::GetTypeInSpecific(context.sem_ir(),
                                                 callee_specific_id_,
@@ -302,7 +302,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
       bool already_in_lookup =
           context.scope_stack()
               .LookupOrAddName(SemIR::NameId::ReturnSlot, return_slot_id)
-              .is_valid();
+              .has_value();
       CARBON_CHECK(!already_in_lookup);
       results_.push_back(entry.scrutinee_id);
       break;
@@ -315,7 +315,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
       if (context.scope_stack().PeekIndex() == ScopeIndex::Package) {
         context.global_init().Resume();
       }
-      if (entry.scrutinee_id.is_valid()) {
+      if (entry.scrutinee_id.has_value()) {
         auto init_id =
             Initialize(context, pattern.loc_id, var_id, entry.scrutinee_id);
         // TODO: Consider using different instruction kinds for assignment
@@ -341,8 +341,8 @@ auto CalleePatternMatch(Context& context,
                         SemIR::InstBlockId param_patterns_id,
                         SemIR::InstId return_slot_pattern_id)
     -> SemIR::InstBlockId {
-  if (!return_slot_pattern_id.is_valid() && !param_patterns_id.is_valid() &&
-      !implicit_param_patterns_id.is_valid()) {
+  if (!return_slot_pattern_id.has_value() && !param_patterns_id.has_value() &&
+      !implicit_param_patterns_id.has_value()) {
     return SemIR::InstBlockId::None;
   }
 
@@ -350,12 +350,12 @@ auto CalleePatternMatch(Context& context,
 
   // We add work to the stack in reverse so that the results will be produced
   // in the original order.
-  if (return_slot_pattern_id.is_valid()) {
+  if (return_slot_pattern_id.has_value()) {
     match.AddWork({.pattern_id = return_slot_pattern_id,
                    .scrutinee_id = SemIR::InstId::None});
   }
 
-  if (param_patterns_id.is_valid()) {
+  if (param_patterns_id.has_value()) {
     for (SemIR::InstId inst_id :
          llvm::reverse(context.inst_blocks().Get(param_patterns_id))) {
       match.AddWork(
@@ -363,7 +363,7 @@ auto CalleePatternMatch(Context& context,
     }
   }
 
-  if (implicit_param_patterns_id.is_valid()) {
+  if (implicit_param_patterns_id.has_value()) {
     for (SemIR::InstId inst_id :
          llvm::reverse(context.inst_blocks().Get(implicit_param_patterns_id))) {
       match.AddWork(
@@ -385,8 +385,8 @@ auto CallerPatternMatch(Context& context, SemIR::SpecificId specific_id,
   MatchContext match(MatchKind::Caller, specific_id);
 
   // Track the return storage, if present.
-  if (return_slot_arg_id.is_valid()) {
-    CARBON_CHECK(return_slot_pattern_id.is_valid());
+  if (return_slot_arg_id.has_value()) {
+    CARBON_CHECK(return_slot_pattern_id.has_value());
     match.AddWork({.pattern_id = return_slot_pattern_id,
                    .scrutinee_id = return_slot_arg_id});
   }
@@ -397,7 +397,7 @@ auto CallerPatternMatch(Context& context, SemIR::SpecificId specific_id,
     auto runtime_index = SemIR::Function::GetParamPatternInfoFromPatternId(
                              context.sem_ir(), param_pattern_id)
                              .inst.runtime_index;
-    if (!runtime_index.is_valid()) {
+    if (!runtime_index.has_value()) {
       // Not a runtime parameter: we don't pass an argument.
       continue;
     }
@@ -405,7 +405,7 @@ auto CallerPatternMatch(Context& context, SemIR::SpecificId specific_id,
     match.AddWork({.pattern_id = param_pattern_id, .scrutinee_id = arg_id});
   }
 
-  if (self_pattern_id.is_valid()) {
+  if (self_pattern_id.has_value()) {
     match.AddWork({.pattern_id = self_pattern_id, .scrutinee_id = self_arg_id});
   }
 

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -29,7 +29,7 @@ static auto GetPrettyName(Context& context, ParamPattern param_pattern)
           param_pattern.subpattern_id)) {
     return context.entity_names().Get(binding_pattern->entity_name_id).name_id;
   }
-  return SemIR::NameId::Invalid;
+  return SemIR::NameId::None;
 }
 
 namespace {
@@ -64,7 +64,7 @@ class MatchContext {
   // match operation is part of implementing the signature of the given
   // specific.
   explicit MatchContext(MatchKind kind, SemIR::SpecificId callee_specific_id =
-                                            SemIR::SpecificId::Invalid)
+                                            SemIR::SpecificId::None)
       : next_index_(0), kind_(kind), callee_specific_id_(callee_specific_id) {}
 
   // Adds a work item to the stack.
@@ -147,8 +147,8 @@ auto MatchContext::EmitPatternMatch(Context& context,
       // to avoid accidentally consuming it twice.
       auto [bind_name_id, type_expr_region_id] = std::exchange(
           context.bind_name_map().Lookup(entry.pattern_id).value(),
-          {.bind_name_id = SemIR::InstId::Invalid,
-           .type_expr_region_id = SemIR::ExprRegionId::Invalid});
+          {.bind_name_id = SemIR::InstId::None,
+           .type_expr_region_id = SemIR::ExprRegionId::None});
       context.InsertHere(type_expr_region_id);
       auto value_id = entry.scrutinee_id;
       switch (kind_) {
@@ -183,7 +183,7 @@ auto MatchContext::EmitPatternMatch(Context& context,
         // the caller side of the pattern, so we traverse without emitting any
         // insts.
         AddWork({.pattern_id = addr_pattern.inner_id,
-                 .scrutinee_id = SemIR::InstId::Invalid});
+                 .scrutinee_id = SemIR::InstId::None});
         break;
       }
       CARBON_CHECK(entry.scrutinee_id.is_valid());
@@ -343,7 +343,7 @@ auto CalleePatternMatch(Context& context,
     -> SemIR::InstBlockId {
   if (!return_slot_pattern_id.is_valid() && !param_patterns_id.is_valid() &&
       !implicit_param_patterns_id.is_valid()) {
-    return SemIR::InstBlockId::Invalid;
+    return SemIR::InstBlockId::None;
   }
 
   MatchContext match(MatchKind::Callee);
@@ -352,14 +352,14 @@ auto CalleePatternMatch(Context& context,
   // in the original order.
   if (return_slot_pattern_id.is_valid()) {
     match.AddWork({.pattern_id = return_slot_pattern_id,
-                   .scrutinee_id = SemIR::InstId::Invalid});
+                   .scrutinee_id = SemIR::InstId::None});
   }
 
   if (param_patterns_id.is_valid()) {
     for (SemIR::InstId inst_id :
          llvm::reverse(context.inst_blocks().Get(param_patterns_id))) {
       match.AddWork(
-          {.pattern_id = inst_id, .scrutinee_id = SemIR::InstId::Invalid});
+          {.pattern_id = inst_id, .scrutinee_id = SemIR::InstId::None});
     }
   }
 
@@ -367,7 +367,7 @@ auto CalleePatternMatch(Context& context,
     for (SemIR::InstId inst_id :
          llvm::reverse(context.inst_blocks().Get(implicit_param_patterns_id))) {
       match.AddWork(
-          {.pattern_id = inst_id, .scrutinee_id = SemIR::InstId::Invalid});
+          {.pattern_id = inst_id, .scrutinee_id = SemIR::InstId::None});
     }
   }
 

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -133,7 +133,7 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
                          SemIR::InstId expr_id) -> void {
   const auto& function = GetCurrentFunctionForReturn(context);
   auto returned_var_id = GetCurrentReturnedVar(context);
-  auto return_slot_id = SemIR::InstId::Invalid;
+  auto return_slot_id = SemIR::InstId::None;
   auto return_info =
       SemIR::ReturnTypeInfo::ForFunction(context.sem_ir(), function);
 
@@ -189,7 +189,7 @@ auto BuildReturnVar(Context& context, Parse::ReturnStatementId node_id)
     // If we don't have a return slot, we're returning by value. Convert to a
     // value expression.
     returned_var_id = ConvertToValueExpr(context, returned_var_id);
-    return_slot_id = SemIR::InstId::Invalid;
+    return_slot_id = SemIR::InstId::None;
   }
 
   context.AddInst<SemIR::ReturnExpr>(

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -80,7 +80,7 @@ auto RegisterReturnedVar(Context& context, Parse::NodeId returned_node,
   }
 
   // A `returned var` requires an explicit return type.
-  if (!return_info.type_id.is_valid()) {
+  if (!return_info.type_id.has_value()) {
     CARBON_DIAGNOSTIC(ReturnedVarWithNoReturnType, Error,
                       "cannot declare a `returned var` in this function");
     auto diag =
@@ -103,7 +103,7 @@ auto RegisterReturnedVar(Context& context, Parse::NodeId returned_node,
   }
 
   auto existing_id = context.scope_stack().SetReturnedVarOrGetExisting(bind_id);
-  if (existing_id.is_valid()) {
+  if (existing_id.has_value()) {
     CARBON_DIAGNOSTIC(ReturnedVarShadowed, Error,
                       "cannot declare a `returned var` in the scope of "
                       "another `returned var`");
@@ -118,7 +118,7 @@ auto BuildReturnWithNoExpr(Context& context, Parse::ReturnStatementId node_id)
   const auto& function = GetCurrentFunctionForReturn(context);
   auto return_type_id = function.GetDeclaredReturnType(context.sem_ir());
 
-  if (return_type_id.is_valid()) {
+  if (return_type_id.has_value()) {
     CARBON_DIAGNOSTIC(ReturnStatementMissingExpr, Error,
                       "missing return value");
     auto diag = context.emitter().Build(node_id, ReturnStatementMissingExpr);
@@ -137,7 +137,7 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
   auto return_info =
       SemIR::ReturnTypeInfo::ForFunction(context.sem_ir(), function);
 
-  if (!return_info.type_id.is_valid()) {
+  if (!return_info.type_id.has_value()) {
     CARBON_DIAGNOSTIC(
         ReturnStatementDisallowExpr, Error,
         "no return expression should be provided in this context");
@@ -145,7 +145,7 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
     NoteNoReturnTypeProvided(diag, function);
     diag.Emit();
     expr_id = SemIR::ErrorInst::SingletonInstId;
-  } else if (returned_var_id.is_valid()) {
+  } else if (returned_var_id.has_value()) {
     CARBON_DIAGNOSTIC(
         ReturnExprWithReturnedVar, Error,
         "can only `return var;` in the scope of a `returned var`");
@@ -159,7 +159,7 @@ auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId node_id,
     expr_id = SemIR::ErrorInst::SingletonInstId;
   } else if (return_info.has_return_slot()) {
     return_slot_id = GetCurrentReturnSlot(context);
-    CARBON_CHECK(return_slot_id.is_valid());
+    CARBON_CHECK(return_slot_id.has_value());
     // Note that this can import a function and invalidate `function`.
     expr_id = Initialize(context, node_id, return_slot_id, expr_id);
   } else {
@@ -176,7 +176,7 @@ auto BuildReturnVar(Context& context, Parse::ReturnStatementId node_id)
   const auto& function = GetCurrentFunctionForReturn(context);
   auto returned_var_id = GetCurrentReturnedVar(context);
 
-  if (!returned_var_id.is_valid()) {
+  if (!returned_var_id.has_value()) {
     CARBON_DIAGNOSTIC(ReturnVarWithNoReturnedVar, Error,
                       "`return var;` with no `returned var` in scope");
     context.emitter().Emit(node_id, ReturnVarWithNoReturnedVar);

--- a/toolchain/check/scope_index.h
+++ b/toolchain/check/scope_index.h
@@ -20,13 +20,13 @@ namespace Carbon::Check {
 struct ScopeIndex : public IndexBase<ScopeIndex> {
   static constexpr llvm::StringLiteral Label = "scope";
   static const ScopeIndex Package;
-  static const ScopeIndex Invalid;
+  static const ScopeIndex None;
 
   using IndexBase::IndexBase;
 };
 
 constexpr ScopeIndex ScopeIndex::Package = ScopeIndex(0);
-constexpr ScopeIndex ScopeIndex::Invalid = ScopeIndex(InvalidIndex);
+constexpr ScopeIndex ScopeIndex::None = ScopeIndex(NoneIndex);
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -31,7 +31,7 @@ auto ScopeStack::Push(SemIR::InstId scope_inst_id, SemIR::NameScopeId scope_id,
   // If this scope doesn't have a specific of its own, it lives in the enclosing
   // scope's specific, if any.
   auto enclosing_specific_id = specific_id;
-  if (!specific_id.is_valid() && !scope_stack_.empty()) {
+  if (!specific_id.has_value() && !scope_stack_.empty()) {
     enclosing_specific_id = PeekSpecificId();
   }
 
@@ -45,7 +45,7 @@ auto ScopeStack::Push(SemIR::InstId scope_inst_id, SemIR::NameScopeId scope_id,
            compile_time_binding_stack_.all_values_size()),
        .lexical_lookup_has_load_error =
            LexicalLookupHasLoadError() || lexical_lookup_has_load_error});
-  if (scope_id.is_valid()) {
+  if (scope_id.has_value()) {
     non_lexical_scope_stack_.push_back({.scope_index = next_scope_index_,
                                         .name_scope_id = scope_id,
                                         .specific_id = enclosing_specific_id});
@@ -53,7 +53,7 @@ auto ScopeStack::Push(SemIR::InstId scope_inst_id, SemIR::NameScopeId scope_id,
     // For lexical lookups, unqualified lookup doesn't know how to find the
     // associated specific, so if we start adding lexical scopes associated with
     // specifics, we'll need to somehow track them in lookup.
-    CARBON_CHECK(!specific_id.is_valid(),
+    CARBON_CHECK(!specific_id.has_value(),
                  "Lexical scope should not have an associated specific.");
   }
 
@@ -75,14 +75,14 @@ auto ScopeStack::Pop() -> void {
     lexical_results.pop_back();
   });
 
-  if (scope.scope_id.is_valid()) {
+  if (scope.scope_id.has_value()) {
     CARBON_CHECK(non_lexical_scope_stack_.back().scope_index == scope.index);
     non_lexical_scope_stack_.pop_back();
   }
 
   if (scope.has_returned_var) {
     CARBON_CHECK(!return_scope_stack_.empty());
-    CARBON_CHECK(return_scope_stack_.back().returned_var.is_valid());
+    CARBON_CHECK(return_scope_stack_.back().returned_var.has_value());
     return_scope_stack_.back().returned_var = SemIR::InstId::None;
   }
 
@@ -150,7 +150,7 @@ auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
   // function, so it should be relatively rare, but it's still not necesasry to
   // recompute this.
   int scope_depth = scope_stack_.size() - 1;
-  if (scope_index.is_valid()) {
+  if (scope_index.has_value()) {
     scope_depth =
         std::lower_bound(scope_stack_.begin(), scope_stack_.end(), scope_index,
                          [](const ScopeStackEntry& entry, ScopeIndex index) {
@@ -185,14 +185,14 @@ auto ScopeStack::SetReturnedVarOrGetExisting(SemIR::InstId inst_id)
     -> SemIR::InstId {
   CARBON_CHECK(!return_scope_stack_.empty(), "`returned var` in no function");
   auto& returned_var = return_scope_stack_.back().returned_var;
-  if (returned_var.is_valid()) {
+  if (returned_var.has_value()) {
     return returned_var;
   }
 
   returned_var = inst_id;
   CARBON_CHECK(!scope_stack_.back().has_returned_var,
                "Scope has returned var but none is set");
-  if (inst_id.is_valid()) {
+  if (inst_id.has_value()) {
     scope_stack_.back().has_returned_var = true;
   }
   return SemIR::InstId::None;
@@ -202,7 +202,7 @@ auto ScopeStack::Suspend() -> SuspendedScope {
   CARBON_CHECK(!scope_stack_.empty(), "No scope to suspend");
   SuspendedScope result = {.entry = scope_stack_.pop_back_val(),
                            .suspended_items = {}};
-  if (result.entry.scope_id.is_valid()) {
+  if (result.entry.scope_id.has_value()) {
     non_lexical_scope_stack_.pop_back();
   }
 
@@ -246,7 +246,7 @@ auto ScopeStack::Restore(SuspendedScope scope) -> void {
 
   VerifyNextCompileTimeBindIndex("Restore", scope.entry);
 
-  if (scope.entry.scope_id.is_valid()) {
+  if (scope.entry.scope_id.has_value()) {
     non_lexical_scope_stack_.push_back(
         {.scope_index = scope.entry.index,
          .name_scope_id = scope.entry.scope_id,

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -83,7 +83,7 @@ auto ScopeStack::Pop() -> void {
   if (scope.has_returned_var) {
     CARBON_CHECK(!return_scope_stack_.empty());
     CARBON_CHECK(return_scope_stack_.back().returned_var.is_valid());
-    return_scope_stack_.back().returned_var = SemIR::InstId::Invalid;
+    return_scope_stack_.back().returned_var = SemIR::InstId::None;
   }
 
   VerifyNextCompileTimeBindIndex("Pop", scope);
@@ -104,12 +104,12 @@ auto ScopeStack::LookupInLexicalScopesWithin(SemIR::NameId name_id,
     -> SemIR::InstId {
   auto& lexical_results = lexical_lookup_.Get(name_id);
   if (lexical_results.empty()) {
-    return SemIR::InstId::Invalid;
+    return SemIR::InstId::None;
   }
 
   auto result = lexical_results.back();
   if (result.scope_index < scope_index) {
-    return SemIR::InstId::Invalid;
+    return SemIR::InstId::None;
   }
 
   return result.inst_id;
@@ -125,7 +125,7 @@ auto ScopeStack::LookupInLexicalScopes(SemIR::NameId name_id)
   // If we have no lexical results, check all non-lexical scopes.
   if (lexical_results.empty()) {
     return {LexicalLookupHasLoadError() ? SemIR::ErrorInst::SingletonInstId
-                                        : SemIR::InstId::Invalid,
+                                        : SemIR::InstId::None,
             non_lexical_scope_stack_};
   }
 
@@ -178,7 +178,7 @@ auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
 
   // Add a corresponding lexical lookup result.
   lexical_results.push_back({.inst_id = target_id, .scope_index = scope_index});
-  return SemIR::InstId::Invalid;
+  return SemIR::InstId::None;
 }
 
 auto ScopeStack::SetReturnedVarOrGetExisting(SemIR::InstId inst_id)
@@ -195,7 +195,7 @@ auto ScopeStack::SetReturnedVarOrGetExisting(SemIR::InstId inst_id)
   if (inst_id.is_valid()) {
     scope_stack_.back().has_returned_var = true;
   }
-  return SemIR::InstId::Invalid;
+  return SemIR::InstId::None;
 }
 
 auto ScopeStack::Suspend() -> SuspendedScope {

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -101,7 +101,7 @@ class ScopeStack {
   template <typename InstT>
   auto GetCurrentScopeAs(const SemIR::File& sem_ir) -> std::optional<InstT> {
     auto inst_id = PeekInstId();
-    if (!inst_id.is_valid()) {
+    if (!inst_id.has_value()) {
       return std::nullopt;
     }
     return sem_ir.insts().TryGetAs<InstT>(inst_id);

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -37,7 +37,7 @@ class ScopeStack {
 
     // The value corresponding to the current `returned var`, if any. Will be
     // set and unset as `returned var`s are declared and go out of scope.
-    SemIR::InstId returned_var = SemIR::InstId::Invalid;
+    SemIR::InstId returned_var = SemIR::InstId::None;
   };
 
   // A non-lexical scope in which unqualified lookup may be required.
@@ -55,13 +55,13 @@ class ScopeStack {
   // Information about a scope that has been temporarily removed from the stack.
   struct SuspendedScope;
 
-  // Pushes a scope onto scope_stack_. NameScopeId::Invalid is used for new
+  // Pushes a scope onto scope_stack_. NameScopeId::None is used for new
   // scopes. lexical_lookup_has_load_error is used to limit diagnostics when a
   // given namespace may contain a mix of both successful and failed name
   // imports.
-  auto Push(SemIR::InstId scope_inst_id = SemIR::InstId::Invalid,
-            SemIR::NameScopeId scope_id = SemIR::NameScopeId::Invalid,
-            SemIR::SpecificId specific_id = SemIR::SpecificId::Invalid,
+  auto Push(SemIR::InstId scope_inst_id = SemIR::InstId::None,
+            SemIR::NameScopeId scope_id = SemIR::NameScopeId::None,
+            SemIR::SpecificId specific_id = SemIR::SpecificId::None,
             bool lexical_lookup_has_load_error = false) -> void;
 
   // Pops the top scope from scope_stack_, cleaning up names from
@@ -129,7 +129,7 @@ class ScopeStack {
   // in that scope or any unfinished scope within it, and otherwise adds the
   // name with the value `target_id` and returns Invalid.
   auto LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
-                       ScopeIndex scope_index = ScopeIndex::Invalid)
+                       ScopeIndex scope_index = ScopeIndex::None)
       -> SemIR::InstId;
 
   // Prepares to add a compile-time binding in the current scope, and returns

--- a/toolchain/check/sem_ir_diagnostic_converter.cpp
+++ b/toolchain/check/sem_ir_diagnostic_converter.cpp
@@ -37,7 +37,7 @@ auto SemIRDiagnosticConverter::ConvertLocImpl(SemIRLoc loc,
     -> ConvertedDiagnosticLoc {
   // Cursors for the current IR and instruction in that IR.
   const auto* cursor_ir = sem_ir_;
-  auto cursor_inst_id = SemIR::InstId::Invalid;
+  auto cursor_inst_id = SemIR::InstId::None;
 
   // Notes an import on the diagnostic and updates cursors to point at the
   // imported IR.
@@ -135,7 +135,7 @@ auto SemIRDiagnosticConverter::ConvertLocImpl(SemIRLoc loc,
     }
 
     // Invalid parse node but not an import; just nothing to point at.
-    return ConvertLocInFile(cursor_ir, Parse::NodeId::Invalid, loc.token_only,
+    return ConvertLocInFile(cursor_ir, Parse::NodeId::None, loc.token_only,
                             context_fn);
   }
 }
@@ -146,7 +146,7 @@ auto SemIRDiagnosticConverter::ConvertArg(llvm::Any arg) const -> llvm::Any {
     if (*library_name_id == SemIR::LibraryNameId::Default) {
       library_name = "default library";
     } else if (!library_name_id->is_valid()) {
-      library_name = "library <invalid>";
+      library_name = "library <none>";
     } else {
       RawStringOstream stream;
       stream << "library \""

--- a/toolchain/check/sem_ir_diagnostic_converter.cpp
+++ b/toolchain/check/sem_ir_diagnostic_converter.cpp
@@ -16,7 +16,7 @@ auto SemIRDiagnosticConverter::ConvertLoc(SemIRLoc loc,
 
   // Use the token when possible, but -1 is the default value.
   auto last_offset = -1;
-  if (last_token_.is_valid()) {
+  if (last_token_.has_value()) {
     last_offset = sem_ir_->parse_tree().tokens().GetByteOffset(last_token_);
   }
 
@@ -44,7 +44,7 @@ auto SemIRDiagnosticConverter::ConvertLocImpl(SemIRLoc loc,
   auto follow_import_ref = [&](SemIR::ImportIRInstId import_ir_inst_id) {
     auto import_ir_inst = cursor_ir->import_ir_insts().Get(import_ir_inst_id);
     const auto& import_ir = cursor_ir->import_irs().Get(import_ir_inst.ir_id);
-    CARBON_CHECK(import_ir.decl_id.is_valid(),
+    CARBON_CHECK(import_ir.decl_id.has_value(),
                  "If we get invalid locations here, we may need to more "
                  "thoroughly track ImportDecls.");
 
@@ -72,7 +72,7 @@ auto SemIRDiagnosticConverter::ConvertLocImpl(SemIRLoc loc,
 
     // TODO: Add an "In implicit import of prelude." note for the case where we
     // don't have a location.
-    if (import_loc_id.is_valid()) {
+    if (import_loc_id.has_value()) {
       // TODO: Include the name of the imported library in the diagnostic.
       CARBON_DIAGNOSTIC(InImport, LocationInfo, "in import");
       context_fn(in_import_loc.loc, InImport);
@@ -103,21 +103,21 @@ auto SemIRDiagnosticConverter::ConvertLocImpl(SemIRLoc loc,
     if (auto diag_loc = handle_loc(loc.loc_id)) {
       return *diag_loc;
     }
-    CARBON_CHECK(cursor_inst_id.is_valid(), "Should have been set");
+    CARBON_CHECK(cursor_inst_id.has_value(), "Should have been set");
   }
 
   while (true) {
-    if (cursor_inst_id.is_valid()) {
+    if (cursor_inst_id.has_value()) {
       auto cursor_inst = cursor_ir->insts().Get(cursor_inst_id);
       if (auto bind_ref = cursor_inst.TryAs<SemIR::ExportDecl>();
-          bind_ref && bind_ref->value_id.is_valid()) {
+          bind_ref && bind_ref->value_id.has_value()) {
         cursor_inst_id = bind_ref->value_id;
         continue;
       }
 
       // If the parse node is valid, use it for the location.
       if (auto loc_id = cursor_ir->insts().GetLocId(cursor_inst_id);
-          loc_id.is_valid()) {
+          loc_id.has_value()) {
         if (auto diag_loc = handle_loc(loc_id)) {
           return *diag_loc;
         }
@@ -127,7 +127,7 @@ auto SemIRDiagnosticConverter::ConvertLocImpl(SemIRLoc loc,
       // If a namespace has an instruction for an import, switch to looking at
       // it.
       if (auto ns = cursor_inst.TryAs<SemIR::Namespace>()) {
-        if (ns->import_id.is_valid()) {
+        if (ns->import_id.has_value()) {
           cursor_inst_id = ns->import_id;
           continue;
         }
@@ -145,7 +145,7 @@ auto SemIRDiagnosticConverter::ConvertArg(llvm::Any arg) const -> llvm::Any {
     std::string library_name;
     if (*library_name_id == SemIR::LibraryNameId::Default) {
       library_name = "default library";
-    } else if (!library_name_id->is_valid()) {
+    } else if (!library_name_id->has_value()) {
       library_name = "library <none>";
     } else {
       RawStringOstream stream;
@@ -161,7 +161,7 @@ auto SemIRDiagnosticConverter::ConvertArg(llvm::Any arg) const -> llvm::Any {
     return sem_ir_->names().GetFormatted(*name_id).str();
   }
   if (auto* type_of_expr = llvm::any_cast<TypeOfInstId>(&arg)) {
-    if (!type_of_expr->inst_id.is_valid()) {
+    if (!type_of_expr->inst_id.has_value()) {
       return "<none>";
     }
     // TODO: Where possible, produce a better description of the type based on

--- a/toolchain/check/sem_ir_diagnostic_converter.h
+++ b/toolchain/check/sem_ir_diagnostic_converter.h
@@ -58,7 +58,7 @@ class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLoc> {
   const SemIR::File* sem_ir_;
 
   // The last token encountered during processing.
-  Lex::TokenIndex last_token_ = Lex::TokenIndex::Invalid;
+  Lex::TokenIndex last_token_ = Lex::TokenIndex::None;
 };
 
 }  // namespace Carbon::Check

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -41,7 +41,7 @@ class Worklist {
   auto back() -> WorklistItem& { return worklist_.back(); }
 
   auto Push(SemIR::InstId inst_id) -> void {
-    CARBON_CHECK(inst_id.is_valid());
+    CARBON_CHECK(inst_id.has_value());
     worklist_.push_back({.inst_id = inst_id,
                          .is_expanded = false,
                          .next_index = static_cast<int>(worklist_.size() + 1)});
@@ -69,19 +69,19 @@ static auto PushOperand(Context& context, Worklist& worklist,
   };
 
   auto push_specific = [&](SemIR::SpecificId specific_id) {
-    if (specific_id.is_valid()) {
+    if (specific_id.has_value()) {
       push_block(context.specifics().Get(specific_id).args_id);
     }
   };
 
   switch (kind) {
     case SemIR::IdKind::For<SemIR::InstId>:
-      if (SemIR::InstId inst_id(arg); inst_id.is_valid()) {
+      if (SemIR::InstId inst_id(arg); inst_id.has_value()) {
         worklist.Push(inst_id);
       }
       break;
     case SemIR::IdKind::For<SemIR::TypeId>:
-      if (SemIR::TypeId type_id(arg); type_id.is_valid()) {
+      if (SemIR::TypeId type_id(arg); type_id.has_value()) {
         worklist.Push(context.types().GetInstId(type_id));
       }
       break;
@@ -151,7 +151,7 @@ static auto PopOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
   };
 
   auto pop_specific = [&](SemIR::SpecificId specific_id) {
-    if (!specific_id.is_valid()) {
+    if (!specific_id.has_value()) {
       return specific_id;
     }
     auto& specific = context.specifics().Get(specific_id);
@@ -162,14 +162,14 @@ static auto PopOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
   switch (kind) {
     case SemIR::IdKind::For<SemIR::InstId>: {
       SemIR::InstId inst_id(arg);
-      if (!inst_id.is_valid()) {
+      if (!inst_id.has_value()) {
         return arg;
       }
       return worklist.Pop().index;
     }
     case SemIR::IdKind::For<SemIR::TypeId>: {
       SemIR::TypeId type_id(arg);
-      if (!type_id.is_valid()) {
+      if (!type_id.has_value()) {
         return arg;
       }
       return context.GetTypeIdForTypeInst(worklist.Pop()).index;

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -326,7 +326,7 @@ class SubstConstantCallbacks final : public SubstInstCallbacks {
       return true;
     }
 
-    auto entity_name_id = SemIR::EntityNameId::Invalid;
+    auto entity_name_id = SemIR::EntityNameId::None;
     if (auto bind =
             context_.insts().TryGetAs<SemIR::BindSymbolicName>(inst_id)) {
       entity_name_id = bind->entity_name_id;
@@ -358,7 +358,7 @@ class SubstConstantCallbacks final : public SubstInstCallbacks {
   // Rebuilds an instruction by building a new constant.
   auto Rebuild(SemIR::InstId /*old_inst_id*/, SemIR::Inst new_inst) const
       -> SemIR::InstId override {
-    auto result_id = TryEvalInst(context_, SemIR::InstId::Invalid, new_inst);
+    auto result_id = TryEvalInst(context_, SemIR::InstId::None, new_inst);
     CARBON_CHECK(result_id.is_constant(),
                  "Substitution into constant produced non-constant");
     return context_.constant_values().GetInstId(result_id);

--- a/toolchain/check/testdata/alias/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/export_name.carbon
@@ -115,7 +115,7 @@ var d: D* = &c;
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %D: type = export D, imports.%Main.D [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -146,7 +146,7 @@ var d: D* = &c;
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -177,7 +177,7 @@ var d: D* = &c;
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d.patt: %C = binding_pattern d
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %d.patt
@@ -218,7 +218,7 @@ var d: D* = &c;
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: <error> = binding_pattern c
 // CHECK:STDOUT:     %.loc10: <error> = var_pattern %c.patt
@@ -259,7 +259,7 @@ var d: D* = &c;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt

--- a/toolchain/check/testdata/alias/no_prelude/fail_local_in_namespace.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_local_in_namespace.carbon
@@ -55,7 +55,7 @@ fn F() -> {} {
 // CHECK:STDOUT: fn @F() -> %empty_struct_type {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc22_17: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc22_12: <error> = bind_alias <invalid>, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc22_12: <error> = bind_alias <none>, <error> [template = <error>]
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/alias/no_prelude/fail_name_conflict.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_name_conflict.carbon
@@ -63,7 +63,7 @@ alias b = C;
 // CHECK:STDOUT:   %C.ref.loc23: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %b: ref %C = bind_name b, %b.var
 // CHECK:STDOUT:   %C.ref.loc31: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:   %.loc31: type = bind_alias <invalid>, %C.decl [template = constants.%C]
+// CHECK:STDOUT:   %.loc31: type = bind_alias <none>, %C.decl [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {

--- a/toolchain/check/testdata/alias/no_prelude/fail_params.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_params.carbon
@@ -31,7 +31,7 @@ alias A(T:! type) = T*;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %ptr: type = ptr_type %T [symbolic = constants.%ptr]
-// CHECK:STDOUT:   %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:   %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:   %A: <error> = bind_alias A, <error> [template = <error>]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/no_prelude/import.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import.carbon
@@ -130,7 +130,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:     .c_alias_alias = %c_alias_alias
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %c_alias.ref.loc6: type = name_ref c_alias, imports.%Main.c_alias [template = constants.%C]
 // CHECK:STDOUT:   %c_alias_alias: type = bind_alias c_alias_alias, imports.%Main.c_alias [template = constants.%C]
 // CHECK:STDOUT:   name_binding_decl {
@@ -174,7 +174,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:     .b = imports.%Main.b
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %ptr = binding_pattern c
 // CHECK:STDOUT:     %.loc6_1: %ptr = var_pattern %c.patt
@@ -248,7 +248,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:     .a_alias_alias = %a_alias_alias
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %a_alias.ref: ref %empty_tuple.type = name_ref a_alias, imports.%Main.a_alias
 // CHECK:STDOUT:   %a_alias_alias: ref %empty_tuple.type = bind_alias a_alias_alias, imports.%Main.a_alias
 // CHECK:STDOUT:   name_binding_decl {
@@ -290,7 +290,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:     .b = imports.%Main.b
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %empty_tuple.type = binding_pattern c
 // CHECK:STDOUT:     %.loc11_1: %empty_tuple.type = var_pattern %c.patt

--- a/toolchain/check/testdata/alias/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import_access.carbon
@@ -102,7 +102,7 @@ var inst: Test.A = {};
 // CHECK:STDOUT:     .inst = %inst
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %inst.patt: %C = binding_pattern inst
 // CHECK:STDOUT:     %.loc4: %C = var_pattern %inst.patt
@@ -143,7 +143,7 @@ var inst: Test.A = {};
 // CHECK:STDOUT:     .C = imports.%Test.C
 // CHECK:STDOUT:     .inst = %inst
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %inst.patt: <error> = binding_pattern inst
 // CHECK:STDOUT:     %.loc10: <error> = var_pattern %inst.patt

--- a/toolchain/check/testdata/alias/no_prelude/import_order.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import_order.carbon
@@ -64,7 +64,7 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc4_11: %C.elem = var_pattern %.loc4_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -108,7 +108,7 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:     .b_val = %b_val
 // CHECK:STDOUT:     .a_val = %a_val
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d_val.patt: %C = binding_pattern d_val
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %d_val.patt

--- a/toolchain/check/testdata/alias/no_prelude/in_namespace.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/in_namespace.carbon
@@ -77,7 +77,7 @@ fn F() -> NS.a {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc11_11: %C.elem = var_pattern %.loc11_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/generic_empty.carbon
+++ b/toolchain/check/testdata/array/generic_empty.carbon
@@ -42,9 +42,9 @@ fn G(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/import.carbon
+++ b/toolchain/check/testdata/array/import.carbon
@@ -91,7 +91,7 @@ fn G(n: i32) -> i32 {
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %n.patt: %i32 = binding_pattern n
 // CHECK:STDOUT:     %n.param_patt: %i32 = value_param_pattern %n.patt, runtime_param0

--- a/toolchain/check/testdata/array/init_dependent_bound.carbon
+++ b/toolchain/check/testdata/array/init_dependent_bound.carbon
@@ -76,9 +76,9 @@ fn H() { G(3); }
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc4_6.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc4_6.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_6.1, runtime_param<invalid> [symbolic = %N.patt.loc4_6.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_6.1, runtime_param<none> [symbolic = %N.patt.loc4_6.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32.loc4 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc4: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc4: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]

--- a/toolchain/check/testdata/as/adapter_conversion.carbon
+++ b/toolchain/check/testdata/as/adapter_conversion.carbon
@@ -254,12 +254,12 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %A.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %A.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %A.elem = field_decl y, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %A.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %A.elem = var <none>
 // CHECK:STDOUT:   %Make.decl: %Make.type = fn_decl @Make [template = constants.%Make] {
 // CHECK:STDOUT:     %return.patt: %A = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %A = out_param_pattern %return.patt, runtime_param0
@@ -587,12 +587,12 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %A.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %A.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %A.elem = field_decl y, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %A.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x.y.871 [template = constants.%complete_type.70a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -701,12 +701,12 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %A.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %A.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %A.elem = field_decl y, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %A.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x.y.871 [template = constants.%complete_type.70a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -988,7 +988,7 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %A.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x.ed6 [template = constants.%complete_type.1ec]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/overloaded.carbon
+++ b/toolchain/check/testdata/as/overloaded.carbon
@@ -148,7 +148,7 @@ let n: i32 = ((4 as i32) as X) as i32;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %X.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %X.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %X.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -14,10 +14,10 @@
 // CHECK:STDOUT: filename:        builtin_insts.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   functions:       {}
 // CHECK:STDOUT:   classes:         {}
@@ -44,7 +44,7 @@
 // CHECK:STDOUT:     'inst(StringType)': {kind: StringType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(VtableType)': {kind: VtableType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(WitnessType)': {kind: WitnessType, type: type(TypeType)}
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     'inst(TypeType)':  template_constant(inst(TypeType))
 // CHECK:STDOUT:     'inst(AutoType)':  template_constant(inst(AutoType))

--- a/toolchain/check/testdata/basics/no_prelude/verbose.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/verbose.carbon
@@ -12,7 +12,7 @@
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
 // CHECK:STDERR: Node Push 0: FunctionIntroducer -> <none>
-// CHECK:STDERR: AddPlaceholderInst: {kind: FunctionDecl, arg0: function<invalid>, arg1: inst_block_empty}
+// CHECK:STDERR: AddPlaceholderInst: {kind: FunctionDecl, arg0: function<none>, arg1: inst_block_empty}
 // CHECK:STDERR: ReplaceInst: inst{{[0-9]+}} -> {kind: FunctionDecl, arg0: function{{[0-9]+}}, arg1: inst_block_empty, type: type(inst{{[0-9]+}})}
 // CHECK:STDERR: inst_block_stack_ Push 1
 // CHECK:STDERR: AddInst: {kind: Return}

--- a/toolchain/check/testdata/builtins/bool/eq.carbon
+++ b/toolchain/check/testdata/builtins/bool/eq.carbon
@@ -113,9 +113,9 @@ var d: C(false == false) = True();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %B.patt.loc6_9.1: bool = symbolic_binding_pattern B, 0 [symbolic = %B.patt.loc6_9.2 (constants.%B.patt)]
-// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc6_9.1, runtime_param<invalid> [symbolic = %B.patt.loc6_9.2 (constants.%B.patt)]
+// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc6_9.1, runtime_param<none> [symbolic = %B.patt.loc6_9.2 (constants.%B.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_13.1: type = splice_block %.loc6_13.3 [template = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [template = bool]
 // CHECK:STDOUT:       %.loc6_13.2: type = value_of_initializer %bool.make_type [template = bool]
@@ -321,9 +321,9 @@ var d: C(false == false) = True();
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %B.patt.loc4_9.1: bool = symbolic_binding_pattern B, 0 [symbolic = %B.patt.loc4_9.2 (constants.%B.patt)]
-// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc4_9.1, runtime_param<invalid> [symbolic = %B.patt.loc4_9.2 (constants.%B.patt)]
+// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc4_9.1, runtime_param<none> [symbolic = %B.patt.loc4_9.2 (constants.%B.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4_13.1: type = splice_block %.loc4_13.3 [template = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [template = bool]
 // CHECK:STDOUT:       %.loc4_13.2: type = value_of_initializer %bool.make_type [template = bool]

--- a/toolchain/check/testdata/builtins/bool/make_type.carbon
+++ b/toolchain/check/testdata/builtins/bool/make_type.carbon
@@ -76,7 +76,7 @@ var b: Bool() = false;
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: bool = binding_pattern b
 // CHECK:STDOUT:     %.loc6_1: bool = var_pattern %b.patt

--- a/toolchain/check/testdata/builtins/bool/neq.carbon
+++ b/toolchain/check/testdata/builtins/bool/neq.carbon
@@ -113,9 +113,9 @@ var d: C(false != false) = False();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %B.patt.loc6_9.1: bool = symbolic_binding_pattern B, 0 [symbolic = %B.patt.loc6_9.2 (constants.%B.patt)]
-// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc6_9.1, runtime_param<invalid> [symbolic = %B.patt.loc6_9.2 (constants.%B.patt)]
+// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc6_9.1, runtime_param<none> [symbolic = %B.patt.loc6_9.2 (constants.%B.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_13.1: type = splice_block %.loc6_13.3 [template = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [template = bool]
 // CHECK:STDOUT:       %.loc6_13.2: type = value_of_initializer %bool.make_type [template = bool]
@@ -321,9 +321,9 @@ var d: C(false != false) = False();
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %B.patt.loc4_9.1: bool = symbolic_binding_pattern B, 0 [symbolic = %B.patt.loc4_9.2 (constants.%B.patt)]
-// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc4_9.1, runtime_param<invalid> [symbolic = %B.patt.loc4_9.2 (constants.%B.patt)]
+// CHECK:STDOUT:     %B.param_patt: bool = value_param_pattern %B.patt.loc4_9.1, runtime_param<none> [symbolic = %B.patt.loc4_9.2 (constants.%B.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %B.param: bool = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4_13.1: type = splice_block %.loc4_13.3 [template = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [template = bool]
 // CHECK:STDOUT:       %.loc4_13.2: type = value_of_initializer %bool.make_type [template = bool]

--- a/toolchain/check/testdata/builtins/float/make_type.carbon
+++ b/toolchain/check/testdata/builtins/float/make_type.carbon
@@ -125,7 +125,7 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:     .GetFloat = %GetFloat.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: f64 = binding_pattern f
 // CHECK:STDOUT:     %.loc6_1: f64 = var_pattern %f.patt
@@ -220,7 +220,7 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:     .dyn = %dyn
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %invalid_float.patt: <error> = binding_pattern invalid_float
 // CHECK:STDOUT:     %.loc10_1: <error> = var_pattern %invalid_float.patt

--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -202,7 +202,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_11: %Circle.elem = var_pattern %.loc5_21
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Circle.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Circle.elem = var <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %SOME_INTERNAL_CONSTANT.patt: %i32 = binding_pattern SOME_INTERNAL_CONSTANT
 // CHECK:STDOUT:   }
@@ -344,7 +344,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_13: %A.elem = var_pattern %.loc5_18
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type.1ec]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -416,7 +416,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_11: %Circle.elem = var_pattern %.loc5_21
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Circle.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Circle.elem = var <none>
 // CHECK:STDOUT:   %GetRadius.decl: %GetRadius.type = fn_decl @GetRadius [template = constants.%GetRadius] {
 // CHECK:STDOUT:     %self.patt: %Circle = binding_pattern self
 // CHECK:STDOUT:     %self.param_patt: %Circle = value_param_pattern %self.patt, runtime_param0

--- a/toolchain/check/testdata/class/adapter/adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/adapt.carbon
@@ -103,12 +103,12 @@ interface I {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %SomeClass.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %SomeClass.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %SomeClass.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %SomeClass.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %SomeClass.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %SomeClass.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %SomeClass.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/adapter/extend_adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/extend_adapt.carbon
@@ -213,12 +213,12 @@ fn F(a: IntAdapter) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc7_3: %SomeClass.elem = var_pattern %.loc7_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc7: ref %SomeClass.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc7: ref %SomeClass.elem = var <none>
 // CHECK:STDOUT:   %.loc8_8: %SomeClass.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc8_3: %SomeClass.elem = var_pattern %.loc8_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc8: ref %SomeClass.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc8: ref %SomeClass.elem = var <none>
 // CHECK:STDOUT:   %StaticMemberFunction.decl: %StaticMemberFunction.type = fn_decl @StaticMemberFunction [template = constants.%StaticMemberFunction] {} {}
 // CHECK:STDOUT:   %AdapterMethod.decl: %AdapterMethod.type = fn_decl @AdapterMethod [template = constants.%AdapterMethod] {
 // CHECK:STDOUT:     %self.patt: %SomeClassAdapter = binding_pattern self
@@ -396,12 +396,12 @@ fn F(a: IntAdapter) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %SomeClass.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %SomeClass.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %SomeClass.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %SomeClass.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %SomeClass.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %SomeClass.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %SomeClass.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/adapter/fail_adapt_with_subobjects.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_with_subobjects.carbon
@@ -119,7 +119,7 @@ class AdaptWithBaseAndFields {
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
 // CHECK:STDOUT:   adapt_decl %i32 [template]
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
-// CHECK:STDOUT:   %.loc15: %AdaptWithBase.elem = base_decl %Base.ref, element<invalid> [template]
+// CHECK:STDOUT:   %.loc15: %AdaptWithBase.elem = base_decl %Base.ref, element<none> [template]
 // CHECK:STDOUT:   complete_type_witness = <error>
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -162,11 +162,11 @@ class AdaptWithBaseAndFields {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
 // CHECK:STDOUT:   adapt_decl %i32 [template]
-// CHECK:STDOUT:   %.loc13_8: %AdaptWithField.elem = field_decl n, element<invalid> [template]
+// CHECK:STDOUT:   %.loc13_8: %AdaptWithField.elem = field_decl n, element<none> [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %AdaptWithField.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %AdaptWithField.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %AdaptWithField.elem = var <none>
 // CHECK:STDOUT:   complete_type_witness = <error>
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -178,21 +178,21 @@ class AdaptWithBaseAndFields {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
 // CHECK:STDOUT:   adapt_decl %i32 [template]
-// CHECK:STDOUT:   %.loc25_8: %AdaptWithFields.elem = field_decl a, element<invalid> [template]
+// CHECK:STDOUT:   %.loc25_8: %AdaptWithFields.elem = field_decl a, element<none> [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc25_3: %AdaptWithFields.elem = var_pattern %.loc25_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc25: ref %AdaptWithFields.elem = var <invalid>
-// CHECK:STDOUT:   %.loc26_8: %AdaptWithFields.elem = field_decl b, element<invalid> [template]
+// CHECK:STDOUT:   %.var.loc25: ref %AdaptWithFields.elem = var <none>
+// CHECK:STDOUT:   %.loc26_8: %AdaptWithFields.elem = field_decl b, element<none> [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc26_3: %AdaptWithFields.elem = var_pattern %.loc26_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc26: ref %AdaptWithFields.elem = var <invalid>
-// CHECK:STDOUT:   %.loc27_8: %AdaptWithFields.elem = field_decl c, element<invalid> [template]
+// CHECK:STDOUT:   %.var.loc26: ref %AdaptWithFields.elem = var <none>
+// CHECK:STDOUT:   %.loc27_8: %AdaptWithFields.elem = field_decl c, element<none> [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc27_3: %AdaptWithFields.elem = var_pattern %.loc27_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc27: ref %AdaptWithFields.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc27: ref %AdaptWithFields.elem = var <none>
 // CHECK:STDOUT:   complete_type_witness = <error>
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -244,12 +244,12 @@ class AdaptWithBaseAndFields {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @AdaptWithBaseAndFields {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
-// CHECK:STDOUT:   %.loc7: %AdaptWithBaseAndFields.elem.767 = base_decl %Base.ref, element<invalid> [template]
-// CHECK:STDOUT:   %.loc8_8: %AdaptWithBaseAndFields.elem.ddf = field_decl n, element<invalid> [template]
+// CHECK:STDOUT:   %.loc7: %AdaptWithBaseAndFields.elem.767 = base_decl %Base.ref, element<none> [template]
+// CHECK:STDOUT:   %.loc8_8: %AdaptWithBaseAndFields.elem.ddf = field_decl n, element<none> [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc8_3: %AdaptWithBaseAndFields.elem.ddf = var_pattern %.loc8_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %AdaptWithBaseAndFields.elem.ddf = var <invalid>
+// CHECK:STDOUT:   %.var: ref %AdaptWithBaseAndFields.elem.ddf = var <none>
 // CHECK:STDOUT:   %.loc16_10: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %.loc16_11: type = converted %.loc16_10, constants.%empty_struct_type [template = constants.%empty_struct_type]
 // CHECK:STDOUT:   adapt_decl %.loc16_11 [template]

--- a/toolchain/check/testdata/class/adapter/init_adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/init_adapt.carbon
@@ -217,12 +217,12 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %C.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %C.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %C.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -403,12 +403,12 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %C.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %C.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %C.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -136,7 +136,7 @@ class Derived {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc4_3: %Base.elem = var_pattern %.loc4_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b.0a3 [template = constants.%complete_type.ba8]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -152,7 +152,7 @@ class Derived {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc10_3: %Derived.elem.344 = var_pattern %.loc10_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.f8f [template = constants.%complete_type.da6]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -260,7 +260,7 @@ class Derived {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc7_3: %Derived.elem = var_pattern %.loc7_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Derived.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Derived.elem = var <none>
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.d [template = constants.%complete_type.860]
 // CHECK:STDOUT:   complete_type_witness = %complete_type

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -88,17 +88,17 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Base.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Base.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Base.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %.loc14_8: %Base.elem = field_decl c, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc14_3: %Base.elem = var_pattern %.loc14_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc14: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc14: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.c [template = constants.%complete_type.ebc]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -116,12 +116,12 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc20_3: %Derived.elem.344 = var_pattern %.loc20_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc20: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var.loc20: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %.loc21_8: %Derived.elem.344 = field_decl e, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc21_3: %Derived.elem.344 = var_pattern %.loc21_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc21: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var.loc21: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.e.6a7 [template = constants.%complete_type.401]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -105,7 +105,7 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Base.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %self.patt: %ptr.11f = binding_pattern self
 // CHECK:STDOUT:     %self.param_patt: %ptr.11f = value_param_pattern %self.patt, runtime_param0

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -137,7 +137,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc18_3: %Class.elem = var_pattern %.loc18_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.k [template = constants.%complete_type.954]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/complete_in_member_fn.carbon
+++ b/toolchain/check/testdata/class/complete_in_member_fn.carbon
@@ -63,7 +63,7 @@ class C {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc14_3: %C.elem = var_pattern %.loc14_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/compound_field.carbon
+++ b/toolchain/check/testdata/class/compound_field.carbon
@@ -155,17 +155,17 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Base.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Base.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Base.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %.loc14_8: %Base.elem = field_decl c, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc14_3: %Base.elem = var_pattern %.loc14_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc14: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc14: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.c [template = constants.%complete_type.ebc]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -183,12 +183,12 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc20_3: %Derived.elem.344 = var_pattern %.loc20_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc20: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var.loc20: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %.loc21_8: %Derived.elem.344 = field_decl e, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc21_3: %Derived.elem.344 = var_pattern %.loc21_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc21: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var.loc21: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.e.6a7 [template = constants.%complete_type.401]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -206,7 +206,7 @@ fn ConvertInit() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %A.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.ba9 [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -222,7 +222,7 @@ fn ConvertInit() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc17_3: %B.elem.5c3 = var_pattern %.loc17_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem.5c3 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem.5c3 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.b.b44 [template = constants.%complete_type.725]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -240,7 +240,7 @@ fn ConvertInit() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc22_3: %C.elem.646 = var_pattern %.loc22_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem.646 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem.646 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.c.8e2 [template = constants.%complete_type.58a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -229,7 +229,7 @@ fn CallReturnAbstract() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc15_3: <error> = var_pattern %.loc15_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref <error> = var <invalid>
+// CHECK:STDOUT:   %.var: ref <error> = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness <error> [template = <error>]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -514,7 +514,7 @@ fn CallReturnAbstract() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc10_3: %Derived.elem.344 = var_pattern %.loc10_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.c44 [template = constants.%complete_type.32a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -599,7 +599,7 @@ fn CallReturnAbstract() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc10_3: %Derived.elem.344 = var_pattern %.loc10_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d [template = constants.%complete_type.32a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -673,7 +673,7 @@ fn CallReturnAbstract() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %Abstract.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Abstract.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Abstract.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -689,7 +689,7 @@ fn CallReturnAbstract() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc11_3: %Derived.elem.344 = var_pattern %.loc11_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Derived.elem.344 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.c44 [template = constants.%complete_type.32a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -56,9 +56,9 @@ class Class {
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %a.patt.loc16_13.2: %ptr = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc16_13.1 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %ptr = value_param_pattern %a.patt.loc16_13.2, runtime_param<invalid> [symbolic = %a.patt.loc16_13.1 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %ptr = value_param_pattern %a.patt.loc16_13.2, runtime_param<none> [symbolic = %a.patt.loc16_13.1 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %ptr = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %ptr = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc16: type = splice_block %ptr [template = constants.%ptr] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class [template = constants.%ptr]

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -833,7 +833,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %Final.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Final.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Final.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_compound_type_mismatch.carbon
+++ b/toolchain/check/testdata/class/fail_compound_type_mismatch.carbon
@@ -84,7 +84,7 @@ fn AccessBInA(a: A) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %A.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -98,7 +98,7 @@ fn AccessBInA(a: A) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc16_3: %B.elem = var_pattern %.loc16_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b [template = constants.%complete_type.ba8]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_convert_to_invalid.carbon
+++ b/toolchain/check/testdata/class/fail_convert_to_invalid.carbon
@@ -60,7 +60,7 @@ fn Make() -> C {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc16_3: <error> = var_pattern %.loc16_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref <error> = var <invalid>
+// CHECK:STDOUT:   %.var: ref <error> = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness <error> [template = <error>]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_derived_to_base.carbon
+++ b/toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -133,7 +133,7 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %A1.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A1.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A1.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -147,7 +147,7 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc16_3: %A2.elem = var_pattern %.loc16_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A2.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A2.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -163,7 +163,7 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc21_3: %B2.elem.4b2 = var_pattern %.loc21_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B2.elem.4b2 = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B2.elem.4b2 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.b.618 [template = constants.%complete_type.92f]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_extend_cycle.carbon
+++ b/toolchain/check/testdata/class/fail_extend_cycle.carbon
@@ -92,7 +92,7 @@ base class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc32_3: <error> = var_pattern %.loc32_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref <error> = var <invalid>
+// CHECK:STDOUT:   %.var: ref <error> = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness <error> [template = <error>]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_field_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -81,12 +81,12 @@ class Class {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc17_11: %Class.elem = var_pattern %.loc17_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc17: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc17: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %.loc23_14: %Class.elem = field_decl k, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc23_9: %Class.elem = var_pattern %.loc23_14
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc23: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc23: ref %Class.elem = var <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %l.patt: %i32 = binding_pattern l
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/fail_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_generic_method.carbon
@@ -70,9 +70,9 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {
@@ -81,7 +81,7 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:     %n.patt: <error> = binding_pattern n
 // CHECK:STDOUT:     %n.param_patt: <error> = value_param_pattern %n.patt, runtime_param1
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc33: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -114,7 +114,7 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc12_3: @Class.%Class.elem (%Class.elem) = var_pattern %.loc12_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <none>
 // CHECK:STDOUT:     %F.decl: @Class.%F.type (%F.type) = fn_decl @F [symbolic = @Class.%F (constants.%F)] {
 // CHECK:STDOUT:       %self.patt: @F.%Class (%Class) = binding_pattern self
 // CHECK:STDOUT:       %self.param_patt: @F.%Class (%Class) = value_param_pattern %self.patt, runtime_param0

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -110,7 +110,7 @@ var a: Incomplete;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.a95] {} {}
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: <error> = binding_pattern a

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -499,7 +499,7 @@ class C {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: <error> = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref <error> = var <invalid>
+// CHECK:STDOUT:   %.var: ref <error> = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness <error> [template = <error>]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -82,12 +82,12 @@ fn F() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Class.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Class.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -95,12 +95,12 @@ fn F() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Class.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Class.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -118,7 +118,7 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc16_3: %B.elem = var_pattern %.loc16_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.72c [template = constants.%complete_type.2b9]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self_param.carbon
+++ b/toolchain/check/testdata/class/fail_self_param.carbon
@@ -42,9 +42,9 @@ var v: C(0);
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %x.patt.loc15_22.1: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc15_22.2 (constants.%x.patt)]
-// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt.loc15_22.1, runtime_param<invalid> [symbolic = %x.patt.loc15_22.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt.loc15_22.1, runtime_param<none> [symbolic = %x.patt.loc15_22.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param<none>
 // CHECK:STDOUT:     %self.ref: <error> = name_ref self, <error> [template = <error>]
 // CHECK:STDOUT:     %x: <error> = bind_symbolic_name x, 0, %x.param [template = <error>]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/fail_self_type_member.carbon
+++ b/toolchain/check/testdata/class/fail_self_type_member.carbon
@@ -42,7 +42,7 @@ fn F() -> bool {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -74,7 +74,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_12
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -71,7 +71,7 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -71,12 +71,12 @@ fn Run() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Class.elem = field_decl k, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Class.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.j.k [template = constants.%complete_type.cf7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -72,12 +72,12 @@ fn Test() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Class.elem = field_decl k, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Class.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.j.k [template = constants.%complete_type.cf7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/adapt.carbon
+++ b/toolchain/check/testdata/class/generic/adapt.carbon
@@ -164,9 +164,9 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Adapter.decl: type = class_decl @Adapter [template = constants.%Adapter] {} {}
@@ -202,7 +202,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @C.%C.elem (%C.elem.66c) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.66c) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.66c) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.x.2ac [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.433)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -309,7 +309,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:     .ImportedAccess = %ImportedAccess.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %ImportedAccess.decl: %ImportedAccess.type = fn_decl @ImportedAccess [template = constants.%ImportedAccess] {
 // CHECK:STDOUT:     %a.patt: %Adapter = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %Adapter = value_param_pattern %a.patt, runtime_param0
@@ -431,9 +431,9 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Adapter.decl: type = class_decl @Adapter [template = constants.%Adapter] {} {}
@@ -469,7 +469,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @C.%C.elem (%C.elem.66c) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.66c) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.66c) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.x.2ac [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.433)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -561,9 +561,9 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc7_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_9.1, runtime_param<invalid> [symbolic = %T.patt.loc7_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_9.1, runtime_param<none> [symbolic = %T.patt.loc7_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Adapter.decl: type = class_decl @Adapter [template = constants.%Adapter] {} {}
@@ -585,7 +585,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc8_3: @C.%C.elem (%C.elem.66c) = var_pattern %.loc8_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.66c) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.66c) = var <none>
 // CHECK:STDOUT:     %complete_type.loc9_1.1: <witness> = complete_type_witness %struct_type.x.2ac [symbolic = %complete_type.loc9_1.2 (constants.%complete_type.433)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc9_1.1
 // CHECK:STDOUT:
@@ -676,7 +676,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:     .ImportedAccess = %ImportedAccess.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %ImportedAccess.decl: %ImportedAccess.type = fn_decl @ImportedAccess [template = constants.%ImportedAccess] {
 // CHECK:STDOUT:     %a.patt: %Adapter = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %Adapter = value_param_pattern %a.patt, runtime_param0
@@ -786,9 +786,9 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Adapter.decl: %Adapter.type = class_decl @Adapter [template = constants.%Adapter.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<invalid> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<none> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Convert.decl: %Convert.type = fn_decl @Convert [template = constants.%Convert] {
@@ -904,7 +904,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:     .ImportedConvertLocal = %ImportedConvertLocal.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %ImportedConvert.decl: %ImportedConvert.type = fn_decl @ImportedConvert [template = constants.%ImportedConvert] {
 // CHECK:STDOUT:     %a.patt: %Adapter.e4c = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %Adapter.e4c = value_param_pattern %a.patt, runtime_param0
@@ -966,7 +966,7 @@ fn ImportedConvertLocal(a: Adapter(C)) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc11_3: %C.elem = var_pattern %.loc11_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/base_is_generic.carbon
+++ b/toolchain/check/testdata/class/generic/base_is_generic.carbon
@@ -134,9 +134,9 @@ fn H() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Base.decl: %Base.type = class_decl @Base [template = constants.%Base.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_17.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_17.1, runtime_param<invalid> [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_17.1, runtime_param<none> [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_17.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_17.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Param.decl: type = class_decl @Param [template = constants.%Param] {} {}
@@ -173,7 +173,7 @@ fn H() {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @Base.%Base.elem (%Base.elem.9af) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Base.%Base.elem (%Base.elem.9af) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Base.%Base.elem (%Base.elem.9af) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.x.2ac [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.433)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -188,7 +188,7 @@ fn H() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc9_3: %Param.elem = var_pattern %.loc9_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Param.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Param.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.y [template = constants.%complete_type.0f9]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -302,7 +302,7 @@ fn H() {
 // CHECK:STDOUT:     .ImportedDoubleFieldAccess = %ImportedDoubleFieldAccess.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %ImportedDoubleFieldAccess.decl: %ImportedDoubleFieldAccess.type = fn_decl @ImportedDoubleFieldAccess [template = constants.%ImportedDoubleFieldAccess] {
 // CHECK:STDOUT:     %d.patt: %Derived = binding_pattern d
 // CHECK:STDOUT:     %d.param_patt: %Derived = value_param_pattern %d.patt, runtime_param0
@@ -424,9 +424,9 @@ fn H() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [template = constants.%X] {} {}
@@ -550,16 +550,16 @@ fn H() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %X.decl: %X.type = class_decl @X [template = constants.%X.generic] {
 // CHECK:STDOUT:     %U.patt.loc4_14.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc4_14.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_14.1, runtime_param<invalid> [symbolic = %U.patt.loc4_14.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_14.1, runtime_param<none> [symbolic = %U.patt.loc4_14.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc4_14.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc4_14.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<invalid> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<none> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
@@ -803,7 +803,7 @@ fn H() {
 // CHECK:STDOUT:     .H = %H.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/basic.carbon
+++ b/toolchain/check/testdata/class/generic/basic.carbon
@@ -64,16 +64,16 @@ class Declaration(T:! type);
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Declaration.decl: %Declaration.type = class_decl @Declaration [template = constants.%Declaration.generic] {
 // CHECK:STDOUT:     %T.patt.loc24_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc24_19.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc24_19.1, runtime_param<invalid> [symbolic = %T.patt.loc24_19.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc24_19.1, runtime_param<none> [symbolic = %T.patt.loc24_19.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc24_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc24_19.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -133,7 +133,7 @@ class Declaration(T:! type);
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc21_3: @Class.%Class.elem (%Class.elem) = var_pattern %.loc21_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <none>
 // CHECK:STDOUT:     %complete_type.loc22_1.1: <witness> = complete_type_witness %struct_type.k [symbolic = %complete_type.loc22_1.2 (constants.%complete_type)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc22_1.1
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/call.carbon
+++ b/toolchain/check/testdata/class/generic/call.carbon
@@ -137,13 +137,13 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc4_23.1: %i32 = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<invalid> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<none> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -267,13 +267,13 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc4_23.1: %i32 = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<invalid> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<none> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -354,13 +354,13 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc4_23.1: %i32 = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<invalid> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<none> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -443,13 +443,13 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc4_23.1: %i32 = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<invalid> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_23.1, runtime_param<none> [symbolic = %N.patt.loc4_23.2 (constants.%N.patt.8cf)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -556,9 +556,9 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Outer.decl: %Outer.type = class_decl @Outer [template = constants.%Outer.generic] {
 // CHECK:STDOUT:     %T.patt.loc2_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc2_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc2_13.1, runtime_param<invalid> [symbolic = %T.patt.loc2_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc2_13.1, runtime_param<none> [symbolic = %T.patt.loc2_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc2_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc2_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -574,9 +574,9 @@ class Outer(T:! type) {
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %Inner.decl: @Outer.%Inner.type (%Inner.type.eae) = class_decl @Inner [symbolic = @Outer.%Inner.generic (constants.%Inner.generic.137)] {
 // CHECK:STDOUT:       %U.patt.loc3_15.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc3_15.2 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc3_15.1, runtime_param<invalid> [symbolic = %U.patt.loc3_15.2 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc3_15.1, runtime_param<none> [symbolic = %U.patt.loc3_15.2 (constants.%U.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc3_15.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc3_15.2 (constants.%U)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]

--- a/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
+++ b/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
@@ -118,9 +118,9 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   %A.decl: %A.type = class_decl @A [template = constants.%A.generic] {
 // CHECK:STDOUT:     %N.patt.loc6_9.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc6_9.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc6_9.1, runtime_param<invalid> [symbolic = %N.patt.loc6_9.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc6_9.1, runtime_param<none> [symbolic = %N.patt.loc6_9.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int.2, @Int.2(constants.%int_32) [template = constants.%i32]
@@ -179,7 +179,7 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc12_3: @A.%A.elem.loc12 (%A.elem.d60) = var_pattern %.loc12_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @A.%A.elem.loc12 (%A.elem.d60) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @A.%A.elem.loc12 (%A.elem.d60) = var <none>
 // CHECK:STDOUT:     %complete_type.loc13_1.1: <witness> = complete_type_witness %struct_type.base.n [symbolic = %complete_type.loc13_1.2 (constants.%complete_type.547)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc13_1.1
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/field.carbon
+++ b/toolchain/check/testdata/class/generic/field.carbon
@@ -80,9 +80,9 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
@@ -106,14 +106,14 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc19_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc19_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc19_6.1, runtime_param<invalid> [symbolic = %T.patt.loc19_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc19_6.1, runtime_param<none> [symbolic = %T.patt.loc19_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %c.patt: @G.%Class.loc19_26.2 (%Class.fe1b2d.1) = binding_pattern c
 // CHECK:STDOUT:     %c.param_patt: @G.%Class.loc19_26.2 (%Class.fe1b2d.1) = value_param_pattern %c.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @G.%T.loc19_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @G.%T.loc19_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc19_32: type = name_ref T, %T.loc19_6.1 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc19_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc19_6.2 (constants.%T)]
 // CHECK:STDOUT:     %c.param: @G.%Class.loc19_26.2 (%Class.fe1b2d.1) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc19: type = splice_block %Class.loc19_26.1 [symbolic = %Class.loc19_26.2 (constants.%Class.fe1b2d.1)] {
@@ -127,14 +127,14 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {
 // CHECK:STDOUT:     %U.patt.loc23_6.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc23_6.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc23_6.1, runtime_param<invalid> [symbolic = %U.patt.loc23_6.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc23_6.1, runtime_param<none> [symbolic = %U.patt.loc23_6.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %c.patt: @H.%Class.loc23_26.2 (%Class.fe1b2d.2) = binding_pattern c
 // CHECK:STDOUT:     %c.param_patt: @H.%Class.loc23_26.2 (%Class.fe1b2d.2) = value_param_pattern %c.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @H.%U.loc23_6.2 (%U) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @H.%U.loc23_6.2 (%U) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.ref.loc23_32: type = name_ref U, %U.loc23_6.1 [symbolic = %U.loc23_6.2 (constants.%U)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc23_6.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc23_6.2 (constants.%U)]
 // CHECK:STDOUT:     %c.param: @H.%Class.loc23_26.2 (%Class.fe1b2d.2) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc23: type = splice_block %Class.loc23_26.1 [symbolic = %Class.loc23_26.2 (constants.%Class.fe1b2d.2)] {
@@ -164,7 +164,7 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc12_3: @Class.%Class.elem (%Class.elem.e262de.1) = var_pattern %.loc12_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem.e262de.1) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem.e262de.1) = var <none>
 // CHECK:STDOUT:     %complete_type.loc13_1.1: <witness> = complete_type_witness %struct_type.x.2ac3f0.1 [symbolic = %complete_type.loc13_1.2 (constants.%complete_type.4339b3.1)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc13_1.1
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -134,16 +134,16 @@ class Class(U:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CompleteClass.decl: %CompleteClass.type = class_decl @CompleteClass [template = constants.%CompleteClass.generic] {
 // CHECK:STDOUT:     %T.patt.loc6_21.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_21.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_21.1, runtime_param<invalid> [symbolic = %T.patt.loc6_21.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_21.1, runtime_param<none> [symbolic = %T.patt.loc6_21.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_21.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_21.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type.b25 = fn_decl @F.2 [template = constants.%F.c41] {
@@ -181,7 +181,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc7_3: @CompleteClass.%CompleteClass.elem (%CompleteClass.elem) = var_pattern %.loc7_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @CompleteClass.%CompleteClass.elem (%CompleteClass.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @CompleteClass.%CompleteClass.elem (%CompleteClass.elem) = var <none>
 // CHECK:STDOUT:     %F.decl: @CompleteClass.%F.type (%F.type.14f) = fn_decl @F.1 [symbolic = @CompleteClass.%F (constants.%F.874)] {
 // CHECK:STDOUT:       %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:       %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0
@@ -305,14 +305,14 @@ class Class(U:! type) {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type.b25 = fn_decl @F.2 [template = constants.%F.c41] {
@@ -344,7 +344,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @Class.%Class.elem (%Class.elem) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.x [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.433)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -482,7 +482,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:     .UseField = %UseField.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %UseMethod.decl: %UseMethod.type = fn_decl @UseMethod [template = constants.%UseMethod] {
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0
@@ -669,7 +669,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:     .Use = %Use.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Use.decl: %Use.type = fn_decl @Use [template = constants.%Use] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -792,14 +792,14 @@ class Class(U:! type) {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %U.patt.loc12_13.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc12_13.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc12_13.1, runtime_param<invalid> [symbolic = %U.patt.loc12_13.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc12_13.1, runtime_param<none> [symbolic = %U.patt.loc12_13.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc12_13.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc12_13.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -822,7 +822,7 @@ class Class(U:! type) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc17_3: <error> = var_pattern %.loc17_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref <error> = var <invalid>
+// CHECK:STDOUT:     %.var: ref <error> = var <none>
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness <error> [template = <error>]
 // CHECK:STDOUT:     complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/init.carbon
+++ b/toolchain/check/testdata/class/generic/init.carbon
@@ -87,21 +87,21 @@ fn InitFromAdaptedSpecific(x: i32) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %InitFromStructGeneric.decl: %InitFromStructGeneric.type = fn_decl @InitFromStructGeneric [template = constants.%InitFromStructGeneric] {
 // CHECK:STDOUT:     %T.patt.loc8_26.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_26.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_26.1, runtime_param<invalid> [symbolic = %T.patt.loc8_26.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_26.1, runtime_param<none> [symbolic = %T.patt.loc8_26.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @InitFromStructGeneric.%T.loc8_26.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @InitFromStructGeneric.%T.loc8_26.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @InitFromStructGeneric.%T.loc8_26.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @InitFromStructGeneric.%T.loc8_26.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_45: type = name_ref T, %T.loc8_26.1 [symbolic = %T.loc8_26.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_26.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_26.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @InitFromStructGeneric.%T.loc8_26.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc8_39: type = name_ref T, %T.loc8_26.1 [symbolic = %T.loc8_26.2 (constants.%T)]
@@ -144,7 +144,7 @@ fn InitFromAdaptedSpecific(x: i32) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @Class.%Class.elem (%Class.elem.e26) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem.e26) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem.e26) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.k.b21 [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.b9e)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -295,21 +295,21 @@ fn InitFromAdaptedSpecific(x: i32) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Adapt.decl: %Adapt.type = class_decl @Adapt [template = constants.%Adapt.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %InitFromAdaptedGeneric.decl: %InitFromAdaptedGeneric.type = fn_decl @InitFromAdaptedGeneric [template = constants.%InitFromAdaptedGeneric] {
 // CHECK:STDOUT:     %T.patt.loc8_27.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_27.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_27.1, runtime_param<invalid> [symbolic = %T.patt.loc8_27.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_27.1, runtime_param<none> [symbolic = %T.patt.loc8_27.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @InitFromAdaptedGeneric.%T.loc8_27.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @InitFromAdaptedGeneric.%T.loc8_27.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @InitFromAdaptedGeneric.%T.loc8_27.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @InitFromAdaptedGeneric.%T.loc8_27.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_46: type = name_ref T, %T.loc8_27.1 [symbolic = %T.loc8_27.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_27.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_27.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @InitFromAdaptedGeneric.%T.loc8_27.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc8_40: type = name_ref T, %T.loc8_27.1 [symbolic = %T.loc8_27.2 (constants.%T)]

--- a/toolchain/check/testdata/class/generic/member_access.carbon
+++ b/toolchain/check/testdata/class/generic/member_access.carbon
@@ -113,9 +113,9 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc2_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc2_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc2_13.1, runtime_param<invalid> [symbolic = %T.patt.loc2_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc2_13.1, runtime_param<none> [symbolic = %T.patt.loc2_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc2_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc2_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DirectFieldAccess.decl: %DirectFieldAccess.type = fn_decl @DirectFieldAccess [template = constants.%DirectFieldAccess] {
@@ -198,7 +198,7 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc3_3: @Class.%Class.elem (%Class.elem.e26) = var_pattern %.loc3_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem.e26) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem.e26) = var <none>
 // CHECK:STDOUT:     %Get.decl: @Class.%Get.type (%Get.type.fd9) = fn_decl @Get [symbolic = @Class.%Get (constants.%Get.cf9)] {
 // CHECK:STDOUT:       %self.patt: @Get.%Class (%Class.fe1) = binding_pattern self
 // CHECK:STDOUT:       %self.param_patt: @Get.%Class (%Class.fe1) = value_param_pattern %self.patt, runtime_param0
@@ -437,21 +437,21 @@ fn StaticMemberFunctionCall(T:! type) -> Class(T) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %StaticMemberFunctionCall.decl: %StaticMemberFunctionCall.type = fn_decl @StaticMemberFunctionCall [template = constants.%StaticMemberFunctionCall] {
 // CHECK:STDOUT:     %T.patt.loc8_29.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_29.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_29.1, runtime_param<invalid> [symbolic = %T.patt.loc8_29.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_29.1, runtime_param<none> [symbolic = %T.patt.loc8_29.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %return.patt: @StaticMemberFunctionCall.%Class.loc8_49.2 (%Class) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @StaticMemberFunctionCall.%Class.loc8_49.2 (%Class) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Class.ref.loc8: %Class.type = name_ref Class, file.%Class.decl [template = constants.%Class.generic]
 // CHECK:STDOUT:     %T.ref.loc8: type = name_ref T, %T.loc8_29.1 [symbolic = %T.loc8_29.2 (constants.%T)]
 // CHECK:STDOUT:     %Class.loc8_49.1: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc8_49.2 (constants.%Class)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_29.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_29.2 (constants.%T)]
 // CHECK:STDOUT:     %return.param: ref @StaticMemberFunctionCall.%Class.loc8_49.2 (%Class) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @StaticMemberFunctionCall.%Class.loc8_49.2 (%Class) = return_slot %return.param

--- a/toolchain/check/testdata/class/generic/member_inline.carbon
+++ b/toolchain/check/testdata/class/generic/member_inline.carbon
@@ -73,9 +73,9 @@ class C(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -129,7 +129,7 @@ class C(T:! type) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc13_3: @Class.%Class.elem (%Class.elem) = var_pattern %.loc13_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <none>
 // CHECK:STDOUT:     %complete_type.loc14_1.1: <witness> = complete_type_witness %struct_type.n [symbolic = %complete_type.loc14_1.2 (constants.%complete_type)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc14_1.1
 // CHECK:STDOUT:
@@ -233,9 +233,9 @@ class C(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -256,7 +256,7 @@ class C(T:! type) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc12_3: @C.%C.elem (%C.elem) = var_pattern %.loc12_11
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem) = var <none>
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %struct_type.data [template = constants.%complete_type]
 // CHECK:STDOUT:     complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/member_lookup.carbon
+++ b/toolchain/check/testdata/class/generic/member_lookup.carbon
@@ -132,28 +132,28 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Base.decl: %Base.type = class_decl @Base [template = constants.%Base.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_17.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_17.1, runtime_param<invalid> [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_17.1, runtime_param<none> [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_17.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_17.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Derived.decl: %Derived.type = class_decl @Derived [template = constants.%Derived.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_15.1, runtime_param<invalid> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_15.1, runtime_param<none> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessDerived.decl: %AccessDerived.type = fn_decl @AccessDerived [template = constants.%AccessDerived] {
 // CHECK:STDOUT:     %T.patt.loc13_18.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_18.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_18.1, runtime_param<invalid> [symbolic = %T.patt.loc13_18.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_18.1, runtime_param<none> [symbolic = %T.patt.loc13_18.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @AccessDerived.%Derived.loc13_40.2 (%Derived.85c) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @AccessDerived.%Derived.loc13_40.2 (%Derived.85c) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @AccessDerived.%T.loc13_18.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @AccessDerived.%T.loc13_18.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc13_46: type = name_ref T, %T.loc13_18.1 [symbolic = %T.loc13_18.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_18.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_18.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @AccessDerived.%Derived.loc13_40.2 (%Derived.85c) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc13: type = splice_block %Derived.loc13_40.1 [symbolic = %Derived.loc13_40.2 (constants.%Derived.85c)] {
@@ -167,14 +167,14 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessBase.decl: %AccessBase.type = fn_decl @AccessBase [template = constants.%AccessBase] {
 // CHECK:STDOUT:     %T.patt.loc17_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_15.1, runtime_param<invalid> [symbolic = %T.patt.loc17_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_15.1, runtime_param<none> [symbolic = %T.patt.loc17_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @AccessBase.%Derived.loc17_37.2 (%Derived.85c) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @AccessBase.%Derived.loc17_37.2 (%Derived.85c) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @AccessBase.%T.loc17_15.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @AccessBase.%T.loc17_15.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc17_43: type = name_ref T, %T.loc17_15.1 [symbolic = %T.loc17_15.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc17_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc17_15.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @AccessBase.%Derived.loc17_37.2 (%Derived.85c) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc17: type = splice_block %Derived.loc17_37.1 [symbolic = %Derived.loc17_37.2 (constants.%Derived.85c)] {
@@ -223,7 +223,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @Base.%Base.elem (%Base.elem.9af) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Base.%Base.elem (%Base.elem.9af) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Base.%Base.elem (%Base.elem.9af) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.b.f69 [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.eaf)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -256,7 +256,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc10_3: @Derived.%Derived.elem.loc10 (%Derived.elem.6d2) = var_pattern %.loc10_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Derived.%Derived.elem.loc10 (%Derived.elem.6d2) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Derived.%Derived.elem.loc10 (%Derived.elem.6d2) = var <none>
 // CHECK:STDOUT:     %complete_type.loc11_1.1: <witness> = complete_type_witness %struct_type.base.d.37c [symbolic = %complete_type.loc11_1.2 (constants.%complete_type.8ad)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc11_1.1
 // CHECK:STDOUT:
@@ -463,28 +463,28 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Base.decl: %Base.type = class_decl @Base [template = constants.%Base.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_17.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_17.1, runtime_param<invalid> [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_17.1, runtime_param<none> [symbolic = %T.patt.loc4_17.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_17.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_17.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Derived.decl: %Derived.type = class_decl @Derived [template = constants.%Derived.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_15.1, runtime_param<invalid> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_15.1, runtime_param<none> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMissingBase.decl: %AccessMissingBase.type = fn_decl @AccessMissingBase [template = constants.%AccessMissingBase] {
 // CHECK:STDOUT:     %T.patt.loc13_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_22.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_22.1, runtime_param<invalid> [symbolic = %T.patt.loc13_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_22.1, runtime_param<none> [symbolic = %T.patt.loc13_22.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @AccessMissingBase.%Base.loc13_41.2 (%Base.370) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @AccessMissingBase.%Base.loc13_41.2 (%Base.370) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @AccessMissingBase.%T.loc13_22.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @AccessMissingBase.%T.loc13_22.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc13_47: type = name_ref T, %T.loc13_22.1 [symbolic = %T.loc13_22.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_22.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @AccessMissingBase.%Base.loc13_41.2 (%Base.370) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc13: type = splice_block %Base.loc13_41.1 [symbolic = %Base.loc13_41.2 (constants.%Base.370)] {
@@ -498,14 +498,14 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMissingDerived.decl: %AccessMissingDerived.type = fn_decl @AccessMissingDerived [template = constants.%AccessMissingDerived] {
 // CHECK:STDOUT:     %T.patt.loc21_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc21_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc21_25.1, runtime_param<invalid> [symbolic = %T.patt.loc21_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc21_25.1, runtime_param<none> [symbolic = %T.patt.loc21_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @AccessMissingDerived.%Derived.loc21_47.2 (%Derived.85c) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @AccessMissingDerived.%Derived.loc21_47.2 (%Derived.85c) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @AccessMissingDerived.%T.loc21_25.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @AccessMissingDerived.%T.loc21_25.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc21_53: type = name_ref T, %T.loc21_25.1 [symbolic = %T.loc21_25.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc21_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc21_25.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @AccessMissingDerived.%Derived.loc21_47.2 (%Derived.85c) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc21: type = splice_block %Derived.loc21_47.1 [symbolic = %Derived.loc21_47.2 (constants.%Derived.85c)] {
@@ -554,7 +554,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc5_3: @Base.%Base.elem (%Base.elem.9af) = var_pattern %.loc5_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Base.%Base.elem (%Base.elem.9af) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Base.%Base.elem (%Base.elem.9af) = var <none>
 // CHECK:STDOUT:     %complete_type.loc6_1.1: <witness> = complete_type_witness %struct_type.b.f69 [symbolic = %complete_type.loc6_1.2 (constants.%complete_type.eaf)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc6_1.1
 // CHECK:STDOUT:
@@ -587,7 +587,7 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc10_3: @Derived.%Derived.elem.loc10 (%Derived.elem.6d2) = var_pattern %.loc10_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Derived.%Derived.elem.loc10 (%Derived.elem.6d2) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Derived.%Derived.elem.loc10 (%Derived.elem.6d2) = var <none>
 // CHECK:STDOUT:     %complete_type.loc11_1.1: <witness> = complete_type_witness %struct_type.base.d.37c [symbolic = %complete_type.loc11_1.2 (constants.%complete_type.8ad)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc11_1.1
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/member_out_of_line.carbon
+++ b/toolchain/check/testdata/class/generic/member_out_of_line.carbon
@@ -140,9 +140,9 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [symbolic = constants.%F] {
@@ -151,7 +151,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     %return.patt: %T = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %T = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc10: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref.loc10_31: type = name_ref T, %T.loc10 [symbolic = constants.%T]
 // CHECK:STDOUT:     %n.param.loc10: %T = value_param runtime_param0
@@ -166,7 +166,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     %return.patt: %T = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %T = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc14: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref.loc14: type = name_ref T, %T.loc14 [symbolic = constants.%T]
 // CHECK:STDOUT:     %self.param.loc14: %Class = value_param runtime_param0
@@ -229,7 +229,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc7_3: @Class.%Class.elem (%Class.elem) = var_pattern %.loc7_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <none>
 // CHECK:STDOUT:     %complete_type.loc8_1.1: <witness> = complete_type_witness %struct_type.n [symbolic = %complete_type.loc8_1.2 (constants.%complete_type)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc8_1.1
 // CHECK:STDOUT:
@@ -338,9 +338,9 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %A.decl: %A.type = class_decl @A [template = constants.%A.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [symbolic = constants.%F] {
@@ -349,9 +349,9 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:     %a.patt: %T = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %T = value_param_pattern %a.patt, runtime_param1
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc10: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
-// CHECK:STDOUT:     %N.param: %T = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %T = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref.loc10_22: type = name_ref T, %T.loc10 [symbolic = constants.%T]
 // CHECK:STDOUT:     %N.loc10: %T = bind_symbolic_name N, 1, %N.param [symbolic = constants.%N]
 // CHECK:STDOUT:     %self.param.loc10: %B = value_param runtime_param0
@@ -377,9 +377,9 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %B.decl: @A.%B.type (%B.type) = class_decl @B [symbolic = @A.%B.generic (constants.%B.generic)] {
 // CHECK:STDOUT:       %N.patt.loc5_11.1: @B.%T (%T) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc5_11.2 (constants.%N.patt)]
-// CHECK:STDOUT:       %N.param_patt: @B.%T (%T) = value_param_pattern %N.patt.loc5_11.1, runtime_param<invalid> [symbolic = %N.patt.loc5_11.2 (constants.%N.patt)]
+// CHECK:STDOUT:       %N.param_patt: @B.%T (%T) = value_param_pattern %N.patt.loc5_11.1, runtime_param<none> [symbolic = %N.patt.loc5_11.2 (constants.%N.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %N.param: @B.%T (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %N.param: @B.%T (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:       %T.ref: type = name_ref T, @A.%T.loc4_9.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %N.loc5_11.1: @B.%T (%T) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc5_11.2 (constants.%N)]
 // CHECK:STDOUT:     }
@@ -502,7 +502,7 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %NotGeneric.decl: type = class_decl @NotGeneric [template = constants.%NotGeneric] {} {}
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc15_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -567,9 +567,9 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Generic.decl: %Generic.type = class_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<invalid> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<none> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {}
@@ -646,15 +646,15 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Generic.decl: %Generic.type = class_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<invalid> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<none> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc15_12.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_12.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc15_22.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc15_22.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -747,13 +747,13 @@ fn Generic(T:! ()).WrongType() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Generic.decl: %Generic.type = class_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_15.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<invalid> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<none> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_15.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {
-// CHECK:STDOUT:     %T.param: %empty_tuple.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %empty_tuple.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc15_17.1: type = splice_block %.loc15_17.3 [template = constants.%empty_tuple.type] {
 // CHECK:STDOUT:       %.loc15_17.2: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:       %.loc15_17.3: type = converted %.loc15_17.2, constants.%empty_tuple.type [template = constants.%empty_tuple.type]

--- a/toolchain/check/testdata/class/generic/method_deduce.carbon
+++ b/toolchain/check/testdata/class/generic/method_deduce.carbon
@@ -86,9 +86,9 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc14_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_13.1, runtime_param<invalid> [symbolic = %T.patt.loc14_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_13.1, runtime_param<none> [symbolic = %T.patt.loc14_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallGenericMethod.decl: %CallGenericMethod.type = fn_decl @CallGenericMethod [template = constants.%CallGenericMethod] {
@@ -162,7 +162,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %Get.decl: @Class.%Get.type (%Get.type.fd9) = fn_decl @Get [symbolic = @Class.%Get (constants.%Get.cf9)] {
 // CHECK:STDOUT:       %U.patt.loc15_10.2: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc15_10.1 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc15_10.2, runtime_param<invalid> [symbolic = %U.patt.loc15_10.1 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc15_10.2, runtime_param<none> [symbolic = %U.patt.loc15_10.1 (constants.%U.patt)]
 // CHECK:STDOUT:       %return.patt: @Get.%tuple.type (%tuple.type.30b) = return_slot_pattern
 // CHECK:STDOUT:       %return.param_patt: @Get.%tuple.type (%tuple.type.30b) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:     } {
@@ -170,7 +170,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:       %U.ref.loc15_27: type = name_ref U, %U.loc15_10.2 [symbolic = %U.loc15_10.1 (constants.%U)]
 // CHECK:STDOUT:       %.loc15_28.1: %tuple.type.24b = tuple_literal (%T.ref, %U.ref.loc15_27)
 // CHECK:STDOUT:       %.loc15_28.2: type = converted %.loc15_28.1, constants.%tuple.type.30b [symbolic = %tuple.type (constants.%tuple.type.30b)]
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc15_10.2: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc15_10.1 (constants.%U)]
 // CHECK:STDOUT:       %return.param: ref @Get.%tuple.type (%tuple.type.30b) = out_param runtime_param0
 // CHECK:STDOUT:       %return: ref @Get.%tuple.type (%tuple.type.30b) = return_slot %return.param
@@ -179,7 +179,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:       %x.patt: @GetNoDeduce.%T (%T) = binding_pattern x
 // CHECK:STDOUT:       %x.param_patt: @GetNoDeduce.%T (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:       %U.patt.loc16_24.2: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc16_24.1 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc16_24.2, runtime_param<invalid> [symbolic = %U.patt.loc16_24.1 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc16_24.2, runtime_param<none> [symbolic = %U.patt.loc16_24.1 (constants.%U.patt)]
 // CHECK:STDOUT:       %return.patt: @GetNoDeduce.%tuple.type (%tuple.type.30b) = return_slot_pattern
 // CHECK:STDOUT:       %return.param_patt: @GetNoDeduce.%tuple.type (%tuple.type.30b) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:     } {
@@ -190,7 +190,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:       %x.param: @GetNoDeduce.%T (%T) = value_param runtime_param0
 // CHECK:STDOUT:       %T.ref.loc16_21: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %x: @GetNoDeduce.%T (%T) = bind_name x, %x.param
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc16_24.2: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc16_24.1 (constants.%U)]
 // CHECK:STDOUT:       %return.param: ref @GetNoDeduce.%tuple.type (%tuple.type.30b) = out_param runtime_param1
 // CHECK:STDOUT:       %return: ref @GetNoDeduce.%tuple.type (%tuple.type.30b) = return_slot %return.param

--- a/toolchain/check/testdata/class/generic/redeclare.carbon
+++ b/toolchain/check/testdata/class/generic/redeclare.carbon
@@ -114,16 +114,16 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Generic.decl.loc4: %Generic.type = class_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc6: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param.loc4: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc4: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_15.1: type = bind_symbolic_name T, 0, %T.param.loc4 [symbolic = %T.loc4_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Generic.decl.loc6: %Generic.type = class_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc6: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param.loc6: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc6: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6: type = bind_symbolic_name T, 0, %T.param.loc6 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -177,9 +177,9 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %T.patt.loc12_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_9.1, runtime_param<invalid> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_9.1, runtime_param<none> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -242,9 +242,9 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %B.decl: %B.type = class_decl @B [template = constants.%B.generic] {
 // CHECK:STDOUT:     %N.patt.loc4_9.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc4_9.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_9.1, runtime_param<invalid> [symbolic = %N.patt.loc4_9.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_9.1, runtime_param<none> [symbolic = %N.patt.loc4_9.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -253,13 +253,13 @@ class E(U:! type) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %T.patt.loc12_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_9.1, runtime_param<invalid> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_9.1, runtime_param<none> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc12_19.1: @.1.%T.loc12_9.2 (%T) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc12_19.2 (constants.%N.patt.51c)]
-// CHECK:STDOUT:     %N.param_patt: @.1.%T.loc12_9.2 (%T) = value_param_pattern %N.patt.loc12_19.1, runtime_param<invalid> [symbolic = %N.patt.loc12_19.2 (constants.%N.patt.51c)]
+// CHECK:STDOUT:     %N.param_patt: @.1.%T.loc12_9.2 (%T) = value_param_pattern %N.patt.loc12_19.1, runtime_param<none> [symbolic = %N.patt.loc12_19.2 (constants.%N.patt.51c)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_9.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: @.1.%T.loc12_9.2 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: @.1.%T.loc12_9.2 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc12_9.1 [symbolic = %T.loc12_9.2 (constants.%T)]
 // CHECK:STDOUT:     %N.loc12_19.1: @.1.%T.loc12_9.2 (%T) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc12_19.2 (constants.%N.f22)]
 // CHECK:STDOUT:   }
@@ -335,20 +335,20 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %T.patt.loc12_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_9.1, runtime_param<invalid> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_9.1, runtime_param<none> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc12_19.1: %i32 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc12_19.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %i32 = value_param_pattern %U.patt.loc12_19.1, runtime_param<invalid> [symbolic = %U.patt.loc12_19.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %i32 = value_param_pattern %U.patt.loc12_19.1, runtime_param<none> [symbolic = %U.patt.loc12_19.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_9.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc12: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -427,16 +427,16 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %D.decl: %D.type = class_decl @D [template = constants.%D.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %T.patt.loc12_9.1: %i32 = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_9.2 (constants.%T.patt.8e2)]
-// CHECK:STDOUT:     %T.param_patt: %i32 = value_param_pattern %T.patt.loc12_9.1, runtime_param<invalid> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt.8e2)]
+// CHECK:STDOUT:     %T.param_patt: %i32 = value_param_pattern %T.patt.loc12_9.1, runtime_param<none> [symbolic = %T.patt.loc12_9.2 (constants.%T.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc12: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -508,16 +508,16 @@ class E(U:! type) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %E.decl: %E.type = class_decl @E [template = constants.%E.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %U.patt.loc12_9.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc12_9.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc12_9.1, runtime_param<invalid> [symbolic = %U.patt.loc12_9.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc12_9.1, runtime_param<none> [symbolic = %U.patt.loc12_9.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc12_9.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc12_9.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/self.carbon
+++ b/toolchain/check/testdata/class/generic/self.carbon
@@ -56,9 +56,9 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/generic/stringify.carbon
+++ b/toolchain/check/testdata/class/generic/stringify.carbon
@@ -206,9 +206,9 @@ var g: E({.a = 1, .b = 2}) = {} as E({.a = 3, .b = 4} as D);
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Outer.decl: %Outer.type = class_decl @Outer [template = constants.%Outer.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   name_binding_decl {
@@ -257,9 +257,9 @@ var g: E({.a = 1, .b = 2}) = {} as E({.a = 3, .b = 4} as D);
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %Inner.decl: @Outer.%Inner.type (%Inner.type.eae) = class_decl @Inner [symbolic = @Outer.%Inner.generic (constants.%Inner.generic.137)] {
 // CHECK:STDOUT:       %U.patt.loc5_15.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc5_15.2 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc5_15.1, runtime_param<invalid> [symbolic = %U.patt.loc5_15.2 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc5_15.1, runtime_param<none> [symbolic = %U.patt.loc5_15.2 (constants.%U.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc5_15.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc5_15.2 (constants.%U)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
@@ -364,9 +364,9 @@ var g: E({.a = 1, .b = 2}) = {} as E({.a = 3, .b = 4} as D);
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %N.patt.loc4_9.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc4_9.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_9.1, runtime_param<invalid> [symbolic = %N.patt.loc4_9.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_9.1, runtime_param<none> [symbolic = %N.patt.loc4_9.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -488,9 +488,9 @@ var g: E({.a = 1, .b = 2}) = {} as E({.a = 3, .b = 4} as D);
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %E.decl: %E.type = class_decl @E [template = constants.%E.generic] {
 // CHECK:STDOUT:     %F.patt.loc9_9.1: %D = symbolic_binding_pattern F, 0 [symbolic = %F.patt.loc9_9.2 (constants.%F.patt)]
-// CHECK:STDOUT:     %F.param_patt: %D = value_param_pattern %F.patt.loc9_9.1, runtime_param<invalid> [symbolic = %F.patt.loc9_9.2 (constants.%F.patt)]
+// CHECK:STDOUT:     %F.param_patt: %D = value_param_pattern %F.patt.loc9_9.1, runtime_param<none> [symbolic = %F.patt.loc9_9.2 (constants.%F.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %F.param: %D = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %F.param: %D = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [template = constants.%D]
 // CHECK:STDOUT:     %F.loc9_9.1: %D = bind_symbolic_name F, 0, %F.param [symbolic = %F.loc9_9.2 (constants.%F)]
 // CHECK:STDOUT:   }
@@ -532,12 +532,12 @@ var g: E({.a = 1, .b = 2}) = {} as E({.a = 3, .b = 4} as D);
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %D.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %D.elem = var <none>
 // CHECK:STDOUT:   %.loc6_8: %D.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %D.elem = var_pattern %.loc6_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %D.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic_method.carbon
+++ b/toolchain/check/testdata/class/generic_method.carbon
@@ -47,9 +47,9 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [symbolic = constants.%F] {
@@ -58,7 +58,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:     %n.patt: %T = binding_pattern n
 // CHECK:STDOUT:     %n.param_patt: %T = value_param_pattern %n.patt, runtime_param1
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc16: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:     %self.param.loc16: %Class = value_param runtime_param0
 // CHECK:STDOUT:     %.loc16_28.1: type = splice_block %Self.ref.loc16 [symbolic = constants.%Class] {
@@ -90,7 +90,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc12_3: @Class.%Class.elem (%Class.elem) = var_pattern %.loc12_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @Class.%Class.elem (%Class.elem) = var <none>
 // CHECK:STDOUT:     %F.decl: @Class.%F.type (%F.type) = fn_decl @F [symbolic = @Class.%F (constants.%F)] {
 // CHECK:STDOUT:       %self.patt: %Class = binding_pattern self
 // CHECK:STDOUT:       %self.param_patt: %Class = value_param_pattern %self.patt, runtime_param0

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -107,7 +107,7 @@ fn Run() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc8_3: %Field.elem = var_pattern %.loc8_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Field.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Field.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type.1ec]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -228,7 +228,7 @@ fn Run() {
 // CHECK:STDOUT:     .Run = %Run.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -95,12 +95,12 @@ fn Run() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc8_3: %Base.elem = var_pattern %.loc8_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc8: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc8: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %.loc9_13: %Base.elem = field_decl unused, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc9_3: %Base.elem = var_pattern %.loc9_13
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc9: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc9: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x.unused [template = constants.%complete_type.20c]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -195,7 +195,7 @@ fn Run() {
 // CHECK:STDOUT:     .Run = %Run.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/import_forward_decl.carbon
+++ b/toolchain/check/testdata/class/import_forward_decl.carbon
@@ -65,8 +65,8 @@ class ForwardDecl {
 // CHECK:STDOUT:     .ForwardDecl = %ForwardDecl.decl
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ForwardDecl.decl: type = class_decl @ForwardDecl [template = constants.%ForwardDecl] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/import_indirect.carbon
+++ b/toolchain/check/testdata/class/import_indirect.carbon
@@ -161,7 +161,7 @@ var ptr: E* = &val;
 // CHECK:STDOUT:     .b_ptr = %b_ptr
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.ref.loc6: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   name_binding_decl {
@@ -231,7 +231,7 @@ var ptr: E* = &val;
 // CHECK:STDOUT:     .c_ptr = %c_ptr
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.ref.loc6: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %E: type = bind_alias E, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   name_binding_decl {
@@ -306,7 +306,7 @@ var ptr: E* = &val;
 // CHECK:STDOUT:     .ptr = %ptr.loc8_5
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %val.patt: %C = binding_pattern val
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %val.patt
@@ -379,7 +379,7 @@ var ptr: E* = &val;
 // CHECK:STDOUT:     .ptr = %ptr.loc8_5
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %val.patt: %C = binding_pattern val
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %val.patt
@@ -456,7 +456,7 @@ var ptr: E* = &val;
 // CHECK:STDOUT:     .ptr = %ptr.loc8_5
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %val.patt: %C = binding_pattern val
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %val.patt
@@ -533,7 +533,7 @@ var ptr: E* = &val;
 // CHECK:STDOUT:     .ptr = %ptr.loc8_5
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %val.patt: %C = binding_pattern val
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %val.patt

--- a/toolchain/check/testdata/class/import_member_cycle.carbon
+++ b/toolchain/check/testdata/class/import_member_cycle.carbon
@@ -57,7 +57,7 @@ fn Run() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %Cycle.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Cycle.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Cycle.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -95,7 +95,7 @@ fn Run() {
 // CHECK:STDOUT:     .Run = %Run.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/import_struct_cyle.carbon
+++ b/toolchain/check/testdata/class/import_struct_cyle.carbon
@@ -76,7 +76,7 @@ fn Run() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc10_3: %Cycle.elem = var_pattern %.loc10_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Cycle.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Cycle.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.c [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -118,7 +118,7 @@ fn Run() {
 // CHECK:STDOUT:     .Run = %Run.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [template = constants.%Run] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/inheritance_access.carbon
+++ b/toolchain/check/testdata/class/inheritance_access.carbon
@@ -270,12 +270,12 @@ class B {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_13: %Shape.elem = var_pattern %.loc5_18
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %Shape.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %Shape.elem = var <none>
 // CHECK:STDOUT:   %.loc6_18: %Shape.elem = field_decl y, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_13: %Shape.elem = var_pattern %.loc6_18
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %Shape.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %Shape.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x.y [template = constants.%complete_type.70a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -646,7 +646,7 @@ class B {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_11: %Shape.elem = var_pattern %.loc5_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Shape.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Shape.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.y [template = constants.%complete_type.0f9]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -1057,7 +1057,7 @@ class B {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc14_11: %B.elem = var_pattern %.loc14_23
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0
@@ -1151,7 +1151,7 @@ class B {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_11: %A.elem = var_pattern %.loc5_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type.1ec]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -1230,7 +1230,7 @@ class B {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_13: %A.elem = var_pattern %.loc5_18
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type.1ec]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -111,12 +111,12 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem.c91 = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Class.elem.c91 = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Class.elem.c91 = var <none>
 // CHECK:STDOUT:   %.loc13_11: %Class.elem.0c0 = field_decl next, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Class.elem.0c0 = var_pattern %.loc13_11
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Class.elem.0c0 = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Class.elem.0c0 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n.next [template = constants.%complete_type.78f]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -77,12 +77,12 @@ fn F() -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Class.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Class.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Class.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -85,12 +85,12 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Inner.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %Inner.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %Inner.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %Inner.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %Inner.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %Inner.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %Inner.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -105,12 +105,12 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc19_3: %Outer.elem = var_pattern %.loc19_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc19: ref %Outer.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc19: ref %Outer.elem = var <none>
 // CHECK:STDOUT:   %.loc20_8: %Outer.elem = field_decl d, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc20_3: %Outer.elem = var_pattern %.loc20_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc20: ref %Outer.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc20: ref %Outer.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.c.d.dce [template = constants.%complete_type.8b6]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/local.carbon
+++ b/toolchain/check/testdata/class/local.carbon
@@ -100,7 +100,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc19_7: %B.elem = var_pattern %.loc19_12
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n.033 [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -288,7 +288,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc17_3: %Class.elem = var_pattern %.loc17_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.k.0bf [template = constants.%complete_type.954]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -110,17 +110,17 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc36_3: %Outer.elem.a16 = var_pattern %.loc36_9
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc36: ref %Outer.elem.a16 = var <invalid>
+// CHECK:STDOUT:   %.var.loc36: ref %Outer.elem.a16 = var <none>
 // CHECK:STDOUT:   %.loc37_9: %Outer.elem.a16 = field_decl qo, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc37_3: %Outer.elem.a16 = var_pattern %.loc37_9
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc37: ref %Outer.elem.a16 = var <invalid>
+// CHECK:STDOUT:   %.var.loc37: ref %Outer.elem.a16 = var <none>
 // CHECK:STDOUT:   %.loc38_9: %Outer.elem.fe9 = field_decl pi, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc38_3: %Outer.elem.fe9 = var_pattern %.loc38_9
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc38: ref %Outer.elem.fe9 = var <invalid>
+// CHECK:STDOUT:   %.var.loc38: ref %Outer.elem.fe9 = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.po.qo.pi [template = constants.%complete_type.e99]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -139,17 +139,17 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc19_5: %Inner.elem.640 = var_pattern %.loc19_11
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc19: ref %Inner.elem.640 = var <invalid>
+// CHECK:STDOUT:   %.var.loc19: ref %Inner.elem.640 = var <none>
 // CHECK:STDOUT:   %.loc20_11: %Inner.elem.c30 = field_decl po, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc20_5: %Inner.elem.c30 = var_pattern %.loc20_11
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc20: ref %Inner.elem.c30 = var <invalid>
+// CHECK:STDOUT:   %.var.loc20: ref %Inner.elem.c30 = var <none>
 // CHECK:STDOUT:   %.loc21_11: %Inner.elem.640 = field_decl qi, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc21_5: %Inner.elem.640 = var_pattern %.loc21_11
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc21: ref %Inner.elem.640 = var <invalid>
+// CHECK:STDOUT:   %.var.loc21: ref %Inner.elem.640 = var <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.pi.po.qi [template = constants.%complete_type.7ae]
 // CHECK:STDOUT:   complete_type_witness = %complete_type

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -99,7 +99,7 @@ fn G(o: Outer) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_5: %Inner.elem = var_pattern %.loc13_10
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Inner.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Inner.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/class/no_prelude/export_name.carbon
@@ -79,7 +79,7 @@ var c: C = {};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -110,7 +110,7 @@ var c: C = {};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt

--- a/toolchain/check/testdata/class/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/class/no_prelude/extern.carbon
@@ -503,7 +503,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_decl_then_extern_decl.carbon
@@ -516,7 +516,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_extern_decl_then_def.carbon
@@ -529,7 +529,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_ownership_conflict.carbon
@@ -542,7 +542,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_import_extern_decl_copy.carbon
@@ -555,7 +555,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_extern_decl_after_import_extern_decl.carbon
@@ -571,7 +571,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -590,7 +590,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -613,7 +613,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -641,7 +641,7 @@ extern class C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon
+++ b/toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon
@@ -108,16 +108,16 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %NotGenericButParams.decl: %NotGenericButParams.type = class_decl @NotGenericButParams [template = constants.%NotGenericButParams.generic] {} {}
 // CHECK:STDOUT:   %GenericAndParams.decl: %GenericAndParams.type.c8d = class_decl @GenericAndParams.1 [template = constants.%GenericAndParams.generic.1e4] {
 // CHECK:STDOUT:     %T.patt.loc6_24.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_24.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_24.1, runtime_param<invalid> [symbolic = %T.patt.loc6_24.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_24.1, runtime_param<none> [symbolic = %T.patt.loc6_24.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_24.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_24.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<invalid> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<none> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [template = constants.%X] {} {}
@@ -221,9 +221,9 @@ fn F(T:! type) {
 // CHECK:STDOUT:     %GenericNoParams.decl: type = class_decl @GenericNoParams [template = constants.%GenericNoParams.72f] {} {}
 // CHECK:STDOUT:     %GenericAndParams.decl: @C.%GenericAndParams.type (%GenericAndParams.type.3ce) = class_decl @GenericAndParams.2 [symbolic = @C.%GenericAndParams.generic (constants.%GenericAndParams.generic.54a)] {
 // CHECK:STDOUT:       %U.patt.loc10_26.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc10_26.2 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc10_26.1, runtime_param<invalid> [symbolic = %U.patt.loc10_26.2 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc10_26.1, runtime_param<none> [symbolic = %U.patt.loc10_26.2 (constants.%U.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc10_26.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc10_26.2 (constants.%U)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
@@ -385,9 +385,9 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %A.decl: %A.type = class_decl @A [template = constants.%A.generic] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
@@ -111,8 +111,8 @@ class B {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -164,8 +164,8 @@ class B {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -218,8 +218,8 @@ class B {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.a95] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -275,8 +275,8 @@ class B {}
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.a95] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/class/no_prelude/import_access.carbon
@@ -219,7 +219,7 @@ private class Redecl {}
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %Def = binding_pattern c
 // CHECK:STDOUT:     %.loc4: %Def = var_pattern %c.patt
@@ -255,7 +255,7 @@ private class Redecl {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: <error> = binding_pattern c
 // CHECK:STDOUT:     %.loc10: <error> = var_pattern %c.patt
@@ -330,7 +330,7 @@ private class Redecl {}
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %ForwardWithDef = binding_pattern c
 // CHECK:STDOUT:     %.loc4: %ForwardWithDef = var_pattern %c.patt
@@ -366,7 +366,7 @@ private class Redecl {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: <error> = binding_pattern c
 // CHECK:STDOUT:     %.loc10: <error> = var_pattern %c.patt
@@ -441,7 +441,7 @@ private class Redecl {}
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %c.patt: %ptr = binding_pattern c
 // CHECK:STDOUT:     %c.param_patt: %ptr = value_param_pattern %c.patt, runtime_param0
@@ -480,7 +480,7 @@ private class Redecl {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %c.patt: <error> = binding_pattern c
 // CHECK:STDOUT:     %c.param_patt: <error> = value_param_pattern %c.patt, runtime_param0

--- a/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
+++ b/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
@@ -142,7 +142,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- c.carbon
@@ -164,7 +164,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -186,7 +186,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- e.carbon
@@ -210,7 +210,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -244,7 +244,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- use_b.carbon
@@ -270,7 +270,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %empty_tuple.type = binding_pattern x
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %x.patt
@@ -325,7 +325,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %empty_tuple.type = binding_pattern x
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %x.patt
@@ -380,7 +380,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %empty_tuple.type = binding_pattern x
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %x.patt
@@ -439,7 +439,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %empty_tuple.type = binding_pattern x
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %x.patt
@@ -507,7 +507,7 @@ var x: () = D.C.F();
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %empty_tuple.type = binding_pattern x
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %x.patt

--- a/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
@@ -102,8 +102,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl.loc4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl.loc4: type = class_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %A.decl.loc6: type = class_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
@@ -132,8 +132,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_only_in_api.carbon
@@ -161,8 +161,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_in_api_decl_in_impl.carbon
@@ -193,8 +193,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -216,8 +216,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
@@ -208,33 +208,33 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl.loc7: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc8: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc7: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_11.1: %C = bind_symbolic_name a, 0, %a.param.loc7 [symbolic = %a.loc7_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo.decl.loc8: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc8: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc8: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc8: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc8: %C = bind_symbolic_name a, 0, %a.param.loc8 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl.loc10: %Bar.type = class_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc11: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc11, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc11, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc10: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc10: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref.loc10: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc10_11.1: %C = bind_symbolic_name a, 0, %a.param.loc10 [symbolic = %a.loc10_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl.loc11: %Bar.type = class_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc11: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc11, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc11, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc11: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc11: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref.loc11: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc11: %C = bind_symbolic_name a, 0, %a.param.loc11 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -309,17 +309,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl.loc6: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc6: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_17.1: %C = bind_symbolic_name a, 0, %a.param.loc6 [symbolic = %a.loc6_17.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo.decl.loc7: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc7: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7: %C = bind_symbolic_name a, 0, %a.param.loc7 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -376,17 +376,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_11.1, runtime_param<invalid> [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_11.1, runtime_param<none> [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc6_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc14_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc14_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc14_11.1, runtime_param<invalid> [symbolic = %a.patt.loc14_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc14_11.1, runtime_param<none> [symbolic = %a.patt.loc14_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc14_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc14_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -453,17 +453,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl.loc6: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc6: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_11.1: %C = bind_symbolic_name a, 0, %a.param.loc6 [symbolic = %a.loc6_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo.decl.loc7: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc7: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7: %C = bind_symbolic_name a, 0, %a.param.loc7 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -523,17 +523,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<invalid> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<none> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl: %Bar.type = class_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc8_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc8_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8_11.1, runtime_param<invalid> [symbolic = %a.patt.loc8_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8_11.1, runtime_param<none> [symbolic = %a.patt.loc8_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc8_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc8_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -601,21 +601,21 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .Bar = %Bar.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc4: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc4, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc4, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:     %a.loc4: %C = bind_symbolic_name a, 0, %a.param [symbolic = constants.%a]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl: %Bar.type = class_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc5: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc5, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc5, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc5: %C = bind_symbolic_name a, 0, %a.param [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -696,17 +696,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<invalid> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<none> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %b.patt.loc15_11.1: %C = symbolic_binding_pattern b, 0 [symbolic = %b.patt.loc15_11.2 (constants.%b.patt)]
-// CHECK:STDOUT:     %b.param_patt: %C = value_param_pattern %b.patt.loc15_11.1, runtime_param<invalid> [symbolic = %b.patt.loc15_11.2 (constants.%b.patt)]
+// CHECK:STDOUT:     %b.param_patt: %C = value_param_pattern %b.patt.loc15_11.1, runtime_param<none> [symbolic = %b.patt.loc15_11.2 (constants.%b.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %b.loc15_11.1: %C = bind_symbolic_name b, 0, %b.param [symbolic = %b.loc15_11.2 (constants.%b)]
 // CHECK:STDOUT:   }
@@ -778,17 +778,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<invalid> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<none> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc15_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc15_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_11.1, runtime_param<invalid> [symbolic = %a.patt.loc15_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_11.1, runtime_param<none> [symbolic = %a.patt.loc15_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc15_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc15_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -860,17 +860,17 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<invalid> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_11.1, runtime_param<none> [symbolic = %a.patt.loc7_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc15_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc15_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_11.1, runtime_param<invalid> [symbolic = %a.patt.loc15_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_11.1, runtime_param<none> [symbolic = %a.patt.loc15_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc15_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc15_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -936,9 +936,9 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_11.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_11.1, runtime_param<invalid> [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_11.1, runtime_param<none> [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_11.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc6_11.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -989,15 +989,15 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6, runtime_param<invalid> [symbolic = constants.%a.patt]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6, runtime_param<none> [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6: %C = bind_symbolic_name a, 0, %a.param [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -1054,9 +1054,9 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_11.1: %const = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc6_11.1, runtime_param<invalid> [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc6_11.1, runtime_param<none> [symbolic = %a.patt.loc6_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6: type = splice_block %const [template = constants.%const] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:       %const: type = const_type %C [template = constants.%const]
@@ -1065,9 +1065,9 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc18_11.1: %const = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc18_11.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc18_11.1, runtime_param<invalid> [symbolic = %a.patt.loc18_11.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc18_11.1, runtime_param<none> [symbolic = %a.patt.loc18_11.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc18: type = splice_block %const.loc18_15 [template = constants.%const] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:       %const.loc18_22: type = const_type %C [template = constants.%const]
@@ -1157,7 +1157,7 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %Base.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %self.patt: %ptr.11f = binding_pattern self
 // CHECK:STDOUT:     %self.param_patt: %ptr.11f = value_param_pattern %self.patt, runtime_param0

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -154,7 +154,7 @@ fn Class.G[self: Self](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc14_3: %Class.elem = var_pattern %.loc14_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/reorder_qualified.carbon
+++ b/toolchain/check/testdata/class/reorder_qualified.carbon
@@ -134,7 +134,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc46_3: %A.elem = var_pattern %.loc46_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %A.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %A.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.ba9 [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -152,7 +152,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc16_5: %B.elem = var_pattern %.loc16_10
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b.0a3 [template = constants.%complete_type.ba8]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -171,7 +171,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc42_5: %C.elem = var_pattern %.loc42_10
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.c.b66 [template = constants.%complete_type.836]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -189,7 +189,7 @@ class A {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc24_7: %D.elem = var_pattern %.loc24_12
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %D.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.d.b7b [template = constants.%complete_type.860]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -144,7 +144,7 @@ class Class {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc8_3: %Class.elem = var_pattern %.loc8_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -133,7 +133,7 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %Base.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [template = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -96,7 +96,7 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc18_3: %Class.elem = var_pattern %.loc18_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Class.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Class.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.p [template = constants.%complete_type.56d]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/syntactic_merge_literal.carbon
+++ b/toolchain/check/testdata/class/syntactic_merge_literal.carbon
@@ -77,9 +77,9 @@ class D(b:! C(1_000)) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %a.patt.loc4_9.1: %i32 = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc4_9.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %i32 = value_param_pattern %a.patt.loc4_9.1, runtime_param<invalid> [symbolic = %a.patt.loc4_9.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %i32 = value_param_pattern %a.patt.loc4_9.1, runtime_param<none> [symbolic = %a.patt.loc4_9.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -88,9 +88,9 @@ class D(b:! C(1_000)) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D.decl.loc5: %D.type = class_decl @D [template = constants.%D.generic] {
 // CHECK:STDOUT:     %b.patt.loc6: %C.262 = symbolic_binding_pattern b, 0 [symbolic = constants.%b.patt]
-// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc6, runtime_param<invalid> [symbolic = constants.%b.patt]
+// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc6, runtime_param<none> [symbolic = constants.%b.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param.loc5: %C.262 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param.loc5: %C.262 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc5_20.1: type = splice_block %C.loc5 [template = constants.%C.262] {
 // CHECK:STDOUT:       %C.ref.loc5: %C.type = name_ref C, file.%C.decl [template = constants.%C.generic]
 // CHECK:STDOUT:       %int_1000.loc5: Core.IntLiteral = int_value 1000 [template = constants.%int_1000.ff9]
@@ -106,9 +106,9 @@ class D(b:! C(1_000)) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D.decl.loc6: %D.type = class_decl @D [template = constants.%D.generic] {
 // CHECK:STDOUT:     %b.patt.loc6: %C.262 = symbolic_binding_pattern b, 0 [symbolic = constants.%b.patt]
-// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc6, runtime_param<invalid> [symbolic = constants.%b.patt]
+// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc6, runtime_param<none> [symbolic = constants.%b.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param.loc6: %C.262 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param.loc6: %C.262 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_20.1: type = splice_block %C.loc6 [template = constants.%C.262] {
 // CHECK:STDOUT:       %C.ref.loc6: %C.type = name_ref C, file.%C.decl [template = constants.%C.generic]
 // CHECK:STDOUT:       %int_1000.loc6: Core.IntLiteral = int_value 1000 [template = constants.%int_1000.ff9]
@@ -217,9 +217,9 @@ class D(b:! C(1_000)) {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %a.patt.loc4_9.1: %i32 = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc4_9.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %i32 = value_param_pattern %a.patt.loc4_9.1, runtime_param<invalid> [symbolic = %a.patt.loc4_9.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %i32 = value_param_pattern %a.patt.loc4_9.1, runtime_param<none> [symbolic = %a.patt.loc4_9.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -228,9 +228,9 @@ class D(b:! C(1_000)) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D.decl: %D.type = class_decl @D [template = constants.%D.generic] {
 // CHECK:STDOUT:     %b.patt.loc5_9.1: %C.262 = symbolic_binding_pattern b, 0 [symbolic = %b.patt.loc5_9.2 (constants.%b.patt)]
-// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc5_9.1, runtime_param<invalid> [symbolic = %b.patt.loc5_9.2 (constants.%b.patt)]
+// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc5_9.1, runtime_param<none> [symbolic = %b.patt.loc5_9.2 (constants.%b.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param: %C.262 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param: %C.262 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc5_19.1: type = splice_block %C [template = constants.%C.262] {
 // CHECK:STDOUT:       %C.ref: %C.type = name_ref C, file.%C.decl [template = constants.%C.generic]
 // CHECK:STDOUT:       %int_1000: Core.IntLiteral = int_value 1000 [template = constants.%int_1000.ff9]
@@ -246,9 +246,9 @@ class D(b:! C(1_000)) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %b.patt.loc13_9.1: %C.262 = symbolic_binding_pattern b, 0 [symbolic = %b.patt.loc13_9.2 (constants.%b.patt)]
-// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc13_9.1, runtime_param<invalid> [symbolic = %b.patt.loc13_9.2 (constants.%b.patt)]
+// CHECK:STDOUT:     %b.param_patt: %C.262 = value_param_pattern %b.patt.loc13_9.1, runtime_param<none> [symbolic = %b.patt.loc13_9.2 (constants.%b.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param: %C.262 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param: %C.262 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc13_20.1: type = splice_block %C [template = constants.%C.262] {
 // CHECK:STDOUT:       %C.ref: %C.type = name_ref C, file.%C.decl [template = constants.%C.generic]
 // CHECK:STDOUT:       %int_1000: Core.IntLiteral = int_value 1000 [template = constants.%int_1000.ff9]

--- a/toolchain/check/testdata/class/todo_access_modifiers.carbon
+++ b/toolchain/check/testdata/class/todo_access_modifiers.carbon
@@ -58,12 +58,12 @@ class Access {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc17_11: %Access.elem = var_pattern %.loc17_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc17: ref %Access.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc17: ref %Access.elem = var <none>
 // CHECK:STDOUT:   %.loc19_18: %Access.elem = field_decl l, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc19_13: %Access.elem = var_pattern %.loc19_18
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc19: ref %Access.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc19: ref %Access.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.k.l [template = constants.%complete_type.48a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/virtual_modifiers.carbon
+++ b/toolchain/check/testdata/class/virtual_modifiers.carbon
@@ -701,12 +701,12 @@ class Derived {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %Base.elem = var_pattern %.loc5_9
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc5: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc5: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %.loc6_9: %Base.elem = field_decl m2, element2 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc6_3: %Base.elem = var_pattern %.loc6_9
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc6: ref %Base.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc6: ref %Base.elem = var <none>
 // CHECK:STDOUT:   %F.decl: %F.type.7c6 = fn_decl @F.1 [template = constants.%F.d17] {} {}
 // CHECK:STDOUT:   %.loc9: <vtable> = vtable (%F.decl) [template = constants.%.5ee]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.vptr.m1.m2 [template = constants.%complete_type.cf7]

--- a/toolchain/check/testdata/const/import.carbon
+++ b/toolchain/check/testdata/const/import.carbon
@@ -131,7 +131,7 @@ var a_ptr: const i32* = a_ptr_ref;
 // CHECK:STDOUT:     .a_ptr = %a_ptr
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %ptr = binding_pattern a

--- a/toolchain/check/testdata/deduce/array.carbon
+++ b/toolchain/check/testdata/deduce/array.carbon
@@ -177,14 +177,14 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %a.patt: @F.%array_type.loc6_24.2 (%array_type.743) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%array_type.loc6_24.2 (%array_type.743) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc6_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc6_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_30: type = name_ref T, %T.loc6_6.1 [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:     %a.param: @F.%array_type.loc6_24.2 (%array_type.743) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc6_24: type = splice_block %array_type.loc6_24.1 [symbolic = %array_type.loc6_24.2 (constants.%array_type.743)] {
@@ -361,7 +361,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc6_6.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc6_6.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc6_6.1, runtime_param<invalid> [symbolic = %N.patt.loc6_6.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc6_6.1, runtime_param<none> [symbolic = %N.patt.loc6_6.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %a.patt: @F.%array_type.loc6_37.2 (%array_type.6a2) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%array_type.loc6_37.2 (%array_type.6a2) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
@@ -369,7 +369,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_26.1: type = splice_block %.loc6_26.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %Core.ref: <namespace> = name_ref Core, imports.%Core [template = imports.%Core]
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, imports.%Core.IntLiteral [template = constants.%IntLiteral]
@@ -542,15 +542,15 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc6_16.1: Core.IntLiteral = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc6_16.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc6_16.1, runtime_param<invalid> [symbolic = %N.patt.loc6_16.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc6_16.1, runtime_param<none> [symbolic = %N.patt.loc6_16.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %a.patt: @F.%array_type.loc6_47.2 (%array_type.bb5) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%array_type.loc6_47.2 (%array_type.bb5) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_36.1: type = splice_block %.loc6_36.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %Core.ref: <namespace> = name_ref Core, imports.%Core [template = imports.%Core]
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, imports.%Core.IntLiteral [template = constants.%IntLiteral]
@@ -710,14 +710,14 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %a.patt: @F.%array_type.loc6_24.2 (%array_type.9d4) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%array_type.loc6_24.2 (%array_type.9d4) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc6_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc6_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_30: type = name_ref T, %T.loc6_6.1 [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:     %a.param: @F.%array_type.loc6_24.2 (%array_type.9d4) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc6_24: type = splice_block %array_type.loc6_24.1 [symbolic = %array_type.loc6_24.2 (constants.%array_type.9d4)] {
@@ -898,7 +898,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc7_6.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc7_6.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc7_6.1, runtime_param<invalid> [symbolic = %N.patt.loc7_6.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc7_6.1, runtime_param<none> [symbolic = %N.patt.loc7_6.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %a.patt: @F.%array_type.loc7_37.2 (%array_type.6a2) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%array_type.loc7_37.2 (%array_type.6a2) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
@@ -906,7 +906,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc7_26.1: type = splice_block %.loc7_26.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %Core.ref: <namespace> = name_ref Core, imports.%Core [template = imports.%Core]
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, imports.%Core.IntLiteral [template = constants.%IntLiteral]
@@ -1089,7 +1089,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc6_6.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc6_6.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc6_6.1, runtime_param<invalid> [symbolic = %N.patt.loc6_6.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc6_6.1, runtime_param<none> [symbolic = %N.patt.loc6_6.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:     %a.patt: @F.%array_type.loc6_23.2 (%array_type.c13) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%array_type.loc6_23.2 (%array_type.c13) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
@@ -1097,7 +1097,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32.loc6_29: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc6_29: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_10: type = splice_block %i32.loc6_10 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc6_10: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc6_10: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]

--- a/toolchain/check/testdata/deduce/generic_type.carbon
+++ b/toolchain/check/testdata/deduce/generic_type.carbon
@@ -105,22 +105,22 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc7_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<invalid> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<none> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%C.loc7_22.2 (%C.f2e) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%C.loc7_22.2 (%C.f2e) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc7_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc7_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc7_28: type = name_ref T, %T.loc7_6.1 [symbolic = %T.loc7_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%C.loc7_22.2 (%C.f2e) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc7_22: type = splice_block %C.loc7_22.1 [symbolic = %C.loc7_22.2 (constants.%C.f2e)] {
@@ -285,22 +285,22 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %I.decl: %I.type = class_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc7_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<invalid> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<none> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%I.loc7_22.2 (%I.ff1) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%I.loc7_22.2 (%I.ff1) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %C = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %C = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%I.loc7_22.2 (%I.ff1) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc7_22: type = splice_block %I.loc7_22.1 [symbolic = %I.loc7_22.2 (constants.%I.ff1)] {
@@ -479,18 +479,18 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Outer.decl: %Outer.type = class_decl @Outer [template = constants.%Outer.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc13_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_6.1, runtime_param<invalid> [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_6.1, runtime_param<none> [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc13_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc13_16.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_16.1, runtime_param<invalid> [symbolic = %U.patt.loc13_16.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_16.1, runtime_param<none> [symbolic = %U.patt.loc13_16.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%Inner.loc13_45.2 (%Inner.c71) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%Inner.loc13_45.2 (%Inner.c71) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%tuple.type (%tuple.type.30b) = return_slot_pattern
@@ -500,9 +500,9 @@ fn G() -> i32 {
 // CHECK:STDOUT:     %U.ref.loc13_55: type = name_ref U, %U.loc13_16.1 [symbolic = %U.loc13_16.2 (constants.%U)]
 // CHECK:STDOUT:     %.loc13_56.1: %tuple.type.24b = tuple_literal (%T.ref.loc13_52, %U.ref.loc13_55)
 // CHECK:STDOUT:     %.loc13_56.2: type = converted %.loc13_56.1, constants.%tuple.type.30b [symbolic = %tuple.type (constants.%tuple.type.30b)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_6.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc13_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc13_16.2 (constants.%U)]
 // CHECK:STDOUT:     %p.param: @F.%Inner.loc13_45.2 (%Inner.c71) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc13_45: type = splice_block %Inner.loc13_45.1 [symbolic = %Inner.loc13_45.2 (constants.%Inner.c71)] {
@@ -555,9 +555,9 @@ fn G() -> i32 {
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %Inner.decl: @Outer.%Inner.type (%Inner.type.eae) = class_decl @Inner [symbolic = @Outer.%Inner.generic (constants.%Inner.generic.137)] {
 // CHECK:STDOUT:       %U.patt.loc5_15.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc5_15.2 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc5_15.1, runtime_param<invalid> [symbolic = %U.patt.loc5_15.2 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc5_15.1, runtime_param<none> [symbolic = %U.patt.loc5_15.2 (constants.%U.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc5_15.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc5_15.2 (constants.%U)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
@@ -780,9 +780,9 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %WithNontype.decl: %WithNontype.type = class_decl @WithNontype [template = constants.%WithNontype.generic] {
 // CHECK:STDOUT:     %N.patt.loc4_19.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc4_19.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_19.1, runtime_param<invalid> [symbolic = %N.patt.loc4_19.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc4_19.1, runtime_param<none> [symbolic = %N.patt.loc4_19.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4: type = splice_block %i32 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -791,7 +791,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc6_6.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc6_6.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc6_6.1, runtime_param<invalid> [symbolic = %N.patt.loc6_6.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc6_6.1, runtime_param<none> [symbolic = %N.patt.loc6_6.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:     %x.patt: @F.%WithNontype.loc6_31.2 (%WithNontype.8a6) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @F.%WithNontype.loc6_31.2 (%WithNontype.8a6) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
@@ -799,7 +799,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32.loc6_37: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc6_37: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_10: type = splice_block %i32.loc6_10 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc6_10: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc6_10: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]

--- a/toolchain/check/testdata/deduce/int_float.carbon
+++ b/toolchain/check/testdata/deduce/int_float.carbon
@@ -79,7 +79,7 @@ fn G(a: f64) -> Core.IntLiteral() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc4_6.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc4_6.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc4_6.1, runtime_param<invalid> [symbolic = %N.patt.loc4_6.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc4_6.1, runtime_param<none> [symbolic = %N.patt.loc4_6.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %n.patt: @F.%Int.loc4_42.2 (%Int) = binding_pattern n
 // CHECK:STDOUT:     %n.param_patt: @F.%Int.loc4_42.2 (%Int) = value_param_pattern %n.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: Core.IntLiteral = return_slot_pattern
@@ -90,7 +90,7 @@ fn G(a: f64) -> Core.IntLiteral() {
 // CHECK:STDOUT:     %int_literal.make_type.loc4_64: init type = call %IntLiteral.ref.loc4_52() [template = Core.IntLiteral]
 // CHECK:STDOUT:     %.loc4_64.1: type = value_of_initializer %int_literal.make_type.loc4_64 [template = Core.IntLiteral]
 // CHECK:STDOUT:     %.loc4_64.2: type = converted %int_literal.make_type.loc4_64, %.loc4_64.1 [template = Core.IntLiteral]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4_26.1: type = splice_block %.loc4_26.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %Core.ref.loc4_10: <namespace> = name_ref Core, imports.%Core [template = imports.%Core]
 // CHECK:STDOUT:       %IntLiteral.ref.loc4_14: %IntLiteral.type = name_ref IntLiteral, imports.%Core.IntLiteral [template = constants.%IntLiteral]
@@ -209,7 +209,7 @@ fn G(a: f64) -> Core.IntLiteral() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc9_6.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc9_6.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc9_6.1, runtime_param<invalid> [symbolic = %N.patt.loc9_6.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc9_6.1, runtime_param<none> [symbolic = %N.patt.loc9_6.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %n.patt: <error> = binding_pattern n
 // CHECK:STDOUT:     %n.param_patt: <error> = value_param_pattern %n.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: Core.IntLiteral = return_slot_pattern
@@ -220,7 +220,7 @@ fn G(a: f64) -> Core.IntLiteral() {
 // CHECK:STDOUT:     %int_literal.make_type.loc9_66: init type = call %IntLiteral.ref.loc9_54() [template = Core.IntLiteral]
 // CHECK:STDOUT:     %.loc9_66.1: type = value_of_initializer %int_literal.make_type.loc9_66 [template = Core.IntLiteral]
 // CHECK:STDOUT:     %.loc9_66.2: type = converted %int_literal.make_type.loc9_66, %.loc9_66.1 [template = Core.IntLiteral]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc9_26.1: type = splice_block %.loc9_26.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %Core.ref.loc9_10: <namespace> = name_ref Core, imports.%Core [template = imports.%Core]
 // CHECK:STDOUT:       %IntLiteral.ref.loc9_14: %IntLiteral.type = name_ref IntLiteral, imports.%Core.IntLiteral [template = constants.%IntLiteral]

--- a/toolchain/check/testdata/deduce/tuple.carbon
+++ b/toolchain/check/testdata/deduce/tuple.carbon
@@ -98,18 +98,18 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc7_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<invalid> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<none> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc7_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc7_16.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc7_16.1, runtime_param<invalid> [symbolic = %U.patt.loc7_16.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc7_16.1, runtime_param<none> [symbolic = %U.patt.loc7_16.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %pair.patt: @F.%tuple.type (%tuple.type.30b) = binding_pattern pair
 // CHECK:STDOUT:     %pair.param_patt: @F.%tuple.type (%tuple.type.30b) = value_param_pattern %pair.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%U.loc7_16.2 (%U) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%U.loc7_16.2 (%U) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.ref.loc7_43: type = name_ref U, %U.loc7_16.1 [symbolic = %U.loc7_16.2 (constants.%U)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_6.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc7_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc7_16.2 (constants.%U)]
 // CHECK:STDOUT:     %pair.param: @F.%tuple.type (%tuple.type.30b) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc7_37.1: type = splice_block %.loc7_37.3 [symbolic = %tuple.type (constants.%tuple.type.30b)] {
@@ -282,9 +282,9 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %HasPair.decl: %HasPair.type = class_decl @HasPair [template = constants.%HasPair.generic] {
 // CHECK:STDOUT:     %Pair.patt.loc4_15.1: %tuple.type.d07 = symbolic_binding_pattern Pair, 0 [symbolic = %Pair.patt.loc4_15.2 (constants.%Pair.patt)]
-// CHECK:STDOUT:     %Pair.param_patt: %tuple.type.d07 = value_param_pattern %Pair.patt.loc4_15.1, runtime_param<invalid> [symbolic = %Pair.patt.loc4_15.2 (constants.%Pair.patt)]
+// CHECK:STDOUT:     %Pair.param_patt: %tuple.type.d07 = value_param_pattern %Pair.patt.loc4_15.1, runtime_param<none> [symbolic = %Pair.patt.loc4_15.2 (constants.%Pair.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Pair.param: %tuple.type.d07 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %Pair.param: %tuple.type.d07 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4_31.1: type = splice_block %.loc4_31.3 [template = constants.%tuple.type.d07] {
 // CHECK:STDOUT:       %int_32.loc4_23: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc4_23: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -297,9 +297,9 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %A.patt.loc6_6.1: %i32 = symbolic_binding_pattern A, 0 [symbolic = %A.patt.loc6_6.2 (constants.%A.patt)]
-// CHECK:STDOUT:     %A.param_patt: %i32 = value_param_pattern %A.patt.loc6_6.1, runtime_param<invalid> [symbolic = %A.patt.loc6_6.2 (constants.%A.patt)]
+// CHECK:STDOUT:     %A.param_patt: %i32 = value_param_pattern %A.patt.loc6_6.1, runtime_param<none> [symbolic = %A.patt.loc6_6.2 (constants.%A.patt)]
 // CHECK:STDOUT:     %B.patt.loc6_15.1: %i32 = symbolic_binding_pattern B, 1 [symbolic = %B.patt.loc6_15.2 (constants.%B.patt)]
-// CHECK:STDOUT:     %B.param_patt: %i32 = value_param_pattern %B.patt.loc6_15.1, runtime_param<invalid> [symbolic = %B.patt.loc6_15.2 (constants.%B.patt)]
+// CHECK:STDOUT:     %B.param_patt: %i32 = value_param_pattern %B.patt.loc6_15.1, runtime_param<none> [symbolic = %B.patt.loc6_15.2 (constants.%B.patt)]
 // CHECK:STDOUT:     %h.patt: @F.%HasPair.loc6_41.2 (%HasPair.568) = binding_pattern h
 // CHECK:STDOUT:     %h.param_patt: @F.%HasPair.loc6_41.2 (%HasPair.568) = value_param_pattern %h.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
@@ -307,13 +307,13 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32.loc6_47: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc6_47: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %A.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %A.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_10: type = splice_block %i32.loc6_10 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc6_10: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc6_10: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %A.loc6_6.1: %i32 = bind_symbolic_name A, 0, %A.param [symbolic = %A.loc6_6.2 (constants.%A)]
-// CHECK:STDOUT:     %B.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %B.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_19: type = splice_block %i32.loc6_19 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc6_19: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc6_19: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -493,14 +493,14 @@ fn G(pair: (C, D)) -> D {
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc7_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<invalid> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<none> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %pair.patt: @F.%tuple.type (%tuple.type.d00) = binding_pattern pair
 // CHECK:STDOUT:     %pair.param_patt: @F.%tuple.type (%tuple.type.d00) = value_param_pattern %pair.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc7_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc7_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc7_33: type = name_ref T, %T.loc7_6.1 [symbolic = %T.loc7_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_6.2 (constants.%T)]
 // CHECK:STDOUT:     %pair.param: @F.%tuple.type (%tuple.type.d00) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc7_27.1: type = splice_block %.loc7_27.3 [symbolic = %tuple.type (constants.%tuple.type.d00)] {

--- a/toolchain/check/testdata/deduce/type_operator.carbon
+++ b/toolchain/check/testdata/deduce/type_operator.carbon
@@ -102,14 +102,14 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%ptr.loc6_20.2 (%ptr.79f) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%ptr.loc6_20.2 (%ptr.79f) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc6_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc6_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_26: type = name_ref T, %T.loc6_6.1 [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%ptr.loc6_20.2 (%ptr.79f) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc6_20: type = splice_block %ptr.loc6_20.1 [symbolic = %ptr.loc6_20.2 (constants.%ptr.79f)] {
@@ -243,14 +243,14 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%ptr.loc6_26.2 (%ptr.6d4) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%ptr.loc6_26.2 (%ptr.6d4) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc6_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc6_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_32: type = name_ref T, %T.loc6_6.1 [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%ptr.loc6_26.2 (%ptr.6d4) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc6_26: type = splice_block %ptr.loc6_26.1 [symbolic = %ptr.loc6_26.2 (constants.%ptr.6d4)] {
@@ -388,14 +388,14 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%ptr.loc6_20.2 (%ptr.79f) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%ptr.loc6_20.2 (%ptr.79f) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc6_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc6_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_26: type = name_ref T, %T.loc6_6.1 [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%ptr.loc6_20.2 (%ptr.79f) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc6_20: type = splice_block %ptr.loc6_20.1 [symbolic = %ptr.loc6_20.2 (constants.%ptr.79f)] {
@@ -529,14 +529,14 @@ fn G(p: C*) -> const C {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%ptr.loc6_26.2 (%ptr.6d4) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%ptr.loc6_26.2 (%ptr.6d4) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc6_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc6_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_32: type = name_ref T, %T.loc6_6.1 [symbolic = %T.loc6_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%ptr.loc6_26.2 (%ptr.6d4) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc6_26: type = splice_block %ptr.loc6_26.1 [symbolic = %ptr.loc6_26.2 (constants.%ptr.6d4)] {

--- a/toolchain/check/testdata/eval/symbolic.carbon
+++ b/toolchain/check/testdata/eval/symbolic.carbon
@@ -71,16 +71,16 @@ fn G(N:! i32) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc12_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_6.1, runtime_param<invalid> [symbolic = %T.patt.loc12_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_6.1, runtime_param<none> [symbolic = %T.patt.loc12_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %N.patt.loc18_6.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc18_6.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc18_6.1, runtime_param<invalid> [symbolic = %N.patt.loc18_6.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc18_6.1, runtime_param<none> [symbolic = %N.patt.loc18_6.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc18: type = splice_block %i32.loc18 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc18: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]

--- a/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/no_prelude/call_from_operator.carbon
@@ -153,16 +153,16 @@ var arr: [i32; (1 as i32) + (2 as i32)] = (3, 4, (3 as i32) + (4 as i32));
 // CHECK:STDOUT:   %Add.decl: type = interface_decl @Add [template = constants.%Add.type] {} {}
 // CHECK:STDOUT:   %As.decl: %As.type.b51 = interface_decl @As [template = constants.%As.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_14.1, runtime_param<invalid> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_14.1, runtime_param<none> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
 // CHECK:STDOUT:     %T.patt.loc15_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_22.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_22.1, runtime_param<invalid> [symbolic = %T.patt.loc15_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_22.1, runtime_param<none> [symbolic = %T.patt.loc15_22.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc15_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_22.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {} {

--- a/toolchain/check/testdata/function/call/prefer_unqualified_lookup.carbon
+++ b/toolchain/check/testdata/function/call/prefer_unqualified_lookup.carbon
@@ -69,16 +69,16 @@ fn Class(F:! type).Inner.G() -> i32 { return F(); }
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [template = constants.%Class.generic] {
 // CHECK:STDOUT:     %F.patt.loc5_13.1: type = symbolic_binding_pattern F, 0 [symbolic = %F.patt.loc5_13.2 (constants.%F.patt)]
-// CHECK:STDOUT:     %F.param_patt: type = value_param_pattern %F.patt.loc5_13.1, runtime_param<invalid> [symbolic = %F.patt.loc5_13.2 (constants.%F.patt)]
+// CHECK:STDOUT:     %F.param_patt: type = value_param_pattern %F.patt.loc5_13.1, runtime_param<none> [symbolic = %F.patt.loc5_13.2 (constants.%F.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %F.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %F.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %F.loc5_13.1: type = bind_symbolic_name F, 0, %F.param [symbolic = %F.loc5_13.2 (constants.%F.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [symbolic = constants.%G] {
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %F.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %F.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %F.loc13_10: type = bind_symbolic_name F, 0, %F.param [symbolic = constants.%F.8b3]
 // CHECK:STDOUT:     %int_32.loc13: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -505,7 +505,7 @@ import library "extern_api";
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %a.patt
@@ -666,7 +666,7 @@ import library "extern_api";
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B [template = constants.%B] {} {
 // CHECK:STDOUT:     %int_32.loc23_24: Core.IntLiteral = int_value 32 [template = constants.%int_32]
@@ -857,7 +857,7 @@ import library "extern_api";
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B [template = constants.%B] {} {
 // CHECK:STDOUT:     %int_32.loc7_24: Core.IntLiteral = int_value 32 [template = constants.%int_32]
@@ -1052,7 +1052,7 @@ import library "extern_api";
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a
 // CHECK:STDOUT:     %.loc52_1: %empty_tuple.type = var_pattern %a.patt
@@ -1217,7 +1217,7 @@ import library "extern_api";
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a
 // CHECK:STDOUT:     %.loc52_1: %empty_tuple.type = var_pattern %a.patt
@@ -1346,7 +1346,7 @@ import library "extern_api";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- unloaded_extern.carbon
@@ -1376,6 +1376,6 @@ import library "extern_api";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/export_name.carbon
@@ -69,7 +69,7 @@ var f: () = F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F: %F.type = export F, imports.%Main.F [template = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -92,7 +92,7 @@ var f: () = F();
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %f.patt

--- a/toolchain/check/testdata/function/declaration/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/extern.carbon
@@ -114,7 +114,7 @@ extern library "basic" fn F();
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %empty_tuple.type = binding_pattern x
 // CHECK:STDOUT:     %.loc4_1: %empty_tuple.type = var_pattern %x.patt
@@ -227,7 +227,7 @@ extern library "basic" fn F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = invalid
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/extern_library.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/extern_library.carbon
@@ -186,7 +186,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -206,7 +206,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -226,7 +226,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -246,7 +246,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = invalid
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -278,7 +278,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- extern_library_mismatch.carbon
@@ -347,7 +347,7 @@ extern library "extern_library_owner" fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = invalid
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/extern_library_for_default.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/extern_library_for_default.carbon
@@ -68,7 +68,7 @@ extern fn F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -88,7 +88,7 @@ extern fn F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/extern_library_from_default.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/extern_library_from_default.carbon
@@ -66,7 +66,7 @@ extern fn F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -86,7 +86,7 @@ extern fn F();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/fail_import_incomplete_return.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/fail_import_incomplete_return.carbon
@@ -220,7 +220,7 @@ fn CallFAndGIncomplete() {
 // CHECK:STDOUT:     .Call = imports.%Main.Call
 // CHECK:STDOUT:     .CallFAndGIncomplete = %CallFAndGIncomplete.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %CallFAndGIncomplete.decl: %CallFAndGIncomplete.type = fn_decl @CallFAndGIncomplete [template = constants.%CallFAndGIncomplete] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/implicit_import.carbon
@@ -94,8 +94,8 @@ extern fn A();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -134,8 +134,8 @@ extern fn A();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -171,8 +171,8 @@ extern fn A();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
@@ -631,7 +631,7 @@ fn F() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc18_3: %D.elem = var_pattern %.loc18_9
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %D.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.C1 [template = constants.%complete_type.ec1]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -1005,7 +1005,7 @@ fn F() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:   %.loc12: type = bind_alias <invalid>, %C.decl [template = constants.%C]
+// CHECK:STDOUT:   %.loc12: type = bind_alias <none>, %C.decl [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
@@ -1038,7 +1038,7 @@ fn F() {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .N = imports.%N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1072,8 +1072,8 @@ fn F() {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .N = imports.%N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1275,7 +1275,7 @@ fn F() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc9_5: %B.elem = var_pattern %.loc9_10
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
 // CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.96d] {} {}
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [template = constants.%complete_type.57e]
 // CHECK:STDOUT:   complete_type_witness = %complete_type

--- a/toolchain/check/testdata/function/declaration/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/no_definition_in_impl_file.carbon
@@ -102,8 +102,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl.loc4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl.loc4: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %A.decl.loc6: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
@@ -129,8 +129,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_only_in_api.carbon
@@ -159,8 +159,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_in_api_decl_in_impl.carbon
@@ -193,8 +193,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.decl: %C.type = fn_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -217,8 +217,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %D.decl: %D.type = fn_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -287,7 +287,7 @@ fn D() {}
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %a.patt
@@ -391,7 +391,7 @@ fn D() {}
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {}
 // CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B [template = constants.%B] {} {
 // CHECK:STDOUT:     %int_32.loc23_17: Core.IntLiteral = int_value 32 [template = constants.%int_32]
@@ -436,7 +436,7 @@ fn D() {}
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %A.decl.loc14: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %A.decl.loc24: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
@@ -472,7 +472,7 @@ fn D() {}
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %D.decl.loc14: %D.type = fn_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %D.decl.loc16: %D.type = fn_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/definition/import_access.carbon
+++ b/toolchain/check/testdata/function/definition/import_access.carbon
@@ -241,7 +241,7 @@ private fn Redecl() {}
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
@@ -284,7 +284,7 @@ private fn Redecl() {}
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
 // CHECK:STDOUT:     %.loc10_1: %empty_tuple.type = var_pattern %f.patt
@@ -371,7 +371,7 @@ private fn Redecl() {}
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
@@ -414,7 +414,7 @@ private fn Redecl() {}
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
 // CHECK:STDOUT:     %.loc10_1: %empty_tuple.type = var_pattern %f.patt
@@ -501,7 +501,7 @@ private fn Redecl() {}
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
@@ -548,7 +548,7 @@ private fn Redecl() {}
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %empty_tuple.type = binding_pattern f
 // CHECK:STDOUT:     %.loc10_1: %empty_tuple.type = var_pattern %f.patt

--- a/toolchain/check/testdata/function/definition/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/extern.carbon
@@ -180,8 +180,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -288,8 +288,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/extern_library.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/extern_library.carbon
@@ -189,8 +189,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -245,8 +245,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -281,7 +281,7 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_indirect_two_file.impl.carbon
@@ -298,8 +298,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -344,8 +344,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/implicit_import.carbon
@@ -151,8 +151,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -191,8 +191,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -231,8 +231,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -274,8 +274,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -317,8 +317,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -367,8 +367,8 @@ fn B() {}
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/syntactic_merge.carbon
@@ -466,8 +466,8 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .Bar = %Bar.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = fn_decl @Foo [template = constants.%Foo] {
 // CHECK:STDOUT:     %a.patt: %C = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt, runtime_param0
@@ -636,17 +636,17 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = fn_decl @Foo [template = constants.%Foo] {
 // CHECK:STDOUT:     %a.patt.loc7_8.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_8.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_8.1, runtime_param<invalid> [symbolic = %a.patt.loc7_8.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_8.1, runtime_param<none> [symbolic = %a.patt.loc7_8.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_8.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_8.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {
 // CHECK:STDOUT:     %a.patt.loc15_8.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc15_8.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_8.1, runtime_param<invalid> [symbolic = %a.patt.loc15_8.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_8.1, runtime_param<none> [symbolic = %a.patt.loc15_8.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc15_8.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc15_8.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -801,8 +801,8 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = fn_decl @Foo [template = constants.%Foo] {

--- a/toolchain/check/testdata/function/generic/deduce.carbon
+++ b/toolchain/check/testdata/function/generic/deduce.carbon
@@ -234,13 +234,13 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ExplicitGenericParam.decl: %ExplicitGenericParam.type = fn_decl @ExplicitGenericParam [template = constants.%ExplicitGenericParam] {
 // CHECK:STDOUT:     %T.patt.loc4_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<invalid> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<none> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %return.patt: @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr.79f) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr.79f) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_38: type = name_ref T, %T.loc4_25.1 [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc4_39.1: type = ptr_type %T [symbolic = %ptr.loc4_39.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %return.param: ref @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr.79f) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr.79f) = return_slot %return.param
@@ -257,14 +257,14 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallExplicitGenericParamWithGenericArg.decl: %CallExplicitGenericParamWithGenericArg.type = fn_decl @CallExplicitGenericParamWithGenericArg [template = constants.%CallExplicitGenericParamWithGenericArg] {
 // CHECK:STDOUT:     %T.patt.loc10_43.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc10_43.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10_43.1, runtime_param<invalid> [symbolic = %T.patt.loc10_43.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10_43.1, runtime_param<none> [symbolic = %T.patt.loc10_43.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %return.patt: @CallExplicitGenericParamWithGenericArg.%ptr.loc10_63.2 (%ptr.48a) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @CallExplicitGenericParamWithGenericArg.%ptr.loc10_63.2 (%ptr.48a) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc10: type = name_ref T, %T.loc10_43.1 [symbolic = %T.loc10_43.2 (constants.%T)]
 // CHECK:STDOUT:     %struct_type.a.loc10_62.1: type = struct_type {.a: %T} [symbolic = %struct_type.a.loc10_62.2 (constants.%struct_type.a)]
 // CHECK:STDOUT:     %ptr.loc10_63.1: type = ptr_type %struct_type.a [symbolic = %ptr.loc10_63.2 (constants.%ptr.48a)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc10_43.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc10_43.2 (constants.%T)]
 // CHECK:STDOUT:     %return.param: ref @CallExplicitGenericParamWithGenericArg.%ptr.loc10_63.2 (%ptr.48a) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @CallExplicitGenericParamWithGenericArg.%ptr.loc10_63.2 (%ptr.48a) = return_slot %return.param
@@ -401,22 +401,22 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ExplicitGenericParam.decl: %ExplicitGenericParam.type = fn_decl @ExplicitGenericParam [template = constants.%ExplicitGenericParam] {
 // CHECK:STDOUT:     %T.patt.loc4_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<invalid> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<none> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %return.patt: @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_38: type = name_ref T, %T.loc4_25.1 [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc4_39.1: type = ptr_type %T [symbolic = %ptr.loc4_39.2 (constants.%ptr)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %return.param: ref @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @ExplicitGenericParam.%ptr.loc4_39.2 (%ptr) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallExplicitGenericParamConst.decl: %CallExplicitGenericParamConst.type = fn_decl @CallExplicitGenericParamConst [template = constants.%CallExplicitGenericParamConst] {
 // CHECK:STDOUT:     %T.patt.loc6_34.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_34.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_34.1, runtime_param<invalid> [symbolic = %T.patt.loc6_34.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_34.1, runtime_param<none> [symbolic = %T.patt.loc6_34.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_34.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_34.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallExplicitGenericParamNonConst.decl: %CallExplicitGenericParamNonConst.type = fn_decl @CallExplicitGenericParamNonConst [template = constants.%CallExplicitGenericParamNonConst] {
@@ -534,7 +534,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %ExplicitAndAlsoDeduced.decl: %ExplicitAndAlsoDeduced.type = fn_decl @ExplicitAndAlsoDeduced [template = constants.%ExplicitAndAlsoDeduced] {
 // CHECK:STDOUT:     %T.patt.loc6_27.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_27.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_27.1, runtime_param<invalid> [symbolic = %T.patt.loc6_27.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_27.1, runtime_param<none> [symbolic = %T.patt.loc6_27.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @ExplicitAndAlsoDeduced.%T.loc6_27.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @ExplicitAndAlsoDeduced.%T.loc6_27.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @ExplicitAndAlsoDeduced.%ptr.loc6_47.2 (%ptr.79f) = return_slot_pattern
@@ -542,7 +542,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6_46: type = name_ref T, %T.loc6_27.1 [symbolic = %T.loc6_27.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc6_47.1: type = ptr_type %T [symbolic = %ptr.loc6_47.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_27.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_27.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @ExplicitAndAlsoDeduced.%T.loc6_27.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc6_40: type = name_ref T, %T.loc6_27.1 [symbolic = %T.loc6_27.2 (constants.%T)]
@@ -672,7 +672,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ImplicitGenericParam.decl: %ImplicitGenericParam.type = fn_decl @ImplicitGenericParam [template = constants.%ImplicitGenericParam] {
 // CHECK:STDOUT:     %T.patt.loc4_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<invalid> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<none> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @ImplicitGenericParam.%T.loc4_25.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @ImplicitGenericParam.%T.loc4_25.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @ImplicitGenericParam.%ptr.loc4_45.2 (%ptr.79f) = return_slot_pattern
@@ -680,7 +680,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_44: type = name_ref T, %T.loc4_25.1 [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc4_45.1: type = ptr_type %T [symbolic = %ptr.loc4_45.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @ImplicitGenericParam.%T.loc4_25.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_38: type = name_ref T, %T.loc4_25.1 [symbolic = %T.loc4_25.2 (constants.%T)]
@@ -814,11 +814,11 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %TupleParam.decl: %TupleParam.type = fn_decl @TupleParam [template = constants.%TupleParam] {
 // CHECK:STDOUT:     %T.patt.loc4_15.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<invalid> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_15.1, runtime_param<none> [symbolic = %T.patt.loc4_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @TupleParam.%tuple.type (%tuple.type.f83) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @TupleParam.%tuple.type (%tuple.type.f83) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_15.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_15.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @TupleParam.%tuple.type (%tuple.type.f83) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc4_35.1: type = splice_block %.loc4_35.3 [symbolic = %tuple.type (constants.%tuple.type.f83)] {
@@ -929,11 +929,11 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %StructParam.decl: %StructParam.type = fn_decl @StructParam [template = constants.%StructParam] {
 // CHECK:STDOUT:     %T.patt.loc4_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<invalid> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<none> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @StructParam.%struct_type.a.b.loc4_44.2 (%struct_type.a.b.46e) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @StructParam.%struct_type.a.b.loc4_44.2 (%struct_type.a.b.46e) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_16.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @StructParam.%struct_type.a.b.loc4_44.2 (%struct_type.a.b.46e) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc4: type = splice_block %struct_type.a.b.loc4_44.1 [symbolic = %struct_type.a.b.loc4_44.2 (constants.%struct_type.a.b.46e)] {
@@ -1030,11 +1030,11 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %BigStructParam.decl: %BigStructParam.type = fn_decl @BigStructParam [template = constants.%BigStructParam] {
 // CHECK:STDOUT:     %T.patt.loc4_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<invalid> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<none> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @BigStructParam.%struct_type.c.d.e.loc4_56.2 (%struct_type.c.d.e) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @BigStructParam.%struct_type.c.d.e.loc4_56.2 (%struct_type.c.d.e) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_19.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @BigStructParam.%struct_type.c.d.e.loc4_56.2 (%struct_type.c.d.e) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc4: type = splice_block %struct_type.c.d.e.loc4_56.1 [symbolic = %struct_type.c.d.e.loc4_56.2 (constants.%struct_type.c.d.e)] {
@@ -1115,11 +1115,11 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %SmallStructParam.decl: %SmallStructParam.type = fn_decl @SmallStructParam [template = constants.%SmallStructParam] {
 // CHECK:STDOUT:     %T.patt.loc4_21.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_21.1, runtime_param<invalid> [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_21.1, runtime_param<none> [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @SmallStructParam.%struct_type.f.g.loc4_49.2 (%struct_type.f.g) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @SmallStructParam.%struct_type.f.g.loc4_49.2 (%struct_type.f.g) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_21.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_21.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @SmallStructParam.%struct_type.f.g.loc4_49.2 (%struct_type.f.g) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc4: type = splice_block %struct_type.f.g.loc4_49.1 [symbolic = %struct_type.f.g.loc4_49.2 (constants.%struct_type.f.g)] {
@@ -1198,11 +1198,11 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %WrongNameStructParam.decl: %WrongNameStructParam.type = fn_decl @WrongNameStructParam [template = constants.%WrongNameStructParam] {
 // CHECK:STDOUT:     %T.patt.loc4_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<invalid> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<none> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @WrongNameStructParam.%struct_type.i.different.loc4_61.2 (%struct_type.i.different) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @WrongNameStructParam.%struct_type.i.different.loc4_61.2 (%struct_type.i.different) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @WrongNameStructParam.%struct_type.i.different.loc4_61.2 (%struct_type.i.different) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc4: type = splice_block %struct_type.i.different.loc4_61.1 [symbolic = %struct_type.i.different.loc4_61.2 (constants.%struct_type.i.different)] {
@@ -1280,11 +1280,11 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %WrongOrderStructParam.decl: %WrongOrderStructParam.type = fn_decl @WrongOrderStructParam [template = constants.%WrongOrderStructParam] {
 // CHECK:STDOUT:     %T.patt.loc4_26.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_26.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_26.1, runtime_param<invalid> [symbolic = %T.patt.loc4_26.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_26.1, runtime_param<none> [symbolic = %T.patt.loc4_26.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @WrongOrderStructParam.%struct_type.first.second.loc4_63.2 (%struct_type.first.second) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @WrongOrderStructParam.%struct_type.first.second.loc4_63.2 (%struct_type.first.second) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_26.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_26.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @WrongOrderStructParam.%struct_type.first.second.loc4_63.2 (%struct_type.first.second) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc4: type = splice_block %struct_type.first.second.loc4_63.1 [symbolic = %struct_type.first.second.loc4_63.2 (constants.%struct_type.first.second)] {
@@ -1357,18 +1357,18 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ImplicitNotDeducible.decl: %ImplicitNotDeducible.type = fn_decl @ImplicitNotDeducible [template = constants.%ImplicitNotDeducible] {
 // CHECK:STDOUT:     %T.patt.loc6_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_25.1, runtime_param<invalid> [symbolic = %T.patt.loc6_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_25.1, runtime_param<none> [symbolic = %T.patt.loc6_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc6_35.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc6_35.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc6_35.1, runtime_param<invalid> [symbolic = %U.patt.loc6_35.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc6_35.1, runtime_param<none> [symbolic = %U.patt.loc6_35.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %x.patt: @ImplicitNotDeducible.%T.loc6_25.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @ImplicitNotDeducible.%T.loc6_25.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @ImplicitNotDeducible.%U.loc6_35.2 (%U) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @ImplicitNotDeducible.%U.loc6_35.2 (%U) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.ref: type = name_ref U, %U.loc6_35.1 [symbolic = %U.loc6_35.2 (constants.%U)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_25.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc6_35.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc6_35.2 (constants.%U)]
 // CHECK:STDOUT:     %x.param: @ImplicitNotDeducible.%T.loc6_25.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc6_25.1 [symbolic = %T.loc6_25.2 (constants.%T)]
@@ -1432,7 +1432,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ImplicitNotDeducible.decl: %ImplicitNotDeducible.type = fn_decl @ImplicitNotDeducible [template = constants.%ImplicitNotDeducible] {
 // CHECK:STDOUT:     %T.patt.loc4_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<invalid> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_25.1, runtime_param<none> [symbolic = %T.patt.loc4_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @ImplicitNotDeducible.%T.loc4_25.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @ImplicitNotDeducible.%T.loc4_25.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %y.patt: @ImplicitNotDeducible.%T.loc4_25.2 (%T) = binding_pattern y
@@ -1441,7 +1441,7 @@ fn CallImplicitNotDeducible() {
 // CHECK:STDOUT:     %return.param_patt: @ImplicitNotDeducible.%T.loc4_25.2 (%T) = out_param_pattern %return.patt, runtime_param2
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_50: type = name_ref T, %T.loc4_25.1 [symbolic = %T.loc4_25.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_25.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @ImplicitNotDeducible.%T.loc4_25.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_38: type = name_ref T, %T.loc4_25.1 [symbolic = %T.loc4_25.2 (constants.%T)]

--- a/toolchain/check/testdata/function/generic/no_prelude/call.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/call.carbon
@@ -86,14 +86,14 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Function.decl: %Function.type = fn_decl @Function [template = constants.%Function] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @Function.%T.loc4_13.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @Function.%T.loc4_13.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @Function.%T.loc4_13.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @Function.%T.loc4_13.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_32: type = name_ref T, %T.loc4_13.1 [symbolic = %T.loc4_13.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @Function.%T.loc4_13.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_26: type = name_ref T, %T.loc4_13.1 [symbolic = %T.loc4_13.2 (constants.%T)]
@@ -103,14 +103,14 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallGeneric.decl: %CallGeneric.type = fn_decl @CallGeneric [template = constants.%CallGeneric] {
 // CHECK:STDOUT:     %T.patt.loc8_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_16.1, runtime_param<invalid> [symbolic = %T.patt.loc8_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_16.1, runtime_param<none> [symbolic = %T.patt.loc8_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @CallGeneric.%T.loc8_16.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @CallGeneric.%T.loc8_16.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @CallGeneric.%T.loc8_16.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @CallGeneric.%T.loc8_16.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_35: type = name_ref T, %T.loc8_16.1 [symbolic = %T.loc8_16.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_16.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @CallGeneric.%T.loc8_16.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc8_29: type = name_ref T, %T.loc8_16.1 [symbolic = %T.loc8_16.2 (constants.%T)]
@@ -120,7 +120,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallGenericPtr.decl: %CallGenericPtr.type = fn_decl @CallGenericPtr [template = constants.%CallGenericPtr] {
 // CHECK:STDOUT:     %T.patt.loc12_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_19.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_19.1, runtime_param<invalid> [symbolic = %T.patt.loc12_19.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_19.1, runtime_param<none> [symbolic = %T.patt.loc12_19.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = return_slot_pattern
@@ -128,7 +128,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc12_39: type = name_ref T, %T.loc12_19.1 [symbolic = %T.loc12_19.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc12_40: type = ptr_type %T [symbolic = %ptr.loc12_33.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_19.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc12: type = splice_block %ptr.loc12_33.1 [symbolic = %ptr.loc12_33.2 (constants.%ptr.79f)] {
@@ -305,14 +305,14 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Function.decl: %Function.type = fn_decl @Function [template = constants.%Function] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @Function.%T.loc4_13.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @Function.%T.loc4_13.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @Function.%T.loc4_13.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @Function.%T.loc4_13.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_32: type = name_ref T, %T.loc4_13.1 [symbolic = %T.loc4_13.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @Function.%T.loc4_13.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_26: type = name_ref T, %T.loc4_13.1 [symbolic = %T.loc4_13.2 (constants.%T)]
@@ -322,14 +322,14 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallGeneric.decl: %CallGeneric.type = fn_decl @CallGeneric [template = constants.%CallGeneric] {
 // CHECK:STDOUT:     %T.patt.loc8_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_16.1, runtime_param<invalid> [symbolic = %T.patt.loc8_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_16.1, runtime_param<none> [symbolic = %T.patt.loc8_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @CallGeneric.%T.loc8_16.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @CallGeneric.%T.loc8_16.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @CallGeneric.%T.loc8_16.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @CallGeneric.%T.loc8_16.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_35: type = name_ref T, %T.loc8_16.1 [symbolic = %T.loc8_16.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_16.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @CallGeneric.%T.loc8_16.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc8_29: type = name_ref T, %T.loc8_16.1 [symbolic = %T.loc8_16.2 (constants.%T)]
@@ -339,7 +339,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallGenericPtr.decl: %CallGenericPtr.type = fn_decl @CallGenericPtr [template = constants.%CallGenericPtr] {
 // CHECK:STDOUT:     %T.patt.loc12_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_19.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_19.1, runtime_param<invalid> [symbolic = %T.patt.loc12_19.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_19.1, runtime_param<none> [symbolic = %T.patt.loc12_19.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = return_slot_pattern
@@ -347,7 +347,7 @@ fn CallSpecific(x: C) -> C {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc12_39: type = name_ref T, %T.loc12_19.1 [symbolic = %T.loc12_19.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc12_40: type = ptr_type %T [symbolic = %ptr.loc12_33.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_19.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @CallGenericPtr.%ptr.loc12_33.2 (%ptr.79f) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc12: type = splice_block %ptr.loc12_33.1 [symbolic = %ptr.loc12_33.2 (constants.%ptr.79f)] {

--- a/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/fail_type_param_mismatch.carbon
@@ -37,13 +37,13 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc11_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc11_16.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc11_16.1, runtime_param<invalid> [symbolic = %U.patt.loc11_16.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc11_16.1, runtime_param<none> [symbolic = %U.patt.loc11_16.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc11_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc11_16.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/forward_decl.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/forward_decl.carbon
@@ -25,9 +25,9 @@ fn F(T:! type);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/import_specific.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/import_specific.carbon
@@ -54,16 +54,16 @@ fn H() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc4_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<invalid> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<none> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc7_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<invalid> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_6.1, runtime_param<none> [symbolic = %T.patt.loc7_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -143,7 +143,7 @@ fn H() {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:     .H = %H.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/indirect_generic_type.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/indirect_generic_type.carbon
@@ -31,7 +31,7 @@ fn F(T:! type, p: T**) -> T* {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %p.patt: @F.%ptr.loc11_21.2 (%ptr.a13) = binding_pattern p
 // CHECK:STDOUT:     %p.param_patt: @F.%ptr.loc11_21.2 (%ptr.a13) = value_param_pattern %p.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%ptr.loc11_20.2 (%ptr.79f) = return_slot_pattern
@@ -39,7 +39,7 @@ fn F(T:! type, p: T**) -> T* {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc11_27: type = name_ref T, %T.loc11_6.1 [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc11_28: type = ptr_type %T [symbolic = %ptr.loc11_20.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:     %p.param: @F.%ptr.loc11_21.2 (%ptr.a13) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc11: type = splice_block %ptr.loc11_21.1 [symbolic = %ptr.loc11_21.2 (constants.%ptr.a13)] {

--- a/toolchain/check/testdata/function/generic/no_prelude/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/type_param.carbon
@@ -31,9 +31,9 @@ fn F(T:! type) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/generic/no_prelude/type_param_scope.carbon
+++ b/toolchain/check/testdata/function/generic/no_prelude/type_param_scope.carbon
@@ -29,14 +29,14 @@ fn F(T:! type, n: T) -> T {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<invalid> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %n.patt: @F.%T.loc11_6.2 (%T) = binding_pattern n
 // CHECK:STDOUT:     %n.param_patt: @F.%T.loc11_6.2 (%T) = value_param_pattern %n.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @F.%T.loc11_6.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%T.loc11_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc11_25: type = name_ref T, %T.loc11_6.1 [symbolic = %T.loc11_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:     %n.param: @F.%T.loc11_6.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc11_19: type = name_ref T, %T.loc11_6.1 [symbolic = %T.loc11_6.2 (constants.%T)]

--- a/toolchain/check/testdata/function/generic/param_in_type.carbon
+++ b/toolchain/check/testdata/function/generic/param_in_type.carbon
@@ -47,11 +47,11 @@ fn F(N:! i32, a: [i32; N]*);
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %N.patt.loc11_6.1: %i32 = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc11_6.2 (constants.%N.patt.8e2)]
-// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc11_6.1, runtime_param<invalid> [symbolic = %N.patt.loc11_6.2 (constants.%N.patt.8e2)]
+// CHECK:STDOUT:     %N.param_patt: %i32 = value_param_pattern %N.patt.loc11_6.1, runtime_param<none> [symbolic = %N.patt.loc11_6.2 (constants.%N.patt.8e2)]
 // CHECK:STDOUT:     %a.patt: @F.%ptr.loc11_26.2 (%ptr) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @F.%ptr.loc11_26.2 (%ptr) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_10: type = splice_block %i32.loc11_10 [template = constants.%i32] {
 // CHECK:STDOUT:       %int_32.loc11_10: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc11_10: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -117,26 +117,26 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl.loc4: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:     %return.patt: %ptr = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %ptr = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4: type = name_ref T, %T.loc4_6.1 [symbolic = %T.loc4_6.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc4_20.1: type = ptr_type %T [symbolic = %ptr.loc4_20.2 (constants.%ptr)]
-// CHECK:STDOUT:     %T.param.loc4: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc4: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_6.1: type = bind_symbolic_name T, 0, %T.param.loc4 [symbolic = %T.loc4_6.2 (constants.%T)]
 // CHECK:STDOUT:     %return.param.loc4: ref @F.%ptr.loc4_20.2 (%ptr) = out_param runtime_param0
 // CHECK:STDOUT:     %return.loc4: ref @F.%ptr.loc4_20.2 (%ptr) = return_slot %return.param.loc4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl.loc6: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:     %return.patt: %ptr = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %ptr = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc6: type = name_ref T, %T.loc6 [symbolic = constants.%T]
 // CHECK:STDOUT:     %ptr.loc6: type = ptr_type %T [symbolic = constants.%ptr]
-// CHECK:STDOUT:     %T.param.loc6: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc6: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6: type = bind_symbolic_name T, 0, %T.param.loc6 [symbolic = constants.%T]
 // CHECK:STDOUT:     %return.param.loc6: ref %ptr = out_param runtime_param0
 // CHECK:STDOUT:     %return.loc6: ref %ptr = return_slot %return.param.loc6
@@ -207,34 +207,34 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc4_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<invalid> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<none> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc4_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc4_16.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_16.1, runtime_param<invalid> [symbolic = %U.patt.loc4_16.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_16.1, runtime_param<none> [symbolic = %U.patt.loc4_16.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %return.patt: @F.%ptr.loc4_30.2 (%ptr.79f) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%ptr.loc4_30.2 (%ptr.79f) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_6.1 [symbolic = %T.loc4_6.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc4_30.1: type = ptr_type %T [symbolic = %ptr.loc4_30.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_6.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc4_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc4_16.2 (constants.%U)]
 // CHECK:STDOUT:     %return.param: ref @F.%ptr.loc4_30.2 (%ptr.79f) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @F.%ptr.loc4_30.2 (%ptr.79f) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {
 // CHECK:STDOUT:     %T.patt.loc13_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_6.1, runtime_param<invalid> [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_6.1, runtime_param<none> [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc13_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc13_16.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_16.1, runtime_param<invalid> [symbolic = %U.patt.loc13_16.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_16.1, runtime_param<none> [symbolic = %U.patt.loc13_16.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %return.patt: @.1.%ptr.loc13_30.2 (%ptr.b51) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @.1.%ptr.loc13_30.2 (%ptr.b51) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.ref: type = name_ref U, %U.loc13_16.1 [symbolic = %U.loc13_16.2 (constants.%U)]
 // CHECK:STDOUT:     %ptr.loc13_30.1: type = ptr_type %U [symbolic = %ptr.loc13_30.2 (constants.%ptr.b51)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_6.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc13_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc13_16.2 (constants.%U)]
 // CHECK:STDOUT:     %return.param: ref @.1.%ptr.loc13_30.2 (%ptr.b51) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @.1.%ptr.loc13_30.2 (%ptr.b51) = return_slot %return.param
@@ -320,34 +320,34 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc4_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_6.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<invalid> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<none> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:     %U.patt.loc4_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc4_16.2 (constants.%U.patt.7a9)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_16.1, runtime_param<invalid> [symbolic = %U.patt.loc4_16.2 (constants.%U.patt.7a9)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_16.1, runtime_param<none> [symbolic = %U.patt.loc4_16.2 (constants.%U.patt.7a9)]
 // CHECK:STDOUT:     %return.patt: @F.%ptr.loc4_30.2 (%ptr.79f) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%ptr.loc4_30.2 (%ptr.79f) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_6.1 [symbolic = %T.loc4_6.2 (constants.%T.8b3)]
 // CHECK:STDOUT:     %ptr.loc4_30.1: type = ptr_type %T.8b3 [symbolic = %ptr.loc4_30.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_6.2 (constants.%T.8b3)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc4_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc4_16.2 (constants.%U.336)]
 // CHECK:STDOUT:     %return.param: ref @F.%ptr.loc4_30.2 (%ptr.79f) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @F.%ptr.loc4_30.2 (%ptr.79f) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {
 // CHECK:STDOUT:     %U.patt.loc13_6.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc13_6.2 (constants.%U.patt.e01)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_6.1, runtime_param<invalid> [symbolic = %U.patt.loc13_6.2 (constants.%U.patt.e01)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_6.1, runtime_param<none> [symbolic = %U.patt.loc13_6.2 (constants.%U.patt.e01)]
 // CHECK:STDOUT:     %T.patt.loc13_16.1: type = symbolic_binding_pattern T, 1 [symbolic = %T.patt.loc13_16.2 (constants.%T.patt.7a9)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_16.1, runtime_param<invalid> [symbolic = %T.patt.loc13_16.2 (constants.%T.patt.7a9)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_16.1, runtime_param<none> [symbolic = %T.patt.loc13_16.2 (constants.%T.patt.7a9)]
 // CHECK:STDOUT:     %return.patt: @.1.%ptr.loc13_30.2 (%ptr.b51) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @.1.%ptr.loc13_30.2 (%ptr.b51) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc13: type = name_ref T, %T.loc13_16.1 [symbolic = %T.loc13_16.2 (constants.%T.336)]
 // CHECK:STDOUT:     %ptr.loc13_30.1: type = ptr_type %T.336 [symbolic = %ptr.loc13_30.2 (constants.%ptr.b51)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc13_6.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc13_6.2 (constants.%U.8b3)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_16.1: type = bind_symbolic_name T, 1, %T.param [symbolic = %T.loc13_16.2 (constants.%T.336)]
 // CHECK:STDOUT:     %return.param: ref @.1.%ptr.loc13_30.2 (%ptr.b51) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @.1.%ptr.loc13_30.2 (%ptr.b51) = return_slot %return.param
@@ -433,34 +433,34 @@ fn F(U:! type, T:! type) -> U* {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc4_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_6.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<invalid> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_6.1, runtime_param<none> [symbolic = %T.patt.loc4_6.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:     %U.patt.loc4_16.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc4_16.2 (constants.%U.patt.7a9)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_16.1, runtime_param<invalid> [symbolic = %U.patt.loc4_16.2 (constants.%U.patt.7a9)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc4_16.1, runtime_param<none> [symbolic = %U.patt.loc4_16.2 (constants.%U.patt.7a9)]
 // CHECK:STDOUT:     %return.patt: @F.%ptr.loc4_30.2 (%ptr.79f131.1) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @F.%ptr.loc4_30.2 (%ptr.79f131.1) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_6.1 [symbolic = %T.loc4_6.2 (constants.%T.8b3)]
 // CHECK:STDOUT:     %ptr.loc4_30.1: type = ptr_type %T.8b3 [symbolic = %ptr.loc4_30.2 (constants.%ptr.79f131.1)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_6.2 (constants.%T.8b3)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc4_16.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc4_16.2 (constants.%U.336)]
 // CHECK:STDOUT:     %return.param: ref @F.%ptr.loc4_30.2 (%ptr.79f131.1) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @F.%ptr.loc4_30.2 (%ptr.79f131.1) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {
 // CHECK:STDOUT:     %U.patt.loc13_6.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc13_6.2 (constants.%U.patt.e01)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_6.1, runtime_param<invalid> [symbolic = %U.patt.loc13_6.2 (constants.%U.patt.e01)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc13_6.1, runtime_param<none> [symbolic = %U.patt.loc13_6.2 (constants.%U.patt.e01)]
 // CHECK:STDOUT:     %T.patt.loc13_16.1: type = symbolic_binding_pattern T, 1 [symbolic = %T.patt.loc13_16.2 (constants.%T.patt.7a9)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_16.1, runtime_param<invalid> [symbolic = %T.patt.loc13_16.2 (constants.%T.patt.7a9)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_16.1, runtime_param<none> [symbolic = %T.patt.loc13_16.2 (constants.%T.patt.7a9)]
 // CHECK:STDOUT:     %return.patt: @.1.%ptr.loc13_30.2 (%ptr.79f131.2) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @.1.%ptr.loc13_30.2 (%ptr.79f131.2) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.ref: type = name_ref U, %U.loc13_6.1 [symbolic = %U.loc13_6.2 (constants.%U.8b3)]
 // CHECK:STDOUT:     %ptr.loc13_30.1: type = ptr_type %U.8b3 [symbolic = %ptr.loc13_30.2 (constants.%ptr.79f131.2)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc13_6.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc13_6.2 (constants.%U.8b3)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_16.1: type = bind_symbolic_name T, 1, %T.param [symbolic = %T.loc13_16.2 (constants.%T.336)]
 // CHECK:STDOUT:     %return.param: ref @.1.%ptr.loc13_30.2 (%ptr.79f131.2) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @.1.%ptr.loc13_30.2 (%ptr.79f131.2) = return_slot %return.param

--- a/toolchain/check/testdata/function/generic/resolve_used.carbon
+++ b/toolchain/check/testdata/function/generic/resolve_used.carbon
@@ -76,9 +76,9 @@ fn CallNegative() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ErrorIfNIsZero.decl: %ErrorIfNIsZero.type = fn_decl @ErrorIfNIsZero [template = constants.%ErrorIfNIsZero] {
 // CHECK:STDOUT:     %N.patt.loc4_19.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc4_19.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc4_19.1, runtime_param<invalid> [symbolic = %N.patt.loc4_19.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc4_19.1, runtime_param<none> [symbolic = %N.patt.loc4_19.2 (constants.%N.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc4_39.1: type = splice_block %.loc4_39.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %Core.ref.loc4: <namespace> = name_ref Core, imports.%Core [template = imports.%Core]
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, imports.%Core.IntLiteral [template = constants.%IntLiteral]

--- a/toolchain/check/testdata/function/generic/return_slot.carbon
+++ b/toolchain/check/testdata/function/generic/return_slot.carbon
@@ -80,9 +80,9 @@ fn G() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Wrap.decl: %Wrap.type = class_decl @Wrap [template = constants.%Wrap.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_12.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_12.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_12.1, runtime_param<invalid> [symbolic = %T.patt.loc11_12.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_12.1, runtime_param<none> [symbolic = %T.patt.loc11_12.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_12.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_12.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
@@ -120,7 +120,7 @@ fn G() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc15_11: %C.elem = var_pattern %.loc15_18
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.arr.5f2 [template = constants.%complete_type.22a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/undefined.carbon
+++ b/toolchain/check/testdata/function/generic/undefined.carbon
@@ -94,14 +94,14 @@ fn CallUndefined() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Defined.decl: %Defined.type = fn_decl @Defined [template = constants.%Defined] {
 // CHECK:STDOUT:     %T.patt.loc4_12.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_12.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_12.1, runtime_param<invalid> [symbolic = %T.patt.loc4_12.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_12.1, runtime_param<none> [symbolic = %T.patt.loc4_12.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @Defined.%T.loc4_12.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @Defined.%T.loc4_12.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @Defined.%T.loc4_12.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @Defined.%T.loc4_12.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_31: type = name_ref T, %T.loc4_12.1 [symbolic = %T.loc4_12.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_12.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_12.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @Defined.%T.loc4_12.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_25: type = name_ref T, %T.loc4_12.1 [symbolic = %T.loc4_12.2 (constants.%T)]
@@ -209,14 +209,14 @@ fn CallUndefined() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Defined.decl.loc4: %Defined.type = fn_decl @Defined [template = constants.%Defined] {
 // CHECK:STDOUT:     %T.patt.loc10: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:     %x.patt: %T = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: %T = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %T = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %T = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_31: type = name_ref T, %T.loc4_12.1 [symbolic = %T.loc4_12.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param.loc4: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc4: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_12.1: type = bind_symbolic_name T, 0, %T.param.loc4 [symbolic = %T.loc4_12.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param.loc4: @Defined.%T.loc4_12.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_25: type = name_ref T, %T.loc4_12.1 [symbolic = %T.loc4_12.2 (constants.%T)]
@@ -235,14 +235,14 @@ fn CallUndefined() -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Defined.decl.loc10: %Defined.type = fn_decl @Defined [template = constants.%Defined] {
 // CHECK:STDOUT:     %T.patt.loc10: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10, runtime_param<invalid> [symbolic = constants.%T.patt]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10, runtime_param<none> [symbolic = constants.%T.patt]
 // CHECK:STDOUT:     %x.patt: %T = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: %T = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: %T = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %T = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc10_31: type = name_ref T, %T.loc10 [symbolic = constants.%T]
-// CHECK:STDOUT:     %T.param.loc10: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc10: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc10: type = bind_symbolic_name T, 0, %T.param.loc10 [symbolic = constants.%T]
 // CHECK:STDOUT:     %x.param.loc10: %T = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc10_25: type = name_ref T, %T.loc10 [symbolic = constants.%T]
@@ -338,14 +338,14 @@ fn CallUndefined() -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Undefined.decl: %Undefined.type = fn_decl @Undefined [template = constants.%Undefined] {
 // CHECK:STDOUT:     %T.patt.loc4_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_14.1, runtime_param<invalid> [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_14.1, runtime_param<none> [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @Undefined.%T.loc4_14.2 (%T) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @Undefined.%T.loc4_14.2 (%T) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @Undefined.%T.loc4_14.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @Undefined.%T.loc4_14.2 (%T) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc4_33: type = name_ref T, %T.loc4_14.1 [symbolic = %T.loc4_14.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_14.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @Undefined.%T.loc4_14.2 (%T) = value_param runtime_param0
 // CHECK:STDOUT:     %T.ref.loc4_27: type = name_ref T, %T.loc4_14.1 [symbolic = %T.loc4_14.2 (constants.%T)]

--- a/toolchain/check/testdata/generic/complete_type.carbon
+++ b/toolchain/check/testdata/generic/complete_type.carbon
@@ -117,9 +117,9 @@ fn G() { F(B); }
 // CHECK:STDOUT:   %B.decl.loc4: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   %A.decl: %A.type = class_decl @A [template = constants.%A.generic] {
 // CHECK:STDOUT:     %T.patt.loc6_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_9.1, runtime_param<invalid> [symbolic = %T.patt.loc6_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_9.1, runtime_param<none> [symbolic = %T.patt.loc6_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
@@ -161,7 +161,7 @@ fn G() { F(B); }
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc13_3: @A.%A.elem (%A.elem.1ce) = var_pattern %.loc13_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @A.%A.elem (%A.elem.1ce) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @A.%A.elem (%A.elem.1ce) = var <none>
 // CHECK:STDOUT:     %complete_type.loc14_1.1: <witness> = complete_type_witness %struct_type.v.ff1 [symbolic = %complete_type.loc14_1.2 (constants.%complete_type.460)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc14_1.1
 // CHECK:STDOUT:
@@ -230,9 +230,9 @@ fn G() { F(B); }
 // CHECK:STDOUT:   %B.decl.loc4: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
@@ -322,9 +322,9 @@ fn G() { F(B); }
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc6_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<invalid> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_6.1, runtime_param<none> [symbolic = %T.patt.loc6_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}

--- a/toolchain/check/testdata/generic/local.carbon
+++ b/toolchain/check/testdata/generic/local.carbon
@@ -111,7 +111,7 @@ class C(C:! type) {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc6_5: @C.%C.elem (%C.elem.cca) = var_pattern %.loc6_10
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.cca) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @C.%C.elem (%C.elem.cca) = var <none>
 // CHECK:STDOUT:     %complete_type.loc7_3.1: <witness> = complete_type_witness %struct_type.x.2ac [symbolic = %complete_type.loc7_3.2 (constants.%complete_type.4339)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc7_3.1
 // CHECK:STDOUT:
@@ -125,9 +125,9 @@ class C(C:! type) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc5_11.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc5_11.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_11.1, runtime_param<invalid> [symbolic = %T.patt.loc5_11.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_11.1, runtime_param<none> [symbolic = %T.patt.loc5_11.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc5_11.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc5_11.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   name_binding_decl {
@@ -225,9 +225,9 @@ class C(C:! type) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.decl: %.type = class_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %C.patt.loc13_11.1: type = symbolic_binding_pattern C, 0 [symbolic = %C.patt.loc13_11.2 (constants.%C.patt)]
-// CHECK:STDOUT:     %C.param_patt: type = value_param_pattern %C.patt.loc13_11.1, runtime_param<invalid> [symbolic = %C.patt.loc13_11.2 (constants.%C.patt)]
+// CHECK:STDOUT:     %C.param_patt: type = value_param_pattern %C.patt.loc13_11.1, runtime_param<none> [symbolic = %C.patt.loc13_11.2 (constants.%C.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %C.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.loc13_11.1: type = bind_symbolic_name C, 0, %C.param [symbolic = %C.loc13_11.2 (constants.%C)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   return
@@ -265,9 +265,9 @@ class C(C:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %C.patt.loc4_9.1: type = symbolic_binding_pattern C, 0 [symbolic = %C.patt.loc4_9.2 (constants.%C.patt)]
-// CHECK:STDOUT:     %C.param_patt: type = value_param_pattern %C.patt.loc4_9.1, runtime_param<invalid> [symbolic = %C.patt.loc4_9.2 (constants.%C.patt)]
+// CHECK:STDOUT:     %C.param_patt: type = value_param_pattern %C.patt.loc4_9.1, runtime_param<none> [symbolic = %C.patt.loc4_9.2 (constants.%C.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %C.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.loc4_9.1: type = bind_symbolic_name C, 0, %C.param [symbolic = %C.loc4_9.2 (constants.%C.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -116,7 +116,7 @@ class C {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc54_3: %C.elem = var_pattern %.loc54_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/extend_impl_generic.carbon
+++ b/toolchain/check/testdata/impl/extend_impl_generic.carbon
@@ -112,9 +112,9 @@ class X(U:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %HasF.decl: %HasF.type.fe3 = interface_decl @HasF [template = constants.%HasF.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<invalid> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<none> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_16.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Param.decl: type = class_decl @Param [template = constants.%Param] {} {}
@@ -180,7 +180,7 @@ class X(U:! type) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc9_3: %Param.elem = var_pattern %.loc9_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %Param.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %Param.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x.ed6 [template = constants.%complete_type.1ec]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -349,16 +349,16 @@ class X(U:! type) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.decl: %X.type = class_decl @X [template = constants.%X.generic] {
 // CHECK:STDOUT:     %U.patt.loc8_9.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc8_9.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc8_9.1, runtime_param<invalid> [symbolic = %U.patt.loc8_9.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc8_9.1, runtime_param<none> [symbolic = %U.patt.loc8_9.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc8_9.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc8_9.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -62,9 +62,9 @@ class C {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %GenericInterface.decl: %GenericInterface.type.c92 = interface_decl @GenericInterface [template = constants.%GenericInterface.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_28.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_28.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_28.1, runtime_param<invalid> [symbolic = %T.patt.loc11_28.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_28.1, runtime_param<none> [symbolic = %T.patt.loc11_28.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_28.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_28.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
@@ -131,13 +131,13 @@ class C {
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc20_23.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_23.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_23.1, runtime_param<invalid> [symbolic = %T.patt.loc20_23.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_23.1, runtime_param<none> [symbolic = %T.patt.loc20_23.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
 // CHECK:STDOUT:     %GenericInterface.ref: %GenericInterface.type.c92 = name_ref GenericInterface, file.%GenericInterface.decl [template = constants.%GenericInterface.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc20_23.1 [symbolic = %T.loc20_23.2 (constants.%T)]
 // CHECK:STDOUT:     %GenericInterface.type.loc20_54.1: type = facet_type <@GenericInterface, @GenericInterface(constants.%T)> [symbolic = %GenericInterface.type.loc20_54.2 (constants.%GenericInterface.type.3fe)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc20_23.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc20_23.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]

--- a/toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
+++ b/toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
@@ -71,13 +71,13 @@ impl i32 as I {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_9.1, runtime_param<invalid> [symbolic = %T.patt.loc11_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_9.1, runtime_param<none> [symbolic = %T.patt.loc11_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %X.patt.loc11_19.1: @C.%T.loc11_9.2 (%T) = symbolic_binding_pattern X, 1 [symbolic = %X.patt.loc11_19.2 (constants.%X.patt)]
-// CHECK:STDOUT:     %X.param_patt: @C.%T.loc11_9.2 (%T) = value_param_pattern %X.patt.loc11_19.1, runtime_param<invalid> [symbolic = %X.patt.loc11_19.2 (constants.%X.patt)]
+// CHECK:STDOUT:     %X.param_patt: @C.%T.loc11_9.2 (%T) = value_param_pattern %X.patt.loc11_19.1, runtime_param<none> [symbolic = %X.patt.loc11_19.2 (constants.%X.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_9.2 (constants.%T)]
-// CHECK:STDOUT:     %X.param: @C.%T.loc11_9.2 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %X.param: @C.%T.loc11_9.2 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_9.1 [symbolic = %T.loc11_9.2 (constants.%T)]
 // CHECK:STDOUT:     %X.loc11_19.1: @C.%T.loc11_9.2 (%T) = bind_symbolic_name X, 1, %X.param [symbolic = %X.loc11_19.2 (constants.%X)]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -49,11 +49,11 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   %Simple.decl: type = interface_decl @Simple [template = constants.%Simple.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc15_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_14.1, runtime_param<invalid> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_14.1, runtime_param<none> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc15_14.1 [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:     %Simple.ref: type = name_ref Simple, file.%Simple.decl [template = constants.%Simple.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc15_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]

--- a/toolchain/check/testdata/impl/lookup/generic.carbon
+++ b/toolchain/check/testdata/impl/lookup/generic.carbon
@@ -164,11 +164,11 @@ fn G(x: A) {
 // CHECK:STDOUT:   %HasF.decl: type = interface_decl @HasF [template = constants.%HasF.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %HasF.ref: type = name_ref HasF, file.%HasF.decl [template = constants.%HasF.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness.d55)]
@@ -315,11 +315,11 @@ fn G(x: A) {
 // CHECK:STDOUT:   %HasF.decl: type = interface_decl @HasF [template = constants.%HasF.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %HasF.ref: type = name_ref HasF, file.%HasF.decl [template = constants.%HasF.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness.d55)]
@@ -528,20 +528,20 @@ fn G(x: A) {
 // CHECK:STDOUT:   %HasF.decl: type = interface_decl @HasF [template = constants.%HasF.type] {} {}
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<invalid> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<none> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc10_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc10_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10_14.1, runtime_param<invalid> [symbolic = %T.patt.loc10_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10_14.1, runtime_param<none> [symbolic = %T.patt.loc10_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [template = constants.%C.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc10_14.1 [symbolic = %T.loc10_14.2 (constants.%T)]
 // CHECK:STDOUT:     %C.loc10_27.1: type = class_type @C, @C(constants.%T) [symbolic = %C.loc10_27.2 (constants.%C.f2e)]
 // CHECK:STDOUT:     %HasF.ref: type = name_ref HasF, file.%HasF.decl [template = constants.%HasF.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc10_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc10_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness.7d1)]
@@ -728,21 +728,21 @@ fn G(x: A) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %HasF.decl: %HasF.type.fe3 = interface_decl @HasF [template = constants.%HasF.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<invalid> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<none> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_16.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc8_25.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:     %.loc8_25.2: type = converted %.loc8_25.1, constants.%empty_struct_type [template = constants.%empty_struct_type]
 // CHECK:STDOUT:     %HasF.ref: %HasF.type.fe3 = name_ref HasF, file.%HasF.decl [template = constants.%HasF.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %HasF.type.loc8_36.1: type = facet_type <@HasF, @HasF(constants.%T)> [symbolic = %HasF.type.loc8_36.2 (constants.%HasF.type.901)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness.142)]
@@ -937,15 +937,15 @@ fn G(x: A) {
 // CHECK:STDOUT:   %HasF.decl: type = interface_decl @HasF [template = constants.%HasF.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc9_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc9_14.1, runtime_param<invalid> [symbolic = %T.patt.loc9_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc9_14.1, runtime_param<none> [symbolic = %T.patt.loc9_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt.loc9_24.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc9_24.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc9_24.1, runtime_param<invalid> [symbolic = %U.patt.loc9_24.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc9_24.1, runtime_param<none> [symbolic = %U.patt.loc9_24.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc9_14.1 [symbolic = %T.loc9_14.2 (constants.%T)]
 // CHECK:STDOUT:     %HasF.ref: type = name_ref HasF, file.%HasF.decl [template = constants.%HasF.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc9_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc9_14.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc9_24.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc9_24.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T, constants.%U) [symbolic = @impl.%impl_witness (constants.%impl_witness)]
@@ -1084,20 +1084,20 @@ fn G(x: A) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %HasF.decl: %HasF.type.fe3 = interface_decl @HasF [template = constants.%HasF.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<invalid> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<none> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_16.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_24: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %HasF.ref: %HasF.type.fe3 = name_ref HasF, file.%HasF.decl [template = constants.%HasF.generic]
 // CHECK:STDOUT:     %T.ref.loc8_34: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %HasF.type.loc8_35.1: type = facet_type <@HasF, @HasF(constants.%T)> [symbolic = %HasF.type.loc8_35.2 (constants.%HasF.type.901)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]

--- a/toolchain/check/testdata/impl/lookup/no_prelude/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/impl_forall.carbon
@@ -121,21 +121,21 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.decl: %A.type = class_decl @A [template = constants.%A.generic] {
 // CHECK:STDOUT:     %T.patt.loc2_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc2_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc2_9.1, runtime_param<invalid> [symbolic = %T.patt.loc2_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc2_9.1, runtime_param<none> [symbolic = %T.patt.loc2_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc2_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc2_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %U.patt.loc6_13.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc6_13.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc6_13.1, runtime_param<invalid> [symbolic = %U.patt.loc6_13.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc6_13.1, runtime_param<none> [symbolic = %U.patt.loc6_13.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc6_13.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc6_13.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %V.patt.loc10_14.1: type = symbolic_binding_pattern V, 0 [symbolic = %V.patt.loc10_14.2 (constants.%V.patt)]
-// CHECK:STDOUT:     %V.param_patt: type = value_param_pattern %V.patt.loc10_14.1, runtime_param<invalid> [symbolic = %V.patt.loc10_14.2 (constants.%V.patt)]
+// CHECK:STDOUT:     %V.param_patt: type = value_param_pattern %V.patt.loc10_14.1, runtime_param<none> [symbolic = %V.patt.loc10_14.2 (constants.%V.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %A.ref: %A.type = name_ref A, file.%A.decl [template = constants.%A.generic]
 // CHECK:STDOUT:     %V.ref.loc10_26: type = name_ref V, %V.loc10_14.1 [symbolic = %V.loc10_14.2 (constants.%V)]
@@ -143,20 +143,20 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, file.%I.decl [template = constants.%I.generic]
 // CHECK:STDOUT:     %V.ref.loc10_34: type = name_ref V, %V.loc10_14.1 [symbolic = %V.loc10_14.2 (constants.%V)]
 // CHECK:STDOUT:     %I.type.loc10_35.1: type = facet_type <@I, @I(constants.%V)> [symbolic = %I.type.loc10_35.2 (constants.%I.type.325e65.2)]
-// CHECK:STDOUT:     %V.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %V.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %V.loc10_14.1: type = bind_symbolic_name V, 0, %V.param [symbolic = %V.loc10_14.2 (constants.%V)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%V) [symbolic = @impl.%impl_witness (constants.%impl_witness.ab3b51.1)]
 // CHECK:STDOUT:   %TestGeneric.decl: %TestGeneric.type = fn_decl @TestGeneric [template = constants.%TestGeneric] {
 // CHECK:STDOUT:     %W.patt.loc16_16.1: type = symbolic_binding_pattern W, 0 [symbolic = %W.patt.loc16_16.2 (constants.%W.patt)]
-// CHECK:STDOUT:     %W.param_patt: type = value_param_pattern %W.patt.loc16_16.1, runtime_param<invalid> [symbolic = %W.patt.loc16_16.2 (constants.%W.patt)]
+// CHECK:STDOUT:     %W.param_patt: type = value_param_pattern %W.patt.loc16_16.1, runtime_param<none> [symbolic = %W.patt.loc16_16.2 (constants.%W.patt)]
 // CHECK:STDOUT:     %a.patt: @TestGeneric.%A.loc16_32.2 (%A.13025a.3) = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: @TestGeneric.%A.loc16_32.2 (%A.13025a.3) = value_param_pattern %a.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @TestGeneric.%W.loc16_16.2 (%W) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @TestGeneric.%W.loc16_16.2 (%W) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %W.ref.loc16_38: type = name_ref W, %W.loc16_16.1 [symbolic = %W.loc16_16.2 (constants.%W)]
-// CHECK:STDOUT:     %W.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %W.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %W.loc16_16.1: type = bind_symbolic_name W, 0, %W.param [symbolic = %W.loc16_16.2 (constants.%W)]
 // CHECK:STDOUT:     %a.param: @TestGeneric.%A.loc16_32.2 (%A.13025a.3) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc16: type = splice_block %A.loc16_32.1 [symbolic = %A.loc16_32.2 (constants.%A.13025a.3)] {
@@ -279,7 +279,7 @@ fn TestSpecific(a: A({})) -> {} {
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %.loc3_3: @A.%A.elem (%A.elem.1ceb36.1) = var_pattern %.loc3_8
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.var: ref @A.%A.elem (%A.elem.1ceb36.1) = var <invalid>
+// CHECK:STDOUT:     %.var: ref @A.%A.elem (%A.elem.1ceb36.1) = var <none>
 // CHECK:STDOUT:     %complete_type.loc4_1.1: <witness> = complete_type_witness %struct_type.n.848971.1 [symbolic = %complete_type.loc4_1.2 (constants.%complete_type.84bb3d.1)]
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc4_1.1
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/import.carbon
@@ -1106,13 +1106,13 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AnyParam.decl: %AnyParam.type = class_decl @AnyParam [template = constants.%AnyParam.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_16.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<invalid> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_16.1, runtime_param<none> [symbolic = %T.patt.loc4_16.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %X.patt.loc4_26.1: @AnyParam.%T.loc4_16.2 (%T) = symbolic_binding_pattern X, 1 [symbolic = %X.patt.loc4_26.2 (constants.%X.patt)]
-// CHECK:STDOUT:     %X.param_patt: @AnyParam.%T.loc4_16.2 (%T) = value_param_pattern %X.patt.loc4_26.1, runtime_param<invalid> [symbolic = %X.patt.loc4_26.2 (constants.%X.patt)]
+// CHECK:STDOUT:     %X.param_patt: @AnyParam.%T.loc4_16.2 (%T) = value_param_pattern %X.patt.loc4_26.1, runtime_param<none> [symbolic = %X.patt.loc4_26.2 (constants.%X.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_16.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_16.2 (constants.%T)]
-// CHECK:STDOUT:     %X.param: @AnyParam.%T.loc4_16.2 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %X.param: @AnyParam.%T.loc4_16.2 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_16.1 [symbolic = %T.loc4_16.2 (constants.%T)]
 // CHECK:STDOUT:     %X.loc4_26.1: @AnyParam.%T.loc4_16.2 (%T) = bind_symbolic_name X, 1, %X.param [symbolic = %X.loc4_26.2 (constants.%X)]
 // CHECK:STDOUT:   }
@@ -1223,9 +1223,9 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:   %PackageHasParam.import = import PackageHasParam
 // CHECK:STDOUT:   %GenericInterface.decl: %GenericInterface.type.c92 = interface_decl @GenericInterface [template = constants.%GenericInterface.generic] {
 // CHECK:STDOUT:     %U.patt.loc6_28.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc6_28.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc6_28.1, runtime_param<invalid> [symbolic = %U.patt.loc6_28.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc6_28.1, runtime_param<none> [symbolic = %U.patt.loc6_28.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc6_28.1: type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc6_28.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
@@ -1588,9 +1588,9 @@ fn Test(c: HasExtraInterfaces.C(type)) {
 // CHECK:STDOUT:   %Extra8.decl: type = interface_decl @Extra8 [template = constants.%Extra8.type] {} {}
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc13_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_9.1, runtime_param<invalid> [symbolic = %T.patt.loc13_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc13_9.1, runtime_param<none> [symbolic = %T.patt.loc13_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc13_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}

--- a/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
@@ -80,16 +80,16 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<invalid> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_13.1, runtime_param<none> [symbolic = %T.patt.loc4_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc5_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc5_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_9.1, runtime_param<invalid> [symbolic = %T.patt.loc5_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_9.1, runtime_param<none> [symbolic = %T.patt.loc5_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc5_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc5_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [template = constants.%X] {} {}
@@ -208,7 +208,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:     .X = imports.%Main.X
 // CHECK:STDOUT:     .InInterfaceArgs = %InInterfaceArgs.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %InInterfaceArgs.decl: type = class_decl @InInterfaceArgs [template = constants.%InInterfaceArgs] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %X.ref: type = name_ref X, imports.%Main.X [template = constants.%X]
@@ -353,7 +353,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:     .InInterfaceArgs = imports.%Main.InInterfaceArgs
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %x.patt: %X = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: %X = value_param_pattern %x.patt, runtime_param0
@@ -497,7 +497,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:     .X = imports.%Main.X
 // CHECK:STDOUT:     .InClassArgs = %InClassArgs.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %InClassArgs.decl: type = class_decl @InClassArgs [template = constants.%InClassArgs] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C.ref: %C.type = name_ref C, imports.%Main.C [template = constants.%C.generic]
@@ -673,7 +673,7 @@ fn H(c: C(InClassArgs)) { c.(I(X).F)(); }
 // CHECK:STDOUT:     .InClassArgs = imports.%Main.InClassArgs
 // CHECK:STDOUT:     .H = %H.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {
 // CHECK:STDOUT:     %c.patt: %C.23b = binding_pattern c
 // CHECK:STDOUT:     %c.param_patt: %C.23b = value_param_pattern %c.patt, runtime_param0

--- a/toolchain/check/testdata/impl/lookup/transitive.carbon
+++ b/toolchain/check/testdata/impl/lookup/transitive.carbon
@@ -122,7 +122,7 @@ fn Call() {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
@@ -195,7 +195,7 @@ fn Call() {
 // CHECK:STDOUT:     .Get = %Get.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Get.decl: %Get.type = fn_decl @Get [template = constants.%Get] {
 // CHECK:STDOUT:     %return.patt: %C = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %C = out_param_pattern %return.patt, runtime_param0
@@ -261,7 +261,7 @@ fn Call() {
 // CHECK:STDOUT:     .Call = %Call.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Call.decl: %Call.type = fn_decl @Call [template = constants.%Call] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/generic_redeclaration.carbon
@@ -135,101 +135,101 @@ impl forall [T:! type] T as I {
 // CHECK:STDOUT:   %L.decl: type = interface_decl @L [template = constants.%L.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc11_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_14.2 (constants.%T.patt.3ad)]
-// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc11_14.1, runtime_param<invalid> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt.3ad)]
+// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc11_14.1, runtime_param<none> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt.3ad)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc11: %I.type = name_ref T, %T.loc11_14.1 [symbolic = %T.loc11_14.2 (constants.%T.826)]
 // CHECK:STDOUT:     %T.as_type.loc11_21.1: type = facet_access_type %T.ref.loc11 [symbolic = %T.as_type.loc11_21.2 (constants.%T.as_type.b70)]
 // CHECK:STDOUT:     %.loc11: type = converted %T.ref.loc11, %T.as_type.loc11_21.1 [symbolic = %T.as_type.loc11_21.2 (constants.%T.as_type.b70)]
 // CHECK:STDOUT:     %Interface.ref.loc11: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc11: %I.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc11: %I.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %I.ref.loc11: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:     %T.loc11_14.1: %I.type = bind_symbolic_name T, 0, %T.param.loc11 [symbolic = %T.loc11_14.2 (constants.%T.826)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc11: <witness> = impl_witness (), @impl.1(constants.%T.826) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.d14)]
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {
 // CHECK:STDOUT:     %T.patt.loc12_14.1: %J.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_14.2 (constants.%T.patt.371)]
-// CHECK:STDOUT:     %T.param_patt: %J.type = value_param_pattern %T.patt.loc12_14.1, runtime_param<invalid> [symbolic = %T.patt.loc12_14.2 (constants.%T.patt.371)]
+// CHECK:STDOUT:     %T.param_patt: %J.type = value_param_pattern %T.patt.loc12_14.1, runtime_param<none> [symbolic = %T.patt.loc12_14.2 (constants.%T.patt.371)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc12: %J.type = name_ref T, %T.loc12_14.1 [symbolic = %T.loc12_14.2 (constants.%T.ccd)]
 // CHECK:STDOUT:     %T.as_type.loc12_21.1: type = facet_access_type %T.ref.loc12 [symbolic = %T.as_type.loc12_21.2 (constants.%T.as_type.3df)]
 // CHECK:STDOUT:     %.loc12: type = converted %T.ref.loc12, %T.as_type.loc12_21.1 [symbolic = %T.as_type.loc12_21.2 (constants.%T.as_type.3df)]
 // CHECK:STDOUT:     %Interface.ref.loc12: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc12: %J.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc12: %J.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %J.ref.loc12: type = name_ref J, file.%J.decl [template = constants.%J.type]
 // CHECK:STDOUT:     %T.loc12_14.1: %J.type = bind_symbolic_name T, 0, %T.param.loc12 [symbolic = %T.loc12_14.2 (constants.%T.ccd)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc12: <witness> = impl_witness (), @impl.2(constants.%T.ccd) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.d94)]
 // CHECK:STDOUT:   impl_decl @impl.3 [template] {
 // CHECK:STDOUT:     %T.patt.loc13_14.1: %K.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_14.2 (constants.%T.patt.036)]
-// CHECK:STDOUT:     %T.param_patt: %K.type = value_param_pattern %T.patt.loc13_14.1, runtime_param<invalid> [symbolic = %T.patt.loc13_14.2 (constants.%T.patt.036)]
+// CHECK:STDOUT:     %T.param_patt: %K.type = value_param_pattern %T.patt.loc13_14.1, runtime_param<none> [symbolic = %T.patt.loc13_14.2 (constants.%T.patt.036)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc13: %K.type = name_ref T, %T.loc13_14.1 [symbolic = %T.loc13_14.2 (constants.%T.09f)]
 // CHECK:STDOUT:     %T.as_type.loc13_21.1: type = facet_access_type %T.ref.loc13 [symbolic = %T.as_type.loc13_21.2 (constants.%T.as_type.037)]
 // CHECK:STDOUT:     %.loc13: type = converted %T.ref.loc13, %T.as_type.loc13_21.1 [symbolic = %T.as_type.loc13_21.2 (constants.%T.as_type.037)]
 // CHECK:STDOUT:     %Interface.ref.loc13: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc13: %K.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc13: %K.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %K.ref.loc13: type = name_ref K, file.%K.decl [template = constants.%K.type]
 // CHECK:STDOUT:     %T.loc13_14.1: %K.type = bind_symbolic_name T, 0, %T.param.loc13 [symbolic = %T.loc13_14.2 (constants.%T.09f)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc13: <witness> = impl_witness (), @impl.3(constants.%T.09f) [symbolic = @impl.3.%impl_witness (constants.%impl_witness.8aa)]
 // CHECK:STDOUT:   impl_decl @impl.4 [template] {
 // CHECK:STDOUT:     %T.patt.loc14_14.1: %L.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_14.2 (constants.%T.patt.29d)]
-// CHECK:STDOUT:     %T.param_patt: %L.type = value_param_pattern %T.patt.loc14_14.1, runtime_param<invalid> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt.29d)]
+// CHECK:STDOUT:     %T.param_patt: %L.type = value_param_pattern %T.patt.loc14_14.1, runtime_param<none> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt.29d)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc14: %L.type = name_ref T, %T.loc14_14.1 [symbolic = %T.loc14_14.2 (constants.%T.1d2)]
 // CHECK:STDOUT:     %T.as_type.loc14_21.1: type = facet_access_type %T.ref.loc14 [symbolic = %T.as_type.loc14_21.2 (constants.%T.as_type.0ed)]
 // CHECK:STDOUT:     %.loc14: type = converted %T.ref.loc14, %T.as_type.loc14_21.1 [symbolic = %T.as_type.loc14_21.2 (constants.%T.as_type.0ed)]
 // CHECK:STDOUT:     %Interface.ref.loc14: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc14: %L.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc14: %L.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %L.ref.loc14: type = name_ref L, file.%L.decl [template = constants.%L.type]
 // CHECK:STDOUT:     %T.loc14_14.1: %L.type = bind_symbolic_name T, 0, %T.param.loc14 [symbolic = %T.loc14_14.2 (constants.%T.1d2)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc14: <witness> = impl_witness (), @impl.4(constants.%T.1d2) [symbolic = @impl.4.%impl_witness (constants.%impl_witness.da5)]
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc11_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_14.2 (constants.%T.patt.3ad)]
-// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc11_14.1, runtime_param<invalid> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt.3ad)]
+// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc11_14.1, runtime_param<none> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt.3ad)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc18: %I.type = name_ref T, %T.loc18 [symbolic = constants.%T.826]
 // CHECK:STDOUT:     %T.as_type.loc18: type = facet_access_type %T.ref.loc18 [symbolic = constants.%T.as_type.b70]
 // CHECK:STDOUT:     %.loc18: type = converted %T.ref.loc18, %T.as_type.loc18 [symbolic = constants.%T.as_type.b70]
 // CHECK:STDOUT:     %Interface.ref.loc18: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc18: %I.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc18: %I.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %I.ref.loc18: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:     %T.loc18: %I.type = bind_symbolic_name T, 0, %T.param.loc18 [symbolic = constants.%T.826]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {
 // CHECK:STDOUT:     %T.patt.loc12_14.1: %J.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_14.2 (constants.%T.patt.371)]
-// CHECK:STDOUT:     %T.param_patt: %J.type = value_param_pattern %T.patt.loc12_14.1, runtime_param<invalid> [symbolic = %T.patt.loc12_14.2 (constants.%T.patt.371)]
+// CHECK:STDOUT:     %T.param_patt: %J.type = value_param_pattern %T.patt.loc12_14.1, runtime_param<none> [symbolic = %T.patt.loc12_14.2 (constants.%T.patt.371)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc19: %J.type = name_ref T, %T.loc19 [symbolic = constants.%T.ccd]
 // CHECK:STDOUT:     %T.as_type.loc19: type = facet_access_type %T.ref.loc19 [symbolic = constants.%T.as_type.3df]
 // CHECK:STDOUT:     %.loc19: type = converted %T.ref.loc19, %T.as_type.loc19 [symbolic = constants.%T.as_type.3df]
 // CHECK:STDOUT:     %Interface.ref.loc19: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc19: %J.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc19: %J.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %J.ref.loc19: type = name_ref J, file.%J.decl [template = constants.%J.type]
 // CHECK:STDOUT:     %T.loc19: %J.type = bind_symbolic_name T, 0, %T.param.loc19 [symbolic = constants.%T.ccd]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.3 [template] {
 // CHECK:STDOUT:     %T.patt.loc13_14.1: %K.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_14.2 (constants.%T.patt.036)]
-// CHECK:STDOUT:     %T.param_patt: %K.type = value_param_pattern %T.patt.loc13_14.1, runtime_param<invalid> [symbolic = %T.patt.loc13_14.2 (constants.%T.patt.036)]
+// CHECK:STDOUT:     %T.param_patt: %K.type = value_param_pattern %T.patt.loc13_14.1, runtime_param<none> [symbolic = %T.patt.loc13_14.2 (constants.%T.patt.036)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc20: %K.type = name_ref T, %T.loc20 [symbolic = constants.%T.09f]
 // CHECK:STDOUT:     %T.as_type.loc20: type = facet_access_type %T.ref.loc20 [symbolic = constants.%T.as_type.037]
 // CHECK:STDOUT:     %.loc20: type = converted %T.ref.loc20, %T.as_type.loc20 [symbolic = constants.%T.as_type.037]
 // CHECK:STDOUT:     %Interface.ref.loc20: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc20: %K.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc20: %K.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %K.ref.loc20: type = name_ref K, file.%K.decl [template = constants.%K.type]
 // CHECK:STDOUT:     %T.loc20: %K.type = bind_symbolic_name T, 0, %T.param.loc20 [symbolic = constants.%T.09f]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.4 [template] {
 // CHECK:STDOUT:     %T.patt.loc14_14.1: %L.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_14.2 (constants.%T.patt.29d)]
-// CHECK:STDOUT:     %T.param_patt: %L.type = value_param_pattern %T.patt.loc14_14.1, runtime_param<invalid> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt.29d)]
+// CHECK:STDOUT:     %T.param_patt: %L.type = value_param_pattern %T.patt.loc14_14.1, runtime_param<none> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt.29d)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc21: %L.type = name_ref T, %T.loc21 [symbolic = constants.%T.1d2]
 // CHECK:STDOUT:     %T.as_type.loc21: type = facet_access_type %T.ref.loc21 [symbolic = constants.%T.as_type.0ed]
 // CHECK:STDOUT:     %.loc21: type = converted %T.ref.loc21, %T.as_type.loc21 [symbolic = constants.%T.as_type.0ed]
 // CHECK:STDOUT:     %Interface.ref.loc21: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
-// CHECK:STDOUT:     %T.param.loc21: %L.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc21: %L.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %L.ref.loc21: type = name_ref L, file.%L.decl [template = constants.%L.type]
 // CHECK:STDOUT:     %T.loc21: %L.type = bind_symbolic_name T, 0, %T.param.loc21 [symbolic = constants.%T.1d2]
 // CHECK:STDOUT:   }
@@ -390,26 +390,26 @@ impl forall [T:! type] T as I {
 // CHECK:STDOUT:   %J.decl: type = interface_decl @J [template = constants.%J.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc7_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc7_14.1, runtime_param<invalid> [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc7_14.1, runtime_param<none> [symbolic = %T.patt.loc7_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: %I.type = name_ref T, %T.loc7_14.1 [symbolic = %T.loc7_14.2 (constants.%T)]
 // CHECK:STDOUT:     %T.as_type.loc7_21.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc7: type = converted %T.ref, %T.as_type.loc7_21.1 [symbolic = %T.as_type.loc7_21.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
-// CHECK:STDOUT:     %T.param: %I.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %I.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:     %T.loc7_14.1: %I.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc7: <witness> = impl_witness (), @impl.1(constants.%T) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.1896b7.1)]
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {
 // CHECK:STDOUT:     %T.patt.loc15_14.1: %I.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc15_14.1, runtime_param<invalid> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %I.type = value_param_pattern %T.patt.loc15_14.1, runtime_param<none> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: %I.type = name_ref T, %T.loc15_14.1 [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:     %T.as_type.loc15_21.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc15_21.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc15: type = converted %T.ref, %T.as_type.loc15_21.1 [symbolic = %T.as_type.loc15_21.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
-// CHECK:STDOUT:     %T.param: %I.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %I.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:     %T.loc15_14.1: %I.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
@@ -564,21 +564,21 @@ impl forall [T:! type] T as I {
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc4_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_14.1, runtime_param<invalid> [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_14.1, runtime_param<none> [symbolic = %T.patt.loc4_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_14.1 [symbolic = %T.loc4_14.2 (constants.%T)]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc4: <witness> = impl_witness (), @impl.1(constants.%T) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.1f09a1.1)]
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {
 // CHECK:STDOUT:     %T.patt.loc15_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_14.1, runtime_param<invalid> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_14.1, runtime_param<none> [symbolic = %T.patt.loc15_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc15_14.1 [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc15_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc15: <witness> = impl_witness (), @impl.2(constants.%T) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.1f09a1.2)]

--- a/toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon
@@ -142,9 +142,9 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %MyInt.decl: %MyInt.type = class_decl @MyInt [template = constants.%MyInt.generic] {
 // CHECK:STDOUT:     %N.patt.loc11_13.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc11_13.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc11_13.1, runtime_param<invalid> [symbolic = %N.patt.loc11_13.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc11_13.1, runtime_param<none> [symbolic = %N.patt.loc11_13.2 (constants.%N.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_28.1: type = splice_block %.loc11_28.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, file.%IntLiteral.decl [template = constants.%IntLiteral]
 // CHECK:STDOUT:       %int_literal.make_type: init type = call %IntLiteral.ref() [template = Core.IntLiteral]
@@ -155,13 +155,13 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %N.patt.loc15_14.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc15_14.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc15_14.1, runtime_param<invalid> [symbolic = %N.patt.loc15_14.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc15_14.1, runtime_param<none> [symbolic = %N.patt.loc15_14.2 (constants.%N.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %MyInt.ref: %MyInt.type = name_ref MyInt, file.%MyInt.decl [template = constants.%MyInt.generic]
 // CHECK:STDOUT:     %N.ref: Core.IntLiteral = name_ref N, %N.loc15_14.1 [symbolic = %N.loc15_14.2 (constants.%N)]
 // CHECK:STDOUT:     %MyInt.loc15_39.1: type = class_type @MyInt, @MyInt(constants.%N) [symbolic = %MyInt.loc15_39.2 (constants.%MyInt)]
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, file.%Add.decl [template = constants.%Add.type]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc15_29.1: type = splice_block %.loc15_29.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, file.%IntLiteral.decl [template = constants.%IntLiteral]
 // CHECK:STDOUT:       %int_literal.make_type: init type = call %IntLiteral.ref() [template = Core.IntLiteral]
@@ -173,7 +173,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%Op.decl), @impl(constants.%N) [symbolic = @impl.%impl_witness (constants.%impl_witness)]
 // CHECK:STDOUT:   %Double.decl: %Double.type = fn_decl @Double [template = constants.%Double] {
 // CHECK:STDOUT:     %N.patt.loc19_11.1: Core.IntLiteral = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc19_11.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc19_11.1, runtime_param<invalid> [symbolic = %N.patt.loc19_11.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: Core.IntLiteral = value_param_pattern %N.patt.loc19_11.1, runtime_param<none> [symbolic = %N.patt.loc19_11.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %x.patt: @Double.%MyInt.loc19_39.2 (%MyInt) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @Double.%MyInt.loc19_39.2 (%MyInt) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     %return.patt: @Double.%MyInt.loc19_39.2 (%MyInt) = return_slot_pattern
@@ -182,7 +182,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:     %MyInt.ref.loc19_45: %MyInt.type = name_ref MyInt, file.%MyInt.decl [template = constants.%MyInt.generic]
 // CHECK:STDOUT:     %N.ref.loc19_51: Core.IntLiteral = name_ref N, %N.loc19_11.1 [symbolic = %N.loc19_11.2 (constants.%N)]
 // CHECK:STDOUT:     %MyInt.loc19_52: type = class_type @MyInt, @MyInt(constants.%N) [symbolic = %MyInt.loc19_39.2 (constants.%MyInt)]
-// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: Core.IntLiteral = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc19_26.1: type = splice_block %.loc19_26.3 [template = Core.IntLiteral] {
 // CHECK:STDOUT:       %IntLiteral.ref: %IntLiteral.type = name_ref IntLiteral, file.%IntLiteral.decl [template = constants.%IntLiteral]
 // CHECK:STDOUT:       %int_literal.make_type: init type = call %IntLiteral.ref() [template = Core.IntLiteral]
@@ -467,7 +467,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:     .LocalDouble = %LocalDouble.decl
 // CHECK:STDOUT:     .CallImportedDouble = %CallImportedDouble.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %LocalDouble.decl: %LocalDouble.type = fn_decl @LocalDouble [template = constants.%LocalDouble] {
 // CHECK:STDOUT:     %x.patt: %MyInt.f30 = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: %MyInt.f30 = value_param_pattern %x.patt, runtime_param0
@@ -810,7 +810,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Make.decl: %Make.type = fn_decl @Make [template = constants.%Make] {
 // CHECK:STDOUT:     %N.patt.loc9_9.1: %i32.builtin = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc9_9.2 (constants.%N.patt.36b)]
-// CHECK:STDOUT:     %N.param_patt: %i32.builtin = value_param_pattern %N.patt.loc9_9.1, runtime_param<invalid> [symbolic = %N.patt.loc9_9.2 (constants.%N.patt.36b)]
+// CHECK:STDOUT:     %N.param_patt: %i32.builtin = value_param_pattern %N.patt.loc9_9.1, runtime_param<none> [symbolic = %N.patt.loc9_9.2 (constants.%N.patt.36b)]
 // CHECK:STDOUT:     %return.patt: @Make.%iN.builtin (%iN.builtin.016) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @Make.%iN.builtin (%iN.builtin.016) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
@@ -823,7 +823,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:     %int.make_type_signed.loc9_41: init type = call %Int.ref.loc9_25(%.loc9_40.2) [symbolic = %iN.builtin (constants.%iN.builtin.016)]
 // CHECK:STDOUT:     %.loc9_41.1: type = value_of_initializer %int.make_type_signed.loc9_41 [symbolic = %iN.builtin (constants.%iN.builtin.016)]
 // CHECK:STDOUT:     %.loc9_41.2: type = converted %int.make_type_signed.loc9_41, %.loc9_41.1 [symbolic = %iN.builtin (constants.%iN.builtin.016)]
-// CHECK:STDOUT:     %N.param: %i32.builtin = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32.builtin = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc9_19.1: type = splice_block %.loc9_19.3 [template = constants.%i32.builtin] {
 // CHECK:STDOUT:       %Int.ref.loc9_13: %Int.type = name_ref Int, file.%Int.decl [template = constants.%Int]
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
@@ -854,7 +854,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %MakeFromClass.decl: %MakeFromClass.type = fn_decl @MakeFromClass [template = constants.%MakeFromClass] {
 // CHECK:STDOUT:     %N.patt.loc18_18.1: %OtherInt = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc18_18.2 (constants.%N.patt.59d)]
-// CHECK:STDOUT:     %N.param_patt: %OtherInt = value_param_pattern %N.patt.loc18_18.1, runtime_param<invalid> [symbolic = %N.patt.loc18_18.2 (constants.%N.patt.59d)]
+// CHECK:STDOUT:     %N.param_patt: %OtherInt = value_param_pattern %N.patt.loc18_18.1, runtime_param<none> [symbolic = %N.patt.loc18_18.2 (constants.%N.patt.59d)]
 // CHECK:STDOUT:     %return.patt: @MakeFromClass.%iN.builtin (%iN.builtin.9ef) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @MakeFromClass.%iN.builtin (%iN.builtin.9ef) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
@@ -868,7 +868,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:     %int.make_type_signed: init type = call %Int.ref(%.loc18_51.2) [symbolic = %iN.builtin (constants.%iN.builtin.9ef)]
 // CHECK:STDOUT:     %.loc18_52.1: type = value_of_initializer %int.make_type_signed [symbolic = %iN.builtin (constants.%iN.builtin.9ef)]
 // CHECK:STDOUT:     %.loc18_52.2: type = converted %int.make_type_signed, %.loc18_52.1 [symbolic = %iN.builtin (constants.%iN.builtin.9ef)]
-// CHECK:STDOUT:     %N.param: %OtherInt = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %OtherInt = value_param runtime_param<none>
 // CHECK:STDOUT:     %OtherInt.ref: type = name_ref OtherInt, file.%OtherInt.decl [template = constants.%OtherInt]
 // CHECK:STDOUT:     %N.loc18_18.1: %OtherInt = bind_symbolic_name N, 0, %N.param [symbolic = %N.loc18_18.2 (constants.%N.335)]
 // CHECK:STDOUT:     %return.param: ref @MakeFromClass.%iN.builtin (%iN.builtin.9ef) = out_param runtime_param0
@@ -1055,7 +1055,7 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:     .m = %m
 // CHECK:STDOUT:     .n = %n
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %m.patt: %i64.builtin = binding_pattern m
 // CHECK:STDOUT:     %.loc6_1: %i64.builtin = var_pattern %m.patt

--- a/toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon
@@ -146,7 +146,7 @@ fn G(c: C) {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %c.param_patt: %C = value_param_pattern %c.patt, runtime_param0

--- a/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
@@ -125,44 +125,44 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %T.patt.loc5_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc5_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_13.1, runtime_param<invalid> [symbolic = %T.patt.loc5_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_13.1, runtime_param<none> [symbolic = %T.patt.loc5_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc5_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc5_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %I.ref.loc8: %I.type.dac = name_ref I, file.%I.decl [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref.loc8: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %I.type.loc8_32.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc8_32.2 (constants.%I.type.325)]
-// CHECK:STDOUT:     %T.param.loc8: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc8: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param.loc8 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc8: <witness> = impl_witness (), @impl.1(constants.%T) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.eff)]
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %I.ref.loc9: %I.type.dac = name_ref I, file.%I.decl [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref.loc9: type = name_ref T, %T.loc9 [symbolic = constants.%T]
 // CHECK:STDOUT:     %I.type.loc9: type = facet_type <@I, @I(constants.%T)> [symbolic = constants.%I.type.325]
-// CHECK:STDOUT:     %T.param.loc9: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param.loc9: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc9: type = bind_symbolic_name T, 0, %T.param.loc9 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {
 // CHECK:STDOUT:     %T.patt.loc12_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_14.1, runtime_param<invalid> [symbolic = %T.patt.loc12_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_14.1, runtime_param<none> [symbolic = %T.patt.loc12_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, file.%I.decl [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc12_14.1 [symbolic = %T.loc12_14.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc12_32.1: type = ptr_type %T [symbolic = %ptr.loc12_32.2 (constants.%ptr)]
 // CHECK:STDOUT:     %I.type.loc12_33.1: type = facet_type <@I, @I(constants.%ptr)> [symbolic = %I.type.loc12_33.2 (constants.%I.type.0e2)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc12_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc12: <witness> = impl_witness (), @impl.2(constants.%T) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.465)]
@@ -312,55 +312,55 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .I = imports.%Main.I
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.3 [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, imports.%Main.I [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %I.type.loc8_32.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc8_32.2 (constants.%I.type.325)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc8: <witness> = impl_witness (), @impl.3(constants.%T) [symbolic = @impl.3.%impl_witness (constants.%impl_witness.eff58b.2)]
 // CHECK:STDOUT:   impl_decl @impl.4 [template] {
 // CHECK:STDOUT:     %T.patt.loc14_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_14.1, runtime_param<invalid> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_14.1, runtime_param<none> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, imports.%Main.I [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_14.1 [symbolic = %T.loc14_14.2 (constants.%T)]
 // CHECK:STDOUT:     %I.type.loc14_32.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc14_32.2 (constants.%I.type.325)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc14_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc14_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc14: <witness> = impl_witness (), @impl.4(constants.%T) [symbolic = @impl.4.%impl_witness (constants.%impl_witness.eff58b.3)]
 // CHECK:STDOUT:   impl_decl @impl.5 [template] {
 // CHECK:STDOUT:     %T.patt.loc20_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_14.1, runtime_param<invalid> [symbolic = %T.patt.loc20_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_14.1, runtime_param<none> [symbolic = %T.patt.loc20_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, imports.%Main.I [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc20_14.1 [symbolic = %T.loc20_14.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc20_32.1: type = ptr_type %T [symbolic = %ptr.loc20_32.2 (constants.%ptr)]
 // CHECK:STDOUT:     %I.type.loc20_33.1: type = facet_type <@I, @I(constants.%ptr)> [symbolic = %I.type.loc20_33.2 (constants.%I.type.0e2)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc20_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc20_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc20: <witness> = impl_witness (), @impl.5(constants.%T) [symbolic = @impl.5.%impl_witness (constants.%impl_witness.46542c.2)]
 // CHECK:STDOUT:   impl_decl @impl.6 [template] {
 // CHECK:STDOUT:     %T.patt.loc26_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc26_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc26_14.1, runtime_param<invalid> [symbolic = %T.patt.loc26_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc26_14.1, runtime_param<none> [symbolic = %T.patt.loc26_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, imports.%Main.I [template = constants.%I.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc26_14.1 [symbolic = %T.loc26_14.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc26_32.1: type = ptr_type %T [symbolic = %ptr.loc26_32.2 (constants.%ptr)]
 // CHECK:STDOUT:     %I.type.loc26_33.1: type = facet_type <@I, @I(constants.%ptr)> [symbolic = %I.type.loc26_33.2 (constants.%I.type.0e2)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc26_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc26_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc26: <witness> = impl_witness (), @impl.6(constants.%T) [symbolic = @impl.6.%impl_witness (constants.%impl_witness.46542c.3)]
@@ -594,33 +594,33 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT:   %J.decl: %J.type.2b8 = interface_decl @J [template = constants.%J.generic] {
 // CHECK:STDOUT:     %T.patt.loc5_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc5_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_13.1, runtime_param<invalid> [symbolic = %T.patt.loc5_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_13.1, runtime_param<none> [symbolic = %T.patt.loc5_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc5_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc5_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {
 // CHECK:STDOUT:     %T.patt.loc11_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_14.1, runtime_param<invalid> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_14.1, runtime_param<none> [symbolic = %T.patt.loc11_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [template = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, file.%J.decl [template = constants.%J.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_14.1 [symbolic = %T.loc11_14.2 (constants.%T)]
 // CHECK:STDOUT:     %J.type.loc11_32.1: type = facet_type <@J, @J(constants.%T)> [symbolic = %J.type.loc11_32.2 (constants.%J.type.b72)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc11: <witness> = impl_witness (), @impl.1(constants.%T) [symbolic = @impl.1.%impl_witness (constants.%impl_witness.0ef)]
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {
 // CHECK:STDOUT:     %T.patt.loc17_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_14.1, runtime_param<invalid> [symbolic = %T.patt.loc17_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_14.1, runtime_param<none> [symbolic = %T.patt.loc17_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [template = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, file.%J.decl [template = constants.%J.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc17_14.1 [symbolic = %T.loc17_14.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc17_32.1: type = ptr_type %T [symbolic = %ptr.loc17_32.2 (constants.%ptr)]
 // CHECK:STDOUT:     %J.type.loc17_33.1: type = facet_type <@J, @J(constants.%ptr)> [symbolic = %J.type.loc17_33.2 (constants.%J.type.628)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc17_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc17_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc17: <witness> = impl_witness (), @impl.2(constants.%T) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.b80)]
@@ -758,55 +758,55 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .J = imports.%Main.J
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.3 [template] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<invalid> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_14.1, runtime_param<none> [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [template = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, imports.%Main.J [template = constants.%J.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc8_14.1 [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:     %J.type.loc8_32.1: type = facet_type <@J, @J(constants.%T)> [symbolic = %J.type.loc8_32.2 (constants.%J.type.b72)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc8: <witness> = impl_witness (), @impl.3(constants.%T) [symbolic = @impl.3.%impl_witness (constants.%impl_witness.0ef94b.2)]
 // CHECK:STDOUT:   impl_decl @impl.4 [template] {
 // CHECK:STDOUT:     %T.patt.loc14_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_14.1, runtime_param<invalid> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_14.1, runtime_param<none> [symbolic = %T.patt.loc14_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [template = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, imports.%Main.J [template = constants.%J.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_14.1 [symbolic = %T.loc14_14.2 (constants.%T)]
 // CHECK:STDOUT:     %J.type.loc14_32.1: type = facet_type <@J, @J(constants.%T)> [symbolic = %J.type.loc14_32.2 (constants.%J.type.b72)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc14_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc14_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc14: <witness> = impl_witness (), @impl.4(constants.%T) [symbolic = @impl.4.%impl_witness (constants.%impl_witness.0ef94b.3)]
 // CHECK:STDOUT:   impl_decl @impl.5 [template] {
 // CHECK:STDOUT:     %T.patt.loc20_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_14.1, runtime_param<invalid> [symbolic = %T.patt.loc20_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_14.1, runtime_param<none> [symbolic = %T.patt.loc20_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [template = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, imports.%Main.J [template = constants.%J.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc20_14.1 [symbolic = %T.loc20_14.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc20_32.1: type = ptr_type %T [symbolic = %ptr.loc20_32.2 (constants.%ptr)]
 // CHECK:STDOUT:     %J.type.loc20_33.1: type = facet_type <@J, @J(constants.%ptr)> [symbolic = %J.type.loc20_33.2 (constants.%J.type.628)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc20_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc20_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc20: <witness> = impl_witness (), @impl.5(constants.%T) [symbolic = @impl.5.%impl_witness (constants.%impl_witness.b80f53.2)]
 // CHECK:STDOUT:   impl_decl @impl.6 [template] {
 // CHECK:STDOUT:     %T.patt.loc26_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc26_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc26_14.1, runtime_param<invalid> [symbolic = %T.patt.loc26_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc26_14.1, runtime_param<none> [symbolic = %T.patt.loc26_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [template = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, imports.%Main.J [template = constants.%J.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc26_14.1 [symbolic = %T.loc26_14.2 (constants.%T)]
 // CHECK:STDOUT:     %ptr.loc26_32.1: type = ptr_type %T [symbolic = %ptr.loc26_32.2 (constants.%ptr)]
 // CHECK:STDOUT:     %J.type.loc26_33.1: type = facet_type <@J, @J(constants.%ptr)> [symbolic = %J.type.loc26_33.2 (constants.%J.type.628)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc26_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc26_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness.loc26: <witness> = impl_witness (), @impl.6(constants.%T) [symbolic = @impl.6.%impl_witness (constants.%impl_witness.b80f53.3)]

--- a/toolchain/check/testdata/impl/no_prelude/import_interface_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_interface_assoc_const.carbon
@@ -277,7 +277,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C1 = %C1.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C1.decl: type = class_decl @C1 [template = constants.%C1] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [template = constants.%C1]
@@ -348,7 +348,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C2 = %C2.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [template = constants.%C2] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C2.ref.loc5: type = name_ref C2, file.%C2.decl [template = constants.%C2]
@@ -433,7 +433,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C3 = %C3.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C3.decl: type = class_decl @C3 [template = constants.%C3] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C3.ref.loc5: type = name_ref C3, file.%C3.decl [template = constants.%C3]
@@ -510,7 +510,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C4 = %C4.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C4.decl: type = class_decl @C4 [template = constants.%C4] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C4.ref.loc5: type = name_ref C4, file.%C4.decl [template = constants.%C4]
@@ -603,7 +603,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C5 = %C5.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C5.decl: type = class_decl @C5 [template = constants.%C5] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C5.ref.loc18: type = name_ref C5, file.%C5.decl [template = constants.%C5]
@@ -715,7 +715,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C6 = %C6.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C6.decl: type = class_decl @C6 [template = constants.%C6] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C6.ref.loc5: type = name_ref C6, file.%C6.decl [template = constants.%C6]
@@ -791,7 +791,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C7 = %C7.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C7.decl: type = class_decl @C7 [template = constants.%C7] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C7.ref: type = name_ref C7, file.%C7.decl [template = constants.%C7]
@@ -868,7 +868,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C8 = %C8.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C8.decl: type = class_decl @C8 [template = constants.%C8] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C8.ref: type = name_ref C8, file.%C8.decl [template = constants.%C8]
@@ -942,7 +942,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .C9 = %C9.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C9.decl: type = class_decl @C9 [template = constants.%C9] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C9.ref: type = name_ref C9, file.%C9.decl [template = constants.%C9]
@@ -1016,7 +1016,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .CA = %CA.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %CA.decl: type = class_decl @CA [template = constants.%CA] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %CA.ref: type = name_ref CA, file.%CA.decl [template = constants.%CA]
@@ -1091,7 +1091,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .CB = %CB.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %CB.decl: type = class_decl @CB [template = constants.%CB] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %CB.ref: type = name_ref CB, file.%CB.decl [template = constants.%CB]
@@ -1172,7 +1172,7 @@ impl CC as NonType where .Y = {.a = {}} { }
 // CHECK:STDOUT:     .NonType = imports.%Main.NonType
 // CHECK:STDOUT:     .CC = %CC.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %CC.decl: type = class_decl @CC [template = constants.%CC] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %CC.ref: type = name_ref CC, file.%CC.decl [template = constants.%CC]

--- a/toolchain/check/testdata/impl/no_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_self.carbon
@@ -131,7 +131,7 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT:     .Add = imports.%Main.Add
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %.loc6_7.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc6_7.2: type = converted %.loc6_7.1, constants.%empty_tuple.type [template = constants.%empty_tuple.type]

--- a/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
@@ -69,21 +69,21 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<invalid> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_9.1, runtime_param<none> [symbolic = %T.patt.loc4_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {
 // CHECK:STDOUT:     %T.patt.loc10_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc10_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10_14.1, runtime_param<invalid> [symbolic = %T.patt.loc10_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc10_14.1, runtime_param<none> [symbolic = %T.patt.loc10_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [template = constants.%C.generic]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc10_14.1 [symbolic = %T.loc10_14.2 (constants.%T)]
 // CHECK:STDOUT:     %C.loc10_27.1: type = class_type @C, @C(constants.%T) [symbolic = %C.loc10_27.2 (constants.%C)]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc10_14.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc10_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]
@@ -225,7 +225,7 @@ fn F() -> c.(I.F)() {}
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C.7a7 = binding_pattern c
 // CHECK:STDOUT:     %.loc6_1: %C.7a7 = var_pattern %c.patt

--- a/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
@@ -121,9 +121,9 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Action.decl: %Action.type.29c = interface_decl @Action [template = constants.%Action.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_18.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_18.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_18.1, runtime_param<invalid> [symbolic = %T.patt.loc4_18.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_18.1, runtime_param<none> [symbolic = %T.patt.loc4_18.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_18.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_18.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {} {}
@@ -309,8 +309,8 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %a.patt: %A = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %A = value_param_pattern %a.patt, runtime_param0
@@ -467,8 +467,8 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %a.patt: %A = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %A = value_param_pattern %a.patt, runtime_param0
@@ -613,9 +613,9 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Factory.decl: %Factory.type.1a8 = interface_decl @Factory [template = constants.%Factory.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<invalid> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<none> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_19.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {} {}
@@ -782,8 +782,8 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:     .MakeB = %MakeB.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %MakeB.decl: %MakeB.type = fn_decl @MakeB [template = constants.%MakeB] {
 // CHECK:STDOUT:     %a.patt: %A = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %A = value_param_pattern %a.patt, runtime_param0
@@ -944,8 +944,8 @@ fn MakeC(a: A) -> C {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:     .MakeC = %MakeC.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %MakeC.decl: %MakeC.type = fn_decl @MakeC [template = constants.%MakeC] {
 // CHECK:STDOUT:     %a.patt: %A = binding_pattern a

--- a/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
@@ -151,8 +151,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
 // CHECK:STDOUT:     %.loc8_7.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc8_7.2: type = converted %.loc8_7.1, constants.%empty_tuple.type [template = constants.%empty_tuple.type]
@@ -198,8 +198,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_decl_only_in_api.carbon
@@ -252,8 +252,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @B [from "fail_decl_only_in_api.carbon"] {
@@ -315,8 +315,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
 // CHECK:STDOUT:     %.loc8_7.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc8_7.2: type = converted %.loc8_7.1, constants.%empty_tuple.type [template = constants.%empty_tuple.type]
@@ -354,8 +354,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %D.decl: type = interface_decl @D [template = constants.%D.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %.loc10_7.1: %empty_tuple.type = tuple_literal ()

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
@@ -234,7 +234,7 @@ fn Interface.C.F[self: Self](U:! type, u: U) -> U { return u; }
 // CHECK:STDOUT:     %self.patt: %C.7e5 = binding_pattern self
 // CHECK:STDOUT:     %self.param_patt: %C.7e5 = value_param_pattern %self.patt, runtime_param0
 // CHECK:STDOUT:     %U.patt.loc20: type = symbolic_binding_pattern U, 1 [symbolic = constants.%U.patt]
-// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc20, runtime_param<invalid> [symbolic = constants.%U.patt]
+// CHECK:STDOUT:     %U.param_patt: type = value_param_pattern %U.patt.loc20, runtime_param<none> [symbolic = constants.%U.patt]
 // CHECK:STDOUT:     %u.patt: %U = binding_pattern u
 // CHECK:STDOUT:     %u.param_patt: %U = value_param_pattern %u.patt, runtime_param1
 // CHECK:STDOUT:     %return.patt: %U = return_slot_pattern
@@ -247,7 +247,7 @@ fn Interface.C.F[self: Self](U:! type, u: U) -> U { return u; }
 // CHECK:STDOUT:       %Self.ref.loc20: type = name_ref Self, %.loc20_24.2 [symbolic = constants.%C.7e5]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self.loc20: %C.7e5 = bind_name self, %self.param.loc20
-// CHECK:STDOUT:     %U.param.loc20: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param.loc20: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %U.loc20: type = bind_symbolic_name U, 1, %U.param.loc20 [symbolic = constants.%U]
 // CHECK:STDOUT:     %u.param.loc20: %U = value_param runtime_param1
 // CHECK:STDOUT:     %U.ref.loc20_43: type = name_ref U, %U.loc20 [symbolic = constants.%U]
@@ -278,7 +278,7 @@ fn Interface.C.F[self: Self](U:! type, u: U) -> U { return u; }
 // CHECK:STDOUT:       %self.patt: %C.7e5 = binding_pattern self
 // CHECK:STDOUT:       %self.param_patt: %C.7e5 = value_param_pattern %self.patt, runtime_param0
 // CHECK:STDOUT:       %U.patt.loc20: type = symbolic_binding_pattern U, 1 [symbolic = constants.%U.patt]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc20, runtime_param<invalid> [symbolic = constants.%U.patt]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc20, runtime_param<none> [symbolic = constants.%U.patt]
 // CHECK:STDOUT:       %u.patt: %U = binding_pattern u
 // CHECK:STDOUT:       %u.param_patt: %U = value_param_pattern %u.patt, runtime_param1
 // CHECK:STDOUT:       %return.patt: %U = return_slot_pattern
@@ -291,7 +291,7 @@ fn Interface.C.F[self: Self](U:! type, u: U) -> U { return u; }
 // CHECK:STDOUT:         %Self.ref.loc14: type = name_ref Self, %.loc14_16.2 [symbolic = %C (constants.%C.7e5)]
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:       %self.loc14: @F.%C (%C.7e5) = bind_name self, %self.param.loc14
-// CHECK:STDOUT:       %U.param.loc14: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param.loc14: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc14_22.2: type = bind_symbolic_name U, 1, %U.param.loc14 [symbolic = %U.loc14_22.1 (constants.%U)]
 // CHECK:STDOUT:       %u.param.loc14: @F.%U.loc14_22.1 (%U) = value_param runtime_param1
 // CHECK:STDOUT:       %U.ref.loc14_35: type = name_ref U, %U.loc14_22.2 [symbolic = %U.loc14_22.1 (constants.%U)]

--- a/toolchain/check/testdata/interface/member_lookup.carbon
+++ b/toolchain/check/testdata/interface/member_lookup.carbon
@@ -100,23 +100,23 @@ fn AccessMissingConcrete(I:! Interface(i32)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Interface.decl: %Interface.type.e32 = interface_decl @Interface [template = constants.%Interface.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_21.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_21.1, runtime_param<invalid> [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_21.1, runtime_param<none> [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_21.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_21.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessGeneric.decl: %AccessGeneric.type = fn_decl @AccessGeneric [template = constants.%AccessGeneric] {
 // CHECK:STDOUT:     %T.patt.loc8_18.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_18.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_18.1, runtime_param<invalid> [symbolic = %T.patt.loc8_18.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_18.1, runtime_param<none> [symbolic = %T.patt.loc8_18.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %I.patt.loc8_28.1: @AccessGeneric.%Interface.type.loc8_43.2 (%Interface.type.d32) = symbolic_binding_pattern I, 1 [symbolic = %I.patt.loc8_28.2 (constants.%I.patt.47c)]
-// CHECK:STDOUT:     %I.param_patt: @AccessGeneric.%Interface.type.loc8_43.2 (%Interface.type.d32) = value_param_pattern %I.patt.loc8_28.1, runtime_param<invalid> [symbolic = %I.patt.loc8_28.2 (constants.%I.patt.47c)]
+// CHECK:STDOUT:     %I.param_patt: @AccessGeneric.%Interface.type.loc8_43.2 (%Interface.type.d32) = value_param_pattern %I.patt.loc8_28.1, runtime_param<none> [symbolic = %I.patt.loc8_28.2 (constants.%I.patt.47c)]
 // CHECK:STDOUT:     %return.patt: @AccessGeneric.%T.loc8_18.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @AccessGeneric.%T.loc8_18.2 (%T) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_49: type = name_ref T, %T.loc8_18.1 [symbolic = %T.loc8_18.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_18.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_18.2 (constants.%T)]
-// CHECK:STDOUT:     %I.param: @AccessGeneric.%Interface.type.loc8_43.2 (%Interface.type.d32) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.param: @AccessGeneric.%Interface.type.loc8_43.2 (%Interface.type.d32) = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8: type = splice_block %Interface.type.loc8_43.1 [symbolic = %Interface.type.loc8_43.2 (constants.%Interface.type.d32)] {
 // CHECK:STDOUT:       %Interface.ref: %Interface.type.e32 = name_ref Interface, file.%Interface.decl [template = constants.%Interface.generic]
 // CHECK:STDOUT:       %T.ref.loc8_42: type = name_ref T, %T.loc8_18.1 [symbolic = %T.loc8_18.2 (constants.%T)]
@@ -128,13 +128,13 @@ fn AccessMissingConcrete(I:! Interface(i32)) -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessConcrete.decl: %AccessConcrete.type = fn_decl @AccessConcrete [template = constants.%AccessConcrete] {
 // CHECK:STDOUT:     %I.patt.loc12_19.1: %Interface.type.981 = symbolic_binding_pattern I, 0 [symbolic = %I.patt.loc12_19.2 (constants.%I.patt.1f8)]
-// CHECK:STDOUT:     %I.param_patt: %Interface.type.981 = value_param_pattern %I.patt.loc12_19.1, runtime_param<invalid> [symbolic = %I.patt.loc12_19.2 (constants.%I.patt.1f8)]
+// CHECK:STDOUT:     %I.param_patt: %Interface.type.981 = value_param_pattern %I.patt.loc12_19.1, runtime_param<none> [symbolic = %I.patt.loc12_19.2 (constants.%I.patt.1f8)]
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32.loc12_42: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc12_42: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %I.param: %Interface.type.981 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.param: %Interface.type.981 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc12: type = splice_block %Interface.type [template = constants.%Interface.type.981] {
 // CHECK:STDOUT:       %Interface.ref: %Interface.type.e32 = name_ref Interface, file.%Interface.decl [template = constants.%Interface.generic]
 // CHECK:STDOUT:       %int_32.loc12_33: Core.IntLiteral = int_value 32 [template = constants.%int_32]
@@ -304,23 +304,23 @@ fn AccessMissingConcrete(I:! Interface(i32)) -> i32 {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Interface.decl: %Interface.type.e32 = interface_decl @Interface [template = constants.%Interface.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_21.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_21.1, runtime_param<invalid> [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_21.1, runtime_param<none> [symbolic = %T.patt.loc4_21.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_21.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_21.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMissingGeneric.decl: %AccessMissingGeneric.type = fn_decl @AccessMissingGeneric [template = constants.%AccessMissingGeneric] {
 // CHECK:STDOUT:     %T.patt.loc8_25.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_25.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_25.1, runtime_param<invalid> [symbolic = %T.patt.loc8_25.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_25.1, runtime_param<none> [symbolic = %T.patt.loc8_25.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %I.patt.loc8_35.1: @AccessMissingGeneric.%Interface.type.loc8_50.2 (%Interface.type.d32) = symbolic_binding_pattern I, 1 [symbolic = %I.patt.loc8_35.2 (constants.%I.patt.47c)]
-// CHECK:STDOUT:     %I.param_patt: @AccessMissingGeneric.%Interface.type.loc8_50.2 (%Interface.type.d32) = value_param_pattern %I.patt.loc8_35.1, runtime_param<invalid> [symbolic = %I.patt.loc8_35.2 (constants.%I.patt.47c)]
+// CHECK:STDOUT:     %I.param_patt: @AccessMissingGeneric.%Interface.type.loc8_50.2 (%Interface.type.d32) = value_param_pattern %I.patt.loc8_35.1, runtime_param<none> [symbolic = %I.patt.loc8_35.2 (constants.%I.patt.47c)]
 // CHECK:STDOUT:     %return.patt: @AccessMissingGeneric.%T.loc8_25.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @AccessMissingGeneric.%T.loc8_25.2 (%T) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc8_56: type = name_ref T, %T.loc8_25.1 [symbolic = %T.loc8_25.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_25.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_25.2 (constants.%T)]
-// CHECK:STDOUT:     %I.param: @AccessMissingGeneric.%Interface.type.loc8_50.2 (%Interface.type.d32) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.param: @AccessMissingGeneric.%Interface.type.loc8_50.2 (%Interface.type.d32) = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8: type = splice_block %Interface.type.loc8_50.1 [symbolic = %Interface.type.loc8_50.2 (constants.%Interface.type.d32)] {
 // CHECK:STDOUT:       %Interface.ref: %Interface.type.e32 = name_ref Interface, file.%Interface.decl [template = constants.%Interface.generic]
 // CHECK:STDOUT:       %T.ref.loc8_49: type = name_ref T, %T.loc8_25.1 [symbolic = %T.loc8_25.2 (constants.%T)]
@@ -332,13 +332,13 @@ fn AccessMissingConcrete(I:! Interface(i32)) -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMissingConcrete.decl: %AccessMissingConcrete.type = fn_decl @AccessMissingConcrete [template = constants.%AccessMissingConcrete] {
 // CHECK:STDOUT:     %I.patt.loc16_26.1: %Interface.type.981 = symbolic_binding_pattern I, 0 [symbolic = %I.patt.loc16_26.2 (constants.%I.patt.1f8)]
-// CHECK:STDOUT:     %I.param_patt: %Interface.type.981 = value_param_pattern %I.patt.loc16_26.1, runtime_param<invalid> [symbolic = %I.patt.loc16_26.2 (constants.%I.patt.1f8)]
+// CHECK:STDOUT:     %I.param_patt: %Interface.type.981 = value_param_pattern %I.patt.loc16_26.1, runtime_param<none> [symbolic = %I.patt.loc16_26.2 (constants.%I.patt.1f8)]
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %i32 = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32.loc16_49: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc16_49: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
-// CHECK:STDOUT:     %I.param: %Interface.type.981 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.param: %Interface.type.981 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc16: type = splice_block %Interface.type [template = constants.%Interface.type.981] {
 // CHECK:STDOUT:       %Interface.ref: %Interface.type.e32 = name_ref Interface, file.%Interface.decl [template = constants.%Interface.generic]
 // CHECK:STDOUT:       %int_32.loc16_40: Core.IntLiteral = int_value 32 [template = constants.%int_32]

--- a/toolchain/check/testdata/interface/no_prelude/as_type_of_type.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/as_type_of_type.carbon
@@ -35,9 +35,9 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:   %Empty.decl: type = interface_decl @Empty [template = constants.%Empty.type] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc13_6.1: %Empty.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %Empty.type = value_param_pattern %T.patt.loc13_6.1, runtime_param<invalid> [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %Empty.type = value_param_pattern %T.patt.loc13_6.1, runtime_param<none> [symbolic = %T.patt.loc13_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Empty.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Empty.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %Empty.ref: type = name_ref Empty, file.%Empty.decl [template = constants.%Empty.type]
 // CHECK:STDOUT:     %T.loc13_6.1: %Empty.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_6.2 (constants.%T)]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/interface/no_prelude/assoc_const_in_generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/assoc_const_in_generic.carbon
@@ -63,16 +63,16 @@ fn H() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc15_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_6.1, runtime_param<invalid> [symbolic = %T.patt.loc15_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc15_6.1, runtime_param<none> [symbolic = %T.patt.loc15_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc15_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc15_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {} {}
@@ -94,12 +94,12 @@ fn H() {
 // CHECK:STDOUT:     %Self.1: @I.%I.type (%I.type.325) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
 // CHECK:STDOUT:     %F.decl: @I.%F.type (%F.type.2ae) = fn_decl @F [symbolic = @I.%F (constants.%F)] {
 // CHECK:STDOUT:       %U.patt.loc12_8.2: type = symbolic_binding_pattern U, 2 [symbolic = %U.patt.loc12_8.1 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc12_8.2, runtime_param<invalid> [symbolic = %U.patt.loc12_8.1 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc12_8.2, runtime_param<none> [symbolic = %U.patt.loc12_8.1 (constants.%U.patt)]
 // CHECK:STDOUT:       %return.patt: @F.%U.loc12_8.1 (%U) = return_slot_pattern
 // CHECK:STDOUT:       %return.param_patt: @F.%U.loc12_8.1 (%U) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %U.ref: type = name_ref U, %U.loc12_8.2 [symbolic = %U.loc12_8.1 (constants.%U)]
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc12_8.2: type = bind_symbolic_name U, 2, %U.param [symbolic = %U.loc12_8.1 (constants.%U)]
 // CHECK:STDOUT:       %return.param: ref @F.%U.loc12_8.1 (%U) = out_param runtime_param0
 // CHECK:STDOUT:       %return: ref @F.%U.loc12_8.1 (%U) = return_slot %return.param

--- a/toolchain/check/testdata/interface/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/export_name.carbon
@@ -75,7 +75,7 @@ fn UseEmpty(i: I) {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .I = %I
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %I: type = export I, imports.%Main.I [template = constants.%I.type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -103,7 +103,7 @@ fn UseEmpty(i: I) {}
 // CHECK:STDOUT:     .I = imports.%Main.I
 // CHECK:STDOUT:     .UseEmpty = %UseEmpty.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %UseEmpty.decl: %UseEmpty.type = fn_decl @UseEmpty [template = constants.%UseEmpty] {
 // CHECK:STDOUT:     %i.patt: %I.type = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: %I.type = value_param_pattern %i.patt, runtime_param0

--- a/toolchain/check/testdata/interface/no_prelude/fail_definition_imported.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_definition_imported.carbon
@@ -60,7 +60,7 @@ interface I {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .I = imports.%Main.I
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %.decl: type = interface_decl @.1 [template = constants.%.type] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_generic_redeclaration.carbon
@@ -72,31 +72,31 @@ interface DifferentParams(T:! ()) {}
 // CHECK:STDOUT:   %NotGeneric.decl: type = interface_decl @NotGeneric [template = constants.%NotGeneric.type] {} {}
 // CHECK:STDOUT:   %.decl.loc19: %.type.abf52e.1 = interface_decl @.1 [template = constants.%.generic.0a9e18.1] {
 // CHECK:STDOUT:     %T.patt.loc19_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc19_22.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc19_22.1, runtime_param<invalid> [symbolic = %T.patt.loc19_22.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc19_22.1, runtime_param<none> [symbolic = %T.patt.loc19_22.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc19_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc19_22.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Generic.decl: %Generic.type = interface_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc21_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc21_19.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc21_19.1, runtime_param<invalid> [symbolic = %T.patt.loc21_19.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc21_19.1, runtime_param<none> [symbolic = %T.patt.loc21_19.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc21_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc21_19.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl.loc29: type = interface_decl @.2 [template = constants.%.type.4ea] {} {}
 // CHECK:STDOUT:   %DifferentParams.decl: %DifferentParams.type = interface_decl @DifferentParams [template = constants.%DifferentParams.generic] {
 // CHECK:STDOUT:     %T.patt.loc31_27.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc31_27.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc31_27.1, runtime_param<invalid> [symbolic = %T.patt.loc31_27.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc31_27.1, runtime_param<none> [symbolic = %T.patt.loc31_27.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc31_27.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc31_27.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl.loc39: %.type.abf52e.2 = interface_decl @.3 [template = constants.%.generic.0a9e18.2] {
 // CHECK:STDOUT:     %T.patt.loc39_27.1: %empty_tuple.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc39_27.2 (constants.%T.patt.e60)]
-// CHECK:STDOUT:     %T.param_patt: %empty_tuple.type = value_param_pattern %T.patt.loc39_27.1, runtime_param<invalid> [symbolic = %T.patt.loc39_27.2 (constants.%T.patt.e60)]
+// CHECK:STDOUT:     %T.param_patt: %empty_tuple.type = value_param_pattern %T.patt.loc39_27.1, runtime_param<none> [symbolic = %T.patt.loc39_27.2 (constants.%T.patt.e60)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %empty_tuple.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %empty_tuple.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc39_32.1: type = splice_block %.loc39_32.3 [template = constants.%empty_tuple.type] {
 // CHECK:STDOUT:       %.loc39_32.2: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:       %.loc39_32.3: type = converted %.loc39_32.2, constants.%empty_tuple.type [template = constants.%empty_tuple.type]

--- a/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_member_lookup.carbon
@@ -69,14 +69,14 @@ fn G(U:! Different) -> U.(Interface.T);
 // CHECK:STDOUT:   %Different.decl: type = interface_decl @Different [template = constants.%Different.type] {} {}
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %U.patt.loc37_6.1: %Different.type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc37_6.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %Different.type = value_param_pattern %U.patt.loc37_6.1, runtime_param<invalid> [symbolic = %U.patt.loc37_6.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %Different.type = value_param_pattern %U.patt.loc37_6.1, runtime_param<none> [symbolic = %U.patt.loc37_6.2 (constants.%U.patt)]
 // CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: <error> = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.ref: %Different.type = name_ref U, %U.loc37_6.1 [symbolic = %U.loc37_6.2 (constants.%U)]
 // CHECK:STDOUT:     %Interface.ref: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
 // CHECK:STDOUT:     %T.ref: %assoc_type = name_ref T, @Interface.%assoc1 [template = constants.%assoc1]
-// CHECK:STDOUT:     %U.param: %Different.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %Different.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %Different.ref: type = name_ref Different, file.%Different.decl [template = constants.%Different.type]
 // CHECK:STDOUT:     %U.loc37_6.1: %Different.type = bind_symbolic_name U, 0, %U.param [symbolic = %U.loc37_6.2 (constants.%U)]
 // CHECK:STDOUT:     %return.param: ref <error> = out_param runtime_param0

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_facet_lookup.carbon
@@ -56,19 +56,19 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:   %Interface.decl: type = interface_decl @Interface [template = constants.%Interface.type] {} {}
 // CHECK:STDOUT:   %CallStatic.decl: %CallStatic.type = fn_decl @CallStatic [template = constants.%CallStatic] {
 // CHECK:STDOUT:     %T.patt.loc13_15.1: %Interface.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc13_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %Interface.type = value_param_pattern %T.patt.loc13_15.1, runtime_param<invalid> [symbolic = %T.patt.loc13_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %Interface.type = value_param_pattern %T.patt.loc13_15.1, runtime_param<none> [symbolic = %T.patt.loc13_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Interface.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Interface.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %Interface.ref: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
 // CHECK:STDOUT:     %T.loc13_15.1: %Interface.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc13_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallFacet.decl: %CallFacet.type = fn_decl @CallFacet [template = constants.%CallFacet] {
 // CHECK:STDOUT:     %T.patt.loc21_14.1: %Interface.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc21_14.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %Interface.type = value_param_pattern %T.patt.loc21_14.1, runtime_param<invalid> [symbolic = %T.patt.loc21_14.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %Interface.type = value_param_pattern %T.patt.loc21_14.1, runtime_param<none> [symbolic = %T.patt.loc21_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @CallFacet.%T.as_type.loc21_32.2 (%T.as_type) = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: @CallFacet.%T.as_type.loc21_32.2 (%T.as_type) = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Interface.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Interface.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %Interface.ref: type = name_ref Interface, file.%Interface.decl [template = constants.%Interface.type]
 // CHECK:STDOUT:     %T.loc21_14.1: %Interface.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc21_14.2 (constants.%T)]
 // CHECK:STDOUT:     %x.param: @CallFacet.%T.as_type.loc21_32.2 (%T.as_type) = value_param runtime_param0

--- a/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_todo_generic_default_fn.carbon
@@ -47,9 +47,9 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [template = constants.%I.generic] {
 // CHECK:STDOUT:     %T.patt.loc11_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<invalid> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_13.1, runtime_param<none> [symbolic = %T.patt.loc11_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [symbolic = constants.%.075] {
@@ -58,7 +58,7 @@ fn I(T:! type).F[self: Self]() -> Self { return self; }
 // CHECK:STDOUT:     %return.patt: @.1.%Self.as_type.loc23_24.2 (%Self.as_type) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @.1.%Self.as_type.loc23_24.2 (%Self.as_type) = out_param_pattern %return.patt, runtime_param1
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc23_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc23_6.2 (constants.%T)]
 // CHECK:STDOUT:     %.loc23_35.1: @.1.%I.type (%I.type.325) = specific_constant @I.%Self.1, @I(constants.%T) [symbolic = %Self (constants.%Self)]
 // CHECK:STDOUT:     %Self.ref.loc23_35: @.1.%I.type (%I.type.325) = name_ref Self, %.loc23_35.1 [symbolic = %Self (constants.%Self)]

--- a/toolchain/check/testdata/interface/no_prelude/generic.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic.carbon
@@ -118,37 +118,37 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Simple.decl: %Simple.type.3b3 = interface_decl @Simple [template = constants.%Simple.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_18.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_18.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_18.1, runtime_param<invalid> [symbolic = %T.patt.loc4_18.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_18.1, runtime_param<none> [symbolic = %T.patt.loc4_18.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_18.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_18.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [template = constants.%X] {} {}
 // CHECK:STDOUT:   %WithAssocFn.decl: %WithAssocFn.type.509 = interface_decl @WithAssocFn [template = constants.%WithAssocFn.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_23.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_23.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_23.1, runtime_param<invalid> [symbolic = %T.patt.loc8_23.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_23.1, runtime_param<none> [symbolic = %T.patt.loc8_23.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_23.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_23.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %WithImplicitArgs.decl: %WithImplicitArgs.type = interface_decl @WithImplicitArgs [template = constants.%WithImplicitArgs.generic] {
 // CHECK:STDOUT:     %T.patt.loc22_28.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc22_28.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc22_28.1, runtime_param<invalid> [symbolic = %T.patt.loc22_28.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc22_28.1, runtime_param<none> [symbolic = %T.patt.loc22_28.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:     %N.patt.loc22_38.1: @WithImplicitArgs.%T.loc22_28.2 (%T.8b3) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc22_38.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: @WithImplicitArgs.%T.loc22_28.2 (%T.8b3) = value_param_pattern %N.patt.loc22_38.1, runtime_param<invalid> [symbolic = %N.patt.loc22_38.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: @WithImplicitArgs.%T.loc22_28.2 (%T.8b3) = value_param_pattern %N.patt.loc22_38.1, runtime_param<none> [symbolic = %N.patt.loc22_38.2 (constants.%N.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc22_28.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc22_28.2 (constants.%T.8b3)]
-// CHECK:STDOUT:     %N.param: @WithImplicitArgs.%T.loc22_28.2 (%T.8b3) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: @WithImplicitArgs.%T.loc22_28.2 (%T.8b3) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc22_28.1 [symbolic = %T.loc22_28.2 (constants.%T.8b3)]
 // CHECK:STDOUT:     %N.loc22_38.1: @WithImplicitArgs.%T.loc22_28.2 (%T.8b3) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc22_38.2 (constants.%N)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Receive.decl: %Receive.type = fn_decl @Receive [template = constants.%Receive] {
 // CHECK:STDOUT:     %T.patt.loc24_12.1: %Simple.type.51f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc24_12.2 (constants.%T.patt.6ae)]
-// CHECK:STDOUT:     %T.param_patt: %Simple.type.51f = value_param_pattern %T.patt.loc24_12.1, runtime_param<invalid> [symbolic = %T.patt.loc24_12.2 (constants.%T.patt.6ae)]
+// CHECK:STDOUT:     %T.param_patt: %Simple.type.51f = value_param_pattern %T.patt.loc24_12.1, runtime_param<none> [symbolic = %T.patt.loc24_12.2 (constants.%T.patt.6ae)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Simple.type.51f = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Simple.type.51f = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc24: type = splice_block %Simple.type [template = constants.%Simple.type.51f] {
 // CHECK:STDOUT:       %Simple.ref: %Simple.type.3b3 = name_ref Simple, file.%Simple.decl [template = constants.%Simple.generic]
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
@@ -158,9 +158,9 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Pass.decl: %Pass.type = fn_decl @Pass [template = constants.%Pass] {
 // CHECK:STDOUT:     %T.patt.loc25_9.1: %Simple.type.51f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc25_9.2 (constants.%T.patt.6ae)]
-// CHECK:STDOUT:     %T.param_patt: %Simple.type.51f = value_param_pattern %T.patt.loc25_9.1, runtime_param<invalid> [symbolic = %T.patt.loc25_9.2 (constants.%T.patt.6ae)]
+// CHECK:STDOUT:     %T.param_patt: %Simple.type.51f = value_param_pattern %T.patt.loc25_9.1, runtime_param<none> [symbolic = %T.patt.loc25_9.2 (constants.%T.patt.6ae)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Simple.type.51f = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Simple.type.51f = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc25: type = splice_block %Simple.type [template = constants.%Simple.type.51f] {
 // CHECK:STDOUT:       %Simple.ref: %Simple.type.3b3 = name_ref Simple, file.%Simple.decl [template = constants.%Simple.generic]
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
@@ -415,18 +415,18 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Generic.decl: %Generic.type.c21 = interface_decl @Generic [template = constants.%Generic.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_19.2 (constants.%T.patt.e01)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<invalid> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<none> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_19.2 (constants.%T.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {} {}
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc9_6.1: %Generic.type.c7c = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_6.2 (constants.%T.patt.3e0)]
-// CHECK:STDOUT:     %T.param_patt: %Generic.type.c7c = value_param_pattern %T.patt.loc9_6.1, runtime_param<invalid> [symbolic = %T.patt.loc9_6.2 (constants.%T.patt.3e0)]
+// CHECK:STDOUT:     %T.param_patt: %Generic.type.c7c = value_param_pattern %T.patt.loc9_6.1, runtime_param<none> [symbolic = %T.patt.loc9_6.2 (constants.%T.patt.3e0)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Generic.type.c7c = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Generic.type.c7c = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc9: type = splice_block %Generic.type [template = constants.%Generic.type.c7c] {
 // CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
 // CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
@@ -436,9 +436,9 @@ fn G(T:! Generic(B)) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc10_6.1: %Generic.type.4ce = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc10_6.2 (constants.%T.patt.53a)]
-// CHECK:STDOUT:     %T.param_patt: %Generic.type.4ce = value_param_pattern %T.patt.loc10_6.1, runtime_param<invalid> [symbolic = %T.patt.loc10_6.2 (constants.%T.patt.53a)]
+// CHECK:STDOUT:     %T.param_patt: %Generic.type.4ce = value_param_pattern %T.patt.loc10_6.1, runtime_param<none> [symbolic = %T.patt.loc10_6.2 (constants.%T.patt.53a)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %Generic.type.4ce = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %Generic.type.4ce = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc10: type = splice_block %Generic.type [template = constants.%Generic.type.4ce] {
 // CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
 // CHECK:STDOUT:       %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]

--- a/toolchain/check/testdata/interface/no_prelude/generic_binding_after_assoc_const.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_binding_after_assoc_const.carbon
@@ -46,9 +46,9 @@ interface I {
 // CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc12_8.2: type = symbolic_binding_pattern T, 1 [symbolic = %T.patt.loc12_8.1 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_8.2, runtime_param<invalid> [symbolic = %T.patt.loc12_8.1 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc12_8.2, runtime_param<none> [symbolic = %T.patt.loc12_8.1 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc12_8.2: type = bind_symbolic_name T, 1, %T.param [symbolic = %T.loc12_8.1 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %F.assoc_type = assoc_entity element0, %F.decl [template = constants.%assoc0]
@@ -56,9 +56,9 @@ interface I {
 // CHECK:STDOUT:   %assoc1: %assoc_type = assoc_entity element1, %U [template = constants.%assoc1]
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc16_8.2: type = symbolic_binding_pattern T, 1 [symbolic = %T.patt.loc16_8.1 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc16_8.2, runtime_param<invalid> [symbolic = %T.patt.loc16_8.1 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc16_8.2, runtime_param<none> [symbolic = %T.patt.loc16_8.1 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc16_8.2: type = bind_symbolic_name T, 1, %T.param [symbolic = %T.loc16_8.1 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc2: %G.assoc_type = assoc_entity element2, %G.decl [template = constants.%assoc2]

--- a/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_import.carbon
@@ -48,9 +48,9 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AddWith.decl: %AddWith.type.b35 = interface_decl @AddWith [template = constants.%AddWith.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_19.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<invalid> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_19.1, runtime_param<none> [symbolic = %T.patt.loc4_19.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_19.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_19.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -133,7 +133,7 @@ impl C as AddWith(C) {
 // CHECK:STDOUT:     .AddWith = imports.%Main.AddWith
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C.ref.loc7_6: type = name_ref C, file.%C.decl [template = constants.%C]

--- a/toolchain/check/testdata/interface/no_prelude/generic_vs_params.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/generic_vs_params.carbon
@@ -98,16 +98,16 @@ interface A(T: type) {}
 // CHECK:STDOUT:   %NotGenericButParams.decl: %NotGenericButParams.type.f26 = interface_decl @NotGenericButParams [template = constants.%NotGenericButParams.generic] {} {}
 // CHECK:STDOUT:   %GenericAndParams.decl: %GenericAndParams.type.cde = interface_decl @GenericAndParams.1 [template = constants.%GenericAndParams.generic.827] {
 // CHECK:STDOUT:     %T.patt.loc6_28.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_28.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_28.1, runtime_param<invalid> [symbolic = %T.patt.loc6_28.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_28.1, runtime_param<none> [symbolic = %T.patt.loc6_28.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_28.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_28.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_9.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<invalid> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_9.1, runtime_param<none> [symbolic = %T.patt.loc8_9.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_9.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [template = constants.%X] {} {}
@@ -253,9 +253,9 @@ interface A(T: type) {}
 // CHECK:STDOUT:     %GenericNoParams.decl: type = interface_decl @GenericNoParams [template = constants.%GenericNoParams.type.f90] {} {}
 // CHECK:STDOUT:     %GenericAndParams.decl: @C.%GenericAndParams.type (%GenericAndParams.type.597) = interface_decl @GenericAndParams.2 [symbolic = @C.%GenericAndParams.generic (constants.%GenericAndParams.generic.2ec)] {
 // CHECK:STDOUT:       %U.patt.loc10_30.1: type = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc10_30.2 (constants.%U.patt)]
-// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc10_30.1, runtime_param<invalid> [symbolic = %U.patt.loc10_30.2 (constants.%U.patt)]
+// CHECK:STDOUT:       %U.param_patt: type = value_param_pattern %U.patt.loc10_30.1, runtime_param<none> [symbolic = %U.patt.loc10_30.2 (constants.%U.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %U.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:       %U.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:       %U.loc10_30.1: type = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc10_30.2 (constants.%U)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]

--- a/toolchain/check/testdata/interface/no_prelude/import.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import.carbon
@@ -205,7 +205,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     .UseForwardDeclaredF = %UseForwardDeclaredF
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %UseEmpty.decl: %UseEmpty.type = fn_decl @UseEmpty [template = constants.%UseEmpty] {
 // CHECK:STDOUT:     %e.patt: %Empty.type = binding_pattern e
 // CHECK:STDOUT:     %e.param_patt: %Empty.type = value_param_pattern %e.patt, runtime_param0

--- a/toolchain/check/testdata/interface/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import_access.carbon
@@ -216,7 +216,7 @@ private interface Redecl {}
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %i.patt: %Def.type = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: %Def.type = value_param_pattern %i.patt, runtime_param0
@@ -249,7 +249,7 @@ private interface Redecl {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %i.patt: <error> = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: <error> = value_param_pattern %i.patt, runtime_param0
@@ -321,7 +321,7 @@ private interface Redecl {}
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %i.patt: %ForwardWithDef.type = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: %ForwardWithDef.type = value_param_pattern %i.patt, runtime_param0
@@ -354,7 +354,7 @@ private interface Redecl {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %i.patt: <error> = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: <error> = value_param_pattern %i.patt, runtime_param0
@@ -421,7 +421,7 @@ private interface Redecl {}
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %i.patt: <error> = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: <error> = value_param_pattern %i.patt, runtime_param0
@@ -460,7 +460,7 @@ private interface Redecl {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %i.patt: <error> = binding_pattern i
 // CHECK:STDOUT:     %i.param_patt: <error> = value_param_pattern %i.patt, runtime_param0

--- a/toolchain/check/testdata/interface/no_prelude/import_interface_decl.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import_interface_decl.carbon
@@ -52,8 +52,8 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc1_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc1_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc1_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_b.carbon
@@ -106,8 +106,8 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc1_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc1_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc1_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @B [from "fail_b.carbon"] {

--- a/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
@@ -216,33 +216,33 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl.loc7: %Foo.type.538 = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<invalid> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<none> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc7: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_15.1: %C = bind_symbolic_name a, 0, %a.param.loc7 [symbolic = %a.loc7_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo.decl.loc8: %Foo.type.538 = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<invalid> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<none> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc8: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc8: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc8: %C = bind_symbolic_name a, 0, %a.param.loc8 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl.loc10: %Bar.type.982 = interface_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc10_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc10_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc10_15.1, runtime_param<invalid> [symbolic = %a.patt.loc10_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc10_15.1, runtime_param<none> [symbolic = %a.patt.loc10_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc10: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc10: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref.loc10: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc10_15.1: %C = bind_symbolic_name a, 0, %a.param.loc10 [symbolic = %a.loc10_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl.loc11: %Bar.type.982 = interface_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc10_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc10_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc10_15.1, runtime_param<invalid> [symbolic = %a.patt.loc10_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc10_15.1, runtime_param<none> [symbolic = %a.patt.loc10_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc11: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc11: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref.loc11: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc11: %C = bind_symbolic_name a, 0, %a.param.loc11 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -326,17 +326,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl.loc6: %Foo.type.538 = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_21.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_21.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_21.1, runtime_param<invalid> [symbolic = %a.patt.loc6_21.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_21.1, runtime_param<none> [symbolic = %a.patt.loc6_21.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc6: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_21.1: %C = bind_symbolic_name a, 0, %a.param.loc6 [symbolic = %a.loc6_21.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo.decl.loc7: %Foo.type.538 = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_21.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_21.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_21.1, runtime_param<invalid> [symbolic = %a.patt.loc6_21.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_21.1, runtime_param<none> [symbolic = %a.patt.loc6_21.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc7: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7: %C = bind_symbolic_name a, 0, %a.param.loc7 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -398,17 +398,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<invalid> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<none> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc6_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type.abf = interface_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc14_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc14_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc14_15.1, runtime_param<invalid> [symbolic = %a.patt.loc14_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc14_15.1, runtime_param<none> [symbolic = %a.patt.loc14_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc14_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc14_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -480,17 +480,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl.loc6: %Foo.type.538 = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<invalid> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<none> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc6: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc6: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_15.1: %C = bind_symbolic_name a, 0, %a.param.loc6 [symbolic = %a.loc6_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo.decl.loc7: %Foo.type.538 = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<invalid> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<none> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param.loc7: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref.loc7: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7: %C = bind_symbolic_name a, 0, %a.param.loc7 [symbolic = constants.%a]
 // CHECK:STDOUT:   }
@@ -554,17 +554,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<invalid> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<none> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Bar.decl: %Bar.type = interface_decl @Bar [template = constants.%Bar.generic] {
 // CHECK:STDOUT:     %a.patt.loc8_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc8_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8_15.1, runtime_param<invalid> [symbolic = %a.patt.loc8_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc8_15.1, runtime_param<none> [symbolic = %a.patt.loc8_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc8_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc8_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -640,21 +640,21 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:     .Foo = imports.%Main.Foo
 // CHECK:STDOUT:     .Bar = imports.%Main.Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %.decl.loc12: %.type.abf52e.1 = interface_decl @.1 [template = constants.%.generic.0a9e18.1] {
 // CHECK:STDOUT:     %a.patt.loc12_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc12_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc12_15.1, runtime_param<invalid> [symbolic = %a.patt.loc12_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc12_15.1, runtime_param<none> [symbolic = %a.patt.loc12_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:     %a.loc12_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc12_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl.loc21: %.type.abf52e.2 = interface_decl @.2 [template = constants.%.generic.0a9e18.2] {
 // CHECK:STDOUT:     %a.patt.loc21_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc21_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc21_15.1, runtime_param<invalid> [symbolic = %a.patt.loc21_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc21_15.1, runtime_param<none> [symbolic = %a.patt.loc21_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc21_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc21_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -768,17 +768,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<invalid> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<none> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type.abf = interface_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %b.patt.loc15_15.1: %C = symbolic_binding_pattern b, 0 [symbolic = %b.patt.loc15_15.2 (constants.%b.patt)]
-// CHECK:STDOUT:     %b.param_patt: %C = value_param_pattern %b.patt.loc15_15.1, runtime_param<invalid> [symbolic = %b.patt.loc15_15.2 (constants.%b.patt)]
+// CHECK:STDOUT:     %b.param_patt: %C = value_param_pattern %b.patt.loc15_15.1, runtime_param<none> [symbolic = %b.patt.loc15_15.2 (constants.%b.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %b.loc15_15.1: %C = bind_symbolic_name b, 0, %b.param [symbolic = %b.loc15_15.2 (constants.%b)]
 // CHECK:STDOUT:   }
@@ -855,17 +855,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<invalid> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<none> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type.abf = interface_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc15_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc15_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_15.1, runtime_param<invalid> [symbolic = %a.patt.loc15_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_15.1, runtime_param<none> [symbolic = %a.patt.loc15_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc15_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc15_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -942,17 +942,17 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %D: type = bind_alias D, %C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc7_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<invalid> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc7_15.1, runtime_param<none> [symbolic = %a.patt.loc7_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc7_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc7_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type.abf = interface_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc15_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc15_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_15.1, runtime_param<invalid> [symbolic = %a.patt.loc15_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc15_15.1, runtime_param<none> [symbolic = %a.patt.loc15_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc15_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc15_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -1022,9 +1022,9 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<invalid> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc6_15.1, runtime_param<none> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc6_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc6_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -1079,15 +1079,15 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:     .Foo = imports.%Main.Foo
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %.decl: %.type.abf = interface_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc17_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc17_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc17_15.1, runtime_param<invalid> [symbolic = %a.patt.loc17_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt.loc17_15.1, runtime_param<none> [symbolic = %a.patt.loc17_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %C = value_param runtime_param<none>
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D [template = constants.%C]
 // CHECK:STDOUT:     %a.loc17_15.1: %C = bind_symbolic_name a, 0, %a.param [symbolic = %a.loc17_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
@@ -1161,9 +1161,9 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = interface_decl @Foo [template = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc6_15.1: %const = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc6_15.1, runtime_param<invalid> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc6_15.1, runtime_param<none> [symbolic = %a.patt.loc6_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6: type = splice_block %const [template = constants.%const] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:       %const: type = const_type %C [template = constants.%const]
@@ -1172,9 +1172,9 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.decl: %.type.abf = interface_decl @.1 [template = constants.%.generic] {
 // CHECK:STDOUT:     %a.patt.loc18_15.1: %const = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc18_15.2 (constants.%a.patt)]
-// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc18_15.1, runtime_param<invalid> [symbolic = %a.patt.loc18_15.2 (constants.%a.patt)]
+// CHECK:STDOUT:     %a.param_patt: %const = value_param_pattern %a.patt.loc18_15.1, runtime_param<none> [symbolic = %a.patt.loc18_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %a.param: %const = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc18: type = splice_block %const.loc18_19 [template = constants.%const] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:       %const.loc18_26: type = const_type %C [template = constants.%const]

--- a/toolchain/check/testdata/let/compile_time_bindings.carbon
+++ b/toolchain/check/testdata/let/compile_time_bindings.carbon
@@ -346,9 +346,9 @@ impl i32 as Empty {
 // CHECK:STDOUT:   %a: %empty_tuple.type = bind_name a, %.loc9_17.2
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %b.patt.loc10_8.2: %tuple.type.9fb = symbolic_binding_pattern b, 0 [symbolic = %b.patt.loc10_8.1 (constants.%b.patt)]
-// CHECK:STDOUT:     %b.param_patt: %tuple.type.9fb = value_param_pattern %b.patt.loc10_8.2, runtime_param<invalid> [symbolic = %b.patt.loc10_8.1 (constants.%b.patt)]
+// CHECK:STDOUT:     %b.param_patt: %tuple.type.9fb = value_param_pattern %b.patt.loc10_8.2, runtime_param<none> [symbolic = %b.patt.loc10_8.1 (constants.%b.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %b.param: %tuple.type.9fb = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %b.param: %tuple.type.9fb = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc10_16.1: type = splice_block %.loc10_16.4 [template = constants.%tuple.type.9fb] {
 // CHECK:STDOUT:       %.loc10_14: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:       %.loc10_16.2: %tuple.type.9fb = tuple_literal (%.loc10_14)

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -84,7 +84,7 @@ let a: T = 0;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: <error> = binding_pattern a

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -85,7 +85,7 @@ var b: T = *a;
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: <error> = binding_pattern a

--- a/toolchain/check/testdata/let/no_prelude/import.carbon
+++ b/toolchain/check/testdata/let/no_prelude/import.carbon
@@ -77,7 +77,7 @@ let b: () = Other.a;
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %empty_tuple.type = binding_pattern b
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/let/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/let/no_prelude/import_access.carbon
@@ -97,7 +97,7 @@ let v2: () = Test.v;
 // CHECK:STDOUT:     .v2 = %v2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %v2.patt: %empty_tuple.type = binding_pattern v2
 // CHECK:STDOUT:   }
@@ -124,7 +124,7 @@ let v2: () = Test.v;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .v2 = %v2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %v2.patt: %empty_tuple.type = binding_pattern v2
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/add_to_import.carbon
+++ b/toolchain/check/testdata/namespace/add_to_import.carbon
@@ -77,7 +77,7 @@ var a: i32 = NS.A();
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [template = constants.%A] {
 // CHECK:STDOUT:     %return.patt: %i32 = return_slot_pattern

--- a/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
@@ -90,7 +90,7 @@ fn NS();
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %NS.loc8: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.decl.loc18: %.type.b6a92a.1 = fn_decl @.1 [template = constants.%.d852be.1] {} {}
 // CHECK:STDOUT:   %NS.loc22: <namespace> = namespace [template] {}

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
@@ -76,7 +76,7 @@ fn NS.Foo();
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {}
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = fn_decl @Foo [template = constants.%Foo] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
@@ -88,7 +88,7 @@ fn NS.Foo();
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %.loc14: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
@@ -123,7 +123,7 @@ fn NS.Bar() {}
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Bar.decl: %Bar.type = fn_decl @Bar [template = constants.%Bar] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
@@ -123,7 +123,7 @@ fn NS.Bar() {}
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Bar.decl: %Bar.type = fn_decl @Bar [template = constants.%Bar] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_params.carbon
+++ b/toolchain/check/testdata/namespace/fail_params.carbon
@@ -80,7 +80,7 @@ fn D(T:! type).F() {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n: %i32 = bind_name n, %n.param
 // CHECK:STDOUT:   %B: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:   %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:   %x.param: %T = value_param runtime_param0
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
@@ -88,7 +88,7 @@ fn D(T:! type).F() {}
 // CHECK:STDOUT:   %C: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %D: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.d85] {} {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc40_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc40_6.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -103,7 +103,7 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:     .package_b = %package_b
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -143,7 +143,7 @@ fn G() { Same.F(); }
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %B: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %return.patt: %C = return_slot_pattern
@@ -181,7 +181,7 @@ fn G() { Same.F(); }
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -209,7 +209,7 @@ fn G() { Same.F(); }
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %D.decl: %D.type = fn_decl @D [template = constants.%D] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -253,7 +253,7 @@ fn G() { Same.F(); }
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %e.patt: %empty_tuple.type = binding_pattern e
 // CHECK:STDOUT:     %.loc5_1: %empty_tuple.type = var_pattern %e.patt
@@ -309,7 +309,7 @@ fn G() { Same.F(); }
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/merging.carbon
+++ b/toolchain/check/testdata/namespace/merging.carbon
@@ -161,7 +161,7 @@ fn Run() {
 // CHECK:STDOUT:     .Run = %Run.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Example.A
 // CHECK:STDOUT:     .B1 = imports.%Example.B1

--- a/toolchain/check/testdata/namespace/merging_with_indirections.carbon
+++ b/toolchain/check/testdata/namespace/merging_with_indirections.carbon
@@ -110,7 +110,7 @@ fn Run() {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %NS1: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = imports.%Other.A
 // CHECK:STDOUT:     .B = %B.decl

--- a/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
+++ b/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
@@ -131,12 +131,12 @@ fn Test() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Source.decl: %Source.type = fn_decl @Source [template = constants.%Source] {
 // CHECK:STDOUT:     %T.patt.loc27_11.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc27_11.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc27_11.1, runtime_param<invalid> [symbolic = %T.patt.loc27_11.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc27_11.1, runtime_param<none> [symbolic = %T.patt.loc27_11.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %return.patt: @Source.%T.loc27_11.2 (%T) = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: @Source.%T.loc27_11.2 (%T) = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc27_24: type = name_ref T, %T.loc27_11.1 [symbolic = %T.loc27_11.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc27_11.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc27_11.2 (constants.%T)]
 // CHECK:STDOUT:     %return.param: ref @Source.%T.loc27_11.2 (%T) = out_param runtime_param0
 // CHECK:STDOUT:     %return: ref @Source.%T.loc27_11.2 (%T) = return_slot %return.param
@@ -193,7 +193,7 @@ fn Test() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %X.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %X.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %X.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
+++ b/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
@@ -153,9 +153,9 @@ fn F() { ()[()]; }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %IndexWith.decl: %IndexWith.type.232 = interface_decl @IndexWith [template = constants.%IndexWith.generic] {
 // CHECK:STDOUT:     %SubscriptType.patt.loc5_26.1: type = symbolic_binding_pattern SubscriptType, 0 [symbolic = %SubscriptType.patt.loc5_26.2 (constants.%SubscriptType.patt)]
-// CHECK:STDOUT:     %SubscriptType.param_patt: type = value_param_pattern %SubscriptType.patt.loc5_26.1, runtime_param<invalid> [symbolic = %SubscriptType.patt.loc5_26.2 (constants.%SubscriptType.patt)]
+// CHECK:STDOUT:     %SubscriptType.param_patt: type = value_param_pattern %SubscriptType.patt.loc5_26.1, runtime_param<none> [symbolic = %SubscriptType.patt.loc5_26.2 (constants.%SubscriptType.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %SubscriptType.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %SubscriptType.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %SubscriptType.loc5_26.1: type = bind_symbolic_name SubscriptType, 0, %SubscriptType.param [symbolic = %SubscriptType.loc5_26.2 (constants.%SubscriptType)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {} {

--- a/toolchain/check/testdata/packages/explicit_imports.carbon
+++ b/toolchain/check/testdata/packages/explicit_imports.carbon
@@ -84,7 +84,7 @@ import library "main_lib_api";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- different_package.carbon
@@ -139,6 +139,6 @@ import library "main_lib_api";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -46,7 +46,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     has_error
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -64,7 +64,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     has_error
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -82,7 +82,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     has_error
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
@@ -110,6 +110,6 @@ import library "var";
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -133,7 +133,7 @@ import B;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     has_error
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_extension.carbon
+++ b/toolchain/check/testdata/packages/fail_extension.carbon
@@ -146,8 +146,8 @@ impl package SwappedExt;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc6_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc6_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc6_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc6_6.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -181,7 +181,7 @@ impl package SwappedExt;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Package.import = import Package
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -215,7 +215,7 @@ impl package SwappedExt;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Package.import = import Package
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -249,7 +249,7 @@ impl package SwappedExt;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %SwappedExt.import = import SwappedExt
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_default.carbon
+++ b/toolchain/check/testdata/packages/fail_import_default.carbon
@@ -76,7 +76,7 @@ import library default;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.import = import A
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -189,7 +189,7 @@ import ImportNotFound;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -223,7 +223,7 @@ import ImportNotFound;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -134,7 +134,7 @@ import library default;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Api.import = import Api
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_default_import.carbon
@@ -151,6 +151,6 @@ import library default;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_type_error.carbon
+++ b/toolchain/check/testdata/packages/fail_import_type_error.carbon
@@ -133,7 +133,7 @@ var d: i32 = d_ref;
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %i32 = binding_pattern a

--- a/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
+++ b/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
@@ -37,7 +37,7 @@ var a: () = A();
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     has_error
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a

--- a/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
+++ b/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
@@ -98,8 +98,8 @@ var b: i32 = a;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %i32 = binding_pattern b

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -87,7 +87,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:     .package_a = %package_a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a
@@ -174,7 +174,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:     .package_b = %package_b
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %empty_tuple.type = binding_pattern b
 // CHECK:STDOUT:     %.loc6_1: %empty_tuple.type = var_pattern %b.patt

--- a/toolchain/check/testdata/packages/no_prelude/cross_package_export.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/cross_package_export.carbon
@@ -214,7 +214,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -252,7 +252,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Other.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_import_copy.carbon
@@ -265,7 +265,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Other.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_import_indirect.carbon
@@ -278,7 +278,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Other.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_name.carbon
@@ -301,7 +301,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Other.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -333,7 +333,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Other.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -365,7 +365,7 @@ alias C = Other.C;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Other.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/cross_package_import.carbon
@@ -310,7 +310,7 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT:     .F = imports.%Other.F
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -490,7 +490,7 @@ fn UseF() { Other.F(); }
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.b19] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/no_prelude/export_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_import.carbon
@@ -193,7 +193,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -212,7 +212,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_copy.carbon
@@ -225,7 +225,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- non_export.carbon
@@ -238,7 +238,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_export.carbon
@@ -251,7 +251,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- import_then_export.carbon
@@ -264,7 +264,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_in_impl.carbon
@@ -296,7 +296,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -354,8 +354,8 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc4: %C = var_pattern %c.patt
@@ -409,7 +409,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -463,7 +463,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -517,7 +517,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -571,7 +571,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -625,7 +625,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -679,7 +679,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -716,7 +716,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Local = %Local
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.ref: <error> = name_ref C, <error> [template = <error>]
 // CHECK:STDOUT:   %Local: <error> = bind_alias Local, <error> [template = <error>]
 // CHECK:STDOUT: }
@@ -744,7 +744,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -800,7 +800,7 @@ var indirect_c: C = {.x = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .indirect_c = %indirect_c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %indirect_c.patt: %C = binding_pattern indirect_c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %indirect_c.patt

--- a/toolchain/check/testdata/packages/no_prelude/export_mixed.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_mixed.carbon
@@ -142,7 +142,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type.9be]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -156,7 +156,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc9_3: %D.elem = var_pattern %.loc9_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %D.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.y [template = constants.%complete_type.9f4]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -177,7 +177,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_import_then_name.carbon
@@ -202,7 +202,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -236,7 +236,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -258,7 +258,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- use_export_import_then_name.carbon
@@ -284,7 +284,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -338,7 +338,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -392,7 +392,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -439,7 +439,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d.patt: <error> = binding_pattern d
 // CHECK:STDOUT:     %.loc11: <error> = var_pattern %d.patt
@@ -480,7 +480,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -544,7 +544,7 @@ var d: D = {.y = ()};
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc8: %C = var_pattern %c.patt

--- a/toolchain/check/testdata/packages/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_name.carbon
@@ -232,7 +232,7 @@ private export C;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.x [template = constants.%complete_type.9be]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -246,7 +246,7 @@ private export C;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc10_3: %NSC.elem = var_pattern %.loc10_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %NSC.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %NSC.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.y [template = constants.%complete_type.9f4]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -287,7 +287,7 @@ private export C;
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %NSC: type = export NSC, imports.%Main.NSC [template = constants.%NSC]
 // CHECK:STDOUT: }
@@ -323,7 +323,7 @@ private export C;
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- export_export.carbon
@@ -358,7 +358,7 @@ private export C;
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT:   %NSC: type = export NSC, imports.%Main.NSC [template = constants.%NSC]
 // CHECK:STDOUT: }
@@ -422,7 +422,7 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .nsc = %nsc
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -516,8 +516,8 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .nsc = %nsc
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc4: %C = var_pattern %c.patt
@@ -611,7 +611,7 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .nsc = %nsc
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -683,7 +683,7 @@ private export C;
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_export_decl.carbon
@@ -734,7 +734,7 @@ private export C;
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C [from "base.carbon"] {
@@ -782,7 +782,7 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .nsc = %nsc
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -876,7 +876,7 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .nsc = %nsc
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc7: %C = var_pattern %c.patt
@@ -940,7 +940,7 @@ private export C;
 // CHECK:STDOUT:     .Local = %Local
 // CHECK:STDOUT:     .NSLocal = %NSLocal
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.ref: <error> = name_ref C, <error> [template = <error>]
 // CHECK:STDOUT:   %Local: <error> = bind_alias Local, <error> [template = <error>]
 // CHECK:STDOUT:   %NS.ref: <error> = name_ref NS, <error> [template = <error>]
@@ -973,7 +973,7 @@ private export C;
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1008,7 +1008,7 @@ private export C;
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc6: %C = var_pattern %c.patt
@@ -1064,7 +1064,7 @@ private export C;
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C: type = export C, imports.%Main.C [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_member.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_member.carbon
@@ -56,7 +56,7 @@ export C.n;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc5_3: %C.elem = var_pattern %.loc5_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -85,7 +85,7 @@ export C.n;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = imports.%Foo.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C [from "a.carbon"] {

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_params.carbon
@@ -47,16 +47,16 @@ export C2(T:! type);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C1.decl: %C1.type = class_decl @C1 [template = constants.%C1.generic] {
 // CHECK:STDOUT:     %T.patt.loc4_10.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_10.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_10.1, runtime_param<invalid> [symbolic = %T.patt.loc4_10.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_10.1, runtime_param<none> [symbolic = %T.patt.loc4_10.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_10.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_10.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C2.decl: %C2.type = class_decl @C2 [template = constants.%C2.generic] {
 // CHECK:STDOUT:     %T.patt.loc5_10.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc5_10.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_10.1, runtime_param<invalid> [symbolic = %T.patt.loc5_10.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc5_10.1, runtime_param<none> [symbolic = %T.patt.loc5_10.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc5_10.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc5_10.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -106,9 +106,9 @@ export C2(T:! type);
 // CHECK:STDOUT:     .C1 = %C1
 // CHECK:STDOUT:     .C2 = %C2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C1: %C1.type = export C1, imports.%Foo.C1 [template = constants.%C1.generic]
-// CHECK:STDOUT:   %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:   %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0, %T.param [symbolic = constants.%T]
 // CHECK:STDOUT:   %C2: %C2.type = export C2, imports.%Foo.C2 [template = constants.%C2.generic]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/no_prelude/implicit_imports_empty.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/implicit_imports_empty.carbon
@@ -70,7 +70,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %WithImpl.import = import WithImpl
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- with_impl_extra.impl.carbon
@@ -78,7 +78,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %WithImpl.import = import WithImpl
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- with_impl_lib.carbon
@@ -92,7 +92,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %WithImpl.import = import WithImpl
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main.carbon
@@ -111,7 +111,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/implicit_imports_entities.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/implicit_imports_entities.carbon
@@ -316,7 +316,7 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C1 = imports.%Main.C1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- mix_current_package.impl.carbon
@@ -346,8 +346,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .c1 = %c1
 // CHECK:STDOUT:     .c2 = %c2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c1.patt: %C1 = binding_pattern c1
 // CHECK:STDOUT:     %.loc6: %C1 = var_pattern %c1.patt
@@ -401,7 +401,7 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C1 = imports.%Main.C1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- dup_c1.impl.carbon
@@ -424,8 +424,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .C1 = imports.%Main.C1
 // CHECK:STDOUT:     .c1 = %c1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c1.patt: %C1 = binding_pattern c1
 // CHECK:STDOUT:     %.loc6: %C1 = var_pattern %c1.patt
@@ -464,7 +464,7 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- use_ns.impl.carbon
@@ -491,8 +491,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc4_1: %C = var_pattern %c.patt
@@ -568,8 +568,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .o1 = %o1
 // CHECK:STDOUT:     .o2 = %o2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %o1.patt: %O1 = binding_pattern o1
@@ -659,8 +659,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:     .o1 = %o1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %o1.patt: %O1 = binding_pattern o1
@@ -717,8 +717,8 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc11_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc11_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc11_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc11_6.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -732,7 +732,7 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Other = imports.%Main.Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_conflict_reverse.impl.carbon
@@ -747,8 +747,8 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <invalid>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <invalid>
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/missing_prelude.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/missing_prelude.carbon
@@ -157,17 +157,17 @@ var n: {} = i32;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Int.decl: %Int.type = fn_decl @Int [template = constants.%Int] {
 // CHECK:STDOUT:     %T.patt.loc4_8.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_8.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_8.1, runtime_param<invalid> [symbolic = %T.patt.loc4_8.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_8.1, runtime_param<none> [symbolic = %T.patt.loc4_8.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc4_18.1: @Int.%T.loc4_8.2 (%T) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc4_18.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc4_8.2 (%T) = value_param_pattern %N.patt.loc4_18.1, runtime_param<invalid> [symbolic = %N.patt.loc4_18.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc4_8.2 (%T) = value_param_pattern %N.patt.loc4_18.1, runtime_param<none> [symbolic = %N.patt.loc4_18.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %return.patt: %empty_struct_type = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %empty_struct_type = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc4_29.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:     %.loc4_29.2: type = converted %.loc4_29.1, constants.%empty_struct_type [template = constants.%empty_struct_type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc4_8.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_8.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: @Int.%T.loc4_8.2 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: @Int.%T.loc4_8.2 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc4_8.1 [symbolic = %T.loc4_8.2 (constants.%T)]
 // CHECK:STDOUT:     %N.loc4_18.1: @Int.%T.loc4_8.2 (%T) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc4_18.2 (constants.%N)]
 // CHECK:STDOUT:     %return.param: ref %empty_struct_type = out_param runtime_param0
@@ -296,17 +296,17 @@ var n: {} = i32;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Int.decl: %Int.type = fn_decl @Int [template = constants.%Int] {
 // CHECK:STDOUT:     %T.patt.loc8_8.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_8.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_8.1, runtime_param<invalid> [symbolic = %T.patt.loc8_8.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_8.1, runtime_param<none> [symbolic = %T.patt.loc8_8.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc8_18.1: @Int.%T.loc8_8.2 (%T) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc8_18.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc8_8.2 (%T) = value_param_pattern %N.patt.loc8_18.1, runtime_param<invalid> [symbolic = %N.patt.loc8_18.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc8_8.2 (%T) = value_param_pattern %N.patt.loc8_18.1, runtime_param<none> [symbolic = %N.patt.loc8_18.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %return.patt: %empty_tuple.type = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %empty_tuple.type = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc8_29.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc8_29.2: type = converted %.loc8_29.1, constants.%empty_tuple.type [template = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_8.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_8.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: @Int.%T.loc8_8.2 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: @Int.%T.loc8_8.2 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc8_8.1 [symbolic = %T.loc8_8.2 (constants.%T)]
 // CHECK:STDOUT:     %N.loc8_18.1: @Int.%T.loc8_8.2 (%T) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc8_18.2 (constants.%N)]
 // CHECK:STDOUT:     %return.param: ref %empty_tuple.type = out_param runtime_param0
@@ -391,17 +391,17 @@ var n: {} = i32;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Int.decl: %Int.type = fn_decl @Int [template = constants.%Int] {
 // CHECK:STDOUT:     %T.patt.loc7_13.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_13.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_13.1, runtime_param<invalid> [symbolic = %T.patt.loc7_13.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc7_13.1, runtime_param<none> [symbolic = %T.patt.loc7_13.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc7_23.1: @Int.%T.loc7_13.2 (%T) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc7_23.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc7_13.2 (%T) = value_param_pattern %N.patt.loc7_23.1, runtime_param<invalid> [symbolic = %N.patt.loc7_23.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc7_13.2 (%T) = value_param_pattern %N.patt.loc7_23.1, runtime_param<none> [symbolic = %N.patt.loc7_23.2 (constants.%N.patt)]
 // CHECK:STDOUT:     %return.patt: %empty_struct_type = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %empty_struct_type = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc7_34.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:     %.loc7_34.2: type = converted %.loc7_34.1, constants.%empty_struct_type [template = constants.%empty_struct_type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc7_13.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc7_13.2 (constants.%T)]
-// CHECK:STDOUT:     %N.param: @Int.%T.loc7_13.2 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: @Int.%T.loc7_13.2 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc7_13.1 [symbolic = %T.loc7_13.2 (constants.%T)]
 // CHECK:STDOUT:     %N.loc7_23.1: @Int.%T.loc7_13.2 (%T) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc7_23.2 (constants.%N)]
 // CHECK:STDOUT:     %return.param: ref %empty_struct_type = out_param runtime_param0
@@ -498,17 +498,17 @@ var n: {} = i32;
 // CHECK:STDOUT: class @Core {
 // CHECK:STDOUT:   %Int.decl: %Int.type = fn_decl @Int [template = constants.%Int] {
 // CHECK:STDOUT:     %T.patt.loc6_10.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc6_10.1 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_10.2, runtime_param<invalid> [symbolic = %T.patt.loc6_10.1 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc6_10.2, runtime_param<none> [symbolic = %T.patt.loc6_10.1 (constants.%T.patt)]
 // CHECK:STDOUT:     %N.patt.loc6_20.2: @Int.%T.loc6_10.1 (%T) = symbolic_binding_pattern N, 1 [symbolic = %N.patt.loc6_20.1 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc6_10.1 (%T) = value_param_pattern %N.patt.loc6_20.2, runtime_param<invalid> [symbolic = %N.patt.loc6_20.1 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: @Int.%T.loc6_10.1 (%T) = value_param_pattern %N.patt.loc6_20.2, runtime_param<none> [symbolic = %N.patt.loc6_20.1 (constants.%N.patt)]
 // CHECK:STDOUT:     %return.patt: %empty_struct_type = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %empty_struct_type = out_param_pattern %return.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc6_31.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:     %.loc6_31.2: type = converted %.loc6_31.1, constants.%empty_struct_type [template = constants.%empty_struct_type]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc6_10.2: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc6_10.1 (constants.%T)]
-// CHECK:STDOUT:     %N.param: @Int.%T.loc6_10.1 (%T) = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: @Int.%T.loc6_10.1 (%T) = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc6_10.2 [symbolic = %T.loc6_10.1 (constants.%T)]
 // CHECK:STDOUT:     %N.loc6_20.2: @Int.%T.loc6_10.1 (%T) = bind_symbolic_name N, 1, %N.param [symbolic = %N.loc6_20.1 (constants.%N)]
 // CHECK:STDOUT:     %return.param: ref %empty_struct_type = out_param runtime_param0

--- a/toolchain/check/testdata/packages/unused_lazy_import.carbon
+++ b/toolchain/check/testdata/packages/unused_lazy_import.carbon
@@ -59,7 +59,7 @@ impl package Implicit;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/arrow.carbon
+++ b/toolchain/check/testdata/pointer/arrow.carbon
@@ -79,7 +79,7 @@ fn Foo(ptr: C*) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %C.elem = var_pattern %.loc13_12
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.field [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/import.carbon
+++ b/toolchain/check/testdata/pointer/import.carbon
@@ -117,7 +117,7 @@ var a: i32* = a_ref;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %ptr = binding_pattern a

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -108,12 +108,12 @@ fn G() -> C {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc23_11: %C.elem = var_pattern %.loc23_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc23_11: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc23_11: ref %C.elem = var <none>
 // CHECK:STDOUT:   %.loc23_28: %C.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc23_23: %C.elem = var_pattern %.loc23_28
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc23_23: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc23_23: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
+++ b/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
@@ -125,9 +125,9 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
 // CHECK:STDOUT:     %T.patt.loc8_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_22.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_22.1, runtime_param<invalid> [symbolic = %T.patt.loc8_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc8_22.1, runtime_param<none> [symbolic = %T.patt.loc8_22.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc8_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_22.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
@@ -399,9 +399,9 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %N.patt.loc6_9.1: %i32.builtin = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc6_9.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: %i32.builtin = value_param_pattern %N.patt.loc6_9.1, runtime_param<invalid> [symbolic = %N.patt.loc6_9.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: %i32.builtin = value_param_pattern %N.patt.loc6_9.1, runtime_param<none> [symbolic = %N.patt.loc6_9.2 (constants.%N.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %i32.builtin = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %i32.builtin = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc6_13.1: type = splice_block %.loc6_13.3 [template = constants.%i32.builtin] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %int.make_type_signed: init type = call constants.%Int(%int_32) [template = constants.%i32.builtin]
@@ -746,12 +746,12 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc7_11: %D.elem = var_pattern %.loc7_16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc7_11: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc7_11: ref %D.elem = var <none>
 // CHECK:STDOUT:   %.loc7_28: %D.elem = field_decl m, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc7_23: %D.elem = var_pattern %.loc7_28
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc7_23: ref %D.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc7_23: ref %D.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n.m.566 [template = constants.%complete_type.682]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -98,12 +98,12 @@ fn G() -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc12_3: %C.elem = var_pattern %.loc12_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc12: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc12: ref %C.elem = var <none>
 // CHECK:STDOUT:   %.loc13_8: %C.elem = field_decl b, element1 [template]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %.loc13_3: %C.elem = var_pattern %.loc13_8
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var.loc13: ref %C.elem = var <invalid>
+// CHECK:STDOUT:   %.var.loc13: ref %C.elem = var <none>
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.501 [template = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -150,9 +150,9 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %b_ref: ref %struct_type.a.d.3d9 = bind_name b_ref, %b_ref.var
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %S.patt.loc8_9.1: %struct_type.a.b.501 = symbolic_binding_pattern S, 0 [symbolic = %S.patt.loc8_9.2 (constants.%S.patt)]
-// CHECK:STDOUT:     %S.param_patt: %struct_type.a.b.501 = value_param_pattern %S.patt.loc8_9.1, runtime_param<invalid> [symbolic = %S.patt.loc8_9.2 (constants.%S.patt)]
+// CHECK:STDOUT:     %S.param_patt: %struct_type.a.b.501 = value_param_pattern %S.patt.loc8_9.1, runtime_param<none> [symbolic = %S.patt.loc8_9.2 (constants.%S.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %S.param: %struct_type.a.b.501 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %S.param: %struct_type.a.b.501 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8: type = splice_block %struct_type.a.b [template = constants.%struct_type.a.b.501] {
 // CHECK:STDOUT:       %int_32.loc8_18: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc8_18: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -330,7 +330,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %struct_type.a = binding_pattern a
@@ -502,7 +502,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:     .c_bad = %c_bad
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c_bad.patt: <error> = binding_pattern c_bad
@@ -614,7 +614,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:     .c_bad = %c_bad
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c_bad.patt: %C.5a7 = binding_pattern c_bad

--- a/toolchain/check/testdata/tuple/import.carbon
+++ b/toolchain/check/testdata/tuple/import.carbon
@@ -164,9 +164,9 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %b_ref: ref %tuple.type.fc1 = bind_name b_ref, %b_ref.var
 // CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [template = constants.%C.generic] {
 // CHECK:STDOUT:     %X.patt.loc7_9.1: %tuple.type.d07 = symbolic_binding_pattern X, 0 [symbolic = %X.patt.loc7_9.2 (constants.%X.patt)]
-// CHECK:STDOUT:     %X.param_patt: %tuple.type.d07 = value_param_pattern %X.patt.loc7_9.1, runtime_param<invalid> [symbolic = %X.patt.loc7_9.2 (constants.%X.patt)]
+// CHECK:STDOUT:     %X.param_patt: %tuple.type.d07 = value_param_pattern %X.patt.loc7_9.1, runtime_param<none> [symbolic = %X.patt.loc7_9.2 (constants.%X.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %X.param: %tuple.type.d07 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %X.param: %tuple.type.d07 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc7_22.1: type = splice_block %.loc7_22.3 [template = constants.%tuple.type.d07] {
 // CHECK:STDOUT:       %int_32.loc7_14: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32.loc7_14: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -359,7 +359,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %tuple.type.dd4 = binding_pattern a
@@ -547,7 +547,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:     .c_bad = %c_bad
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c_bad.patt: <error> = binding_pattern c_bad
@@ -660,7 +660,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:     .c_bad = %c_bad
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c_bad.patt: %C.ed5 = binding_pattern c_bad

--- a/toolchain/check/testdata/var/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/var/no_prelude/export_name.carbon
@@ -80,7 +80,7 @@ var w: () = v;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .v = %v
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %v: ref %empty_tuple.type = export v, imports.%Main.v
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -100,7 +100,7 @@ var w: () = v;
 // CHECK:STDOUT:     .v = imports.%Main.v
 // CHECK:STDOUT:     .w = %w
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %w.patt: %empty_tuple.type = binding_pattern w
 // CHECK:STDOUT:     %.loc12_1: %empty_tuple.type = var_pattern %w.patt

--- a/toolchain/check/testdata/var/no_prelude/import.carbon
+++ b/toolchain/check/testdata/var/no_prelude/import.carbon
@@ -69,7 +69,7 @@ var a: () = a_ref;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import = import Implicit
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %empty_tuple.type = binding_pattern a
 // CHECK:STDOUT:     %.loc4_1: %empty_tuple.type = var_pattern %a.patt

--- a/toolchain/check/testdata/var/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/var/no_prelude/import_access.carbon
@@ -101,7 +101,7 @@ var v2: () = Test.v;
 // CHECK:STDOUT:     .v2 = %v2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.import = import Test
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %v2.patt: %empty_tuple.type = binding_pattern v2
 // CHECK:STDOUT:     %.loc4_1: %empty_tuple.type = var_pattern %v2.patt
@@ -133,7 +133,7 @@ var v2: () = Test.v;
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .v2 = %v2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %v2.patt: %empty_tuple.type = binding_pattern v2
 // CHECK:STDOUT:     %.loc10_1: %empty_tuple.type = var_pattern %v2.patt

--- a/toolchain/check/testdata/where_expr/constraints.carbon
+++ b/toolchain/check/testdata/where_expr/constraints.carbon
@@ -172,9 +172,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
 // CHECK:STDOUT:   %EqualEqual.decl: %EqualEqual.type = fn_decl @EqualEqual [template = constants.%EqualEqual] {
 // CHECK:STDOUT:     %U.patt.loc11_15.1: %I_where.type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc11_15.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %I_where.type = value_param_pattern %U.patt.loc11_15.1, runtime_param<invalid> [symbolic = %U.patt.loc11_15.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %I_where.type = value_param_pattern %U.patt.loc11_15.1, runtime_param<none> [symbolic = %U.patt.loc11_15.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: %I_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %I_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_21.1: type = splice_block %.loc11_21.2 [template = constants.%I_where.type] {
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:       %.Self: %I.type = bind_symbolic_name .Self [symbolic = constants.%.Self.258]
@@ -188,9 +188,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Impls.decl: %Impls.type = fn_decl @Impls [template = constants.%Impls] {
 // CHECK:STDOUT:     %V.patt.loc13_10.1: %J_where.type = symbolic_binding_pattern V, 0 [symbolic = %V.patt.loc13_10.2 (constants.%V.patt)]
-// CHECK:STDOUT:     %V.param_patt: %J_where.type = value_param_pattern %V.patt.loc13_10.1, runtime_param<invalid> [symbolic = %V.patt.loc13_10.2 (constants.%V.patt)]
+// CHECK:STDOUT:     %V.param_patt: %J_where.type = value_param_pattern %V.patt.loc13_10.1, runtime_param<none> [symbolic = %V.patt.loc13_10.2 (constants.%V.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %V.param: %J_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %V.param: %J_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc13_16.1: type = splice_block %.loc13_16.2 [template = constants.%J_where.type] {
 // CHECK:STDOUT:       %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
 // CHECK:STDOUT:       %.Self: %J.type = bind_symbolic_name .Self [symbolic = constants.%.Self.968]
@@ -206,9 +206,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %And.decl: %And.type = fn_decl @And [template = constants.%And] {
 // CHECK:STDOUT:     %W.patt.loc15_8.1: %I_where.type = symbolic_binding_pattern W, 0 [symbolic = %W.patt.loc15_8.2 (constants.%W.patt)]
-// CHECK:STDOUT:     %W.param_patt: %I_where.type = value_param_pattern %W.patt.loc15_8.1, runtime_param<invalid> [symbolic = %W.patt.loc15_8.2 (constants.%W.patt)]
+// CHECK:STDOUT:     %W.param_patt: %I_where.type = value_param_pattern %W.patt.loc15_8.1, runtime_param<none> [symbolic = %W.patt.loc15_8.2 (constants.%W.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %W.param: %I_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %W.param: %I_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc15_14.1: type = splice_block %.loc15_14.2 [template = constants.%I_where.type] {
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:       %.Self: %I.type = bind_symbolic_name .Self [symbolic = constants.%.Self.258]
@@ -331,9 +331,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   %K.decl: type = interface_decl @K [template = constants.%K.type] {} {}
 // CHECK:STDOUT:   %AssociatedTypeImpls.decl: %AssociatedTypeImpls.type = fn_decl @AssociatedTypeImpls [template = constants.%AssociatedTypeImpls] {
 // CHECK:STDOUT:     %W.patt.loc11_24.1: %K_where.type = symbolic_binding_pattern W, 0 [symbolic = %W.patt.loc11_24.2 (constants.%W.patt)]
-// CHECK:STDOUT:     %W.param_patt: %K_where.type = value_param_pattern %W.patt.loc11_24.1, runtime_param<invalid> [symbolic = %W.patt.loc11_24.2 (constants.%W.patt)]
+// CHECK:STDOUT:     %W.param_patt: %K_where.type = value_param_pattern %W.patt.loc11_24.1, runtime_param<none> [symbolic = %W.patt.loc11_24.2 (constants.%W.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %W.param: %K_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %W.param: %K_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_30.1: type = splice_block %.loc11_30.2 [template = constants.%K_where.type] {
 // CHECK:STDOUT:       %K.ref: type = name_ref K, file.%K.decl [template = constants.%K.type]
 // CHECK:STDOUT:       %.Self: %K.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -419,9 +419,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %NonTypeImpls.decl: %NonTypeImpls.type = fn_decl @NonTypeImpls [template = constants.%NonTypeImpls] {
 // CHECK:STDOUT:     %U.patt.loc11_17.1: %type_where = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc11_17.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %type_where = value_param_pattern %U.patt.loc11_17.1, runtime_param<invalid> [symbolic = %U.patt.loc11_17.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %type_where = value_param_pattern %U.patt.loc11_17.1, runtime_param<none> [symbolic = %U.patt.loc11_17.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: %type_where = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %type_where = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_26.1: type = splice_block %.loc11_26.2 [template = constants.%type_where] {
 // CHECK:STDOUT:       %.Self: type = bind_symbolic_name .Self [symbolic = constants.%.Self]
 // CHECK:STDOUT:       %int_7: Core.IntLiteral = int_value 7 [template = constants.%int_7]
@@ -474,9 +474,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ImplsNonType.decl: %ImplsNonType.type = fn_decl @ImplsNonType [template = constants.%ImplsNonType] {
 // CHECK:STDOUT:     %U.patt.loc11_17.1: %type_where = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc11_17.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %type_where = value_param_pattern %U.patt.loc11_17.1, runtime_param<invalid> [symbolic = %U.patt.loc11_17.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %type_where = value_param_pattern %U.patt.loc11_17.1, runtime_param<none> [symbolic = %U.patt.loc11_17.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: %type_where = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %type_where = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_26.1: type = splice_block %.loc11_26.2 [template = constants.%type_where] {
 // CHECK:STDOUT:       %.Self: type = bind_symbolic_name .Self [symbolic = constants.%.Self]
 // CHECK:STDOUT:       %.Self.ref: type = name_ref .Self, %.Self [symbolic = constants.%.Self]
@@ -531,9 +531,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ImplsOfNonFacetType.decl: %ImplsOfNonFacetType.type = fn_decl @ImplsOfNonFacetType [template = constants.%ImplsOfNonFacetType] {
 // CHECK:STDOUT:     %U.patt.loc8_24.1: %type_where = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc8_24.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %type_where = value_param_pattern %U.patt.loc8_24.1, runtime_param<invalid> [symbolic = %U.patt.loc8_24.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %type_where = value_param_pattern %U.patt.loc8_24.1, runtime_param<none> [symbolic = %U.patt.loc8_24.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: %type_where = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %type_where = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_33.1: type = splice_block %.loc8_33.2 [template = constants.%type_where] {
 // CHECK:STDOUT:       %.Self: type = bind_symbolic_name .Self [symbolic = constants.%.Self]
 // CHECK:STDOUT:       %.Self.ref: type = name_ref .Self, %.Self [symbolic = constants.%.Self]
@@ -611,7 +611,7 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:     .NotEmptyStruct = %NotEmptyStruct.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   impl_decl @impl [template] {} {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
@@ -621,9 +621,9 @@ fn NotEmptyStruct() {
 // CHECK:STDOUT:   %DoesNotImplI.decl: %DoesNotImplI.type = fn_decl @DoesNotImplI [template = constants.%DoesNotImplI] {} {}
 // CHECK:STDOUT:   %EmptyStruct.decl: %EmptyStruct.type = fn_decl @EmptyStruct [template = constants.%EmptyStruct] {
 // CHECK:STDOUT:     %Y.patt.loc26_16.1: %J_where.type = symbolic_binding_pattern Y, 0 [symbolic = %Y.patt.loc26_16.2 (constants.%Y.patt)]
-// CHECK:STDOUT:     %Y.param_patt: %J_where.type = value_param_pattern %Y.patt.loc26_16.1, runtime_param<invalid> [symbolic = %Y.patt.loc26_16.2 (constants.%Y.patt)]
+// CHECK:STDOUT:     %Y.param_patt: %J_where.type = value_param_pattern %Y.patt.loc26_16.1, runtime_param<none> [symbolic = %Y.patt.loc26_16.2 (constants.%Y.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Y.param: %J_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %Y.param: %J_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc26_22.1: type = splice_block %.loc26_22.2 [template = constants.%J_where.type] {
 // CHECK:STDOUT:       %J.ref: type = name_ref J, imports.%Main.J [template = constants.%J.type]
 // CHECK:STDOUT:       %.Self: %J.type = bind_symbolic_name .Self [symbolic = constants.%.Self]

--- a/toolchain/check/testdata/where_expr/designator.carbon
+++ b/toolchain/check/testdata/where_expr/designator.carbon
@@ -134,9 +134,9 @@ class D {
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
 // CHECK:STDOUT:   %PeriodSelf.decl: %PeriodSelf.type = fn_decl @PeriodSelf [template = constants.%PeriodSelf] {
 // CHECK:STDOUT:     %T.patt.loc8_15.1: %I_where.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %I_where.type = value_param_pattern %T.patt.loc8_15.1, runtime_param<invalid> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %I_where.type = value_param_pattern %T.patt.loc8_15.1, runtime_param<none> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %I_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %I_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_21.1: type = splice_block %.loc8_21.2 [template = constants.%I_where.type] {
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:       %.Self: %I.type = bind_symbolic_name .Self [symbolic = constants.%.Self.258]
@@ -150,9 +150,9 @@ class D {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %PeriodMember.decl: %PeriodMember.type = fn_decl @PeriodMember [template = constants.%PeriodMember] {
 // CHECK:STDOUT:     %U.patt.loc10_17.1: %I_where.type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc10_17.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: %I_where.type = value_param_pattern %U.patt.loc10_17.1, runtime_param<invalid> [symbolic = %U.patt.loc10_17.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: %I_where.type = value_param_pattern %U.patt.loc10_17.1, runtime_param<none> [symbolic = %U.patt.loc10_17.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: %I_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: %I_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc10_23.1: type = splice_block %.loc10_23.2 [template = constants.%I_where.type] {
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:       %.Self: %I.type = bind_symbolic_name .Self [symbolic = constants.%.Self.258]
@@ -169,9 +169,9 @@ class D {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TypeSelfImpls.decl: %TypeSelfImpls.type = fn_decl @TypeSelfImpls [template = constants.%TypeSelfImpls] {
 // CHECK:STDOUT:     %V.patt.loc12_18.1: %type_where = symbolic_binding_pattern V, 0 [symbolic = %V.patt.loc12_18.2 (constants.%V.patt)]
-// CHECK:STDOUT:     %V.param_patt: %type_where = value_param_pattern %V.patt.loc12_18.1, runtime_param<invalid> [symbolic = %V.patt.loc12_18.2 (constants.%V.patt)]
+// CHECK:STDOUT:     %V.param_patt: %type_where = value_param_pattern %V.patt.loc12_18.1, runtime_param<none> [symbolic = %V.patt.loc12_18.2 (constants.%V.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %V.param: %type_where = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %V.param: %type_where = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc12_27.1: type = splice_block %.loc12_27.2 [template = constants.%type_where] {
 // CHECK:STDOUT:       %.Self: type = bind_symbolic_name .Self [symbolic = constants.%.Self.644]
 // CHECK:STDOUT:       %.Self.ref: type = name_ref .Self, %.Self [symbolic = constants.%.Self.644]
@@ -262,9 +262,9 @@ class D {
 // CHECK:STDOUT:   %J.decl: type = interface_decl @J [template = constants.%J.type] {} {}
 // CHECK:STDOUT:   %PeriodMismatch.decl: %PeriodMismatch.type = fn_decl @PeriodMismatch [template = constants.%PeriodMismatch] {
 // CHECK:STDOUT:     %W.patt.loc12_19.1: <error> = symbolic_binding_pattern W, 0 [symbolic = %W.patt.loc12_19.2 (constants.%W.patt)]
-// CHECK:STDOUT:     %W.param_patt: <error> = value_param_pattern %W.patt.loc12_19.1, runtime_param<invalid> [symbolic = %W.patt.loc12_19.2 (constants.%W.patt)]
+// CHECK:STDOUT:     %W.param_patt: <error> = value_param_pattern %W.patt.loc12_19.1, runtime_param<none> [symbolic = %W.patt.loc12_19.2 (constants.%W.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %W.param: <error> = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %W.param: <error> = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc12_25.1: type = splice_block %.loc12_25.2 [template = <error>] {
 // CHECK:STDOUT:       %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
 // CHECK:STDOUT:       %.Self: %J.type = bind_symbolic_name .Self [symbolic = constants.%.Self]

--- a/toolchain/check/testdata/where_expr/dot_self_index.carbon
+++ b/toolchain/check/testdata/where_expr/dot_self_index.carbon
@@ -87,20 +87,20 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Empty.decl: %Empty.type.d5a = interface_decl @Empty [template = constants.%Empty.generic] {
 // CHECK:STDOUT:     %W.patt.loc11_17.1: type = symbolic_binding_pattern W, 0 [symbolic = %W.patt.loc11_17.2 (constants.%W.patt)]
-// CHECK:STDOUT:     %W.param_patt: type = value_param_pattern %W.patt.loc11_17.1, runtime_param<invalid> [symbolic = %W.patt.loc11_17.2 (constants.%W.patt)]
+// CHECK:STDOUT:     %W.param_patt: type = value_param_pattern %W.patt.loc11_17.1, runtime_param<none> [symbolic = %W.patt.loc11_17.2 (constants.%W.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %W.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %W.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %W.loc11_17.1: type = bind_symbolic_name W, 0, %W.param [symbolic = %W.loc11_17.2 (constants.%W)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {
 // CHECK:STDOUT:     %T.patt.loc18_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc18_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc18_6.1, runtime_param<invalid> [symbolic = %T.patt.loc18_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc18_6.1, runtime_param<none> [symbolic = %T.patt.loc18_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %U.patt: @H.%Empty_where.type (%Empty_where.type.4ed) = binding_pattern U
 // CHECK:STDOUT:     %U.param_patt: @H.%Empty_where.type (%Empty_where.type.4ed) = value_param_pattern %U.patt, runtime_param0
 // CHECK:STDOUT:     %V.patt.loc18_43.1: type = symbolic_binding_pattern V, 1 [symbolic = %V.patt.loc18_43.2 (constants.%V.patt)]
-// CHECK:STDOUT:     %V.param_patt: type = value_param_pattern %V.patt.loc18_43.1, runtime_param<invalid> [symbolic = %V.patt.loc18_43.2 (constants.%V.patt)]
+// CHECK:STDOUT:     %V.param_patt: type = value_param_pattern %V.patt.loc18_43.1, runtime_param<none> [symbolic = %V.patt.loc18_43.2 (constants.%V.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc18_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc18_6.2 (constants.%T)]
 // CHECK:STDOUT:     %U.param: @H.%Empty_where.type (%Empty_where.type.4ed) = value_param runtime_param0
 // CHECK:STDOUT:     %.loc18_28.1: type = splice_block %.loc18_28.2 [symbolic = %Empty_where.type (constants.%Empty_where.type.4ed)] {
@@ -120,7 +120,7 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %U: @H.%Empty_where.type (%Empty_where.type.4ed) = bind_name U, %U.param
-// CHECK:STDOUT:     %V.param: type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %V.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %V.loc18_43.1: type = bind_symbolic_name V, 1, %V.param [symbolic = %V.loc18_43.2 (constants.%V)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {

--- a/toolchain/check/testdata/where_expr/equal_rewrite.carbon
+++ b/toolchain/check/testdata/where_expr/equal_rewrite.carbon
@@ -254,9 +254,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %N.decl: type = interface_decl @N [template = constants.%N.type] {} {}
 // CHECK:STDOUT:   %Equal.decl: %Equal.type = fn_decl @Equal [template = constants.%Equal] {
 // CHECK:STDOUT:     %T.patt.loc8_10.1: %N_where.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_10.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: %N_where.type = value_param_pattern %T.patt.loc8_10.1, runtime_param<invalid> [symbolic = %T.patt.loc8_10.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %N_where.type = value_param_pattern %T.patt.loc8_10.1, runtime_param<none> [symbolic = %T.patt.loc8_10.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: %N_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: %N_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_16.1: type = splice_block %.loc8_16.2 [template = constants.%N_where.type] {
 // CHECK:STDOUT:       %N.ref: type = name_ref N, file.%N.decl [template = constants.%N.type]
 // CHECK:STDOUT:       %.Self: %N.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -340,9 +340,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %A.decl: type = interface_decl @A [template = constants.%A.type] {} {}
 // CHECK:STDOUT:   %NestedRewrite.decl: %NestedRewrite.type = fn_decl @NestedRewrite [template = constants.%NestedRewrite] {
 // CHECK:STDOUT:     %D.patt.loc9_18.1: %A_where.type.791 = symbolic_binding_pattern D, 0 [symbolic = %D.patt.loc9_18.2 (constants.%D.patt)]
-// CHECK:STDOUT:     %D.param_patt: %A_where.type.791 = value_param_pattern %D.patt.loc9_18.1, runtime_param<invalid> [symbolic = %D.patt.loc9_18.2 (constants.%D.patt)]
+// CHECK:STDOUT:     %D.param_patt: %A_where.type.791 = value_param_pattern %D.patt.loc9_18.1, runtime_param<none> [symbolic = %D.patt.loc9_18.2 (constants.%D.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %D.param: %A_where.type.791 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %D.param: %A_where.type.791 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc9_42.1: type = splice_block %.loc9_42.2 [template = constants.%A_where.type.791] {
 // CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [template = constants.%A.type]
 // CHECK:STDOUT:       %.Self.1: %A.type = bind_symbolic_name .Self [symbolic = constants.%.Self.3ca]
@@ -448,9 +448,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %E.decl: type = interface_decl @E [template = constants.%E.type] {} {}
 // CHECK:STDOUT:   %OneRewrite.decl: %OneRewrite.type = fn_decl @OneRewrite [template = constants.%OneRewrite] {
 // CHECK:STDOUT:     %G.patt.loc8_15.1: %E_where.type = symbolic_binding_pattern G, 0 [symbolic = %G.patt.loc8_15.2 (constants.%G.patt)]
-// CHECK:STDOUT:     %G.param_patt: %E_where.type = value_param_pattern %G.patt.loc8_15.1, runtime_param<invalid> [symbolic = %G.patt.loc8_15.2 (constants.%G.patt)]
+// CHECK:STDOUT:     %G.param_patt: %E_where.type = value_param_pattern %G.patt.loc8_15.1, runtime_param<none> [symbolic = %G.patt.loc8_15.2 (constants.%G.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %G.param: %E_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %G.param: %E_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_21.1: type = splice_block %.loc8_21.2 [template = constants.%E_where.type] {
 // CHECK:STDOUT:       %E.ref: type = name_ref E, file.%E.decl [template = constants.%E.type]
 // CHECK:STDOUT:       %.Self: %E.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -468,9 +468,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %RepeatedRewrite.decl: %RepeatedRewrite.type = fn_decl @RepeatedRewrite [template = constants.%RepeatedRewrite] {
 // CHECK:STDOUT:     %H.patt.loc10_20.1: %E_where.type = symbolic_binding_pattern H, 0 [symbolic = %H.patt.loc10_20.2 (constants.%H.patt)]
-// CHECK:STDOUT:     %H.param_patt: %E_where.type = value_param_pattern %H.patt.loc10_20.1, runtime_param<invalid> [symbolic = %H.patt.loc10_20.2 (constants.%H.patt)]
+// CHECK:STDOUT:     %H.param_patt: %E_where.type = value_param_pattern %H.patt.loc10_20.1, runtime_param<none> [symbolic = %H.patt.loc10_20.2 (constants.%H.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %H.param: %E_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %H.param: %E_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc10_26.1: type = splice_block %.loc10_26.2 [template = constants.%E_where.type] {
 // CHECK:STDOUT:       %E.ref: type = name_ref E, file.%E.decl [template = constants.%E.type]
 // CHECK:STDOUT:       %.Self: %E.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -495,9 +495,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %OneRewriteAgain.decl: %OneRewriteAgain.type = fn_decl @OneRewriteAgain [template = constants.%OneRewriteAgain] {
 // CHECK:STDOUT:     %I.patt.loc14_20.1: %E_where.type = symbolic_binding_pattern I, 0 [symbolic = %I.patt.loc14_20.2 (constants.%I.patt)]
-// CHECK:STDOUT:     %I.param_patt: %E_where.type = value_param_pattern %I.patt.loc14_20.1, runtime_param<invalid> [symbolic = %I.patt.loc14_20.2 (constants.%I.patt)]
+// CHECK:STDOUT:     %I.param_patt: %E_where.type = value_param_pattern %I.patt.loc14_20.1, runtime_param<none> [symbolic = %I.patt.loc14_20.2 (constants.%I.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %I.param: %E_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %I.param: %E_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc14_26.1: type = splice_block %.loc14_26.2 [template = constants.%E_where.type] {
 // CHECK:STDOUT:       %E.ref: type = name_ref E, file.%E.decl [template = constants.%E.type]
 // CHECK:STDOUT:       %.Self: %E.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -657,9 +657,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %J.decl: type = interface_decl @J [template = constants.%J.type] {} {}
 // CHECK:STDOUT:   %Alphabetical.decl: %Alphabetical.type = fn_decl @Alphabetical [template = constants.%Alphabetical] {
 // CHECK:STDOUT:     %M.patt.loc9_17.1: %J_where.type = symbolic_binding_pattern M, 0 [symbolic = %M.patt.loc9_17.2 (constants.%M.patt)]
-// CHECK:STDOUT:     %M.param_patt: %J_where.type = value_param_pattern %M.patt.loc9_17.1, runtime_param<invalid> [symbolic = %M.patt.loc9_17.2 (constants.%M.patt)]
+// CHECK:STDOUT:     %M.param_patt: %J_where.type = value_param_pattern %M.patt.loc9_17.1, runtime_param<none> [symbolic = %M.patt.loc9_17.2 (constants.%M.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %M.param: %J_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %M.param: %J_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc9_23.1: type = splice_block %.loc9_23.2 [template = constants.%J_where.type] {
 // CHECK:STDOUT:       %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
 // CHECK:STDOUT:       %.Self: %J.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -685,9 +685,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Reversed.decl: %Reversed.type = fn_decl @Reversed [template = constants.%Reversed] {
 // CHECK:STDOUT:     %N.patt.loc11_13.1: %J_where.type = symbolic_binding_pattern N, 0 [symbolic = %N.patt.loc11_13.2 (constants.%N.patt)]
-// CHECK:STDOUT:     %N.param_patt: %J_where.type = value_param_pattern %N.patt.loc11_13.1, runtime_param<invalid> [symbolic = %N.patt.loc11_13.2 (constants.%N.patt)]
+// CHECK:STDOUT:     %N.param_patt: %J_where.type = value_param_pattern %N.patt.loc11_13.1, runtime_param<none> [symbolic = %N.patt.loc11_13.2 (constants.%N.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.param: %J_where.type = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %N.param: %J_where.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_19.1: type = splice_block %.loc11_19.2 [template = constants.%J_where.type] {
 // CHECK:STDOUT:       %J.ref: type = name_ref J, file.%J.decl [template = constants.%J.type]
 // CHECK:STDOUT:       %.Self: %J.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -822,9 +822,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %O.decl: type = interface_decl @O [template = constants.%O.type] {} {}
 // CHECK:STDOUT:   %WithInteger.decl: %WithInteger.type = fn_decl @WithInteger [template = constants.%WithInteger] {
 // CHECK:STDOUT:     %Q.patt.loc8_16.1: %O_where.type.9eb = symbolic_binding_pattern Q, 0 [symbolic = %Q.patt.loc8_16.2 (constants.%Q.patt)]
-// CHECK:STDOUT:     %Q.param_patt: %O_where.type.9eb = value_param_pattern %Q.patt.loc8_16.1, runtime_param<invalid> [symbolic = %Q.patt.loc8_16.2 (constants.%Q.patt)]
+// CHECK:STDOUT:     %Q.param_patt: %O_where.type.9eb = value_param_pattern %Q.patt.loc8_16.1, runtime_param<none> [symbolic = %Q.patt.loc8_16.2 (constants.%Q.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Q.param: %O_where.type.9eb = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %Q.param: %O_where.type.9eb = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_22.1: type = splice_block %.loc8_22.2 [template = constants.%O_where.type.9eb] {
 // CHECK:STDOUT:       %O.ref: type = name_ref O, file.%O.decl [template = constants.%O.type]
 // CHECK:STDOUT:       %.Self: %O.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -842,9 +842,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %WithBool.decl: %WithBool.type = fn_decl @WithBool [template = constants.%WithBool] {
 // CHECK:STDOUT:     %R.patt.loc10_13.1: %O_where.type.0f2 = symbolic_binding_pattern R, 0 [symbolic = %R.patt.loc10_13.2 (constants.%R.patt)]
-// CHECK:STDOUT:     %R.param_patt: %O_where.type.0f2 = value_param_pattern %R.patt.loc10_13.1, runtime_param<invalid> [symbolic = %R.patt.loc10_13.2 (constants.%R.patt)]
+// CHECK:STDOUT:     %R.param_patt: %O_where.type.0f2 = value_param_pattern %R.patt.loc10_13.1, runtime_param<none> [symbolic = %R.patt.loc10_13.2 (constants.%R.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %R.param: %O_where.type.0f2 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %R.param: %O_where.type.0f2 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc10_19.1: type = splice_block %.loc10_19.2 [template = constants.%O_where.type.0f2] {
 // CHECK:STDOUT:       %O.ref: type = name_ref O, file.%O.decl [template = constants.%O.type]
 // CHECK:STDOUT:       %.Self: %O.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -955,9 +955,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %S.decl: type = interface_decl @S [template = constants.%S.type] {} {}
 // CHECK:STDOUT:   %WithT.decl: %WithT.type = fn_decl @WithT [template = constants.%WithT] {
 // CHECK:STDOUT:     %V.patt.loc9_10.1: %S_where.type.e40 = symbolic_binding_pattern V, 0 [symbolic = %V.patt.loc9_10.2 (constants.%V.patt)]
-// CHECK:STDOUT:     %V.param_patt: %S_where.type.e40 = value_param_pattern %V.patt.loc9_10.1, runtime_param<invalid> [symbolic = %V.patt.loc9_10.2 (constants.%V.patt)]
+// CHECK:STDOUT:     %V.param_patt: %S_where.type.e40 = value_param_pattern %V.patt.loc9_10.1, runtime_param<none> [symbolic = %V.patt.loc9_10.2 (constants.%V.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %V.param: %S_where.type.e40 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %V.param: %S_where.type.e40 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc9_16.1: type = splice_block %.loc9_16.2 [template = constants.%S_where.type.e40] {
 // CHECK:STDOUT:       %S.ref: type = name_ref S, file.%S.decl [template = constants.%S.type]
 // CHECK:STDOUT:       %.Self: %S.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -975,9 +975,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %WithU.decl: %WithU.type = fn_decl @WithU [template = constants.%WithU] {
 // CHECK:STDOUT:     %W.patt.loc11_10.1: %S_where.type.357 = symbolic_binding_pattern W, 0 [symbolic = %W.patt.loc11_10.2 (constants.%W.patt)]
-// CHECK:STDOUT:     %W.param_patt: %S_where.type.357 = value_param_pattern %W.patt.loc11_10.1, runtime_param<invalid> [symbolic = %W.patt.loc11_10.2 (constants.%W.patt)]
+// CHECK:STDOUT:     %W.param_patt: %S_where.type.357 = value_param_pattern %W.patt.loc11_10.1, runtime_param<none> [symbolic = %W.patt.loc11_10.2 (constants.%W.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %W.param: %S_where.type.357 = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %W.param: %S_where.type.357 = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc11_16.1: type = splice_block %.loc11_16.2 [template = constants.%S_where.type.357] {
 // CHECK:STDOUT:       %S.ref: type = name_ref S, file.%S.decl [template = constants.%S.type]
 // CHECK:STDOUT:       %.Self: %S.type = bind_symbolic_name .Self [symbolic = constants.%.Self]
@@ -1113,7 +1113,7 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:     .Calls = %Calls.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %default.import = import <invalid>
+// CHECK:STDOUT:   %default.import = import <none>
 // CHECK:STDOUT:   %Calls.decl: %Calls.type = fn_decl @Calls [template = constants.%Calls] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1202,9 +1202,9 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
 // CHECK:STDOUT:   %RewriteTypeMismatch.decl: %RewriteTypeMismatch.type = fn_decl @RewriteTypeMismatch [template = constants.%RewriteTypeMismatch] {
 // CHECK:STDOUT:     %X.patt.loc16_24.1: <error> = symbolic_binding_pattern X, 0 [symbolic = %X.patt.loc16_24.2 (constants.%X.patt)]
-// CHECK:STDOUT:     %X.param_patt: <error> = value_param_pattern %X.patt.loc16_24.1, runtime_param<invalid> [symbolic = %X.patt.loc16_24.2 (constants.%X.patt)]
+// CHECK:STDOUT:     %X.param_patt: <error> = value_param_pattern %X.patt.loc16_24.1, runtime_param<none> [symbolic = %X.patt.loc16_24.2 (constants.%X.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %X.param: <error> = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %X.param: <error> = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc16_30.1: type = splice_block %.loc16_30.2 [template = <error>] {
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
 // CHECK:STDOUT:       %.Self: %I.type = bind_symbolic_name .Self [symbolic = constants.%.Self]

--- a/toolchain/check/testdata/where_expr/fail_not_facet.carbon
+++ b/toolchain/check/testdata/where_expr/fail_not_facet.carbon
@@ -67,9 +67,9 @@ var v: e where .x = 3;
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc8_6.1: <error> = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: <error> = value_param_pattern %T.patt.loc8_6.1, runtime_param<invalid> [symbolic = %T.patt.loc8_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: <error> = value_param_pattern %T.patt.loc8_6.1, runtime_param<none> [symbolic = %T.patt.loc8_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: <error> = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %T.param: <error> = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_14.1: type = splice_block %.loc8_14.2 [template = <error>] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [template = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [template = constants.%i32]
@@ -120,9 +120,9 @@ var v: e where .x = 3;
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {
 // CHECK:STDOUT:     %U.patt.loc8_6.1: <error> = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc8_6.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: <error> = value_param_pattern %U.patt.loc8_6.1, runtime_param<invalid> [symbolic = %U.patt.loc8_6.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: <error> = value_param_pattern %U.patt.loc8_6.1, runtime_param<none> [symbolic = %U.patt.loc8_6.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.param: <error> = value_param runtime_param<invalid>
+// CHECK:STDOUT:     %U.param: <error> = value_param runtime_param<none>
 // CHECK:STDOUT:     %.loc8_23.1: type = splice_block %.loc8_23.2 [template = <error>] {
 // CHECK:STDOUT:       %NOT_DECLARED.ref: <error> = name_ref NOT_DECLARED, <error> [template = <error>]
 // CHECK:STDOUT:       %.Self: <error> = bind_symbolic_name .Self [template = <error>]

--- a/toolchain/driver/testdata/compile/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/driver/testdata/compile/multifile_raw_and_textual_ir.carbon
@@ -30,10 +30,10 @@ fn B() {
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst13}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst13}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, body: [inst_block5]}
@@ -51,9 +51,9 @@ fn B() {
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst13:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst14)}
-// CHECK:STDOUT:     inst14:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst14:          {kind: FunctionType, arg0: function0, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst15:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
 // CHECK:STDOUT:     inst16:          {kind: StructValue, arg0: inst_block_empty, type: type(inst14)}
 // CHECK:STDOUT:     inst17:          {kind: Return}
@@ -101,16 +101,16 @@ fn B() {
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     ir1:             {decl_id: inst13, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
 // CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst13}
 // CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst13}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst14, name0: inst15}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst14, name0: inst15}}
 // CHECK:STDOUT:     name_scope1:     {inst: inst14, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst20}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: comp_time_bind<invalid>}
+// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: comp_time_bind<none>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, body: [inst_block5]}
 // CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1}
@@ -129,17 +129,17 @@ fn B() {
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst13:          {kind: ImportDecl, arg0: name1}
 // CHECK:STDOUT:     inst14:          {kind: Namespace, arg0: name_scope1, arg1: inst13, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst15:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst16)}
-// CHECK:STDOUT:     inst16:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst16:          {kind: FunctionType, arg0: function0, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst17:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
 // CHECK:STDOUT:     inst18:          {kind: StructValue, arg0: inst_block_empty, type: type(inst16)}
 // CHECK:STDOUT:     inst19:          {kind: NameRef, arg0: name1, arg1: inst14, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst20:          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst22)}
 // CHECK:STDOUT:     inst21:          {kind: FunctionDecl, arg0: function1, arg1: inst_block_empty, type: type(inst22)}
-// CHECK:STDOUT:     inst22:          {kind: FunctionType, arg0: function1, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst22:          {kind: FunctionType, arg0: function1, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst23:          {kind: StructValue, arg0: inst_block_empty, type: type(inst22)}
 // CHECK:STDOUT:     inst24:          {kind: NameRef, arg0: name1, arg1: inst20, type: type(inst22)}
 // CHECK:STDOUT:     inst25:          {kind: Call, arg0: inst24, arg1: inst_block_empty, type: type(inst17)}

--- a/toolchain/driver/testdata/compile/multifile_raw_ir.carbon
+++ b/toolchain/driver/testdata/compile/multifile_raw_ir.carbon
@@ -30,10 +30,10 @@ fn B() {
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst13}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst13}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, body: [inst_block5]}
@@ -51,9 +51,9 @@ fn B() {
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst13:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst14)}
-// CHECK:STDOUT:     inst14:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst14:          {kind: FunctionType, arg0: function0, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst15:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
 // CHECK:STDOUT:     inst16:          {kind: StructValue, arg0: inst_block_empty, type: type(inst14)}
 // CHECK:STDOUT:     inst17:          {kind: Return}
@@ -81,16 +81,16 @@ fn B() {
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     ir1:             {decl_id: inst13, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
 // CHECK:STDOUT:     import_ir_inst0: {ir_id: ir1, inst_id: inst13}
 // CHECK:STDOUT:     import_ir_inst1: {ir_id: ir1, inst_id: inst13}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name1: inst14, name0: inst15}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst14, name0: inst15}}
 // CHECK:STDOUT:     name_scope1:     {inst: inst14, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst20}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: comp_time_bind<invalid>}
+// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: comp_time_bind<none>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, body: [inst_block5]}
 // CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1}
@@ -109,17 +109,17 @@ fn B() {
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     type_block0:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst13:          {kind: ImportDecl, arg0: name1}
 // CHECK:STDOUT:     inst14:          {kind: Namespace, arg0: name_scope1, arg1: inst13, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst15:          {kind: FunctionDecl, arg0: function0, arg1: inst_block_empty, type: type(inst16)}
-// CHECK:STDOUT:     inst16:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst16:          {kind: FunctionType, arg0: function0, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst17:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
 // CHECK:STDOUT:     inst18:          {kind: StructValue, arg0: inst_block_empty, type: type(inst16)}
 // CHECK:STDOUT:     inst19:          {kind: NameRef, arg0: name1, arg1: inst14, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst20:          {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst22)}
 // CHECK:STDOUT:     inst21:          {kind: FunctionDecl, arg0: function1, arg1: inst_block_empty, type: type(inst22)}
-// CHECK:STDOUT:     inst22:          {kind: FunctionType, arg0: function1, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst22:          {kind: FunctionType, arg0: function1, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst23:          {kind: StructValue, arg0: inst_block_empty, type: type(inst22)}
 // CHECK:STDOUT:     inst24:          {kind: NameRef, arg0: name1, arg1: inst20, type: type(inst22)}
 // CHECK:STDOUT:     inst25:          {kind: Call, arg0: inst24, arg1: inst_block_empty, type: type(inst17)}

--- a/toolchain/driver/testdata/compile/raw_and_textual_ir.carbon
+++ b/toolchain/driver/testdata/compile/raw_and_textual_ir.carbon
@@ -20,12 +20,12 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT: filename:        raw_and_textual_ir.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst32}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst32}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
+// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<none>, index: comp_time_bind<none>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, return_slot_pattern: inst27, body: [inst_block10]}
 // CHECK:STDOUT:   classes:         {}
@@ -47,7 +47,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:       0:               type(inst13)
 // CHECK:STDOUT:       1:               type(inst13)
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst13:          {kind: TupleType, arg0: type_block0, type: type(TypeType)}
 // CHECK:STDOUT:     inst14:          {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst13)}
 // CHECK:STDOUT:     inst15:          {kind: Converted, arg0: inst14, arg1: inst13, type: type(TypeType)}
@@ -68,7 +68,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     inst30:          {kind: OutParam, arg0: runtime_param1, arg1: name(ReturnSlot), type: type(inst21)}
 // CHECK:STDOUT:     inst31:          {kind: ReturnSlot, arg0: inst22, arg1: inst30, type: type(inst21)}
 // CHECK:STDOUT:     inst32:          {kind: FunctionDecl, arg0: function0, arg1: inst_block9, type: type(inst33)}
-// CHECK:STDOUT:     inst33:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst33:          {kind: FunctionType, arg0: function0, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst34:          {kind: StructValue, arg0: inst_block_empty, type: type(inst33)}
 // CHECK:STDOUT:     inst35:          {kind: PointerType, arg0: type(inst21), type: type(TypeType)}
 // CHECK:STDOUT:     inst36:          {kind: NameRef, arg0: name1, arg1: inst16, type: type(inst13)}

--- a/toolchain/driver/testdata/compile/raw_ir.carbon
+++ b/toolchain/driver/testdata/compile/raw_ir.carbon
@@ -20,13 +20,13 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT: filename:        raw_ir.carbon
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   import_irs:
-// CHECK:STDOUT:     ir0:             {decl_id: inst<invalid>, is_export: false}
+// CHECK:STDOUT:     ir0:             {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst36}}
+// CHECK:STDOUT:     name_scope0:     {inst: inst12, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst36}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<invalid>, index: comp_time_bind0}
-// CHECK:STDOUT:     entity_name1:    {name: name2, parent_scope: name_scope<invalid>, index: comp_time_bind<invalid>}
+// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<none>, index: comp_time_bind0}
+// CHECK:STDOUT:     entity_name1:    {name: name2, parent_scope: name_scope<none>, index: comp_time_bind<none>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, return_slot_pattern: inst31, body: [inst_block16]}
 // CHECK:STDOUT:   classes:         {}
@@ -60,12 +60,12 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:       0:               type(symbolic_constant3)
 // CHECK:STDOUT:       1:               type(inst23)
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst12:          {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst13:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst32, type: type(TypeType)}
-// CHECK:STDOUT:     inst14:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst14:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst15:          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
 // CHECK:STDOUT:     inst16:          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
-// CHECK:STDOUT:     inst17:          {kind: ValueParamPattern, arg0: inst15, arg1: runtime_param<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst17:          {kind: ValueParamPattern, arg0: inst15, arg1: runtime_param<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst18:          {kind: NameRef, arg0: name1, arg1: inst13, type: type(TypeType)}
 // CHECK:STDOUT:     inst19:          {kind: BindName, arg0: entity_name1, arg1: inst33, type: type(symbolic_constant3)}
 // CHECK:STDOUT:     inst20:          {kind: BindingPattern, arg0: entity_name1, type: type(symbolic_constant3)}
@@ -80,15 +80,15 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     inst29:          {kind: Converted, arg0: inst26, arg1: inst28, type: type(TypeType)}
 // CHECK:STDOUT:     inst30:          {kind: ReturnSlotPattern, arg0: inst26, type: type(symbolic_constant5)}
 // CHECK:STDOUT:     inst31:          {kind: OutParamPattern, arg0: inst30, arg1: runtime_param1, type: type(symbolic_constant5)}
-// CHECK:STDOUT:     inst32:          {kind: ValueParam, arg0: runtime_param<invalid>, arg1: name1, type: type(TypeType)}
+// CHECK:STDOUT:     inst32:          {kind: ValueParam, arg0: runtime_param<none>, arg1: name1, type: type(TypeType)}
 // CHECK:STDOUT:     inst33:          {kind: ValueParam, arg0: runtime_param0, arg1: name2, type: type(symbolic_constant3)}
 // CHECK:STDOUT:     inst34:          {kind: OutParam, arg0: runtime_param1, arg1: name(ReturnSlot), type: type(symbolic_constant5)}
 // CHECK:STDOUT:     inst35:          {kind: ReturnSlot, arg0: inst26, arg1: inst34, type: type(symbolic_constant5)}
 // CHECK:STDOUT:     inst36:          {kind: FunctionDecl, arg0: function0, arg1: inst_block11, type: type(inst40)}
-// CHECK:STDOUT:     inst37:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst37:          {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst38:          {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(TypeType)}
 // CHECK:STDOUT:     inst39:          {kind: TupleType, arg0: type_block3, type: type(TypeType)}
-// CHECK:STDOUT:     inst40:          {kind: FunctionType, arg0: function0, arg1: specific<invalid>, type: type(TypeType)}
+// CHECK:STDOUT:     inst40:          {kind: FunctionType, arg0: function0, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst41:          {kind: StructValue, arg0: inst_block_empty, type: type(inst40)}
 // CHECK:STDOUT:     inst42:          {kind: PointerType, arg0: type(symbolic_constant2), type: type(TypeType)}
 // CHECK:STDOUT:     inst43:          {kind: RequireCompleteType, arg0: type(symbolic_constant2), type: type(inst(WitnessType))}
@@ -144,15 +144,15 @@ fn Foo[T:! type](n: T) -> (T, ()) {
 // CHECK:STDOUT:     inst61:          symbolic_constant9
 // CHECK:STDOUT:     inst62:          symbolic_constant10
 // CHECK:STDOUT:   symbolic_constants:
-// CHECK:STDOUT:     symbolic_constant0: {inst: inst14, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant1: {inst: inst16, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant2: {inst: inst28, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant0: {inst: inst14, generic: generic<none>, index: generic_inst<none>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant1: {inst: inst16, generic: generic<none>, index: generic_inst<none>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant2: {inst: inst28, generic: generic<none>, index: generic_inst<none>, .Self: false}
 // CHECK:STDOUT:     symbolic_constant3: {inst: inst14, generic: generic0, index: generic_inst_in_decl0, .Self: false}
 // CHECK:STDOUT:     symbolic_constant4: {inst: inst16, generic: generic0, index: generic_inst_in_decl1, .Self: false}
 // CHECK:STDOUT:     symbolic_constant5: {inst: inst28, generic: generic0, index: generic_inst_in_decl2, .Self: false}
-// CHECK:STDOUT:     symbolic_constant6: {inst: inst42, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant7: {inst: inst44, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
-// CHECK:STDOUT:     symbolic_constant8: {inst: inst46, generic: generic<invalid>, index: generic_inst<invalid>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant6: {inst: inst42, generic: generic<none>, index: generic_inst<none>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant7: {inst: inst44, generic: generic<none>, index: generic_inst<none>, .Self: false}
+// CHECK:STDOUT:     symbolic_constant8: {inst: inst46, generic: generic<none>, index: generic_inst<none>, .Self: false}
 // CHECK:STDOUT:     symbolic_constant9: {inst: inst44, generic: generic0, index: generic_inst_in_def0, .Self: false}
 // CHECK:STDOUT:     symbolic_constant10: {inst: inst46, generic: generic0, index: generic_inst_in_def1, .Self: false}
 // CHECK:STDOUT:   inst_blocks:

--- a/toolchain/lex/dump.cpp
+++ b/toolchain/lex/dump.cpp
@@ -11,7 +11,7 @@
 namespace Carbon::Lex {
 
 auto DumpNoNewline(const TokenizedBuffer& tokens, TokenIndex token) -> void {
-  if (!token.is_valid()) {
+  if (!token.has_value()) {
     llvm::errs() << "TokenIndex(invalid)";
     return;
   }

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1148,7 +1148,7 @@ auto Lexer::LexClosingSymbolToken(llvm::StringRef source_text, TokenKind kind,
   auto& opening_token_info = buffer_.GetTokenInfo(opening_token);
   if (LLVM_UNLIKELY(opening_token_info.kind() != kind.opening_symbol())) {
     has_mismatched_brackets_ = true;
-    buffer_.GetTokenInfo(token).set_opening_token_index(TokenIndex::Invalid);
+    buffer_.GetTokenInfo(token).set_opening_token_index(TokenIndex::None);
     return token;
   }
 

--- a/toolchain/lex/token_index.h
+++ b/toolchain/lex/token_index.h
@@ -31,13 +31,13 @@ struct TokenIndex : public IndexBase<TokenIndex> {
   static constexpr int Max = 1 << Bits;
 
   static constexpr llvm::StringLiteral Label = "token";
-  static const TokenIndex Invalid;
+  static const TokenIndex None;
   // Comments aren't tokenized, so this is the first token after FileStart.
   static const TokenIndex FirstNonCommentToken;
   using IndexBase::IndexBase;
 };
 
-constexpr TokenIndex TokenIndex::Invalid(TokenIndex::InvalidIndex);
+constexpr TokenIndex TokenIndex::None(TokenIndex::NoneIndex);
 constexpr TokenIndex TokenIndex::FirstNonCommentToken(1);
 
 // A lightweight handle to a lexed token in a `TokenizedBuffer` whose kind is

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -39,20 +39,20 @@ class TokenizedBuffer;
 // All other APIs to query a `LineIndex` are on the `TokenizedBuffer`.
 struct LineIndex : public IndexBase<LineIndex> {
   static constexpr llvm::StringLiteral Label = "line";
-  static const LineIndex Invalid;
+  static const LineIndex None;
   using IndexBase::IndexBase;
 };
 
-constexpr LineIndex LineIndex::Invalid(InvalidIndex);
+constexpr LineIndex LineIndex::None(InvalidIndex);
 
 // Indices for comments within the buffer.
 struct CommentIndex : public IndexBase<CommentIndex> {
   static constexpr llvm::StringLiteral Label = "comment";
-  static const CommentIndex Invalid;
+  static const CommentIndex None;
   using IndexBase::IndexBase;
 };
 
-constexpr CommentIndex CommentIndex::Invalid(InvalidIndex);
+constexpr CommentIndex CommentIndex::None(InvalidIndex);
 
 // Random-access iterator over comments within the buffer.
 using CommentIterator = IndexIterator<CommentIndex>;

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -43,7 +43,7 @@ struct LineIndex : public IndexBase<LineIndex> {
   using IndexBase::IndexBase;
 };
 
-constexpr LineIndex LineIndex::None(InvalidIndex);
+constexpr LineIndex LineIndex::None(NoneIndex);
 
 // Indices for comments within the buffer.
 struct CommentIndex : public IndexBase<CommentIndex> {
@@ -52,7 +52,7 @@ struct CommentIndex : public IndexBase<CommentIndex> {
   using IndexBase::IndexBase;
 };
 
-constexpr CommentIndex CommentIndex::None(InvalidIndex);
+constexpr CommentIndex CommentIndex::None(NoneIndex);
 
 // Random-access iterator over comments within the buffer.
 using CommentIterator = IndexIterator<CommentIndex>;

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -260,7 +260,7 @@ auto LowerConstants(FileContext& file_context,
     }
 
     auto inst = file_context.sem_ir().insts().Get(inst_id);
-    if (inst.type_id().is_valid() &&
+    if (inst.type_id().has_value() &&
         !file_context.sem_ir().types().IsComplete(inst.type_id())) {
       // If a constant doesn't have a complete type, that means we imported it
       // but didn't actually use it.

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -248,7 +248,7 @@ auto LowerConstants(FileContext& file_context,
   // dependencies of a constant before we lower the constant itself.
   for (auto [inst_id_val, const_id] :
        llvm::enumerate(file_context.sem_ir().constant_values().array_ref())) {
-    if (!const_id.is_valid() || !const_id.is_template()) {
+    if (!const_id.has_value() || !const_id.is_template()) {
       // We are only interested in lowering template constants.
       continue;
     }

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -169,7 +169,7 @@ auto FileContext::GetOrCreateFunction(SemIR::FunctionId function_id,
                                       SemIR::SpecificId specific_id)
     -> llvm::Function* {
   // Non-generic functions are declared eagerly.
-  if (!specific_id.is_valid()) {
+  if (!specific_id.has_value()) {
     return GetFunction(function_id);
   }
 
@@ -191,7 +191,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
 
   // Don't lower generic functions. Note that associated functions in interfaces
   // have `Self` in scope, so are implicitly generic functions.
-  if (function.generic_id.is_valid() && !specific_id.is_valid()) {
+  if (function.generic_id.has_value() && !specific_id.has_value()) {
     return nullptr;
   }
 
@@ -214,7 +214,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
       sem_ir().inst_blocks().GetOrEmpty(function.param_patterns_id);
 
   auto* return_type =
-      return_info.type_id.is_valid() ? GetType(return_info.type_id) : nullptr;
+      return_info.type_id.has_value() ? GetType(return_info.type_id) : nullptr;
 
   llvm::SmallVector<llvm::Type*> param_types;
   // TODO: Consider either storing `param_inst_ids` somewhere so that we can
@@ -238,7 +238,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
     auto param_pattern = SemIR::Function::GetParamPatternInfoFromPatternId(
                              sem_ir(), param_pattern_id)
                              .inst;
-    if (!param_pattern.runtime_index.is_valid()) {
+    if (!param_pattern.runtime_index.has_value()) {
       continue;
     }
     auto param_type_id =
@@ -349,10 +349,10 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   // The subset of call_param_ids that is already in the order that the LLVM
   // calling convention expects.
   llvm::ArrayRef<SemIR::InstId> sequential_param_ids;
-  if (function.return_slot_pattern_id.is_valid()) {
+  if (function.return_slot_pattern_id.has_value()) {
     // The LLVM calling convention has the return slot first rather than last.
     // Note that this queries whether there is a return slot at the LLVM level,
-    // whereas `function.return_slot_pattern_id.is_valid()` queries whether
+    // whereas `function.return_slot_pattern_id.has_value()` queries whether
     // there is a return slot at the SemIR level.
     if (SemIR::ReturnTypeInfo::ForFunction(sem_ir(), function, specific_id)
             .has_return_slot()) {

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -84,7 +84,7 @@ auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
   }
   // Append `__global_init` to `llvm::global_ctors` to initialize global
   // variables.
-  if (sem_ir().global_ctor_id().is_valid()) {
+  if (sem_ir().global_ctor_id().has_value()) {
     llvm::appendToGlobalCtors(llvm_module(),
                               GetFunction(sem_ir().global_ctor_id()),
                               /*Priority=*/0);
@@ -226,7 +226,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
                          implicit_param_patterns.size() + param_patterns.size();
   param_types.reserve(max_llvm_params);
   param_inst_ids.reserve(max_llvm_params);
-  auto return_param_id = SemIR::InstId::Invalid;
+  auto return_param_id = SemIR::InstId::None;
   if (return_info.has_return_slot()) {
     param_types.push_back(
         llvm::PointerType::get(return_type, /*AddressSpace=*/0));
@@ -282,7 +282,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
   // Set up parameters and the return slot.
   for (auto [inst_id, arg] :
        llvm::zip_equal(param_inst_ids, llvm_function->args())) {
-    auto name_id = SemIR::NameId::Invalid;
+    auto name_id = SemIR::NameId::None;
     if (inst_id == return_param_id) {
       name_id = SemIR::NameId::ReturnSlot;
       arg.addAttr(
@@ -317,7 +317,7 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
                                     vlog_stream_);
 
   // TODO: Pass in a specific ID for generic functions.
-  const auto specific_id = SemIR::SpecificId::Invalid;
+  const auto specific_id = SemIR::SpecificId::None;
 
   // Add parameters to locals.
   // TODO: This duplicates the mapping between sem_ir instructions and LLVM
@@ -367,7 +367,7 @@ auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
     lower_param(param_id);
   }
 
-  auto decl_block_id = SemIR::InstBlockId::Invalid;
+  auto decl_block_id = SemIR::InstBlockId::None;
   if (function_id == sem_ir().global_ctor_id()) {
     decl_block_id = SemIR::InstBlockId::Empty;
   } else {

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -99,7 +99,7 @@ class FileContext {
   // by the caller.
   auto BuildFunctionDecl(SemIR::FunctionId function_id,
                          SemIR::SpecificId specific_id =
-                             SemIR::SpecificId::Invalid) -> llvm::Function*;
+                             SemIR::SpecificId::None) -> llvm::Function*;
 
   // Builds the definition for the given function. If the function is only a
   // declaration with no definition, does nothing.

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -115,7 +115,7 @@ auto FunctionContext::LowerInst(SemIR::InstId inst_id) -> void {
 #include "toolchain/sem_ir/inst_kind.def"
   }
 
-  builder_.getInserter().SetCurrentInstId(SemIR::InstId::Invalid);
+  builder_.getInserter().SetCurrentInstId(SemIR::InstId::None);
   if (di_subprogram_) {
     builder_.SetCurrentDebugLocation(llvm::DebugLoc());
   }

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -153,7 +153,7 @@ class FunctionContext {
     const SemIR::InstNamer* inst_namer_;
 
     // The current instruction ID.
-    SemIR::InstId inst_id_ = SemIR::InstId::Invalid;
+    SemIR::InstId inst_id_ = SemIR::InstId::None;
   };
 
   // Emits a value copy for type `type_id` from `source_id` to `dest_id`.

--- a/toolchain/lower/handle_call.cpp
+++ b/toolchain/lower/handle_call.cpp
@@ -421,7 +421,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
 
   auto callee_function =
       SemIR::GetCalleeFunction(context.sem_ir(), inst.callee_id);
-  CARBON_CHECK(callee_function.function_id.is_valid());
+  CARBON_CHECK(callee_function.function_id.has_value());
 
   if (auto builtin_kind = context.sem_ir()
                               .functions()

--- a/toolchain/lower/mangler.cpp
+++ b/toolchain/lower/mangler.cpp
@@ -32,7 +32,7 @@ auto Mangler::MangleInverseQualifiedNameScope(llvm::raw_ostream& os,
       os << prefix;
     }
     if (name_scope_id == SemIR::NameScopeId::Package) {
-      if (auto package_id = sem_ir().package_id(); package_id.is_valid()) {
+      if (auto package_id = sem_ir().package_id(); package_id.has_value()) {
         os << sem_ir().identifiers().Get(package_id);
       } else {
         os << "Main";
@@ -129,7 +129,7 @@ auto Mangler::Mangle(SemIR::FunctionId function_id,
                      SemIR::SpecificId specific_id) -> std::string {
   const auto& function = sem_ir().functions().Get(function_id);
   if (SemIR::IsEntryPoint(sem_ir(), function_id)) {
-    CARBON_CHECK(!specific_id.is_valid(), "entry point should not be generic");
+    CARBON_CHECK(!specific_id.has_value(), "entry point should not be generic");
     return "main";
   }
   RawStringOstream os;
@@ -142,7 +142,7 @@ auto Mangler::Mangle(SemIR::FunctionId function_id,
   // TODO: Add proper support for mangling generic entities. For now we use a
   // fingerprint of the specific arguments, which should be stable across files,
   // but isn't necessarily stable across toolchain changes.
-  if (specific_id.is_valid()) {
+  if (specific_id.has_value()) {
     os << ".";
     llvm::write_hex(
         os,

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -391,7 +391,7 @@ auto Context::ParseLibraryName(bool accept_default)
   if (accept_default) {
     if (auto default_token = ConsumeIf(Lex::TokenKind::Default)) {
       AddLeafNode(NodeKind::DefaultLibrary, *default_token);
-      return StringLiteralValueId::Invalid;
+      return StringLiteralValueId::None;
     }
   }
 

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -398,7 +398,7 @@ class Context {
     return first_non_packaging_token_;
   }
   auto set_first_non_packaging_token(Lex::TokenIndex token) -> void {
-    CARBON_CHECK(!first_non_packaging_token_.is_valid());
+    CARBON_CHECK(!first_non_packaging_token_.has_value());
     first_non_packaging_token_ = token;
   }
 

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -454,7 +454,7 @@ class Context {
   PackagingState packaging_state_ = PackagingState::FileStart;
   // The first non-packaging token, starting as invalid. Used for packaging
   // state warnings.
-  Lex::TokenIndex first_non_packaging_token_ = Lex::TokenIndex::Invalid;
+  Lex::TokenIndex first_non_packaging_token_ = Lex::TokenIndex::None;
 };
 
 }  // namespace Carbon::Parse

--- a/toolchain/parse/dump.cpp
+++ b/toolchain/parse/dump.cpp
@@ -12,7 +12,7 @@
 namespace Carbon::Parse {
 
 auto DumpNoNewline(const Tree& tree, NodeId node_id) -> void {
-  if (!node_id.is_valid()) {
+  if (!node_id.has_value()) {
     llvm::errs() << "NodeId(invalid)";
     return;
   }

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -36,7 +36,7 @@ class NodeExtractor {
 
   auto at_end() const -> bool { return it_ == end_; }
   auto kind() const -> NodeKind { return tree_->tree().node_kind(*it_); }
-  auto has_token() const -> bool { return node_id_.is_valid(); }
+  auto has_token() const -> bool { return node_id_.has_value(); }
   auto token() const -> Lex::TokenIndex {
     return tree_->tree().node_token(node_id_);
   }
@@ -295,7 +295,7 @@ struct Extractable<std::optional<T>> {
 
 auto NodeExtractor::MatchesTokenKind(Lex::TokenKind expected_kind) const
     -> bool {
-  if (!node_id_.is_valid()) {
+  if (!node_id_.has_value()) {
     MaybeTrace("Token {0} expected but processing root node\n", expected_kind);
     return false;
   }
@@ -407,7 +407,7 @@ CARBON_PARSE_NODE_KIND(File)
 #include "toolchain/parse/node_kind.def"
 
 auto TreeAndSubtrees::ExtractFile() const -> File {
-  return ExtractNodeFromChildren<File>(NodeId::Invalid, roots());
+  return ExtractNodeFromChildren<File>(NodeId::None, roots());
 }
 
 }  // namespace Carbon::Parse

--- a/toolchain/parse/handle_decl_scope_loop.cpp
+++ b/toolchain/parse/handle_decl_scope_loop.cpp
@@ -142,7 +142,7 @@ static auto TryHandleAsDecl(Context& context, Context::StateStackEntry state,
       // Misplaced packaging keywords may lead to this being re-triggered.
       if (context.packaging_state() !=
           Context::PackagingState::AfterNonPackagingDecl) {
-        if (!context.first_non_packaging_token().is_valid()) {
+        if (!context.first_non_packaging_token().has_value()) {
           context.set_first_non_packaging_token(*context.position());
         }
         context.set_packaging_state(

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -71,7 +71,7 @@ static auto HandleDeclContent(Context& context, Context::StateStackEntry state,
   }
 
   // Parse the optional library keyword.
-  bool accept_default = !names.package_id.is_valid();
+  bool accept_default = !names.package_id.has_value();
   if (declaration == NodeKind::LibraryDecl) {
     auto library_id = context.ParseLibraryName(accept_default);
     if (!library_id) {

--- a/toolchain/parse/handle_var.cpp
+++ b/toolchain/parse/handle_var.cpp
@@ -9,7 +9,7 @@ namespace Carbon::Parse {
 
 // Handles VarAs(Decl|Returned).
 static auto HandleVar(Context& context, State finish_state,
-                      Lex::TokenIndex returned_token = Lex::TokenIndex::Invalid)
+                      Lex::TokenIndex returned_token = Lex::TokenIndex::None)
     -> void {
   auto state = context.PopState();
 

--- a/toolchain/parse/handle_var.cpp
+++ b/toolchain/parse/handle_var.cpp
@@ -21,7 +21,7 @@ static auto HandleVar(Context& context, State finish_state,
   state.token = *(context.position() - 1);
   context.PushState(state, State::VarAfterPattern);
 
-  if (returned_token.is_valid()) {
+  if (returned_token.has_value()) {
     context.AddLeafNode(NodeKind::ReturnedModifier, returned_token);
   }
 

--- a/toolchain/parse/node_ids.h
+++ b/toolchain/parse/node_ids.h
@@ -27,7 +27,7 @@ struct NodeId : public IdBase<NodeId> {
 
   using IdBase::IdBase;
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeId(NoneNodeId /*none*/) : IdBase(NodeId::NoneIndex) {}
+  constexpr NodeId(NoneNodeId /*none*/) : IdBase(NoneIndex) {}
 };
 
 // For looking up the type associated with a given id type.
@@ -42,7 +42,7 @@ struct NodeIdForKind : public NodeId {
   static const NodeKind& Kind;
   constexpr explicit NodeIdForKind(NodeId node_id) : NodeId(node_id) {}
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdForKind(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
+  constexpr NodeIdForKind(NoneNodeId /*none*/) : NodeId(NoneIndex) {}
 };
 template <const NodeKind& K>
 const NodeKind& NodeIdForKind<K>::Kind = K;
@@ -64,7 +64,7 @@ struct NodeIdInCategory : public NodeId {
 
   constexpr explicit NodeIdInCategory(NodeId node_id) : NodeId(node_id) {}
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdInCategory(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
+  constexpr NodeIdInCategory(NoneNodeId /*none*/) : NodeId(NoneIndex) {}
 };
 
 // Aliases for `NodeIdInCategory` to describe particular categories of nodes.
@@ -93,7 +93,7 @@ struct NodeIdOneOf : public NodeId {
     static_assert(((T::Kind == Kind) || ...));
   }
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdOneOf(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
+  constexpr NodeIdOneOf(NoneNodeId /*none*/) : NodeId(NoneIndex) {}
 };
 
 using AnyClassDeclId = NodeIdOneOf<ClassDeclId, ClassDefinitionStartId>;
@@ -111,7 +111,7 @@ template <typename T>
 struct NodeIdNot : public NodeId {
   constexpr explicit NodeIdNot(NodeId node_id) : NodeId(node_id) {}
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdNot(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
+  constexpr NodeIdNot(NoneNodeId /*none*/) : NodeId(NoneIndex) {}
 };
 
 // Note that the support for extracting these types using the `Tree::Extract*`

--- a/toolchain/parse/node_ids.h
+++ b/toolchain/parse/node_ids.h
@@ -12,7 +12,7 @@
 namespace Carbon::Parse {
 
 // Represents an invalid node id of any type
-struct InvalidNodeId {};
+struct NoneNodeId {};
 
 // A lightweight handle representing a node in the tree.
 //
@@ -23,11 +23,11 @@ struct NodeId : public IdBase<NodeId> {
   static constexpr llvm::StringLiteral Label = "node";
 
   // An explicitly invalid node ID.
-  static constexpr InvalidNodeId Invalid;
+  static constexpr NoneNodeId None;
 
   using IdBase::IdBase;
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeId(InvalidNodeId /*invalid*/) : IdBase(NodeId::InvalidIndex) {}
+  constexpr NodeId(NoneNodeId /*none*/) : IdBase(NodeId::NoneIndex) {}
 };
 
 // For looking up the type associated with a given id type.
@@ -42,8 +42,7 @@ struct NodeIdForKind : public NodeId {
   static const NodeKind& Kind;
   constexpr explicit NodeIdForKind(NodeId node_id) : NodeId(node_id) {}
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdForKind(InvalidNodeId /*invalid*/)
-      : NodeId(NodeId::InvalidIndex) {}
+  constexpr NodeIdForKind(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
 };
 template <const NodeKind& K>
 const NodeKind& NodeIdForKind<K>::Kind = K;
@@ -65,8 +64,7 @@ struct NodeIdInCategory : public NodeId {
 
   constexpr explicit NodeIdInCategory(NodeId node_id) : NodeId(node_id) {}
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdInCategory(InvalidNodeId /*invalid*/)
-      : NodeId(NodeId::InvalidIndex) {}
+  constexpr NodeIdInCategory(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
 };
 
 // Aliases for `NodeIdInCategory` to describe particular categories of nodes.
@@ -95,8 +93,7 @@ struct NodeIdOneOf : public NodeId {
     static_assert(((T::Kind == Kind) || ...));
   }
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdOneOf(InvalidNodeId /*invalid*/)
-      : NodeId(NodeId::InvalidIndex) {}
+  constexpr NodeIdOneOf(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
 };
 
 using AnyClassDeclId = NodeIdOneOf<ClassDeclId, ClassDefinitionStartId>;
@@ -114,8 +111,7 @@ template <typename T>
 struct NodeIdNot : public NodeId {
   constexpr explicit NodeIdNot(NodeId node_id) : NodeId(node_id) {}
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr NodeIdNot(InvalidNodeId /*invalid*/)
-      : NodeId(NodeId::InvalidIndex) {}
+  constexpr NodeIdNot(NoneNodeId /*none*/) : NodeId(NodeId::NoneIndex) {}
 };
 
 // Note that the support for extracting these types using the `Tree::Extract*`

--- a/toolchain/parse/tree.cpp
+++ b/toolchain/parse/tree.cpp
@@ -22,7 +22,7 @@ auto Tree::postorder() const -> llvm::iterator_range<PostorderIterator> {
 }
 
 auto Tree::node_token(NodeId n) const -> Lex::TokenIndex {
-  CARBON_CHECK(n.is_valid());
+  CARBON_CHECK(n.has_value());
   return node_impls_[n.index].token();
 }
 
@@ -77,7 +77,7 @@ auto Tree::CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
 
 auto Tree::PostorderIterator::MakeRange(NodeId begin, NodeId end)
     -> llvm::iterator_range<PostorderIterator> {
-  CARBON_CHECK(begin.is_valid() && end.is_valid());
+  CARBON_CHECK(begin.has_value() && end.has_value());
   return llvm::iterator_range<PostorderIterator>(
       PostorderIterator(begin), PostorderIterator(NodeId(end.index + 1)));
 }

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -118,13 +118,13 @@ class Tree : public Printable<Tree> {
   // Tests whether a particular node contains an error and may not match the
   // full expected structure of the grammar.
   auto node_has_error(NodeId n) const -> bool {
-    CARBON_DCHECK(n.is_valid());
+    CARBON_DCHECK(n.has_value());
     return node_impls_[n.index].has_error();
   }
 
   // Returns the kind of the given parse tree node.
   auto node_kind(NodeId n) const -> NodeKind {
-    CARBON_DCHECK(n.is_valid());
+    CARBON_DCHECK(n.has_value());
     return node_impls_[n.index].kind();
   }
 
@@ -148,7 +148,7 @@ class Tree : public Printable<Tree> {
   // the constraint on `T`.
   template <typename T>
   auto TryAs(NodeId n) const -> std::optional<T> {
-    CARBON_DCHECK(n.is_valid());
+    CARBON_DCHECK(n.has_value());
     if (ConvertTo<T>::AllowedFor(node_kind(n))) {
       return T(n);
     } else {
@@ -160,7 +160,7 @@ class Tree : public Printable<Tree> {
   // `node_kind(n)` matches the constraint on `T`.
   template <typename T>
   auto As(NodeId n) const -> T {
-    CARBON_DCHECK(n.is_valid());
+    CARBON_DCHECK(n.has_value());
     CARBON_CHECK(ConvertTo<T>::AllowedFor(node_kind(n)));
     return T(n);
   }

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -29,13 +29,13 @@ struct DeferredDefinitionIndex : public IndexBase<DeferredDefinitionIndex> {
   static constexpr llvm::StringLiteral Label = "deferred_def";
   using ValueType = DeferredDefinition;
 
-  static const DeferredDefinitionIndex Invalid;
+  static const DeferredDefinitionIndex None;
 
   using IndexBase::IndexBase;
 };
 
-constexpr DeferredDefinitionIndex DeferredDefinitionIndex::Invalid =
-    DeferredDefinitionIndex(InvalidIndex);
+constexpr DeferredDefinitionIndex DeferredDefinitionIndex::None =
+    DeferredDefinitionIndex(NoneIndex);
 
 // A function whose definition is deferred because it is defined inline in a
 // class or similar scope.
@@ -47,10 +47,9 @@ struct DeferredDefinition {
   // The node that starts the function definition.
   FunctionDefinitionStartId start_id;
   // The function definition node.
-  FunctionDefinitionId definition_id = NodeId::Invalid;
+  FunctionDefinitionId definition_id = NodeId::None;
   // The index of the next method that is not nested within this one.
-  DeferredDefinitionIndex next_definition_index =
-      DeferredDefinitionIndex::Invalid;
+  DeferredDefinitionIndex next_definition_index = DeferredDefinitionIndex::None;
 };
 
 // Defined in typed_nodes.h. Include that to call `Tree::ExtractFile()`.
@@ -85,8 +84,8 @@ class Tree : public Printable<Tree> {
   // to the node for diagnostics.
   struct PackagingNames {
     ImportDeclId node_id;
-    IdentifierId package_id = IdentifierId::Invalid;
-    StringLiteralValueId library_id = StringLiteralValueId::Invalid;
+    IdentifierId package_id = IdentifierId::None;
+    StringLiteralValueId library_id = StringLiteralValueId::None;
     // Whether an import is exported. This is on the file's packaging
     // declaration even though it doesn't apply, for consistency in structure.
     bool is_export = false;

--- a/toolchain/parse/tree_and_subtrees.cpp
+++ b/toolchain/parse/tree_and_subtrees.cpp
@@ -118,7 +118,7 @@ auto TreeAndSubtrees::postorder(NodeId n) const
 
 auto TreeAndSubtrees::children(NodeId n) const
     -> llvm::iterator_range<SiblingIterator> {
-  CARBON_CHECK(n.is_valid());
+  CARBON_CHECK(n.has_value());
   int end_index = n.index - subtree_sizes_[n.index];
   return llvm::iterator_range<SiblingIterator>(
       SiblingIterator(*this, NodeId(n.index - 1)),

--- a/toolchain/parse/tree_and_subtrees.cpp
+++ b/toolchain/parse/tree_and_subtrees.cpp
@@ -98,10 +98,10 @@ auto TreeAndSubtrees::Verify() const -> ErrorOr<Success> {
   }
 
   // Validate the roots. Also ensures Tree::ExtractFile() doesn't error.
-  if (!TryExtractNodeFromChildren<File>(NodeId::Invalid, roots(), nullptr)) {
+  if (!TryExtractNodeFromChildren<File>(NodeId::None, roots(), nullptr)) {
     ErrorBuilder trace;
     trace << "Roots of tree couldn't be extracted as a `File`. Trace:\n";
-    TryExtractNodeFromChildren<File>(NodeId::Invalid, roots(), &trace);
+    TryExtractNodeFromChildren<File>(NodeId::None, roots(), &trace);
     return trace;
   }
 
@@ -173,7 +173,7 @@ auto TreeAndSubtrees::Print(llvm::raw_ostream& output) const -> void {
   }
 
   while (!node_stack.empty()) {
-    NodeId n = NodeId::Invalid;
+    NodeId n = NodeId::None;
     int depth;
     std::tie(n, depth) = node_stack.pop_back_val();
     for (NodeId sibling_n : children(n)) {
@@ -206,7 +206,7 @@ auto TreeAndSubtrees::PrintPreorder(llvm::raw_ostream& output) const -> void {
   }
 
   while (!node_stack.empty()) {
-    NodeId n = NodeId::Invalid;
+    NodeId n = NodeId::None;
     int depth;
     std::tie(n, depth) = node_stack.pop_back_val();
 

--- a/toolchain/parse/tree_node_diagnostic_converter.h
+++ b/toolchain/parse/tree_node_diagnostic_converter.h
@@ -64,7 +64,7 @@ class NodeLocConverter : public DiagnosticConverter<NodeLoc> {
     Lex::TokenIndex end_token = start_token;
     for (NodeId desc : tree.postorder(node_loc.node_id())) {
       Lex::TokenIndex desc_token = tree.tree().node_token(desc);
-      if (!desc_token.is_valid()) {
+      if (!desc_token.has_value()) {
         continue;
       }
       if (desc_token < start_token) {

--- a/toolchain/parse/tree_node_diagnostic_converter.h
+++ b/toolchain/parse/tree_node_diagnostic_converter.h
@@ -23,7 +23,7 @@ class NodeLoc {
   // TODO: Have some other way of representing diagnostic that applies to a file
   // as a whole.
   // NOLINTNEXTLINE(google-explicit-constructor)
-  NodeLoc(InvalidNodeId node_id) : NodeLoc(node_id, false) {}
+  NodeLoc(NoneNodeId node_id) : NodeLoc(node_id, false) {}
 
   auto node_id() const -> NodeId { return node_id_; }
   auto token_only() const -> bool { return token_only_; }
@@ -47,7 +47,7 @@ class NodeLocConverter : public DiagnosticConverter<NodeLoc> {
       -> ConvertedDiagnosticLoc override {
     // Support the invalid token as a way to emit only the filename, when there
     // is no line association.
-    if (!node_loc.node_id().is_valid()) {
+    if (!node_loc.node_id().has_value()) {
       return {{.filename = filename_}, -1};
     }
 

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -35,7 +35,7 @@ class TreeTest : public ::testing::Test {
 
 TEST_F(TreeTest, IsValid) {
   Tree& tree = compile_helper_.GetTree("");
-  EXPECT_TRUE((*tree.postorder().begin()).is_valid());
+  EXPECT_TRUE((*tree.postorder().begin()).has_value());
 }
 
 TEST_F(TreeTest, AsAndTryAs) {

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -42,7 +42,7 @@ struct TypeParam {
 
   static auto Check(const File& sem_ir, ValidateState& state, TypeId type_id)
       -> bool {
-    if (state.type_params[I].is_valid() && type_id != state.type_params[I]) {
+    if (state.type_params[I].has_value() && type_id != state.type_params[I]) {
       return false;
     }
     if (!TypeConstraint::Check(sem_ir, state, type_id)) {
@@ -112,7 +112,7 @@ struct AnyFloat {
 // Checks that the specified type matches the given type constraint.
 template <typename TypeConstraint>
 auto Check(const File& sem_ir, ValidateState& state, TypeId type_id) -> bool {
-  while (type_id.is_valid()) {
+  while (type_id.has_value()) {
     // Allow a type that satisfies the constraint.
     if (TypeConstraint::Check(sem_ir, state, type_id)) {
       return true;

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -31,7 +31,7 @@ constexpr int MaxTypeParams = 2;
 struct ValidateState {
   // The type values of type parameters in the builtin signature. Invalid if
   // either no value has been deduced yet or the parameter is not used.
-  TypeId type_params[MaxTypeParams] = {TypeId::Invalid, TypeId::Invalid};
+  TypeId type_params[MaxTypeParams] = {TypeId::None, TypeId::None};
 };
 
 // Constraint that a type is generic type parameter `I` of the builtin,

--- a/toolchain/sem_ir/class.cpp
+++ b/toolchain/sem_ir/class.cpp
@@ -13,7 +13,7 @@ namespace Carbon::SemIR {
 
 static auto GetFoundationType(const File& file, SpecificId specific_id,
                               InstId inst_id) -> TypeId {
-  if (!inst_id.is_valid()) {
+  if (!inst_id.has_value()) {
     return TypeId::None;
   }
   if (inst_id == SemIR::ErrorInst::SingletonInstId) {
@@ -36,7 +36,7 @@ auto Class::GetBaseType(const File& file, SpecificId specific_id) const
 
 auto Class::GetObjectRepr(const File& file, SpecificId specific_id) const
     -> TypeId {
-  if (!complete_type_witness_id.is_valid()) {
+  if (!complete_type_witness_id.has_value()) {
     return TypeId::None;
   }
   auto witness_id =

--- a/toolchain/sem_ir/class.cpp
+++ b/toolchain/sem_ir/class.cpp
@@ -14,7 +14,7 @@ namespace Carbon::SemIR {
 static auto GetFoundationType(const File& file, SpecificId specific_id,
                               InstId inst_id) -> TypeId {
   if (!inst_id.is_valid()) {
-    return TypeId::Invalid;
+    return TypeId::None;
   }
   if (inst_id == SemIR::ErrorInst::SingletonInstId) {
     return ErrorInst::SingletonTypeId;
@@ -37,7 +37,7 @@ auto Class::GetBaseType(const File& file, SpecificId specific_id) const
 auto Class::GetObjectRepr(const File& file, SpecificId specific_id) const
     -> TypeId {
   if (!complete_type_witness_id.is_valid()) {
-    return TypeId::Invalid;
+    return TypeId::None;
   }
   auto witness_id =
       GetConstantValueInSpecific(file, specific_id, complete_type_witness_id);

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -36,10 +36,10 @@ struct ClassFields {
   // The following members are set at the `{` of the class definition.
 
   // The class scope.
-  NameScopeId scope_id = NameScopeId::Invalid;
+  NameScopeId scope_id = NameScopeId::None;
   // The first block of the class body.
   // TODO: Handle control flow in the class body, such as if-expressions.
-  InstBlockId body_block_id = InstBlockId::Invalid;
+  InstBlockId body_block_id = InstBlockId::None;
 
   // The following members are accumulated throughout the class definition.
 
@@ -47,10 +47,10 @@ struct ClassFields {
   // adapter. This is an AdaptDecl instruction.
   // TODO: Consider sharing the storage for `adapt_id` and `base_id`. A class
   // can't have both.
-  InstId adapt_id = InstId::Invalid;
+  InstId adapt_id = InstId::None;
   // The base class declaration. Invalid if the class has no base class. This is
   // a BaseDecl instruction.
-  InstId base_id = InstId::Invalid;
+  InstId base_id = InstId::None;
 
   // The following members are set at the `}` of the class definition.
 
@@ -58,11 +58,11 @@ struct ClassFields {
   // complete, and tracking its object representation. This is valid once the
   // class is defined. For an adapter, the object representation is the
   // non-adapter type that this class directly or transitively adapts.
-  InstId complete_type_witness_id = InstId::Invalid;
+  InstId complete_type_witness_id = InstId::None;
 
   // The virtual function table. Invalid if the class has no (direct or
   // inherited) virtual functions.
-  InstId vtable_id = InstId::Invalid;
+  InstId vtable_id = InstId::None;
 };
 
 // A class. See EntityWithParamsBase regarding the inheritance here.

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -78,7 +78,7 @@ struct Class : public EntityWithParamsBase,
   // Determines whether this class has been fully defined. This is false until
   // we reach the `}` of the class definition.
   auto is_defined() const -> bool {
-    return complete_type_witness_id.is_valid();
+    return complete_type_witness_id.has_value();
   }
 
   // Gets the type that this class type adapts. Returns Invalid if there is no

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -43,24 +43,24 @@ struct ClassFields {
 
   // The following members are accumulated throughout the class definition.
 
-  // The adapted type declaration, if any. Invalid if the class is not an
+  // The adapted type declaration, if any. `None` if the class is not an
   // adapter. This is an AdaptDecl instruction.
   // TODO: Consider sharing the storage for `adapt_id` and `base_id`. A class
   // can't have both.
   InstId adapt_id = InstId::None;
-  // The base class declaration. Invalid if the class has no base class. This is
+  // The base class declaration. `None` if the class has no base class. This is
   // a BaseDecl instruction.
   InstId base_id = InstId::None;
 
   // The following members are set at the `}` of the class definition.
 
   // A `CompleteTypeWitness` instruction witnessing that this class type is
-  // complete, and tracking its object representation. This is valid once the
+  // complete, and tracking its object representation. This has a value once the
   // class is defined. For an adapter, the object representation is the
   // non-adapter type that this class directly or transitively adapts.
   InstId complete_type_witness_id = InstId::None;
 
-  // The virtual function table. Invalid if the class has no (direct or
+  // The virtual function table. `None` if the class has no (direct or
   // inherited) virtual functions.
   InstId vtable_id = InstId::None;
 };
@@ -81,15 +81,15 @@ struct Class : public EntityWithParamsBase,
     return complete_type_witness_id.has_value();
   }
 
-  // Gets the type that this class type adapts. Returns Invalid if there is no
+  // Gets the type that this class type adapts. Returns `None` if there is no
   // such type, or if the class is not yet defined.
   auto GetAdaptedType(const File& file, SpecificId specific_id) const -> TypeId;
 
-  // Gets the base class for this class type. Returns Invalid if there is no
+  // Gets the base class for this class type. Returns `None` if there is no
   // such type, or if the class is not yet defined.
   auto GetBaseType(const File& file, SpecificId specific_id) const -> TypeId;
 
-  // Gets the object representation for this class. Returns Invalid if the class
+  // Gets the object representation for this class. Returns `None` if the class
   // is not yet defined.
   auto GetObjectRepr(const File& file, SpecificId specific_id) const -> TypeId;
 };

--- a/toolchain/sem_ir/constant.cpp
+++ b/toolchain/sem_ir/constant.cpp
@@ -11,7 +11,7 @@ namespace Carbon::SemIR {
 auto ConstantStore::GetOrAdd(Inst inst, PhaseKind phase) -> ConstantId {
   auto result = map_.Insert(inst, [&] {
     auto inst_id = sem_ir_->insts().AddInNoBlock(LocIdAndInst::NoLoc(inst));
-    ConstantId const_id = ConstantId::Invalid;
+    ConstantId const_id = ConstantId::None;
     if (phase == IsTemplate) {
       const_id = SemIR::ConstantId::ForTemplateConstant(inst_id);
     } else {
@@ -19,8 +19,8 @@ auto ConstantStore::GetOrAdd(Inst inst, PhaseKind phase) -> ConstantId {
       // constant, not associated with any particular generic.
       SymbolicConstant symbolic_constant = {
           .inst_id = inst_id,
-          .generic_id = GenericId::Invalid,
-          .index = GenericInstIndex::Invalid,
+          .generic_id = GenericId::None,
+          .index = GenericInstIndex::None,
           .period_self_only = (phase == IsPeriodSelfSymbolic)};
       const_id =
           sem_ir_->constant_values().AddSymbolicConstant(symbolic_constant);
@@ -29,7 +29,7 @@ auto ConstantStore::GetOrAdd(Inst inst, PhaseKind phase) -> ConstantId {
     constants_.push_back(inst_id);
     return const_id;
   });
-  CARBON_CHECK(result.value() != ConstantId::Invalid);
+  CARBON_CHECK(result.value() != ConstantId::None);
   CARBON_CHECK(
       result.value().is_symbolic() == (phase != IsTemplate),
       "Constant {0} registered as both symbolic and template constant.", inst);

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -17,12 +17,12 @@ namespace Carbon::SemIR {
 struct SymbolicConstant : Printable<SymbolicConstant> {
   // The constant instruction that defines the value of this symbolic constant.
   InstId inst_id;
-  // The enclosing generic. If this is invalid, then this is an abstract
+  // The enclosing generic. If this is `None`, then this is an abstract
   // symbolic constant, such as a constant instruction in the constants block,
   // rather than one associated with a particular generic.
   GenericId generic_id;
   // The index of this symbolic constant within the generic's list of symbolic
-  // constants, or invalid if `generic_id` is invalid.
+  // constants, or `None` if `generic_id` is `None`.
   GenericInstIndex index;
   // True if this is constant is symbolic just because it uses `.Self`.
   bool period_self_only;
@@ -61,7 +61,8 @@ class ConstantValueStore {
   }
 
   // Gets the instruction ID that defines the value of the given constant.
-  // Returns Invalid if the constant ID is non-constant. Requires is_valid.
+  // Returns `None` if the constant ID is non-constant. Requires
+  // `const_id.has_value()`.
   auto GetInstId(ConstantId const_id) const -> InstId {
     if (const_id.is_template()) {
       return const_id.template_inst_id();
@@ -73,13 +74,13 @@ class ConstantValueStore {
   }
 
   // Gets the instruction ID that defines the value of the given constant.
-  // Returns Invalid if the constant ID is non-constant or invalid.
+  // Returns `None` if the constant ID is non-constant or `None`.
   auto GetInstIdIfValid(ConstantId const_id) const -> InstId {
     return const_id.has_value() ? GetInstId(const_id) : InstId::None;
   }
 
   // Given an instruction, returns the unique constant instruction that is
-  // equivalent to it. Returns Invalid for a non-constant instruction.
+  // equivalent to it. Returns `None` for a non-constant instruction.
   auto GetConstantInstId(InstId inst_id) const -> InstId {
     return GetInstId(Get(inst_id));
   }
@@ -121,7 +122,7 @@ class ConstantValueStore {
   }
 
   // Returns the constant values mapping as an ArrayRef whose keys are
-  // instruction indexes. Some of the elements in this mapping may be Invalid or
+  // instruction indexes. Some of the elements in this mapping may be `None` or
   // NotConstant.
   auto array_ref() const -> llvm::ArrayRef<ConstantId> { return values_; }
 

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -69,13 +69,13 @@ class ConstantValueStore {
     if (const_id.is_symbolic()) {
       return GetSymbolicConstant(const_id).inst_id;
     }
-    return InstId::Invalid;
+    return InstId::None;
   }
 
   // Gets the instruction ID that defines the value of the given constant.
   // Returns Invalid if the constant ID is non-constant or invalid.
   auto GetInstIdIfValid(ConstantId const_id) const -> InstId {
-    return const_id.is_valid() ? GetInstId(const_id) : InstId::Invalid;
+    return const_id.is_valid() ? GetInstId(const_id) : InstId::None;
   }
 
   // Given an instruction, returns the unique constant instruction that is

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -75,7 +75,7 @@ class ConstantValueStore {
   // Gets the instruction ID that defines the value of the given constant.
   // Returns Invalid if the constant ID is non-constant or invalid.
   auto GetInstIdIfValid(ConstantId const_id) const -> InstId {
-    return const_id.is_valid() ? GetInstId(const_id) : InstId::None;
+    return const_id.has_value() ? GetInstId(const_id) : InstId::None;
   }
 
   // Given an instruction, returns the unique constant instruction that is

--- a/toolchain/sem_ir/copy_on_write_block.h
+++ b/toolchain/sem_ir/copy_on_write_block.h
@@ -35,7 +35,7 @@ class CopyOnWriteBlock {
   // with `size` elements.
   explicit CopyOnWriteBlock(SemIR::File& file, UninitializedBlock uninit)
       : file_(file),
-        source_id_(BlockIdType::Invalid),
+        source_id_(BlockIdType::None),
         id_((file_.*ValueStore)().AddUninitialized(uninit.size)) {}
 
   // Gets a block ID containing the resulting elements. Note that further

--- a/toolchain/sem_ir/copy_on_write_block.h
+++ b/toolchain/sem_ir/copy_on_write_block.h
@@ -52,7 +52,7 @@ class CopyOnWriteBlock {
   // Sets the element at index `i` within the block. Lazily allocates a new
   // block when the value changes for the first time.
   auto Set(int i, typename BlockIdType::ElementType value) -> void {
-    if (source_id_.is_valid() && (file_.*ValueStore)().Get(id_)[i] == value) {
+    if (source_id_.has_value() && (file_.*ValueStore)().Get(id_)[i] == value) {
       return;
     }
     if (id_ == source_id_) {

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -12,7 +12,7 @@
 namespace Carbon::SemIR {
 
 static auto DumpNameIfValid(const File& file, NameId name_id) -> void {
-  if (name_id.is_valid()) {
+  if (name_id.has_value()) {
     llvm::errs() << " `" << file.names().GetFormatted(name_id) << "`";
   }
 }
@@ -31,14 +31,14 @@ static auto DumpNoNewline(const File& file, ConstantId const_id) -> void {
 
 static auto DumpNoNewline(const File& file, InstId inst_id) -> void {
   llvm::errs() << inst_id;
-  if (inst_id.is_valid()) {
+  if (inst_id.has_value()) {
     llvm::errs() << ": " << file.insts().Get(inst_id);
   }
 }
 
 static auto DumpNoNewline(const File& file, InterfaceId interface_id) -> void {
   llvm::errs() << interface_id;
-  if (interface_id.is_valid()) {
+  if (interface_id.has_value()) {
     auto interface = file.interfaces().Get(interface_id);
     llvm::errs() << ": " << interface;
     DumpNameIfValid(file, interface.name_id);
@@ -47,14 +47,14 @@ static auto DumpNoNewline(const File& file, InterfaceId interface_id) -> void {
 
 static auto DumpNoNewline(const File& file, SpecificId specific_id) -> void {
   llvm::errs() << specific_id;
-  if (specific_id.is_valid()) {
+  if (specific_id.has_value()) {
     llvm::errs() << ": " << file.specifics().Get(specific_id);
   }
 }
 
 LLVM_DUMP_METHOD auto Dump(const File& file, ClassId class_id) -> void {
   llvm::errs() << class_id;
-  if (class_id.is_valid()) {
+  if (class_id.has_value()) {
     auto class_obj = file.classes().Get(class_id);
     llvm::errs() << ": " << class_obj;
     DumpNameIfValid(file, class_obj.name_id);
@@ -70,7 +70,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, ConstantId const_id) -> void {
 LLVM_DUMP_METHOD auto Dump(const File& file, EntityNameId entity_name_id)
     -> void {
   llvm::errs() << entity_name_id;
-  if (entity_name_id.is_valid()) {
+  if (entity_name_id.has_value()) {
     auto entity_name = file.entity_names().Get(entity_name_id);
     llvm::errs() << ": " << entity_name;
     DumpNameIfValid(file, entity_name.name_id);
@@ -81,13 +81,13 @@ LLVM_DUMP_METHOD auto Dump(const File& file, EntityNameId entity_name_id)
 LLVM_DUMP_METHOD auto Dump(const File& file, FacetTypeId facet_type_id)
     -> void {
   llvm::errs() << facet_type_id;
-  if (facet_type_id.is_valid()) {
+  if (facet_type_id.has_value()) {
     auto facet_type = file.facet_types().Get(facet_type_id);
     llvm::errs() << ": " << facet_type;
     for (auto impls : facet_type.impls_constraints) {
       llvm::errs() << "\n  - ";
       DumpNoNewline(file, impls.interface_id);
-      if (impls.specific_id.is_valid()) {
+      if (impls.specific_id.has_value()) {
         llvm::errs() << "; ";
         DumpNoNewline(file, impls.specific_id);
       }
@@ -104,7 +104,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, FacetTypeId facet_type_id)
 
 LLVM_DUMP_METHOD auto Dump(const File& file, FunctionId function_id) -> void {
   llvm::errs() << function_id;
-  if (function_id.is_valid()) {
+  if (function_id.has_value()) {
     auto function = file.functions().Get(function_id);
     llvm::errs() << ": " << function;
     DumpNameIfValid(file, function.name_id);
@@ -114,7 +114,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, FunctionId function_id) -> void {
 
 LLVM_DUMP_METHOD auto Dump(const File& file, GenericId generic_id) -> void {
   llvm::errs() << generic_id;
-  if (generic_id.is_valid()) {
+  if (generic_id.has_value()) {
     llvm::errs() << ": " << file.generics().Get(generic_id);
   }
   llvm::errs() << '\n';
@@ -122,7 +122,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, GenericId generic_id) -> void {
 
 LLVM_DUMP_METHOD auto Dump(const File& file, ImplId impl_id) -> void {
   llvm::errs() << impl_id;
-  if (impl_id.is_valid()) {
+  if (impl_id.has_value()) {
     llvm::errs() << ": " << file.impls().Get(impl_id);
   }
   llvm::errs() << '\n';
@@ -131,7 +131,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, ImplId impl_id) -> void {
 LLVM_DUMP_METHOD auto Dump(const File& file, InstBlockId inst_block_id)
     -> void {
   llvm::errs() << inst_block_id;
-  if (inst_block_id.is_valid()) {
+  if (inst_block_id.has_value()) {
     llvm::errs() << ":";
     auto inst_block = file.inst_blocks().Get(inst_block_id);
     for (auto inst_id : inst_block) {
@@ -145,14 +145,14 @@ LLVM_DUMP_METHOD auto Dump(const File& file, InstBlockId inst_block_id)
 LLVM_DUMP_METHOD auto Dump(const File& file, InstId inst_id) -> void {
   DumpNoNewline(file, inst_id);
   llvm::errs() << '\n';
-  if (inst_id.is_valid()) {
+  if (inst_id.has_value()) {
     Inst inst = file.insts().Get(inst_id);
     if (inst.type_id().has_value()) {
       llvm::errs() << "  - type ";
       Dump(file, inst.type_id());
     }
     ConstantId const_id = file.constant_values().Get(inst_id);
-    if (const_id.is_valid()) {
+    if (const_id.has_value()) {
       InstId const_inst_id = file.constant_values().GetInstId(const_id);
       llvm::errs() << "  - value ";
       if (const_inst_id == inst_id) {
@@ -178,7 +178,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, NameId name_id) -> void {
 LLVM_DUMP_METHOD auto Dump(const File& file, NameScopeId name_scope_id)
     -> void {
   llvm::errs() << name_scope_id;
-  if (name_scope_id.is_valid()) {
+  if (name_scope_id.has_value()) {
     auto name_scope = file.name_scopes().Get(name_scope_id);
     llvm::errs() << ": " << name_scope;
     if (name_scope.inst_id().has_value()) {
@@ -197,13 +197,13 @@ LLVM_DUMP_METHOD auto Dump(const File& file, SpecificId specific_id) -> void {
 LLVM_DUMP_METHOD auto Dump(const File& file,
                            StructTypeFieldsId struct_type_fields_id) -> void {
   llvm::errs() << struct_type_fields_id;
-  if (struct_type_fields_id.is_valid()) {
+  if (struct_type_fields_id.has_value()) {
     llvm::errs() << ":";
     auto block = file.struct_type_fields().Get(struct_type_fields_id);
     for (auto field : block) {
       llvm::errs() << "\n  - " << field;
       DumpNameIfValid(file, field.name_id);
-      if (field.type_id.is_valid()) {
+      if (field.type_id.has_value()) {
         InstId inst_id =
             file.constant_values().GetInstId(field.type_id.AsConstantId());
         llvm::errs() << ": " << StringifyTypeExpr(file, inst_id);
@@ -216,7 +216,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file,
 LLVM_DUMP_METHOD auto Dump(const File& file, TypeBlockId type_block_id)
     -> void {
   llvm::errs() << type_block_id;
-  if (type_block_id.is_valid()) {
+  if (type_block_id.has_value()) {
     llvm::errs() << ":\n";
     auto type_block = file.type_blocks().Get(type_block_id);
     for (auto type_id : type_block) {
@@ -230,7 +230,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, TypeBlockId type_block_id)
 
 LLVM_DUMP_METHOD auto Dump(const File& file, TypeId type_id) -> void {
   llvm::errs() << type_id;
-  if (type_id.is_valid()) {
+  if (type_id.has_value()) {
     InstId inst_id = file.constant_values().GetInstId(type_id.AsConstantId());
     llvm::errs() << ": " << StringifyTypeExpr(file, inst_id) << "; "
                  << file.insts().Get(inst_id);

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -147,7 +147,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, InstId inst_id) -> void {
   llvm::errs() << '\n';
   if (inst_id.is_valid()) {
     Inst inst = file.insts().Get(inst_id);
-    if (inst.type_id().is_valid()) {
+    if (inst.type_id().has_value()) {
       llvm::errs() << "  - type ";
       Dump(file, inst.type_id());
     }
@@ -181,7 +181,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file, NameScopeId name_scope_id)
   if (name_scope_id.is_valid()) {
     auto name_scope = file.name_scopes().Get(name_scope_id);
     llvm::errs() << ": " << name_scope;
-    if (name_scope.inst_id().is_valid()) {
+    if (name_scope.inst_id().has_value()) {
       llvm::errs() << " " << file.insts().Get(name_scope.inst_id());
     }
     DumpNameIfValid(file, name_scope.name_id());

--- a/toolchain/sem_ir/entity_with_params_base.h
+++ b/toolchain/sem_ir/entity_with_params_base.h
@@ -146,7 +146,7 @@ struct EntityWithParamsBase {
   // The following members are set at the `{` of the definition.
 
   // The definition of the entity. This will be a <entity>Decl.
-  InstId definition_id = InstId::Invalid;
+  InstId definition_id = InstId::None;
 };
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/entity_with_params_base.h
+++ b/toolchain/sem_ir/entity_with_params_base.h
@@ -54,15 +54,15 @@ struct EntityWithParamsBase {
   // Determines whether the definition of this entity has begun. This is false
   // until we reach the `{` of the definition.
   auto has_definition_started() const -> bool {
-    return definition_id.is_valid();
+    return definition_id.has_value();
   }
 
   // Returns the instruction for the first declaration.
   auto first_decl_id() const -> SemIR::InstId {
-    if (non_owning_decl_id.is_valid()) {
+    if (non_owning_decl_id.has_value()) {
       return non_owning_decl_id;
     }
-    CARBON_CHECK(first_owning_decl_id.is_valid());
+    CARBON_CHECK(first_owning_decl_id.has_value());
     return first_owning_decl_id;
   }
 
@@ -71,7 +71,7 @@ struct EntityWithParamsBase {
     if (has_definition_started()) {
       return definition_id;
     }
-    if (first_owning_decl_id.is_valid()) {
+    if (first_owning_decl_id.has_value()) {
       return first_owning_decl_id;
     }
     return non_owning_decl_id;
@@ -79,8 +79,8 @@ struct EntityWithParamsBase {
 
   // Determines whether this entity has any parameter lists.
   auto has_parameters() const -> bool {
-    return implicit_param_patterns_id.is_valid() ||
-           param_patterns_id.is_valid();
+    return implicit_param_patterns_id.has_value() ||
+           param_patterns_id.has_value();
   }
 
   // The following members always have values, and do not change throughout the

--- a/toolchain/sem_ir/entry_point.cpp
+++ b/toolchain/sem_ir/entry_point.cpp
@@ -15,7 +15,7 @@ auto IsEntryPoint(const SemIR::File& file, SemIR::FunctionId function_id)
   // TODO: Check if `file` is in the `Main` package.
   const auto& function = file.functions().Get(function_id);
   // TODO: Check if `function` is in a namespace.
-  return function.name_id.is_valid() &&
+  return function.name_id.has_value() &&
          file.names().GetAsStringIfIdentifier(function.name_id) ==
              EntryPointFunction;
 }

--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -26,7 +26,7 @@ auto FacetTypeInfo::Print(llvm::raw_ostream& out) const -> void {
     llvm::ListSeparator sep;
     for (ImplsConstraint req : impls_constraints) {
       out << sep << req.interface_id;
-      if (req.specific_id.is_valid()) {
+      if (req.specific_id.has_value()) {
         out << "(" << req.specific_id << ")";
       }
     }

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -122,7 +122,7 @@ auto File::OutputYaml(bool include_singletons) const -> Yaml::OutputMapping {
                     for (int i : llvm::seq(start, insts_.size())) {
                       auto id = InstId(i);
                       auto value = constant_values_.Get(id);
-                      if (!value.is_valid() || value.is_constant()) {
+                      if (!value.has_value() || value.is_constant()) {
                         map.Add(PrintToString(id), Yaml::OutputScalar(value));
                       }
                     }
@@ -303,7 +303,7 @@ auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
         // TODO: Don't rely on value_id for expression category, since it may
         // not be valid yet. This workaround only works because we don't support
         // `var` in function signatures yet.
-        if (!inst.value_id.is_valid()) {
+        if (!inst.value_id.has_value()) {
           return value_category;
         }
         inst_id = inst.value_id;

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -24,7 +24,7 @@ File::File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
     : parse_tree_(parse_tree),
       check_ir_id_(check_ir_id),
       package_id_(packaging_decl ? packaging_decl->names.package_id
-                                 : IdentifierId::Invalid),
+                                 : IdentifierId::None),
       library_id_(packaging_decl ? LibraryNameId::ForStringLiteralValueId(
                                        packaging_decl->names.library_id)
                                  : LibraryNameId::Default),

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -219,10 +219,10 @@ class File : public Printable<File> {
   CheckIRId check_ir_id_;
 
   // The file's package.
-  IdentifierId package_id_ = IdentifierId::Invalid;
+  IdentifierId package_id_ = IdentifierId::None;
 
   // The file's library.
-  LibraryNameId library_id_ = LibraryNameId::Invalid;
+  LibraryNameId library_id_ = LibraryNameId::None;
 
   // Shared, compile-scoped values.
   SharedValueStores* value_stores_;
@@ -284,10 +284,10 @@ class File : public Printable<File> {
   InstBlockStore inst_blocks_;
 
   // The top instruction block ID.
-  InstBlockId top_inst_block_id_ = InstBlockId::Invalid;
+  InstBlockId top_inst_block_id_ = InstBlockId::None;
 
   // The global constructor function id.
-  FunctionId global_ctor_id_ = FunctionId::Invalid;
+  FunctionId global_ctor_id_ = FunctionId::None;
 
   // Storage for instructions that represent computed global constants, such as
   // types.

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -62,7 +62,7 @@ class FormatterImpl {
     // TODO: Handle the case where there are multiple top-level instruction
     // blocks. For example, there may be branching in the initializer of a
     // global or a type expression.
-    if (auto block_id = sem_ir_->top_inst_block_id(); block_id.is_valid()) {
+    if (auto block_id = sem_ir_->top_inst_block_id(); block_id.has_value()) {
       llvm::SaveAndRestore file_scope(scope_, InstNamer::ScopeId::File);
       FormatCodeBlock(block_id);
     }
@@ -272,7 +272,7 @@ class FormatterImpl {
 
     llvm::SaveAndRestore class_scope(scope_, inst_namer_->GetScopeFor(id));
 
-    if (class_info.scope_id.is_valid()) {
+    if (class_info.scope_id.has_value()) {
       out_ << ' ';
       OpenBrace();
       FormatCodeBlock(class_info.body_block_id);
@@ -302,7 +302,7 @@ class FormatterImpl {
 
     llvm::SaveAndRestore interface_scope(scope_, inst_namer_->GetScopeFor(id));
 
-    if (interface_info.scope_id.is_valid()) {
+    if (interface_info.scope_id.has_value()) {
       out_ << ' ';
       OpenBrace();
       FormatCodeBlock(interface_info.body_block_id);
@@ -352,7 +352,7 @@ class FormatterImpl {
       // always list the witness in this section.
       IndentLabel();
       out_ << "!members:\n";
-      if (impl_info.scope_id.is_valid()) {
+      if (impl_info.scope_id.has_value()) {
         FormatNameScope(impl_info.scope_id);
       }
 
@@ -402,7 +402,7 @@ class FormatterImpl {
     FormatParamList(fn.implicit_param_patterns_id, /*is_implicit=*/true);
     FormatParamList(fn.param_patterns_id, /*is_implicit=*/false);
 
-    if (fn.return_slot_pattern_id.is_valid()) {
+    if (fn.return_slot_pattern_id.has_value()) {
       out_ << " -> ";
       auto return_info = ReturnTypeInfo::ForFunction(*sem_ir_, fn);
       if (!fn.body_block_ids.empty() && return_info.is_valid() &&
@@ -445,7 +445,7 @@ class FormatterImpl {
   auto FormatSpecificRegion(const Generic& generic, const Specific& specific,
                             GenericInstIndex::Region region,
                             llvm::StringRef region_name) -> void {
-    if (!specific.GetValueBlock(region).is_valid()) {
+    if (!specific.GetValueBlock(region).has_value()) {
       return;
     }
 
@@ -518,7 +518,7 @@ class FormatterImpl {
     out_ << " ";
     OpenBrace();
     FormatCodeBlock(generic.decl_block_id);
-    if (generic.definition_block_id.is_valid()) {
+    if (generic.definition_block_id.has_value()) {
       IndentLabel();
       out_ << "!definition:\n";
       FormatCodeBlock(generic.definition_block_id);
@@ -532,7 +532,7 @@ class FormatterImpl {
       -> void {
     // If this entity was imported from a different IR, annotate the name of
     // that IR in the output before the `{` or `;`.
-    if (entity.first_owning_decl_id.is_valid()) {
+    if (entity.first_owning_decl_id.has_value()) {
       auto loc_id = sem_ir_->insts().GetLocId(entity.first_owning_decl_id);
       if (loc_id.is_import_ir_inst_id()) {
         auto import_ir_id =
@@ -544,7 +544,7 @@ class FormatterImpl {
     }
 
     auto generic_id = entity.generic_id;
-    if (generic_id.is_valid()) {
+    if (generic_id.has_value()) {
       FormatGenericStart(entity_kind, generic_id);
     }
 
@@ -554,7 +554,7 @@ class FormatterImpl {
 
     // If there's a generic, it will have attached the name. Otherwise, add the
     // name here.
-    if (!generic_id.is_valid()) {
+    if (!generic_id.has_value()) {
       out_ << " ";
       FormatName(entity_id);
     }
@@ -562,7 +562,7 @@ class FormatterImpl {
 
   // Provides common formatting for entities, paired with FormatEntityStart.
   auto FormatEntityEnd(GenericId generic_id) -> void {
-    if (generic_id.is_valid()) {
+    if (generic_id.has_value()) {
       CloseBrace();
       out_ << '\n';
     }
@@ -573,7 +573,7 @@ class FormatterImpl {
   // parameters.
   auto FormatParamList(InstBlockId param_patterns_id, bool is_implicit)
       -> void {
-    if (!param_patterns_id.is_valid()) {
+    if (!param_patterns_id.has_value()) {
       return;
     }
 
@@ -582,7 +582,7 @@ class FormatterImpl {
     llvm::ListSeparator sep;
     for (InstId param_id : sem_ir_->inst_blocks().Get(param_patterns_id)) {
       out_ << sep;
-      if (!param_id.is_valid()) {
+      if (!param_id.has_value()) {
         out_ << "invalid";
         continue;
       }
@@ -687,7 +687,7 @@ class FormatterImpl {
 
   // Prints a single instruction.
   auto FormatInst(InstId inst_id) -> void {
-    if (!inst_id.is_valid()) {
+    if (!inst_id.has_value()) {
       Indent();
       out_ << "invalid\n";
       return;
@@ -762,7 +762,7 @@ class FormatterImpl {
       out_ << ' ';
     }
     out_ << '[';
-    if (pending_constant_value_.is_valid()) {
+    if (pending_constant_value_.has_value()) {
       out_ << (pending_constant_value_.is_symbolic() ? "symbolic" : "template");
       if (!pending_constant_value_is_self_) {
         out_ << " = ";
@@ -828,7 +828,7 @@ class FormatterImpl {
       // specific, that is, when we're not in a generic context.
       if constexpr (std::is_same_v<typename Info::template ArgType<1>,
                                    SemIR::SpecificId>) {
-        if (!Info::template Get<1>(inst).is_valid()) {
+        if (!Info::template Get<1>(inst).has_value()) {
           FormatArgs(Info::template Get<0>(inst));
           return;
         }
@@ -844,7 +844,7 @@ class FormatterImpl {
   auto FormatInstRHS(BindSymbolicName inst) -> void {
     // A BindSymbolicName with no value is a purely symbolic binding, such as
     // the `Self` in an interface. Don't print out `invalid` for the value.
-    if (inst.value_id.is_valid()) {
+    if (inst.value_id.has_value()) {
       FormatArgs(inst.entity_name_id, inst.value_id);
     } else {
       FormatArgs(inst.entity_name_id);
@@ -857,7 +857,7 @@ class FormatterImpl {
   }
 
   auto FormatInstRHS(Namespace inst) -> void {
-    if (inst.import_id.is_valid()) {
+    if (inst.import_id.has_value()) {
       FormatArgs(inst.import_id, inst.name_scope_id);
     } else {
       FormatArgs(inst.name_scope_id);
@@ -902,7 +902,7 @@ class FormatterImpl {
     out_ << " ";
     FormatArg(inst.callee_id);
 
-    if (!inst.args_id.is_valid()) {
+    if (!inst.args_id.has_value()) {
       out_ << "(<none>)";
       return;
     }
@@ -958,7 +958,7 @@ class FormatterImpl {
 
   auto FormatInstRHS(ReturnExpr ret) -> void {
     FormatArgs(ret.expr_id);
-    if (ret.dest_id.is_valid()) {
+    if (ret.dest_id.has_value()) {
       FormatReturnSlotArg(ret.dest_id);
     }
   }
@@ -1037,7 +1037,7 @@ class FormatterImpl {
     auto import_ir_inst = sem_ir_->import_ir_insts().Get(import_ir_inst_id);
     FormatArg(import_ir_inst.ir_id);
     out_ << ", ";
-    if (entity_name_id.is_valid()) {
+    if (entity_name_id.has_value()) {
       // Prefer to show the entity name when possible.
       FormatArg(entity_name_id);
     } else {
@@ -1045,7 +1045,7 @@ class FormatterImpl {
       // instruction as a last resort.
       const auto& import_ir = sem_ir_->import_irs().Get(import_ir_inst.ir_id);
       auto loc_id = import_ir.sem_ir->insts().GetLocId(import_ir_inst.inst_id);
-      if (!loc_id.is_valid()) {
+      if (!loc_id.has_value()) {
         out_ << import_ir_inst.inst_id << " [no loc]";
       } else if (loc_id.is_import_ir_inst_id()) {
         // TODO: Probably don't want to format each indirection, but maybe reuse
@@ -1120,7 +1120,7 @@ class FormatterImpl {
   auto FormatArg(EntityNameId id) -> void {
     const auto& info = sem_ir_->entity_names().Get(id);
     FormatName(info.name_id);
-    if (info.bind_index.is_valid()) {
+    if (info.bind_index.has_value()) {
       out_ << ", " << info.bind_index.index;
     }
   }
@@ -1138,7 +1138,7 @@ class FormatterImpl {
       for (auto interface : info.impls_constraints) {
         out_ << sep;
         FormatName(interface.interface_id);
-        if (interface.specific_id.is_valid()) {
+        if (interface.specific_id.has_value()) {
           out_ << ", ";
           FormatName(interface.specific_id);
         }
@@ -1167,7 +1167,7 @@ class FormatterImpl {
   auto FormatArg(FloatKind k) -> void { k.Print(out_); }
 
   auto FormatArg(ImportIRId id) -> void {
-    if (id.is_valid()) {
+    if (id.has_value()) {
       out_ << GetImportIRLabel(id);
     } else {
       out_ << id;
@@ -1190,7 +1190,7 @@ class FormatterImpl {
   }
 
   auto FormatArg(InstBlockId id) -> void {
-    if (!id.is_valid()) {
+    if (!id.has_value()) {
       out_ << "invalid";
       return;
     }
@@ -1252,7 +1252,7 @@ class FormatterImpl {
   }
 
   auto FormatName(InstId id) -> void {
-    if (id.is_valid()) {
+    if (id.has_value()) {
       IncludeChunkInOutput(tentative_inst_chunks_[id.index]);
     }
     out_ << inst_namer_->GetNameFor(scope_, id);
@@ -1273,7 +1273,7 @@ class FormatterImpl {
   }
 
   auto FormatConstant(ConstantId id) -> void {
-    if (!id.is_valid()) {
+    if (!id.has_value()) {
       out_ << "<not constant>";
       return;
     }
@@ -1283,7 +1283,7 @@ class FormatterImpl {
     if (id.is_symbolic()) {
       const auto& symbolic_constant =
           sem_ir_->constant_values().GetSymbolicConstant(id);
-      if (symbolic_constant.generic_id.is_valid()) {
+      if (symbolic_constant.generic_id.has_value()) {
         const auto& generic =
             sem_ir_->generics().Get(symbolic_constant.generic_id);
         FormatName(sem_ir_->inst_blocks().Get(generic.GetEvalBlock(
@@ -1300,7 +1300,7 @@ class FormatterImpl {
   }
 
   auto FormatType(TypeId id) -> void {
-    if (!id.is_valid()) {
+    if (!id.has_value()) {
       out_ << "invalid";
     } else {
       // Types are formatted in the `constants` scope because they only refer to
@@ -1312,7 +1312,7 @@ class FormatterImpl {
 
   // Returns the label for the indicated IR.
   auto GetImportIRLabel(ImportIRId id) -> std::string {
-    CARBON_CHECK(id.is_valid(),
+    CARBON_CHECK(id.has_value(),
                  "GetImportIRLabel should only be called where we a valid ID.");
     const auto& import_ir = *sem_ir_->import_irs().Get(id).sem_ir;
     CARBON_CHECK(import_ir.library_id().has_value());

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -182,7 +182,7 @@ class FormatterImpl {
   // Determines whether the specified entity should be included in the formatted
   // output.
   auto ShouldFormatEntity(const EntityWithParamsBase& entity) -> bool {
-    if (!entity.latest_decl_id().is_valid()) {
+    if (!entity.latest_decl_id().has_value()) {
       return true;
     }
     return should_format_entity_(entity.latest_decl_id());
@@ -903,7 +903,7 @@ class FormatterImpl {
     FormatArg(inst.callee_id);
 
     if (!inst.args_id.is_valid()) {
-      out_ << "(<invalid>)";
+      out_ << "(<none>)";
       return;
     }
 
@@ -915,7 +915,7 @@ class FormatterImpl {
       return;
     }
     bool has_return_slot = return_info.has_return_slot();
-    InstId return_slot_arg_id = InstId::Invalid;
+    InstId return_slot_arg_id = InstId::None;
     if (has_return_slot) {
       return_slot_arg_id = args.back();
       args = args.drop_back();
@@ -1315,10 +1315,10 @@ class FormatterImpl {
     CARBON_CHECK(id.is_valid(),
                  "GetImportIRLabel should only be called where we a valid ID.");
     const auto& import_ir = *sem_ir_->import_irs().Get(id).sem_ir;
-    CARBON_CHECK(import_ir.library_id().is_valid());
+    CARBON_CHECK(import_ir.library_id().has_value());
 
     llvm::StringRef package_name =
-        import_ir.package_id().is_valid()
+        import_ir.package_id().has_value()
             ? import_ir.identifiers().Get(import_ir.package_id())
             : "Main";
     llvm::StringRef library_name =

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -30,7 +30,7 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id) -> CalleeFunction {
 
   // Identify the function we're calling.
   auto val_id = sem_ir.constant_values().GetConstantInstId(callee_id);
-  if (!val_id.is_valid()) {
+  if (!val_id.has_value()) {
     return result;
   }
   auto val_inst = sem_ir.insts().Get(val_id);
@@ -104,7 +104,7 @@ auto Function::GetNameFromPatternId(const File& sem_ir, InstId pattern_id)
 
 auto Function::GetDeclaredReturnType(const File& file,
                                      SpecificId specific_id) const -> TypeId {
-  if (!return_slot_pattern_id.is_valid()) {
+  if (!return_slot_pattern_id.has_value()) {
     return TypeId::None;
   }
   return GetTypeInSpecific(file, specific_id,

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -11,10 +11,10 @@
 namespace Carbon::SemIR {
 
 auto GetCalleeFunction(const File& sem_ir, InstId callee_id) -> CalleeFunction {
-  CalleeFunction result = {.function_id = FunctionId::Invalid,
-                           .enclosing_specific_id = SpecificId::Invalid,
-                           .resolved_specific_id = SpecificId::Invalid,
-                           .self_id = InstId::Invalid,
+  CalleeFunction result = {.function_id = FunctionId::None,
+                           .enclosing_specific_id = SpecificId::None,
+                           .resolved_specific_id = SpecificId::None,
+                           .self_id = InstId::None,
                            .is_error = false};
 
   if (auto specific_function =
@@ -87,7 +87,7 @@ auto Function::GetNameFromPatternId(const File& sem_ir, InstId pattern_id)
   }
 
   if (inst_id == SemIR::ErrorInst::SingletonInstId) {
-    return SemIR::NameId::Invalid;
+    return SemIR::NameId::None;
   }
 
   auto param_pattern_inst = inst.As<SemIR::AnyParamPattern>();
@@ -105,7 +105,7 @@ auto Function::GetNameFromPatternId(const File& sem_ir, InstId pattern_id)
 auto Function::GetDeclaredReturnType(const File& file,
                                      SpecificId specific_id) const -> TypeId {
   if (!return_slot_pattern_id.is_valid()) {
-    return TypeId::Invalid;
+    return TypeId::None;
   }
   return GetTypeInSpecific(file, specific_id,
                            file.insts().Get(return_slot_pattern_id).type_id());

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -88,7 +88,7 @@ struct Function : public EntityWithParamsBase,
 
   // Gets the declared return type for a specific version of this function, or
   // the canonical return type for the original declaration no specific is
-  // specified.  Returns `Invalid` if no return type was specified, in which
+  // specified.  Returns `None` if no return type was specified, in which
   // case the effective return type is an empty tuple.
   auto GetDeclaredReturnType(const File& file,
                              SpecificId specific_id = SpecificId::None) const

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -54,7 +54,7 @@ struct Function : public EntityWithParamsBase,
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{";
     PrintBaseFields(out);
-    if (return_slot_pattern_id.is_valid()) {
+    if (return_slot_pattern_id.has_value()) {
       out << ", return_slot_pattern: " << return_slot_pattern_id;
     }
     if (!body_block_ids.empty()) {

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -91,7 +91,7 @@ struct Function : public EntityWithParamsBase,
   // specified.  Returns `Invalid` if no return type was specified, in which
   // case the effective return type is an empty tuple.
   auto GetDeclaredReturnType(const File& file,
-                             SpecificId specific_id = SpecificId::Invalid) const
+                             SpecificId specific_id = SpecificId::None) const
       -> TypeId;
 };
 

--- a/toolchain/sem_ir/generic.cpp
+++ b/toolchain/sem_ir/generic.cpp
@@ -32,7 +32,7 @@ class SpecificStore::KeyContext : public TranslatingKeyContext<KeyContext> {
 
 auto SpecificStore::GetOrAdd(GenericId generic_id, InstBlockId args_id)
     -> SpecificId {
-  CARBON_CHECK(generic_id.is_valid());
+  CARBON_CHECK(generic_id.has_value());
   return lookup_table_
       .Insert(
           KeyContext::Key{.generic_id = generic_id, .args_id = args_id},
@@ -59,13 +59,13 @@ auto GetConstantInSpecific(const File& sem_ir, SpecificId specific_id,
   }
 
   const auto& symbolic = sem_ir.constant_values().GetSymbolicConstant(const_id);
-  if (!symbolic.generic_id.is_valid()) {
+  if (!symbolic.generic_id.has_value()) {
     // Constant is an abstract symbolic constant, not associated with some
     // particular generic.
     return const_id;
   }
 
-  if (!specific_id.is_valid()) {
+  if (!specific_id.has_value()) {
     // We have a generic constant but no specific. We treat as a request for the
     // canonical value of the constant.
     return sem_ir.constant_values().Get(symbolic.inst_id);
@@ -77,7 +77,7 @@ auto GetConstantInSpecific(const File& sem_ir, SpecificId specific_id,
 
   auto value_block_id = specific.GetValueBlock(symbolic.index.region());
   CARBON_CHECK(
-      value_block_id.is_valid(),
+      value_block_id.has_value(),
       "Queried {0} in {1} for {2} before it was resolved.", symbolic.index,
       specific_id,
       sem_ir.insts().Get(sem_ir.generics().Get(specific.generic_id).decl_id));

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -47,9 +47,9 @@ struct Generic : public Printable<Generic> {
   // generic.
 
   // The eval block for the declaration region of the generic.
-  InstBlockId decl_block_id = InstBlockId::Invalid;
+  InstBlockId decl_block_id = InstBlockId::None;
   // The eval block for the definition region of the generic.
-  InstBlockId definition_block_id = InstBlockId::Invalid;
+  InstBlockId definition_block_id = InstBlockId::None;
 };
 
 // Provides storage for generics.
@@ -58,7 +58,7 @@ class GenericStore : public ValueStore<GenericId> {
   // Get the self specific for a generic, or an invalid specific for an invalid
   // generic ID.
   auto GetSelfSpecific(GenericId id) -> SpecificId {
-    return id.is_valid() ? Get(id).self_specific_id : SpecificId::Invalid;
+    return id.is_valid() ? Get(id).self_specific_id : SpecificId::None;
   }
 };
 
@@ -91,9 +91,9 @@ struct Specific : Printable<Specific> {
   // is resolved.
 
   // The value block for the declaration region of the specific.
-  InstBlockId decl_block_id = InstBlockId::Invalid;
+  InstBlockId decl_block_id = InstBlockId::None;
   // The value block for the definition region of the specific.
-  InstBlockId definition_block_id = InstBlockId::Invalid;
+  InstBlockId definition_block_id = InstBlockId::None;
 };
 
 // Provides storage for deduplicated specifics, which represent generics plus

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -58,7 +58,7 @@ class GenericStore : public ValueStore<GenericId> {
   // Get the self specific for a generic, or an invalid specific for an invalid
   // generic ID.
   auto GetSelfSpecific(GenericId id) -> SpecificId {
-    return id.is_valid() ? Get(id).self_specific_id : SpecificId::None;
+    return id.has_value() ? Get(id).self_specific_id : SpecificId::None;
   }
 };
 

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -140,18 +140,18 @@ class SpecificStore : public Yaml::Printable<SpecificStore> {
 
 // Gets the substituted value of a potentially generic constant within a
 // specific. Note that this does not perform substitution, and will return
-// `Invalid` if the substituted constant value is not yet known.
+// `None` if the substituted constant value is not yet known.
 auto GetConstantInSpecific(const File& sem_ir, SpecificId specific_id,
                            ConstantId const_id) -> ConstantId;
 
 // Gets the substituted constant value of a potentially generic instruction
 // within a specific. Note that this does not perform substitution, and will
-// return `Invalid` if the substituted constant value is not yet known.
+// return `None` if the substituted constant value is not yet known.
 auto GetConstantValueInSpecific(const File& sem_ir, SpecificId specific_id,
                                 InstId inst_id) -> ConstantId;
 
 // Gets the substituted value of a potentially generic type within a specific.
-// Note that this does not perform substitution, and will return `Invalid` if
+// Note that this does not perform substitution, and will return `None` if
 // the substituted type is not yet known.
 auto GetTypeInSpecific(const File& sem_ir, SpecificId specific_id,
                        TypeId type_id) -> TypeId;

--- a/toolchain/sem_ir/ids.cpp
+++ b/toolchain/sem_ir/ids.cpp
@@ -52,7 +52,7 @@ auto GenericInstIndex::Print(llvm::raw_ostream& out) const -> void {
   if (is_valid()) {
     out << (region() == Declaration ? "_in_decl" : "_in_def") << index();
   } else {
-    out << "<invalid>";
+    out << "<none>";
   }
 }
 
@@ -80,7 +80,7 @@ auto NameId::ForIdentifier(IdentifierId id) -> NameId {
   if (id.index >= 0) {
     return NameId(id.index);
   } else if (!id.is_valid()) {
-    return NameId::Invalid;
+    return NameId::None;
   } else {
     CARBON_FATAL("Unexpected identifier ID {0}", id);
   }
@@ -144,7 +144,7 @@ auto TypeId::Print(llvm::raw_ostream& out) const -> void {
 auto LibraryNameId::ForStringLiteralValueId(StringLiteralValueId id)
     -> LibraryNameId {
   CARBON_CHECK(id.index >= InvalidIndex, "Unexpected library name ID {0}", id);
-  if (id == StringLiteralValueId::Invalid) {
+  if (id == StringLiteralValueId::None) {
     // Prior to SemIR, we use invalid to indicate `default`.
     return LibraryNameId::Default;
   } else {

--- a/toolchain/sem_ir/ids.cpp
+++ b/toolchain/sem_ir/ids.cpp
@@ -19,7 +19,7 @@ auto InstId::Print(llvm::raw_ostream& out) const -> void {
 
 auto ConstantId::Print(llvm::raw_ostream& out, bool disambiguate) const
     -> void {
-  if (!is_valid()) {
+  if (!has_value()) {
     IdBase::Print(out);
     return;
   }
@@ -49,7 +49,7 @@ auto RuntimeParamIndex::Print(llvm::raw_ostream& out) const -> void {
 
 auto GenericInstIndex::Print(llvm::raw_ostream& out) const -> void {
   out << "generic_inst";
-  if (is_valid()) {
+  if (has_value()) {
     out << (region() == Declaration ? "_in_decl" : "_in_def") << index();
   } else {
     out << "<none>";
@@ -79,7 +79,7 @@ auto IntKind::Print(llvm::raw_ostream& out) const -> void {
 auto NameId::ForIdentifier(IdentifierId id) -> NameId {
   if (id.index >= 0) {
     return NameId(id.index);
-  } else if (!id.is_valid()) {
+  } else if (!id.has_value()) {
     return NameId::None;
   } else {
     CARBON_FATAL("Unexpected identifier ID {0}", id);
@@ -87,7 +87,7 @@ auto NameId::ForIdentifier(IdentifierId id) -> NameId {
 }
 
 auto NameId::Print(llvm::raw_ostream& out) const -> void {
-  if (!is_valid() || index >= 0) {
+  if (!has_value() || index >= 0) {
     IdBase::Print(out);
     return;
   }
@@ -143,9 +143,9 @@ auto TypeId::Print(llvm::raw_ostream& out) const -> void {
 
 auto LibraryNameId::ForStringLiteralValueId(StringLiteralValueId id)
     -> LibraryNameId {
-  CARBON_CHECK(id.index >= InvalidIndex, "Unexpected library name ID {0}", id);
+  CARBON_CHECK(id.index >= NoneIndex, "Unexpected library name ID {0}", id);
   if (id == StringLiteralValueId::None) {
-    // Prior to SemIR, we use invalid to indicate `default`.
+    // Prior to SemIR, we use `None` to indicate `default`.
     return LibraryNameId::Default;
   } else {
     return LibraryNameId(id.index);
@@ -164,7 +164,7 @@ auto LibraryNameId::Print(llvm::raw_ostream& out) const -> void {
 
 auto LocId::Print(llvm::raw_ostream& out) const -> void {
   out << Label << "_";
-  if (is_node_id() || !is_valid()) {
+  if (is_node_id() || !has_value()) {
     out << node_id();
   } else {
     out << import_ir_inst_id();

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -38,7 +38,7 @@ struct InstId : public IdBase<InstId> {
   using ValueType = Inst;
 
   // An explicitly invalid ID.
-  static const InstId Invalid;
+  static const InstId None;
 
   // Represents the result of a name lookup that is temporarily disallowed
   // because the name is currently being initialized.
@@ -49,8 +49,8 @@ struct InstId : public IdBase<InstId> {
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 
-constexpr InstId InstId::Invalid = InstId(InvalidIndex);
-constexpr InstId InstId::InitTombstone = InstId(InvalidIndex - 2);
+constexpr InstId InstId::None = InstId(NoneIndex);
+constexpr InstId InstId::InitTombstone = InstId(NoneIndex - 2);
 
 // An ID of an instruction that is referenced absolutely by another instruction.
 // This should only be used as the type of a field within a typed instruction
@@ -89,7 +89,7 @@ struct ConstantId : public IdBase<ConstantId> {
   // An ID for an expression that is not constant.
   static const ConstantId NotConstant;
   // An explicitly invalid ID.
-  static const ConstantId Invalid;
+  static const ConstantId None;
 
   // Returns the constant ID corresponding to a template constant, which should
   // either be in the `constants` block in the file or should be known to be
@@ -155,7 +155,7 @@ struct ConstantId : public IdBase<ConstantId> {
 };
 
 constexpr ConstantId ConstantId::NotConstant = ConstantId(NotConstantIndex);
-constexpr ConstantId ConstantId::Invalid = ConstantId(InvalidIndex);
+constexpr ConstantId ConstantId::None = ConstantId(NoneIndex);
 
 // The ID of a EntityName.
 struct EntityNameId : public IdBase<EntityNameId> {
@@ -163,12 +163,12 @@ struct EntityNameId : public IdBase<EntityNameId> {
   using ValueType = EntityName;
 
   // An explicitly invalid ID.
-  static const EntityNameId Invalid;
+  static const EntityNameId None;
 
   using IdBase::IdBase;
 };
 
-constexpr EntityNameId EntityNameId::Invalid = EntityNameId(InvalidIndex);
+constexpr EntityNameId EntityNameId::None = EntityNameId(NoneIndex);
 
 // The index of a compile-time binding. This is the de Bruijn level for the
 // binding -- that is, this is the number of other compile time bindings whose
@@ -177,13 +177,13 @@ struct CompileTimeBindIndex : public IndexBase<CompileTimeBindIndex> {
   static constexpr llvm::StringLiteral Label = "comp_time_bind";
 
   // An explicitly invalid index.
-  static const CompileTimeBindIndex Invalid;
+  static const CompileTimeBindIndex None;
 
   using IndexBase::IndexBase;
 };
 
-constexpr CompileTimeBindIndex CompileTimeBindIndex::Invalid =
-    CompileTimeBindIndex(InvalidIndex);
+constexpr CompileTimeBindIndex CompileTimeBindIndex::None =
+    CompileTimeBindIndex(NoneIndex);
 
 // The index of a runtime parameter in a function. These are allocated
 // sequentially, left-to-right, to the function parameters that will have
@@ -196,7 +196,7 @@ struct RuntimeParamIndex : public IndexBase<RuntimeParamIndex> {
   static constexpr llvm::StringLiteral Label = "runtime_param";
 
   // An explicitly invalid index.
-  static const RuntimeParamIndex Invalid;
+  static const RuntimeParamIndex None;
 
   // An placeholder for index whose value is not yet known.
   static const RuntimeParamIndex Unknown;
@@ -206,11 +206,11 @@ struct RuntimeParamIndex : public IndexBase<RuntimeParamIndex> {
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 
-constexpr RuntimeParamIndex RuntimeParamIndex::Invalid =
-    RuntimeParamIndex(InvalidIndex);
+constexpr RuntimeParamIndex RuntimeParamIndex::None =
+    RuntimeParamIndex(NoneIndex);
 
 constexpr RuntimeParamIndex RuntimeParamIndex::Unknown =
-    RuntimeParamIndex(InvalidIndex - 1);
+    RuntimeParamIndex(NoneIndex - 1);
 
 // The ID of a function.
 struct FunctionId : public IdBase<FunctionId> {
@@ -218,12 +218,12 @@ struct FunctionId : public IdBase<FunctionId> {
   using ValueType = Function;
 
   // An explicitly invalid ID.
-  static const FunctionId Invalid;
+  static const FunctionId None;
 
   using IdBase::IdBase;
 };
 
-constexpr FunctionId FunctionId::Invalid = FunctionId(InvalidIndex);
+constexpr FunctionId FunctionId::None = FunctionId(NoneIndex);
 
 // The ID of an IR within the set of all IRs being evaluated in the current
 // check execution.
@@ -238,12 +238,12 @@ struct ClassId : public IdBase<ClassId> {
   using ValueType = Class;
 
   // An explicitly invalid ID.
-  static const ClassId Invalid;
+  static const ClassId None;
 
   using IdBase::IdBase;
 };
 
-constexpr ClassId ClassId::Invalid = ClassId(InvalidIndex);
+constexpr ClassId ClassId::None = ClassId(NoneIndex);
 
 // The ID of an interface.
 struct InterfaceId : public IdBase<InterfaceId> {
@@ -251,12 +251,12 @@ struct InterfaceId : public IdBase<InterfaceId> {
   using ValueType = Interface;
 
   // An explicitly invalid ID.
-  static const InterfaceId Invalid;
+  static const InterfaceId None;
 
   using IdBase::IdBase;
 };
 
-constexpr InterfaceId InterfaceId::Invalid = InterfaceId(InvalidIndex);
+constexpr InterfaceId InterfaceId::None = InterfaceId(NoneIndex);
 
 // The ID of an faceet type value.
 struct FacetTypeId : public IdBase<FacetTypeId> {
@@ -264,12 +264,12 @@ struct FacetTypeId : public IdBase<FacetTypeId> {
   using ValueType = FacetTypeInfo;
 
   // An explicitly invalid ID.
-  static const FacetTypeId Invalid;
+  static const FacetTypeId None;
 
   using IdBase::IdBase;
 };
 
-constexpr FacetTypeId FacetTypeId::Invalid = FacetTypeId(InvalidIndex);
+constexpr FacetTypeId FacetTypeId::None = FacetTypeId(NoneIndex);
 
 // The ID of an impl.
 struct ImplId : public IdBase<ImplId> {
@@ -277,12 +277,12 @@ struct ImplId : public IdBase<ImplId> {
   using ValueType = Impl;
 
   // An explicitly invalid ID.
-  static const ImplId Invalid;
+  static const ImplId None;
 
   using IdBase::IdBase;
 };
 
-constexpr ImplId ImplId::Invalid = ImplId(InvalidIndex);
+constexpr ImplId ImplId::None = ImplId(NoneIndex);
 
 // The ID of a generic.
 struct GenericId : public IdBase<GenericId> {
@@ -290,12 +290,12 @@ struct GenericId : public IdBase<GenericId> {
   using ValueType = Generic;
 
   // An explicitly invalid ID.
-  static const GenericId Invalid;
+  static const GenericId None;
 
   using IdBase::IdBase;
 };
 
-constexpr GenericId GenericId::Invalid = GenericId(InvalidIndex);
+constexpr GenericId GenericId::None = GenericId(NoneIndex);
 
 // The ID of a specific, which is the result of specifying the generic arguments
 // for a generic.
@@ -305,12 +305,12 @@ struct SpecificId : public IdBase<SpecificId> {
 
   // An explicitly invalid ID. This is typically used to represent a non-generic
   // entity.
-  static const SpecificId Invalid;
+  static const SpecificId None;
 
   using IdBase::IdBase;
 };
 
-constexpr SpecificId SpecificId::Invalid = SpecificId(InvalidIndex);
+constexpr SpecificId SpecificId::None = SpecificId(NoneIndex);
 
 // The index of an instruction that depends on generic parameters within a
 // region of a generic. A corresponding specific version of the instruction can
@@ -326,7 +326,7 @@ struct GenericInstIndex : public IndexBase<GenericInstIndex> {
   };
 
   // An explicitly invalid index.
-  static const GenericInstIndex Invalid;
+  static const GenericInstIndex None;
 
   explicit constexpr GenericInstIndex(Region region, int32_t index)
       : IndexBase(region == Declaration ? index
@@ -359,7 +359,7 @@ struct GenericInstIndex : public IndexBase<GenericInstIndex> {
   static constexpr int32_t FirstDefinitionIndex = InvalidIndex - 1;
 };
 
-constexpr GenericInstIndex GenericInstIndex::Invalid =
+constexpr GenericInstIndex GenericInstIndex::None =
     GenericInstIndex::MakeInvalid();
 
 // The ID of an IR within the set of imported IRs, both direct and indirect.
@@ -368,7 +368,7 @@ struct ImportIRId : public IdBase<ImportIRId> {
   using ValueType = ImportIR;
 
   // An explicitly invalid ID.
-  static const ImportIRId Invalid;
+  static const ImportIRId None;
 
   // The implicit `api` import, for an `impl` file. A null entry is added if
   // there is none, as in an `api`, in which case this ID should not show up in
@@ -378,7 +378,7 @@ struct ImportIRId : public IdBase<ImportIRId> {
   using IdBase::IdBase;
 };
 
-constexpr ImportIRId ImportIRId::Invalid = ImportIRId(InvalidIndex);
+constexpr ImportIRId ImportIRId::None = ImportIRId(NoneIndex);
 constexpr ImportIRId ImportIRId::ApiForImpl = ImportIRId(0);
 
 // A boolean value.
@@ -447,7 +447,7 @@ struct NameId : public IdBase<NameId> {
   using DiagnosticType = DiagnosticTypeInfo<std::string>;
 
   // An explicitly invalid ID.
-  static const NameId Invalid;
+  static const NameId None;
   // The name of `self`.
   static const NameId SelfValue;
   // The name of `Self`.
@@ -475,20 +475,20 @@ struct NameId : public IdBase<NameId> {
   // Returns the IdentifierId corresponding to this NameId, or an invalid
   // IdentifierId if this is a special name.
   auto AsIdentifierId() const -> IdentifierId {
-    return index >= 0 ? IdentifierId(index) : IdentifierId::Invalid;
+    return index >= 0 ? IdentifierId(index) : IdentifierId::None;
   }
 
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 
-constexpr NameId NameId::Invalid = NameId(InvalidIndex);
-constexpr NameId NameId::SelfValue = NameId(InvalidIndex - 1);
-constexpr NameId NameId::SelfType = NameId(InvalidIndex - 2);
-constexpr NameId NameId::PeriodSelf = NameId(InvalidIndex - 3);
-constexpr NameId NameId::ReturnSlot = NameId(InvalidIndex - 4);
-constexpr NameId NameId::PackageNamespace = NameId(InvalidIndex - 5);
-constexpr NameId NameId::Base = NameId(InvalidIndex - 6);
-constexpr NameId NameId::Vptr = NameId(InvalidIndex - 7);
+constexpr NameId NameId::None = NameId(NoneIndex);
+constexpr NameId NameId::SelfValue = NameId(NoneIndex - 1);
+constexpr NameId NameId::SelfType = NameId(NoneIndex - 2);
+constexpr NameId NameId::PeriodSelf = NameId(NoneIndex - 3);
+constexpr NameId NameId::ReturnSlot = NameId(NoneIndex - 4);
+constexpr NameId NameId::PackageNamespace = NameId(NoneIndex - 5);
+constexpr NameId NameId::Base = NameId(NoneIndex - 6);
+constexpr NameId NameId::Vptr = NameId(NoneIndex - 7);
 constexpr int NameId::NonIndexValueCount = 8;
 // Enforce the link between SpecialValueCount and the last special value.
 static_assert(NameId::NonIndexValueCount == -NameId::Vptr.index);
@@ -499,14 +499,14 @@ struct NameScopeId : public IdBase<NameScopeId> {
   using ValueType = NameScope;
 
   // An explicitly invalid ID.
-  static const NameScopeId Invalid;
+  static const NameScopeId None;
   // The package (or file) name scope, guaranteed to be the first added.
   static const NameScopeId Package;
 
   using IdBase::IdBase;
 };
 
-constexpr NameScopeId NameScopeId::Invalid = NameScopeId(InvalidIndex);
+constexpr NameScopeId NameScopeId::None = NameScopeId(NoneIndex);
 constexpr NameScopeId NameScopeId::Package = NameScopeId(0);
 
 // The ID of an instruction block.
@@ -534,7 +534,7 @@ struct InstBlockId : public IdBase<InstBlockId> {
   static const InstBlockId GlobalInit;
 
   // An explicitly invalid ID.
-  static const InstBlockId Invalid;
+  static const InstBlockId None;
 
   // An ID for unreachable code.
   static const InstBlockId Unreachable;
@@ -547,8 +547,8 @@ constexpr InstBlockId InstBlockId::Empty = InstBlockId(0);
 constexpr InstBlockId InstBlockId::Exports = InstBlockId(1);
 constexpr InstBlockId InstBlockId::ImportRefs = InstBlockId(2);
 constexpr InstBlockId InstBlockId::GlobalInit = InstBlockId(3);
-constexpr InstBlockId InstBlockId::Invalid = InstBlockId(InvalidIndex);
-constexpr InstBlockId InstBlockId::Unreachable = InstBlockId(InvalidIndex - 1);
+constexpr InstBlockId InstBlockId::None = InstBlockId(NoneIndex);
+constexpr InstBlockId InstBlockId::Unreachable = InstBlockId(NoneIndex - 1);
 
 // An ID of an instruction block that is referenced absolutely by an
 // instruction. This should only be used as the type of a field within a typed
@@ -601,12 +601,12 @@ struct ExprRegionId : public IdBase<ExprRegionId> {
   using ValueType = ExprRegion;
 
   // An explicitly invalid ID.
-  static const ExprRegionId Invalid;
+  static const ExprRegionId None;
 
   using IdBase::IdBase;
 };
 
-constexpr ExprRegionId ExprRegionId::Invalid = ExprRegionId(InvalidIndex);
+constexpr ExprRegionId ExprRegionId::None = ExprRegionId(NoneIndex);
 
 // The ID of a struct type field block.
 struct StructTypeFieldsId : public IdBase<StructTypeFieldsId> {
@@ -616,7 +616,7 @@ struct StructTypeFieldsId : public IdBase<StructTypeFieldsId> {
   using ValueType = llvm::MutableArrayRef<StructTypeField>;
 
   // An explicitly invalid ID.
-  static const StructTypeFieldsId Invalid;
+  static const StructTypeFieldsId None;
 
   // The canonical empty block, reused to avoid allocating empty vectors. Always
   // the 0-index block.
@@ -625,8 +625,8 @@ struct StructTypeFieldsId : public IdBase<StructTypeFieldsId> {
   using IdBase::IdBase;
 };
 
-constexpr StructTypeFieldsId StructTypeFieldsId::Invalid =
-    StructTypeFieldsId(InvalidIndex);
+constexpr StructTypeFieldsId StructTypeFieldsId::None =
+    StructTypeFieldsId(NoneIndex);
 constexpr StructTypeFieldsId StructTypeFieldsId::Empty = StructTypeFieldsId(0);
 
 // The ID of a type.
@@ -639,7 +639,7 @@ struct TypeId : public IdBase<TypeId> {
   using DiagnosticType = DiagnosticTypeInfo<std::string>;
 
   // An explicitly invalid ID.
-  static const TypeId Invalid;
+  static const TypeId None;
 
   using IdBase::IdBase;
 
@@ -656,7 +656,7 @@ struct TypeId : public IdBase<TypeId> {
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 
-constexpr TypeId TypeId::Invalid = TypeId(InvalidIndex);
+constexpr TypeId TypeId::None = TypeId(NoneIndex);
 
 // The ID of a type block.
 struct TypeBlockId : public IdBase<TypeBlockId> {
@@ -666,7 +666,7 @@ struct TypeBlockId : public IdBase<TypeBlockId> {
   using ValueType = llvm::MutableArrayRef<ElementType>;
 
   // An explicitly invalid ID.
-  static const TypeBlockId Invalid;
+  static const TypeBlockId None;
 
   // The canonical empty block, reused to avoid allocating empty vectors. Always
   // the 0-index block.
@@ -675,7 +675,7 @@ struct TypeBlockId : public IdBase<TypeBlockId> {
   using IdBase::IdBase;
 };
 
-constexpr TypeBlockId TypeBlockId::Invalid = TypeBlockId(InvalidIndex);
+constexpr TypeBlockId TypeBlockId::None = TypeBlockId(NoneIndex);
 constexpr TypeBlockId TypeBlockId::Empty = TypeBlockId(0);
 
 // An index for element access, for structs, tuples, and classes.
@@ -684,10 +684,10 @@ struct ElementIndex : public IndexBase<ElementIndex> {
   using IndexBase::IndexBase;
 
   // An explicitly invalid ID.
-  static const ElementIndex Invalid;
+  static const ElementIndex None;
 };
 
-constexpr ElementIndex ElementIndex::Invalid = ElementIndex(InvalidIndex);
+constexpr ElementIndex ElementIndex::None = ElementIndex(NoneIndex);
 
 // The ID of a library name. This is either a string literal or `default`.
 struct LibraryNameId : public IdBase<LibraryNameId> {
@@ -695,7 +695,7 @@ struct LibraryNameId : public IdBase<LibraryNameId> {
   using DiagnosticType = DiagnosticTypeInfo<std::string>;
 
   // An explicitly invalid ID.
-  static const LibraryNameId Invalid;
+  static const LibraryNameId None;
   // The name of `default`.
   static const LibraryNameId Default;
   // Track cases where the library name was set, but has been diagnosed and
@@ -716,10 +716,9 @@ struct LibraryNameId : public IdBase<LibraryNameId> {
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 
-constexpr LibraryNameId LibraryNameId::Invalid = LibraryNameId(InvalidIndex);
-constexpr LibraryNameId LibraryNameId::Default =
-    LibraryNameId(InvalidIndex - 1);
-constexpr LibraryNameId LibraryNameId::Error = LibraryNameId(InvalidIndex - 2);
+constexpr LibraryNameId LibraryNameId::None = LibraryNameId(NoneIndex);
+constexpr LibraryNameId LibraryNameId::Default = LibraryNameId(NoneIndex - 1);
+constexpr LibraryNameId LibraryNameId::Error = LibraryNameId(NoneIndex - 2);
 
 // The ID of an ImportIRInst.
 struct ImportIRInstId : public IdBase<ImportIRInstId> {
@@ -727,12 +726,12 @@ struct ImportIRInstId : public IdBase<ImportIRInstId> {
   using ValueType = ImportIRInst;
 
   // An explicitly invalid ID.
-  static const ImportIRInstId Invalid;
+  static const ImportIRInstId None;
 
   using IdBase::IdBase;
 };
 
-constexpr ImportIRInstId ImportIRInstId::Invalid = ImportIRInstId(InvalidIndex);
+constexpr ImportIRInstId ImportIRInstId::None = ImportIRInstId(NoneIndex);
 
 // A SemIR location used as the location of instructions.
 //
@@ -748,12 +747,12 @@ struct LocId : public IdBase<LocId> {
   static const int32_t ImplicitBit = 1 << 30;
 
   // An explicitly invalid ID.
-  static const LocId Invalid;
+  static const LocId None;
 
   using IdBase::IdBase;
 
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr LocId(Parse::InvalidNodeId /*invalid*/) : IdBase(InvalidIndex) {}
+  constexpr LocId(Parse::NoneNodeId /*none*/) : IdBase(NoneIndex) {}
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   constexpr LocId(Parse::NodeId node_id) : IdBase(node_id.index) {
@@ -763,7 +762,7 @@ struct LocId : public IdBase<LocId> {
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   constexpr LocId(ImportIRInstId inst_id)
-      : IdBase(InvalidIndex + ImportIRInstId::InvalidIndex - inst_id.index) {
+      : IdBase(NoneIndex + ImportIRInstId::NoneIndex - inst_id.index) {
     CARBON_CHECK(inst_id.is_valid() == is_valid());
     CARBON_CHECK(index & ImplicitBit);
   }
@@ -785,7 +784,7 @@ struct LocId : public IdBase<LocId> {
   // valid InstId.
   auto node_id() const -> Parse::NodeId {
     if (!is_valid()) {
-      return Parse::NodeId::Invalid;
+      return Parse::NodeId::None;
     }
     CARBON_CHECK(is_node_id());
     return Parse::NodeId(index & ~ImplicitBit);
@@ -795,13 +794,13 @@ struct LocId : public IdBase<LocId> {
   // valid NodeId.
   auto import_ir_inst_id() const -> ImportIRInstId {
     CARBON_CHECK(is_import_ir_inst_id() || !is_valid());
-    return ImportIRInstId(InvalidIndex + ImportIRInstId::InvalidIndex - index);
+    return ImportIRInstId(NoneIndex + ImportIRInstId::NoneIndex - index);
   }
 
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 
-constexpr LocId LocId::Invalid = LocId(Parse::NodeId::Invalid);
+constexpr LocId LocId::None = LocId(Parse::NodeId::None);
 
 // Polymorphic id for fields in `Any[...]` typed instruction category. Used for
 // fields where the specific instruction structs have different field types in
@@ -821,7 +820,7 @@ struct AnyRawId : public AnyIdBase {
   // For IdKind.
   static constexpr llvm::StringLiteral Label = "any_raw";
 
-  constexpr explicit AnyRawId() : AnyIdBase(AnyIdBase::InvalidIndex) {}
+  constexpr explicit AnyRawId() : AnyIdBase(AnyIdBase::NoneIndex) {}
   constexpr explicit AnyRawId(int32_t id) : AnyIdBase(id) {}
 };
 

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -37,7 +37,7 @@ struct InstId : public IdBase<InstId> {
   static constexpr llvm::StringLiteral Label = "inst";
   using ValueType = Inst;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const InstId None;
 
   // Represents the result of a name lookup that is temporarily disallowed
@@ -88,7 +88,7 @@ struct ConstantId : public IdBase<ConstantId> {
 
   // An ID for an expression that is not constant.
   static const ConstantId NotConstant;
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ConstantId None;
 
   // Returns the constant ID corresponding to a template constant, which should
@@ -106,19 +106,19 @@ struct ConstantId : public IdBase<ConstantId> {
 
   using IdBase::IdBase;
 
-  // Returns whether this represents a constant. Requires is_valid.
+  // Returns whether this represents a constant. Requires has_value.
   auto is_constant() const -> bool {
-    CARBON_DCHECK(is_valid());
+    CARBON_DCHECK(has_value());
     return *this != ConstantId::NotConstant;
   }
-  // Returns whether this represents a symbolic constant. Requires is_valid.
+  // Returns whether this represents a symbolic constant. Requires has_value.
   auto is_symbolic() const -> bool {
-    CARBON_DCHECK(is_valid());
+    CARBON_DCHECK(has_value());
     return index <= FirstSymbolicIndex;
   }
-  // Returns whether this represents a template constant. Requires is_valid.
+  // Returns whether this represents a template constant. Requires has_value.
   auto is_template() const -> bool {
-    CARBON_DCHECK(is_valid());
+    CARBON_DCHECK(has_value());
     return index >= 0;
   }
 
@@ -150,8 +150,8 @@ struct ConstantId : public IdBase<ConstantId> {
     return FirstSymbolicIndex - index;
   }
 
-  static constexpr int32_t NotConstantIndex = InvalidIndex - 1;
-  static constexpr int32_t FirstSymbolicIndex = InvalidIndex - 2;
+  static constexpr int32_t NotConstantIndex = NoneIndex - 1;
+  static constexpr int32_t FirstSymbolicIndex = NoneIndex - 2;
 };
 
 constexpr ConstantId ConstantId::NotConstant = ConstantId(NotConstantIndex);
@@ -162,7 +162,7 @@ struct EntityNameId : public IdBase<EntityNameId> {
   static constexpr llvm::StringLiteral Label = "entity_name";
   using ValueType = EntityName;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const EntityNameId None;
 
   using IdBase::IdBase;
@@ -176,7 +176,7 @@ constexpr EntityNameId EntityNameId::None = EntityNameId(NoneIndex);
 struct CompileTimeBindIndex : public IndexBase<CompileTimeBindIndex> {
   static constexpr llvm::StringLiteral Label = "comp_time_bind";
 
-  // An explicitly invalid index.
+  // An index with no value.
   static const CompileTimeBindIndex None;
 
   using IndexBase::IndexBase;
@@ -195,7 +195,7 @@ constexpr CompileTimeBindIndex CompileTimeBindIndex::None =
 struct RuntimeParamIndex : public IndexBase<RuntimeParamIndex> {
   static constexpr llvm::StringLiteral Label = "runtime_param";
 
-  // An explicitly invalid index.
+  // An index with no value.
   static const RuntimeParamIndex None;
 
   // An placeholder for index whose value is not yet known.
@@ -217,7 +217,7 @@ struct FunctionId : public IdBase<FunctionId> {
   static constexpr llvm::StringLiteral Label = "function";
   using ValueType = Function;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const FunctionId None;
 
   using IdBase::IdBase;
@@ -237,7 +237,7 @@ struct ClassId : public IdBase<ClassId> {
   static constexpr llvm::StringLiteral Label = "class";
   using ValueType = Class;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ClassId None;
 
   using IdBase::IdBase;
@@ -250,7 +250,7 @@ struct InterfaceId : public IdBase<InterfaceId> {
   static constexpr llvm::StringLiteral Label = "interface";
   using ValueType = Interface;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const InterfaceId None;
 
   using IdBase::IdBase;
@@ -263,7 +263,7 @@ struct FacetTypeId : public IdBase<FacetTypeId> {
   static constexpr llvm::StringLiteral Label = "facet_type";
   using ValueType = FacetTypeInfo;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const FacetTypeId None;
 
   using IdBase::IdBase;
@@ -276,7 +276,7 @@ struct ImplId : public IdBase<ImplId> {
   static constexpr llvm::StringLiteral Label = "impl";
   using ValueType = Impl;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ImplId None;
 
   using IdBase::IdBase;
@@ -289,7 +289,7 @@ struct GenericId : public IdBase<GenericId> {
   static constexpr llvm::StringLiteral Label = "generic";
   using ValueType = Generic;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const GenericId None;
 
   using IdBase::IdBase;
@@ -303,7 +303,7 @@ struct SpecificId : public IdBase<SpecificId> {
   static constexpr llvm::StringLiteral Label = "specific";
   using ValueType = Specific;
 
-  // An explicitly invalid ID. This is typically used to represent a non-generic
+  // An ID with no value. This is typically used to represent a non-generic
   // entity.
   static const SpecificId None;
 
@@ -325,7 +325,7 @@ struct GenericInstIndex : public IndexBase<GenericInstIndex> {
     Definition,
   };
 
-  // An explicitly invalid index.
+  // An index with no value.
   static const GenericInstIndex None;
 
   explicit constexpr GenericInstIndex(Region region, int32_t index)
@@ -336,38 +336,38 @@ struct GenericInstIndex : public IndexBase<GenericInstIndex> {
 
   // Returns the index of the instruction within the region.
   auto index() const -> int32_t {
-    CARBON_CHECK(is_valid());
+    CARBON_CHECK(has_value());
     return IndexBase::index >= 0 ? IndexBase::index
                                  : FirstDefinitionIndex - IndexBase::index;
   }
 
   // Returns the region within which this instruction was first used.
   auto region() const -> Region {
-    CARBON_CHECK(is_valid());
+    CARBON_CHECK(has_value());
     return IndexBase::index >= 0 ? Declaration : Definition;
   }
 
   auto Print(llvm::raw_ostream& out) const -> void;
 
  private:
-  static constexpr auto MakeInvalid() -> GenericInstIndex {
+  static constexpr auto MakeNone() -> GenericInstIndex {
     GenericInstIndex result(Declaration, 0);
-    result.IndexBase::index = InvalidIndex;
+    result.IndexBase::index = NoneIndex;
     return result;
   }
 
-  static constexpr int32_t FirstDefinitionIndex = InvalidIndex - 1;
+  static constexpr int32_t FirstDefinitionIndex = NoneIndex - 1;
 };
 
 constexpr GenericInstIndex GenericInstIndex::None =
-    GenericInstIndex::MakeInvalid();
+    GenericInstIndex::MakeNone();
 
 // The ID of an IR within the set of imported IRs, both direct and indirect.
 struct ImportIRId : public IdBase<ImportIRId> {
   static constexpr llvm::StringLiteral Label = "ir";
   using ValueType = ImportIR;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ImportIRId None;
 
   // The implicit `api` import, for an `impl` file. A null entry is added if
@@ -446,7 +446,7 @@ struct NameId : public IdBase<NameId> {
   // names().GetFormatted() is used for diagnostics.
   using DiagnosticType = DiagnosticTypeInfo<std::string>;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const NameId None;
   // The name of `self`.
   static const NameId SelfValue;
@@ -472,8 +472,8 @@ struct NameId : public IdBase<NameId> {
 
   using IdBase::IdBase;
 
-  // Returns the IdentifierId corresponding to this NameId, or an invalid
-  // IdentifierId if this is a special name.
+  // Returns the IdentifierId corresponding to this NameId, or `None` if this is
+  // a special name.
   auto AsIdentifierId() const -> IdentifierId {
     return index >= 0 ? IdentifierId(index) : IdentifierId::None;
   }
@@ -498,7 +498,7 @@ struct NameScopeId : public IdBase<NameScopeId> {
   static constexpr llvm::StringLiteral Label = "name_scope";
   using ValueType = NameScope;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const NameScopeId None;
   // The package (or file) name scope, guaranteed to be the first added.
   static const NameScopeId Package;
@@ -533,7 +533,7 @@ struct InstBlockId : public IdBase<InstBlockId> {
   // be inserted into it.
   static const InstBlockId GlobalInit;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const InstBlockId None;
 
   // An ID for unreachable code.
@@ -600,7 +600,7 @@ struct ExprRegionId : public IdBase<ExprRegionId> {
   static constexpr llvm::StringLiteral Label = "region";
   using ValueType = ExprRegion;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ExprRegionId None;
 
   using IdBase::IdBase;
@@ -615,7 +615,7 @@ struct StructTypeFieldsId : public IdBase<StructTypeFieldsId> {
   using ElementType = StructTypeField;
   using ValueType = llvm::MutableArrayRef<StructTypeField>;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const StructTypeFieldsId None;
 
   // The canonical empty block, reused to avoid allocating empty vectors. Always
@@ -638,7 +638,7 @@ struct TypeId : public IdBase<TypeId> {
   // `InstIdAsType` or `TypeOfInstId` as the diagnostic argument type.
   using DiagnosticType = DiagnosticTypeInfo<std::string>;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const TypeId None;
 
   using IdBase::IdBase;
@@ -665,7 +665,7 @@ struct TypeBlockId : public IdBase<TypeBlockId> {
   using ElementType = TypeId;
   using ValueType = llvm::MutableArrayRef<ElementType>;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const TypeBlockId None;
 
   // The canonical empty block, reused to avoid allocating empty vectors. Always
@@ -683,7 +683,7 @@ struct ElementIndex : public IndexBase<ElementIndex> {
   static constexpr llvm::StringLiteral Label = "element";
   using IndexBase::IndexBase;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ElementIndex None;
 };
 
@@ -694,7 +694,7 @@ struct LibraryNameId : public IdBase<LibraryNameId> {
   static constexpr llvm::StringLiteral Label = "library_name";
   using DiagnosticType = DiagnosticTypeInfo<std::string>;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const LibraryNameId None;
   // The name of `default`.
   static const LibraryNameId Default;
@@ -709,7 +709,7 @@ struct LibraryNameId : public IdBase<LibraryNameId> {
 
   // Converts a LibraryNameId back to a string literal.
   auto AsStringLiteralValueId() const -> StringLiteralValueId {
-    CARBON_CHECK(index >= InvalidIndex, "{0} must be handled directly", *this);
+    CARBON_CHECK(index >= NoneIndex, "{0} must be handled directly", *this);
     return StringLiteralValueId(index);
   }
 
@@ -725,7 +725,7 @@ struct ImportIRInstId : public IdBase<ImportIRInstId> {
   static constexpr llvm::StringLiteral Label = "import_ir_inst";
   using ValueType = ImportIRInst;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const ImportIRInstId None;
 
   using IdBase::IdBase;
@@ -736,9 +736,9 @@ constexpr ImportIRInstId ImportIRInstId::None = ImportIRInstId(NoneIndex);
 // A SemIR location used as the location of instructions.
 //
 // Contents:
-// - index > Invalid: A Parse::NodeId in the current IR.
-// - index < Invalid: An ImportIRInstId.
-// - index == Invalid: Can be used for either.
+// - index > None: A Parse::NodeId in the current IR.
+// - index < None: An ImportIRInstId.
+// - index == None: Can be used for either.
 struct LocId : public IdBase<LocId> {
   static constexpr llvm::StringLiteral Label = "loc";
 
@@ -746,7 +746,7 @@ struct LocId : public IdBase<LocId> {
   // operations performed implicitly.
   static const int32_t ImplicitBit = 1 << 30;
 
-  // An explicitly invalid ID.
+  // An ID with no value.
   static const LocId None;
 
   using IdBase::IdBase;
@@ -756,44 +756,44 @@ struct LocId : public IdBase<LocId> {
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   constexpr LocId(Parse::NodeId node_id) : IdBase(node_id.index) {
-    CARBON_CHECK(node_id.is_valid() == is_valid());
+    CARBON_CHECK(node_id.has_value() == has_value());
     CARBON_CHECK(!is_implicit());
   }
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   constexpr LocId(ImportIRInstId inst_id)
       : IdBase(NoneIndex + ImportIRInstId::NoneIndex - inst_id.index) {
-    CARBON_CHECK(inst_id.is_valid() == is_valid());
+    CARBON_CHECK(inst_id.has_value() == has_value());
     CARBON_CHECK(index & ImplicitBit);
   }
 
   // Forms an equivalent LocId for an implicit location.
   auto ToImplicit() const -> LocId {
-    // For import IR locations and the invalid location, the implicit bit is
+    // For import IR locations and the `None` location, the implicit bit is
     // always set, so this is a no-op.
     return LocId(index | ImplicitBit);
   }
 
-  auto is_node_id() const -> bool { return index > InvalidIndex; }
-  auto is_import_ir_inst_id() const -> bool { return index < InvalidIndex; }
+  auto is_node_id() const -> bool { return index > NoneIndex; }
+  auto is_import_ir_inst_id() const -> bool { return index < NoneIndex; }
   auto is_implicit() const -> bool {
     return is_node_id() && (index & ImplicitBit) != 0;
   }
 
-  // This is allowed to return an invalid NodeId, but should never be used for a
-  // valid InstId.
+  // This is allowed to return `NodeId::None`, but should never be used for
+  // `InstId` other than `InstId::None`.
   auto node_id() const -> Parse::NodeId {
-    if (!is_valid()) {
+    if (!has_value()) {
       return Parse::NodeId::None;
     }
     CARBON_CHECK(is_node_id());
     return Parse::NodeId(index & ~ImplicitBit);
   }
 
-  // This is allowed to return an invalid InstId, but should never be used for a
-  // valid NodeId.
+  // This is allowed to return `InstId::None`, but should never be used for
+  // `NodeId` other than `NodeId::None`.
   auto import_ir_inst_id() const -> ImportIRInstId {
-    CARBON_CHECK(is_import_ir_inst_id() || !is_valid());
+    CARBON_CHECK(is_import_ir_inst_id() || !has_value());
     return ImportIRInstId(NoneIndex + ImportIRInstId::NoneIndex - index);
   }
 
@@ -814,7 +814,7 @@ constexpr LocId LocId::None = LocId(Parse::NodeId::None);
 //   same position, the `Any[...]` type will hold its raw value in the
 //   `AnyRawId` field.
 // - In the case the specific instruction has no field in the same position, the
-//   `Any[...]` type will hold a default constructed `AnyRawId` with an invalid
+//   `Any[...]` type will hold a default constructed `AnyRawId` with a `None`
 //   value.
 struct AnyRawId : public AnyIdBase {
   // For IdKind.

--- a/toolchain/sem_ir/impl.cpp
+++ b/toolchain/sem_ir/impl.cpp
@@ -10,8 +10,8 @@ namespace Carbon::SemIR {
 
 auto ImplStore::GetOrAddLookupBucket(const Impl& impl) -> LookupBucketRef {
   auto self_id = sem_ir_.constant_values().GetConstantInstId(impl.self_id);
-  InterfaceId interface_id = InterfaceId::Invalid;
-  SpecificId specific_id = SpecificId::Invalid;
+  InterfaceId interface_id = InterfaceId::None;
+  SpecificId specific_id = SpecificId::None;
   auto facet_type_id = TypeId::ForTypeConstant(
       sem_ir_.constant_values().Get(impl.constraint_id));
   if (auto facet_type =
@@ -26,7 +26,7 @@ auto ImplStore::GetOrAddLookupBucket(const Impl& impl) -> LookupBucketRef {
   return LookupBucketRef(
       *this, lookup_
                  .Insert(std::tuple{self_id, interface_id, specific_id},
-                         [] { return ImplOrLookupBucketId::Invalid; })
+                         [] { return ImplOrLookupBucketId::None; })
                  .value());
 }
 

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -196,7 +196,7 @@ class ImplStore {
 };
 
 constexpr inline ImplStore::ImplOrLookupBucketId
-    ImplStore::ImplOrLookupBucketId::None(InvalidIndex);
+    ImplStore::ImplOrLookupBucketId::None(NoneIndex);
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -24,14 +24,14 @@ struct ImplFields {
   // The following members are set at the `{` of the impl definition.
 
   // The impl scope.
-  NameScopeId scope_id = NameScopeId::Invalid;
+  NameScopeId scope_id = NameScopeId::None;
   // The first block of the impl body.
   // TODO: Handle control flow in the impl body, such as if-expressions.
-  InstBlockId body_block_id = InstBlockId::Invalid;
+  InstBlockId body_block_id = InstBlockId::None;
   // The witness for the impl. This can be `BuiltinErrorInst` or an import
   // reference. Note that the entries in the witness are updated at the end of
   // the impl definition.
-  InstId witness_id = InstId::Invalid;
+  InstId witness_id = InstId::None;
 
   // The following members are set at the `}` of the impl definition.
   bool defined = false;
@@ -65,25 +65,25 @@ class ImplStore {
    public:
     static constexpr llvm::StringLiteral Label = "impl_or_lookup_bucket";
 
-    // An explicitly invalid ID, corresponding to to ImplId::Invalid.
-    static const ImplOrLookupBucketId Invalid;
+    // An explicitly invalid ID, corresponding to to ImplId::None.
+    static const ImplOrLookupBucketId None;
 
     static auto ForImplId(ImplId impl_id) -> ImplOrLookupBucketId {
       return ImplOrLookupBucketId(impl_id.index);
     }
 
     static auto ForBucket(int bucket) -> ImplOrLookupBucketId {
-      return ImplOrLookupBucketId(ImplId::InvalidIndex - bucket - 1);
+      return ImplOrLookupBucketId(ImplId::NoneIndex - bucket - 1);
     }
 
     // Returns whether this ID represents a bucket index, rather than an ImplId.
     // An invalid ID is not a bucket index.
-    auto is_bucket() const { return index < ImplId::InvalidIndex; }
+    auto is_bucket() const { return index < ImplId::NoneIndex; }
 
     // Returns the bucket index represented by this ID. Requires is_bucket().
     auto bucket() const -> int {
       CARBON_CHECK(is_bucket());
-      return ImplId::InvalidIndex - index - 1;
+      return ImplId::NoneIndex - index - 1;
     }
 
     // Returns the ImplId index represented by this ID. Requires !is_bucket().
@@ -111,7 +111,7 @@ class ImplStore {
   class LookupBucketRef {
    public:
     LookupBucketRef(ImplStore& store, ImplOrLookupBucketId& id)
-        : store_(&store), id_(&id), single_id_storage_(ImplId::Invalid) {
+        : store_(&store), id_(&id), single_id_storage_(ImplId::None) {
       if (!id.is_bucket()) {
         single_id_storage_ = id.impl_id();
       }
@@ -128,14 +128,14 @@ class ImplStore {
       if (id_->is_bucket()) {
         return store_->lookup_buckets_[id_->bucket()].end();
       }
-      return &single_id_storage_ + (id_->is_valid() ? 1 : 0);
+      return &single_id_storage_ + (id_->has_value() ? 1 : 0);
     }
 
     // Adds an impl to this lookup bucket. Only impls from the current file and
     // its API file should be added in this way. Impls from other files do not
     // need to be found by impl redeclaration lookup so should not be added.
     auto push_back(ImplId impl_id) -> void {
-      if (!id_->is_valid()) {
+      if (!id_->has_value()) {
         *id_ = ImplOrLookupBucketId::ForImplId(impl_id);
         single_id_storage_ = impl_id;
       } else if (!id_->is_bucket()) {
@@ -196,7 +196,7 @@ class ImplStore {
 };
 
 constexpr inline ImplStore::ImplOrLookupBucketId
-    ImplStore::ImplOrLookupBucketId::Invalid(InvalidIndex);
+    ImplStore::ImplOrLookupBucketId::None(InvalidIndex);
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/inst.cpp
+++ b/toolchain/sem_ir/inst.cpp
@@ -26,7 +26,7 @@ auto Inst::Print(llvm::raw_ostream& out) const -> void {
     break;
 #include "toolchain/sem_ir/inst_kind.def"
   }
-  if (type_id_.is_valid()) {
+  if (type_id_.has_value()) {
     out << ", type: " << type_id_;
   }
   out << "}";

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -397,7 +397,7 @@ class InstStore {
   // of that type. Otherwise returns nullopt.
   template <typename InstT>
   auto TryGetAsIfValid(InstId inst_id) const -> std::optional<InstT> {
-    if (!inst_id.is_valid()) {
+    if (!inst_id.has_value()) {
       return std::nullopt;
     }
     return TryGetAs<InstT>(inst_id);
@@ -471,7 +471,7 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
   // Returns the contents of the specified block, or an empty array if the block
   // is invalid.
   auto GetOrEmpty(InstBlockId block_id) const -> llvm::ArrayRef<InstId> {
-    return block_id.is_valid() ? Get(block_id) : llvm::ArrayRef<InstId>();
+    return block_id.has_value() ? Get(block_id) : llvm::ArrayRef<InstId>();
   }
 };
 

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -136,7 +136,7 @@ class Inst : public Printable<Inst> {
     // self-referential TypeType.
     auto type_id = kind == InstKind::ErrorInst ? ErrorInst::SingletonTypeId
                                                : TypeType::SingletonTypeId;
-    return Inst(kind, type_id, InstId::InvalidIndex, InstId::InvalidIndex);
+    return Inst(kind, type_id, InstId::NoneIndex, InstId::NoneIndex);
   }
 
   template <typename TypedInst>
@@ -145,9 +145,9 @@ class Inst : public Printable<Inst> {
   Inst(TypedInst typed_inst)
       // kind_ is always overwritten below.
       : kind_(),
-        type_id_(TypeId::Invalid),
-        arg0_(InstId::InvalidIndex),
-        arg1_(InstId::InvalidIndex) {
+        type_id_(TypeId::None),
+        arg0_(InstId::NoneIndex),
+        arg1_(InstId::NoneIndex) {
     if constexpr (Internal::HasKindMemberAsField<TypedInst>) {
       kind_ = typed_inst.kind.AsInt();
     } else {
@@ -322,7 +322,7 @@ struct LocIdAndInst {
   // constants block.
   template <typename InstT>
   static auto NoLoc(InstT inst) -> LocIdAndInst {
-    return LocIdAndInst(LocId::Invalid, inst, /*is_unchecked=*/true);
+    return LocIdAndInst(LocId::None, inst, /*is_unchecked=*/true);
   }
 
   // Unsafely form a pair of a location and an instruction. Used in the cases

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -67,12 +67,12 @@ struct Worklist {
   }
 
   auto Add(EntityNameId entity_name_id) -> void {
-    if (!entity_name_id.is_valid()) {
+    if (!entity_name_id.has_value()) {
       AddInvalid();
       return;
     }
     const auto& entity_name = sem_ir->entity_names().Get(entity_name_id);
-    if (entity_name.bind_index.is_valid()) {
+    if (entity_name.bind_index.has_value()) {
       Add(entity_name.bind_index);
       // Don't include the name. While it is part of the canonical identity of a
       // compile-time binding, renaming it (and its uses) is a compatible change
@@ -84,7 +84,7 @@ struct Worklist {
   }
 
   auto AddInFile(const File* file, InstId inner_id) -> void {
-    if (!inner_id.is_valid()) {
+    if (!inner_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -98,7 +98,7 @@ struct Worklist {
   auto Add(InstId inner_id) -> void { AddInFile(sem_ir, inner_id); }
 
   auto Add(ConstantId constant_id) -> void {
-    if (!constant_id.is_valid()) {
+    if (!constant_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -106,7 +106,7 @@ struct Worklist {
   }
 
   auto Add(TypeId type_id) -> void {
-    if (!type_id.is_valid()) {
+    if (!type_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -122,7 +122,7 @@ struct Worklist {
   }
 
   auto Add(InstBlockId inst_block_id) -> void {
-    if (!inst_block_id.is_valid()) {
+    if (!inst_block_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -130,7 +130,7 @@ struct Worklist {
   }
 
   auto Add(TypeBlockId type_block_id) -> void {
-    if (!type_block_id.is_valid()) {
+    if (!type_block_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -143,7 +143,7 @@ struct Worklist {
   }
 
   auto Add(StructTypeFieldsId struct_type_fields_id) -> void {
-    if (!struct_type_fields_id.is_valid()) {
+    if (!struct_type_fields_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -151,7 +151,7 @@ struct Worklist {
   }
 
   auto Add(NameScopeId name_scope_id) -> void {
-    if (!name_scope_id.is_valid()) {
+    if (!name_scope_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -165,7 +165,7 @@ struct Worklist {
 
   auto AddEntity(const EntityWithParamsBase& entity) -> void {
     Add(entity.name_id);
-    if (entity.parent_scope_id.is_valid()) {
+    if (entity.parent_scope_id.has_value()) {
       Add(sem_ir->name_scopes().Get(entity.parent_scope_id).inst_id());
     }
   }
@@ -212,7 +212,7 @@ struct Worklist {
   }
 
   auto Add(GenericId generic_id) -> void {
-    if (!generic_id.is_valid()) {
+    if (!generic_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -220,7 +220,7 @@ struct Worklist {
   }
 
   auto Add(SpecificId specific_id) -> void {
-    if (!specific_id.is_valid()) {
+    if (!specific_id.has_value()) {
       AddInvalid();
       return;
     }
@@ -248,7 +248,7 @@ struct Worklist {
       AddString("");
     } else if (lib_name_id == LibraryNameId::Error) {
       AddString("<error>");
-    } else if (lib_name_id.is_valid()) {
+    } else if (lib_name_id.has_value()) {
       Add(lib_name_id.AsStringLiteralValueId());
     } else {
       AddInvalid();

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -158,7 +158,7 @@ struct Worklist {
     const auto& scope = sem_ir->name_scopes().Get(name_scope_id);
     Add(scope.name_id());
     if (!sem_ir->name_scopes().IsPackage(name_scope_id) &&
-        scope.parent_scope_id().is_valid()) {
+        scope.parent_scope_id().has_value()) {
       Add(sem_ir->name_scopes().Get(scope.parent_scope_id()).inst_id());
     }
   }

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -128,7 +128,7 @@ auto InstNamer::GetScopeName(ScopeId scope) const -> std::string {
 }
 
 auto InstNamer::GetUnscopedNameFor(InstId inst_id) const -> llvm::StringRef {
-  if (!inst_id.is_valid()) {
+  if (!inst_id.has_value()) {
     return "";
   }
   const auto& inst_name = insts_[inst_id.index].second;
@@ -137,7 +137,7 @@ auto InstNamer::GetUnscopedNameFor(InstId inst_id) const -> llvm::StringRef {
 
 auto InstNamer::GetNameFor(ScopeId scope_id, InstId inst_id) const
     -> std::string {
-  if (!inst_id.is_valid()) {
+  if (!inst_id.has_value()) {
     return "invalid";
   }
 
@@ -173,7 +173,7 @@ auto InstNamer::GetNameFor(ScopeId scope_id, InstId inst_id) const
 
 auto InstNamer::GetUnscopedLabelFor(InstBlockId block_id) const
     -> llvm::StringRef {
-  if (!block_id.is_valid()) {
+  if (!block_id.has_value()) {
     return "";
   }
   const auto& label_name = labels_[block_id.index].second;
@@ -183,7 +183,7 @@ auto InstNamer::GetUnscopedLabelFor(InstBlockId block_id) const
 // Returns the IR name to use for a label, when referenced from a given scope.
 auto InstNamer::GetLabelFor(ScopeId scope_id, InstBlockId block_id) const
     -> std::string {
-  if (!block_id.is_valid()) {
+  if (!block_id.has_value()) {
     return "!invalid";
   }
 
@@ -288,11 +288,11 @@ auto InstNamer::Namespace::AllocateName(
 
 auto InstNamer::AddBlockLabel(ScopeId scope_id, InstBlockId block_id,
                               std::string name, SemIR::LocId loc_id) -> void {
-  if (!block_id.is_valid() || labels_[block_id.index].second) {
+  if (!block_id.has_value() || labels_[block_id.index].second) {
     return;
   }
 
-  if (!loc_id.is_valid()) {
+  if (!loc_id.has_value()) {
     if (const auto& block = sem_ir_->inst_blocks().Get(block_id);
         !block.empty()) {
       loc_id = sem_ir_->insts().GetLocId(block.front());
@@ -380,7 +380,7 @@ auto InstNamer::AddBlockLabel(ScopeId scope_id, SemIR::LocId loc_id,
 
 auto InstNamer::CollectNamesInBlock(ScopeId scope_id, InstBlockId block_id)
     -> void {
-  if (block_id.is_valid()) {
+  if (block_id.has_value()) {
     CollectNamesInBlock(scope_id, sem_ir_->inst_blocks().Get(block_id));
   }
 }
@@ -397,13 +397,13 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
   auto queue_block_insts = [&](ScopeId scope_id,
                                llvm::ArrayRef<InstId> inst_ids) {
     for (auto inst_id : llvm::reverse(inst_ids)) {
-      if (inst_id.is_valid()) {
+      if (inst_id.has_value()) {
         insts.push_back(std::make_pair(scope_id, inst_id));
       }
     }
   };
   auto queue_block_id = [&](ScopeId scope_id, InstBlockId block_id) {
-    if (block_id.is_valid()) {
+    if (block_id.has_value()) {
       queue_block_insts(scope_id, sem_ir_->inst_blocks().Get(block_id));
     }
   };
@@ -536,7 +536,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
       case CARBON_KIND(Call inst): {
         auto callee_function =
             SemIR::GetCalleeFunction(*sem_ir_, inst.callee_id);
-        if (!callee_function.function_id.is_valid()) {
+        if (!callee_function.function_id.has_value()) {
           break;
         }
         const auto& function =
@@ -582,7 +582,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
       }
       case CARBON_KIND(FacetAccessType inst): {
         auto name_id = facet_access_name_id(inst.facet_value_inst_id);
-        if (name_id.is_valid()) {
+        if (name_id.has_value()) {
           add_inst_name_id(name_id, ".as_type");
         } else {
           add_inst_name("as_type");
@@ -591,7 +591,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
       }
       case CARBON_KIND(FacetAccessWitness inst): {
         auto name_id = facet_access_name_id(inst.facet_value_inst_id);
-        if (name_id.is_valid()) {
+        if (name_id.has_value()) {
           add_inst_name_id(name_id, ".as_wit");
         } else {
           add_inst_name("as_wit");
@@ -682,7 +682,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
         continue;
       }
       case CARBON_KIND(ImportDecl inst): {
-        if (inst.package_id.is_valid()) {
+        if (inst.package_id.has_value()) {
           add_inst_name_id(inst.package_id, ".import");
         } else {
           add_inst_name("default.import");
@@ -707,7 +707,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
         out << ".";
 
         // Add entity name if available.
-        if (inst.entity_name_id.is_valid()) {
+        if (inst.entity_name_id.has_value()) {
           auto name_id =
               sem_ir_->entity_names().Get(inst.entity_name_id).name_id;
           out << sem_ir_->names().GetIRBaseName(name_id);
@@ -721,7 +721,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
         // a block. Constants that refer to them need to be separately
         // named.
         auto const_id = sem_ir_->constant_values().Get(inst_id);
-        if (const_id.is_valid() && const_id.is_template()) {
+        if (const_id.has_value() && const_id.is_template()) {
           auto const_inst_id = sem_ir_->constant_values().GetInstId(const_id);
           if (!insts_[const_inst_id.index].second) {
             queue_block_insts(ScopeId::ImportRefs,
@@ -911,7 +911,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
 
 auto InstNamer::CollectNamesInGeneric(ScopeId scope_id, GenericId generic_id)
     -> void {
-  if (!generic_id.is_valid()) {
+  if (!generic_id.has_value()) {
     return;
   }
   generic_scopes_[generic_id.index] = scope_id;

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -46,7 +46,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
     auto fn_scope = GetScopeFor(fn_id);
     // TODO: Provide a location for the function for use as a
     // disambiguator.
-    auto fn_loc = Parse::NodeId::Invalid;
+    auto fn_loc = Parse::NodeId::None;
     GetScopeInfo(fn_scope).name = globals_.AllocateName(
         *this, fn_loc, sem_ir->names().GetIRBaseName(fn.name_id).str());
     CollectNamesInBlock(fn_scope, fn.implicit_param_patterns_id);
@@ -68,7 +68,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
     ClassId class_id(i);
     auto class_scope = GetScopeFor(class_id);
     // TODO: Provide a location for the class for use as a disambiguator.
-    auto class_loc = Parse::NodeId::Invalid;
+    auto class_loc = Parse::NodeId::None;
     GetScopeInfo(class_scope).name = globals_.AllocateName(
         *this, class_loc,
         sem_ir->names().GetIRBaseName(class_info.name_id).str());
@@ -83,7 +83,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
     InterfaceId interface_id(i);
     auto interface_scope = GetScopeFor(interface_id);
     // TODO: Provide a location for the interface for use as a disambiguator.
-    auto interface_loc = Parse::NodeId::Invalid;
+    auto interface_loc = Parse::NodeId::None;
     GetScopeInfo(interface_scope).name = globals_.AllocateName(
         *this, interface_loc,
         sem_ir->names().GetIRBaseName(interface_info.name_id).str());
@@ -98,7 +98,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
     ImplId impl_id(i);
     auto impl_scope = GetScopeFor(impl_id);
     // TODO: Provide a location for the impl for use as a disambiguator.
-    auto impl_loc = Parse::NodeId::Invalid;
+    auto impl_loc = Parse::NodeId::None;
     // TODO: Invent a name based on the self and constraint types.
     GetScopeInfo(impl_scope).name =
         globals_.AllocateName(*this, impl_loc, "impl");
@@ -308,7 +308,7 @@ auto InstNamer::AddBlockLabel(ScopeId scope_id, InstBlockId block_id,
 // represents some kind of branch.
 auto InstNamer::AddBlockLabel(ScopeId scope_id, SemIR::LocId loc_id,
                               AnyBranch branch) -> void {
-  if (!loc_id.node_id().is_valid()) {
+  if (!loc_id.node_id().has_value()) {
     AddBlockLabel(scope_id, branch.target_id, "", loc_id);
     return;
   }
@@ -421,7 +421,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
       ScopeId old_scope_id = insts_[inst_id.index].first;
       if (old_scope_id == ScopeId::None) {
         std::variant<SemIR::LocId, uint64_t> loc_id_or_fingerprint =
-            SemIR::LocId::Invalid;
+            SemIR::LocId::None;
         if (scope_id == ScopeId::Constants || scope_id == ScopeId::ImportRefs) {
           loc_id_or_fingerprint = fingerprinter_.GetOrCompute(sem_ir_, inst_id);
         } else {
@@ -459,7 +459,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
                      facet_value_inst_id)) {
         return sem_ir_->entity_names().Get(symbolic->entity_name_id).name_id;
       }
-      return NameId::Invalid;
+      return NameId::None;
     };
 
     if (auto branch = untyped_inst.TryAs<AnyBranch>()) {
@@ -699,7 +699,7 @@ auto InstNamer::CollectNamesInBlock(ScopeId top_scope_id,
             sem_ir_->import_ir_insts().Get(inst.import_ir_inst_id);
         const auto& import_ir =
             *sem_ir_->import_irs().Get(import_ir_inst.ir_id).sem_ir;
-        if (import_ir.package_id().is_valid()) {
+        if (import_ir.package_id().has_value()) {
           out << import_ir.identifiers().Get(import_ir.package_id());
         } else {
           out << "Main";

--- a/toolchain/sem_ir/inst_namer.h
+++ b/toolchain/sem_ir/inst_namer.h
@@ -153,7 +153,7 @@ class InstNamer {
 
   auto AddBlockLabel(ScopeId scope_id, InstBlockId block_id,
                      std::string name = "",
-                     SemIR::LocId loc_id = SemIR::LocId::Invalid) -> void;
+                     SemIR::LocId loc_id = SemIR::LocId::None) -> void;
 
   // Finds and adds a suitable block label for the given SemIR instruction that
   // represents some kind of branch.

--- a/toolchain/sem_ir/inst_namer.h
+++ b/toolchain/sem_ir/inst_namer.h
@@ -72,7 +72,7 @@ class InstNamer {
   // Returns the IR name to use for a function, class, or interface.
   template <typename IdT>
   auto GetNameFor(IdT id) const -> std::string {
-    if (!id.is_valid()) {
+    if (!id.has_value()) {
       return "invalid";
     }
     return GetScopeName(GetScopeFor(id));

--- a/toolchain/sem_ir/interface.h
+++ b/toolchain/sem_ir/interface.h
@@ -38,7 +38,7 @@ struct Interface : public EntityWithParamsBase,
 
   // Determines whether this interface has been fully defined. This is false
   // until we reach the `}` of the interface definition.
-  auto is_defined() const -> bool { return associated_entities_id.is_valid(); }
+  auto is_defined() const -> bool { return associated_entities_id.has_value(); }
 
   // Determines whether we're currently defining the interface. This is true
   // between the braces of the interface.

--- a/toolchain/sem_ir/interface.h
+++ b/toolchain/sem_ir/interface.h
@@ -15,15 +15,15 @@ struct InterfaceFields {
   // The following members are set at the `{` of the interface definition.
 
   // The interface scope.
-  NameScopeId scope_id = NameScopeId::Invalid;
+  NameScopeId scope_id = NameScopeId::None;
   // The first block of the interface body.
   // TODO: Handle control flow in the interface body, such as if-expressions.
-  InstBlockId body_block_id = InstBlockId::Invalid;
+  InstBlockId body_block_id = InstBlockId::None;
   // The implicit `Self` parameter. This is a BindSymbolicName instruction.
-  InstId self_param_id = InstId::Invalid;
+  InstId self_param_id = InstId::None;
 
   // The following members are set at the `}` of the interface definition.
-  InstBlockId associated_entities_id = InstBlockId::Invalid;
+  InstBlockId associated_entities_id = InstBlockId::None;
 };
 
 // An interface. See EntityWithParamsBase regarding the inheritance here.

--- a/toolchain/sem_ir/name.cpp
+++ b/toolchain/sem_ir/name.cpp
@@ -11,8 +11,8 @@ namespace Carbon::SemIR {
 // Get the spelling to use for a special name.
 static auto GetSpecialName(NameId name_id, bool for_ir) -> llvm::StringRef {
   switch (name_id.index) {
-    case NameId::Invalid.index:
-      return for_ir ? "" : "<invalid>";
+    case NameId::None.index:
+      return for_ir ? "" : "<none>";
     case NameId::SelfValue.index:
       return "self";
     case NameId::SelfType.index:

--- a/toolchain/sem_ir/name.h
+++ b/toolchain/sem_ir/name.h
@@ -34,7 +34,7 @@ class NameStoreWrapper {
   auto GetAsStringIfIdentifier(NameId name_id) const
       -> std::optional<llvm::StringRef> {
     if (auto identifier_id = name_id.AsIdentifierId();
-        identifier_id.is_valid()) {
+        identifier_id.has_value()) {
       return identifiers_->Get(identifier_id);
     }
     return std::nullopt;

--- a/toolchain/sem_ir/name_scope.cpp
+++ b/toolchain/sem_ir/name_scope.cpp
@@ -67,7 +67,7 @@ auto NameScope::LookupOrPoison(NameId name_id) -> std::optional<EntryId> {
   auto insert_result = name_map_.Insert(name_id, EntryId(names_.size()));
   if (insert_result.is_inserted()) {
     names_.push_back({.name_id = name_id,
-                      .inst_id = InstId::Invalid,
+                      .inst_id = InstId::None,
                       .access_kind = AccessKind::Public,
                       .is_poisoned = true});
     return std::nullopt;
@@ -78,11 +78,11 @@ auto NameScope::LookupOrPoison(NameId name_id) -> std::optional<EntryId> {
 auto NameScopeStore::GetInstIfValid(NameScopeId scope_id) const
     -> std::pair<InstId, std::optional<Inst>> {
   if (!scope_id.is_valid()) {
-    return {InstId::Invalid, std::nullopt};
+    return {InstId::None, std::nullopt};
   }
   auto inst_id = Get(scope_id).inst_id();
   if (!inst_id.is_valid()) {
-    return {InstId::Invalid, std::nullopt};
+    return {InstId::None, std::nullopt};
   }
   return {inst_id, file_->insts().Get(inst_id)};
 }

--- a/toolchain/sem_ir/name_scope.cpp
+++ b/toolchain/sem_ir/name_scope.cpp
@@ -77,11 +77,11 @@ auto NameScope::LookupOrPoison(NameId name_id) -> std::optional<EntryId> {
 
 auto NameScopeStore::GetInstIfValid(NameScopeId scope_id) const
     -> std::pair<InstId, std::optional<Inst>> {
-  if (!scope_id.is_valid()) {
+  if (!scope_id.has_value()) {
     return {InstId::None, std::nullopt};
   }
   auto inst_id = Get(scope_id).inst_id();
-  if (!inst_id.is_valid()) {
+  if (!inst_id.has_value()) {
     return {InstId::None, std::nullopt};
   }
   return {inst_id, file_->insts().Get(inst_id)};

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -205,7 +205,7 @@ class NameScopeStore {
 
   // Returns whether the provided scope ID is for a package scope.
   auto IsPackage(NameScopeId scope_id) const -> bool {
-    if (!scope_id.is_valid()) {
+    if (!scope_id.has_value()) {
       return false;
     }
     // A package is either the current package or an imported package.

--- a/toolchain/sem_ir/name_scope_test.cpp
+++ b/toolchain/sem_ir/name_scope_test.cpp
@@ -202,7 +202,7 @@ TEST(NameScope, Poison) {
   EXPECT_THAT(name_scope.entries(),
               ElementsAre(NameScopeEntryEquals(
                   NameScope::Entry({.name_id = poison1,
-                                    .inst_id = InstId::Invalid,
+                                    .inst_id = InstId::None,
                                     .access_kind = AccessKind::Public,
                                     .is_poisoned = true}))));
 
@@ -211,12 +211,12 @@ TEST(NameScope, Poison) {
   EXPECT_THAT(name_scope.entries(),
               ElementsAre(NameScopeEntryEquals(NameScope::Entry(
                               {.name_id = poison1,
-                               .inst_id = InstId::Invalid,
+                               .inst_id = InstId::None,
                                .access_kind = AccessKind::Public,
                                .is_poisoned = true})),
                           NameScopeEntryEquals(NameScope::Entry(
                               {.name_id = poison2,
-                               .inst_id = InstId::Invalid,
+                               .inst_id = InstId::None,
                                .access_kind = AccessKind::Public,
                                .is_poisoned = true}))));
 
@@ -225,7 +225,7 @@ TEST(NameScope, Poison) {
   EXPECT_THAT(
       name_scope.GetEntry(*lookup),
       NameScopeEntryEquals(NameScope::Entry({.name_id = poison1,
-                                             .inst_id = InstId::Invalid,
+                                             .inst_id = InstId::None,
                                              .access_kind = AccessKind::Public,
                                              .is_poisoned = true})));
 }
@@ -245,7 +245,7 @@ TEST(NameScope, AddRequiredAfterPoison) {
   EXPECT_THAT(name_scope.entries(),
               ElementsAre(NameScopeEntryEquals(
                   NameScope::Entry({.name_id = name_id,
-                                    .inst_id = InstId::Invalid,
+                                    .inst_id = InstId::None,
                                     .access_kind = AccessKind::Public,
                                     .is_poisoned = true}))));
 

--- a/toolchain/sem_ir/stringify_type.cpp
+++ b/toolchain/sem_ir/stringify_type.cpp
@@ -74,7 +74,7 @@ class StepStack {
   // Pushes all components of a qualified name (`A.B.C`) onto the stack.
   auto PushQualifiedName(NameScopeId name_scope_id, NameId name_id) -> void {
     PushNameId(name_id);
-    while (name_scope_id.is_valid() && name_scope_id != NameScopeId::Package) {
+    while (name_scope_id.has_value() && name_scope_id != NameScopeId::Package) {
       const auto& name_scope = sem_ir_->name_scopes().Get(name_scope_id);
       // TODO: Decide how to print unnamed scopes.
       if (name_scope.name_id().has_value()) {
@@ -113,7 +113,7 @@ class StepStack {
   // `A.B(T)`.
   auto PushSpecificId(const EntityWithParamsBase& entity,
                       SpecificId specific_id) -> void {
-    if (!entity.param_patterns_id.is_valid()) {
+    if (!entity.param_patterns_id.has_value()) {
       return;
     }
     int num_params =
@@ -122,7 +122,7 @@ class StepStack {
       PushString("()");
       return;
     }
-    if (!specific_id.is_valid()) {
+    if (!specific_id.has_value()) {
       // The name of the generic was used within the generic itself.
       // TODO: Should we print the names of the generic parameters in this
       // case?
@@ -165,7 +165,7 @@ auto StringifyTypeExpr(const SemIR::File& sem_ir, InstId outer_inst_id)
         out << sem_ir.names().GetFormatted(step.name_id);
         continue;
       case StepStack::Step::Inst:
-        if (!step.inst_id.is_valid()) {
+        if (!step.inst_id.has_value()) {
           out << "<invalid type>";
           continue;
         }
@@ -384,7 +384,7 @@ auto StringifyTypeExpr(const SemIR::File& sem_ir, InstId outer_inst_id)
         break;
       }
       case CARBON_KIND(ImportRefUnloaded inst): {
-        if (inst.entity_name_id.is_valid()) {
+        if (inst.entity_name_id.has_value()) {
           step_stack.PushEntityName(inst.entity_name_id);
         } else {
           out << "<import ref unloaded invalid entity name>";
@@ -426,7 +426,7 @@ auto StringifyTypeExpr(const SemIR::File& sem_ir, InstId outer_inst_id)
       }
       case CARBON_KIND(SpecificFunction inst): {
         auto callee = SemIR::GetCalleeFunction(sem_ir, inst.callee_id);
-        if (callee.function_id.is_valid()) {
+        if (callee.function_id.has_value()) {
           step_stack.PushEntityName(sem_ir.functions().Get(callee.function_id),
                                     inst.specific_id);
         } else {
@@ -603,7 +603,7 @@ auto StringifyTypeExpr(const SemIR::File& sem_ir, InstId outer_inst_id)
         // constant value that we can print.
         auto const_inst_id =
             sem_ir.constant_values().GetConstantInstId(step.inst_id);
-        if (const_inst_id.is_valid() && const_inst_id != step.inst_id) {
+        if (const_inst_id.has_value() && const_inst_id != step.inst_id) {
           step_stack.PushInstId(const_inst_id);
           break;
         }

--- a/toolchain/sem_ir/stringify_type.cpp
+++ b/toolchain/sem_ir/stringify_type.cpp
@@ -77,7 +77,7 @@ class StepStack {
     while (name_scope_id.is_valid() && name_scope_id != NameScopeId::Package) {
       const auto& name_scope = sem_ir_->name_scopes().Get(name_scope_id);
       // TODO: Decide how to print unnamed scopes.
-      if (name_scope.name_id().is_valid()) {
+      if (name_scope.name_id().has_value()) {
         PushString(".");
         // TODO: For a generic scope, pass a SpecificId to this function and
         // include the relevant arguments.

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -39,7 +39,7 @@ auto TypeStore::GetUnqualifiedType(TypeId type_id) const -> TypeId {
 static auto TryGetIntTypeInfo(const File& file, TypeId type_id)
     -> std::optional<TypeStore::IntTypeInfo> {
   auto object_repr_id = file.types().GetObjectRepr(type_id);
-  if (!object_repr_id.is_valid()) {
+  if (!object_repr_id.has_value()) {
     return std::nullopt;
   }
   auto inst_id = file.types().GetInstId(object_repr_id);

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -24,7 +24,7 @@ auto TypeStore::GetObjectRepr(TypeId type_id) const -> TypeId {
   }
   const auto& class_info = file_->classes().Get(class_type->class_id);
   if (!class_info.is_defined()) {
-    return TypeId::Invalid;
+    return TypeId::None;
   }
   return class_info.GetObjectRepr(*file_, class_type->specific_id);
 }
@@ -45,8 +45,7 @@ static auto TryGetIntTypeInfo(const File& file, TypeId type_id)
   auto inst_id = file.types().GetInstId(object_repr_id);
   if (inst_id == IntLiteralType::SingletonInstId) {
     // `Core.IntLiteral` has an unknown bit-width.
-    return TypeStore::IntTypeInfo{.is_signed = true,
-                                  .bit_width = IntId::Invalid};
+    return TypeStore::IntTypeInfo{.is_signed = true, .bit_width = IntId::None};
   }
   auto int_type = file.insts().TryGetAs<IntType>(inst_id);
   if (!int_type) {
@@ -55,7 +54,7 @@ static auto TryGetIntTypeInfo(const File& file, TypeId type_id)
   auto bit_width_inst = file.insts().TryGetAs<IntValue>(int_type->bit_width_id);
   return TypeStore::IntTypeInfo{
       .is_signed = int_type->int_kind.is_signed(),
-      .bit_width = bit_width_inst ? bit_width_inst->int_id : IntId::Invalid};
+      .bit_width = bit_width_inst ? bit_width_inst->int_id : IntId::None};
 }
 
 auto TypeStore::IsSignedInt(TypeId int_type_id) const -> bool {

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -109,7 +109,7 @@ class TypeStore : public Yaml::Printable<TypeStore> {
   // Returns integer type information from a type ID that is known to represent
   // an integer type. Abstracts away the difference between an `IntType`
   // instruction defined type, a singleton instruction defined type, and a class
-  // adapting such a type. Uses IntId::Invalid for types that have a
+  // adapting such a type. Uses IntId::None for types that have a
   // non-constant width and for IntLiteral.
   auto GetIntTypeInfo(TypeId int_type_id) const -> IntTypeInfo;
 

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -26,7 +26,7 @@ class TypeStore : public Yaml::Printable<TypeStore> {
 
   // Returns the ID of the constant used to define the specified type.
   auto GetConstantId(TypeId type_id) const -> ConstantId {
-    if (!type_id.is_valid()) {
+    if (!type_id.has_value()) {
       // TODO: Investigate replacing this with a CHECK or returning Invalid.
       return ConstantId::NotConstant;
     }

--- a/toolchain/sem_ir/type_info.cpp
+++ b/toolchain/sem_ir/type_info.cpp
@@ -71,13 +71,13 @@ auto InitRepr::ForType(const File& file, TypeId type_id) -> InitRepr {
 auto NumericTypeLiteralInfo::ForType(const File& file, ClassType class_type)
     -> NumericTypeLiteralInfo {
   // Quickly rule out any class that's not a specific.
-  if (!class_type.specific_id.is_valid()) {
+  if (!class_type.specific_id.has_value()) {
     return NumericTypeLiteralInfo::Invalid;
   }
 
   // The class must be declared in the `Core` package.
   const auto& class_info = file.classes().Get(class_type.class_id);
-  if (!class_info.scope_id.is_valid() ||
+  if (!class_info.scope_id.has_value() ||
       !file.name_scopes().IsCorePackage(
           file.name_scopes().Get(class_info.scope_id).parent_scope_id())) {
     return NumericTypeLiteralInfo::Invalid;

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -68,7 +68,7 @@ struct ValueRepr : public Printable<ValueRepr> {
   // The kind of aggregate representation used by this type.
   AggregateKind aggregate_kind = AggregateKind::NotAggregate;
   // The type used to model the value representation.
-  TypeId type_id = TypeId::Invalid;
+  TypeId type_id = TypeId::None;
 };
 
 // Information stored about a TypeId corresponding to a complete type.
@@ -126,7 +126,7 @@ struct ReturnTypeInfo {
 
   // Builds return type information for a given function.
   static auto ForFunction(const File& file, const Function& function,
-                          SpecificId specific_id = SpecificId::Invalid)
+                          SpecificId specific_id = SpecificId::None)
       -> ReturnTypeInfo {
     return ForType(file, function.GetDeclaredReturnType(file, specific_id));
   }
@@ -181,7 +181,7 @@ struct NumericTypeLiteralInfo {
 };
 
 inline constexpr NumericTypeLiteralInfo NumericTypeLiteralInfo::Invalid = {
-    .kind = None, .bit_width_id = IntId::Invalid};
+    .kind = None, .bit_width_id = IntId::None};
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -120,8 +120,9 @@ struct ReturnTypeInfo {
   // Builds return type information for a given declared return type.
   static auto ForType(const File& file, TypeId type_id) -> ReturnTypeInfo {
     return {.type_id = type_id,
-            .init_repr = type_id.is_valid() ? InitRepr::ForType(file, type_id)
-                                            : InitRepr{.kind = InitRepr::None}};
+            .init_repr = type_id.has_value()
+                             ? InitRepr::ForType(file, type_id)
+                             : InitRepr{.kind = InitRepr::None}};
   }
 
   // Builds return type information for a given function.

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -50,7 +50,7 @@ namespace Carbon::SemIR {
 
 // Used for the type of patterns that do not match a fixed type.
 struct AutoType {
-  static constexpr auto Kind = InstKind::AutoType.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::AutoType.Define<Parse::NoneNodeId>(
       {.ir_name = "auto",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
@@ -63,7 +63,7 @@ struct AutoType {
 
 // The type of bool literals and branch conditions, bool.
 struct BoolType {
-  static constexpr auto Kind = InstKind::BoolType.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::BoolType.Define<Parse::NoneNodeId>(
       {.ir_name = "bool",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
@@ -240,7 +240,7 @@ struct AssociatedEntity {
 // `InterfaceName.Function`.
 struct AssociatedEntityType {
   static constexpr auto Kind =
-      InstKind::AssociatedEntityType.Define<Parse::InvalidNodeId>(
+      InstKind::AssociatedEntityType.Define<Parse::NoneNodeId>(
           {.ir_name = "assoc_entity_type",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Conditional});
@@ -405,7 +405,7 @@ struct BoundMethod {
 // The type of bound method values.
 struct BoundMethodType {
   static constexpr auto Kind =
-      InstKind::BoundMethodType.Define<Parse::InvalidNodeId>(
+      InstKind::BoundMethodType.Define<Parse::NoneNodeId>(
           {.ir_name = "<bound method>",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Always});
@@ -587,7 +587,7 @@ struct Deref {
 // in the type_id. It's typically used as a cue that semantic checking doesn't
 // need to issue further diagnostics.
 struct ErrorInst {
-  static constexpr auto Kind = InstKind::ErrorInst.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::ErrorInst.Define<Parse::NoneNodeId>(
       {.ir_name = "<error>",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
@@ -693,7 +693,7 @@ struct FloatLiteral {
 
 // A floating point type.
 struct FloatType {
-  static constexpr auto Kind = InstKind::FloatType.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::FloatType.Define<Parse::NoneNodeId>(
       {.ir_name = "float_type",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Conditional,
@@ -710,7 +710,7 @@ struct FloatType {
 // integers, likely replacing this with a `FloatLiteralType`.
 struct LegacyFloatType {
   static constexpr auto Kind =
-      InstKind::LegacyFloatType.Define<Parse::InvalidNodeId>(
+      InstKind::LegacyFloatType.Define<Parse::NoneNodeId>(
           {.ir_name = "f64",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Always});
@@ -752,7 +752,7 @@ struct FunctionType {
 struct GenericClassType {
   // This is only ever created as a constant, so doesn't have a location.
   static constexpr auto Kind =
-      InstKind::GenericClassType.Define<Parse::InvalidNodeId>(
+      InstKind::GenericClassType.Define<Parse::NoneNodeId>(
           {.ir_name = "generic_class_type",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Conditional});
@@ -767,7 +767,7 @@ struct GenericClassType {
 struct GenericInterfaceType {
   // This is only ever created as a constant, so doesn't have a location.
   static constexpr auto Kind =
-      InstKind::GenericInterfaceType.Define<Parse::InvalidNodeId>(
+      InstKind::GenericInterfaceType.Define<Parse::NoneNodeId>(
           {.ir_name = "generic_interface_type",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Conditional});
@@ -907,7 +907,7 @@ struct IntValue {
 // runtime.
 struct IntLiteralType {
   static constexpr auto Kind =
-      InstKind::IntLiteralType.Define<Parse::InvalidNodeId>(
+      InstKind::IntLiteralType.Define<Parse::NoneNodeId>(
           {.ir_name = "Core.IntLiteral",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Always});
@@ -922,7 +922,7 @@ struct IntLiteralType {
 // the toolchain. The `Core.Int` and `Core.UInt` classes are defined as adapters
 // for this type.
 struct IntType {
-  static constexpr auto Kind = InstKind::IntType.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::IntType.Define<Parse::NoneNodeId>(
       {.ir_name = "int_type",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Conditional,
@@ -976,7 +976,7 @@ struct Namespace {
 // The type of namespace and imported package names.
 struct NamespaceType {
   static constexpr auto Kind =
-      InstKind::NamespaceType.Define<Parse::InvalidNodeId>(
+      InstKind::NamespaceType.Define<Parse::NoneNodeId>(
           {.ir_name = "<namespace>",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Always});
@@ -1227,7 +1227,7 @@ struct SpecificFunction {
 // The type of specific functions.
 struct SpecificFunctionType {
   static constexpr auto Kind =
-      InstKind::SpecificFunctionType.Define<Parse::InvalidNodeId>(
+      InstKind::SpecificFunctionType.Define<Parse::NoneNodeId>(
           {.ir_name = "<specific function>",
            .is_type = InstIsType::Always,
            .constant_kind = InstConstantKind::Always});
@@ -1264,11 +1264,10 @@ struct StringLiteral {
 
 // The type of string values and String literals.
 struct StringType {
-  static constexpr auto Kind =
-      InstKind::StringType.Define<Parse::InvalidNodeId>(
-          {.ir_name = "String",
-           .is_type = InstIsType::Always,
-           .constant_kind = InstConstantKind::Always});
+  static constexpr auto Kind = InstKind::StringType.Define<Parse::NoneNodeId>(
+      {.ir_name = "String",
+       .is_type = InstIsType::Always,
+       .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
   static constexpr auto SingletonInstId = MakeSingletonInstId<Kind>();
@@ -1387,7 +1386,7 @@ struct TupleLiteral {
 
 // The type of a tuple.
 struct TupleType {
-  static constexpr auto Kind = InstKind::TupleType.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::TupleType.Define<Parse::NoneNodeId>(
       {.ir_name = "tuple_type",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Conditional,
@@ -1411,7 +1410,7 @@ struct TupleValue {
 // Tracks expressions which are valid as types. This has a deliberately
 // self-referential type.
 struct TypeType {
-  static constexpr auto Kind = InstKind::TypeType.Define<Parse::InvalidNodeId>(
+  static constexpr auto Kind = InstKind::TypeType.Define<Parse::NoneNodeId>(
       {.ir_name = "type",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
@@ -1499,11 +1498,10 @@ struct VarStorage {
 
 // The type of virtual function tables.
 struct VtableType {
-  static constexpr auto Kind =
-      InstKind::VtableType.Define<Parse::InvalidNodeId>(
-          {.ir_name = "<vtable>",
-           .is_type = InstIsType::Always,
-           .constant_kind = InstConstantKind::Always});
+  static constexpr auto Kind = InstKind::VtableType.Define<Parse::NoneNodeId>(
+      {.ir_name = "<vtable>",
+       .is_type = InstIsType::Always,
+       .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
   static constexpr auto SingletonInstId = MakeSingletonInstId<Kind>();
@@ -1544,11 +1542,10 @@ struct WhereExpr {
 
 // The type of witnesses.
 struct WitnessType {
-  static constexpr auto Kind =
-      InstKind::WitnessType.Define<Parse::InvalidNodeId>(
-          {.ir_name = "<witness>",
-           .is_type = InstIsType::Always,
-           .constant_kind = InstConstantKind::Always});
+  static constexpr auto Kind = InstKind::WitnessType.Define<Parse::NoneNodeId>(
+      {.ir_name = "<witness>",
+       .is_type = InstIsType::Always,
+       .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
   static constexpr auto SingletonInstId = MakeSingletonInstId<Kind>();
@@ -1561,8 +1558,8 @@ namespace Internal {
 
 // HasNodeId is true if T has an associated parse node.
 template <typename T>
-concept HasNodeId = !std::same_as<typename decltype(T::Kind)::TypedNodeId,
-                                  Parse::InvalidNodeId>;
+concept HasNodeId =
+    !std::same_as<typename decltype(T::Kind)::TypedNodeId, Parse::NoneNodeId>;
 
 // HasUntypedNodeId is true if T has an associated parse node which can be any
 // kind of node.


### PR DESCRIPTION
High level, replacing `Id::Invalid` with `Id::None` and `Id::is_valid` with `Id::has_value` for clarity, as discussed [here](https://discord.com/channels/655572317891461132/655578254970716160/1331664574545395794). The `IntId` refactoring is needed together with `AnyIdBase` because it's also used with `ValueStore`.

Note, trying to be careful not to rewrite `EnumBase::InvalidIndex`, or `is_valid` in general (e.g., `IdKind::is_valid`).

I've tried to sequence commits here:

1. Automatic replacements:

  - `((?:Id|Index)(?: |::|\(|Base(?:\(|::)))Invalid((?:Index)?\W)` -> `$1None$2`
  - `<invalid>` -> `<none>`
  - `InvalidNodeId` -> `NoneNodeId`
  - `/\*invalid\*/` -> `/*none*/`
  - `id((?:_|\(\))(?:\.|->))is_valid` -> `id$1has_value`

2. Manual edits:

  - In `int.h` and `int_test.cpp`
    - `IntT` has `is_value`, which I'm renaming to `is_embedded_value`.
    - Manual edits to comments in this file.
  - `AnyIdBase` and `IdBase`
    - Declaration of `is_valid` -> `has_value`, `InvalidIndex` -> `NoneIndex`.
  - In `ids.h` and `ids.cpp`
    - `is_valid` -> `has_value`
    - `// An explicitly invalid ID.` -> `// An ID with no value.`; similar for index
    - Various math on `InvalidIndex` -> `NoneIndex`
    - Various mentions of "valid" in comments
  - In `value_store.h`, for `IdT::Invalid`, plus one comment
  - In `impl.h` and `tokenized_buffer.h`, we had different initialization of `::None` values (versus `ids.h` syntax) that I fixed manually.
  - Spot checks to compile
    - Particularly where `is_valid` replacements didn't catch spots due to different naming.

3. Autoupdate tests

4. verbose.carbon (NOAUTOUPDATE)

5. Comment spot checks

Note there are probably other mentions of "Invalid" that should be swept up, but I'd like to argue for merging and separating out remaining cleanup since this is so sweeping (and likely to hit merge conflicts from churn). We'll probably have lingering mentions of "invalid" for a bit regardless, just because there are uses of "invalid" in non-Id APIs.