### PR TITLE
Refactor `stdout` and `stderr` capturing to a library

### DIFF
--- a/testing/base/BUILD
+++ b/testing/base/BUILD
@@ -46,6 +46,17 @@ cc_library(
 )
 
 cc_library(
+    name = "capture_std_streams",
+    testonly = 1,
+    srcs = ["capture_std_streams.cpp"],
+    hdrs = ["capture_std_streams.h"],
+    deps = [
+        "//common:ostream",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "source_gen_lib",
     testonly = 1,
     srcs = ["source_gen.cpp"],

--- a/testing/base/capture_std_streams.cpp
+++ b/testing/base/capture_std_streams.cpp
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing/base/capture_std_streams.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+
+#include "common/ostream.h"
+
+namespace Carbon::Testing::Internal {
+
+// While these are marked as "internal" APIs, they seem to work and be pretty
+// widely used for their exact documented behavior.
+using ::testing::internal::CaptureStderr;
+using ::testing::internal::CaptureStdout;
+using ::testing::internal::GetCapturedStderr;
+using ::testing::internal::GetCapturedStdout;
+
+auto BeginStdStreamCapture() -> void {
+  CaptureStderr();
+  CaptureStdout();
+}
+auto EndStdStreamCapture(std::string& out, std::string& err) -> void {
+  // No need to flush stderr.
+  err = GetCapturedStderr();
+  llvm::outs().flush();
+  out = GetCapturedStdout();
+}
+
+}  // namespace Carbon::Testing::Internal

--- a/testing/base/capture_std_streams.h
+++ b/testing/base/capture_std_streams.h
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TESTING_BASE_CAPTURE_STD_STREAMS_H_
+#define CARBON_TESTING_BASE_CAPTURE_STD_STREAMS_H_
+
+#include <string>
+
+namespace Carbon::Testing {
+
+// Implementation details.
+namespace Internal {
+auto BeginStdStreamCapture() -> void;
+auto EndStdStreamCapture(std::string& out, std::string& err) -> void;
+}  // namespace Internal
+
+// Calls the provided function while capturing both `stdout` and `stderr`. The
+// `out` and `err` strings are set to whatever is captured after the function
+// returns.
+//
+// Note that any output that is captured will not be visible when running, which
+// can make debugging tests that use this routine difficult. Make sure to either
+// print back out or otherwise expose any of the contents of the captured output
+// that are needed when debugging.
+template <typename FnT>
+static auto CallWithCapturedOutput(std::string& out, std::string& err,
+                                   FnT function) {
+  Internal::BeginStdStreamCapture();
+  auto result = function();
+  Internal::EndStdStreamCapture(out, err);
+  return result;
+}
+
+}  // namespace Carbon::Testing
+
+#endif  // CARBON_TESTING_BASE_CAPTURE_STD_STREAMS_H_

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -49,6 +49,7 @@ cc_test(
         "//common:check",
         "//common:ostream",
         "//common:raw_string_ostream",
+        "//testing/base:capture_std_streams",
         "//testing/base:global_exe_path",
         "//testing/base:gtest_main",
         "@googletest//:gtest",


### PR DESCRIPTION
This should make it easy to add more tests which need the specific behavior here. It also isolates where we reach into GoogleTest's internals to a single common place.