### PR TITLE
Deduce facet values for arguments to generic fns receiving a facet type

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -335,6 +335,9 @@ auto DeductionContext::Deduce() -> bool {
       DiagnosticAnnotationScope annotate_diagnostics(
           &context().emitter(),
           [&](auto& builder) { NoteInitializingParam(param_id, builder); });
+      // TODO: The call logic should reuse the conversion here (if any) instead
+      // of doing the same conversion again. At the moment we throw away the
+      // converted arg_id.
       arg_id = ConvertToValueOfType(context(), loc_id_, arg_id, param_type_id);
       if (arg_id == SemIR::ErrorInst::SingletonInstId) {
         return false;
@@ -434,6 +437,20 @@ auto DeductionContext::Deduce() -> bool {
       case SemIR::StructValue::Kind:
         // TODO: Match field name order between param and arg.
         break;
+
+      case SemIR::FacetAccessType::Kind:
+        // Given `fn F[G:! Interface](g: G)`, the type of `g` is `G as type`.
+        // `G` is a symbolic binding, whose type is a facet type, but `G as
+        // type` converts into a `FacetAccessType`.
+        //
+        // When we see a `FacetAccessType` parameter here, we want to deduce the
+        // facet type of `G`, not `G as type`, for the argument (so that the
+        // argument would be a facet value, whose type is the same facet type of
+        // `G`. So here we "undo" the `as type` operation that's built into the
+        // `g` parameter's type.
+        Add(param_inst.As<SemIR::FacetAccessType>().facet_value_inst_id, arg_id,
+            needs_substitution);
+        continue;
 
         // TODO: Handle more cases.
 

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -551,7 +551,6 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
       auto param_type_const_id = SubstConstant(
           context(), binding_type_id.AsConstantId(), substitutions_);
       CARBON_CHECK(param_type_const_id.has_value());
-      CARBON_CHECK(!param_type_const_id.is_symbolic());
       binding_type_id = context().GetTypeIdForTypeConstant(param_type_const_id);
 
       // TODO: Suppress diagnostics here if `diagnose_` is false.

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -130,10 +130,20 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
     }
   }
 
-  // TODO: Add a better impl lookup system. At the very least, we should only be
-  // considering impls that are for the same interface we're querying. We can
-  // also skip impls that mention any types that aren't part of our impl query.
   for (const auto& impl : context.impls().array_ref()) {
+    // If impl.constraint_id is not symbolic, and doesn't match the query, then
+    // we don't need to proceed.
+    auto impl_interface_const_id =
+        context.constant_values().Get(impl.constraint_id);
+    if (!impl_interface_const_id.is_symbolic() &&
+        interface_const_id != impl_interface_const_id) {
+      continue;
+    }
+
+    // TODO: If the interface id of the `impl` and the query are not the same,
+    // then we can skip this `impl`. (The interface id is the root of the
+    // constraint, the unique `interface` declaration.)
+
     auto specific_id = SemIR::SpecificId::None;
     if (impl.generic_id.has_value()) {
       specific_id = DeduceImplArguments(context, loc_id, impl, type_const_id,

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_type_to_generic_facet_value.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_type_to_generic_facet_value.carbon
@@ -8,6 +8,20 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_type_to_generic_facet_value.carbon
 
+// --- core.carbon
+
+package Core;
+
+interface ImplicitAs(T:! type) {
+  fn Convert[self: Self]() -> T;
+}
+
+// --- generic_facet_type.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
 interface Generic(Scalar:! type) {
   fn F();
 }
@@ -33,7 +47,125 @@ fn H() {
   PassThroughToGenericMethod(GenericParam, ImplsGeneric);
 }
 
-// CHECK:STDOUT: --- convert_class_type_to_generic_facet_value.carbon
+// --- generic_facet_type_from_implicit_param.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
+interface Generic(Scalar:! type) {
+  fn F();
+}
+
+class GenericParam {}
+
+class ImplsGeneric {}
+impl ImplsGeneric as Generic(GenericParam) {
+  fn F() {}
+}
+
+fn CallGenericMethod[T:! type](U:! Generic(T), t: T) {}
+
+fn G() {
+  CallGenericMethod(ImplsGeneric, {} as GenericParam);
+}
+
+// CHECK:STDOUT: --- core.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [template]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert: %Convert.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type %ImplicitAs.type.07f [symbolic]
+// CHECK:STDOUT:   %assoc0: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %T.patt.loc4_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_22.1, runtime_param<none> [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc4_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%T.loc4_22.1: type) {
+// CHECK:STDOUT:   %T.loc4_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T.loc4_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T.loc4_22.2) [symbolic = %Convert.type (constants.%Convert.type)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type) = struct_value () [symbolic = %Convert (constants.%Convert)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_32.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type) = fn_decl @Convert [symbolic = @ImplicitAs.%Convert (constants.%Convert)] {
+// CHECK:STDOUT:       %self.patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = binding_pattern self
+// CHECK:STDOUT:       %self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param_pattern %self.patt, runtime_param0
+// CHECK:STDOUT:       %return.patt: @Convert.%T (%T) = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: @Convert.%T (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @ImplicitAs.%T.loc4_22.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %self.param: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param runtime_param0
+// CHECK:STDOUT:       %.loc5_20.1: type = splice_block %.loc5_20.3 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:         %.loc5_20.2: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%T) [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.ref: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc5_20.2 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.as_type.loc5_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:         %.loc5_20.3: type = converted %Self.ref, %Self.as_type.loc5_20.2 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.%T (%T) = out_param runtime_param1
+// CHECK:STDOUT:       %return: ref @Convert.%T (%T) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_32.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Convert = %assoc0.loc5_32.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(@ImplicitAs.%T.loc4_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_22.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1 => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc4_22.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- generic_facet_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Scalar: type = bind_symbolic_name Scalar, 0 [symbolic]
@@ -78,8 +210,15 @@ fn H() {
 // CHECK:STDOUT:   %PassThroughToGenericMethod.specific_fn: <specific function> = specific_function %PassThroughToGenericMethod, @PassThroughToGenericMethod(%GenericParam, %Generic.facet) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     .Generic = %Generic.decl
 // CHECK:STDOUT:     .GenericParam = %GenericParam.decl
 // CHECK:STDOUT:     .ImplsGeneric = %ImplsGeneric.decl
@@ -88,12 +227,13 @@ fn H() {
 // CHECK:STDOUT:     .PassThroughToGenericMethod = %PassThroughToGenericMethod.decl
 // CHECK:STDOUT:     .H = %H.decl
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Generic.decl: %Generic.type.c21 = interface_decl @Generic [template = constants.%Generic.generic] {
-// CHECK:STDOUT:     %Scalar.patt.loc11_19.1: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc11_19.2 (constants.%Scalar.patt)]
-// CHECK:STDOUT:     %Scalar.param_patt: type = value_param_pattern %Scalar.patt.loc11_19.1, runtime_param<none> [symbolic = %Scalar.patt.loc11_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:     %Scalar.patt.loc6_19.1: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:     %Scalar.param_patt: type = value_param_pattern %Scalar.patt.loc6_19.1, runtime_param<none> [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Scalar.param: type = value_param runtime_param<none>
-// CHECK:STDOUT:     %Scalar.loc11_19.1: type = bind_symbolic_name Scalar, 0, %Scalar.param [symbolic = %Scalar.loc11_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:     %Scalar.loc6_19.1: type = bind_symbolic_name Scalar, 0, %Scalar.param [symbolic = %Scalar.loc6_19.2 (constants.%Scalar)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %GenericParam.decl: type = class_decl @GenericParam [template = constants.%GenericParam] {} {}
 // CHECK:STDOUT:   %ImplsGeneric.decl: type = class_decl @ImplsGeneric [template = constants.%ImplsGeneric] {} {}
@@ -105,61 +245,61 @@ fn H() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl) [template = constants.%impl_witness]
 // CHECK:STDOUT:   %CallGenericMethod.decl: %CallGenericMethod.type = fn_decl @CallGenericMethod [template = constants.%CallGenericMethod] {
-// CHECK:STDOUT:     %T.patt.loc22_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc22_22.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc22_22.1, runtime_param<none> [symbolic = %T.patt.loc22_22.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %U.patt.loc22_32.1: @CallGenericMethod.%Generic.type.loc22_45.2 (%Generic.type.91ccba.2) = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc22_32.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: @CallGenericMethod.%Generic.type.loc22_45.2 (%Generic.type.91ccba.2) = value_param_pattern %U.patt.loc22_32.1, runtime_param<none> [symbolic = %U.patt.loc22_32.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %T.patt.loc17_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_22.1, runtime_param<none> [symbolic = %T.patt.loc17_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %U.patt.loc17_32.1: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc17_32.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = value_param_pattern %U.patt.loc17_32.1, runtime_param<none> [symbolic = %U.patt.loc17_32.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
-// CHECK:STDOUT:     %T.loc22_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc22_22.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: @CallGenericMethod.%Generic.type.loc22_45.2 (%Generic.type.91ccba.2) = value_param runtime_param<none>
-// CHECK:STDOUT:     %.loc22: type = splice_block %Generic.type.loc22_45.1 [symbolic = %Generic.type.loc22_45.2 (constants.%Generic.type.91ccba.2)] {
+// CHECK:STDOUT:     %T.loc17_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:     %U.param: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = value_param runtime_param<none>
+// CHECK:STDOUT:     %.loc17: type = splice_block %Generic.type.loc17_45.1 [symbolic = %Generic.type.loc17_45.2 (constants.%Generic.type.91ccba.2)] {
 // CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
-// CHECK:STDOUT:       %T.ref: type = name_ref T, %T.loc22_22.1 [symbolic = %T.loc22_22.2 (constants.%T)]
-// CHECK:STDOUT:       %Generic.type.loc22_45.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc22_45.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, %T.loc17_22.1 [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:       %Generic.type.loc17_45.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc17_45.2 (constants.%Generic.type.91ccba.2)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %U.loc22_32.1: @CallGenericMethod.%Generic.type.loc22_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc22_32.2 (constants.%U)]
+// CHECK:STDOUT:     %U.loc17_32.1: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc17_32.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
 // CHECK:STDOUT:   %PassThroughToGenericMethod.decl: %PassThroughToGenericMethod.type = fn_decl @PassThroughToGenericMethod [template = constants.%PassThroughToGenericMethod] {
-// CHECK:STDOUT:     %T.patt.loc28_31.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc28_31.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc28_31.1, runtime_param<none> [symbolic = %T.patt.loc28_31.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %U.patt.loc28_41.1: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2) = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc28_41.2 (constants.%U.patt)]
-// CHECK:STDOUT:     %U.param_patt: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2) = value_param_pattern %U.patt.loc28_41.1, runtime_param<none> [symbolic = %U.patt.loc28_41.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %T.patt.loc23_31.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc23_31.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc23_31.1, runtime_param<none> [symbolic = %T.patt.loc23_31.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %U.patt.loc23_41.1: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2) = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc23_41.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2) = value_param_pattern %U.patt.loc23_41.1, runtime_param<none> [symbolic = %U.patt.loc23_41.2 (constants.%U.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
-// CHECK:STDOUT:     %T.loc28_31.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc28_31.2 (constants.%T)]
-// CHECK:STDOUT:     %U.param: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2) = value_param runtime_param<none>
-// CHECK:STDOUT:     %.loc28: type = splice_block %Generic.type.loc28_54.1 [symbolic = %Generic.type.loc28_54.2 (constants.%Generic.type.91ccba.2)] {
+// CHECK:STDOUT:     %T.loc23_31.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc23_31.2 (constants.%T)]
+// CHECK:STDOUT:     %U.param: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2) = value_param runtime_param<none>
+// CHECK:STDOUT:     %.loc23: type = splice_block %Generic.type.loc23_54.1 [symbolic = %Generic.type.loc23_54.2 (constants.%Generic.type.91ccba.2)] {
 // CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
-// CHECK:STDOUT:       %T.ref.loc28: type = name_ref T, %T.loc28_31.1 [symbolic = %T.loc28_31.2 (constants.%T)]
-// CHECK:STDOUT:       %Generic.type.loc28_54.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc28_54.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:       %T.ref.loc23: type = name_ref T, %T.loc23_31.1 [symbolic = %T.loc23_31.2 (constants.%T)]
+// CHECK:STDOUT:       %Generic.type.loc23_54.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc23_54.2 (constants.%Generic.type.91ccba.2)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %U.loc28_41.1: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc28_41.2 (constants.%U)]
+// CHECK:STDOUT:     %U.loc23_41.1: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc23_41.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [template = constants.%H] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic interface @Generic(%Scalar.loc11_19.1: type) {
-// CHECK:STDOUT:   %Scalar.loc11_19.2: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc11_19.2 (constants.%Scalar)]
-// CHECK:STDOUT:   %Scalar.patt.loc11_19.2: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc11_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT: generic interface @Generic(%Scalar.loc6_19.1: type) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc6_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Generic.type: type = facet_type <@Generic, @Generic(%Scalar.loc11_19.2)> [symbolic = %Generic.type (constants.%Generic.type.91ccba.1)]
+// CHECK:STDOUT:   %Generic.type: type = facet_type <@Generic, @Generic(%Scalar.loc6_19.2)> [symbolic = %Generic.type (constants.%Generic.type.91ccba.1)]
 // CHECK:STDOUT:   %Self.2: %Generic.type.91ccba.1 = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%Scalar.loc11_19.2) [symbolic = %F.type (constants.%F.type.f43)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%Scalar.loc6_19.2) [symbolic = %F.type (constants.%F.type.f43)]
 // CHECK:STDOUT:   %F: @Generic.%F.type (%F.type.f43) = struct_value () [symbolic = %F (constants.%F.8a2)]
 // CHECK:STDOUT:   %Generic.assoc_type: type = assoc_entity_type @Generic.%Generic.type (%Generic.type.91ccba.1) [symbolic = %Generic.assoc_type (constants.%Generic.assoc_type.de9)]
-// CHECK:STDOUT:   %assoc0.loc12_9.2: @Generic.%Generic.assoc_type (%Generic.assoc_type.de9) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc12_9.2 (constants.%assoc0.29c)]
+// CHECK:STDOUT:   %assoc0.loc7_9.2: @Generic.%Generic.assoc_type (%Generic.assoc_type.de9) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc7_9.2 (constants.%assoc0.29c)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
 // CHECK:STDOUT:     %F.decl: @Generic.%F.type (%F.type.f43) = fn_decl @F.1 [symbolic = @Generic.%F (constants.%F.8a2)] {} {}
-// CHECK:STDOUT:     %assoc0.loc12_9.1: @Generic.%Generic.assoc_type (%Generic.assoc_type.de9) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc12_9.2 (constants.%assoc0.29c)]
+// CHECK:STDOUT:     %assoc0.loc7_9.1: @Generic.%Generic.assoc_type (%Generic.assoc_type.de9) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc7_9.2 (constants.%assoc0.29c)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.1
-// CHECK:STDOUT:     .F = %assoc0.loc12_9.1
+// CHECK:STDOUT:     .F = %assoc0.loc7_9.1
 // CHECK:STDOUT:     witness = (%F.decl)
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -188,7 +328,7 @@ fn H() {
 // CHECK:STDOUT:   .Self = constants.%ImplsGeneric
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.1(@Generic.%Scalar.loc11_19.1: type, @Generic.%Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1)) {
+// CHECK:STDOUT: generic fn @F.1(@Generic.%Scalar.loc6_19.1: type, @Generic.%Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1)) {
 // CHECK:STDOUT:   fn();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -197,16 +337,16 @@ fn H() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @CallGenericMethod(%T.loc22_22.1: type, %U.loc22_32.1: @CallGenericMethod.%Generic.type.loc22_45.2 (%Generic.type.91ccba.2)) {
-// CHECK:STDOUT:   %T.loc22_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc22_22.2 (constants.%T)]
-// CHECK:STDOUT:   %T.patt.loc22_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc22_22.2 (constants.%T.patt)]
-// CHECK:STDOUT:   %Generic.type.loc22_45.2: type = facet_type <@Generic, @Generic(%T.loc22_22.2)> [symbolic = %Generic.type.loc22_45.2 (constants.%Generic.type.91ccba.2)]
-// CHECK:STDOUT:   %U.loc22_32.2: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic = %U.loc22_32.2 (constants.%U)]
-// CHECK:STDOUT:   %U.patt.loc22_32.2: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc22_32.2 (constants.%U.patt)]
+// CHECK:STDOUT: generic fn @CallGenericMethod(%T.loc17_22.1: type, %U.loc17_32.1: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   %T.loc17_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc17_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %Generic.type.loc17_45.2: type = facet_type <@Generic, @Generic(%T.loc17_22.2)> [symbolic = %Generic.type.loc17_45.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:   %U.loc17_32.2: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic = %U.loc17_32.2 (constants.%U)]
+// CHECK:STDOUT:   %U.patt.loc17_32.2: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc17_32.2 (constants.%U.patt)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%T.param_patt: type, %U.param_patt: @CallGenericMethod.%Generic.type.loc22_45.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   fn(%T.param_patt: type, %U.param_patt: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
@@ -218,29 +358,29 @@ fn H() {
 // CHECK:STDOUT:   %GenericParam.ref: type = name_ref GenericParam, file.%GenericParam.decl [template = constants.%GenericParam]
 // CHECK:STDOUT:   %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [template = constants.%ImplsGeneric]
 // CHECK:STDOUT:   %Generic.facet: %Generic.type.769 = facet_value constants.%ImplsGeneric, constants.%impl_witness [template = constants.%Generic.facet]
-// CHECK:STDOUT:   %.loc25: %Generic.type.769 = converted constants.%ImplsGeneric, %Generic.facet [template = constants.%Generic.facet]
-// CHECK:STDOUT:   %CallGenericMethod.specific_fn: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%GenericParam, %.loc25) [template = constants.%CallGenericMethod.specific_fn.d8c]
+// CHECK:STDOUT:   %.loc20: %Generic.type.769 = converted constants.%ImplsGeneric, %Generic.facet [template = constants.%Generic.facet]
+// CHECK:STDOUT:   %CallGenericMethod.specific_fn: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%GenericParam, %.loc20) [template = constants.%CallGenericMethod.specific_fn.d8c]
 // CHECK:STDOUT:   %CallGenericMethod.call: init %empty_tuple.type = call %CallGenericMethod.specific_fn()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @PassThroughToGenericMethod(%T.loc28_31.1: type, %U.loc28_41.1: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2)) {
-// CHECK:STDOUT:   %T.loc28_31.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc28_31.2 (constants.%T)]
-// CHECK:STDOUT:   %T.patt.loc28_31.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc28_31.2 (constants.%T.patt)]
-// CHECK:STDOUT:   %Generic.type.loc28_54.2: type = facet_type <@Generic, @Generic(%T.loc28_31.2)> [symbolic = %Generic.type.loc28_54.2 (constants.%Generic.type.91ccba.2)]
-// CHECK:STDOUT:   %U.loc28_41.2: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic = %U.loc28_41.2 (constants.%U)]
-// CHECK:STDOUT:   %U.patt.loc28_41.2: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc28_41.2 (constants.%U.patt)]
+// CHECK:STDOUT: generic fn @PassThroughToGenericMethod(%T.loc23_31.1: type, %U.loc23_41.1: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   %T.loc23_31.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc23_31.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc23_31.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc23_31.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %Generic.type.loc23_54.2: type = facet_type <@Generic, @Generic(%T.loc23_31.2)> [symbolic = %Generic.type.loc23_54.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:   %U.loc23_41.2: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic = %U.loc23_41.2 (constants.%U)]
+// CHECK:STDOUT:   %U.patt.loc23_41.2: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc23_41.2 (constants.%U.patt)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %CallGenericMethod.specific_fn.loc29_3.2: <specific function> = specific_function constants.%CallGenericMethod, @CallGenericMethod(%T.loc28_31.2, %U.loc28_41.2) [symbolic = %CallGenericMethod.specific_fn.loc29_3.2 (constants.%CallGenericMethod.specific_fn.a24)]
+// CHECK:STDOUT:   %CallGenericMethod.specific_fn.loc24_3.2: <specific function> = specific_function constants.%CallGenericMethod, @CallGenericMethod(%T.loc23_31.2, %U.loc23_41.2) [symbolic = %CallGenericMethod.specific_fn.loc24_3.2 (constants.%CallGenericMethod.specific_fn.a24)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%T.param_patt: type, %U.param_patt: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   fn(%T.param_patt: type, %U.param_patt: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %CallGenericMethod.ref: %CallGenericMethod.type = name_ref CallGenericMethod, file.%CallGenericMethod.decl [template = constants.%CallGenericMethod]
-// CHECK:STDOUT:     %T.ref.loc29: type = name_ref T, %T.loc28_31.1 [symbolic = %T.loc28_31.2 (constants.%T)]
-// CHECK:STDOUT:     %U.ref: @PassThroughToGenericMethod.%Generic.type.loc28_54.2 (%Generic.type.91ccba.2) = name_ref U, %U.loc28_41.1 [symbolic = %U.loc28_41.2 (constants.%U)]
-// CHECK:STDOUT:     %CallGenericMethod.specific_fn.loc29_3.1: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%T, constants.%U) [symbolic = %CallGenericMethod.specific_fn.loc29_3.2 (constants.%CallGenericMethod.specific_fn.a24)]
-// CHECK:STDOUT:     %CallGenericMethod.call: init %empty_tuple.type = call %CallGenericMethod.specific_fn.loc29_3.1()
+// CHECK:STDOUT:     %T.ref.loc24: type = name_ref T, %T.loc23_31.1 [symbolic = %T.loc23_31.2 (constants.%T)]
+// CHECK:STDOUT:     %U.ref: @PassThroughToGenericMethod.%Generic.type.loc23_54.2 (%Generic.type.91ccba.2) = name_ref U, %U.loc23_41.1 [symbolic = %U.loc23_41.2 (constants.%U)]
+// CHECK:STDOUT:     %CallGenericMethod.specific_fn.loc24_3.1: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%T, constants.%U) [symbolic = %CallGenericMethod.specific_fn.loc24_3.2 (constants.%CallGenericMethod.specific_fn.a24)]
+// CHECK:STDOUT:     %CallGenericMethod.call: init %empty_tuple.type = call %CallGenericMethod.specific_fn.loc24_3.1()
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -251,24 +391,24 @@ fn H() {
 // CHECK:STDOUT:   %GenericParam.ref: type = name_ref GenericParam, file.%GenericParam.decl [template = constants.%GenericParam]
 // CHECK:STDOUT:   %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [template = constants.%ImplsGeneric]
 // CHECK:STDOUT:   %Generic.facet: %Generic.type.769 = facet_value constants.%ImplsGeneric, constants.%impl_witness [template = constants.%Generic.facet]
-// CHECK:STDOUT:   %.loc33: %Generic.type.769 = converted constants.%ImplsGeneric, %Generic.facet [template = constants.%Generic.facet]
-// CHECK:STDOUT:   %PassThroughToGenericMethod.specific_fn: <specific function> = specific_function %PassThroughToGenericMethod.ref, @PassThroughToGenericMethod(constants.%GenericParam, %.loc33) [template = constants.%PassThroughToGenericMethod.specific_fn]
+// CHECK:STDOUT:   %.loc28: %Generic.type.769 = converted constants.%ImplsGeneric, %Generic.facet [template = constants.%Generic.facet]
+// CHECK:STDOUT:   %PassThroughToGenericMethod.specific_fn: <specific function> = specific_function %PassThroughToGenericMethod.ref, @PassThroughToGenericMethod(constants.%GenericParam, %.loc28) [template = constants.%PassThroughToGenericMethod.specific_fn]
 // CHECK:STDOUT:   %PassThroughToGenericMethod.call: init %empty_tuple.type = call %PassThroughToGenericMethod.specific_fn()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%Scalar) {
-// CHECK:STDOUT:   %Scalar.loc11_19.2 => constants.%Scalar
-// CHECK:STDOUT:   %Scalar.patt.loc11_19.2 => constants.%Scalar
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%Scalar
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%Scalar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Scalar, constants.%Self) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(%Scalar.loc11_19.2) {}
+// CHECK:STDOUT: specific @Generic(%Scalar.loc6_19.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%GenericParam) {
-// CHECK:STDOUT:   %Scalar.loc11_19.2 => constants.%GenericParam
-// CHECK:STDOUT:   %Scalar.patt.loc11_19.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%GenericParam
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Generic.type => constants.%Generic.type.769
@@ -276,74 +416,320 @@ fn H() {
 // CHECK:STDOUT:   %F.type => constants.%F.type.4cf
 // CHECK:STDOUT:   %F => constants.%F.118
 // CHECK:STDOUT:   %Generic.assoc_type => constants.%Generic.assoc_type.9f1
-// CHECK:STDOUT:   %assoc0.loc12_9.2 => constants.%assoc0.9b7
+// CHECK:STDOUT:   %assoc0.loc7_9.2 => constants.%assoc0.9b7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%GenericParam, constants.%Generic.facet) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%T) {
-// CHECK:STDOUT:   %Scalar.loc11_19.2 => constants.%T
-// CHECK:STDOUT:   %Scalar.patt.loc11_19.2 => constants.%T
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%T
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallGenericMethod(constants.%T, constants.%U) {
-// CHECK:STDOUT:   %T.loc22_22.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc22_22.2 => constants.%T
-// CHECK:STDOUT:   %Generic.type.loc22_45.2 => constants.%Generic.type.91ccba.2
-// CHECK:STDOUT:   %U.loc22_32.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc22_32.2 => constants.%U
+// CHECK:STDOUT:   %T.loc17_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc17_22.2 => constants.%T
+// CHECK:STDOUT:   %Generic.type.loc17_45.2 => constants.%Generic.type.91ccba.2
+// CHECK:STDOUT:   %U.loc17_32.2 => constants.%U
+// CHECK:STDOUT:   %U.patt.loc17_32.2 => constants.%U
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(@CallGenericMethod.%T.loc22_22.2) {}
+// CHECK:STDOUT: specific @Generic(@CallGenericMethod.%T.loc17_22.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @CallGenericMethod(constants.%GenericParam, @G.%.loc25) {
-// CHECK:STDOUT:   %T.loc22_22.2 => constants.%GenericParam
-// CHECK:STDOUT:   %T.patt.loc22_22.2 => constants.%GenericParam
-// CHECK:STDOUT:   %Generic.type.loc22_45.2 => constants.%Generic.type.769
-// CHECK:STDOUT:   %U.loc22_32.2 => constants.%Generic.facet
-// CHECK:STDOUT:   %U.patt.loc22_32.2 => constants.%Generic.facet
+// CHECK:STDOUT: specific @CallGenericMethod(constants.%GenericParam, @G.%.loc20) {
+// CHECK:STDOUT:   %T.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc17_45.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc17_32.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %U.patt.loc17_32.2 => constants.%Generic.facet
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallGenericMethod(constants.%GenericParam, constants.%Generic.facet) {
-// CHECK:STDOUT:   %T.loc22_22.2 => constants.%GenericParam
-// CHECK:STDOUT:   %T.patt.loc22_22.2 => constants.%GenericParam
-// CHECK:STDOUT:   %Generic.type.loc22_45.2 => constants.%Generic.type.769
-// CHECK:STDOUT:   %U.loc22_32.2 => constants.%Generic.facet
-// CHECK:STDOUT:   %U.patt.loc22_32.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %T.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc17_45.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc17_32.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %U.patt.loc17_32.2 => constants.%Generic.facet
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @PassThroughToGenericMethod(constants.%T, constants.%U) {
-// CHECK:STDOUT:   %T.loc28_31.2 => constants.%T
-// CHECK:STDOUT:   %T.patt.loc28_31.2 => constants.%T
-// CHECK:STDOUT:   %Generic.type.loc28_54.2 => constants.%Generic.type.91ccba.2
-// CHECK:STDOUT:   %U.loc28_41.2 => constants.%U
-// CHECK:STDOUT:   %U.patt.loc28_41.2 => constants.%U
+// CHECK:STDOUT:   %T.loc23_31.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc23_31.2 => constants.%T
+// CHECK:STDOUT:   %Generic.type.loc23_54.2 => constants.%Generic.type.91ccba.2
+// CHECK:STDOUT:   %U.loc23_41.2 => constants.%U
+// CHECK:STDOUT:   %U.patt.loc23_41.2 => constants.%U
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Generic(@PassThroughToGenericMethod.%T.loc28_31.2) {}
+// CHECK:STDOUT: specific @Generic(@PassThroughToGenericMethod.%T.loc23_31.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @CallGenericMethod(@PassThroughToGenericMethod.%T.loc28_31.2, @PassThroughToGenericMethod.%U.loc28_41.2) {}
+// CHECK:STDOUT: specific @CallGenericMethod(@PassThroughToGenericMethod.%T.loc23_31.2, @PassThroughToGenericMethod.%U.loc23_41.2) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @PassThroughToGenericMethod(constants.%GenericParam, @H.%.loc33) {
-// CHECK:STDOUT:   %T.loc28_31.2 => constants.%GenericParam
-// CHECK:STDOUT:   %T.patt.loc28_31.2 => constants.%GenericParam
-// CHECK:STDOUT:   %Generic.type.loc28_54.2 => constants.%Generic.type.769
-// CHECK:STDOUT:   %U.loc28_41.2 => constants.%Generic.facet
-// CHECK:STDOUT:   %U.patt.loc28_41.2 => constants.%Generic.facet
+// CHECK:STDOUT: specific @PassThroughToGenericMethod(constants.%GenericParam, @H.%.loc28) {
+// CHECK:STDOUT:   %T.loc23_31.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc23_31.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc23_54.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc23_41.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %U.patt.loc23_41.2 => constants.%Generic.facet
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %CallGenericMethod.specific_fn.loc29_3.2 => constants.%CallGenericMethod.specific_fn.d8c
+// CHECK:STDOUT:   %CallGenericMethod.specific_fn.loc24_3.2 => constants.%CallGenericMethod.specific_fn.d8c
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @PassThroughToGenericMethod(constants.%GenericParam, constants.%Generic.facet) {
-// CHECK:STDOUT:   %T.loc28_31.2 => constants.%GenericParam
-// CHECK:STDOUT:   %T.patt.loc28_31.2 => constants.%GenericParam
-// CHECK:STDOUT:   %Generic.type.loc28_54.2 => constants.%Generic.type.769
-// CHECK:STDOUT:   %U.loc28_41.2 => constants.%Generic.facet
-// CHECK:STDOUT:   %U.patt.loc28_41.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %T.loc23_31.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc23_31.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc23_54.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc23_41.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %U.patt.loc23_41.2 => constants.%Generic.facet
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- generic_facet_type_from_implicit_param.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Scalar: type = bind_symbolic_name Scalar, 0 [symbolic]
+// CHECK:STDOUT:   %Scalar.patt: type = symbolic_binding_pattern Scalar, 0 [symbolic]
+// CHECK:STDOUT:   %Generic.type.c21: type = generic_interface_type @Generic [template]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [template]
+// CHECK:STDOUT:   %Generic.generic: %Generic.type.c21 = struct_value () [template]
+// CHECK:STDOUT:   %Generic.type.91ccba.1: type = facet_type <@Generic, @Generic(%Scalar)> [symbolic]
+// CHECK:STDOUT:   %Self: %Generic.type.91ccba.1 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %F.type.f43: type = fn_type @F.1, @Generic(%Scalar) [symbolic]
+// CHECK:STDOUT:   %F.8a2: %F.type.f43 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Generic.assoc_type.de9: type = assoc_entity_type %Generic.type.91ccba.1 [symbolic]
+// CHECK:STDOUT:   %assoc0.29c: %Generic.assoc_type.de9 = assoc_entity element0, @Generic.%F.decl [symbolic]
+// CHECK:STDOUT:   %GenericParam: type = class_type @GenericParam [template]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
+// CHECK:STDOUT:   %ImplsGeneric: type = class_type @ImplsGeneric [template]
+// CHECK:STDOUT:   %Generic.type.769: type = facet_type <@Generic, @Generic(%GenericParam)> [template]
+// CHECK:STDOUT:   %F.type.4cf: type = fn_type @F.1, @Generic(%GenericParam) [template]
+// CHECK:STDOUT:   %F.118: %F.type.4cf = struct_value () [template]
+// CHECK:STDOUT:   %Generic.assoc_type.9f1: type = assoc_entity_type %Generic.type.769 [template]
+// CHECK:STDOUT:   %assoc0.9b7: %Generic.assoc_type.9f1 = assoc_entity element0, @Generic.%F.decl [template]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl) [template]
+// CHECK:STDOUT:   %F.type.17b: type = fn_type @F.2 [template]
+// CHECK:STDOUT:   %F.a56: %F.type.17b = struct_value () [template]
+// CHECK:STDOUT:   %Generic.facet: %Generic.type.769 = facet_value %ImplsGeneric, %impl_witness [template]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %Generic.type.91ccba.2: type = facet_type <@Generic, @Generic(%T)> [symbolic]
+// CHECK:STDOUT:   %U: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic]
+// CHECK:STDOUT:   %U.patt: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic]
+// CHECK:STDOUT:   %CallGenericMethod.type: type = fn_type @CallGenericMethod [template]
+// CHECK:STDOUT:   %CallGenericMethod: %CallGenericMethod.type = struct_value () [template]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T [symbolic]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %GenericParam.val: %GenericParam = struct_value () [template]
+// CHECK:STDOUT:   %CallGenericMethod.specific_fn: <specific function> = specific_function %CallGenericMethod, @CallGenericMethod(%GenericParam, %Generic.facet) [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Generic = %Generic.decl
+// CHECK:STDOUT:     .GenericParam = %GenericParam.decl
+// CHECK:STDOUT:     .ImplsGeneric = %ImplsGeneric.decl
+// CHECK:STDOUT:     .CallGenericMethod = %CallGenericMethod.decl
+// CHECK:STDOUT:     .G = %G.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Generic.decl: %Generic.type.c21 = interface_decl @Generic [template = constants.%Generic.generic] {
+// CHECK:STDOUT:     %Scalar.patt.loc6_19.1: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:     %Scalar.param_patt: type = value_param_pattern %Scalar.patt.loc6_19.1, runtime_param<none> [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Scalar.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Scalar.loc6_19.1: type = bind_symbolic_name Scalar, 0, %Scalar.param [symbolic = %Scalar.loc6_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %GenericParam.decl: type = class_decl @GenericParam [template = constants.%GenericParam] {} {}
+// CHECK:STDOUT:   %ImplsGeneric.decl: type = class_decl @ImplsGeneric [template = constants.%ImplsGeneric] {} {}
+// CHECK:STDOUT:   impl_decl @impl [template] {} {
+// CHECK:STDOUT:     %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [template = constants.%ImplsGeneric]
+// CHECK:STDOUT:     %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
+// CHECK:STDOUT:     %GenericParam.ref: type = name_ref GenericParam, file.%GenericParam.decl [template = constants.%GenericParam]
+// CHECK:STDOUT:     %Generic.type: type = facet_type <@Generic, @Generic(constants.%GenericParam)> [template = constants.%Generic.type.769]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl) [template = constants.%impl_witness]
+// CHECK:STDOUT:   %CallGenericMethod.decl: %CallGenericMethod.type = fn_decl @CallGenericMethod [template = constants.%CallGenericMethod] {
+// CHECK:STDOUT:     %T.patt.loc17_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_22.1, runtime_param<none> [symbolic = %T.patt.loc17_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %U.patt.loc17_32.1: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc17_32.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = value_param_pattern %U.patt.loc17_32.1, runtime_param<none> [symbolic = %U.patt.loc17_32.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %t.patt: @CallGenericMethod.%T.loc17_22.2 (%T) = binding_pattern t
+// CHECK:STDOUT:     %t.param_patt: @CallGenericMethod.%T.loc17_22.2 (%T) = value_param_pattern %t.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc17_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:     %U.param: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = value_param runtime_param<none>
+// CHECK:STDOUT:     %.loc17: type = splice_block %Generic.type.loc17_45.1 [symbolic = %Generic.type.loc17_45.2 (constants.%Generic.type.91ccba.2)] {
+// CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
+// CHECK:STDOUT:       %T.ref.loc17_44: type = name_ref T, %T.loc17_22.1 [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:       %Generic.type.loc17_45.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc17_45.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %U.loc17_32.1: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc17_32.2 (constants.%U)]
+// CHECK:STDOUT:     %t.param: @CallGenericMethod.%T.loc17_22.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.ref.loc17_51: type = name_ref T, %T.loc17_22.1 [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:     %t: @CallGenericMethod.%T.loc17_22.2 (%T) = bind_name t, %t.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @Generic(%Scalar.loc6_19.1: type) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc6_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Generic.type: type = facet_type <@Generic, @Generic(%Scalar.loc6_19.2)> [symbolic = %Generic.type (constants.%Generic.type.91ccba.1)]
+// CHECK:STDOUT:   %Self.2: %Generic.type.91ccba.1 = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%Scalar.loc6_19.2) [symbolic = %F.type (constants.%F.type.f43)]
+// CHECK:STDOUT:   %F: @Generic.%F.type (%F.type.f43) = struct_value () [symbolic = %F (constants.%F.8a2)]
+// CHECK:STDOUT:   %Generic.assoc_type: type = assoc_entity_type @Generic.%Generic.type (%Generic.type.91ccba.1) [symbolic = %Generic.assoc_type (constants.%Generic.assoc_type.de9)]
+// CHECK:STDOUT:   %assoc0.loc7_9.2: @Generic.%Generic.assoc_type (%Generic.assoc_type.de9) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc7_9.2 (constants.%assoc0.29c)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %F.decl: @Generic.%F.type (%F.type.f43) = fn_decl @F.1 [symbolic = @Generic.%F (constants.%F.8a2)] {} {}
+// CHECK:STDOUT:     %assoc0.loc7_9.1: @Generic.%Generic.assoc_type (%Generic.assoc_type.de9) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc7_9.2 (constants.%assoc0.29c)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .F = %assoc0.loc7_9.1
+// CHECK:STDOUT:     witness = (%F.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: %ImplsGeneric.ref as %Generic.type {
+// CHECK:STDOUT:   %F.decl: %F.type.17b = fn_decl @F.2 [template = constants.%F.a56] {} {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F.decl
+// CHECK:STDOUT:   witness = file.%impl_witness
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @GenericParam {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%GenericParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @ImplsGeneric {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%ImplsGeneric
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F.1(@Generic.%Scalar.loc6_19.1: type, @Generic.%Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1)) {
+// CHECK:STDOUT:   fn();
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.2() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @CallGenericMethod(%T.loc17_22.1: type, %U.loc17_32.1: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   %T.loc17_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc17_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc17_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %Generic.type.loc17_45.2: type = facet_type <@Generic, @Generic(%T.loc17_22.2)> [symbolic = %Generic.type.loc17_45.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:   %U.loc17_32.2: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic = %U.loc17_32.2 (constants.%U)]
+// CHECK:STDOUT:   %U.patt.loc17_32.2: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc17_32.2 (constants.%U.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @CallGenericMethod.%T.loc17_22.2 (%T) [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: type](%U.param_patt: @CallGenericMethod.%Generic.type.loc17_45.2 (%Generic.type.91ccba.2), %t.param_patt: @CallGenericMethod.%T.loc17_22.2 (%T)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %CallGenericMethod.ref: %CallGenericMethod.type = name_ref CallGenericMethod, file.%CallGenericMethod.decl [template = constants.%CallGenericMethod]
+// CHECK:STDOUT:   %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [template = constants.%ImplsGeneric]
+// CHECK:STDOUT:   %.loc20_36.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %GenericParam.ref: type = name_ref GenericParam, file.%GenericParam.decl [template = constants.%GenericParam]
+// CHECK:STDOUT:   %.loc20_36.2: ref %GenericParam = temporary_storage
+// CHECK:STDOUT:   %.loc20_36.3: init %GenericParam = class_init (), %.loc20_36.2 [template = constants.%GenericParam.val]
+// CHECK:STDOUT:   %.loc20_36.4: ref %GenericParam = temporary %.loc20_36.2, %.loc20_36.3
+// CHECK:STDOUT:   %.loc20_38.1: ref %GenericParam = converted %.loc20_36.1, %.loc20_36.4
+// CHECK:STDOUT:   %Generic.facet: %Generic.type.769 = facet_value constants.%ImplsGeneric, constants.%impl_witness [template = constants.%Generic.facet]
+// CHECK:STDOUT:   %.loc20_53: %Generic.type.769 = converted constants.%ImplsGeneric, %Generic.facet [template = constants.%Generic.facet]
+// CHECK:STDOUT:   %CallGenericMethod.specific_fn: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%GenericParam, %.loc20_53) [template = constants.%CallGenericMethod.specific_fn]
+// CHECK:STDOUT:   %.loc20_38.2: %GenericParam = bind_value %.loc20_38.1
+// CHECK:STDOUT:   %CallGenericMethod.call: init %empty_tuple.type = call %CallGenericMethod.specific_fn(%.loc20_38.2)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(constants.%Scalar) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%Scalar
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%Scalar
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F.1(constants.%Scalar, constants.%Self) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(%Scalar.loc6_19.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(constants.%GenericParam) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%GenericParam
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Generic.type => constants.%Generic.type.769
+// CHECK:STDOUT:   %Self.2 => constants.%Self
+// CHECK:STDOUT:   %F.type => constants.%F.type.4cf
+// CHECK:STDOUT:   %F => constants.%F.118
+// CHECK:STDOUT:   %Generic.assoc_type => constants.%Generic.assoc_type.9f1
+// CHECK:STDOUT:   %assoc0.loc7_9.2 => constants.%assoc0.9b7
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F.1(constants.%GenericParam, constants.%Generic.facet) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(constants.%T) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%T
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @CallGenericMethod(constants.%T, constants.%U) {
+// CHECK:STDOUT:   %T.loc17_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc17_22.2 => constants.%T
+// CHECK:STDOUT:   %Generic.type.loc17_45.2 => constants.%Generic.type.91ccba.2
+// CHECK:STDOUT:   %U.loc17_32.2 => constants.%U
+// CHECK:STDOUT:   %U.patt.loc17_32.2 => constants.%U
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(@CallGenericMethod.%T.loc17_22.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @CallGenericMethod(constants.%GenericParam, @G.%.loc20_53) {
+// CHECK:STDOUT:   %T.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc17_45.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc17_32.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %U.patt.loc17_32.2 => constants.%Generic.facet
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%complete_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @CallGenericMethod(constants.%GenericParam, constants.%Generic.facet) {
+// CHECK:STDOUT:   %T.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc17_22.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc17_45.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc17_32.2 => constants.%Generic.facet
+// CHECK:STDOUT:   %U.patt.loc17_32.2 => constants.%Generic.facet
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_facet_value_value.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_facet_value_value.carbon
@@ -1,0 +1,264 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_facet_value_value.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_facet_value_value.carbon
+
+// --- core.carbon
+
+package Core;
+
+interface ImplicitAs(T:! type) {
+  fn Convert[self: Self]() -> T;
+}
+
+// --- convert_class_value_to_facet_value_value.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
+interface Animal {}
+
+fn WalkAnimal[T:! Animal](a: T) {}
+
+class Goat {}
+impl Goat as Animal {}
+
+fn F() {
+  WalkAnimal({} as Goat);
+}
+
+// CHECK:STDOUT: --- core.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [template]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert: %Convert.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type %ImplicitAs.type.07f [symbolic]
+// CHECK:STDOUT:   %assoc0: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %T.patt.loc4_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_22.1, runtime_param<none> [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc4_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%T.loc4_22.1: type) {
+// CHECK:STDOUT:   %T.loc4_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T.loc4_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T.loc4_22.2) [symbolic = %Convert.type (constants.%Convert.type)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type) = struct_value () [symbolic = %Convert (constants.%Convert)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_32.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type) = fn_decl @Convert [symbolic = @ImplicitAs.%Convert (constants.%Convert)] {
+// CHECK:STDOUT:       %self.patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = binding_pattern self
+// CHECK:STDOUT:       %self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param_pattern %self.patt, runtime_param0
+// CHECK:STDOUT:       %return.patt: @Convert.%T (%T) = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: @Convert.%T (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @ImplicitAs.%T.loc4_22.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %self.param: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param runtime_param0
+// CHECK:STDOUT:       %.loc5_20.1: type = splice_block %.loc5_20.3 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:         %.loc5_20.2: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%T) [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.ref: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc5_20.2 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.as_type.loc5_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:         %.loc5_20.3: type = converted %Self.ref, %Self.as_type.loc5_20.2 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.%T (%T) = out_param runtime_param1
+// CHECK:STDOUT:       %return: ref @Convert.%T (%T) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_32.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Convert = %assoc0.loc5_32.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(@ImplicitAs.%T.loc4_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_22.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1 => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc4_22.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- convert_class_value_to_facet_value_value.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Animal.type: type = facet_type <@Animal> [template]
+// CHECK:STDOUT:   %Self: %Animal.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %T: %Animal.type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: %Animal.type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %T.as_type: type = facet_access_type %T [symbolic]
+// CHECK:STDOUT:   %WalkAnimal.type: type = fn_type @WalkAnimal [template]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [template]
+// CHECK:STDOUT:   %WalkAnimal: %WalkAnimal.type = struct_value () [template]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type [symbolic]
+// CHECK:STDOUT:   %Goat: type = class_type @Goat [template]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [template]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %Goat.val: %Goat = struct_value () [template]
+// CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value %Goat, %impl_witness [template]
+// CHECK:STDOUT:   %WalkAnimal.specific_fn: <specific function> = specific_function %WalkAnimal, @WalkAnimal(%Animal.facet) [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Animal = %Animal.decl
+// CHECK:STDOUT:     .WalkAnimal = %WalkAnimal.decl
+// CHECK:STDOUT:     .Goat = %Goat.decl
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Animal.decl: type = interface_decl @Animal [template = constants.%Animal.type] {} {}
+// CHECK:STDOUT:   %WalkAnimal.decl: %WalkAnimal.type = fn_decl @WalkAnimal [template = constants.%WalkAnimal] {
+// CHECK:STDOUT:     %T.patt.loc8_15.1: %Animal.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: %Animal.type = value_param_pattern %T.patt.loc8_15.1, runtime_param<none> [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %a.patt: @WalkAnimal.%T.as_type.loc8_30.2 (%T.as_type) = binding_pattern a
+// CHECK:STDOUT:     %a.param_patt: @WalkAnimal.%T.as_type.loc8_30.2 (%T.as_type) = value_param_pattern %a.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: %Animal.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:     %T.loc8_15.1: %Animal.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc8_15.2 (constants.%T)]
+// CHECK:STDOUT:     %a.param: @WalkAnimal.%T.as_type.loc8_30.2 (%T.as_type) = value_param runtime_param0
+// CHECK:STDOUT:     %.loc8_30.1: type = splice_block %.loc8_30.2 [symbolic = %T.as_type.loc8_30.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc8_15.1 [symbolic = %T.loc8_15.2 (constants.%T)]
+// CHECK:STDOUT:       %T.as_type.loc8_30.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc8_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc8_30.2: type = converted %T.ref, %T.as_type.loc8_30.1 [symbolic = %T.as_type.loc8_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %a: @WalkAnimal.%T.as_type.loc8_30.2 (%T.as_type) = bind_name a, %a.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [template = constants.%Goat] {} {}
+// CHECK:STDOUT:   impl_decl @impl [template] {} {
+// CHECK:STDOUT:     %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [template = constants.%impl_witness]
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @Animal {
+// CHECK:STDOUT:   %Self: %Animal.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: %Goat.ref as %Animal.ref {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = file.%impl_witness
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Goat {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Goat
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @WalkAnimal(%T.loc8_15.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc8_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc8_15.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc8_15.2: %Animal.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %T.as_type.loc8_30.2: type = facet_access_type %T.loc8_15.2 [symbolic = %T.as_type.loc8_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @WalkAnimal.%T.as_type.loc8_30.2 (%T.as_type) [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: %Animal.type](%a.param_patt: @WalkAnimal.%T.as_type.loc8_30.2 (%T.as_type)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %WalkAnimal.ref: %WalkAnimal.type = name_ref WalkAnimal, file.%WalkAnimal.decl [template = constants.%WalkAnimal]
+// CHECK:STDOUT:   %.loc14_15.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
+// CHECK:STDOUT:   %.loc14_15.2: ref %Goat = temporary_storage
+// CHECK:STDOUT:   %.loc14_15.3: init %Goat = class_init (), %.loc14_15.2 [template = constants.%Goat.val]
+// CHECK:STDOUT:   %.loc14_15.4: ref %Goat = temporary %.loc14_15.2, %.loc14_15.3
+// CHECK:STDOUT:   %.loc14_17.1: ref %Goat = converted %.loc14_15.1, %.loc14_15.4
+// CHECK:STDOUT:   %Animal.facet.loc14_24.1: %Animal.type = facet_value constants.%Goat, constants.%impl_witness [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc14_24.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc14_24.1 [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %Animal.facet.loc14_24.2: %Animal.type = facet_value constants.%Goat, constants.%impl_witness [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc14_24.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc14_24.2 [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %WalkAnimal.specific_fn: <specific function> = specific_function %WalkAnimal.ref, @WalkAnimal(constants.%Animal.facet) [template = constants.%WalkAnimal.specific_fn]
+// CHECK:STDOUT:   %.loc14_17.2: %Goat = bind_value %.loc14_17.1
+// CHECK:STDOUT:   %WalkAnimal.call: init %empty_tuple.type = call %WalkAnimal.specific_fn(%.loc14_17.2)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @WalkAnimal(constants.%T) {
+// CHECK:STDOUT:   %T.loc8_15.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc8_30.2 => constants.%T.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @WalkAnimal(constants.%Animal.facet) {
+// CHECK:STDOUT:   %T.loc8_15.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.patt.loc8_15.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.as_type.loc8_30.2 => constants.%Goat
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%complete_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_generic_facet_value_value.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_generic_facet_value_value.carbon
@@ -1,0 +1,460 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_generic_facet_value_value.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/convert_class_value_to_generic_facet_value_value.carbon
+
+// --- core.carbon
+
+package Core;
+
+interface ImplicitAs(T:! type) {
+  fn Convert[self: Self]() -> T;
+}
+
+// --- convert_class_value_to_generic_facet_value_value.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
+interface Generic(Scalar:! type) {
+  fn F();
+}
+
+class GenericParam {}
+
+class ImplsGeneric {}
+impl ImplsGeneric as Generic(GenericParam) {
+  fn F() {}
+}
+
+fn CallGenericMethod2[T:! type, U:! Generic(T)](a: U, s: T) {
+  U.F();
+}
+
+fn G() {
+  CallGenericMethod2({} as ImplsGeneric, {} as GenericParam);
+}
+
+// CHECK:STDOUT: --- core.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [template]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert: %Convert.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type %ImplicitAs.type.07f [symbolic]
+// CHECK:STDOUT:   %assoc0: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %T.patt.loc4_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_22.1, runtime_param<none> [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc4_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%T.loc4_22.1: type) {
+// CHECK:STDOUT:   %T.loc4_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T.loc4_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T.loc4_22.2) [symbolic = %Convert.type (constants.%Convert.type)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type) = struct_value () [symbolic = %Convert (constants.%Convert)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_32.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type) = fn_decl @Convert [symbolic = @ImplicitAs.%Convert (constants.%Convert)] {
+// CHECK:STDOUT:       %self.patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = binding_pattern self
+// CHECK:STDOUT:       %self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param_pattern %self.patt, runtime_param0
+// CHECK:STDOUT:       %return.patt: @Convert.%T (%T) = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: @Convert.%T (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @ImplicitAs.%T.loc4_22.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %self.param: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param runtime_param0
+// CHECK:STDOUT:       %.loc5_20.1: type = splice_block %.loc5_20.3 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:         %.loc5_20.2: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%T) [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.ref: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc5_20.2 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.as_type.loc5_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:         %.loc5_20.3: type = converted %Self.ref, %Self.as_type.loc5_20.2 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.%T (%T) = out_param runtime_param1
+// CHECK:STDOUT:       %return: ref @Convert.%T (%T) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_32.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Convert = %assoc0.loc5_32.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(@ImplicitAs.%T.loc4_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_22.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1 => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc4_22.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- convert_class_value_to_generic_facet_value_value.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Scalar: type = bind_symbolic_name Scalar, 0 [symbolic]
+// CHECK:STDOUT:   %Scalar.patt: type = symbolic_binding_pattern Scalar, 0 [symbolic]
+// CHECK:STDOUT:   %Generic.type.c21: type = generic_interface_type @Generic [template]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [template]
+// CHECK:STDOUT:   %Generic.generic: %Generic.type.c21 = struct_value () [template]
+// CHECK:STDOUT:   %Generic.type.91ccba.1: type = facet_type <@Generic, @Generic(%Scalar)> [symbolic]
+// CHECK:STDOUT:   %Self: %Generic.type.91ccba.1 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %F.type.f439a9.1: type = fn_type @F.1, @Generic(%Scalar) [symbolic]
+// CHECK:STDOUT:   %F.8a2d67.1: %F.type.f439a9.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Generic.assoc_type.de973d.1: type = assoc_entity_type %Generic.type.91ccba.1 [symbolic]
+// CHECK:STDOUT:   %assoc0.29ce53.1: %Generic.assoc_type.de973d.1 = assoc_entity element0, @Generic.%F.decl [symbolic]
+// CHECK:STDOUT:   %GenericParam: type = class_type @GenericParam [template]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [template]
+// CHECK:STDOUT:   %ImplsGeneric: type = class_type @ImplsGeneric [template]
+// CHECK:STDOUT:   %Generic.type.769: type = facet_type <@Generic, @Generic(%GenericParam)> [template]
+// CHECK:STDOUT:   %F.type.4cf: type = fn_type @F.1, @Generic(%GenericParam) [template]
+// CHECK:STDOUT:   %F.118: %F.type.4cf = struct_value () [template]
+// CHECK:STDOUT:   %Generic.assoc_type.9f1: type = assoc_entity_type %Generic.type.769 [template]
+// CHECK:STDOUT:   %assoc0.9b7: %Generic.assoc_type.9f1 = assoc_entity element0, @Generic.%F.decl [template]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl) [template]
+// CHECK:STDOUT:   %F.type.17b: type = fn_type @F.2 [template]
+// CHECK:STDOUT:   %F.a56: %F.type.17b = struct_value () [template]
+// CHECK:STDOUT:   %Generic.facet.b0a: %Generic.type.769 = facet_value %ImplsGeneric, %impl_witness [template]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %Generic.type.91ccba.2: type = facet_type <@Generic, @Generic(%T)> [symbolic]
+// CHECK:STDOUT:   %U: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic]
+// CHECK:STDOUT:   %U.patt: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic]
+// CHECK:STDOUT:   %U.as_type: type = facet_access_type %U [symbolic]
+// CHECK:STDOUT:   %CallGenericMethod2.type: type = fn_type @CallGenericMethod2 [template]
+// CHECK:STDOUT:   %CallGenericMethod2: %CallGenericMethod2.type = struct_value () [template]
+// CHECK:STDOUT:   %require_complete.7b2: <witness> = require_complete_type %U.as_type [symbolic]
+// CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %T [symbolic]
+// CHECK:STDOUT:   %require_complete.02a: <witness> = require_complete_type %Generic.type.91ccba.2 [symbolic]
+// CHECK:STDOUT:   %F.type.f439a9.2: type = fn_type @F.1, @Generic(%T) [symbolic]
+// CHECK:STDOUT:   %F.8a2d67.2: %F.type.f439a9.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Generic.assoc_type.de973d.2: type = assoc_entity_type %Generic.type.91ccba.2 [symbolic]
+// CHECK:STDOUT:   %assoc0.29ce53.2: %Generic.assoc_type.de973d.2 = assoc_entity element0, @Generic.%F.decl [symbolic]
+// CHECK:STDOUT:   %U.as_wit: <witness> = facet_access_witness %U [symbolic]
+// CHECK:STDOUT:   %Generic.facet.2ea: %Generic.type.91ccba.2 = facet_value %U.as_type, %U.as_wit [symbolic]
+// CHECK:STDOUT:   %.da8: type = fn_type_with_self_type %F.type.f439a9.2, %Generic.facet.2ea [symbolic]
+// CHECK:STDOUT:   %impl.elem0: %.da8 = impl_witness_access %U.as_wit, element0 [symbolic]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @F.1(%T, %Generic.facet.2ea) [symbolic]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [template]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [template]
+// CHECK:STDOUT:   %ImplsGeneric.val: %ImplsGeneric = struct_value () [template]
+// CHECK:STDOUT:   %GenericParam.val: %GenericParam = struct_value () [template]
+// CHECK:STDOUT:   %CallGenericMethod2.specific_fn: <specific function> = specific_function %CallGenericMethod2, @CallGenericMethod2(%GenericParam, %Generic.facet.b0a) [template]
+// CHECK:STDOUT:   %complete_type.997: <witness> = complete_type_witness %Generic.type.769 [template]
+// CHECK:STDOUT:   %.db1: type = fn_type_with_self_type %F.type.4cf, %Generic.facet.b0a [template]
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F.a56, @F.1(%GenericParam, %Generic.facet.b0a) [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Generic = %Generic.decl
+// CHECK:STDOUT:     .GenericParam = %GenericParam.decl
+// CHECK:STDOUT:     .ImplsGeneric = %ImplsGeneric.decl
+// CHECK:STDOUT:     .CallGenericMethod2 = %CallGenericMethod2.decl
+// CHECK:STDOUT:     .G = %G.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Generic.decl: %Generic.type.c21 = interface_decl @Generic [template = constants.%Generic.generic] {
+// CHECK:STDOUT:     %Scalar.patt.loc6_19.1: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:     %Scalar.param_patt: type = value_param_pattern %Scalar.patt.loc6_19.1, runtime_param<none> [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Scalar.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Scalar.loc6_19.1: type = bind_symbolic_name Scalar, 0, %Scalar.param [symbolic = %Scalar.loc6_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %GenericParam.decl: type = class_decl @GenericParam [template = constants.%GenericParam] {} {}
+// CHECK:STDOUT:   %ImplsGeneric.decl: type = class_decl @ImplsGeneric [template = constants.%ImplsGeneric] {} {}
+// CHECK:STDOUT:   impl_decl @impl [template] {} {
+// CHECK:STDOUT:     %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [template = constants.%ImplsGeneric]
+// CHECK:STDOUT:     %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
+// CHECK:STDOUT:     %GenericParam.ref: type = name_ref GenericParam, file.%GenericParam.decl [template = constants.%GenericParam]
+// CHECK:STDOUT:     %Generic.type: type = facet_type <@Generic, @Generic(constants.%GenericParam)> [template = constants.%Generic.type.769]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl) [template = constants.%impl_witness]
+// CHECK:STDOUT:   %CallGenericMethod2.decl: %CallGenericMethod2.type = fn_decl @CallGenericMethod2 [template = constants.%CallGenericMethod2] {
+// CHECK:STDOUT:     %T.patt.loc17_23.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_23.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc17_23.1, runtime_param<none> [symbolic = %T.patt.loc17_23.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %U.patt.loc17_33.1: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc17_33.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %U.param_patt: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = value_param_pattern %U.patt.loc17_33.1, runtime_param<none> [symbolic = %U.patt.loc17_33.2 (constants.%U.patt)]
+// CHECK:STDOUT:     %a.patt: @CallGenericMethod2.%U.as_type.loc17_52.2 (%U.as_type) = binding_pattern a
+// CHECK:STDOUT:     %a.param_patt: @CallGenericMethod2.%U.as_type.loc17_52.2 (%U.as_type) = value_param_pattern %a.patt, runtime_param0
+// CHECK:STDOUT:     %s.patt: @CallGenericMethod2.%T.loc17_23.2 (%T) = binding_pattern s
+// CHECK:STDOUT:     %s.param_patt: @CallGenericMethod2.%T.loc17_23.2 (%T) = value_param_pattern %s.patt, runtime_param1
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc17_23.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc17_23.2 (constants.%T)]
+// CHECK:STDOUT:     %U.param: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = value_param runtime_param<none>
+// CHECK:STDOUT:     %.loc17_46: type = splice_block %Generic.type.loc17_46.1 [symbolic = %Generic.type.loc17_46.2 (constants.%Generic.type.91ccba.2)] {
+// CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [template = constants.%Generic.generic]
+// CHECK:STDOUT:       %T.ref.loc17_45: type = name_ref T, %T.loc17_23.1 [symbolic = %T.loc17_23.2 (constants.%T)]
+// CHECK:STDOUT:       %Generic.type.loc17_46.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc17_46.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %U.loc17_33.1: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1, %U.param [symbolic = %U.loc17_33.2 (constants.%U)]
+// CHECK:STDOUT:     %a.param: @CallGenericMethod2.%U.as_type.loc17_52.2 (%U.as_type) = value_param runtime_param0
+// CHECK:STDOUT:     %.loc17_52.1: type = splice_block %.loc17_52.2 [symbolic = %U.as_type.loc17_52.2 (constants.%U.as_type)] {
+// CHECK:STDOUT:       %U.ref.loc17: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = name_ref U, %U.loc17_33.1 [symbolic = %U.loc17_33.2 (constants.%U)]
+// CHECK:STDOUT:       %U.as_type.loc17_52.1: type = facet_access_type %U.ref.loc17 [symbolic = %U.as_type.loc17_52.2 (constants.%U.as_type)]
+// CHECK:STDOUT:       %.loc17_52.2: type = converted %U.ref.loc17, %U.as_type.loc17_52.1 [symbolic = %U.as_type.loc17_52.2 (constants.%U.as_type)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %a: @CallGenericMethod2.%U.as_type.loc17_52.2 (%U.as_type) = bind_name a, %a.param
+// CHECK:STDOUT:     %s.param: @CallGenericMethod2.%T.loc17_23.2 (%T) = value_param runtime_param1
+// CHECK:STDOUT:     %T.ref.loc17_58: type = name_ref T, %T.loc17_23.1 [symbolic = %T.loc17_23.2 (constants.%T)]
+// CHECK:STDOUT:     %s: @CallGenericMethod2.%T.loc17_23.2 (%T) = bind_name s, %s.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [template = constants.%G] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @Generic(%Scalar.loc6_19.1: type) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc6_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2: type = symbolic_binding_pattern Scalar, 0 [symbolic = %Scalar.patt.loc6_19.2 (constants.%Scalar.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Generic.type: type = facet_type <@Generic, @Generic(%Scalar.loc6_19.2)> [symbolic = %Generic.type (constants.%Generic.type.91ccba.1)]
+// CHECK:STDOUT:   %Self.2: %Generic.type.91ccba.1 = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%Scalar.loc6_19.2) [symbolic = %F.type (constants.%F.type.f439a9.1)]
+// CHECK:STDOUT:   %F: @Generic.%F.type (%F.type.f439a9.1) = struct_value () [symbolic = %F (constants.%F.8a2d67.1)]
+// CHECK:STDOUT:   %Generic.assoc_type: type = assoc_entity_type @Generic.%Generic.type (%Generic.type.91ccba.1) [symbolic = %Generic.assoc_type (constants.%Generic.assoc_type.de973d.1)]
+// CHECK:STDOUT:   %assoc0.loc7_9.2: @Generic.%Generic.assoc_type (%Generic.assoc_type.de973d.1) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc7_9.2 (constants.%assoc0.29ce53.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %F.decl: @Generic.%F.type (%F.type.f439a9.1) = fn_decl @F.1 [symbolic = @Generic.%F (constants.%F.8a2d67.1)] {} {}
+// CHECK:STDOUT:     %assoc0.loc7_9.1: @Generic.%Generic.assoc_type (%Generic.assoc_type.de973d.1) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc7_9.2 (constants.%assoc0.29ce53.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .F = %assoc0.loc7_9.1
+// CHECK:STDOUT:     witness = (%F.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: %ImplsGeneric.ref as %Generic.type {
+// CHECK:STDOUT:   %F.decl: %F.type.17b = fn_decl @F.2 [template = constants.%F.a56] {} {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F.decl
+// CHECK:STDOUT:   witness = file.%impl_witness
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @GenericParam {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%GenericParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @ImplsGeneric {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%ImplsGeneric
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F.1(@Generic.%Scalar.loc6_19.1: type, @Generic.%Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1)) {
+// CHECK:STDOUT:   fn();
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.2() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @CallGenericMethod2(%T.loc17_23.1: type, %U.loc17_33.1: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   %T.loc17_23.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc17_23.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc17_23.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc17_23.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %Generic.type.loc17_46.2: type = facet_type <@Generic, @Generic(%T.loc17_23.2)> [symbolic = %Generic.type.loc17_46.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:   %U.loc17_33.2: %Generic.type.91ccba.2 = bind_symbolic_name U, 1 [symbolic = %U.loc17_33.2 (constants.%U)]
+// CHECK:STDOUT:   %U.patt.loc17_33.2: %Generic.type.91ccba.2 = symbolic_binding_pattern U, 1 [symbolic = %U.patt.loc17_33.2 (constants.%U.patt)]
+// CHECK:STDOUT:   %U.as_type.loc17_52.2: type = facet_access_type %U.loc17_33.2 [symbolic = %U.as_type.loc17_52.2 (constants.%U.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc17_50: <witness> = require_complete_type @CallGenericMethod2.%U.as_type.loc17_52.2 (%U.as_type) [symbolic = %require_complete.loc17_50 (constants.%require_complete.7b2)]
+// CHECK:STDOUT:   %require_complete.loc17_56: <witness> = require_complete_type @CallGenericMethod2.%T.loc17_23.2 (%T) [symbolic = %require_complete.loc17_56 (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %require_complete.loc18: <witness> = require_complete_type @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) [symbolic = %require_complete.loc18 (constants.%require_complete.02a)]
+// CHECK:STDOUT:   %Generic.assoc_type: type = assoc_entity_type @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) [symbolic = %Generic.assoc_type (constants.%Generic.assoc_type.de973d.2)]
+// CHECK:STDOUT:   %assoc0: @CallGenericMethod2.%Generic.assoc_type (%Generic.assoc_type.de973d.2) = assoc_entity element0, @Generic.%F.decl [symbolic = %assoc0 (constants.%assoc0.29ce53.2)]
+// CHECK:STDOUT:   %U.as_wit.loc18_4.2: <witness> = facet_access_witness %U.loc17_33.2 [symbolic = %U.as_wit.loc18_4.2 (constants.%U.as_wit)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%T.loc17_23.2) [symbolic = %F.type (constants.%F.type.f439a9.2)]
+// CHECK:STDOUT:   %Generic.facet: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = facet_value %U.as_type.loc17_52.2, %U.as_wit.loc18_4.2 [symbolic = %Generic.facet (constants.%Generic.facet.2ea)]
+// CHECK:STDOUT:   %.loc18_4.3: type = fn_type_with_self_type %F.type, %Generic.facet [symbolic = %.loc18_4.3 (constants.%.da8)]
+// CHECK:STDOUT:   %impl.elem0.loc18_4.2: @CallGenericMethod2.%.loc18_4.3 (%.da8) = impl_witness_access %U.as_wit.loc18_4.2, element0 [symbolic = %impl.elem0.loc18_4.2 (constants.%impl.elem0)]
+// CHECK:STDOUT:   %specific_fn.loc18_4.2: <specific function> = specific_function %impl.elem0.loc18_4.2, @F.1(%T.loc17_23.2, %Generic.facet) [symbolic = %specific_fn.loc18_4.2 (constants.%specific_fn)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: type, %U.param_patt: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2)](%a.param_patt: @CallGenericMethod2.%U.as_type.loc17_52.2 (%U.as_type), %s.param_patt: @CallGenericMethod2.%T.loc17_23.2 (%T)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %U.ref.loc18: @CallGenericMethod2.%Generic.type.loc17_46.2 (%Generic.type.91ccba.2) = name_ref U, %U.loc17_33.1 [symbolic = %U.loc17_33.2 (constants.%U)]
+// CHECK:STDOUT:     %.loc18_4.1: @CallGenericMethod2.%Generic.assoc_type (%Generic.assoc_type.de973d.2) = specific_constant @Generic.%assoc0.loc7_9.1, @Generic(constants.%T) [symbolic = %assoc0 (constants.%assoc0.29ce53.2)]
+// CHECK:STDOUT:     %F.ref: @CallGenericMethod2.%Generic.assoc_type (%Generic.assoc_type.de973d.2) = name_ref F, %.loc18_4.1 [symbolic = %assoc0 (constants.%assoc0.29ce53.2)]
+// CHECK:STDOUT:     %U.as_type.loc18: type = facet_access_type %U.ref.loc18 [symbolic = %U.as_type.loc17_52.2 (constants.%U.as_type)]
+// CHECK:STDOUT:     %.loc18_4.2: type = converted %U.ref.loc18, %U.as_type.loc18 [symbolic = %U.as_type.loc17_52.2 (constants.%U.as_type)]
+// CHECK:STDOUT:     %U.as_wit.loc18_4.1: <witness> = facet_access_witness %U.ref.loc18 [symbolic = %U.as_wit.loc18_4.2 (constants.%U.as_wit)]
+// CHECK:STDOUT:     %impl.elem0.loc18_4.1: @CallGenericMethod2.%.loc18_4.3 (%.da8) = impl_witness_access %U.as_wit.loc18_4.1, element0 [symbolic = %impl.elem0.loc18_4.2 (constants.%impl.elem0)]
+// CHECK:STDOUT:     %specific_fn.loc18_4.1: <specific function> = specific_function %impl.elem0.loc18_4.1, @F.1(constants.%T, constants.%Generic.facet.2ea) [symbolic = %specific_fn.loc18_4.2 (constants.%specific_fn)]
+// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %specific_fn.loc18_4.1()
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %CallGenericMethod2.ref: %CallGenericMethod2.type = name_ref CallGenericMethod2, file.%CallGenericMethod2.decl [template = constants.%CallGenericMethod2]
+// CHECK:STDOUT:   %.loc22_23.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [template = constants.%ImplsGeneric]
+// CHECK:STDOUT:   %.loc22_23.2: ref %ImplsGeneric = temporary_storage
+// CHECK:STDOUT:   %.loc22_23.3: init %ImplsGeneric = class_init (), %.loc22_23.2 [template = constants.%ImplsGeneric.val]
+// CHECK:STDOUT:   %.loc22_23.4: ref %ImplsGeneric = temporary %.loc22_23.2, %.loc22_23.3
+// CHECK:STDOUT:   %.loc22_25.1: ref %ImplsGeneric = converted %.loc22_23.1, %.loc22_23.4
+// CHECK:STDOUT:   %.loc22_43.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %GenericParam.ref: type = name_ref GenericParam, file.%GenericParam.decl [template = constants.%GenericParam]
+// CHECK:STDOUT:   %.loc22_43.2: ref %GenericParam = temporary_storage
+// CHECK:STDOUT:   %.loc22_43.3: init %GenericParam = class_init (), %.loc22_43.2 [template = constants.%GenericParam.val]
+// CHECK:STDOUT:   %.loc22_43.4: ref %GenericParam = temporary %.loc22_43.2, %.loc22_43.3
+// CHECK:STDOUT:   %.loc22_45.1: ref %GenericParam = converted %.loc22_43.1, %.loc22_43.4
+// CHECK:STDOUT:   %Generic.facet: %Generic.type.769 = facet_value constants.%ImplsGeneric, constants.%impl_witness [template = constants.%Generic.facet.b0a]
+// CHECK:STDOUT:   %.loc22_60: %Generic.type.769 = converted constants.%ImplsGeneric, %Generic.facet [template = constants.%Generic.facet.b0a]
+// CHECK:STDOUT:   %CallGenericMethod2.specific_fn: <specific function> = specific_function %CallGenericMethod2.ref, @CallGenericMethod2(constants.%GenericParam, %.loc22_60) [template = constants.%CallGenericMethod2.specific_fn]
+// CHECK:STDOUT:   %.loc22_25.2: %ImplsGeneric = bind_value %.loc22_25.1
+// CHECK:STDOUT:   %.loc22_45.2: %GenericParam = bind_value %.loc22_45.1
+// CHECK:STDOUT:   %CallGenericMethod2.call: init %empty_tuple.type = call %CallGenericMethod2.specific_fn(%.loc22_25.2, %.loc22_45.2)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(constants.%Scalar) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%Scalar
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%Scalar
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F.1(constants.%Scalar, constants.%Self) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(%Scalar.loc6_19.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(constants.%GenericParam) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%GenericParam
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Generic.type => constants.%Generic.type.769
+// CHECK:STDOUT:   %Self.2 => constants.%Self
+// CHECK:STDOUT:   %F.type => constants.%F.type.4cf
+// CHECK:STDOUT:   %F => constants.%F.118
+// CHECK:STDOUT:   %Generic.assoc_type => constants.%Generic.assoc_type.9f1
+// CHECK:STDOUT:   %assoc0.loc7_9.2 => constants.%assoc0.9b7
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F.1(constants.%GenericParam, constants.%Generic.facet.b0a) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(constants.%T) {
+// CHECK:STDOUT:   %Scalar.loc6_19.2 => constants.%T
+// CHECK:STDOUT:   %Scalar.patt.loc6_19.2 => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Generic.type => constants.%Generic.type.91ccba.2
+// CHECK:STDOUT:   %Self.2 => constants.%Self
+// CHECK:STDOUT:   %F.type => constants.%F.type.f439a9.2
+// CHECK:STDOUT:   %F => constants.%F.8a2d67.2
+// CHECK:STDOUT:   %Generic.assoc_type => constants.%Generic.assoc_type.de973d.2
+// CHECK:STDOUT:   %assoc0.loc7_9.2 => constants.%assoc0.29ce53.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @CallGenericMethod2(constants.%T, constants.%U) {
+// CHECK:STDOUT:   %T.loc17_23.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc17_23.2 => constants.%T
+// CHECK:STDOUT:   %Generic.type.loc17_46.2 => constants.%Generic.type.91ccba.2
+// CHECK:STDOUT:   %U.loc17_33.2 => constants.%U
+// CHECK:STDOUT:   %U.patt.loc17_33.2 => constants.%U
+// CHECK:STDOUT:   %U.as_type.loc17_52.2 => constants.%U.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Generic(@CallGenericMethod2.%T.loc17_23.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F.1(constants.%T, constants.%Generic.facet.2ea) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F.1(@CallGenericMethod2.%T.loc17_23.2, @CallGenericMethod2.%Generic.facet) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @CallGenericMethod2(constants.%GenericParam, @G.%.loc22_60) {
+// CHECK:STDOUT:   %T.loc17_23.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc17_23.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc17_46.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc17_33.2 => constants.%Generic.facet.b0a
+// CHECK:STDOUT:   %U.patt.loc17_33.2 => constants.%Generic.facet.b0a
+// CHECK:STDOUT:   %U.as_type.loc17_52.2 => constants.%ImplsGeneric
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc17_50 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc17_56 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc18 => constants.%complete_type.997
+// CHECK:STDOUT:   %Generic.assoc_type => constants.%Generic.assoc_type.9f1
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0.9b7
+// CHECK:STDOUT:   %U.as_wit.loc18_4.2 => constants.%impl_witness
+// CHECK:STDOUT:   %F.type => constants.%F.type.4cf
+// CHECK:STDOUT:   %Generic.facet => constants.%Generic.facet.b0a
+// CHECK:STDOUT:   %.loc18_4.3 => constants.%.db1
+// CHECK:STDOUT:   %impl.elem0.loc18_4.2 => constants.%F.a56
+// CHECK:STDOUT:   %specific_fn.loc18_4.2 => constants.%F.specific_fn
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @CallGenericMethod2(constants.%GenericParam, constants.%Generic.facet.b0a) {
+// CHECK:STDOUT:   %T.loc17_23.2 => constants.%GenericParam
+// CHECK:STDOUT:   %T.patt.loc17_23.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Generic.type.loc17_46.2 => constants.%Generic.type.769
+// CHECK:STDOUT:   %U.loc17_33.2 => constants.%Generic.facet.b0a
+// CHECK:STDOUT:   %U.patt.loc17_33.2 => constants.%Generic.facet.b0a
+// CHECK:STDOUT:   %U.as_type.loc17_52.2 => constants.%ImplsGeneric
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_facet_value.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_facet_value.carbon
@@ -9,31 +9,33 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_facet_value.carbon
 
 interface Eats {}
-interface Goat {}
+interface Animal {}
 
-class Ginger {}
-impl Ginger as Goat {}
-
-impl Goat as Eats {}
+// TODO: This may be rejected in the future.
+// https://github.com/carbon-language/carbon-lang/issues/4853
+impl Animal as Eats {}
 
 fn Feed(e:! Eats) {}
 
+class Goat {}
+impl Goat as Animal {}
+
 fn F() {
   // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+14]]:3: error: semantics TODO: `Facet value converting to facet value` [SemanticsTodo]
-  // CHECK:STDERR:   Feed(Ginger as Goat);
+  // CHECK:STDERR:   Feed(Goat as Animal);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-6]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-9]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
   // CHECK:STDERR: fn Feed(e:! Eats) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
   // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+7]]:3: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
-  // CHECK:STDERR:   Feed(Ginger as Goat);
+  // CHECK:STDERR:   Feed(Goat as Animal);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-13]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-16]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
   // CHECK:STDERR: fn Feed(e:! Eats) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
-  Feed(Ginger as Goat);
+  Feed(Goat as Animal);
 }
 
 // CHECK:STDOUT: --- fail_todo_convert_facet_value_to_facet_value.carbon
@@ -41,50 +43,50 @@ fn F() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats> [template]
 // CHECK:STDOUT:   %Self.1b5: %Eats.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %Goat.type: type = facet_type <@Goat> [template]
-// CHECK:STDOUT:   %Self.092: %Goat.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %Ginger: type = class_type @Ginger [template]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
+// CHECK:STDOUT:   %Animal.type: type = facet_type <@Animal> [template]
+// CHECK:STDOUT:   %Self.fd4: %Animal.type = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [template]
 // CHECK:STDOUT:   %e: %Eats.type = bind_symbolic_name e, 0 [symbolic]
 // CHECK:STDOUT:   %e.patt: %Eats.type = symbolic_binding_pattern e, 0 [symbolic]
 // CHECK:STDOUT:   %Feed.type: type = fn_type @Feed [template]
 // CHECK:STDOUT:   %Feed: %Feed.type = struct_value () [template]
+// CHECK:STDOUT:   %Goat: type = class_type @Goat [template]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
-// CHECK:STDOUT:   %Goat.facet: %Goat.type = facet_value %Ginger, %impl_witness [template]
+// CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value %Goat, %impl_witness [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Eats = %Eats.decl
-// CHECK:STDOUT:     .Goat = %Goat.decl
-// CHECK:STDOUT:     .Ginger = %Ginger.decl
+// CHECK:STDOUT:     .Animal = %Animal.decl
 // CHECK:STDOUT:     .Feed = %Feed.decl
+// CHECK:STDOUT:     .Goat = %Goat.decl
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Eats.decl: type = interface_decl @Eats [template = constants.%Eats.type] {} {}
-// CHECK:STDOUT:   %Goat.decl: type = interface_decl @Goat [template = constants.%Goat.type] {} {}
-// CHECK:STDOUT:   %Ginger.decl: type = class_decl @Ginger [template = constants.%Ginger] {} {}
+// CHECK:STDOUT:   %Animal.decl: type = interface_decl @Animal [template = constants.%Animal.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {} {
-// CHECK:STDOUT:     %Ginger.ref: type = name_ref Ginger, file.%Ginger.decl [template = constants.%Ginger]
-// CHECK:STDOUT:     %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat.type]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness.loc15: <witness> = impl_witness () [template = constants.%impl_witness]
-// CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
-// CHECK:STDOUT:     %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat.type]
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [template = constants.%Eats.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness.loc17: <witness> = impl_witness () [template = constants.%impl_witness]
+// CHECK:STDOUT:   %impl_witness.loc16: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT:   %Feed.decl: %Feed.type = fn_decl @Feed [template = constants.%Feed] {
-// CHECK:STDOUT:     %e.patt.loc19_9.1: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc19_9.2 (constants.%e.patt)]
-// CHECK:STDOUT:     %e.param_patt: %Eats.type = value_param_pattern %e.patt.loc19_9.1, runtime_param<none> [symbolic = %e.patt.loc19_9.2 (constants.%e.patt)]
+// CHECK:STDOUT:     %e.patt.loc18_9.1: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc18_9.2 (constants.%e.patt)]
+// CHECK:STDOUT:     %e.param_patt: %Eats.type = value_param_pattern %e.patt.loc18_9.1, runtime_param<none> [symbolic = %e.patt.loc18_9.2 (constants.%e.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %e.param: %Eats.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [template = constants.%Eats.type]
-// CHECK:STDOUT:     %e.loc19_9.1: %Eats.type = bind_symbolic_name e, 0, %e.param [symbolic = %e.loc19_9.2 (constants.%e)]
+// CHECK:STDOUT:     %e.loc18_9.1: %Eats.type = bind_symbolic_name e, 0, %e.param [symbolic = %e.loc18_9.2 (constants.%e)]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [template = constants.%Goat] {} {}
+// CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
+// CHECK:STDOUT:     %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc21: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -96,35 +98,35 @@ fn F() {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @Goat {
-// CHECK:STDOUT:   %Self: %Goat.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.092]
+// CHECK:STDOUT: interface @Animal {
+// CHECK:STDOUT:   %Self: %Animal.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.fd4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.1: %Ginger.ref as %Goat.ref {
+// CHECK:STDOUT: impl @impl.1: %Animal.ref as %Eats.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness.loc15
+// CHECK:STDOUT:   witness = file.%impl_witness.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.2: %Goat.ref as %Eats.ref {
+// CHECK:STDOUT: impl @impl.2: %Goat.ref as %Animal.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness.loc17
+// CHECK:STDOUT:   witness = file.%impl_witness.loc21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @Ginger {
+// CHECK:STDOUT: class @Goat {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%Ginger
+// CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Feed(%e.loc19_9.1: %Eats.type) {
-// CHECK:STDOUT:   %e.loc19_9.2: %Eats.type = bind_symbolic_name e, 0 [symbolic = %e.loc19_9.2 (constants.%e)]
-// CHECK:STDOUT:   %e.patt.loc19_9.2: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc19_9.2 (constants.%e.patt)]
+// CHECK:STDOUT: generic fn @Feed(%e.loc18_9.1: %Eats.type) {
+// CHECK:STDOUT:   %e.loc18_9.2: %Eats.type = bind_symbolic_name e, 0 [symbolic = %e.loc18_9.2 (constants.%e)]
+// CHECK:STDOUT:   %e.patt.loc18_9.2: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc18_9.2 (constants.%e.patt)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -137,16 +139,16 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Feed.ref: %Feed.type = name_ref Feed, file.%Feed.decl [template = constants.%Feed]
-// CHECK:STDOUT:   %Ginger.ref: type = name_ref Ginger, file.%Ginger.decl [template = constants.%Ginger]
-// CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat.type]
-// CHECK:STDOUT:   %Goat.facet: %Goat.type = facet_value %Ginger.ref, constants.%impl_witness [template = constants.%Goat.facet]
-// CHECK:STDOUT:   %.loc36_15: %Goat.type = converted %Ginger.ref, %Goat.facet [template = constants.%Goat.facet]
-// CHECK:STDOUT:   %.loc36_22: %Eats.type = converted %.loc36_15, <error> [template = <error>]
+// CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
+// CHECK:STDOUT:   %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value %Goat.ref, constants.%impl_witness [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc38_13: %Animal.type = converted %Goat.ref, %Animal.facet [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc38_22: %Eats.type = converted %.loc38_13, <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%e) {
-// CHECK:STDOUT:   %e.loc19_9.2 => constants.%e
-// CHECK:STDOUT:   %e.patt.loc19_9.2 => constants.%e
+// CHECK:STDOUT:   %e.loc18_9.2 => constants.%e
+// CHECK:STDOUT:   %e.patt.loc18_9.2 => constants.%e
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_facet_value.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_facet_value.carbon
@@ -8,6 +8,20 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_facet_value.carbon
 
+// --- core.carbon
+
+package Core;
+
+interface ImplicitAs(T:! type) {
+  fn Convert[self: Self]() -> T;
+}
+
+// --- fail_todo_convert_facet_value_to_facet_value.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
 interface Eats {}
 interface Animal {}
 
@@ -21,23 +35,121 @@ class Goat {}
 impl Goat as Animal {}
 
 fn F() {
-  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+14]]:3: error: semantics TODO: `Facet value converting to facet value` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+17]]:3: error: semantics TODO: `Facet value converting to facet value` [SemanticsTodo]
   // CHECK:STDERR:   Feed(Goat as Animal);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-9]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
   // CHECK:STDERR: fn Feed(e:! Eats) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+7]]:3: error: `Core.ImplicitAs` implicitly referenced here, but package `Core` not found [CoreNotFound]
+  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+10]]:3: error: cannot implicitly convert from `Animal` to `Eats` [ImplicitAsConversionFailure]
   // CHECK:STDERR:   Feed(Goat as Animal);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-16]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE+7]]:3: note: type `Animal` does not implement interface `Core.ImplicitAs(Eats)` [MissingImplInMemberAccessNote]
+  // CHECK:STDERR:   Feed(Goat as Animal);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_todo_convert_facet_value_to_facet_value.carbon:[[@LINE-19]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
   // CHECK:STDERR: fn Feed(e:! Eats) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
   Feed(Goat as Animal);
 }
 
+// CHECK:STDOUT: --- core.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [template]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert: %Convert.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type %ImplicitAs.type.07f [symbolic]
+// CHECK:STDOUT:   %assoc0: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %T.patt.loc4_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_22.1, runtime_param<none> [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc4_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%T.loc4_22.1: type) {
+// CHECK:STDOUT:   %T.loc4_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T.loc4_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T.loc4_22.2) [symbolic = %Convert.type (constants.%Convert.type)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type) = struct_value () [symbolic = %Convert (constants.%Convert)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_32.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type) = fn_decl @Convert [symbolic = @ImplicitAs.%Convert (constants.%Convert)] {
+// CHECK:STDOUT:       %self.patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = binding_pattern self
+// CHECK:STDOUT:       %self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param_pattern %self.patt, runtime_param0
+// CHECK:STDOUT:       %return.patt: @Convert.%T (%T) = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: @Convert.%T (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @ImplicitAs.%T.loc4_22.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %self.param: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param runtime_param0
+// CHECK:STDOUT:       %.loc5_20.1: type = splice_block %.loc5_20.3 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:         %.loc5_20.2: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%T) [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.ref: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc5_20.2 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.as_type.loc5_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:         %.loc5_20.3: type = converted %Self.ref, %Self.as_type.loc5_20.2 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.%T (%T) = out_param runtime_param1
+// CHECK:STDOUT:       %return: ref @Convert.%T (%T) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_32.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Convert = %assoc0.loc5_32.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(@ImplicitAs.%T.loc4_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_22.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1 => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc4_22.2) {}
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_todo_convert_facet_value_to_facet_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -56,37 +168,68 @@ fn F() {
 // CHECK:STDOUT:   %F.type: type = fn_type @F [template]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [template]
 // CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value %Goat, %impl_witness [template]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.d62: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.519: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %Convert.type.275: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert.42e: %Convert.type.275 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self.519 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.837: type = assoc_entity_type %ImplicitAs.type.d62 [symbolic]
+// CHECK:STDOUT:   %assoc0.43db8b.1: %ImplicitAs.assoc_type.837 = assoc_entity element0, imports.%Core.import_ref.207961.1 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.af9: type = facet_type <@ImplicitAs, @ImplicitAs(%Eats.type)> [template]
+// CHECK:STDOUT:   %Convert.type.9a9: type = fn_type @Convert, @ImplicitAs(%Eats.type) [template]
+// CHECK:STDOUT:   %Convert.35d: %Convert.type.9a9 = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.9a7: type = assoc_entity_type %ImplicitAs.type.af9 [template]
+// CHECK:STDOUT:   %assoc0.152: %ImplicitAs.assoc_type.9a7 = assoc_entity element0, imports.%Core.import_ref.207961.1 [template]
+// CHECK:STDOUT:   %assoc0.43db8b.2: %ImplicitAs.assoc_type.837 = assoc_entity element0, imports.%Core.import_ref.207961.2 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.f6b058.1: type = import_ref Core//default, loc4_22, loaded [symbolic = @ImplicitAs.%T (constants.%T)]
+// CHECK:STDOUT:   %Core.import_ref.ff5 = import_ref Core//default, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %Core.import_ref.630: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.837) = import_ref Core//default, loc5_32, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.43db8b.2)]
+// CHECK:STDOUT:   %Core.Convert = import_ref Core//default, Convert, unloaded
+// CHECK:STDOUT:   %Core.import_ref.f6b058.2: type = import_ref Core//default, loc4_22, loaded [symbolic = @ImplicitAs.%T (constants.%T)]
+// CHECK:STDOUT:   %Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) = import_ref Core//default, inst26 [no loc], loaded [symbolic = @ImplicitAs.%Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Core.import_ref.207961.1 = import_ref Core//default, loc5_32, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     .Eats = %Eats.decl
 // CHECK:STDOUT:     .Animal = %Animal.decl
 // CHECK:STDOUT:     .Feed = %Feed.decl
 // CHECK:STDOUT:     .Goat = %Goat.decl
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Eats.decl: type = interface_decl @Eats [template = constants.%Eats.type] {} {}
 // CHECK:STDOUT:   %Animal.decl: type = interface_decl @Animal [template = constants.%Animal.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.1 [template] {} {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [template = constants.%Eats.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness.loc16: <witness> = impl_witness () [template = constants.%impl_witness]
+// CHECK:STDOUT:   %impl_witness.loc11: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT:   %Feed.decl: %Feed.type = fn_decl @Feed [template = constants.%Feed] {
-// CHECK:STDOUT:     %e.patt.loc18_9.1: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc18_9.2 (constants.%e.patt)]
-// CHECK:STDOUT:     %e.param_patt: %Eats.type = value_param_pattern %e.patt.loc18_9.1, runtime_param<none> [symbolic = %e.patt.loc18_9.2 (constants.%e.patt)]
+// CHECK:STDOUT:     %e.patt.loc13_9.1: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc13_9.2 (constants.%e.patt)]
+// CHECK:STDOUT:     %e.param_patt: %Eats.type = value_param_pattern %e.patt.loc13_9.1, runtime_param<none> [symbolic = %e.patt.loc13_9.2 (constants.%e.patt)]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %e.param: %Eats.type = value_param runtime_param<none>
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [template = constants.%Eats.type]
-// CHECK:STDOUT:     %e.loc18_9.1: %Eats.type = bind_symbolic_name e, 0, %e.param [symbolic = %e.loc18_9.2 (constants.%e)]
+// CHECK:STDOUT:     %e.loc13_9.1: %Eats.type = bind_symbolic_name e, 0, %e.param [symbolic = %e.loc13_9.2 (constants.%e)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [template = constants.%Goat] {} {}
 // CHECK:STDOUT:   impl_decl @impl.2 [template] {} {
 // CHECK:STDOUT:     %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness.loc21: <witness> = impl_witness () [template = constants.%impl_witness]
+// CHECK:STDOUT:   %impl_witness.loc16: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -106,14 +249,34 @@ fn F() {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(imports.%Core.import_ref.f6b058.1: type) [from "core.carbon"] {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic = %Convert.type (constants.%Convert.type.275)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type.275) = struct_value () [symbolic = %Convert (constants.%Convert.42e)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.837)]
+// CHECK:STDOUT:   %assoc0: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.837) = assoc_entity element0, imports.%Core.import_ref.207961.1 [symbolic = %assoc0 (constants.%assoc0.43db8b.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Core.import_ref.ff5
+// CHECK:STDOUT:     .Convert = imports.%Core.import_ref.630
+// CHECK:STDOUT:     witness = (imports.%Core.Convert)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.1: %Animal.ref as %Eats.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness.loc16
+// CHECK:STDOUT:   witness = file.%impl_witness.loc11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.2: %Goat.ref as %Animal.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness.loc21
+// CHECK:STDOUT:   witness = file.%impl_witness.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Goat {
@@ -124,9 +287,9 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Feed(%e.loc18_9.1: %Eats.type) {
-// CHECK:STDOUT:   %e.loc18_9.2: %Eats.type = bind_symbolic_name e, 0 [symbolic = %e.loc18_9.2 (constants.%e)]
-// CHECK:STDOUT:   %e.patt.loc18_9.2: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc18_9.2 (constants.%e.patt)]
+// CHECK:STDOUT: generic fn @Feed(%e.loc13_9.1: %Eats.type) {
+// CHECK:STDOUT:   %e.loc13_9.2: %Eats.type = bind_symbolic_name e, 0 [symbolic = %e.loc13_9.2 (constants.%e)]
+// CHECK:STDOUT:   %e.patt.loc13_9.2: %Eats.type = symbolic_binding_pattern e, 0 [symbolic = %e.patt.loc13_9.2 (constants.%e.patt)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -142,13 +305,51 @@ fn F() {
 // CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
 // CHECK:STDOUT:   %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
 // CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value %Goat.ref, constants.%impl_witness [template = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc38_13: %Animal.type = converted %Goat.ref, %Animal.facet [template = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc38_22: %Eats.type = converted %.loc38_13, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc36_13: %Animal.type = converted %Goat.ref, %Animal.facet [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc36_22: %Eats.type = converted %.loc36_13, <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(imports.%Core.import_ref.f6b058.2: type, imports.%Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62)) [from "core.carbon"] {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic = %Self.as_type (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%e) {
-// CHECK:STDOUT:   %e.loc18_9.2 => constants.%e
-// CHECK:STDOUT:   %e.patt.loc18_9.2 => constants.%e
+// CHECK:STDOUT:   %e.loc13_9.2 => constants.%e
+// CHECK:STDOUT:   %e.patt.loc13_9.2 => constants.%e
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %T.patt => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self.519) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.d62
+// CHECK:STDOUT:   %Self => constants.%Self.519
+// CHECK:STDOUT:   %Self.as_type => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%Eats.type) {
+// CHECK:STDOUT:   %T => constants.%Eats.type
+// CHECK:STDOUT:   %T.patt => constants.%Eats.type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.af9
+// CHECK:STDOUT:   %Self => constants.%Self.519
+// CHECK:STDOUT:   %Convert.type => constants.%Convert.type.9a9
+// CHECK:STDOUT:   %Convert => constants.%Convert.35d
+// CHECK:STDOUT:   %ImplicitAs.assoc_type => constants.%ImplicitAs.assoc_type.9a7
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0.152
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_narrowed_facet_type.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_narrowed_facet_type.carbon
@@ -1,0 +1,253 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_narrowed_facet_type.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_to_narrowed_facet_type.carbon
+
+// --- core.carbon
+
+package Core;
+
+interface ImplicitAs(T:! type) {
+  fn Convert[self: Self]() -> T;
+}
+
+// --- fail_todo_convert_to_narrowed_facet_type.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
+interface Eats {}
+interface Animal {}
+
+fn Feed[T:! Eats](e: T) {}
+
+// CHECK:STDERR: fail_todo_convert_to_narrowed_facet_type.carbon:[[@LINE+4]]:21: error: name `Core.BitAnd` implicitly referenced here, but not found [CoreNameNotFound]
+// CHECK:STDERR: fn HandleAnimal[T:! Animal & Eats](a: T) { Feed(a); }
+// CHECK:STDERR:                     ^~~~~~~~~~~~~
+// CHECK:STDERR:
+fn HandleAnimal[T:! Animal & Eats](a: T) { Feed(a); }
+
+// CHECK:STDOUT: --- core.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [template]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert: %Convert.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type %ImplicitAs.type.07f [symbolic]
+// CHECK:STDOUT:   %assoc0: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %T.patt.loc4_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_22.1, runtime_param<none> [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc4_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%T.loc4_22.1: type) {
+// CHECK:STDOUT:   %T.loc4_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T.loc4_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T.loc4_22.2) [symbolic = %Convert.type (constants.%Convert.type)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type) = struct_value () [symbolic = %Convert (constants.%Convert)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_32.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type) = fn_decl @Convert [symbolic = @ImplicitAs.%Convert (constants.%Convert)] {
+// CHECK:STDOUT:       %self.patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = binding_pattern self
+// CHECK:STDOUT:       %self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param_pattern %self.patt, runtime_param0
+// CHECK:STDOUT:       %return.patt: @Convert.%T (%T) = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: @Convert.%T (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @ImplicitAs.%T.loc4_22.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %self.param: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param runtime_param0
+// CHECK:STDOUT:       %.loc5_20.1: type = splice_block %.loc5_20.3 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:         %.loc5_20.2: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%T) [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.ref: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc5_20.2 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.as_type.loc5_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:         %.loc5_20.3: type = converted %Self.ref, %Self.as_type.loc5_20.2 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.%T (%T) = out_param runtime_param1
+// CHECK:STDOUT:       %return: ref @Convert.%T (%T) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_32.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Convert = %assoc0.loc5_32.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(@ImplicitAs.%T.loc4_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_22.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1 => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc4_22.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_todo_convert_to_narrowed_facet_type.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats> [template]
+// CHECK:STDOUT:   %Self.1b5: %Eats.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %Animal.type: type = facet_type <@Animal> [template]
+// CHECK:STDOUT:   %Self.fd4: %Animal.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %T: %Eats.type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt.6be: %Eats.type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %T.as_type: type = facet_access_type %T [symbolic]
+// CHECK:STDOUT:   %Feed.type: type = fn_type @Feed [template]
+// CHECK:STDOUT:   %Feed: %Feed.type = struct_value () [template]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type [symbolic]
+// CHECK:STDOUT:   %T.patt.e01: <error> = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %HandleAnimal.type: type = fn_type @HandleAnimal [template]
+// CHECK:STDOUT:   %HandleAnimal: %HandleAnimal.type = struct_value () [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Eats = %Eats.decl
+// CHECK:STDOUT:     .Animal = %Animal.decl
+// CHECK:STDOUT:     .Feed = %Feed.decl
+// CHECK:STDOUT:     .HandleAnimal = %HandleAnimal.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Eats.decl: type = interface_decl @Eats [template = constants.%Eats.type] {} {}
+// CHECK:STDOUT:   %Animal.decl: type = interface_decl @Animal [template = constants.%Animal.type] {} {}
+// CHECK:STDOUT:   %Feed.decl: %Feed.type = fn_decl @Feed [template = constants.%Feed] {
+// CHECK:STDOUT:     %T.patt.loc9_9.1: %Eats.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_9.2 (constants.%T.patt.6be)]
+// CHECK:STDOUT:     %T.param_patt: %Eats.type = value_param_pattern %T.patt.loc9_9.1, runtime_param<none> [symbolic = %T.patt.loc9_9.2 (constants.%T.patt.6be)]
+// CHECK:STDOUT:     %e.patt: @Feed.%T.as_type.loc9_22.2 (%T.as_type) = binding_pattern e
+// CHECK:STDOUT:     %e.param_patt: @Feed.%T.as_type.loc9_22.2 (%T.as_type) = value_param_pattern %e.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: %Eats.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [template = constants.%Eats.type]
+// CHECK:STDOUT:     %T.loc9_9.1: %Eats.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc9_9.2 (constants.%T)]
+// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc9_22.2 (%T.as_type) = value_param runtime_param0
+// CHECK:STDOUT:     %.loc9_22.1: type = splice_block %.loc9_22.2 [symbolic = %T.as_type.loc9_22.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref: %Eats.type = name_ref T, %T.loc9_9.1 [symbolic = %T.loc9_9.2 (constants.%T)]
+// CHECK:STDOUT:       %T.as_type.loc9_22.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc9_22.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc9_22.2: type = converted %T.ref, %T.as_type.loc9_22.1 [symbolic = %T.as_type.loc9_22.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc9_22.2 (%T.as_type) = bind_name e, %e.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [template = constants.%HandleAnimal] {
+// CHECK:STDOUT:     %T.patt.loc15_17.1: <error> = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_17.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %T.param_patt: <error> = value_param_pattern %T.patt.loc15_17.1, runtime_param<none> [symbolic = %T.patt.loc15_17.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:     %a.patt: <error> = binding_pattern a
+// CHECK:STDOUT:     %a.param_patt: <error> = value_param_pattern %a.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: <error> = value_param runtime_param<none>
+// CHECK:STDOUT:     %.1: <error> = splice_block <error> [template = <error>] {
+// CHECK:STDOUT:       %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:       %Eats.ref: type = name_ref Eats, file.%Eats.decl [template = constants.%Eats.type]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T: <error> = bind_symbolic_name T, 0, %T.param [template = <error>]
+// CHECK:STDOUT:     %a.param: <error> = value_param runtime_param0
+// CHECK:STDOUT:     %T.ref: <error> = name_ref T, %T [template = <error>]
+// CHECK:STDOUT:     %a: <error> = bind_name a, %a.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @Eats {
+// CHECK:STDOUT:   %Self: %Eats.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.1b5]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @Animal {
+// CHECK:STDOUT:   %Self: %Animal.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.fd4]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Feed(%T.loc9_9.1: %Eats.type) {
+// CHECK:STDOUT:   %T.loc9_9.2: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc9_9.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc9_9.2: %Eats.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_9.2 (constants.%T.patt.6be)]
+// CHECK:STDOUT:   %T.as_type.loc9_22.2: type = facet_access_type %T.loc9_9.2 [symbolic = %T.as_type.loc9_22.2 (constants.%T.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @Feed.%T.as_type.loc9_22.2 (%T.as_type) [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: %Eats.type](%e.param_patt: @Feed.%T.as_type.loc9_22.2 (%T.as_type)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @HandleAnimal(%T: <error>) {
+// CHECK:STDOUT:   %T.patt.loc15_17.2: <error> = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc15_17.2 (constants.%T.patt.e01)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: <error>](%a.param_patt: <error>) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %Feed.ref: %Feed.type = name_ref Feed, file.%Feed.decl [template = constants.%Feed]
+// CHECK:STDOUT:     %a.ref: <error> = name_ref a, %a
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Feed(constants.%T) {
+// CHECK:STDOUT:   %T.loc9_9.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc9_9.2 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc9_22.2 => constants.%T.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @HandleAnimal(<error>) {
+// CHECK:STDOUT:   %T.patt.loc15_17.2 => <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon
+++ b/toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon
@@ -1,0 +1,601 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/builtin_conversions/no_prelude/fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon
+
+// --- core.carbon
+
+package Core;
+
+interface ImplicitAs(T:! type) {
+  fn Convert[self: Self]() -> T;
+}
+
+// --- fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon
+
+library "[[@TEST_NAME]]";
+
+import Core;
+
+class Grass {}
+
+interface Animal {}
+interface Eats(Food:! type) {}
+
+fn Feed[Food:! type, T:! Eats(Food)](e: T, food: Food) {}
+// CHECK:STDERR: fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon:[[@LINE+10]]:62: error: cannot implicitly convert from `type` to `Eats(Food)` [ImplicitAsConversionFailure]
+// CHECK:STDERR: fn HandleAnimal[T:! Animal, Food:! type](a: T, food: Food) { Feed(a, food); }
+// CHECK:STDERR:                                                              ^~~~~~~~~~~~~
+// CHECK:STDERR: fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon:[[@LINE+7]]:62: note: type `type` does not implement interface `Core.ImplicitAs(Eats(Food))` [MissingImplInMemberAccessNote]
+// CHECK:STDERR: fn HandleAnimal[T:! Animal, Food:! type](a: T, food: Food) { Feed(a, food); }
+// CHECK:STDERR:                                                              ^~~~~~~~~~~~~
+// CHECK:STDERR: fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon:[[@LINE-7]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+// CHECK:STDERR: fn Feed[Food:! type, T:! Eats(Food)](e: T, food: Food) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn HandleAnimal[T:! Animal, Food:! type](a: T, food: Food) { Feed(a, food); }
+
+class Goat {}
+impl Goat as Animal {}
+
+impl forall [T:! Animal] T as Eats(Grass) {}
+
+fn F() {
+  HandleAnimal({} as Goat, {} as Grass);
+}
+
+// CHECK:STDOUT: --- core.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [template]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [template]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic]
+// CHECK:STDOUT:   %Convert: %Convert.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type %ImplicitAs.type.07f [symbolic]
+// CHECK:STDOUT:   %assoc0: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [template = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %T.patt.loc4_22.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc4_22.1, runtime_param<none> [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc4_22.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%T.loc4_22.1: type) {
+// CHECK:STDOUT:   %T.loc4_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_22.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc4_22.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc4_22.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T.loc4_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T.loc4_22.2) [symbolic = %Convert.type (constants.%Convert.type)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type) = struct_value () [symbolic = %Convert (constants.%Convert)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_32.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type) = fn_decl @Convert [symbolic = @ImplicitAs.%Convert (constants.%Convert)] {
+// CHECK:STDOUT:       %self.patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = binding_pattern self
+// CHECK:STDOUT:       %self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param_pattern %self.patt, runtime_param0
+// CHECK:STDOUT:       %return.patt: @Convert.%T (%T) = return_slot_pattern
+// CHECK:STDOUT:       %return.param_patt: @Convert.%T (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @ImplicitAs.%T.loc4_22.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %self.param: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = value_param runtime_param0
+// CHECK:STDOUT:       %.loc5_20.1: type = splice_block %.loc5_20.3 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:         %.loc5_20.2: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%T) [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.ref: @Convert.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc5_20.2 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:         %Self.as_type.loc5_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:         %.loc5_20.3: type = converted %Self.ref, %Self.as_type.loc5_20.2 [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.%T (%T) = out_param runtime_param1
+// CHECK:STDOUT:       %return: ref @Convert.%T (%T) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_32.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc5_32.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Convert = %assoc0.loc5_32.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(@ImplicitAs.%T.loc4_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc5_20.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type.loc5_20.1 (%Self.as_type)]() -> @Convert.%T (%T);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_22.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc4_22.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T, constants.%Self) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type.loc5_20.1 => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T.loc4_22.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_todo_convert_facet_value_value_to_generic_facet_value_value.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Grass: type = class_type @Grass [template]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [template]
+// CHECK:STDOUT:   %Animal.type: type = facet_type <@Animal> [template]
+// CHECK:STDOUT:   %Self.fd4: %Animal.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %Food.8b3: type = bind_symbolic_name Food, 0 [symbolic]
+// CHECK:STDOUT:   %Food.patt.e01: type = symbolic_binding_pattern Food, 0 [symbolic]
+// CHECK:STDOUT:   %Eats.type.ba2: type = generic_interface_type @Eats [template]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [template]
+// CHECK:STDOUT:   %Eats.generic: %Eats.type.ba2 = struct_value () [template]
+// CHECK:STDOUT:   %Eats.type.6c0: type = facet_type <@Eats, @Eats(%Food.8b3)> [symbolic]
+// CHECK:STDOUT:   %Self.4eb: %Eats.type.6c0 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %T.4eb: %Eats.type.6c0 = bind_symbolic_name T, 1 [symbolic]
+// CHECK:STDOUT:   %T.patt.41f: %Eats.type.6c0 = symbolic_binding_pattern T, 1 [symbolic]
+// CHECK:STDOUT:   %T.as_type.7b9: type = facet_access_type %T.4eb [symbolic]
+// CHECK:STDOUT:   %Feed.type: type = fn_type @Feed [template]
+// CHECK:STDOUT:   %Feed: %Feed.type = struct_value () [template]
+// CHECK:STDOUT:   %require_complete.c74: <witness> = require_complete_type %T.as_type.7b9 [symbolic]
+// CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %Food.8b3 [symbolic]
+// CHECK:STDOUT:   %T.fd4: %Animal.type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt.a9c: %Animal.type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %Food.336: type = bind_symbolic_name Food, 1 [symbolic]
+// CHECK:STDOUT:   %Food.patt.7a9: type = symbolic_binding_pattern Food, 1 [symbolic]
+// CHECK:STDOUT:   %T.as_type.2ad: type = facet_access_type %T.fd4 [symbolic]
+// CHECK:STDOUT:   %HandleAnimal.type: type = fn_type @HandleAnimal [template]
+// CHECK:STDOUT:   %HandleAnimal: %HandleAnimal.type = struct_value () [template]
+// CHECK:STDOUT:   %require_complete.234: <witness> = require_complete_type %T.as_type.2ad [symbolic]
+// CHECK:STDOUT:   %require_complete.b54: <witness> = require_complete_type %Food.336 [symbolic]
+// CHECK:STDOUT:   %Eats.type.3ec: type = facet_type <@Eats, @Eats(%Food.336)> [symbolic]
+// CHECK:STDOUT:   %require_complete.588: <witness> = require_complete_type %Eats.type.3ec [symbolic]
+// CHECK:STDOUT:   %T.8b3: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.d62: type = facet_type <@ImplicitAs, @ImplicitAs(%T.8b3)> [symbolic]
+// CHECK:STDOUT:   %Self.519: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %T.patt.e01: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %Convert.type.275: type = fn_type @Convert, @ImplicitAs(%T.8b3) [symbolic]
+// CHECK:STDOUT:   %Convert.42e: %Convert.type.275 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self.519 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.837: type = assoc_entity_type %ImplicitAs.type.d62 [symbolic]
+// CHECK:STDOUT:   %assoc0.43db8b.1: %ImplicitAs.assoc_type.837 = assoc_entity element0, imports.%Core.import_ref.207961.1 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.dd1: type = facet_type <@ImplicitAs, @ImplicitAs(%Eats.type.3ec)> [symbolic]
+// CHECK:STDOUT:   %require_complete.959: <witness> = require_complete_type %ImplicitAs.type.dd1 [symbolic]
+// CHECK:STDOUT:   %Convert.type.d69: type = fn_type @Convert, @ImplicitAs(%Eats.type.3ec) [symbolic]
+// CHECK:STDOUT:   %Convert.561: %Convert.type.d69 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.163: type = assoc_entity_type %ImplicitAs.type.dd1 [symbolic]
+// CHECK:STDOUT:   %assoc0.676: %ImplicitAs.assoc_type.163 = assoc_entity element0, imports.%Core.import_ref.207961.1 [symbolic]
+// CHECK:STDOUT:   %assoc0.43db8b.2: %ImplicitAs.assoc_type.837 = assoc_entity element0, imports.%Core.import_ref.207961.2 [symbolic]
+// CHECK:STDOUT:   %Goat: type = class_type @Goat [template]
+// CHECK:STDOUT:   %impl_witness.1bc: <witness> = impl_witness () [template]
+// CHECK:STDOUT:   %Eats.type.1ae: type = facet_type <@Eats, @Eats(%Grass)> [template]
+// CHECK:STDOUT:   %impl_witness.8fd: <witness> = impl_witness (), @impl.2(%T.fd4) [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [template]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [template]
+// CHECK:STDOUT:   %Goat.val: %Goat = struct_value () [template]
+// CHECK:STDOUT:   %Grass.val: %Grass = struct_value () [template]
+// CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value %Goat, %impl_witness.1bc [template]
+// CHECK:STDOUT:   %HandleAnimal.specific_fn: <specific function> = specific_function %HandleAnimal, @HandleAnimal(%Animal.facet, %Grass) [template]
+// CHECK:STDOUT:   %complete_type.004: <witness> = complete_type_witness %Eats.type.1ae [template]
+// CHECK:STDOUT:   %ImplicitAs.type.849: type = facet_type <@ImplicitAs, @ImplicitAs(%Eats.type.1ae)> [template]
+// CHECK:STDOUT:   %complete_type.eef: <witness> = complete_type_witness %ImplicitAs.type.849 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [template] {
+// CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
+// CHECK:STDOUT:     import Core//default
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.f6b058.1: type = import_ref Core//default, loc4_22, loaded [symbolic = @ImplicitAs.%T (constants.%T.8b3)]
+// CHECK:STDOUT:   %Core.import_ref.ff5 = import_ref Core//default, inst26 [no loc], unloaded
+// CHECK:STDOUT:   %Core.import_ref.630: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.837) = import_ref Core//default, loc5_32, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.43db8b.2)]
+// CHECK:STDOUT:   %Core.Convert = import_ref Core//default, Convert, unloaded
+// CHECK:STDOUT:   %Core.import_ref.f6b058.2: type = import_ref Core//default, loc4_22, loaded [symbolic = @ImplicitAs.%T (constants.%T.8b3)]
+// CHECK:STDOUT:   %Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) = import_ref Core//default, inst26 [no loc], loaded [symbolic = @ImplicitAs.%Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Core.import_ref.207961.1 = import_ref Core//default, loc5_32, unloaded
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Grass = %Grass.decl
+// CHECK:STDOUT:     .Animal = %Animal.decl
+// CHECK:STDOUT:     .Eats = %Eats.decl
+// CHECK:STDOUT:     .Feed = %Feed.decl
+// CHECK:STDOUT:     .HandleAnimal = %HandleAnimal.decl
+// CHECK:STDOUT:     .Goat = %Goat.decl
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Grass.decl: type = class_decl @Grass [template = constants.%Grass] {} {}
+// CHECK:STDOUT:   %Animal.decl: type = interface_decl @Animal [template = constants.%Animal.type] {} {}
+// CHECK:STDOUT:   %Eats.decl: %Eats.type.ba2 = interface_decl @Eats [template = constants.%Eats.generic] {
+// CHECK:STDOUT:     %Food.patt.loc9_16.1: type = symbolic_binding_pattern Food, 0 [symbolic = %Food.patt.loc9_16.2 (constants.%Food.patt.e01)]
+// CHECK:STDOUT:     %Food.param_patt: type = value_param_pattern %Food.patt.loc9_16.1, runtime_param<none> [symbolic = %Food.patt.loc9_16.2 (constants.%Food.patt.e01)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Food.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Food.loc9_16.1: type = bind_symbolic_name Food, 0, %Food.param [symbolic = %Food.loc9_16.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Feed.decl: %Feed.type = fn_decl @Feed [template = constants.%Feed] {
+// CHECK:STDOUT:     %Food.patt.loc11_9.1: type = symbolic_binding_pattern Food, 0 [symbolic = %Food.patt.loc11_9.2 (constants.%Food.patt.e01)]
+// CHECK:STDOUT:     %Food.param_patt: type = value_param_pattern %Food.patt.loc11_9.1, runtime_param<none> [symbolic = %Food.patt.loc11_9.2 (constants.%Food.patt.e01)]
+// CHECK:STDOUT:     %T.patt.loc11_22.1: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0) = symbolic_binding_pattern T, 1 [symbolic = %T.patt.loc11_22.2 (constants.%T.patt.41f)]
+// CHECK:STDOUT:     %T.param_patt: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0) = value_param_pattern %T.patt.loc11_22.1, runtime_param<none> [symbolic = %T.patt.loc11_22.2 (constants.%T.patt.41f)]
+// CHECK:STDOUT:     %e.patt: @Feed.%T.as_type.loc11_41.2 (%T.as_type.7b9) = binding_pattern e
+// CHECK:STDOUT:     %e.param_patt: @Feed.%T.as_type.loc11_41.2 (%T.as_type.7b9) = value_param_pattern %e.patt, runtime_param0
+// CHECK:STDOUT:     %food.patt: @Feed.%Food.loc11_9.2 (%Food.8b3) = binding_pattern food
+// CHECK:STDOUT:     %food.param_patt: @Feed.%Food.loc11_9.2 (%Food.8b3) = value_param_pattern %food.patt, runtime_param1
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Food.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Food.loc11_9.1: type = bind_symbolic_name Food, 0, %Food.param [symbolic = %Food.loc11_9.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:     %T.param: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0) = value_param runtime_param<none>
+// CHECK:STDOUT:     %.loc11_35: type = splice_block %Eats.type.loc11_35.1 [symbolic = %Eats.type.loc11_35.2 (constants.%Eats.type.6c0)] {
+// CHECK:STDOUT:       %Eats.ref: %Eats.type.ba2 = name_ref Eats, file.%Eats.decl [template = constants.%Eats.generic]
+// CHECK:STDOUT:       %Food.ref.loc11_31: type = name_ref Food, %Food.loc11_9.1 [symbolic = %Food.loc11_9.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:       %Eats.type.loc11_35.1: type = facet_type <@Eats, @Eats(constants.%Food.8b3)> [symbolic = %Eats.type.loc11_35.2 (constants.%Eats.type.6c0)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T.loc11_22.1: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0) = bind_symbolic_name T, 1, %T.param [symbolic = %T.loc11_22.2 (constants.%T.4eb)]
+// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc11_41.2 (%T.as_type.7b9) = value_param runtime_param0
+// CHECK:STDOUT:     %.loc11_41.1: type = splice_block %.loc11_41.2 [symbolic = %T.as_type.loc11_41.2 (constants.%T.as_type.7b9)] {
+// CHECK:STDOUT:       %T.ref: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0) = name_ref T, %T.loc11_22.1 [symbolic = %T.loc11_22.2 (constants.%T.4eb)]
+// CHECK:STDOUT:       %T.as_type.loc11_41.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc11_41.2 (constants.%T.as_type.7b9)]
+// CHECK:STDOUT:       %.loc11_41.2: type = converted %T.ref, %T.as_type.loc11_41.1 [symbolic = %T.as_type.loc11_41.2 (constants.%T.as_type.7b9)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc11_41.2 (%T.as_type.7b9) = bind_name e, %e.param
+// CHECK:STDOUT:     %food.param: @Feed.%Food.loc11_9.2 (%Food.8b3) = value_param runtime_param1
+// CHECK:STDOUT:     %Food.ref.loc11_50: type = name_ref Food, %Food.loc11_9.1 [symbolic = %Food.loc11_9.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:     %food: @Feed.%Food.loc11_9.2 (%Food.8b3) = bind_name food, %food.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [template = constants.%HandleAnimal] {
+// CHECK:STDOUT:     %T.patt.loc22_17.1: %Animal.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc22_17.2 (constants.%T.patt.a9c)]
+// CHECK:STDOUT:     %T.param_patt: %Animal.type = value_param_pattern %T.patt.loc22_17.1, runtime_param<none> [symbolic = %T.patt.loc22_17.2 (constants.%T.patt.a9c)]
+// CHECK:STDOUT:     %Food.patt.loc22_29.1: type = symbolic_binding_pattern Food, 1 [symbolic = %Food.patt.loc22_29.2 (constants.%Food.patt.7a9)]
+// CHECK:STDOUT:     %Food.param_patt: type = value_param_pattern %Food.patt.loc22_29.1, runtime_param<none> [symbolic = %Food.patt.loc22_29.2 (constants.%Food.patt.7a9)]
+// CHECK:STDOUT:     %a.patt: @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad) = binding_pattern a
+// CHECK:STDOUT:     %a.param_patt: @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad) = value_param_pattern %a.patt, runtime_param0
+// CHECK:STDOUT:     %food.patt: @HandleAnimal.%Food.loc22_29.2 (%Food.336) = binding_pattern food
+// CHECK:STDOUT:     %food.param_patt: @HandleAnimal.%Food.loc22_29.2 (%Food.336) = value_param_pattern %food.patt, runtime_param1
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: %Animal.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:     %T.loc22_17.1: %Animal.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %Food.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Food.loc22_29.1: type = bind_symbolic_name Food, 1, %Food.param [symbolic = %Food.loc22_29.2 (constants.%Food.336)]
+// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad) = value_param runtime_param0
+// CHECK:STDOUT:     %.loc22_45.1: type = splice_block %.loc22_45.2 [symbolic = %T.as_type.loc22_45.2 (constants.%T.as_type.2ad)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc22_17.1 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:       %T.as_type.loc22_45.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc22_45.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:       %.loc22_45.2: type = converted %T.ref, %T.as_type.loc22_45.1 [symbolic = %T.as_type.loc22_45.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad) = bind_name a, %a.param
+// CHECK:STDOUT:     %food.param: @HandleAnimal.%Food.loc22_29.2 (%Food.336) = value_param runtime_param1
+// CHECK:STDOUT:     %Food.ref: type = name_ref Food, %Food.loc22_29.1 [symbolic = %Food.loc22_29.2 (constants.%Food.336)]
+// CHECK:STDOUT:     %food: @HandleAnimal.%Food.loc22_29.2 (%Food.336) = bind_name food, %food.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [template = constants.%Goat] {} {}
+// CHECK:STDOUT:   impl_decl @impl.1 [template] {} {
+// CHECK:STDOUT:     %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc25: <witness> = impl_witness () [template = constants.%impl_witness.1bc]
+// CHECK:STDOUT:   impl_decl @impl.2 [template] {
+// CHECK:STDOUT:     %T.patt.loc27_14.1: %Animal.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc27_14.2 (constants.%T.patt.a9c)]
+// CHECK:STDOUT:     %T.param_patt: %Animal.type = value_param_pattern %T.patt.loc27_14.1, runtime_param<none> [symbolic = %T.patt.loc27_14.2 (constants.%T.patt.a9c)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.ref: %Animal.type = name_ref T, %T.loc27_14.1 [symbolic = %T.loc27_14.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %T.as_type.loc27_26.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc27_26.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc27: type = converted %T.ref, %T.as_type.loc27_26.1 [symbolic = %T.as_type.loc27_26.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %Eats.ref: %Eats.type.ba2 = name_ref Eats, file.%Eats.decl [template = constants.%Eats.generic]
+// CHECK:STDOUT:     %Grass.ref: type = name_ref Grass, file.%Grass.decl [template = constants.%Grass]
+// CHECK:STDOUT:     %Eats.type: type = facet_type <@Eats, @Eats(constants.%Grass)> [template = constants.%Eats.type.1ae]
+// CHECK:STDOUT:     %T.param: %Animal.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [template = constants.%Animal.type]
+// CHECK:STDOUT:     %T.loc27_14.1: %Animal.type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc27_14.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness.loc27: <witness> = impl_witness (), @impl.2(constants.%T.fd4) [symbolic = @impl.2.%impl_witness (constants.%impl_witness.8fd)]
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [template = constants.%F] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @Animal {
+// CHECK:STDOUT:   %Self: %Animal.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.fd4]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @Eats(%Food.loc9_16.1: type) {
+// CHECK:STDOUT:   %Food.loc9_16.2: type = bind_symbolic_name Food, 0 [symbolic = %Food.loc9_16.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:   %Food.patt.loc9_16.2: type = symbolic_binding_pattern Food, 0 [symbolic = %Food.patt.loc9_16.2 (constants.%Food.patt.e01)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats, @Eats(%Food.loc9_16.2)> [symbolic = %Eats.type (constants.%Eats.type.6c0)]
+// CHECK:STDOUT:   %Self.2: %Eats.type.6c0 = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.4eb)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @Eats.%Eats.type (%Eats.type.6c0) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.4eb)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(imports.%Core.import_ref.f6b058.1: type) [from "core.carbon"] {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T.8b3)]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt (constants.%T.patt.e01)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%T) [symbolic = %Convert.type (constants.%Convert.type.275)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type.275) = struct_value () [symbolic = %Convert (constants.%Convert.42e)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.837)]
+// CHECK:STDOUT:   %assoc0: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.837) = assoc_entity element0, imports.%Core.import_ref.207961.1 [symbolic = %assoc0 (constants.%assoc0.43db8b.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Core.import_ref.ff5
+// CHECK:STDOUT:     .Convert = imports.%Core.import_ref.630
+// CHECK:STDOUT:     witness = (imports.%Core.Convert)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.1: %Goat.ref as %Animal.ref {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = file.%impl_witness.loc25
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @impl.2(%T.loc27_14.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc27_14.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc27_14.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   %T.patt.loc27_14.2: %Animal.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc27_14.2 (constants.%T.patt.a9c)]
+// CHECK:STDOUT:   %T.as_type.loc27_26.2: type = facet_access_type %T.loc27_14.2 [symbolic = %T.as_type.loc27_26.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (), @impl.2(%T.loc27_14.2) [symbolic = %impl_witness (constants.%impl_witness.8fd)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %.loc27 as %Eats.type {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%impl_witness.loc27
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Grass {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Grass
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Goat {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Goat
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Feed(%Food.loc11_9.1: type, %T.loc11_22.1: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0)) {
+// CHECK:STDOUT:   %Food.loc11_9.2: type = bind_symbolic_name Food, 0 [symbolic = %Food.loc11_9.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:   %Food.patt.loc11_9.2: type = symbolic_binding_pattern Food, 0 [symbolic = %Food.patt.loc11_9.2 (constants.%Food.patt.e01)]
+// CHECK:STDOUT:   %Eats.type.loc11_35.2: type = facet_type <@Eats, @Eats(%Food.loc11_9.2)> [symbolic = %Eats.type.loc11_35.2 (constants.%Eats.type.6c0)]
+// CHECK:STDOUT:   %T.loc11_22.2: %Eats.type.6c0 = bind_symbolic_name T, 1 [symbolic = %T.loc11_22.2 (constants.%T.4eb)]
+// CHECK:STDOUT:   %T.patt.loc11_22.2: %Eats.type.6c0 = symbolic_binding_pattern T, 1 [symbolic = %T.patt.loc11_22.2 (constants.%T.patt.41f)]
+// CHECK:STDOUT:   %T.as_type.loc11_41.2: type = facet_access_type %T.loc11_22.2 [symbolic = %T.as_type.loc11_41.2 (constants.%T.as_type.7b9)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc11_39: <witness> = require_complete_type @Feed.%T.as_type.loc11_41.2 (%T.as_type.7b9) [symbolic = %require_complete.loc11_39 (constants.%require_complete.c74)]
+// CHECK:STDOUT:   %require_complete.loc11_48: <witness> = require_complete_type @Feed.%Food.loc11_9.2 (%Food.8b3) [symbolic = %require_complete.loc11_48 (constants.%require_complete.4ae)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%Food.param_patt: type, %T.param_patt: @Feed.%Eats.type.loc11_35.2 (%Eats.type.6c0)](%e.param_patt: @Feed.%T.as_type.loc11_41.2 (%T.as_type.7b9), %food.param_patt: @Feed.%Food.loc11_9.2 (%Food.8b3)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc22_17.1: %Animal.type, %Food.loc22_29.1: type) {
+// CHECK:STDOUT:   %T.loc22_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   %T.patt.loc22_17.2: %Animal.type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc22_17.2 (constants.%T.patt.a9c)]
+// CHECK:STDOUT:   %Food.loc22_29.2: type = bind_symbolic_name Food, 1 [symbolic = %Food.loc22_29.2 (constants.%Food.336)]
+// CHECK:STDOUT:   %Food.patt.loc22_29.2: type = symbolic_binding_pattern Food, 1 [symbolic = %Food.patt.loc22_29.2 (constants.%Food.patt.7a9)]
+// CHECK:STDOUT:   %T.as_type.loc22_45.2: type = facet_access_type %T.loc22_17.2 [symbolic = %T.as_type.loc22_45.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc22_43: <witness> = require_complete_type @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad) [symbolic = %require_complete.loc22_43 (constants.%require_complete.234)]
+// CHECK:STDOUT:   %require_complete.loc22_52: <witness> = require_complete_type @HandleAnimal.%Food.loc22_29.2 (%Food.336) [symbolic = %require_complete.loc22_52 (constants.%require_complete.b54)]
+// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats, @Eats(%Food.loc22_29.2)> [symbolic = %Eats.type (constants.%Eats.type.3ec)]
+// CHECK:STDOUT:   %require_complete.loc22_74.1: <witness> = require_complete_type @HandleAnimal.%Eats.type (%Eats.type.3ec) [symbolic = %require_complete.loc22_74.1 (constants.%require_complete.588)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Eats.type)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.dd1)]
+// CHECK:STDOUT:   %require_complete.loc22_74.2: <witness> = require_complete_type @HandleAnimal.%ImplicitAs.type (%ImplicitAs.type.dd1) [symbolic = %require_complete.loc22_74.2 (constants.%require_complete.959)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: %Animal.type, %Food.param_patt: type](%a.param_patt: @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad), %food.param_patt: @HandleAnimal.%Food.loc22_29.2 (%Food.336)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %Feed.ref: %Feed.type = name_ref Feed, file.%Feed.decl [template = constants.%Feed]
+// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc22_45.2 (%T.as_type.2ad) = name_ref a, %a
+// CHECK:STDOUT:     %food.ref: @HandleAnimal.%Food.loc22_29.2 (%Food.336) = name_ref food, %food
+// CHECK:STDOUT:     %.loc22_74: @HandleAnimal.%Eats.type (%Eats.type.3ec) = converted constants.%T.as_type.2ad, <error> [template = <error>]
+// CHECK:STDOUT:     %Feed.specific_fn: <specific function> = specific_function %Feed.ref, @Feed(constants.%Food.336, <error>) [template = <error>]
+// CHECK:STDOUT:     %Feed.call: init %empty_tuple.type = call %Feed.specific_fn(<error>, %food.ref)
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(imports.%Core.import_ref.f6b058.2: type, imports.%Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62)) [from "core.carbon"] {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T.8b3)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%T)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic = %Self.as_type (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%self.param_patt: @Convert.%Self.as_type (%Self.as_type)]() -> @Convert.%T (%T.8b3);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %HandleAnimal.ref: %HandleAnimal.type = name_ref HandleAnimal, file.%HandleAnimal.decl [template = constants.%HandleAnimal]
+// CHECK:STDOUT:   %.loc30_17.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [template = constants.%Goat]
+// CHECK:STDOUT:   %.loc30_17.2: ref %Goat = temporary_storage
+// CHECK:STDOUT:   %.loc30_17.3: init %Goat = class_init (), %.loc30_17.2 [template = constants.%Goat.val]
+// CHECK:STDOUT:   %.loc30_17.4: ref %Goat = temporary %.loc30_17.2, %.loc30_17.3
+// CHECK:STDOUT:   %.loc30_19.1: ref %Goat = converted %.loc30_17.1, %.loc30_17.4
+// CHECK:STDOUT:   %.loc30_29.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %Grass.ref: type = name_ref Grass, file.%Grass.decl [template = constants.%Grass]
+// CHECK:STDOUT:   %.loc30_29.2: ref %Grass = temporary_storage
+// CHECK:STDOUT:   %.loc30_29.3: init %Grass = class_init (), %.loc30_29.2 [template = constants.%Grass.val]
+// CHECK:STDOUT:   %.loc30_29.4: ref %Grass = temporary %.loc30_29.2, %.loc30_29.3
+// CHECK:STDOUT:   %.loc30_31.1: ref %Grass = converted %.loc30_29.1, %.loc30_29.4
+// CHECK:STDOUT:   %Animal.facet.loc30_39.1: %Animal.type = facet_value constants.%Goat, constants.%impl_witness.1bc [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc30_39.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc30_39.1 [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %Animal.facet.loc30_39.2: %Animal.type = facet_value constants.%Goat, constants.%impl_witness.1bc [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc30_39.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc30_39.2 [template = constants.%Animal.facet]
+// CHECK:STDOUT:   %HandleAnimal.specific_fn: <specific function> = specific_function %HandleAnimal.ref, @HandleAnimal(constants.%Animal.facet, constants.%Grass) [template = constants.%HandleAnimal.specific_fn]
+// CHECK:STDOUT:   %.loc30_19.2: %Goat = bind_value %.loc30_19.1
+// CHECK:STDOUT:   %.loc30_31.2: %Grass = bind_value %.loc30_31.1
+// CHECK:STDOUT:   %HandleAnimal.call: init %empty_tuple.type = call %HandleAnimal.specific_fn(%.loc30_19.2, %.loc30_31.2)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Eats(constants.%Food.8b3) {
+// CHECK:STDOUT:   %Food.loc9_16.2 => constants.%Food.8b3
+// CHECK:STDOUT:   %Food.patt.loc9_16.2 => constants.%Food.8b3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Eats(%Food.loc9_16.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Feed(constants.%Food.8b3, constants.%T.4eb) {
+// CHECK:STDOUT:   %Food.loc11_9.2 => constants.%Food.8b3
+// CHECK:STDOUT:   %Food.patt.loc11_9.2 => constants.%Food.8b3
+// CHECK:STDOUT:   %Eats.type.loc11_35.2 => constants.%Eats.type.6c0
+// CHECK:STDOUT:   %T.loc11_22.2 => constants.%T.4eb
+// CHECK:STDOUT:   %T.patt.loc11_22.2 => constants.%T.4eb
+// CHECK:STDOUT:   %T.as_type.loc11_41.2 => constants.%T.as_type.7b9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Eats(@Feed.%Food.loc11_9.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @HandleAnimal(constants.%T.fd4, constants.%Food.336) {
+// CHECK:STDOUT:   %T.loc22_17.2 => constants.%T.fd4
+// CHECK:STDOUT:   %T.patt.loc22_17.2 => constants.%T.fd4
+// CHECK:STDOUT:   %Food.loc22_29.2 => constants.%Food.336
+// CHECK:STDOUT:   %Food.patt.loc22_29.2 => constants.%Food.336
+// CHECK:STDOUT:   %T.as_type.loc22_45.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Eats(constants.%Food.336) {
+// CHECK:STDOUT:   %Food.loc9_16.2 => constants.%Food.336
+// CHECK:STDOUT:   %Food.patt.loc9_16.2 => constants.%Food.336
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%T.8b3) {
+// CHECK:STDOUT:   %T => constants.%T.8b3
+// CHECK:STDOUT:   %T.patt => constants.%T.8b3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@Convert.%T) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%T.8b3, constants.%Self.519) {
+// CHECK:STDOUT:   %T => constants.%T.8b3
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.d62
+// CHECK:STDOUT:   %Self => constants.%Self.519
+// CHECK:STDOUT:   %Self.as_type => constants.%Self.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%Eats.type.3ec) {
+// CHECK:STDOUT:   %T => constants.%Eats.type.3ec
+// CHECK:STDOUT:   %T.patt => constants.%Eats.type.3ec
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.dd1
+// CHECK:STDOUT:   %Self => constants.%Self.519
+// CHECK:STDOUT:   %Convert.type => constants.%Convert.type.d69
+// CHECK:STDOUT:   %Convert => constants.%Convert.561
+// CHECK:STDOUT:   %ImplicitAs.assoc_type => constants.%ImplicitAs.assoc_type.163
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0.676
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Feed(constants.%Food.336, <error>) {
+// CHECK:STDOUT:   %Food.loc11_9.2 => constants.%Food.336
+// CHECK:STDOUT:   %Food.patt.loc11_9.2 => constants.%Food.336
+// CHECK:STDOUT:   %Eats.type.loc11_35.2 => constants.%Eats.type.3ec
+// CHECK:STDOUT:   %T.loc11_22.2 => <error>
+// CHECK:STDOUT:   %T.patt.loc11_22.2 => <error>
+// CHECK:STDOUT:   %T.as_type.loc11_41.2 => <error>
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc11_39 => <error>
+// CHECK:STDOUT:   %require_complete.loc11_48 => constants.%require_complete.b54
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Eats(@HandleAnimal.%Food.loc22_29.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(@HandleAnimal.%Eats.type) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Eats(constants.%Grass) {
+// CHECK:STDOUT:   %Food.loc9_16.2 => constants.%Grass
+// CHECK:STDOUT:   %Food.patt.loc9_16.2 => constants.%Grass
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Eats.type => constants.%Eats.type.1ae
+// CHECK:STDOUT:   %Self.2 => constants.%Self.4eb
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(constants.%T.fd4) {
+// CHECK:STDOUT:   %T.loc27_14.2 => constants.%T.fd4
+// CHECK:STDOUT:   %T.patt.loc27_14.2 => constants.%T.fd4
+// CHECK:STDOUT:   %T.as_type.loc27_26.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %impl_witness => constants.%impl_witness.8fd
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @impl.2(%T.loc27_14.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @HandleAnimal(constants.%Animal.facet, constants.%Grass) {
+// CHECK:STDOUT:   %T.loc22_17.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.patt.loc22_17.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %Food.loc22_29.2 => constants.%Grass
+// CHECK:STDOUT:   %Food.patt.loc22_29.2 => constants.%Grass
+// CHECK:STDOUT:   %T.as_type.loc22_45.2 => constants.%Goat
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc22_43 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc22_52 => constants.%complete_type.357
+// CHECK:STDOUT:   %Eats.type => constants.%Eats.type.1ae
+// CHECK:STDOUT:   %require_complete.loc22_74.1 => constants.%complete_type.004
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.849
+// CHECK:STDOUT:   %require_complete.loc22_74.2 => constants.%complete_type.eef
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%Eats.type.1ae) {
+// CHECK:STDOUT:   %T => constants.%Eats.type.1ae
+// CHECK:STDOUT:   %T.patt => constants.%Eats.type.1ae
+// CHECK:STDOUT: }
+// CHECK:STDOUT:


### PR DESCRIPTION
The fn receiving a facet type needs to deduce a type from a FacetAccessType, which is the SemIR type representing the parameter type that is a generic parameter. For example:

```
  fn F[T: Interface](val: T);
```

Here T is a generic parameter that is a facet value, but the `val` parameter's type is the facet value converted from a FacetType to a TypeType, with `as type`. The result of that conversion is a FacetAccessType. So the deduction code sees a FacetAccessType for the type of `val`.

We make deduction undo the `as type` conversion to move back to the `T` parameter declaration, which has type FacetType in order to deduce the required facet value (which is itself a type constrained by the FacetType). And when we have a facet value (of type FacetType) to be deduced, we will also convert the argument if it is of an appropriate type to a FacetValue that matches the FacetType using the changes from PR #4863.

Tests with `impl forall` can cause impl deduction to recurse forever and crash, so those tests are omitted in this PR and they will come in follow-up work that address the infinite recursion.

Rebased on top of PR #4885
