### PR TITLE
Fix `NodeCategory` printing.

### DIFF
--- a/toolchain/parse/node_kind.cpp
+++ b/toolchain/parse/node_kind.cpp
@@ -10,25 +10,34 @@
 namespace Carbon::Parse {
 
 auto NodeCategory::Print(llvm::raw_ostream& out) const -> void {
-  if (!value_) {
-    out << "<none>";
-  } else {
-    llvm::ListSeparator sep("|");
-
-#define CARBON_NODE_CATEGORY(Name)   \
-  if (value_ & NodeCategory::Name) { \
-    out << sep << #Name;             \
+  llvm::ListSeparator sep("|");
+  auto value = value_;
+  do {
+    // The lowest set bit in the value, or 0 (`None`) if no bits are set.
+    auto lowest_bit = static_cast<RawEnumType>(value & -value);
+    switch (lowest_bit) {
+#define CARBON_NODE_CATEGORY(Name) \
+  case NodeCategory::Name: {       \
+    out << sep << #Name;           \
+    break;                         \
   }
-    CARBON_NODE_CATEGORY(Decl);
-    CARBON_NODE_CATEGORY(Expr);
-    CARBON_NODE_CATEGORY(ImplAs);
-    CARBON_NODE_CATEGORY(MemberExpr);
-    CARBON_NODE_CATEGORY(MemberName);
-    CARBON_NODE_CATEGORY(Modifier);
-    CARBON_NODE_CATEGORY(Pattern);
-    CARBON_NODE_CATEGORY(Statement);
+      CARBON_NODE_CATEGORY(Decl);
+      CARBON_NODE_CATEGORY(Expr);
+      CARBON_NODE_CATEGORY(ImplAs);
+      CARBON_NODE_CATEGORY(MemberExpr);
+      CARBON_NODE_CATEGORY(MemberName);
+      CARBON_NODE_CATEGORY(Modifier);
+      CARBON_NODE_CATEGORY(Pattern);
+      CARBON_NODE_CATEGORY(Statement);
+      CARBON_NODE_CATEGORY(IntConst);
+      CARBON_NODE_CATEGORY(Requirement);
+      CARBON_NODE_CATEGORY(NonExprIdentifierName);
+      CARBON_NODE_CATEGORY(PackageName);
+      CARBON_NODE_CATEGORY(None);
 #undef CARBON_NODE_CATEGORY
-  }
+    }
+    value &= ~lowest_bit;
+  } while (value);
 }
 
 CARBON_DEFINE_ENUM_CLASS_NAMES(NodeKind) = {

--- a/toolchain/parse/node_kind.h
+++ b/toolchain/parse/node_kind.h
@@ -37,6 +37,7 @@ class NodeCategory : public Printable<NodeCategory> {
     Requirement = 1 << 9,
     NonExprIdentifierName = 1 << 10,
     PackageName = 1 << 11,
+    // If you add a new category here, also add it to the Print function.
     None = 0,
 
     LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/PackageName)
@@ -48,15 +49,14 @@ class NodeCategory : public Printable<NodeCategory> {
   constexpr NodeCategory(RawEnumType value) : value_(value) {}
 
   // Returns true if there's a non-empty set intersection.
-  constexpr auto HasAnyOf(NodeCategory other) -> bool {
+  constexpr auto HasAnyOf(NodeCategory other) const -> bool {
     return value_ & other.value_;
   }
 
   // Returns the set inverse.
-  constexpr auto operator~() -> NodeCategory { return ~value_; }
+  constexpr auto operator~() const -> NodeCategory { return ~value_; }
 
-  friend auto operator==(const NodeCategory& lhs, const NodeCategory& rhs)
-      -> bool {
+  friend auto operator==(NodeCategory lhs, NodeCategory rhs) -> bool {
     return lhs.value_ == rhs.value_;
   }
 

--- a/toolchain/parse/typed_nodes.h
+++ b/toolchain/parse/typed_nodes.h
@@ -236,7 +236,7 @@ struct PackageDecl {
 
   PackageIntroducerId introducer;
   llvm::SmallVector<AnyModifierId> modifiers;
-  std::optional<AnyPackageNameId> name;
+  AnyPackageNameId name;
   std::optional<LibrarySpecifierId> library;
   Lex::SemiTokenIndex token;
 };


### PR DESCRIPTION
Rearrange `NodeCategory` printing so we get a compile-time error for missing switch cases if it's missing any categories. Add several missing categories.

In passing, fix some minor things in the `NodeCategory` class definition, and fix an overly-permissive typed node.