### PR TITLE
Remove Context::DumpFormattedFile

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -116,9 +116,4 @@ auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {
   args_type_info_stack_.PrintForStackDump(Indent, output);
 }
 
-auto Context::DumpFormattedFile() const -> void {
-  SemIR::Formatter formatter(sem_ir_);
-  formatter.Print(llvm::errs());
-}
-
 }  // namespace Carbon::Check

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -89,9 +89,6 @@ class Context {
   // Prints information for a stack dump.
   auto PrintForStackDump(llvm::raw_ostream& output) const -> void;
 
-  // Prints the the formatted sem_ir to stderr.
-  LLVM_DUMP_METHOD auto DumpFormattedFile() const -> void;
-
   // Get the Lex::TokenKind of a node for diagnostics.
   auto token_kind(Parse::NodeId node_id) -> Lex::TokenKind {
     return tokens().GetKind(parse_tree().node_token(node_id));


### PR DESCRIPTION
Asked on [#toolchain](https://discord.com/channels/655572317891461132/655578254970716160/1339388316977729627), it sound like this is unused. Also with the `Dump` methods, having `Dump(context)` might be more helpful for findability (could just move it here if that's desired).