### PR TITLE
Replace GetImportIRId with check_ir_map accessor logic

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -399,11 +399,6 @@ class Context {
 
   auto Finalize() -> void;
 
-  // Returns the imported IR ID for an IR, or `None` if not imported.
-  auto GetImportIRId(const SemIR::File& sem_ir) -> SemIR::ImportIRId& {
-    return check_ir_map_[sem_ir.check_ir_id().index];
-  }
-
   // True if the current file is an impl file.
   auto IsImplFile() -> bool {
     return sem_ir_->import_irs().Get(SemIR::ImportIRId::ApiForImpl).sem_ir !=
@@ -483,6 +478,10 @@ class Context {
   }
 
   auto vtable_stack() -> InstBlockStack& { return vtable_stack_; }
+
+  auto check_ir_map() -> llvm::MutableArrayRef<SemIR::ImportIRId> {
+    return check_ir_map_;
+  }
 
   auto import_ir_constant_values()
       -> llvm::SmallVector<SemIR::ConstantValueStore, 0>& {

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -43,7 +43,7 @@ auto SetApiImportIR(Context& context, SemIR::ImportIR import_ir) -> void {
 
 auto AddImportIR(Context& context, SemIR::ImportIR import_ir)
     -> SemIR::ImportIRId {
-  auto& ir_id = context.GetImportIRId(*import_ir.sem_ir);
+  auto& ir_id = context.check_ir_map()[import_ir.sem_ir->check_ir_id().index];
   if (!ir_id.has_value()) {
     // Note this updates check_ir_map.
     ir_id = InternalAddImportIR(context, import_ir);
@@ -595,7 +595,8 @@ class ImportRefResolver : public ImportContext {
       auto prev_inst_id = cursor_inst_id;
 
       cursor_ir = cursor_ir->import_irs().Get(ir_inst.ir_id).sem_ir;
-      cursor_ir_id = local_context().GetImportIRId(*cursor_ir);
+      cursor_ir_id =
+          local_context().check_ir_map()[cursor_ir->check_ir_id().index];
       if (!cursor_ir_id.has_value()) {
         // TODO: Should we figure out a location to assign here?
         cursor_ir_id =


### PR DESCRIPTION
This is particularly subtle for me because `GetImportIRId` was deliberately returning a mutable reference...