### PR TITLE
Remove FileTestBase::ValidateRun

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -58,16 +58,13 @@ class ExplorerFileTest : public FileTestBase {
                      output_stream, error_stream,
                      check_trace_output() ? output_stream : trace_stream_, *fs);
 
-    return {{.success = exit_code == EXIT_SUCCESS}};
-  }
-
-  auto ValidateRun() -> void override {
     // Skip trace test check as they use stdout stream instead of
     // trace_stream_ostream
-    if (absl::GetFlag(FLAGS_trace)) {
-      EXPECT_FALSE(trace_stream_.TakeStr().empty())
-          << "Tracing should always do something";
+    if (absl::GetFlag(FLAGS_trace) && trace_stream_.TakeStr().empty()) {
+      return Error("Tracing should always do something");
     }
+
+    return {{.success = exit_code == EXIT_SUCCESS}};
   }
 
   auto GetDefaultArgs() -> llvm::SmallVector<std::string> override {

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -157,7 +157,6 @@ auto FileTestBase::TestBody() -> void {
       ProcessTestFileAndRun(this, output_mutex_, /*dump_output=*/false,
                             absl::GetFlag(FLAGS_autoupdate));
   ASSERT_TRUE(test_file.ok()) << test_file.error();
-  ValidateRun();
   auto test_filename = std::filesystem::path(test_name_.str()).filename();
 
   // Check success/failure against `fail_` prefixes.

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -63,7 +63,7 @@ class FileTestBase : public testing::Test {
   // provided at `input_stream` instead of `fs`. Otherwise, `input_stream` will
   // be null.
   //
-  // Any test expectations should be called from ValidateRun, not Run.
+  // This cannot be used for test expectations, such as EXPECT_TRUE.
   //
   // The return value should be an error if there was an abnormal error, and
   // RunResult otherwise.
@@ -72,11 +72,6 @@ class FileTestBase : public testing::Test {
                    FILE* input_stream, llvm::raw_pwrite_stream& output_stream,
                    llvm::raw_pwrite_stream& error_stream)
       -> ErrorOr<RunResult> = 0;
-
-  // Implemented by children to do post-Run test expectations. Only called when
-  // testing. Does not need to be provided if only CHECK test expectations are
-  // used.
-  virtual auto ValidateRun() -> void {}
 
   // Returns default arguments. Only called when a file doesn't set ARGS.
   virtual auto GetDefaultArgs() -> llvm::SmallVector<std::string> = 0;


### PR DESCRIPTION
`ValidateRun` is explorer-specific, so move out the error production to be specific within explorer. This is related to other work I'm trying to do which would make this require more special-casing to maintain; since the toolchain doesn't need it, it's easier to drop.