### PR TITLE
Check explicit params exist.

### DIFF
--- a/toolchain/check/name_component.cpp
+++ b/toolchain/check/name_component.cpp
@@ -36,9 +36,9 @@ auto PopNameComponent(Context& context, SemIR::InstId return_slot_pattern_id)
         context.node_stack()
             .PopForSoloNodeId<Parse::NodeKind::ImplicitParamListStart>();
     // Only use the end of implicit params if there weren't explicit params.
-    if (last_param_node_id.has_value()) {
-      last_param_node_id = params_loc_id;
-    }
+    CARBON_CHECK(last_param_node_id.has_value(),
+                 "Implicit parameters currently only occur before explicit "
+                 "parameters, update and test when this changes");
   } else {
     implicit_param_patterns_id = SemIR::InstBlockId::None;
   }


### PR DESCRIPTION
If there are no explicit params, then `last_param_node_id` should be `implicit_params_loc_id`. But there is no use case currently, so for now we assume explicit params exist and assert if not, so this can be found and updated then.

