### PR TITLE
Move `AddImportNamespace()` to the bottom of the file

### DIFF
--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -86,76 +86,6 @@ static auto CopyNameFromImportIR(Context& context,
   return import_name_id;
 }
 
-auto AddImportNamespace(Context& context, SemIR::TypeId namespace_type_id,
-                        SemIR::NameId name_id,
-                        SemIR::NameScopeId parent_scope_id,
-                        bool diagnose_duplicate_namespace,
-                        llvm::function_ref<SemIR::InstId()> make_import_id)
-    -> AddImportNamespaceResult {
-  auto* parent_scope = &context.name_scopes().Get(parent_scope_id);
-  auto [inserted, entry_id] = parent_scope->LookupOrAdd(
-      name_id,
-      // This InstId is temporary and would be overridden if used.
-      SemIR::InstId::None, SemIR::AccessKind::Public);
-  if (!inserted) {
-    const auto& prev_entry = parent_scope->GetEntry(entry_id);
-    if (!prev_entry.result.is_poisoned()) {
-      auto prev_inst_id = prev_entry.result.target_inst_id();
-      if (auto namespace_inst =
-              context.insts().TryGetAs<SemIR::Namespace>(prev_inst_id)) {
-        if (diagnose_duplicate_namespace) {
-          auto import_id = make_import_id();
-          CARBON_CHECK(import_id.has_value());
-          DiagnoseDuplicateName(context, import_id, prev_inst_id);
-        }
-        return {.name_scope_id = namespace_inst->name_scope_id,
-                .inst_id = prev_inst_id,
-                .is_duplicate_of_namespace_in_current_package = true};
-      }
-    }
-  }
-
-  auto import_id = make_import_id();
-  CARBON_CHECK(import_id.has_value());
-  auto import_loc_id = context.insts().GetLocId(import_id);
-
-  auto namespace_inst =
-      SemIR::Namespace{.type_id = namespace_type_id,
-                       .name_scope_id = SemIR::NameScopeId::None,
-                       .import_id = import_id};
-  auto namespace_inst_and_loc =
-      import_loc_id.is_import_ir_inst_id()
-          ? context.MakeImportedLocAndInst(import_loc_id.import_ir_inst_id(),
-                                           namespace_inst)
-          // TODO: Check that this actually is an `AnyNamespaceId`.
-          : SemIR::LocIdAndInst(Parse::AnyNamespaceId(import_loc_id.node_id()),
-                                namespace_inst);
-  auto namespace_id =
-      context.AddPlaceholderInstInNoBlock(namespace_inst_and_loc);
-  context.import_ref_ids().push_back(namespace_id);
-  namespace_inst.name_scope_id =
-      context.name_scopes().Add(namespace_id, name_id, parent_scope_id);
-  context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);
-
-  // Note we have to get the parent scope freshly, creating the imported
-  // namespace may invalidate the pointer above.
-  parent_scope = &context.name_scopes().Get(parent_scope_id);
-
-  // Diagnose if there's a name conflict, but still produce the namespace to
-  // supersede the name conflict in order to avoid repeat diagnostics. Names are
-  // poisoned optimistically by name lookup before checking for imports, so we
-  // may be overwriting a poisoned entry here.
-  auto& result = parent_scope->GetEntry(entry_id).result;
-  if (!result.is_poisoned() && !inserted) {
-    DiagnoseDuplicateName(context, namespace_id, result.target_inst_id());
-  }
-  result = SemIR::ScopeLookupResult::MakeFound(namespace_id,
-                                               SemIR::AccessKind::Public);
-  return {.name_scope_id = namespace_inst.name_scope_id,
-          .inst_id = namespace_id,
-          .is_duplicate_of_namespace_in_current_package = false};
-}
-
 // Adds a copied namespace to the cache.
 static auto CacheCopiedNamespace(
     Map<SemIR::NameScopeId, SemIR::NameScopeId>& copied_namespaces,
@@ -604,6 +534,76 @@ auto ImportNameFromOtherPackage(
   }
 
   return result_id;
+}
+
+auto AddImportNamespace(Context& context, SemIR::TypeId namespace_type_id,
+                        SemIR::NameId name_id,
+                        SemIR::NameScopeId parent_scope_id,
+                        bool diagnose_duplicate_namespace,
+                        llvm::function_ref<SemIR::InstId()> make_import_id)
+    -> AddImportNamespaceResult {
+  auto* parent_scope = &context.name_scopes().Get(parent_scope_id);
+  auto [inserted, entry_id] = parent_scope->LookupOrAdd(
+      name_id,
+      // This InstId is temporary and would be overridden if used.
+      SemIR::InstId::None, SemIR::AccessKind::Public);
+  if (!inserted) {
+    const auto& prev_entry = parent_scope->GetEntry(entry_id);
+    if (!prev_entry.result.is_poisoned()) {
+      auto prev_inst_id = prev_entry.result.target_inst_id();
+      if (auto namespace_inst =
+              context.insts().TryGetAs<SemIR::Namespace>(prev_inst_id)) {
+        if (diagnose_duplicate_namespace) {
+          auto import_id = make_import_id();
+          CARBON_CHECK(import_id.has_value());
+          DiagnoseDuplicateName(context, import_id, prev_inst_id);
+        }
+        return {.name_scope_id = namespace_inst->name_scope_id,
+                .inst_id = prev_inst_id,
+                .is_duplicate_of_namespace_in_current_package = true};
+      }
+    }
+  }
+
+  auto import_id = make_import_id();
+  CARBON_CHECK(import_id.has_value());
+  auto import_loc_id = context.insts().GetLocId(import_id);
+
+  auto namespace_inst =
+      SemIR::Namespace{.type_id = namespace_type_id,
+                       .name_scope_id = SemIR::NameScopeId::None,
+                       .import_id = import_id};
+  auto namespace_inst_and_loc =
+      import_loc_id.is_import_ir_inst_id()
+          ? context.MakeImportedLocAndInst(import_loc_id.import_ir_inst_id(),
+                                           namespace_inst)
+          // TODO: Check that this actually is an `AnyNamespaceId`.
+          : SemIR::LocIdAndInst(Parse::AnyNamespaceId(import_loc_id.node_id()),
+                                namespace_inst);
+  auto namespace_id =
+      context.AddPlaceholderInstInNoBlock(namespace_inst_and_loc);
+  context.import_ref_ids().push_back(namespace_id);
+  namespace_inst.name_scope_id =
+      context.name_scopes().Add(namespace_id, name_id, parent_scope_id);
+  context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);
+
+  // Note we have to get the parent scope freshly, creating the imported
+  // namespace may invalidate the pointer above.
+  parent_scope = &context.name_scopes().Get(parent_scope_id);
+
+  // Diagnose if there's a name conflict, but still produce the namespace to
+  // supersede the name conflict in order to avoid repeat diagnostics. Names are
+  // poisoned optimistically by name lookup before checking for imports, so we
+  // may be overwriting a poisoned entry here.
+  auto& result = parent_scope->GetEntry(entry_id).result;
+  if (!result.is_poisoned() && !inserted) {
+    DiagnoseDuplicateName(context, namespace_id, result.target_inst_id());
+  }
+  result = SemIR::ScopeLookupResult::MakeFound(namespace_id,
+                                               SemIR::AccessKind::Public);
+  return {.name_scope_id = namespace_inst.name_scope_id,
+          .inst_id = namespace_id,
+          .is_duplicate_of_namespace_in_current_package = false};
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/import.h
+++ b/toolchain/check/import.h
@@ -11,23 +11,6 @@
 
 namespace Carbon::Check {
 
-struct AddImportNamespaceResult {
-  SemIR::NameScopeId name_scope_id;
-  SemIR::InstId inst_id;
-  bool is_duplicate_of_namespace_in_current_package;
-};
-
-// Adds a namespace to the IR. The bool on return is true if there was a name
-// conflict. diagnose_duplicate_namespace is used when handling a cross-package
-// import, where an existing namespace is in the current package and the new
-// namespace is a different package.
-auto AddImportNamespace(Context& context, SemIR::TypeId namespace_type_id,
-                        SemIR::NameId name_id,
-                        SemIR::NameScopeId parent_scope_id,
-                        bool diagnose_duplicate_namespace,
-                        llvm::function_ref<SemIR::InstId()> make_import_id)
-    -> AddImportNamespaceResult;
-
 // Imports the API file's name lookup information into a corresponding
 // implementation file. Only information for the current package will be copied;
 // information for other packages should be handled through
@@ -71,6 +54,23 @@ auto ImportNameFromOtherPackage(
     llvm::ArrayRef<std::pair<SemIR::ImportIRId, SemIR::NameScopeId>>
         import_ir_scopes,
     SemIR::NameId name_id) -> SemIR::InstId;
+
+struct AddImportNamespaceResult {
+  SemIR::NameScopeId name_scope_id;
+  SemIR::InstId inst_id;
+  bool is_duplicate_of_namespace_in_current_package;
+};
+
+// Adds a namespace to the IR. The bool on return is true if there was a name
+// conflict. diagnose_duplicate_namespace is used when handling a cross-package
+// import, where an existing namespace is in the current package and the new
+// namespace is a different package.
+auto AddImportNamespace(Context& context, SemIR::TypeId namespace_type_id,
+                        SemIR::NameId name_id,
+                        SemIR::NameScopeId parent_scope_id,
+                        bool diagnose_duplicate_namespace,
+                        llvm::function_ref<SemIR::InstId()> make_import_id)
+    -> AddImportNamespaceResult;
 
 }  // namespace Carbon::Check
 


### PR DESCRIPTION
This function is used by `import.cpp` and `import_cpp.cpp` to deduplicate some of the logic.
However, it's not really part of the importing API, so it makes more sense to put it in the bottom.
In the .cpp, it was between static functions, just for easier reviewing of the refactoring PR (#4873).

Part of #4666.