### PR TITLE
Adds emacs mode for carbon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,6 +209,11 @@ repos:
           - '" '
           - ''
           - --custom_format
+          - '\.el$'
+          - ''
+          - ';;; '
+          - ''
+          - --custom_format
           - '\.scm$'
           - ''
           - '; '

--- a/utils/emacs/README.md
+++ b/utils/emacs/README.md
@@ -1,0 +1,32 @@
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+# Emacs plugin for Carbon
+
+For now, simply derives from cc-mode.
+
+Install:
+
+1. copy carbon-mode.el to lisp package path
+2. add to config
+
+```emacs-lisp
+(require 'carbon-mode)
+(add-to-list 'auto-mode-alist '("\\.carbon\\'" . carbon-mode))
+```
+
+Testing:
+
+If you are adding a feature, the test.sh script will copy carbon-mode.el to your
+emacs lisp package path and open an example file in carbon mode.
+
+You can specify the emacs lisp package path for example
+
+```shell
+EMACS_MODULES=/i/keep/it/here ./test.sh
+```
+
+By default, it assumes emacs packages are stored in $HOME/.emacs.d/lisp/

--- a/utils/emacs/carbon-mode.el
+++ b/utils/emacs/carbon-mode.el
@@ -1,0 +1,12 @@
+;;; carbon-mode.el --- major mode for carbon  -*- lexical-binding: t; -*-
+
+;;; Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+;;; Exceptions. See /LICENSE for license information.
+;;; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+(require 'cc-mode)
+
+(define-derived-mode carbon-mode c++-mode
+  "Carbon")
+
+(provide 'carbon-mode)

--- a/utils/emacs/test.sh
+++ b/utils/emacs/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Performs a local install. This will replace any previous carbon installs
+# without prompting.
+
+# Because the set of all possible emacs configurations is uncountably infinite
+# this script forms an opinion and sticks to it for testing.
+#
+# $ ./test.sh
+#
+# Copies carbon-mode to lisp package location and opens emacs on sieve.
+#
+# You can change where carbon mode elisp gets copied to
+# $ EMACS_MODULES=/i/keep/it/here ./test.sh
+#
+
+set -eu
+
+EMACS_MODULES=$HOME/.emacs.d/lisp
+
+# Next line enforces that we run this test within the same directory.
+cp ./carbon-mode.el $EMACS_MODULES
+
+emacs --eval "(require 'carbon-mode)" ../../examples/sieve.carbon -f carbon-mode &


### PR DESCRIPTION
Tested by opening examples/ and core/.

As the language is flushed out more, we can add more but deriving from cc-mode works for now.

Also adds elisp to license pre-commit hook.
