### PR TITLE
Fix crash when driver fuzzer finds language-server.

### DIFF
--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -228,5 +228,10 @@ TEST_F(DriverTest, FileOutput) {
   EXPECT_THAT(ReadFile("test.s"), ContainsRegex("Main:"));
 }
 
+TEST_F(DriverTest, LanguageServerNoStdin) {
+  EXPECT_FALSE(driver_.RunCommand({"language-server"}).success);
+  EXPECT_THAT(test_error_stream_.TakeStr(), HasSubstr("requires input_stream"));
+}
+
 }  // namespace
 }  // namespace Carbon

--- a/toolchain/driver/language_server_subcommand.cpp
+++ b/toolchain/driver/language_server_subcommand.cpp
@@ -22,6 +22,7 @@ auto LanguageServerSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   if (!driver_env.input_stream) {
     *driver_env.error_stream
         << "error: language-server requires input_stream\n";
+    return {.success = false};
   }
 
   auto err =


### PR DESCRIPTION
The driver fuzzer, unlike the actual driver, provides a null `input_stream`, which caused the `language-server` subcommand to crash.