### PR TITLE
Don't use an impl when 'extend impl' is an error

### DIFF
--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -145,6 +145,15 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
     // constraint, the unique `interface` declaration.)
 
     auto specific_id = SemIR::SpecificId::None;
+    // This check comes first to avoid deduction when the witness_id is missing.
+    // We use an error value to indicate an error during creation of the impl,
+    // such as a recursive impl which will cause deduction to recurse
+    // infinitely.
+    if (!impl.witness_id.has_value() ||
+        impl.witness_id == SemIR::ErrorInst::SingletonInstId) {
+      // TODO: Diagnose if the impl isn't defined yet?
+      return SemIR::InstId::None;
+    }
     if (impl.generic_id.has_value()) {
       specific_id = DeduceImplArguments(context, loc_id, impl, type_const_id,
                                         interface_const_id);
@@ -165,10 +174,6 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
       // TODO: An impl of a constraint type should be treated as implementing
       // the constraint's interfaces.
       continue;
-    }
-    if (!impl.witness_id.has_value()) {
-      // TODO: Diagnose if the impl isn't defined yet?
-      return SemIR::InstId::None;
     }
     LoadImportRef(context, impl.witness_id);
     if (specific_id.has_value()) {

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -37,10 +37,9 @@ class C {
 // CHECK:STDOUT:   %assoc0: %GenericInterface.assoc_type = assoc_entity element0, @GenericInterface.%F.decl [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %require_complete.70f: <witness> = require_complete_type %GenericInterface.type.3fe [symbolic]
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(%T) [symbolic]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (invalid), @impl(%T) [symbolic]
 // CHECK:STDOUT:   %F.type.2cb: type = fn_type @F.2, @impl(%T) [symbolic]
 // CHECK:STDOUT:   %F.4b1: %F.type.2cb = struct_value () [symbolic]
-// CHECK:STDOUT:   %GenericInterface.facet: %GenericInterface.type.3fe = facet_value %C, %impl_witness [symbolic]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [template]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template]
 // CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %T [symbolic]
@@ -106,7 +105,7 @@ class C {
 // CHECK:STDOUT:   %T.patt.loc20_23.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_23.2 (constants.%T.patt)]
 // CHECK:STDOUT:   %GenericInterface.type.loc20_54.2: type = facet_type <@GenericInterface, @GenericInterface(%T.loc20_23.2)> [symbolic = %GenericInterface.type.loc20_54.2 (constants.%GenericInterface.type.3fe)]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @impl.%GenericInterface.type.loc20_54.2 (%GenericInterface.type.3fe) [symbolic = %require_complete (constants.%require_complete.70f)]
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (%F.decl), @impl(%T.loc20_23.2) [symbolic = %impl_witness (constants.%impl_witness)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (invalid), @impl(%T.loc20_23.2) [symbolic = %impl_witness (constants.%impl_witness)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %F.type: type = fn_type @F.2, @impl(%T.loc20_23.2) [symbolic = %F.type (constants.%F.type.2cb)]
@@ -124,7 +123,7 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .F = %F.decl
-// CHECK:STDOUT:     witness = @C.%impl_witness
+// CHECK:STDOUT:     witness = <error>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -140,7 +139,7 @@ class C {
 // CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
 // CHECK:STDOUT:     %T.loc20_23.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc20_23.2 (constants.%T)]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (@impl.%F.decl), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness (invalid), @impl(constants.%T) [symbolic = @impl.%impl_witness (constants.%impl_witness)]
 // CHECK:STDOUT:   %.loc20: type = specific_constant @impl.%GenericInterface.type.loc20_54.1, @impl(constants.%T) [symbolic = constants.%GenericInterface.type.3fe]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [template = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -204,10 +203,6 @@ class C {
 // CHECK:STDOUT: specific @impl(%T.loc20_23.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.2(constants.%T) {
-// CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F.1(constants.%T, constants.%GenericInterface.facet) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
@@ -92,7 +92,7 @@ class E {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.1: %i32 as %I.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = @C.%impl_witness
+// CHECK:STDOUT:   witness = <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.2: %D.ref as %I.ref;

--- a/toolchain/check/testdata/impl/no_prelude/fail_extend_impl_scope.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_extend_impl_scope.carbon
@@ -32,6 +32,38 @@ fn F() {
   extend impl {} as J {}
 }
 
+// --- fail_extend_impl_self_interface.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  fn Zero() -> Self;
+
+  // CHECK:STDERR: fail_extend_impl_self_interface.carbon:[[@LINE+4]]:15: error: `impl as` can only be used in a class [ImplAsOutsideClass]
+  // CHECK:STDERR:   extend impl as Z {
+  // CHECK:STDERR:               ^~
+  // CHECK:STDERR:
+  extend impl as Z {
+    fn Zero() -> Self {
+      return {};
+    }
+  }
+}
+
+class Point {
+  extend impl as Z {
+    fn Zero() -> Self {
+      return {};
+    }
+  }
+}
+
+fn F() {
+  // Even if the `extend impl` is diagnosed above, we must not add the impl of
+  // the interface to itself in a way that allows it to be used during impl
+  // lookup, or we end up with infinite impl lookup recursion here.
+  ({} as Point).Zero();
+}
+
 // CHECK:STDOUT: --- fail_extend_impl_file_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -64,7 +96,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: %.loc9_14.2 as %I.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%impl_witness
+// CHECK:STDOUT:   witness = <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_extend_impl_function_scope.carbon
@@ -97,7 +129,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: %.loc10_16.2 as %J.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = @F.%impl_witness
+// CHECK:STDOUT:   witness = <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -109,5 +141,34 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [template = constants.%impl_witness]
 // CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_extend_impl_self_interface.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [template]
+// CHECK:STDOUT:   %Self: %Z.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @Z {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = <unexpected>.inst15
+// CHECK:STDOUT:   .Zero = <unexpected>.inst32.loc4_20
+// CHECK:STDOUT:   witness = invalid
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Zero(<unexpected>.inst15: %Z.type) {
+// CHECK:STDOUT:   %Self: %Z.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic = %Self.as_type (constants.%Self.as_type)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() -> @Zero.%Self.as_type (%Self.as_type);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Zero(constants.%Self) {
+// CHECK:STDOUT:   %Self => constants.%Self
+// CHECK:STDOUT:   %Self.as_type => constants.%Self.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
If 'extend impl' is invalid, mark the impl as invalid by putting an ErrorInst in the witness_id field.

The construction of the witness_id can otherwise return an ErrorInst but impl lookup was not checking for that. Now have impl lookup check for an error there before attempting to deduce generic parameters, which avoids infinite recursion through deduction in cases like a cyclical impl of itself.

Adds a testcase for infinite impl-of-itself lookup found by fuzzer.
