### PR TITLE
Organize symbol hierarchy in LSP documentSymbol handler

### DIFF
--- a/toolchain/language_server/BUILD
+++ b/toolchain/language_server/BUILD
@@ -54,8 +54,11 @@ cc_library(
     hdrs = ["handle.h"],
     deps = [
         ":context",
+        "//common:check",
         "//toolchain/base:shared_value_stores",
         "//toolchain/lex",
+        "//toolchain/lex:token_index",
+        "//toolchain/lex:token_kind",
         "//toolchain/parse",
         "//toolchain/parse:node_kind",
         "//toolchain/parse:tree",

--- a/toolchain/language_server/handle_document_symbol.cpp
+++ b/toolchain/language_server/handle_document_symbol.cpp
@@ -37,10 +37,14 @@ static auto GetIdentifierName(const Parse::TreeAndSubtrees& tree_and_subtrees,
   return std::nullopt;
 }
 
+// Helper class to collect all symbols during traversal of AST.
+// Symbols are "open" when their signature has been declared but their body is
+// still ongoing. New symbols are added to last open symbol, or top level list
+// if no symbols are open.
 class SymbolStore {
  public:
   // Adds a symbol with no children.
-  void AddSymbol(clang::clangd::DocumentSymbol symbol) {
+  auto AddSymbol(clang::clangd::DocumentSymbol symbol) -> void {
     if (open_symbols_.empty()) {
       top_level_symbols_.push_back(std::move(symbol));
     } else {
@@ -49,24 +53,21 @@ class SymbolStore {
   }
 
   // Starts a symbol potentially with children.
-  void StartSymbol(clang::clangd::DocumentSymbol symbol) {
+  auto StartSymbol(clang::clangd::DocumentSymbol symbol) -> void {
     open_symbols_.push_back(std::move(symbol));
   }
 
   auto HasOpenSymbol() const -> bool { return !open_symbols_.empty(); }
 
   // Completes a symbol, appending to parent list.
-  void EndSymbol() {
+  auto EndSymbol() -> void {
     CARBON_CHECK(HasOpenSymbol());
     AddSymbol(open_symbols_.pop_back_val());
   }
 
+  // Returns final top level symbols.
   auto Collect() -> std::vector<clang::clangd::DocumentSymbol> {
-    // Shouldn't happen in a valid tree but may as well handle gracefully.
-    while (!open_symbols_.empty()) {
-      EndSymbol();
-    }
-
+    CARBON_CHECK(!HasOpenSymbol());
     return std::move(top_level_symbols_);
   }
 

--- a/toolchain/language_server/handle_document_symbol.cpp
+++ b/toolchain/language_server/handle_document_symbol.cpp
@@ -2,13 +2,15 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "toolchain/base/shared_value_stores.h"
+#include <optional>
+
+#include "common/check.h"
 #include "toolchain/language_server/handle.h"
-#include "toolchain/lex/lex.h"
+#include "toolchain/lex/token_index.h"
+#include "toolchain/lex/token_kind.h"
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/node_kind.h"
-#include "toolchain/parse/parse.h"
 #include "toolchain/parse/tree_and_subtrees.h"
-#include "toolchain/source/source_buffer.h"
 
 namespace Carbon::LanguageServer {
 
@@ -35,6 +37,44 @@ static auto GetIdentifierName(const Parse::TreeAndSubtrees& tree_and_subtrees,
   return std::nullopt;
 }
 
+class SymbolStore {
+ public:
+  // Adds a symbol with no children.
+  void AddSymbol(clang::clangd::DocumentSymbol symbol) {
+    if (open_symbols_.empty()) {
+      top_level_symbols_.push_back(std::move(symbol));
+    } else {
+      open_symbols_.back().children.push_back(symbol);
+    }
+  }
+
+  // Starts a symbol potentially with children.
+  void StartSymbol(clang::clangd::DocumentSymbol symbol) {
+    open_symbols_.push_back(std::move(symbol));
+  }
+
+  auto HasOpenSymbol() const -> bool { return !open_symbols_.empty(); }
+
+  // Completes a symbol, appending to parent list.
+  void EndSymbol() {
+    CARBON_CHECK(HasOpenSymbol());
+    AddSymbol(open_symbols_.pop_back_val());
+  }
+
+  auto Collect() -> std::vector<clang::clangd::DocumentSymbol> {
+    // Shouldn't happen in a valid tree but may aswell handle gracefully.
+    while (!open_symbols_.empty()) {
+      EndSymbol();
+    }
+
+    return std::move(top_level_symbols_);
+  }
+
+ private:
+  std::vector<clang::clangd::DocumentSymbol> top_level_symbols_;
+  llvm::SmallVector<clang::clangd::DocumentSymbol> open_symbols_;
+};
+
 auto HandleDocumentSymbol(
     Context& context, const clang::clangd::DocumentSymbolParams& params,
     llvm::function_ref<
@@ -49,11 +89,16 @@ auto HandleDocumentSymbol(
   const auto& tree = tree_and_subtrees.tree();
   const auto& tokens = tree.tokens();
 
-  std::vector<clang::clangd::DocumentSymbol> result;
-  for (const auto& node_id : tree.postorder()) {
+  SymbolStore symbols;
+  for (const auto node_id : tree.postorder()) {
+    auto node_kind = tree.node_kind(node_id);
     clang::clangd::SymbolKind symbol_kind;
-    switch (tree.node_kind(node_id)) {
+    bool is_leaf = false;
+    switch (node_kind) {
       case Parse::NodeKind::FunctionDecl:
+        is_leaf = true;
+        symbol_kind = clang::clangd::SymbolKind::Function;
+        break;
       case Parse::NodeKind::FunctionDefinitionStart:
         symbol_kind = clang::clangd::SymbolKind::Function;
         break;
@@ -64,9 +109,26 @@ auto HandleDocumentSymbol(
       case Parse::NodeKind::NamedConstraintDefinitionStart:
         symbol_kind = clang::clangd::SymbolKind::Interface;
         break;
+      case Parse::NodeKind::ClassDecl:
+        is_leaf = true;
+        symbol_kind = clang::clangd::SymbolKind::Class;
+        break;
       case Parse::NodeKind::ClassDefinitionStart:
         symbol_kind = clang::clangd::SymbolKind::Class;
         break;
+
+      case Parse::NodeKind::FunctionDefinition:
+      case Parse::NodeKind::NamedConstraintDefinition:
+      case Parse::NodeKind::InterfaceDefinition:
+      case Parse::NodeKind::ClassDefinition: {
+        if (symbols.HasOpenSymbol()) {
+          // Symbols definition has completed, pop it from stack and add to
+          // parent/root.
+          symbols.EndSymbol();
+        }
+        continue;
+      }
+
       default:
         continue;
     }
@@ -83,10 +145,15 @@ auto HandleDocumentSymbol(
           .selectionRange = {.start = pos, .end = pos},
       };
 
-      result.push_back(symbol);
+      if (is_leaf) {
+        symbols.AddSymbol(std::move(symbol));
+      } else {
+        symbols.StartSymbol(std::move(symbol));
+      }
     }
   }
-  on_done(result);
+
+  on_done(symbols.Collect());
 }
 
 }  // namespace Carbon::LanguageServer

--- a/toolchain/language_server/handle_document_symbol.cpp
+++ b/toolchain/language_server/handle_document_symbol.cpp
@@ -62,7 +62,7 @@ class SymbolStore {
   }
 
   auto Collect() -> std::vector<clang::clangd::DocumentSymbol> {
-    // Shouldn't happen in a valid tree but may aswell handle gracefully.
+    // Shouldn't happen in a valid tree but may as well handle gracefully.
     while (!open_symbols_.empty()) {
       EndSymbol();
     }
@@ -90,7 +90,7 @@ auto HandleDocumentSymbol(
   const auto& tokens = tree.tokens();
 
   SymbolStore symbols;
-  for (const auto node_id : tree.postorder()) {
+  for (const auto& node_id : tree.postorder()) {
     auto node_kind = tree.node_kind(node_id);
     clang::clangd::SymbolKind symbol_kind;
     bool is_leaf = false;

--- a/toolchain/language_server/testdata/document_symbol/nested.carbon
+++ b/toolchain/language_server/testdata/document_symbol/nested.carbon
@@ -1,0 +1,104 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/language_server/testdata/document_symbol/nested.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/language_server/testdata/document_symbol/nested.carbon
+
+// --- STDIN
+[[@LSP-NOTIFY:textDocument/didOpen:
+  "textDocument": {"uri": "file:/class.carbon", "languageId": "carbon",
+                   "text": "class A {\n  fn F();\n  fn G() {}\n}\n"}
+]]
+[[@LSP-CALL:textDocument/documentSymbol:
+  "textDocument": {"uri": "file:/class.carbon"}
+]]
+[[@LSP-NOTIFY:exit]]
+
+// --- AUTOUPDATE-SPLIT
+
+// CHECK:STDOUT: Content-Length: 1494{{\r}}
+// CHECK:STDOUT: {{\r}}
+// CHECK:STDOUT: {
+// CHECK:STDOUT:   "id": 1,
+// CHECK:STDOUT:   "jsonrpc": "2.0",
+// CHECK:STDOUT:   "result": [
+// CHECK:STDOUT:     {
+// CHECK:STDOUT:       "children": [
+// CHECK:STDOUT:         {
+// CHECK:STDOUT:           "kind": 12,
+// CHECK:STDOUT:           "name": "F",
+// CHECK:STDOUT:           "range": {
+// CHECK:STDOUT:             "end": {
+// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "line": 1
+// CHECK:STDOUT:             },
+// CHECK:STDOUT:             "start": {
+// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "line": 1
+// CHECK:STDOUT:             }
+// CHECK:STDOUT:           },
+// CHECK:STDOUT:           "selectionRange": {
+// CHECK:STDOUT:             "end": {
+// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "line": 1
+// CHECK:STDOUT:             },
+// CHECK:STDOUT:             "start": {
+// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "line": 1
+// CHECK:STDOUT:             }
+// CHECK:STDOUT:           }
+// CHECK:STDOUT:         },
+// CHECK:STDOUT:         {
+// CHECK:STDOUT:           "kind": 12,
+// CHECK:STDOUT:           "name": "G",
+// CHECK:STDOUT:           "range": {
+// CHECK:STDOUT:             "end": {
+// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "line": 2
+// CHECK:STDOUT:             },
+// CHECK:STDOUT:             "start": {
+// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "line": 2
+// CHECK:STDOUT:             }
+// CHECK:STDOUT:           },
+// CHECK:STDOUT:           "selectionRange": {
+// CHECK:STDOUT:             "end": {
+// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "line": 2
+// CHECK:STDOUT:             },
+// CHECK:STDOUT:             "start": {
+// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "line": 2
+// CHECK:STDOUT:             }
+// CHECK:STDOUT:           }
+// CHECK:STDOUT:         }
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       "kind": 5,
+// CHECK:STDOUT:       "name": "A",
+// CHECK:STDOUT:       "range": {
+// CHECK:STDOUT:         "end": {
+// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "line": 0
+// CHECK:STDOUT:         },
+// CHECK:STDOUT:         "start": {
+// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "line": 0
+// CHECK:STDOUT:         }
+// CHECK:STDOUT:       },
+// CHECK:STDOUT:       "selectionRange": {
+// CHECK:STDOUT:         "end": {
+// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "line": 0
+// CHECK:STDOUT:         },
+// CHECK:STDOUT:         "start": {
+// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "line": 0
+// CHECK:STDOUT:         }
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   ]
+// CHECK:STDOUT: }

--- a/toolchain/language_server/testdata/document_symbol/nested.carbon
+++ b/toolchain/language_server/testdata/document_symbol/nested.carbon
@@ -29,7 +29,7 @@
 // CHECK:STDOUT:     "diagnostics": [],
 // CHECK:STDOUT:     "uri": "file:///class.carbon"
 // CHECK:STDOUT:   }
-// CHECK:STDOUT: }Content-Length: 1494{{\r}}
+// CHECK:STDOUT: }Content-Length: 1495{{\r}}
 // CHECK:STDOUT: {{\r}}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   "id": 1,
@@ -42,21 +42,21 @@
 // CHECK:STDOUT:           "name": "F",
 // CHECK:STDOUT:           "range": {
 // CHECK:STDOUT:             "end": {
-// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "character": 9,
 // CHECK:STDOUT:               "line": 1
 // CHECK:STDOUT:             },
 // CHECK:STDOUT:             "start": {
-// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "character": 2,
 // CHECK:STDOUT:               "line": 1
 // CHECK:STDOUT:             }
 // CHECK:STDOUT:           },
 // CHECK:STDOUT:           "selectionRange": {
 // CHECK:STDOUT:             "end": {
-// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "character": 6,
 // CHECK:STDOUT:               "line": 1
 // CHECK:STDOUT:             },
 // CHECK:STDOUT:             "start": {
-// CHECK:STDOUT:               "character": 8,
+// CHECK:STDOUT:               "character": 5,
 // CHECK:STDOUT:               "line": 1
 // CHECK:STDOUT:             }
 // CHECK:STDOUT:           }
@@ -66,21 +66,21 @@
 // CHECK:STDOUT:           "name": "G",
 // CHECK:STDOUT:           "range": {
 // CHECK:STDOUT:             "end": {
-// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "character": 11,
 // CHECK:STDOUT:               "line": 2
 // CHECK:STDOUT:             },
 // CHECK:STDOUT:             "start": {
-// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "character": 2,
 // CHECK:STDOUT:               "line": 2
 // CHECK:STDOUT:             }
 // CHECK:STDOUT:           },
 // CHECK:STDOUT:           "selectionRange": {
 // CHECK:STDOUT:             "end": {
-// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "character": 6,
 // CHECK:STDOUT:               "line": 2
 // CHECK:STDOUT:             },
 // CHECK:STDOUT:             "start": {
-// CHECK:STDOUT:               "character": 9,
+// CHECK:STDOUT:               "character": 5,
 // CHECK:STDOUT:               "line": 2
 // CHECK:STDOUT:             }
 // CHECK:STDOUT:           }
@@ -90,21 +90,21 @@
 // CHECK:STDOUT:       "name": "A",
 // CHECK:STDOUT:       "range": {
 // CHECK:STDOUT:         "end": {
-// CHECK:STDOUT:           "character": 8,
-// CHECK:STDOUT:           "line": 0
+// CHECK:STDOUT:           "character": 1,
+// CHECK:STDOUT:           "line": 3
 // CHECK:STDOUT:         },
 // CHECK:STDOUT:         "start": {
-// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "character": 0,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         }
 // CHECK:STDOUT:       },
 // CHECK:STDOUT:       "selectionRange": {
 // CHECK:STDOUT:         "end": {
-// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "character": 7,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         },
 // CHECK:STDOUT:         "start": {
-// CHECK:STDOUT:           "character": 8,
+// CHECK:STDOUT:           "character": 6,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         }
 // CHECK:STDOUT:       }

--- a/toolchain/language_server/testdata/document_symbol/nested.carbon
+++ b/toolchain/language_server/testdata/document_symbol/nested.carbon
@@ -20,7 +20,16 @@
 
 // --- AUTOUPDATE-SPLIT
 
-// CHECK:STDOUT: Content-Length: 1494{{\r}}
+// CHECK:STDOUT: Content-Length: 145{{\r}}
+// CHECK:STDOUT: {{\r}}
+// CHECK:STDOUT: {
+// CHECK:STDOUT:   "jsonrpc": "2.0",
+// CHECK:STDOUT:   "method": "textDocument/publishDiagnostics",
+// CHECK:STDOUT:   "params": {
+// CHECK:STDOUT:     "diagnostics": [],
+// CHECK:STDOUT:     "uri": "file:///class.carbon"
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }Content-Length: 1494{{\r}}
 // CHECK:STDOUT: {{\r}}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   "id": 1,


### PR DESCRIPTION
This PR updates the HandleDocumentSymbol function to build a tree of symbols, rather than a flat list. Symbols found while traversing another symbols body are added as a child.

Adds a simple test showing functions within nested class.