### PR TITLE
Reorder the token in a parse node to match its actual location.

### DIFF
--- a/toolchain/parse/typed_nodes.h
+++ b/toolchain/parse/typed_nodes.h
@@ -590,6 +590,8 @@ struct ReturnStatement {
        .bracketed_by = ReturnStatementStart::Kind});
 
   ReturnStatementStartId introducer;
+  // TODO: This should be optional<OneOf<AnyExprId, ReturnVarModifierId>>,
+  // but we don't have support for OneOf between a node kind and a category.
   std::optional<AnyExprId> expr;
   std::optional<ReturnVarModifierId> var;
   Lex::SemiTokenIndex token;
@@ -604,8 +606,8 @@ struct ForIn {
       {.bracketed_by = VariableIntroducer::Kind, .child_count = 2});
 
   VariableIntroducerId introducer;
-  Lex::InTokenIndex token;
   AnyPatternId pattern;
+  Lex::InTokenIndex token;
 };
 
 // The `for (var ... in ...)` portion of a `for` statement.


### PR DESCRIPTION
Also add a TODO for another parse node whose typed representation is imprecise. Just clarifications; no behavior change is intended.