### PR TITLE
Update compiler explorer mentions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,9 @@ and provides a deeper view into our goals for the Carbon project and language.
 
 ## Project status
 
-Carbon Language is currently an experimental project. You can see the demo
-interpreter for Carbon on
-[compiler-explorer.com](http://carbon.compiler-explorer.com/). We are also hard
-at work on a toolchain implementation with compiler and linker.
+Carbon Language is currently an experimental project. We are hard at work on a
+toolchain implementation with compiler and linker. You can try out the current
+state at [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
 We want to better understand whether we can build a language that meets our
 successor language criteria, and whether the resulting language can gather a
@@ -268,8 +267,7 @@ semantics onto C++ such as Rust-inspired
 
 ## Getting started
 
-To try out Carbon immediately in your browser, you can use the demo interpreter
-for Carbon on:
+To try out Carbon immediately in your browser, you can use the toolchain at:
 [carbon.compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
 We are developing a traditional toolchain for Carbon that can compile and link


### PR DESCRIPTION
The explorer interpreter is still there, but it's non-default so it's a little hard to link to (we could do a shortlink like https://carbon.compiler-explorer.com/z/8P1WE97nn if you want to keep that). As is, I assume it's okay to just state that this is now the toolchain.