### PR TITLE
Improve decl_name_stack comments

### DIFF
--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -255,10 +255,8 @@ auto DeclNameStack::ApplyNameQualifier(const NameComponent& name) -> void {
 auto DeclNameStack::ApplyAndLookupName(NameContext& name_context,
                                        SemIR::LocId loc_id,
                                        SemIR::NameId name_id) -> void {
-  // The location of the name is the location of the last name token we've
-  // processed so far.
+  // Update the final name component.
   name_context.loc_id = loc_id;
-
   name_context.name_id = name_id;
 
   // Don't perform any more lookups after we hit an error. We still track the

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -145,8 +145,11 @@ class DeclNameStack {
     // should be used.
     SemIR::NameScopeId parent_scope_id;
 
-    // The last location ID used.
+    // The location of the final name component.
     SemIR::LocId loc_id = SemIR::LocId::None;
+
+    // The name of the final name component.
+    SemIR::NameId name_id = SemIR::NameId::None;
 
     union {
       // The ID of a resolved qualifier, including both identifiers and
@@ -157,9 +160,6 @@ class DeclNameStack {
       // the poisoning location.
       SemIR::LocId poisoning_loc_id = SemIR::LocId::None;
     };
-
-    // The ID of an identifier.
-    SemIR::NameId name_id = SemIR::NameId::None;
   };
 
   // Information about a declaration name that has been temporarily removed from


### PR DESCRIPTION
Trying to make it clearer what these correspond to. Had suggested a small edit on https://github.com/carbon-language/carbon-lang/pull/4902/files#r1960682518, but since that was missed, suggesting an incrementally larger edit since `name_id` and `loc_id` are now more tied.