### PR TITLE
Refactor implicit Self param into a member on SemIR::Function

### DIFF
--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -124,6 +124,7 @@ static auto MergeFunctionRedecl(Context& context,
     // match IDs in the signature.
     prev_function.MergeDefinition(new_function);
     prev_function.return_slot_pattern_id = new_function.return_slot_pattern_id;
+    prev_function.self_param_id = new_function.self_param_id;
   }
   if (prev_import_ir_id.has_value()) {
     ReplacePrevInstForMerge(context, new_function.parent_scope_id,
@@ -264,6 +265,17 @@ static auto BuildFunctionDecl(Context& context,
                           name, decl_id, is_extern, introducer.extern_library)},
                       {.return_slot_pattern_id = name.return_slot_pattern_id,
                        .virtual_modifier = virtual_modifier}};
+  // Find self parameter pattern.
+  // TODO: Do this during initial traversal of implicit params.
+  for (auto implicit_param_id : context.inst_blocks().GetOrEmpty(
+           function_info.implicit_param_patterns_id)) {
+    if (SemIR::Function::GetNameFromPatternId(
+            context.sem_ir(), implicit_param_id) == SemIR::NameId::SelfValue) {
+      CARBON_CHECK(!function_info.self_param_id.has_value());
+      function_info.self_param_id = implicit_param_id;
+    }
+  }
+
   if (is_definition) {
     function_info.definition_id = decl_id;
   }

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -258,24 +258,30 @@ static auto BuildFunctionDecl(Context& context,
   auto decl_id =
       context.AddPlaceholderInst(SemIR::LocIdAndInst(node_id, function_decl));
 
+  // Find self parameter pattern.
+  // TODO: Do this during initial traversal of implicit params.
+  auto self_param_id = SemIR::InstId::None;
+  auto implicit_param_patterns =
+      context.inst_blocks().GetOrEmpty(name.implicit_param_patterns_id);
+  if (auto i = llvm::find_if(implicit_param_patterns,
+                             [&](auto implicit_param_id) {
+                               return SemIR::Function::GetNameFromPatternId(
+                                          context.sem_ir(),
+                                          implicit_param_id) ==
+                                      SemIR::NameId::SelfValue;
+                             });
+      i != implicit_param_patterns.end()) {
+    self_param_id = *i;
+  }
+
   // Build the function entity. This will be merged into an existing function if
   // there is one, or otherwise added to the function store.
   auto function_info =
       SemIR::Function{{name_context.MakeEntityWithParamsBase(
                           name, decl_id, is_extern, introducer.extern_library)},
                       {.return_slot_pattern_id = name.return_slot_pattern_id,
-                       .virtual_modifier = virtual_modifier}};
-  // Find self parameter pattern.
-  // TODO: Do this during initial traversal of implicit params.
-  for (auto implicit_param_id : context.inst_blocks().GetOrEmpty(
-           function_info.implicit_param_patterns_id)) {
-    if (SemIR::Function::GetNameFromPatternId(
-            context.sem_ir(), implicit_param_id) == SemIR::NameId::SelfValue) {
-      CARBON_CHECK(!function_info.self_param_id.has_value());
-      function_info.self_param_id = implicit_param_id;
-    }
-  }
-
+                       .virtual_modifier = virtual_modifier,
+                       .self_param_id = self_param_id}};
   if (is_definition) {
     function_info.definition_id = decl_id;
   }

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -263,13 +263,13 @@ static auto BuildFunctionDecl(Context& context,
   auto self_param_id = SemIR::InstId::None;
   auto implicit_param_patterns =
       context.inst_blocks().GetOrEmpty(name.implicit_param_patterns_id);
-  if (auto i = llvm::find_if(implicit_param_patterns,
-                             [&](auto implicit_param_id) {
-                               return SemIR::Function::GetNameFromPatternId(
-                                          context.sem_ir(),
-                                          implicit_param_id) ==
-                                      SemIR::NameId::SelfValue;
-                             });
+  if (const auto* i =
+          llvm::find_if(implicit_param_patterns,
+                        [&](auto implicit_param_id) {
+                          return SemIR::Function::GetNameFromPatternId(
+                                     context.sem_ir(), implicit_param_id) ==
+                                 SemIR::NameId::SelfValue;
+                        });
       i != implicit_param_patterns.end()) {
     self_param_id = *i;
   }

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -978,9 +978,6 @@ static auto LoadLocalPatternConstantIds(ImportRefResolver& resolver,
 // LoadLocalPatternConstantIds(param_patterns_id) has completed without adding
 // any new work to work_stack_.
 //
-// `self_param_id` is an optional out parameter, populated with the InstId in
-// the resulting parameter patterns that represents the Self parameter.
-//
 // TODO: This is inconsistent with the rest of this class, which expects
 // the relevant constants to be explicitly passed in. That makes it
 // easier to statically detect when an input isn't loaded, but makes it
@@ -988,6 +985,9 @@ static auto LoadLocalPatternConstantIds(ImportRefResolver& resolver,
 // take a holistic look at how to balance those concerns. For example,
 // could the same function be used to load the constants and use them, with
 // a parameter to select between the two?
+//
+// `self_param_id` is an optional out parameter, populated with the InstId in
+// the resulting parameter patterns that represents the Self parameter.
 static auto GetLocalParamPatternsId(ImportContext& context,
                                     SemIR::InstBlockId param_patterns_id,
                                     SemIR::InstId* self_param_id = nullptr)

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -978,6 +978,9 @@ static auto LoadLocalPatternConstantIds(ImportRefResolver& resolver,
 // LoadLocalPatternConstantIds(param_patterns_id) has completed without adding
 // any new work to work_stack_.
 //
+// `self_param_id` is an optional out parameter, populated with the InstId in
+// the resulting parameter patterns that represents the Self parameter.
+//
 // TODO: This is inconsistent with the rest of this class, which expects
 // the relevant constants to be explicitly passed in. That makes it
 // easier to statically detect when an input isn't loaded, but makes it
@@ -986,8 +989,10 @@ static auto LoadLocalPatternConstantIds(ImportRefResolver& resolver,
 // could the same function be used to load the constants and use them, with
 // a parameter to select between the two?
 static auto GetLocalParamPatternsId(ImportContext& context,
-                                    SemIR::InstBlockId param_patterns_id)
+                                    SemIR::InstBlockId param_patterns_id,
+                                    SemIR::InstId* self_param_id = nullptr)
     -> SemIR::InstBlockId {
+  CARBON_CHECK(!self_param_id || !self_param_id->has_value());
   if (!param_patterns_id.has_value() ||
       param_patterns_id == SemIR::InstBlockId::Empty) {
     return param_patterns_id;
@@ -1064,6 +1069,11 @@ static auto GetLocalParamPatternsId(ImportContext& context,
           context.local_context().MakeImportedLocAndInst<SemIR::AddrPattern>(
               AddImportIRInst(context, addr_pattern_id),
               {.type_id = type_id, .inner_id = new_param_id}));
+    }
+    if (self_param_id &&
+        context.import_entity_names().Get(binding.entity_name_id).name_id ==
+            SemIR::NameId::SelfValue) {
+      *self_param_id = new_param_id;
     }
     new_patterns.push_back(new_param_id);
   }
@@ -1935,8 +1945,10 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   // Add the function declaration.
   new_function.parent_scope_id = parent_scope_id;
+  SemIR::InstId self_param_id = SemIR::InstId::None;
   new_function.implicit_param_patterns_id = GetLocalParamPatternsId(
-      resolver, import_function.implicit_param_patterns_id);
+      resolver, import_function.implicit_param_patterns_id, &self_param_id);
+  new_function.self_param_id = self_param_id;
   new_function.param_patterns_id =
       GetLocalParamPatternsId(resolver, import_function.param_patterns_id);
   new_function.return_slot_pattern_id = GetLocalReturnSlotPatternId(

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -31,6 +31,8 @@ struct FunctionFields {
   // this function.
   VirtualModifier virtual_modifier;
 
+  InstId self_param_id = SemIR::InstId::None;
+
   // The following member is set on the first call to the function, or at the
   // point where the function is defined.
 

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -31,6 +31,8 @@ struct FunctionFields {
   // this function.
   VirtualModifier virtual_modifier;
 
+  // The implicit self parameter, if any, in implicit_param_patterns_id from
+  // EntityWithParamsBase.
   InstId self_param_id = SemIR::InstId::None;
 
   // The following member is set on the first call to the function, or at the


### PR DESCRIPTION
This ensures the data is available for more uses (specifically for diagnosing virtual/abstract/impl functions on non-instance methods).

It still doesn't quite address the TODO to move the Self param search all the way back to the param walk in all cases. To do that in the case that still has a separate search loop, I think we'd have to change `Check::NameComponent` to carry this information (as it carries the implicit_param_patterns-id) - though there's comments in NameComponent suggesting it shouldn't carry function-specific things like `call_params_id` and `return_slot_pattern_id` - so I wasn't sure if it was suitable to add more there, but I can - possibly in a follow-up change.