### PR TITLE
Reduce clangd-displayed errors for def files

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -9,3 +9,13 @@ Diagnostics:
   # `unused-includes`: has false positives, reporting includes unused when
   #   they are used.
   Suppress: [unused-includes]
+
+---
+
+# Suppress common diagnostics for x-macro files.
+If:
+  PathMatch: .*\.def
+Diagnostics:
+  Suppress:
+    # The `#error` requiring a macro definition.
+    - pp_hash_error

--- a/common/enum_base_test.def
+++ b/common/enum_base_test.def
@@ -8,6 +8,7 @@
 
 #ifndef CARBON_ENUM_BASE_TEST_KIND
 #error "Must define the x-macro to use this file."
+#define CARBON_ENUM_BASE_TEST_KIND(Name)
 #endif
 
 CARBON_ENUM_BASE_TEST_KIND(Beep)

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -43,7 +43,7 @@ def load_diagnostic_kind() -> Set[str]:
     """
     path = Path("toolchain/diagnostics/diagnostic_kind.def")
     content = path.read_text()
-    decls = set(re.findall(r"CARBON_DIAGNOSTIC_KIND\((.+)\)", content))
+    decls = set(re.findall(r"^\s+CARBON_DIAGNOSTIC_KIND\((.+)\)", content))
     return decls.difference(IGNORED)
 
 

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -14,6 +14,7 @@
 
 #ifndef CARBON_DIAGNOSTIC_KIND
 #error "Must define the x-macro to use this file."
+#define CARBON_DIAGNOSTIC_KIND(Name)
 #endif
 
 // ============================================================================

--- a/toolchain/parse/node_kind.def
+++ b/toolchain/parse/node_kind.def
@@ -31,6 +31,7 @@
 
 #if !defined(CARBON_PARSE_NODE_KIND)
 #error "Must define CARBON_PARSE_NODE_KIND family x-macros to use this file."
+#define CARBON_PARSE_NODE_KIND(Name)
 #endif
 
 // This is expected to be used with something like:

--- a/toolchain/parse/state.def
+++ b/toolchain/parse/state.def
@@ -36,6 +36,7 @@
 
 #ifndef CARBON_PARSE_STATE
 #error "Must define the x-macro to use this file."
+#define CARBON_PARSE_STATE(Name)
 #endif
 
 // Use CARBON_PARSE_STATE_VARIANTSN(State, Variant1, Variant2, ...) to generate

--- a/toolchain/sem_ir/builtin_function_kind.def
+++ b/toolchain/sem_ir/builtin_function_kind.def
@@ -14,6 +14,7 @@
 #if !defined(CARBON_SEM_IR_BUILTIN_FUNCTION_KIND)
 #error \
     "Must define CARBON_SEM_IR_BUILTIN_FUNCTION_KIND x-macro to use this file."
+#define CARBON_SEM_IR_BUILTIN_FUNCTION_KIND(Name)
 #endif
 
 CARBON_SEM_IR_BUILTIN_FUNCTION_KIND(None)

--- a/toolchain/sem_ir/inst_kind.def
+++ b/toolchain/sem_ir/inst_kind.def
@@ -13,6 +13,7 @@
 
 #ifndef CARBON_SEM_IR_INST_KIND
 #error "Must define the x-macro to use this file."
+#define CARBON_SEM_IR_INST_KIND(Name)
 #endif
 
 // For each instruction kind declared here there is a matching definition in


### PR DESCRIPTION
When I open a .def file, there are often 4 errors:

- The #error
- The #define is not defined
- Missing `;`
- Identifier naming

This PR is meant to disable all of these, since they can be distracting from fixable diagnostics.