### PR TITLE
Add SemIR::MakeSymbolicConstantId(int)

### DIFF
--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -246,6 +246,9 @@ LLVM_DUMP_METHOD static auto MakeClassId(int id) -> ClassId {
 LLVM_DUMP_METHOD static auto MakeConstantId(int id) -> ConstantId {
   return ConstantId(id);
 }
+LLVM_DUMP_METHOD static auto MakeSymbolicConstantId(int id) -> ConstantId {
+  return ConstantId::ForSymbolicConstantIndex(id);
+}
 LLVM_DUMP_METHOD static auto MakeEntityNameId(int id) -> EntityNameId {
   return EntityNameId(id);
 }


### PR DESCRIPTION
Symbolic constants are negative values (starting at -3 at the moment) but instead of having to figure the correct integer value for MakeConstantId, provide a function to make a symbolic constant directly.
