### PR TITLE
Move test file writing to our common testing `file_helpers`

### DIFF
--- a/testing/base/BUILD
+++ b/testing/base/BUILD
@@ -107,7 +107,10 @@ cc_library(
     testonly = 1,
     srcs = ["file_helpers.cpp"],
     hdrs = ["file_helpers.h"],
-    deps = ["//common:error"],
+    deps = [
+        "//common:error",
+        "@googletest//:gtest",
+    ],
 )
 
 cc_library(

--- a/testing/base/file_helpers.cpp
+++ b/testing/base/file_helpers.cpp
@@ -4,8 +4,12 @@
 
 #include "testing/base/file_helpers.h"
 
+#include <gtest/gtest.h>
+
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <system_error>
 
 namespace Carbon::Testing {
 
@@ -20,6 +24,39 @@ auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string> {
     return Error(llvm::formatv("Error reading file: {0}", path));
   }
   return buffer.str();
+}
+
+auto WriteTestFile(llvm::StringRef name, llvm::StringRef contents)
+    -> ErrorOr<std::filesystem::path> {
+  std::filesystem::path test_tmpdir;
+  if (char* tmpdir_env = getenv("TEST_TMPDIR"); tmpdir_env != nullptr) {
+    test_tmpdir = std::string(tmpdir_env);
+  } else {
+    test_tmpdir = std::filesystem::temp_directory_path();
+  }
+
+  const auto* unit_test = ::testing::UnitTest::GetInstance();
+  const auto* test_info = unit_test->current_test_info();
+  std::filesystem::path test_file =
+      test_tmpdir / llvm::formatv("{0}_{1}_{2}", test_info->test_suite_name(),
+                                  test_info->name(), name)
+                        .str();
+  // Make debugging a bit easier by cleaning up any files from previous runs.
+  // This is only necessary when not run in Bazel's test environment.
+  std::filesystem::remove(test_file);
+  if (std::filesystem::exists(test_file)) {
+    return Error(
+        llvm::formatv("Unable to remove an existing file: {0}", test_file));
+  }
+
+  std::error_code ec;
+  llvm::raw_fd_ostream test_file_stream(test_file.string(), ec);
+  if (ec) {
+    return Error(llvm::formatv("Test file error: {0}", ec.message()));
+  }
+  test_file_stream << contents;
+
+  return test_file;
 }
 
 }  // namespace Carbon::Testing

--- a/testing/base/file_helpers.h
+++ b/testing/base/file_helpers.h
@@ -15,6 +15,23 @@ namespace Carbon::Testing {
 // Reads a file to string.
 auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string>;
 
+// Writes a test file to disk and returns an error or the full path to the file.
+//
+// Note that this expects to be run from within a GoogleTest test, and relies on
+// global state of GoogleTest.
+//
+// This locates a suitable temporary directory for the test, creates a file with
+// the requested name in that directory, and writes the provided content to that
+// file. The full path to the written file is returned.
+//
+// Where possible, this will use a Bazel-provided test temporary directory.
+// However, if unavailable, it falls back to a system temporary directory. This
+// helps tests be runnable outside of Bazel, for example under a debugger. It
+// also works to create test file names that are unlikely to conflict with other
+// tests when run.
+auto WriteTestFile(llvm::StringRef name, llvm::StringRef contents)
+    -> ErrorOr<std::filesystem::path>;
+
 }  // namespace Carbon::Testing
 
 #endif  // CARBON_TESTING_BASE_FILE_HELPERS_H_

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -50,6 +50,7 @@ cc_test(
         "//common:ostream",
         "//common:raw_string_ostream",
         "//testing/base:capture_std_streams",
+        "//testing/base:file_helpers",
         "//testing/base:global_exe_path",
         "//testing/base:gtest_main",
         "@googletest//:gtest",


### PR DESCRIPTION
This will make it easy to share across tests. Factored out of a change adding new uses of the file.