### PR TITLE
Allow pre-commit to talk to googleapis

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -37,6 +37,7 @@ jobs:
             pypi.org:443
             registry.npmjs.org:443
             releases.bazel.build:443
+            storage.googleapis.com:443
             sourceforge.net:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Example:
- https://app.stepsecurity.io/github/carbon-language/carbon-lang/actions/runs/13320074606
- https://github.com/carbon-language/carbon-lang/actions/runs/13320074606/job/37247235705

I'm not sure what it's being used for (even blocked, nothing unexpected failed) but if bazel or similar is trying to talk to this it should be fine.