### PR TITLE
Update HandleDocumentSymbol to provide accurate symbol ranges

### DIFF
--- a/toolchain/language_server/handle_document_symbol.cpp
+++ b/toolchain/language_server/handle_document_symbol.cpp
@@ -12,11 +12,11 @@
 
 namespace Carbon::LanguageServer {
 
-// Returns the text of first child of kind IdentifierNameBeforeParams or
+// Returns the token of first child of kind IdentifierNameBeforeParams or
 // IdentifierNameNotBeforeParams.
-static auto GetIdentifierName(const Parse::TreeAndSubtrees& tree_and_subtrees,
-                              Parse::NodeId node)
-    -> std::optional<llvm::StringRef> {
+static auto GetSymbolIdentifier(const Parse::TreeAndSubtrees& tree_and_subtrees,
+                                Parse::NodeId node)
+    -> std::optional<Lex::TokenIndex> {
   const auto& tokens = tree_and_subtrees.tree().tokens();
   for (auto child : tree_and_subtrees.children(node)) {
     switch (tree_and_subtrees.tree().node_kind(child)) {
@@ -24,7 +24,7 @@ static auto GetIdentifierName(const Parse::TreeAndSubtrees& tree_and_subtrees,
       case Parse::NodeKind::IdentifierNameNotBeforeParams: {
         auto token = tree_and_subtrees.tree().node_token(child);
         if (tokens.GetKind(token) == Lex::TokenKind::Identifier) {
-          return tokens.GetTokenText(token);
+          return token;
         }
         break;
       }
@@ -33,6 +33,42 @@ static auto GetIdentifierName(const Parse::TreeAndSubtrees& tree_and_subtrees,
     }
   }
   return std::nullopt;
+}
+
+// Constructs a Range from a closed interval of tokens [start, end].
+static auto GetTokenRange(const Lex::TokenizedBuffer& tokens,
+                          Lex::TokenIndex start,
+                          Lex::TokenIndex end) -> clang::clangd::Range {
+  auto start_line = tokens.GetLine(start);
+  auto start_col = tokens.GetColumnNumber(start);
+  auto [end_line, end_col] = tokens.GetEndLoc(end);
+
+  return clang::clangd::Range{
+      .start = {.line = start_line.index, .character = start_col - 1},
+      .end = {.line = end_line.index, .character = end_col - 1},
+  };
+}
+
+// Finds a spanning range for provided definition / declaration ast node.
+// In the case of a definition start, will include the body aswell.
+static auto GetSymbolRange(const Parse::TreeAndSubtrees& tree_and_subtrees,
+                           const Parse::NodeId& ast_node)
+    -> clang::clangd::Range {
+  const auto& tokens = tree_and_subtrees.tree().tokens();
+
+  // Left most node will always be first node in postorder traversal.
+  auto start_node = *tree_and_subtrees.postorder(ast_node).begin();
+
+  auto start_token = tree_and_subtrees.tree().node_token(start_node);
+  auto end_token = tree_and_subtrees.tree().node_token(ast_node);
+  if (tokens.GetKind(end_token).is_opening_symbol()) {
+    // DefinitionStart nodes use a opening token, so find its closing token to
+    // span entire class/function body.
+    return GetTokenRange(tokens, start_token,
+                         tokens.GetMatchedClosingToken(end_token));
+  } else {
+    return GetTokenRange(tokens, start_token, end_token);
+  }
 }
 
 auto HandleDocumentSymbol(
@@ -71,16 +107,12 @@ auto HandleDocumentSymbol(
         continue;
     }
 
-    if (auto name = GetIdentifierName(tree_and_subtrees, node_id)) {
-      auto token = tree.node_token(node_id);
-      clang::clangd::Position pos{tokens.GetLineNumber(token) - 1,
-                                  tokens.GetColumnNumber(token) - 1};
-
+    if (auto identifier = GetSymbolIdentifier(tree_and_subtrees, node_id)) {
       clang::clangd::DocumentSymbol symbol{
-          .name = std::string(*name),
+          .name = std::string(tokens.GetTokenText(*identifier)),
           .kind = symbol_kind,
-          .range = {.start = pos, .end = pos},
-          .selectionRange = {.start = pos, .end = pos},
+          .range = GetSymbolRange(tree_and_subtrees, node_id),
+          .selectionRange = GetTokenRange(tokens, *identifier, *identifier),
       };
 
       result.push_back(symbol);

--- a/toolchain/language_server/handle_document_symbol.cpp
+++ b/toolchain/language_server/handle_document_symbol.cpp
@@ -37,8 +37,8 @@ static auto GetSymbolIdentifier(const Parse::TreeAndSubtrees& tree_and_subtrees,
 
 // Constructs a Range from a closed interval of tokens [start, end].
 static auto GetTokenRange(const Lex::TokenizedBuffer& tokens,
-                          Lex::TokenIndex start,
-                          Lex::TokenIndex end) -> clang::clangd::Range {
+                          Lex::TokenIndex start, Lex::TokenIndex end)
+    -> clang::clangd::Range {
   auto start_line = tokens.GetLine(start);
   auto start_col = tokens.GetColumnNumber(start);
   auto [end_line, end_col] = tokens.GetEndLoc(end);
@@ -49,21 +49,21 @@ static auto GetTokenRange(const Lex::TokenizedBuffer& tokens,
   };
 }
 
-// Finds a spanning range for provided definition / declaration ast node.
-// In the case of a definition start, will include the body aswell.
+// Finds a spanning range for the provided definition / declaration ast node.
+// In the case of a definition start, will include the body as well.
 static auto GetSymbolRange(const Parse::TreeAndSubtrees& tree_and_subtrees,
                            const Parse::NodeId& ast_node)
     -> clang::clangd::Range {
   const auto& tokens = tree_and_subtrees.tree().tokens();
 
-  // Left most node will always be first node in postorder traversal.
+  // The left-most node will always be the first node in postorder traversal.
   auto start_node = *tree_and_subtrees.postorder(ast_node).begin();
 
   auto start_token = tree_and_subtrees.tree().node_token(start_node);
   auto end_token = tree_and_subtrees.tree().node_token(ast_node);
   if (tokens.GetKind(end_token).is_opening_symbol()) {
-    // DefinitionStart nodes use a opening token, so find its closing token to
-    // span entire class/function body.
+    // DefinitionStart nodes use an opening token, so find its closing token to
+    // span the entire class/function body.
     return GetTokenRange(tokens, start_token,
                          tokens.GetMatchedClosingToken(end_token));
   } else {

--- a/toolchain/language_server/testdata/document_symbol/basics.carbon
+++ b/toolchain/language_server/testdata/document_symbol/basics.carbon
@@ -84,21 +84,21 @@
 // CHECK:STDOUT:       "name": "F",
 // CHECK:STDOUT:       "range": {
 // CHECK:STDOUT:         "end": {
-// CHECK:STDOUT:           "character": 7,
+// CHECK:STDOUT:           "character": 9,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         },
 // CHECK:STDOUT:         "start": {
-// CHECK:STDOUT:           "character": 7,
+// CHECK:STDOUT:           "character": 0,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         }
 // CHECK:STDOUT:       },
 // CHECK:STDOUT:       "selectionRange": {
 // CHECK:STDOUT:         "end": {
-// CHECK:STDOUT:           "character": 7,
+// CHECK:STDOUT:           "character": 4,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         },
 // CHECK:STDOUT:         "start": {
-// CHECK:STDOUT:           "character": 7,
+// CHECK:STDOUT:           "character": 3,
 // CHECK:STDOUT:           "line": 0
 // CHECK:STDOUT:         }
 // CHECK:STDOUT:       }


### PR DESCRIPTION
This PR updates the construction of clang::clangd::DocumentSymbol to produce "range" and "selectionRange" properties that match the [textDocument/documentSymbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol) spec.

"selectionRange" is constructed by finding start and end position of the symbols identifier.

"range" property is constructed by finding the left most and right most token of the AST, the code makes an assumption that left most token is always the first node in postorder traversal from that node, and the right most is the node itself. AFAIK this is true for most of the grammar other than infix operators. For symbols with a body, the right most token is the open bracket, so we extend the range to its matching closing bracket.