### PR TITLE
Add enumerate() for ValueStore and ImplStore

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -101,11 +101,11 @@ class ValueStore
   auto array_ref() const -> llvm::ArrayRef<ValueType> { return values_; }
   auto size() const -> size_t { return values_.size(); }
 
-  // Makes an iterable range over pairs of the index and value for each value in
-  // the store.
+  // Makes an iterable range over pairs of the index and a reference to the
+  // value for each value in the store.
   //
-  // The range is over references to the values in the store, even if used
-  // with `auto` to destructure the pair. In this example, the `value` is a
+  // The range is over references to the values in the store, even if used with
+  // `auto` to destructure the pair. In this example, the `value` is a
   // `ConstRefType`:
   // ```
   // for (auto [id, value] : store.enumerate()) { ... }

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -103,6 +103,13 @@ class ValueStore
 
   // Makes an iterable range over pairs of the index and value for each value in
   // the store.
+  //
+  // The range is over references to the values in the store, even if used
+  // with `auto` to destructure the pair. In this example, the `value` is a
+  // `ConstRefType`:
+  // ```
+  // for (auto [id, value] : store.enumerate()) { ... }
+  // ```
   auto enumerate() const -> auto {
     auto index_to_id = [](auto pair) -> std::pair<IdT, ConstRefType> {
       auto [index, value] = pair;

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -86,9 +86,8 @@ class ValueStore
   // These are to support printable structures, and are not guaranteed.
   auto OutputYaml() const -> Yaml::OutputMapping {
     return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-      for (auto i : llvm::seq(values_.size())) {
-        IdT id(i);
-        map.Add(PrintToString(id), Yaml::OutputScalar(Get(id)));
+      for (auto [id, value] : enumerate()) {
+        map.Add(PrintToString(id), Yaml::OutputScalar(value));
       }
     });
   }

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -11,8 +11,10 @@
 #include "common/hashtable_key_context.h"
 #include "common/ostream.h"
 #include "common/set.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/iterator_range.h"
 #include "toolchain/base/mem_usage.h"
 #include "toolchain/base/yaml.h"
 
@@ -99,6 +101,21 @@ class ValueStore
 
   auto array_ref() const -> llvm::ArrayRef<ValueType> { return values_; }
   auto size() const -> size_t { return values_.size(); }
+
+  // Makes an iterable range over pairs of the index and value for each value in
+  // the store.
+  auto enumerate() const -> auto {
+    auto index_to_id = [](auto pair) -> std::pair<IdT, ConstRefType> {
+      auto [index, value] = pair;
+      return std::pair<IdT, ConstRefType>(IdT(index), value);
+    };
+    auto range = llvm::enumerate(values_);
+    using Iter =
+        llvm::mapped_iterator<decltype(range.begin()), decltype(index_to_id)>;
+    auto begin = Iter(range.begin(), index_to_id);
+    auto end = Iter(range.end(), index_to_id);
+    return llvm::make_range(begin, end);
+  }
 
  private:
   // Set inline size to 0 because these will typically be too large for the

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -338,6 +338,8 @@ auto DeductionContext::Deduce() -> bool {
       // TODO: The call logic should reuse the conversion here (if any) instead
       // of doing the same conversion again. At the moment we throw away the
       // converted arg_id.
+      //
+      // TODO: Suppress diagnostics here if `diagnose_` is false.
       arg_id = ConvertToValueOfType(context(), loc_id_, arg_id, param_type_id);
       if (arg_id == SemIR::ErrorInst::SingletonInstId) {
         return false;

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -338,8 +338,6 @@ auto DeductionContext::Deduce() -> bool {
       // TODO: The call logic should reuse the conversion here (if any) instead
       // of doing the same conversion again. At the moment we throw away the
       // converted arg_id.
-      //
-      // TODO: Suppress diagnostics here if `diagnose_` is false.
       arg_id = ConvertToValueOfType(context(), loc_id_, arg_id, param_type_id);
       if (arg_id == SemIR::ErrorInst::SingletonInstId) {
         return false;

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -3209,9 +3209,7 @@ auto ImportImplsFromApiFile(Context& context) -> void {
     return;
   }
 
-  for (auto impl_index : llvm::seq(import_ir.sem_ir->impls().size())) {
-    SemIR::ImplId impl_id(impl_index);
-
+  for (auto [impl_id, _] : import_ir.sem_ir->impls().enumerate()) {
     // Resolve the imported impl to a local impl ID.
     ImportImpl(context, import_ir_id, impl_id);
   }

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -246,15 +246,15 @@ auto LowerConstants(FileContext& file_context,
   ConstantContext context(file_context, constants);
   // Lower each constant in InstId order. This guarantees we lower the
   // dependencies of a constant before we lower the constant itself.
-  for (auto [inst_id_val, const_id] :
-       llvm::enumerate(file_context.sem_ir().constant_values().array_ref())) {
+  for (auto [inst_id, const_id] :
+       file_context.sem_ir().constant_values().enumerate()) {
     if (!const_id.has_value() || !const_id.is_concrete()) {
       // We are only interested in lowering concrete constants.
       continue;
     }
-    auto inst_id = file_context.sem_ir().constant_values().GetInstId(const_id);
-
-    if (inst_id.index != static_cast<int32_t>(inst_id_val)) {
+    auto defining_inst_id =
+        file_context.sem_ir().constant_values().GetInstId(const_id);
+    if (defining_inst_id != inst_id) {
       // This isn't the instruction that defines the constant.
       continue;
     }

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -60,8 +60,9 @@ auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
 
   // Lower function declarations.
   functions_.resize_for_overwrite(sem_ir_->functions().size());
-  for (auto i : llvm::seq(sem_ir_->functions().size())) {
-    functions_[i] = BuildFunctionDecl(SemIR::FunctionId(i));
+  for (auto [i, pair] : llvm::enumerate(sem_ir_->functions().enumerate())) {
+    auto [id, _] = pair;
+    functions_[i] = BuildFunctionDecl(id);
   }
 
   // Specific functions are lowered when we emit a reference to them.
@@ -82,8 +83,8 @@ auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
   LowerConstants(*this, constants_);
 
   // Lower function definitions.
-  for (auto i : llvm::seq(sem_ir_->functions().size())) {
-    BuildFunctionDefinition(SemIR::FunctionId(i));
+  for (auto [id, _] : sem_ir_->functions().enumerate()) {
+    BuildFunctionDefinition(id);
   }
   // Append `__global_init` to `llvm::global_ctors` to initialize global
   // variables.

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -60,9 +60,8 @@ auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
 
   // Lower function declarations.
   functions_.resize_for_overwrite(sem_ir_->functions().size());
-  for (auto [i, pair] : llvm::enumerate(sem_ir_->functions().enumerate())) {
-    auto [id, _] = pair;
-    functions_[i] = BuildFunctionDecl(id);
+  for (auto [id, _] : sem_ir_->functions().enumerate()) {
+    functions_[id.index] = BuildFunctionDecl(id);
   }
 
   // Specific functions are lowered when we emit a reference to them.

--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -81,11 +81,9 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
 
   auto OutputYaml() const -> Yaml::OutputMapping {
     return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-      for (auto block_index : llvm::seq(values_.size())) {
-        auto block_id = IdT(block_index);
+      for (auto [block_id, block] : values_.enumerate()) {
         map.Add(PrintToString(block_id),
                 Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                  auto block = Get(block_id);
                   for (auto i : llvm::seq(block.size())) {
                     map.Add(llvm::itostr(i), Yaml::OutputScalar(block[i]));
                   }

--- a/toolchain/sem_ir/block_value_store.h
+++ b/toolchain/sem_ir/block_value_store.h
@@ -84,8 +84,8 @@ class BlockValueStore : public Yaml::Printable<BlockValueStore<IdT>> {
       for (auto [block_id, block] : values_.enumerate()) {
         map.Add(PrintToString(block_id),
                 Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                  for (auto i : llvm::seq(block.size())) {
-                    map.Add(llvm::itostr(i), Yaml::OutputScalar(block[i]));
+                  for (auto [i, elem_id] : llvm::enumerate(block)) {
+                    map.Add(llvm::itostr(i), Yaml::OutputScalar(elem_id));
                   }
                 }));
       }

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -121,10 +121,20 @@ class ConstantValueStore {
                       symbolic_constants_);
   }
 
-  // Returns the constant values mapping as an ArrayRef whose keys are
-  // instruction indexes. Some of the elements in this mapping may be `None` or
-  // NotConstant.
-  auto array_ref() const -> llvm::ArrayRef<ConstantId> { return values_; }
+  // Makes an iterable range over pairs of the instruction id and constant value
+  // id for each value in the store.
+  auto enumerate() const -> auto {
+    auto index_to_id = [](auto pair) -> std::pair<InstId, ConstantId> {
+      auto [index, value] = pair;
+      return std::pair<InstId, ConstantId>(InstId(index), value);
+    };
+    auto range = llvm::enumerate(values_);
+    using Iter =
+        llvm::mapped_iterator<decltype(range.begin()), decltype(index_to_id)>;
+    auto begin = Iter(range.begin(), index_to_id);
+    auto end = Iter(range.end(), index_to_id);
+    return llvm::make_range(begin, end);
+  }
 
   // Returns the symbolic constants mapping as an ArrayRef whose keys are
   // symbolic indexes of constants.

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -106,21 +106,21 @@ auto File::OutputYaml(bool include_singletons) const -> Yaml::OutputMapping {
           map.Add("struct_type_fields", struct_type_fields_.OutputYaml());
           map.Add("types", types_.OutputYaml());
           map.Add("type_blocks", type_blocks_.OutputYaml());
-          map.Add(
-              "insts", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                int start = include_singletons ? 0 : SingletonInstKinds.size();
-                for (int i : llvm::seq(start, insts_.size())) {
-                  auto id = InstId(i);
-                  map.Add(PrintToString(id),
-                          Yaml::OutputScalar(insts_.Get(id)));
-                }
-              }));
+          map.Add("insts",
+                  Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+                    for (auto [id, inst] : insts_.enumerate()) {
+                      if (!include_singletons && IsSingletonInstId(id)) {
+                        continue;
+                      }
+                      map.Add(PrintToString(id), Yaml::OutputScalar(inst));
+                    }
+                  }));
           map.Add("constant_values",
                   Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                    int start =
-                        include_singletons ? 0 : SingletonInstKinds.size();
-                    for (int i : llvm::seq(start, insts_.size())) {
-                      auto id = InstId(i);
+                    for (auto [id, _] : insts_.enumerate()) {
+                      if (!include_singletons && IsSingletonInstId(id)) {
+                        continue;
+                      }
                       auto value = constant_values_.Get(id);
                       if (!value.has_value() || value.is_constant()) {
                         map.Add(PrintToString(id), Yaml::OutputScalar(value));

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -70,28 +70,28 @@ class FormatterImpl {
     CloseBrace();
     out_ << '\n';
 
-    for (int i : llvm::seq(sem_ir_->interfaces().size())) {
-      FormatInterface(InterfaceId(i));
+    for (auto [id, _] : sem_ir_->interfaces().enumerate()) {
+      FormatInterface(id);
     }
 
-    for (int i : llvm::seq(sem_ir_->associated_constants().size())) {
-      FormatAssociatedConstant(AssociatedConstantId(i));
+    for (auto [id, _] : sem_ir_->associated_constants().enumerate()) {
+      FormatAssociatedConstant(id);
     }
 
-    for (int i : llvm::seq(sem_ir_->impls().size())) {
-      FormatImpl(ImplId(i));
+    for (auto [id, _] : sem_ir_->impls().enumerate()) {
+      FormatImpl(id);
     }
 
-    for (int i : llvm::seq(sem_ir_->classes().size())) {
-      FormatClass(ClassId(i));
+    for (auto [id, _] : sem_ir_->classes().enumerate()) {
+      FormatClass(id);
     }
 
-    for (int i : llvm::seq(sem_ir_->functions().size())) {
-      FormatFunction(FunctionId(i));
+    for (auto [id, _] : sem_ir_->functions().enumerate()) {
+      FormatFunction(id);
     }
 
-    for (int i : llvm::seq(sem_ir_->specifics().size())) {
-      FormatSpecific(SpecificId(i));
+    for (auto [id, _] : sem_ir_->specifics().enumerate()) {
+      FormatSpecific(id);
     }
 
     // End-of-file newline.

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -135,6 +135,7 @@ class SpecificStore : public Yaml::Printable<SpecificStore> {
     return specifics_.array_ref();
   }
   auto size() const -> size_t { return specifics_.size(); }
+  auto enumerate() const -> auto { return specifics_.enumerate(); }
 
  private:
   // Context for hashing keys.

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -185,6 +185,7 @@ class ImplStore {
 
   auto array_ref() const -> llvm::ArrayRef<Impl> { return values_.array_ref(); }
   auto size() const -> size_t { return values_.size(); }
+  auto enumerate() const -> auto { return values_.enumerate(); }
 
  private:
   File& sem_ir_;

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -439,6 +439,7 @@ class InstStore {
 
   auto array_ref() const -> llvm::ArrayRef<Inst> { return values_.array_ref(); }
   auto size() const -> int { return values_.size(); }
+  auto enumerate() const -> auto { return values_.enumerate(); }
 
  private:
   llvm::SmallVector<LocId> loc_ids_;

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -41,8 +41,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
   CollectNamesInBlock(ScopeId::File, sem_ir->top_inst_block_id());
 
   // Build each function scope.
-  for (auto [i, fn] : llvm::enumerate(sem_ir->functions().array_ref())) {
-    FunctionId fn_id(i);
+  for (auto [fn_id, fn] : sem_ir->functions().enumerate()) {
     auto fn_scope = GetScopeFor(fn_id);
     // TODO: Provide a location for the function for use as a
     // disambiguator.
@@ -64,8 +63,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
   }
 
   // Build each class scope.
-  for (auto [i, class_info] : llvm::enumerate(sem_ir->classes().array_ref())) {
-    ClassId class_id(i);
+  for (auto [class_id, class_info] : sem_ir->classes().enumerate()) {
     auto class_scope = GetScopeFor(class_id);
     // TODO: Provide a location for the class for use as a disambiguator.
     auto class_loc = Parse::NodeId::None;
@@ -78,9 +76,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
   }
 
   // Build each interface scope.
-  for (auto [i, interface_info] :
-       llvm::enumerate(sem_ir->interfaces().array_ref())) {
-    InterfaceId interface_id(i);
+  for (auto [interface_id, interface_info] : sem_ir->interfaces().enumerate()) {
     auto interface_scope = GetScopeFor(interface_id);
     // TODO: Provide a location for the interface for use as a disambiguator.
     auto interface_loc = Parse::NodeId::None;
@@ -94,9 +90,8 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
   }
 
   // Build each associated constant scope.
-  for (auto [i, assoc_const_info] :
-       llvm::enumerate(sem_ir->associated_constants().array_ref())) {
-    AssociatedConstantId assoc_const_id(i);
+  for (auto [assoc_const_id, assoc_const_info] :
+       sem_ir->associated_constants().enumerate()) {
     auto assoc_const_scope = GetScopeFor(assoc_const_id);
     auto assoc_const_loc = sem_ir->insts().GetLocId(assoc_const_info.decl_id);
     GetScopeInfo(assoc_const_scope).name = globals_.AllocateName(
@@ -106,8 +101,7 @@ InstNamer::InstNamer(const File* sem_ir) : sem_ir_(sem_ir) {
   }
 
   // Build each impl scope.
-  for (auto [i, impl_info] : llvm::enumerate(sem_ir->impls().array_ref())) {
-    ImplId impl_id(i);
+  for (auto [impl_id, impl_info] : sem_ir->impls().enumerate()) {
     auto impl_scope = GetScopeFor(impl_id);
     // TODO: Provide a location for the impl for use as a disambiguator.
     auto impl_loc = Parse::NodeId::None;


### PR DESCRIPTION
This allows iterating on all values in a store along with the Id for each value, instead of `llvm::enumerate(store.array_ref())` which would give you the indices.

While the indices are really the same as the Ids, this provides a typesafe way to enumerate() over a store.

There's no use for this right now, but I thought I needed this, and it helped me debug, and it was a pain to write correctly without dangling references.
