### PR TITLE
Avoid diagnosing conversion errors inside deduction of impl arguments

### DIFF
--- a/toolchain/check/convert.h
+++ b/toolchain/check/convert.h
@@ -43,6 +43,10 @@ struct ConversionTarget {
   // form the value of `init_id`, and that can be discarded if no
   // initialization is needed.
   PendingBlock* init_block = nullptr;
+  // Whether failure of conversion is an error and is diagnosed to the user.
+  // When looking for a possible conversion but with graceful fallback, diagnose
+  // should be false.
+  bool diagnose = true;
 
   // Are we converting this value into an initializer for an object?
   auto is_initializer() const -> bool {
@@ -80,6 +84,13 @@ auto ConvertToValueOrRefOfType(Context& context, SemIR::LocId loc_id,
                                SemIR::InstId expr_id, SemIR::TypeId type_id)
     -> SemIR::InstId;
 
+// Attempted to convert `expr_id` to a value expression of type `type_id`, with
+// graceful failure, which does not result in diagnostics. An ErrorInst
+// instruction is still returned on failure.
+auto TryConvertToValueOfType(Context& context, SemIR::LocId loc_id,
+                             SemIR::InstId expr_id, SemIR::TypeId type_id)
+    -> SemIR::InstId;
+
 // Converts `value_id` to a value expression of type `bool`.
 auto ConvertToBoolValue(Context& context, SemIR::LocId loc_id,
                         SemIR::InstId value_id) -> SemIR::InstId;
@@ -109,11 +120,15 @@ struct TypeExpr {
 };
 
 // Converts an expression for use as a type.
+//
+// If `diagnose` is true, errors are diagnosed to the user. Set it to false when
+// looking to see if a conversion is possible but with graceful fallback.
+//
 // TODO: Most of the callers of this function discard the `inst_id` and lose
 // track of the conversion. In most cases we should be retaining that as the
 // operand of some downstream instruction.
-auto ExprAsType(Context& context, SemIR::LocId loc_id, SemIR::InstId value_id)
-    -> TypeExpr;
+auto ExprAsType(Context& context, SemIR::LocId loc_id, SemIR::InstId value_id,
+                bool diagnose = true) -> TypeExpr;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/testdata/impl/no_prelude/impl_cycle.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_cycle.carbon
@@ -145,7 +145,7 @@ fn F() {
   ({} as Wraps(C)) as (Wraps(C) as ComparableTo(Wraps(D)));
 }
 
-// --- fail_todo_impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon
+// --- impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon
 library "[[@TEST_NAME]]";
 
 import Core;
@@ -166,10 +166,6 @@ impl C as ComparableTo(D) {}
 // T is always ComparableWith(T).
 impl forall [T:! type] T as ComparableWith(T) {}
 // If U is ComparableTo(T), U is ComparableWith(T).
-//
-// TODO: When we look for the impl of `D as ComparableTo(C)` here, we find that
-// it's not implemented. We then go to the next impl which does match, but
-// deduction generates an error here regardless.
 impl forall [T:! type, U:! ComparableTo(T)] U as ComparableWith(T) {}
 // If U is ComparableTo(T), T is ComparableWith(U).
 impl forall [T:! type, U:! ComparableTo(T)] T as ComparableWith(U) {}
@@ -178,19 +174,6 @@ fn Compare[T:! type, U:! ComparableWith(T)](t: T, u: U) {}
 
 fn F() {
   Compare({} as C, {} as C);
-  // CHECK:STDERR: fail_todo_impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon:[[@LINE+13]]:3: error: cannot implicitly convert from `type` to `ComparableTo(C)` [ImplicitAsConversionFailure]
-  // CHECK:STDERR:   Compare({} as C, {} as D);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon:[[@LINE+10]]:3: note: type `type` does not implement interface `Core.ImplicitAs(ComparableTo(C))` [MissingImplInMemberAccessNote]
-  // CHECK:STDERR:   Compare({} as C, {} as D);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon:[[@LINE-14]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
-  // CHECK:STDERR: impl forall [T:! type, U:! ComparableTo(T)] U as ComparableWith(T) {}
-  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon:[[@LINE-13]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
-  // CHECK:STDERR: fn Compare[T:! type, U:! ComparableWith(T)](t: T, u: U) {}
-  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Compare({} as C, {} as D);
   Compare({} as D, {} as C);
 }


### PR DESCRIPTION
When conversion fails, the impl should simply not match, no error should be generated.
