### PR TITLE
Share ReadFile in tests

### DIFF
--- a/testing/base/BUILD
+++ b/testing/base/BUILD
@@ -92,6 +92,14 @@ cc_binary(
 )
 
 cc_library(
+    name = "file_helpers",
+    testonly = 1,
+    srcs = ["file_helpers.cpp"],
+    hdrs = ["file_helpers.h"],
+    deps = ["//common:error"],
+)
+
+cc_library(
     name = "global_exe_path",
     testonly = 1,
     srcs = ["global_exe_path.cpp"],

--- a/testing/base/file_helpers.cpp
+++ b/testing/base/file_helpers.cpp
@@ -19,7 +19,6 @@ auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string> {
   if (file_stream.fail()) {
     return Error(llvm::formatv("Error reading file: {0}", path));
   }
-  file_stream.close();
   return buffer.str();
 }
 

--- a/testing/base/file_helpers.cpp
+++ b/testing/base/file_helpers.cpp
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing/base/file_helpers.h"
+
+#include <fstream>
+#include <sstream>
+
+namespace Carbon::Testing {
+
+auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string> {
+  std::ifstream file_stream(path);
+  if (file_stream.fail()) {
+    return Error(llvm::formatv("Error opening file: {0}", path));
+  }
+  std::stringstream buffer;
+  buffer << file_stream.rdbuf();
+  if (file_stream.fail()) {
+    return Error(llvm::formatv("Error reading file: {0}", path));
+  }
+  file_stream.close();
+  return buffer.str();
+}
+
+}  // namespace Carbon::Testing

--- a/testing/base/file_helpers.h
+++ b/testing/base/file_helpers.h
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TESTING_BASE_FILE_HELPERS_H_
+#define CARBON_TESTING_BASE_FILE_HELPERS_H_
+
+#include <filesystem>
+#include <string>
+
+#include "common/error.h"
+
+namespace Carbon::Testing {
+
+// Reads a file to string.
+auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string>;
+
+}  // namespace Carbon::Testing
+
+#endif  // CARBON_TESTING_BASE_FILE_HELPERS_H_

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "//common:init_llvm",
         "//common:ostream",
         "//common:raw_string_ostream",
+        "//testing/base:file_helpers",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
         "@googletest//:gtest",

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -153,6 +153,7 @@ cc_test(
         ":driver",
         "//common:all_llvm_targets",
         "//common:raw_string_ostream",
+        "//testing/base:file_helpers",
         "//testing/base:global_exe_path",
         "//testing/base:gtest_main",
         "//toolchain/diagnostics:diagnostic_emitter",

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "testing/base/file_helpers.h"
 #include "testing/base/global_exe_path.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
@@ -27,16 +28,6 @@ using ::testing::HasSubstr;
 using ::testing::StrEq;
 
 namespace Yaml = ::Carbon::Testing::Yaml;
-
-// Reads a file to string.
-// TODO: Extract this to a helper and share it with other tests.
-static auto ReadFile(std::filesystem::path path) -> std::string {
-  std::ifstream proto_file(path);
-  std::stringstream buffer;
-  buffer << proto_file.rdbuf();
-  proto_file.close();
-  return buffer.str();
-}
 
 class DriverTest : public testing::Test {
  public:
@@ -222,7 +213,7 @@ TEST_F(DriverTest, FileOutput) {
                   .success);
   EXPECT_THAT(test_error_stream_.TakeStr(), StrEq(""));
   // TODO: This may need to be tailored to other assembly formats.
-  EXPECT_THAT(ReadFile("test.s"), ContainsRegex("Main:"));
+  EXPECT_THAT(*Testing::ReadFile("test.s"), ContainsRegex("Main:"));
 }
 
 }  // namespace

--- a/utils/tree_sitter/BUILD
+++ b/utils/tree_sitter/BUILD
@@ -62,6 +62,7 @@ cc_binary(
     tags = ["manual"],
     deps = [
         ":parser",
+        "//testing/base:file_helpers",
     ],
 )
 
@@ -74,6 +75,7 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":parser",
+        "//testing/base:file_helpers",
     ],
 )
 
@@ -99,6 +101,7 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":parser",
+        "//testing/base:file_helpers",
     ],
 )
 
@@ -114,5 +117,6 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":parser",
+        "//testing/base:file_helpers",
     ],
 )

--- a/utils/tree_sitter/test_runner.cpp
+++ b/utils/tree_sitter/test_runner.cpp
@@ -5,26 +5,15 @@
 #include <tree_sitter/api.h>
 
 #include <cstdlib>
-#include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
+#include "testing/base/file_helpers.h"
 #include "utils/tree_sitter/src/tree_sitter/parser.h"
 
 extern "C" {
 auto tree_sitter_carbon() -> TSLanguage*;
-}
-
-// Reads a file to string.
-static auto ReadFile(std::filesystem::path path) -> std::string {
-  std::ifstream file(path);
-  std::stringstream buffer;
-  buffer << file.rdbuf();
-  file.close();
-  return buffer.str();
 }
 
 // TODO: use file_test.cpp
@@ -42,7 +31,7 @@ auto main(int argc, char** argv) -> int {
   std::vector<std::string> incorrect;
   for (int i = 1; i < argc; i++) {
     std::string file_path = argv[i];
-    std::string source = ReadFile(file_path);
+    std::string source = std::move(*Carbon::Testing::ReadFile(file_path));
 
     auto* tree =
         ts_parser_parse_string(parser, nullptr, source.data(), source.size());


### PR DESCRIPTION
Small cleanup for code sharing. Note, `*ReadFile` will trigger a CHECK-failure on error; the relevant implementations would previously have failed silently (empty string).