### PR TITLE
Return the `NameId` for a new instruction regardless if it's unresolved because it's poisoned or not

### DIFF
--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -122,8 +122,13 @@ class DeclNameStack {
     // Returns the name_id for a new instruction. This is `None` when the name
     // resolved.
     auto name_id_for_new_inst() -> SemIR::NameId {
-      return state == State::Unresolved ? unresolved_name_id
-                                        : SemIR::NameId::None;
+      switch (state) {
+        case State::Unresolved:
+        case State::Poisoned:
+          return unresolved_name_id;
+        default:
+          return SemIR::NameId::None;
+      }
     }
 
     // The current scope when this name began. This is the scope that we will

--- a/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
@@ -450,100 +450,100 @@ fn F() {
 // CHECK:STDOUT: --- fail_poison_class_without_usage.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [template]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [template]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [template]
-// CHECK:STDOUT:   %.fb7: type = class_type @.1 [template]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .C = %C.decl.loc5
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc5: type = class_decl @C.1 [template = constants.%C.f79] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F1 = %F1.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [template = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc5 [template = constants.%C.f79]
+// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.fb7] {} {}
+// CHECK:STDOUT:   %C.decl.loc17: type = class_decl @C.2 [template = constants.%C.9f4] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
+// CHECK:STDOUT: class @C.1 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .Self = constants.%C.f79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.1 {
+// CHECK:STDOUT: class @C.2 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.fb7
+// CHECK:STDOUT:   .Self = constants.%C.9f4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_poison_interface_without_usage.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I.type: type = facet_type <@I> [template]
-// CHECK:STDOUT:   %Self.826: %I.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [template]
+// CHECK:STDOUT:   %Self.826: %I.type.733 = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [template]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [template]
-// CHECK:STDOUT:   %.type: type = facet_type <@.1> [template]
-// CHECK:STDOUT:   %Self.d73: %.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [template]
+// CHECK:STDOUT:   %Self.f85: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .I = %I.decl.loc5
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
+// CHECK:STDOUT:   %I.decl.loc5: type = interface_decl @I.1 [template = constants.%I.type.733] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F1 = %F1.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [template = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %I.type.733 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%I.type]
-// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc5 [template = constants.%I.type.733]
+// CHECK:STDOUT:     %x: %I.type.733 = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.decl: type = interface_decl @.1 [template = constants.%.type] {} {}
+// CHECK:STDOUT:   %I.decl.loc17: type = interface_decl @I.2 [template = constants.%I.type.4da] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.826]
+// CHECK:STDOUT: interface @I.1 {
+// CHECK:STDOUT:   %Self: %I.type.733 = bind_symbolic_name Self, 0 [symbolic = constants.%Self.826]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @.1 {
-// CHECK:STDOUT:   %Self: %.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.d73]
+// CHECK:STDOUT: interface @I.2 {
+// CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic = constants.%Self.f85]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type.733);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_poison_namespace_without_usage.carbon
 // CHECK:STDOUT:
@@ -572,7 +572,7 @@ fn F() {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %x: %C = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc17: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %C: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
@@ -654,46 +654,46 @@ fn F() {
 // CHECK:STDOUT: --- fail_poison_function_without_usage.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %C.f79: type = class_type @C.2 [template]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [template]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [template]
-// CHECK:STDOUT:   %.type: type = fn_type @.1 [template]
-// CHECK:STDOUT:   %.236: %.type = struct_value () [template]
+// CHECK:STDOUT:   %C.type: type = fn_type @C.1 [template]
+// CHECK:STDOUT:   %C.3f2: %C.type = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .C = %C.decl.loc5
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc5: type = class_decl @C.2 [template = constants.%C.f79] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F1 = %F1.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [template = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc5 [template = constants.%C.f79]
+// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.decl: %.type = fn_decl @.1 [template = constants.%.236] {} {}
+// CHECK:STDOUT:   %C.decl.loc17: %C.type = fn_decl @C.1 [template = constants.%C.3f2] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
+// CHECK:STDOUT: class @C.2 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .Self = constants.%C.f79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @.1();
+// CHECK:STDOUT: fn @C.1();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_use_undefined_poisoned_name.carbon
 // CHECK:STDOUT:
@@ -751,69 +751,69 @@ fn F() {
 // CHECK:STDOUT: --- fail_poison_with_usage.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [template]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [template]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [template]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [template]
-// CHECK:STDOUT:   %.fb7: type = class_type @.1 [template]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [template]
 // CHECK:STDOUT:   %F2.type: type = fn_type @F2 [template]
 // CHECK:STDOUT:   %F2: %F2.type = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .C = %C.decl.loc5
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc5: type = class_decl @C.1 [template = constants.%C.f79] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .F1 = %F1.decl
 // CHECK:STDOUT:     .F2 = %F2.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [template = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc5 [template = constants.%C.f79]
+// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.fb7] {} {}
+// CHECK:STDOUT:   %C.decl.loc17: type = class_decl @C.2 [template = constants.%C.9f4] {} {}
 // CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [template = constants.%F2] {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc5 [template = constants.%C.f79]
+// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
+// CHECK:STDOUT: class @C.1 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .Self = constants.%C.f79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.1 {
+// CHECK:STDOUT: class @C.2 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.fb7
+// CHECK:STDOUT:   .Self = constants.%C.9f4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F2(%x.param_patt: %C) {
+// CHECK:STDOUT: fn @F2(%x.param_patt: %C.f79) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%N [template = file.%N]
 // CHECK:STDOUT:   %F1.ref: %F1.type = name_ref F1, file.%F1.decl [template = constants.%F1]
-// CHECK:STDOUT:   %x.ref: %C = name_ref x, %x
+// CHECK:STDOUT:   %x.ref: %C.f79 = name_ref x, %x
 // CHECK:STDOUT:   %F1.call: init %empty_tuple.type = call %F1.ref(%x.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -821,7 +821,7 @@ fn F() {
 // CHECK:STDOUT: --- fail_poison_multiple_scopes.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [template]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %D1: type = class_type @D1 [template]
@@ -831,23 +831,23 @@ fn F() {
 // CHECK:STDOUT:   %D3.68e: type = class_type @D3, @D3(%Self.8cf) [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F, @D3(%Self.8cf) [symbolic]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [symbolic]
-// CHECK:STDOUT:   %.c1e: type = class_type @.1 [template]
-// CHECK:STDOUT:   %.180: type = class_type @.1, @.1(%Self.8cf) [symbolic]
-// CHECK:STDOUT:   %.9af: type = class_type @.2 [template]
-// CHECK:STDOUT:   %.5c1: type = class_type @.2, @.2(%Self.8cf) [symbolic]
-// CHECK:STDOUT:   %.6ae: type = class_type @.3 [template]
-// CHECK:STDOUT:   %.1c0: type = class_type @.4 [template]
-// CHECK:STDOUT:   %.type: type = facet_type <@.6> [template]
-// CHECK:STDOUT:   %Self.501: %.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %.4b5: type = class_type @.5 [template]
+// CHECK:STDOUT:   %C.fef: type = class_type @C.2 [template]
+// CHECK:STDOUT:   %C.5a3: type = class_type @C.2, @C.2(%Self.8cf) [symbolic]
+// CHECK:STDOUT:   %C.2fa: type = class_type @C.3 [template]
+// CHECK:STDOUT:   %C.4bd: type = class_type @C.3, @C.3(%Self.8cf) [symbolic]
+// CHECK:STDOUT:   %C.6f6: type = class_type @C.4 [template]
+// CHECK:STDOUT:   %C.0b8: type = class_type @C.5 [template]
+// CHECK:STDOUT:   %C.type: type = facet_type <@C.7> [template]
+// CHECK:STDOUT:   %Self.b2a: %C.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %C.6f1: type = class_type @C.6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .C = %C.decl.loc5
 // CHECK:STDOUT:     .N1 = %N1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc5: type = class_decl @C.1 [template = constants.%C.f79] {} {}
 // CHECK:STDOUT:   %N1: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .N2 = %N2
 // CHECK:STDOUT:   }
@@ -858,15 +858,15 @@ fn F() {
 // CHECK:STDOUT:     .D1 = %D1.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D1.decl: type = class_decl @D1 [template = constants.%D1] {} {}
-// CHECK:STDOUT:   %.decl.loc49: type = class_decl @.4 [template = constants.%.1c0] {} {}
-// CHECK:STDOUT:   %.decl.loc56: type = interface_decl @.6 [template = constants.%.type] {} {}
-// CHECK:STDOUT:   %.decl.loc62: type = class_decl @.5 [template = constants.%.4b5] {} {}
+// CHECK:STDOUT:   %C.decl.loc49: type = class_decl @C.5 [template = constants.%C.0b8] {} {}
+// CHECK:STDOUT:   %C.decl.loc56: type = interface_decl @C.7 [template = constants.%C.type] {} {}
+// CHECK:STDOUT:   %C.decl.loc62: type = class_decl @C.6 [template = constants.%C.6f1] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @D2 {
 // CHECK:STDOUT:   %Self: %D2.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.8cf]
 // CHECK:STDOUT:   %D3.decl: type = class_decl @D3 [template = constants.%D3.b65] {} {}
-// CHECK:STDOUT:   %.decl: type = class_decl @.2 [template = constants.%.9af] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C.3 [template = constants.%C.2fa] {} {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -874,25 +874,25 @@ fn F() {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @.6 {
-// CHECK:STDOUT:   %Self: %.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.501]
+// CHECK:STDOUT: interface @C.7 {
+// CHECK:STDOUT:   %Self: %C.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.b2a]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
+// CHECK:STDOUT: class @C.1 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .Self = constants.%C.f79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D1 {
 // CHECK:STDOUT:   %D2.decl: type = interface_decl @D2 [template = constants.%D2.type] {} {}
-// CHECK:STDOUT:   %.decl: type = class_decl @.3 [template = constants.%.6ae] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C.4 [template = constants.%C.6f6] {} {}
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -909,14 +909,14 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %F.decl: @D3.%F.type (%F.type) = fn_decl @F [symbolic = @D3.%F (constants.%F)] {
-// CHECK:STDOUT:       %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:       %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:       %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:       %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:       %x: %C = bind_name x, %x.param
+// CHECK:STDOUT:       %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl.loc5 [template = constants.%C.f79]
+// CHECK:STDOUT:       %x: %C.f79 = bind_name x, %x.param
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %.decl: type = class_decl @.1 [template = constants.%.c1e] {} {}
+// CHECK:STDOUT:     %C.decl: type = class_decl @C.2 [template = constants.%C.fef] {} {}
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:     complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -926,7 +926,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @.1(@D2.%Self: %D2.type) {
+// CHECK:STDOUT: generic class @C.2(@D2.%Self: %D2.type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
@@ -934,11 +934,11 @@ fn F() {
 // CHECK:STDOUT:     complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     .Self = constants.%.180
+// CHECK:STDOUT:     .Self = constants.%C.5a3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @.2(@D2.%Self: %D2.type) {
+// CHECK:STDOUT: generic class @C.3(@D2.%Self: %D2.type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
@@ -946,47 +946,47 @@ fn F() {
 // CHECK:STDOUT:     complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     .Self = constants.%.5c1
+// CHECK:STDOUT:     .Self = constants.%C.4bd
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.3 {
+// CHECK:STDOUT: class @C.4 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.6ae
+// CHECK:STDOUT:   .Self = constants.%C.6f6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.4 {
+// CHECK:STDOUT: class @C.5 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.1c0
+// CHECK:STDOUT:   .Self = constants.%C.0b8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.5 {
+// CHECK:STDOUT: class @C.6 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.4b5
+// CHECK:STDOUT:   .Self = constants.%C.6f1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F(@D2.%Self: %D2.type) {
-// CHECK:STDOUT:   fn(%x.param_patt: %C);
+// CHECK:STDOUT:   fn(%x.param_patt: %C.f79);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D3(constants.%Self.8cf) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%Self.8cf) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.1(constants.%Self.8cf) {}
+// CHECK:STDOUT: specific @C.2(constants.%Self.8cf) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D3(%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @.2(constants.%Self.8cf) {}
+// CHECK:STDOUT: specific @C.3(constants.%Self.8cf) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_alias.carbon
 // CHECK:STDOUT:
@@ -1004,7 +1004,7 @@ fn F() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:   %.loc12: type = bind_alias <none>, %C.decl [template = constants.%C]
+// CHECK:STDOUT:   %C: type = bind_alias C, %C.decl [template = constants.%C]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
@@ -1195,10 +1195,10 @@ fn F() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
-// CHECK:STDOUT:   %.a95: type = class_type @.1 [template]
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [template]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
-// CHECK:STDOUT:   %.fb7: type = class_type @.2 [template]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -1216,24 +1216,24 @@ fn F() {
 // CHECK:STDOUT:     %C.ref: <error> = name_ref C, <error> [template = <error>]
 // CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.decl.loc18: type = class_decl @.1 [template = constants.%.a95] {} {}
-// CHECK:STDOUT:   %.decl.loc23: type = class_decl @.2 [template = constants.%.fb7] {} {}
+// CHECK:STDOUT:   %C.decl.loc18: type = class_decl @C.1 [template = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %C.decl.loc23: type = class_decl @C.2 [template = constants.%C.9f4] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.1 {
+// CHECK:STDOUT: class @C.1 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.a95
+// CHECK:STDOUT:   .Self = constants.%C.f79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.2 {
+// CHECK:STDOUT: class @C.2 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.fb7
+// CHECK:STDOUT:   .Self = constants.%C.9f4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%x.param_patt: <error>);
@@ -1243,13 +1243,13 @@ fn F() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
-// CHECK:STDOUT:   %A: type = class_type @A [template]
+// CHECK:STDOUT:   %A.666: type = class_type @A.1 [template]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %B: type = class_type @B [template]
-// CHECK:STDOUT:   %B.elem: type = unbound_element_type %B, %A [template]
-// CHECK:STDOUT:   %.96d: type = class_type @.1 [template]
-// CHECK:STDOUT:   %struct_type.v: type = struct_type {.v: %A} [template]
+// CHECK:STDOUT:   %B.elem: type = unbound_element_type %B, %A.666 [template]
+// CHECK:STDOUT:   %A.9b6: type = class_type @A.2 [template]
+// CHECK:STDOUT:   %struct_type.v: type = struct_type {.v: %A.666} [template]
 // CHECK:STDOUT:   %complete_type.57e: <witness> = complete_type_witness %struct_type.v [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1260,12 +1260,12 @@ fn F() {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @A {
+// CHECK:STDOUT: class @A.1 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .Self = constants.%A.666
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
@@ -1274,7 +1274,7 @@ fn F() {
 // CHECK:STDOUT:     %.loc9_5: %B.elem = var_pattern %.loc9_10
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.var: ref %B.elem = var <none>
-// CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.96d] {} {}
+// CHECK:STDOUT:   %A.decl: type = class_decl @A.2 [template = constants.%A.9b6] {} {}
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [template = constants.%complete_type.57e]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
@@ -1283,17 +1283,17 @@ fn F() {
 // CHECK:STDOUT:   .v = %.loc9_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @.1 {
+// CHECK:STDOUT: class @A.2 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%.96d
+// CHECK:STDOUT:   .Self = constants.%A.9b6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.decl: type = class_decl @A [template = constants.%A] {} {}
+// CHECK:STDOUT:   %A.decl: type = class_decl @A.1 [template = constants.%A.666] {} {}
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {} {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import_access.carbon
@@ -412,8 +412,8 @@ private interface Redecl {}
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
-// CHECK:STDOUT:   %.type: type = facet_type <@.1> [template]
-// CHECK:STDOUT:   %Self: %.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %Forward.type: type = facet_type <@Forward> [template]
+// CHECK:STDOUT:   %Self: %Forward.type = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -433,11 +433,11 @@ private interface Redecl {}
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %i: <error> = bind_name i, %i.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.decl: type = interface_decl @.1 [template = constants.%.type] {} {}
+// CHECK:STDOUT:   %Forward.decl: type = interface_decl @Forward [template = constants.%Forward.type] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @.1 {
-// CHECK:STDOUT:   %Self: %.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT: interface @Forward {
+// CHECK:STDOUT:   %Self: %Forward.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self


### PR DESCRIPTION
i.e. Support `Poisoned` in `NameContext::name_id_for_new_inst()`.
Part of #4622.