### PR TITLE
Register a vscode build task to save all files and run autoupdate.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "saveAll",
+      "command": "${command:workbench.action.files.saveAll}"
+    },
+    {
+      "label": "autoupdate: toolchain tests",
+      "type": "process",
+      "command": "toolchain/autoupdate_testdata.py",
+      "group": "build",
+      "dependsOn": ["saveAll"],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "echo": false,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": {
+        "owner": "cpp",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "source": "autoupdate",
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Also exclude external and bazel-out directories from vscode so that the build tasks list can be brought up quickly.