### PR TITLE
Update actions/cache version

### DIFF
--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -28,7 +28,7 @@ runs:
     # minimum supported LLVM version.
     - name: Cache Homebrew
       id: cache-homebrew-macos
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       env:
         cache-name: cache-homebrew
       with:

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -27,7 +27,7 @@ runs:
     # reliability.
     - name: Cache LLVM and Clang installation
       id: cache-llvm-ubuntu
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       env:
         cache-name: cache-llvm
       with:


### PR DESCRIPTION
Seeing if an update fixes this, or if this is just a bug in GitHub's enforcement.

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```