### PR TITLE
Fold Context::GetCurrentScopeAs back into ScopeStack

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -52,7 +52,7 @@ Context::Context(DiagnosticEmitter* emitter,
       param_and_arg_refs_stack_(*sem_ir, vlog_stream, node_stack_),
       args_type_info_stack_("args_type_info_stack_", *sem_ir, vlog_stream),
       decl_name_stack_(this),
-      scope_stack_(sem_ir_->identifiers()),
+      scope_stack_(sem_ir_),
       vtable_stack_("vtable_stack_", *sem_ir, vlog_stream),
       global_init_(this),
       region_stack_(

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -287,13 +287,6 @@ class Context {
   auto NoteUndefinedInterface(SemIR::InterfaceId interface_id,
                               DiagnosticBuilder& builder) -> void;
 
-  // Returns the current scope, if it is of the specified kind. Otherwise,
-  // returns nullopt.
-  template <typename InstT>
-  auto GetCurrentScopeAs() -> std::optional<InstT> {
-    return scope_stack().GetCurrentScopeAs<InstT>(sem_ir());
-  }
-
   // Returns the type ID for a constant that is a type value, i.e. it is a value
   // of type `TypeType`.
   //

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -110,7 +110,8 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
 
   // A `var` binding in a class scope declares a field, not a true binding,
   // so we handle it separately.
-  if (auto parent_class_decl = context.GetCurrentScopeAs<SemIR::ClassDecl>();
+  if (auto parent_class_decl =
+          context.scope_stack().GetCurrentScopeAs<SemIR::ClassDecl>();
       parent_class_decl.has_value() &&
       node_kind == Parse::NodeKind::VarBindingPattern) {
     cast_type_id = AsConcreteType(
@@ -151,7 +152,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   // A binding in an interface scope declares an associated constant, not a
   // true binding, so we handle it separately.
   if (auto parent_interface_decl =
-          context.GetCurrentScopeAs<SemIR::InterfaceDecl>();
+          context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>();
       parent_interface_decl.has_value() && is_generic) {
     cast_type_id = AsCompleteType(context, cast_type_id, type_node, [&] {
       CARBON_DIAGNOSTIC(IncompleteTypeInAssociatedDecl, Error,

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -333,7 +333,8 @@ static auto DiagnoseClassSpecificDeclOutsideClass(Context& context,
 static auto GetCurrentScopeAsClassOrDiagnose(Context& context, SemIRLoc loc,
                                              Lex::TokenKind tok)
     -> std::optional<SemIR::ClassDecl> {
-  auto class_scope = context.GetCurrentScopeAs<SemIR::ClassDecl>();
+  auto class_scope =
+      context.scope_stack().GetCurrentScopeAs<SemIR::ClassDecl>();
   if (!class_scope) {
     DiagnoseClassSpecificDeclOutsideClass(context, loc, tok);
   }

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -87,7 +87,7 @@ static auto HandleIntroducer(Context& context, Parse::NodeId node_id) -> bool {
 }
 
 auto HandleParseNode(Context& context, Parse::LetIntroducerId node_id) -> bool {
-  if (context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+  if (context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
     StartAssociatedConstant(context);
   }
 
@@ -153,7 +153,7 @@ auto HandleParseNode(Context& context, Parse::VariablePatternId node_id)
 // Handle the end of the full-pattern of a let/var declaration (before the
 // start of the initializer, if any).
 static auto EndFullPattern(Context& context) -> void {
-  if (context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+  if (context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
     // Don't emit NameBindingDecl for an associated constant, because it will
     // always be empty.
     context.pattern_block_stack().PopAndDiscard();
@@ -189,7 +189,8 @@ static auto HandleInitializer(Context& context, Parse::NodeId node_id) -> bool {
 
 auto HandleParseNode(Context& context, Parse::LetInitializerId node_id)
     -> bool {
-  if (auto interface_decl = context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+  if (auto interface_decl =
+          context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
     EndAssociatedConstantDeclRegion(context, interface_decl->interface_id);
 
     // Start building the definition region of the constant.
@@ -238,7 +239,7 @@ static auto HandleDecl(Context& context) -> DeclInfo {
     // now. We will have done this at the `=` if there was an initializer.
     if (IntroducerTokenKind == Lex::TokenKind::Let) {
       if (auto interface_decl =
-              context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+              context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
         EndAssociatedConstantDeclRegion(context, interface_decl->interface_id);
       }
     }
@@ -346,7 +347,7 @@ auto HandleParseNode(Context& context, Parse::LetDeclId node_id) -> bool {
   // At interface scope, we are forming an associated constant, which has
   // different rules.
   if (auto interface_scope =
-          context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+          context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
     FinishAssociatedConstant(context, node_id, interface_scope->interface_id,
                              decl_info);
     return true;
@@ -378,7 +379,7 @@ auto HandleParseNode(Context& context, Parse::VariableDeclId node_id) -> bool {
       context, decl_info.introducer,
       KeywordModifierSet::Access | KeywordModifierSet::Returned);
 
-  if (context.GetCurrentScopeAs<SemIR::ClassDecl>()) {
+  if (context.scope_stack().GetCurrentScopeAs<SemIR::ClassDecl>()) {
     if (decl_info.init_id.has_value()) {
       // TODO: In a class scope, we should instead save the initializer
       // somewhere so that we can use it as a default.
@@ -386,7 +387,7 @@ auto HandleParseNode(Context& context, Parse::VariableDeclId node_id) -> bool {
     }
     return true;
   }
-  if (context.GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
+  if (context.scope_stack().GetCurrentScopeAs<SemIR::InterfaceDecl>()) {
     CARBON_DIAGNOSTIC(VarInInterfaceDecl, Error,
                       "`var` declaration in interface");
     context.emitter().Emit(node_id, VarInInterfaceDecl);


### PR DESCRIPTION
This adds a `SemIR::File` pointer to `scope_stack` so that `GetCurrentScopeAs` doesn't require the argument, which would be why the helper existed on `context`.