### PR TITLE
When looking up a name in a scope, propagate the lookup result when it's poisoned

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -431,9 +431,8 @@ auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
     auto lookup_result = scope.GetEntry(*entry_id).result;
     if (!lookup_result.is_poisoned()) {
       LoadImportRef(*this, lookup_result.target_inst_id());
-      return lookup_result;
     }
-    return SemIR::ScopeLookupResult::MakePoisoned();
+    return lookup_result;
   }
 
   if (!scope.import_ir_scopes().empty()) {


### PR DESCRIPTION
Instead of creating a new poisoned result.
This would allow propagating the poisoning location when we add it.
Part of #4622.