### PR TITLE
Delete unused ParamPatternInfo::GetNameId

### DIFF
--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -18,7 +18,6 @@ namespace Carbon::Check {
 
 // Returns a best-effort name for the given ParamPattern, suitable for use in
 // IR pretty-printing.
-// TODO: Resolve overlap with SemIR::Function::ParamPatternInfo::GetNameId
 template <typename ParamPattern>
 static auto GetPrettyName(Context& context, ParamPattern param_pattern)
     -> SemIR::NameId {

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -55,10 +55,6 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id) -> CalleeFunction {
   return result;
 }
 
-auto Function::ParamPatternInfo::GetNameId(const File& sem_ir) -> NameId {
-  return sem_ir.entity_names().Get(entity_name_id).name_id;
-}
-
 auto Function::GetParamPatternInfoFromPatternId(const File& sem_ir,
                                                 InstId pattern_id)
     -> ParamPatternInfo {

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -51,6 +51,12 @@ struct FunctionFields {
 struct Function : public EntityWithParamsBase,
                   public FunctionFields,
                   public Printable<Function> {
+  struct ParamPatternInfo {
+    InstId inst_id;
+    AnyParamPattern inst;
+    EntityNameId entity_name_id;
+  };
+
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{";
     PrintBaseFields(out);
@@ -69,14 +75,6 @@ struct Function : public EntityWithParamsBase,
   // `implicit_param_patterns_id`, returns a `ParamPatternInfo` value with the
   // corresponding instruction, its ID, and the entity_name_id of the underlying
   // binding pattern.
-  struct ParamPatternInfo {
-    InstId inst_id;
-    AnyParamPattern inst;
-    EntityNameId entity_name_id;
-
-    auto GetNameId(const File& sem_ir) -> NameId;
-  };
-
   static auto GetParamPatternInfoFromPatternId(const File& sem_ir,
                                                InstId param_pattern_id)
       -> ParamPatternInfo;


### PR DESCRIPTION
Perhaps GetPrettyName replaced all uses?

As long as I'm here, also fix struct declaration order.