### PR TITLE
Change `LookupNameInExactScope::LookupNameInExactScope()` and `ImportNameFromOtherPackage()` to take `LocId` instead of `SemIRLoc`

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -421,7 +421,7 @@ auto Context::LookupUnqualifiedName(Parse::NodeId node_id,
           .scope_result = SemIR::ScopeLookupResult::MakeError()};
 }
 
-auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
+auto Context::LookupNameInExactScope(SemIR::LocId loc_id, SemIR::NameId name_id,
                                      SemIR::NameScopeId scope_id,
                                      SemIR::NameScope& scope,
                                      bool is_being_declared)
@@ -438,7 +438,7 @@ auto Context::LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
   if (!scope.import_ir_scopes().empty()) {
     // TODO: Enforce other access modifiers for imports.
     return SemIR::ScopeLookupResult::MakeWrappedLookupResult(
-        ImportNameFromOtherPackage(*this, loc, scope_id,
+        ImportNameFromOtherPackage(*this, loc_id, scope_id,
                                    scope.import_ir_scopes(), name_id),
         SemIR::AccessKind::Public);
   }

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -235,7 +235,7 @@ class Context {
   // poisoned name will be treated as if it is not declared. Otherwise, this is
   // a lookup for a name being declared, so the name will not be poisoned, but
   // poison will be returned if it's already been looked up.
-  auto LookupNameInExactScope(SemIRLoc loc, SemIR::NameId name_id,
+  auto LookupNameInExactScope(SemIR::LocId loc_id, SemIR::NameId name_id,
                               SemIR::NameScopeId scope_id,
                               SemIR::NameScope& scope,
                               bool is_being_declared = false)

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -376,7 +376,8 @@ auto FinishImplWitness(Context& context, SemIR::Impl& impl) -> void {
         }
         auto& fn = context.functions().Get(fn_type->function_id);
         auto lookup_result = context.LookupNameInExactScope(
-            decl_id, fn.name_id, impl.scope_id, impl_scope);
+            context.insts().GetLocId(decl_id), fn.name_id, impl.scope_id,
+            impl_scope);
         if (lookup_result.is_found()) {
           used_decl_ids.push_back(lookup_result.target_inst_id());
           witness_block[index] = CheckAssociatedFunctionImplementation(

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -531,7 +531,7 @@ static auto AddNamespaceFromOtherPackage(Context& context,
 }
 
 auto ImportNameFromOtherPackage(
-    Context& context, SemIRLoc loc, SemIR::NameScopeId scope_id,
+    Context& context, SemIR::LocId loc_id, SemIR::NameScopeId scope_id,
     llvm::ArrayRef<std::pair<SemIR::ImportIRId, SemIR::NameScopeId>>
         import_ir_scopes,
     SemIR::NameId name_id) -> SemIR::InstId {
@@ -549,7 +549,7 @@ auto ImportNameFromOtherPackage(
       &context.emitter(), [&](auto& builder) {
         CARBON_DIAGNOSTIC(InNameLookup, Note, "in name lookup for `{0}`",
                           SemIR::NameId);
-        builder.Note(loc, InNameLookup, name_id);
+        builder.Note(loc_id, InNameLookup, name_id);
       });
 
   // Although we track the result here and look in each IR, we pretty much use

--- a/toolchain/check/import.h
+++ b/toolchain/check/import.h
@@ -50,7 +50,7 @@ auto ImportLibrariesFromOtherPackage(Context& context,
 // Arguments are all in the context of the current IR. Scope lookup is expected
 // to be resolved first.
 auto ImportNameFromOtherPackage(
-    Context& context, SemIRLoc loc, SemIR::NameScopeId scope_id,
+    Context& context, SemIR::LocId loc_id, SemIR::NameScopeId scope_id,
     llvm::ArrayRef<std::pair<SemIR::ImportIRId, SemIR::NameScopeId>>
         import_ir_scopes,
     SemIR::NameId name_id) -> SemIR::InstId;


### PR DESCRIPTION
This will make it simpler to have a poisoning location in `NameScope`, since `SemIRLoc` is not part of `SemIR` and so cannot be used in `NameScope`.
Part of #4622.