### PR TITLE
Remove obsolete '...' hints on node kind macros

### DIFF
--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -95,8 +95,8 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
   return true;
 }
 
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...)                  \
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name)                       \
   auto HandleParseNode(Context& context, Parse::Name##ModifierId node_id) \
       -> bool {                                                           \
     HandleModifier(context, node_id, KeywordModifierSet::Name);           \

--- a/toolchain/parse/handle_decl_scope_loop.cpp
+++ b/toolchain/parse/handle_decl_scope_loop.cpp
@@ -184,9 +184,8 @@ static auto ResolveAmbiguousTokenAsDeclaration(Context& context,
         case Lex::TokenKind::Library:
         case Lex::TokenKind::Namespace:
         case Lex::TokenKind::Var:
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...) \
-  case Lex::TokenKind::Name:
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name) case Lex::TokenKind::Name:
 #include "toolchain/parse/node_kind.def"
 
           return false;
@@ -214,8 +213,8 @@ static auto TryHandleAsModifier(Context& context) -> bool {
   }
 
   switch (position_kind) {
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...)              \
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name)                   \
   case Lex::TokenKind::Name:                                          \
     context.AddLeafNode(NodeKind::Name##Modifier, context.Consume()); \
     return true;

--- a/toolchain/parse/handle_expr.cpp
+++ b/toolchain/parse/handle_expr.cpp
@@ -355,10 +355,10 @@ auto HandleExprLoop(Context& context) -> void {
   } else {
     NodeKind node_kind;
     switch (operator_kind) {
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_POSTFIX_OPERATOR(Name, ...) \
-  case Lex::TokenKind::Name:                               \
-    node_kind = NodeKind::PostfixOperator##Name;           \
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_POSTFIX_OPERATOR(Name) \
+  case Lex::TokenKind::Name:                          \
+    node_kind = NodeKind::PostfixOperator##Name;      \
     break;
 #include "toolchain/parse/node_kind.def"
 
@@ -386,8 +386,8 @@ auto HandleExprLoopForInfixOperator(Context& context) -> void {
   auto state = context.PopState();
 
   switch (auto token_kind = context.tokens().GetKind(state.token)) {
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_INFIX_OPERATOR(Name, ...)                      \
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_INFIX_OPERATOR(Name)                           \
   case Lex::TokenKind::Name:                                                  \
     HandleExprLoopForOperator(context, state, NodeKind::InfixOperator##Name); \
     break;
@@ -402,8 +402,8 @@ auto HandleExprLoopForPrefixOperator(Context& context) -> void {
   auto state = context.PopState();
 
   switch (auto token_kind = context.tokens().GetKind(state.token)) {
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_PREFIX_OPERATOR(Name, ...)                      \
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_PREFIX_OPERATOR(Name)                           \
   case Lex::TokenKind::Name:                                                   \
     HandleExprLoopForOperator(context, state, NodeKind::PrefixOperator##Name); \
     break;

--- a/toolchain/parse/handle_statement.cpp
+++ b/toolchain/parse/handle_statement.cpp
@@ -48,9 +48,8 @@ auto HandleStatement(Context& context) -> void {
       context.PushState(State::MatchIntroducer);
       break;
     }
-#define CARBON_PARSE_NODE_KIND(...)
-#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...) \
-  case Lex::TokenKind::Name:
+#define CARBON_PARSE_NODE_KIND(Name)
+#define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name) case Lex::TokenKind::Name:
 #include "toolchain/parse/node_kind.def"
     case Lex::TokenKind::Adapt:
     case Lex::TokenKind::Alias:

--- a/toolchain/parse/node_kind.def
+++ b/toolchain/parse/node_kind.def
@@ -19,7 +19,7 @@
 //     Defines a parse node for a postfix operator, with the Name as token.
 //   - CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, LexTokenKind)
 //     Defines a parse node that corresponds to a token that is a single-token
-//     literal. The token is wrapped for LexTokenKinds.
+//     literal. The token is wrapped for LexTokenKind.
 //   - CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name)
 //     A token-based modifier. The Name is the TokenKind, and will be appended
 //     with "Modifier" for the parse kind.
@@ -36,8 +36,8 @@
 // This is expected to be used with something like:
 //
 //   // Use x-macros to handle modifier cases.
-//   #define CARBON_PARSE_NODE_KIND(...)
-//   #define CARBON_PARSE_NODE_KIND_PREFIX_OPERATOR(Name, ...) <code>
+//   #define CARBON_PARSE_NODE_KIND(Name)
+//   #define CARBON_PARSE_NODE_KIND_PREFIX_OPERATOR(Name) <code>
 #ifndef CARBON_PARSE_NODE_KIND_PREFIX_OPERATOR
 #define CARBON_PARSE_NODE_KIND_PREFIX_OPERATOR(Name) \
   CARBON_PARSE_NODE_KIND(PrefixOperator##Name)
@@ -46,8 +46,8 @@
 // This is expected to be used with something like:
 //
 //   // Use x-macros to handle modifier cases.
-//   #define CARBON_PARSE_NODE_KIND(...)
-//   #define CARBON_PARSE_NODE_KIND_INFIX_OPERATOR(Name, ...) <code>
+//   #define CARBON_PARSE_NODE_KIND(Name)
+//   #define CARBON_PARSE_NODE_KIND_INFIX_OPERATOR(Name) <code>
 #ifndef CARBON_PARSE_NODE_KIND_INFIX_OPERATOR
 #define CARBON_PARSE_NODE_KIND_INFIX_OPERATOR(Name) \
   CARBON_PARSE_NODE_KIND(InfixOperator##Name)
@@ -56,8 +56,8 @@
 // This is expected to be used with something like:
 //
 //   // Use x-macros to handle modifier cases.
-//   #define CARBON_PARSE_NODE_KIND(...)
-//   #define CARBON_PARSE_NODE_KIND_POSTFIX_OPERATOR(Name, ...) <code>
+//   #define CARBON_PARSE_NODE_KIND(Name)
+//   #define CARBON_PARSE_NODE_KIND_POSTFIX_OPERATOR(Name) <code>
 #ifndef CARBON_PARSE_NODE_KIND_POSTFIX_OPERATOR
 #define CARBON_PARSE_NODE_KIND_POSTFIX_OPERATOR(Name) \
   CARBON_PARSE_NODE_KIND(PostfixOperator##Name)
@@ -66,18 +66,18 @@
 // This is expected to be used with something like:
 //
 //   // Use x-macros to handle literal cases.
-//   #define CARBON_PARSE_NODE_KIND(...)
-//   #define CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, ...) <code>
+//   #define CARBON_PARSE_NODE_KIND(Name)
+//   #define CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, LexTokenKind) <code>
 #ifndef CARBON_PARSE_NODE_KIND_TOKEN_LITERAL
-#define CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, LexTokenKinds) \
+#define CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, LexTokenKind) \
   CARBON_PARSE_NODE_KIND(Name)
 #endif
 
 // This is expected to be used with something like:
 //
 //   // Use x-macros to handle modifier cases.
-//   #define CARBON_PARSE_NODE_KIND(...)
-//   #define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...) <code>
+//   #define CARBON_PARSE_NODE_KIND(Name)
+//   #define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name) <code>
 #ifndef CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER
 #define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name) \
   CARBON_PARSE_NODE_KIND(Name##Modifier)

--- a/toolchain/parse/node_kind.def
+++ b/toolchain/parse/node_kind.def
@@ -19,7 +19,7 @@
 //     Defines a parse node for a postfix operator, with the Name as token.
 //   - CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, LexTokenKind)
 //     Defines a parse node that corresponds to a token that is a single-token
-//     literal. The token is wrapped for LexTokenKind.
+//     literal.
 //   - CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name)
 //     A token-based modifier. The Name is the TokenKind, and will be appended
 //     with "Modifier" for the parse kind.

--- a/toolchain/parse/typed_nodes.h
+++ b/toolchain/parse/typed_nodes.h
@@ -945,7 +945,7 @@ struct PostfixOperator {
 
 // Literals, operators, and modifiers
 
-#define CARBON_PARSE_NODE_KIND(...)
+#define CARBON_PARSE_NODE_KIND(Name)
 #define CARBON_PARSE_NODE_KIND_TOKEN_LITERAL(Name, LexTokenKind)       \
   using Name = LeafNode<NodeKind::Name, Lex::LexTokenKind##TokenIndex, \
                         NodeCategory::Expr>;


### PR DESCRIPTION
We used to have more arguments, but they've mostly been removed now.