### PR TITLE
Add `HasId` method to `ValueStore` for debug checks

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -68,13 +68,13 @@ class ValueStore
 
   // Returns a mutable value for an ID.
   auto Get(IdT id) -> RefType {
-    CARBON_DCHECK(id.index >= 0, "{0}", id);
+    CARBON_DCHECK(HasId(id), "{0}", id);
     return values_[id.index];
   }
 
   // Returns the value for an ID.
   auto Get(IdT id) const -> ConstRefType {
-    CARBON_DCHECK(id.index >= 0, "{0}", id);
+    CARBON_DCHECK(HasId(id), "{0}", id);
     return values_[id.index];
   }
 
@@ -95,6 +95,15 @@ class ValueStore
   auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
       -> void {
     mem_usage.Collect(label.str(), values_);
+  }
+
+  // Checks whether the ID has a value in this store.
+  //
+  // This is usually unnecessary to check, but can add safety to debug code.
+  // Note that the ID may originate from a different store with a different
+  // value.
+  auto HasId(IdT id) const -> bool {
+    return id.index >= 0 && static_cast<size_t>(id.index) < size();
   }
 
   auto array_ref() const -> llvm::ArrayRef<ValueType> { return values_; }


### PR DESCRIPTION
Small addition to `ValueStore` to check if an ID can be safely used to access values from the store. This change iterates on the DCHECK bounds check that currently exists in `ValueStore::Get`.

When working with multiple `ValueStore`s, IDs can become mixed up and misused to access the wrong `ValueStore`. This always indicates a bug in the code, so this method is added for the convenience of debug checks to identify bugs.

In many situations there is only one `ValueStore` instance available with a unique ID type, so it's guaranteed that those IDs came from `ValueStore::Add`; thus, this check is usually unnecessary. To deter overly-cautious code, this method is documented as a debug tool.

I plan to use this method in a follow-up PR to harden `Dump` functions against out-of-bounds IDs.
