### PR TITLE
Diagnose `var` in interfaces

### DIFF
--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -388,7 +388,7 @@ auto HandleParseNode(Context& context, Parse::VariableDeclId node_id) -> bool {
   }
   if (context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
     CARBON_DIAGNOSTIC(VarInInterfaceDecl, Error,
-                      "interfaces cannot have `var` members");
+                      "`var` declaration in interface");
     context.emitter().Emit(node_id, VarInInterfaceDecl);
     return true;
   }

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -386,6 +386,12 @@ auto HandleParseNode(Context& context, Parse::VariableDeclId node_id) -> bool {
     }
     return true;
   }
+  if (context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+    CARBON_DIAGNOSTIC(VarInInterfaceDecl, Error,
+                      "interfaces cannot have `var` members");
+    context.emitter().Emit(node_id, VarInInterfaceDecl);
+    return true;
+  }
 
   LocalPatternMatch(context, decl_info.pattern_id, decl_info.init_id);
   return true;

--- a/toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
@@ -9,7 +9,7 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
 
 interface I {
-  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:3: error: interfaces cannot have `var` members [VarInInterfaceDecl]
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:3: error: `var` declaration in interface [VarInInterfaceDecl]
   // CHECK:STDERR:   var v: ();
   // CHECK:STDERR:   ^~~~~~~~~~
   // CHECK:STDERR:
@@ -35,7 +35,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .v = <unexpected>.inst20.loc12_7
+// CHECK:STDOUT:   .v = <unexpected>.inst20.loc16_7
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
+
+interface I {
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:3: error: interfaces cannot have `var` members [VarInInterfaceDecl]
+  // CHECK:STDERR:   var v: ();
+  // CHECK:STDERR:   ^~~~~~~~~~
+  // CHECK:STDERR:
+  var v: ();
+}
+
+// CHECK:STDOUT: --- fail_in_interface.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [template]
+// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%I.type] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I {
+// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .v = <unexpected>.inst20.loc12_7
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -272,6 +272,7 @@ CARBON_DIAGNOSTIC_KIND(ExportPrevious)
 // Interface checking.
 CARBON_DIAGNOSTIC_KIND(InterfaceForwardDeclaredHere)
 CARBON_DIAGNOSTIC_KIND(InterfaceUndefinedWithinDefinition)
+CARBON_DIAGNOSTIC_KIND(VarInInterfaceDecl)
 
 // Impl checking.
 CARBON_DIAGNOSTIC_KIND(AssociatedConstantHere)


### PR DESCRIPTION
Previously this was ignored, and then #4720 accidentally made it a crash bug

