### PR TITLE
Add a test for the case that `extend` poisons a class member

### DIFF
--- a/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -1,0 +1,75 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+
+// --- fail_extend_poison_class_members.carbon
+
+library "[[@TEST_NAME]]";
+
+base class B {}
+
+class C {
+  // CHECK:STDERR: fail_extend_poison_class_members.carbon:[[@LINE+3]]:16: error: name used before it was declared [NameUseBeforeDecl]
+  // CHECK:STDERR:   extend base: B;
+  // CHECK:STDERR:                ^
+  extend base: B;
+
+  // CHECK:STDERR: fail_extend_poison_class_members.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
+  // CHECK:STDERR:   fn B();
+  // CHECK:STDERR:      ^
+  // CHECK:STDERR:
+  fn B();
+}
+
+// CHECK:STDOUT: --- fail_extend_poison_class_members.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %B.fa3: type = class_type @B.2 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %C.elem: type = unbound_element_type %C, %B.fa3 [concrete]
+// CHECK:STDOUT:   %B.type: type = fn_type @B.1 [concrete]
+// CHECK:STDOUT:   %B.489: %B.type = struct_value () [concrete]
+// CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B.fa3} [concrete]
+// CHECK:STDOUT:   %complete_type.98e: <witness> = complete_type_witness %struct_type.base [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %B.decl: type = class_decl @B.2 [concrete = constants.%B.fa3] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B.2 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B.fa3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B.fa3]
+// CHECK:STDOUT:   %.loc10: %C.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B.1 [concrete = constants.%B.489] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .base = %.loc10
+// CHECK:STDOUT:   extend %B.ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @B.1();
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// EXTRA-ARGS: --no-dump-sem-ir
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -26,50 +28,3 @@ class C {
   // CHECK:STDERR:
   fn B();
 }
-
-// CHECK:STDOUT: --- fail_extend_poison_class_members.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %B.fa3: type = class_type @B.2 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %C.elem: type = unbound_element_type %C, %B.fa3 [concrete]
-// CHECK:STDOUT:   %B.type: type = fn_type @B.1 [concrete]
-// CHECK:STDOUT:   %B.489: %B.type = struct_value () [concrete]
-// CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B.fa3} [concrete]
-// CHECK:STDOUT:   %complete_type.98e: <witness> = complete_type_witness %struct_type.base [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .B = %B.decl
-// CHECK:STDOUT:     .C = %C.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %B.decl: type = class_decl @B.2 [concrete = constants.%B.fa3] {} {}
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @B.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%B.fa3
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B.fa3]
-// CHECK:STDOUT:   %.loc10: %C.elem = base_decl %B.ref, element0 [concrete]
-// CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B.1 [concrete = constants.%B.489] {} {}
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT:   .base = %.loc10
-// CHECK:STDOUT:   extend %B.ref
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @B.1();
-// CHECK:STDOUT:


### PR DESCRIPTION
Part of #4622.