### PR TITLE
Refactor name poisoning tests to be more organized, complete and consistent

### DIFF
--- a/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -164,7 +164,7 @@ class N.C;
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should fail since N.C was poisoned in the api.
+// TODO: #4622 This should fail since N.C was poisoned in the api.
 class N.C {}
 
 // --- fail_poison_when_lookup_fails.carbon

--- a/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -2,13 +2,243 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
-//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+
+// --- no_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+class C;
+
+// N.F uses N.C and not C.
+namespace N;
+class N.C;
+fn N.F(x: C);
+
+// --- poison.carbon
+
+library "[[@TEST_NAME]]";
+
+class C;
+
+namespace N;
+// Use C and poison N.C.
+fn N.F(x: C);
+
+// --- fail_declare_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+class C;
+
+namespace N;
+// Use C and poison N.C.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:11: error: name `C` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: C);
+// CHECK:STDERR:           ^
+fn N.F(x: C);
+
+// Failure: N.C declared after it was poisoned.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: class N.C;
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+class N.C;
+
+// --- fail_use_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+class C;
+
+namespace N;
+// Use C and poison N.C.
+fn N.F1() -> C;
+
+// Use N.C which was poisoned and not declared.
+// CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:14: error: member name `C` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: fn N.F2() -> N.C;
+// CHECK:STDERR:              ^~~
+// CHECK:STDERR:
+fn N.F2() -> N.C;
+
+// --- fail_use_declaration_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+class C;
+
+namespace N;
+// Use C and poison N.C.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:12: error: name `C` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F1(x: C);
+// CHECK:STDERR:            ^
+fn N.F1(x: C);
+
+// Failure: N.C declared after it was poisoned.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: class N.C;
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+class N.C;
+
+// Failure: N.C used after declaration failed.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:12: error: member name `C` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: fn N.F2(x: N.C);
+// CHECK:STDERR:            ^~~
+// CHECK:STDERR:
+fn N.F2(x: N.C);
+
+// --- fail_alias.carbon
+
+library "[[@TEST_NAME]]";
+
+class C;
+
+namespace N;
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+7]]:13: error: name `C` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.C = C;
+// CHECK:STDERR:             ^
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: alias N.C = C;
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+alias N.C = C;
+
+// --- fail_poison_multiple_scopes.carbon
+
+library "[[@TEST_NAME]]";
+
+class C1;
+
+class C2 {
+  class C3 {
+    class C4 {
+      // Use C1 and poison:
+      // * C2.C1
+      // * C2.C3.C1
+      // * C2.C3.C4.C1
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `C1` used before it was declared [NameUseBeforeDecl]
+      // CHECK:STDERR:       fn F(x: C1);
+      // CHECK:STDERR:               ^~
+      fn F(x: C1);
+
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:13: note: declared here [NameUseBeforeDeclNote]
+      // CHECK:STDERR:       class C1;
+      // CHECK:STDERR:             ^~
+      // CHECK:STDERR:
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:15: error: name `C1` used before it was declared [NameUseBeforeDecl]
+      // CHECK:STDERR:       fn F(x: C1);
+      // CHECK:STDERR:               ^~
+      class C1;
+    }
+    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
+    // CHECK:STDERR:     class C1;
+    // CHECK:STDERR:           ^~
+    // CHECK:STDERR:
+    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-15]]:15: error: name `C1` used before it was declared [NameUseBeforeDecl]
+    // CHECK:STDERR:       fn F(x: C1);
+    // CHECK:STDERR:               ^~
+    class C1;
+  }
+  // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:10: note: declared here [NameUseBeforeDeclNote]
+  // CHECK:STDERR:   class  C1;
+  // CHECK:STDERR:          ^~
+  // CHECK:STDERR:
+  class  C1;
+}
+
+// --- ignored_poison_in_import.carbon
+
+library "[[@TEST_NAME]]";
+import library "poison";
+
+// This doesn't fail.
+class N.C;
+
+// --- poison.impl.carbon
+
+impl library "[[@TEST_NAME]]";
+
+// TODO: This should fail since N.C was poisoned in the api.
+class N.C {}
+
+// --- fail_poison_when_lookup_fails.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N;
+// C poisoned when not found.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `C` not found [NameNotFound]
+// CHECK:STDERR: fn N.F(x: C);
+// CHECK:STDERR:           ^
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `C` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: C);
+// CHECK:STDERR:           ^
+fn N.F(x: C);
+
+// TODO: We should ideally only produce one diagnostic here.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:7: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: class C;
+// CHECK:STDERR:       ^
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `C` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: C);
+// CHECK:STDERR:           ^
+class C;
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: class N.C;
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+class N.C;
+
+// --- fail_poison_with_lexical_result.carbon
+
+library "[[@TEST_NAME]]";
+
+fn F() {
+  class C1 {}
+
+  class C2 {
+    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+3]]:12: error: name `C1` used before it was declared [NameUseBeforeDecl]
+    // CHECK:STDERR:     var v: C1;
+    // CHECK:STDERR:            ^~
+    var v: C1;
+
+    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+4]]:11: note: declared here [NameUseBeforeDeclNote]
+    // CHECK:STDERR:     class C1;
+    // CHECK:STDERR:           ^~
+    // CHECK:STDERR:
+    class C1;
+  }
+}
+
+// --- fail_declare_data_member_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+class C1;
+
+class C2 {
+  // Use C1 and poison C2.C1.
+  // CHECK:STDERR: fail_declare_data_member_after_poison.carbon:[[@LINE+3]]:11: error: name `C1` used before it was declared [NameUseBeforeDecl]
+  // CHECK:STDERR:   fn F(x: C1);
+  // CHECK:STDERR:           ^~
+  fn F(x: C1);
+
+  class C2 {}
+  // Failure: C2.C1 declared after it was poisoned.
+  // CHECK:STDERR: fail_declare_data_member_after_poison.carbon:[[@LINE+4]]:7: note: declared here [NameUseBeforeDeclNote]
+  // CHECK:STDERR:   var C1: C2;
+  // CHECK:STDERR:       ^~~~~~
+  // CHECK:STDERR:
+  var C1: C2;
+}
 
 // --- fail_extend_poison_class_members.carbon
 
@@ -28,3 +258,567 @@ class C {
   // CHECK:STDERR:
   fn B();
 }
+
+// CHECK:STDOUT: --- no_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl.loc8
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc8: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %C.9f4 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.9f4 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C.9f4 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc8 [concrete = constants.%C.9f4]
+// CHECK:STDOUT:     %x: %C.9f4 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %C.9f4);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %C);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_declare_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
+// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc18: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %C.f79);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_use_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
+// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .N = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
+// CHECK:STDOUT:     %return.patt: %C = return_slot_pattern
+// CHECK:STDOUT:     %return.param_patt: %C = out_param_pattern %return.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %return.param: ref %C = out_param runtime_param0
+// CHECK:STDOUT:     %return: ref %C = return_slot %return.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
+// CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern
+// CHECK:STDOUT:     %return.param_patt: <error> = out_param_pattern %return.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:     %C.ref: <error> = name_ref C, <error> [concrete = <error>]
+// CHECK:STDOUT:     %return.param: ref <error> = out_param runtime_param0
+// CHECK:STDOUT:     %return: ref <error> = return_slot %return.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1() -> %C;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F2() -> <error>;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_use_declaration_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
+// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
+// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .N = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
+// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
+// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc18: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
+// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
+// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
+// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
+// CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:       %C.ref: <error> = name_ref C, <error> [concrete = <error>]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_alias.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.ref: type = name_ref C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %C: type = bind_alias C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_multiple_scopes.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C1.26b: type = class_type @C1.1 [concrete]
+// CHECK:STDOUT:   %C2: type = class_type @C2 [concrete]
+// CHECK:STDOUT:   %C3: type = class_type @C3 [concrete]
+// CHECK:STDOUT:   %C4: type = class_type @C4 [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C1.d8b: type = class_type @C1.2 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C1.a31: type = class_type @C1.3 [concrete]
+// CHECK:STDOUT:   %C1.f31: type = class_type @C1.4 [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C1 = %C1.decl
+// CHECK:STDOUT:     .C2 = %C2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1.1 [concrete = constants.%C1.26b] {} {}
+// CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [concrete = constants.%C2] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C2 {
+// CHECK:STDOUT:   %C3.decl: type = class_decl @C3 [concrete = constants.%C3] {} {}
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1.4 [concrete = constants.%C1.f31] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C2
+// CHECK:STDOUT:   .C3 = %C3.decl
+// CHECK:STDOUT:   .C1 = <poisoned>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C3 {
+// CHECK:STDOUT:   %C4.decl: type = class_decl @C4 [concrete = constants.%C4] {} {}
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1.3 [concrete = constants.%C1.a31] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C3
+// CHECK:STDOUT:   .C4 = %C4.decl
+// CHECK:STDOUT:   .C1 = <poisoned>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C4 {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %C1.26b = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C1.26b = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C1.26b = value_param runtime_param0
+// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1.26b]
+// CHECK:STDOUT:     %x: %C1.26b = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1.2 [concrete = constants.%C1.d8b] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C4
+// CHECK:STDOUT:   .C1 = <poisoned>
+// CHECK:STDOUT:   .F = %F.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1.3;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1.4;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %C1.26b);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- ignored_poison_in_import.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.C = import_ref Main//poison, C, unloaded
+// CHECK:STDOUT:   %Main.N: <namespace> = import_ref Main//poison, N, loaded
+// CHECK:STDOUT:   %N: <namespace> = namespace %Main.N, [concrete] {
+// CHECK:STDOUT:     .F = %Main.F
+// CHECK:STDOUT:     .C = file.%C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = imports.%Main.C
+// CHECK:STDOUT:     .N = imports.%N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import = import <none>
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- poison.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.C = import_ref Main//poison, C, unloaded
+// CHECK:STDOUT:   %Main.N: <namespace> = import_ref Main//poison, N, loaded
+// CHECK:STDOUT:   %N: <namespace> = namespace %Main.N, [concrete] {
+// CHECK:STDOUT:     .F = %Main.F
+// CHECK:STDOUT:     .C = file.%C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = imports.%Main.C
+// CHECK:STDOUT:     .N = imports.%N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_when_lookup_fails.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
+// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
+// CHECK:STDOUT:     %C.ref: <error> = name_ref C, <error> [concrete = <error>]
+// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl.loc23: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %C.decl.loc28: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: <error>);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_with_lexical_result.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C1.138: type = class_type @C1.1 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C2: type = class_type @C2 [concrete]
+// CHECK:STDOUT:   %C2.elem: type = unbound_element_type %C2, %C1.138 [concrete]
+// CHECK:STDOUT:   %C1.46c: type = class_type @C1.2 [concrete]
+// CHECK:STDOUT:   %struct_type.v: type = struct_type {.v: %C1.138} [concrete]
+// CHECK:STDOUT:   %complete_type.fb7: <witness> = complete_type_witness %struct_type.v [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1.1 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C1.138
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C2 {
+// CHECK:STDOUT:   %.loc11_10: %C2.elem = field_decl v, element0 [concrete]
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %.loc11_5: %C2.elem = var_pattern %.loc11_10
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.var: ref %C2.elem = var <none>
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1.2 [concrete = constants.%C1.46c] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [concrete = constants.%complete_type.fb7]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C2
+// CHECK:STDOUT:   .C1 = <poisoned>
+// CHECK:STDOUT:   .v = %.loc11_10
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1.1 [concrete = constants.%C1.138] {} {}
+// CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [concrete = constants.%C2] {} {}
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_declare_data_member_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C1: type = class_type @C1 [concrete]
+// CHECK:STDOUT:   %C2.311: type = class_type @C2.1 [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C2.0a0: type = class_type @C2.2 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C2.elem: type = unbound_element_type %C2.311, %C2.0a0 [concrete]
+// CHECK:STDOUT:   %struct_type.C1: type = struct_type {.C1: %C2.0a0} [concrete]
+// CHECK:STDOUT:   %complete_type.979: <witness> = complete_type_witness %struct_type.C1 [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C1 = %C1.decl
+// CHECK:STDOUT:     .C2 = %C2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1 [concrete = constants.%C1] {} {}
+// CHECK:STDOUT:   %C2.decl: type = class_decl @C2.1 [concrete = constants.%C2.311] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C2.1 {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %C1 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C1 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C1 = value_param runtime_param0
+// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1]
+// CHECK:STDOUT:     %x: %C1 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C2.decl: type = class_decl @C2.2 [concrete = constants.%C2.0a0] {} {}
+// CHECK:STDOUT:   %.loc19_9: %C2.elem = field_decl C1, element0 [concrete]
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %.loc19_3: %C2.elem = var_pattern %.loc19_9
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.var: ref %C2.elem = var <none>
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.C1 [concrete = constants.%complete_type.979]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C2.311
+// CHECK:STDOUT:   .C1 = <poisoned>
+// CHECK:STDOUT:   .F = %F.decl
+// CHECK:STDOUT:   .C2 = %C2.decl
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C2.2 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C2.0a0
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %C1);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_extend_poison_class_members.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %B.fa3: type = class_type @B.2 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %C.elem: type = unbound_element_type %C, %B.fa3 [concrete]
+// CHECK:STDOUT:   %B.type: type = fn_type @B.1 [concrete]
+// CHECK:STDOUT:   %B.489: %B.type = struct_value () [concrete]
+// CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B.fa3} [concrete]
+// CHECK:STDOUT:   %complete_type.98e: <witness> = complete_type_witness %struct_type.base [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .B = %B.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %B.decl: type = class_decl @B.2 [concrete = constants.%B.fa3] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B.2 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%B.fa3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B.fa3]
+// CHECK:STDOUT:   %.loc10: %C.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B.1 [concrete = constants.%B.489] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .B = <poisoned>
+// CHECK:STDOUT:   .base = %.loc10
+// CHECK:STDOUT:   extend %B.ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @B.1();
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -14,10 +14,15 @@ library "[[@TEST_NAME]]";
 
 class C;
 
-// N.F uses N.C and not C.
+// `N.F` uses `N.C` and not `package.C`.
 namespace N;
-class N.C;
+class N.C {}
 fn N.F(x: C);
+
+fn TestCall(x: N.C) {
+  // `N.F` accepts an `N.C` not a `package.C`.
+  N.F(x);
+}
 
 // --- poison.carbon
 
@@ -26,7 +31,7 @@ library "[[@TEST_NAME]]";
 class C;
 
 namespace N;
-// Use C and poison N.C.
+// Use `package.C` and poison `N.C`.
 fn N.F(x: C);
 
 // --- fail_declare_after_poison.carbon
@@ -36,13 +41,13 @@ library "[[@TEST_NAME]]";
 class C;
 
 namespace N;
-// Use C and poison N.C.
+// Use `package.C` and poison `N.C`.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:11: error: name `C` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: fn N.F(x: C);
 // CHECK:STDERR:           ^
 fn N.F(x: C);
 
-// Failure: N.C declared after it was poisoned.
+// Failure: `N.C` declared after it was poisoned.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: class N.C;
 // CHECK:STDERR:         ^
@@ -56,10 +61,10 @@ library "[[@TEST_NAME]]";
 class C;
 
 namespace N;
-// Use C and poison N.C.
+// Use `package.C` and poison `N.C`.
 fn N.F1() -> C;
 
-// Use N.C which was poisoned and not declared.
+// Use `N.C` which was poisoned and not declared.
 // CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:14: error: member name `C` not found in `N` [MemberNameNotFoundInScope]
 // CHECK:STDERR: fn N.F2() -> N.C;
 // CHECK:STDERR:              ^~~
@@ -73,7 +78,7 @@ library "[[@TEST_NAME]]";
 class C;
 
 namespace N;
-// Use C and poison N.C.
+// Use `package.C` and poison `N.C`.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:12: error: name `C` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: fn N.F1(x: C);
 // CHECK:STDERR:            ^
@@ -86,7 +91,7 @@ fn N.F1(x: C);
 // CHECK:STDERR:
 class N.C;
 
-// Failure: N.C used after declaration failed.
+// Failure: `N.C` used after declaration failed.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:12: error: member name `C` not found in `N` [MemberNameNotFoundInScope]
 // CHECK:STDERR: fn N.F2(x: N.C);
 // CHECK:STDERR:            ^~~
@@ -118,10 +123,10 @@ class C1;
 class C2 {
   class C3 {
     class C4 {
-      // Use C1 and poison:
-      // * C2.C1
-      // * C2.C3.C1
-      // * C2.C3.C4.C1
+      // Use `package.C1` and poison:
+      // * `C2.C1`
+      // * `C2.C3.C1`
+      // * `C2.C3.C4.C1`
       // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `C1` used before it was declared [NameUseBeforeDecl]
       // CHECK:STDERR:       fn F(x: C1);
       // CHECK:STDERR:               ^~
@@ -145,11 +150,11 @@ class C2 {
     // CHECK:STDERR:               ^~
     class C1;
   }
-  // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:10: note: declared here [NameUseBeforeDeclNote]
-  // CHECK:STDERR:   class  C1;
-  // CHECK:STDERR:          ^~
+  // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
+  // CHECK:STDERR:   class C1;
+  // CHECK:STDERR:         ^~
   // CHECK:STDERR:
-  class  C1;
+  class C1;
 }
 
 // --- ignored_poison_in_import.carbon
@@ -164,7 +169,7 @@ class N.C;
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: #4622 This should fail since N.C was poisoned in the api.
+// TODO: #4622 This should fail since `N.C` was poisoned in the api.
 class N.C {}
 
 // --- fail_poison_when_lookup_fails.carbon
@@ -172,7 +177,7 @@ class N.C {}
 library "[[@TEST_NAME]]";
 
 namespace N;
-// C poisoned when not found.
+// `package.C` and `N.C` poisoned when not found.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `C` not found [NameNotFound]
 // CHECK:STDERR: fn N.F(x: C);
 // CHECK:STDERR:           ^
@@ -225,14 +230,14 @@ library "[[@TEST_NAME]]";
 class C1;
 
 class C2 {
-  // Use C1 and poison C2.C1.
+  // Use `package.C1` and poison `C2.C1`.
   // CHECK:STDERR: fail_declare_data_member_after_poison.carbon:[[@LINE+3]]:11: error: name `C1` used before it was declared [NameUseBeforeDecl]
   // CHECK:STDERR:   fn F(x: C1);
   // CHECK:STDERR:           ^~
   fn F(x: C1);
 
   class C2 {}
-  // Failure: C2.C1 declared after it was poisoned.
+  // Failure: `C2.C1` declared after it was poisoned.
   // CHECK:STDERR: fail_declare_data_member_after_poison.carbon:[[@LINE+4]]:7: note: declared here [NameUseBeforeDeclNote]
   // CHECK:STDERR:   var C1: C2;
   // CHECK:STDERR:       ^~~~~~
@@ -264,14 +269,20 @@ class C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
 // CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %TestCall.type: type = fn_type @TestCall [concrete]
+// CHECK:STDOUT:   %TestCall: %TestCall.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = %C.decl.loc4
 // CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:     .TestCall = %TestCall.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
@@ -287,13 +298,39 @@ class C {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc8 [concrete = constants.%C.9f4]
 // CHECK:STDOUT:     %x: %C.9f4 = bind_name x, %x.param
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %TestCall.decl: %TestCall.type = fn_decl @TestCall [concrete = constants.%TestCall] {
+// CHECK:STDOUT:     %x.patt: %C.9f4 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C.9f4 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C.9f4 = value_param runtime_param0
+// CHECK:STDOUT:     %.loc11: type = splice_block %C.ref [concrete = constants.%C.9f4] {
+// CHECK:STDOUT:       %N.ref.loc11: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl.loc8 [concrete = constants.%C.9f4]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %C.9f4 = bind_name x, %x.param
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C.1;
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C.2;
+// CHECK:STDOUT: class @C.2 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C.9f4
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%x.param_patt: %C.9f4);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @TestCall(%x.param_patt: %C.9f4) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %N.ref.loc13: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %x.ref: %C.9f4 = name_ref x, %x
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.ref(%x.ref)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.carbon
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
@@ -160,7 +160,7 @@ fn N.F1();
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should fail since N.F1 was poisoned in the api.
+// TODO: #4622 This should fail since N.F1 was poisoned in the api.
 fn N.F1() {}
 
 // --- fail_poison_when_lookup_fails.carbon

--- a/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
@@ -12,264 +12,141 @@
 
 library "[[@TEST_NAME]]";
 
-class C {};
+fn F1();
 
-// Both N.F1 and N.F2 use N.C and not C.
+// N.F2 uses N.F1 and not F1.
 namespace N;
-class N.C {}
-fn N.F1(x: C);
-fn N.F2(x: C) { N.F1(x); }
+fn N.F1();
+alias N.F2 = F1;
 
 // --- poison.carbon
 
 library "[[@TEST_NAME]]";
 
-class C {};
+fn F1();
 
+// Use F1 and poison N.F1.
 namespace N;
-// Here we use C and poison N.C.
-fn N.F1(x: C);
+alias N.F2 = F1;
 
-// --- fail_poison_class_without_usage.carbon
+// --- fail_declare_after_poison.carbon
 
 library "[[@TEST_NAME]]";
 
-class C {};
+fn F1();
 
 namespace N;
-// Here we use C and poison N.C.
-// CHECK:STDERR: fail_poison_class_without_usage.carbon:[[@LINE+3]]:12: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: C);
-// CHECK:STDERR:            ^
-fn N.F1(x: C);
+// Use F1 and poison N.F1.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:14: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.F2 = F1;
+// CHECK:STDERR:              ^~
+alias N.F2 = F1;
 
-// Should fail here since C was poisoned for namespace N when it was used in N
-// context without qualification.
-// CHECK:STDERR: fail_poison_class_without_usage.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: class N.C {}
-// CHECK:STDERR:         ^
+// Failure: N.F1 declared after it was poisoned.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: fn N.F1();
+// CHECK:STDERR:      ^~
 // CHECK:STDERR:
-class N.C {}
+fn N.F1();
 
-// --- fail_poison_interface_without_usage.carbon
+// --- fail_use_poison.carbon
 
 library "[[@TEST_NAME]]";
 
-interface I {};
+fn F1();
+
+// Use F1 and poison N.F1.
+namespace N;
+alias N.F2 = F1;
+
+// CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:14: error: member name `F1` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: alias N.F3 = N.F1;
+// CHECK:STDERR:              ^~~~
+// CHECK:STDERR:
+alias N.F3 = N.F1;
+
+// --- fail_use_declaration_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+fn F1();
 
 namespace N;
-// Here we use I and poison N.I.
-// CHECK:STDERR: fail_poison_interface_without_usage.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: I);
-// CHECK:STDERR:            ^
-fn N.F1(x: I);
+// Use F1 and poison N.F1.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:14: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.F2 = F1;
+// CHECK:STDERR:              ^~
+alias N.F2 = F1;
 
-// Should fail here since I was poisoned for namespace N when it was used in N
-// context without qualification.
-// CHECK:STDERR: fail_poison_interface_without_usage.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: interface N.I {}
-// CHECK:STDERR:             ^
+// Failure: N.F1 declared after it was poisoned.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: fn N.F1();
+// CHECK:STDERR:      ^~
 // CHECK:STDERR:
-interface N.I {}
+fn N.F1();
 
-// --- fail_poison_namespace_without_usage.carbon
-
-library "[[@TEST_NAME]]";
-
-class C {};
-
-namespace N;
-// Here we use C and poison N.C.
-// CHECK:STDERR: fail_poison_namespace_without_usage.carbon:[[@LINE+3]]:12: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: C);
-// CHECK:STDERR:            ^
-fn N.F1(x: C);
-
-// Should fail here since C was poisoned for namespace N when it was used in N
-// context without qualification.
-// CHECK:STDERR: fail_poison_namespace_without_usage.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: namespace N.C;
-// CHECK:STDERR:             ^
+// Failure: N.F1 used after declaration failed.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:14: error: member name `F1` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: alias N.F3 = N.F1;
+// CHECK:STDERR:              ^~~~
 // CHECK:STDERR:
-namespace N.C;
-
-// --- fail_poison_member_without_usage.carbon
-
-library "[[@TEST_NAME]]";
-
-class C1 {};
-
-class D {
-  // Here we use C1 and poison D.C1.
-  // CHECK:STDERR: fail_poison_member_without_usage.carbon:[[@LINE+3]]:12: error: name `C1` used before it was declared [NameUseBeforeDecl]
-  // CHECK:STDERR:   fn F1(x: C1);
-  // CHECK:STDERR:            ^~
-  fn F1(x: C1);
-
-  class C2 {};
-  // Should fail here since C1 was poisoned for namespace class D when it was
-  // used in D context without qualification.
-  // CHECK:STDERR: fail_poison_member_without_usage.carbon:[[@LINE+4]]:7: note: declared here [NameUseBeforeDeclNote]
-  // CHECK:STDERR:   var C1: C2;
-  // CHECK:STDERR:       ^~~~~~
-  // CHECK:STDERR:
-  var C1: C2;
-}
-
-// --- fail_poison_function_without_usage.carbon
-
-library "[[@TEST_NAME]]";
-
-class C {};
-
-namespace N;
-// Here we use C and poison N.C.
-// CHECK:STDERR: fail_poison_function_without_usage.carbon:[[@LINE+3]]:12: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: C);
-// CHECK:STDERR:            ^
-fn N.F1(x: C);
-
-// Should fail here since C was poisoned for namespace N when it was used in N
-// context without qualification.
-// CHECK:STDERR: fail_poison_function_without_usage.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: fn N.C();
-// CHECK:STDERR:      ^
-// CHECK:STDERR:
-fn N.C();
-
-// --- fail_use_undefined_poisoned_name.carbon
-
-library "[[@TEST_NAME]]";
-
-class C {};
-
-namespace N;
-// Here we use C and poison N.C.
-fn N.F1() -> C;
-
-// Try to use N.C which was never defined and poisoned.
-// CHECK:STDERR: fail_use_undefined_poisoned_name.carbon:[[@LINE+4]]:14: error: member name `C` not found in `N` [MemberNameNotFoundInScope]
-// CHECK:STDERR: fn N.F2() -> N.C;
-// CHECK:STDERR:              ^~~
-// CHECK:STDERR:
-fn N.F2() -> N.C;
-
-// --- fail_poison_with_usage.carbon
-
-library "[[@TEST_NAME]]";
-
-class C {};
-
-namespace N;
-// Here we use C and poison N.C.
-// CHECK:STDERR: fail_poison_with_usage.carbon:[[@LINE+3]]:12: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: C);
-// CHECK:STDERR:            ^
-fn N.F1(x: C);
-
-// Should fail here since C was poisoned for namespace N when it was used in N
-// context without qualification.
-// CHECK:STDERR: fail_poison_with_usage.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: class N.C {}
-// CHECK:STDERR:         ^
-// CHECK:STDERR:
-class N.C {}
-
-// Should not fail here since both N.F2() and N.F1() input is the class C and
-// not class N.C.
-fn N.F2(x: C) { N.F1(x); }
+alias N.F3 = N.F1;
 
 // --- fail_poison_multiple_scopes.carbon
 
 library "[[@TEST_NAME]]";
 
-class C {};
+fn F1();
 
 namespace N1;
 namespace N1.N2;
 namespace N1.N2.N3;
-class N1.N2.N3.D1 {
-  interface D2 {
-    class D3 {
-      // Here we use C and poison:
-      // * N1.C
-      // * N1.N2.C
-      // * N1.N2.N3.C
-      // * N1.N2.N3.D1.C
-      // * N1.N2.N3.D1.D2.C
-      // * N1.N2.N3.D1.D2.D3.C
-      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `C` used before it was declared [NameUseBeforeDecl]
-      // CHECK:STDERR:       fn F(x: C);
-      // CHECK:STDERR:               ^
-      fn F(x: C);
+// Use F1 and poison:
+// * N1.F1
+// * N1.N2.F1
+// * N1.N2.N3.F1
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:21: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N1.N2.N3.F2 = F1;
+// CHECK:STDERR:                     ^~
+alias N1.N2.N3.F2 = F1;
 
-      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:13: note: declared here [NameUseBeforeDeclNote]
-      // CHECK:STDERR:       class C {}
-      // CHECK:STDERR:             ^
-      // CHECK:STDERR:
-      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:15: error: name `C` used before it was declared [NameUseBeforeDecl]
-      // CHECK:STDERR:       fn F(x: C);
-      // CHECK:STDERR:               ^
-      class C {}
-    }
-    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
-    // CHECK:STDERR:     class C {}
-    // CHECK:STDERR:           ^
-    // CHECK:STDERR:
-    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-15]]:15: error: name `C` used before it was declared [NameUseBeforeDecl]
-    // CHECK:STDERR:       fn F(x: C);
-    // CHECK:STDERR:               ^
-    class C {}
-  }
-  // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:9: note: declared here [NameUseBeforeDeclNote]
-  // CHECK:STDERR:   class C {}
-  // CHECK:STDERR:         ^
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-24]]:15: error: name `C` used before it was declared [NameUseBeforeDecl]
-  // CHECK:STDERR:       fn F(x: C);
-  // CHECK:STDERR:               ^
-  class C {}
-}
-
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:7: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: fn N1.F1();
+// CHECK:STDERR:       ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:21: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N1.N2.N3.F2 = F1;
+// CHECK:STDERR:                     ^~
+fn N1.F1();
 // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:10: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: class N1.C {}
-// CHECK:STDERR:          ^
+// CHECK:STDERR: fn N1.N2.F1();
+// CHECK:STDERR:          ^~
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-34]]:15: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR:       fn F(x: C);
-// CHECK:STDERR:               ^
-class N1.C {}
-
-// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:17: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: interface N1.N2.C {}
-// CHECK:STDERR:                 ^
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-14]]:21: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N1.N2.N3.F2 = F1;
+// CHECK:STDERR:                     ^~
+fn N1.N2.F1();
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: fn N1.N2.N3.F1();
+// CHECK:STDERR:             ^~
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-43]]:15: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR:       fn F(x: C);
-// CHECK:STDERR:               ^
-interface N1.N2.C {}
-
-// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:16: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: class N1.N2.N3.C {}
-// CHECK:STDERR:                ^
-// CHECK:STDERR:
-class N1.N2.N3.C {}
+fn N1.N2.N3.F1();
 
 // --- fail_alias.carbon
 
 library "[[@TEST_NAME]]";
 
-class C {}
+fn F();
 
 namespace N;
-// CHECK:STDERR: fail_alias.carbon:[[@LINE+7]]:13: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: alias N.C = C;
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+7]]:13: error: name `F` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.F = F;
 // CHECK:STDERR:             ^
 // CHECK:STDERR: fail_alias.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: alias N.C = C;
+// CHECK:STDERR: alias N.F = F;
 // CHECK:STDERR:         ^
 // CHECK:STDERR:
-alias N.C = C;
+alias N.F = F;
 
 // --- ignored_poison_in_import.carbon
 
@@ -277,1019 +154,402 @@ library "[[@TEST_NAME]]";
 import library "poison";
 
 // This doesn't fail.
-class N.C {}
+fn N.F1();
 
 // --- poison.impl.carbon
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should fail since N.C was poisoned in the api.
-class N.C {}
-
-// --- using_poisoned_name_in_impl.carbon
-
-library "[[@TEST_NAME]]";
-
-interface C {};
-
-namespace N;
-// Here we use C and poison N.C.
-fn N.F1(x: C);
-
-class N.X {
-  extend impl as C {
-  }
-}
+// TODO: This should fail since N.F1 was poisoned in the api.
+fn N.F1() {}
 
 // --- fail_poison_when_lookup_fails.carbon
 
 library "[[@TEST_NAME]]";
 
 namespace N;
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `C` not found [NameNotFound]
-// CHECK:STDERR: fn N.F(x: C);
-// CHECK:STDERR:           ^
+// N.F1 poisoned when not found.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:14: error: name `F1` not found [NameNotFound]
+// CHECK:STDERR: alias N.F2 = F1;
+// CHECK:STDERR:              ^~
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: C);
-// CHECK:STDERR:           ^
-fn N.F(x: C);
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:14: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.F2 = F1;
+// CHECK:STDERR:              ^~
+alias N.F2 = F1;
 
 // TODO: We should ideally only produce one diagnostic here.
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:7: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: class C {}
-// CHECK:STDERR:       ^
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:4: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: fn F1();
+// CHECK:STDERR:    ^~
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `C` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: C);
-// CHECK:STDERR:           ^
-class C {}
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: class N.C {}
-// CHECK:STDERR:         ^
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:14: error: name `F1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.F2 = F1;
+// CHECK:STDERR:              ^~
+fn F1();
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: fn N.F1();
+// CHECK:STDERR:      ^~
 // CHECK:STDERR:
-class N.C {}
+fn N.F1();
 
 // --- fail_poison_with_lexical_result.carbon
 
 library "[[@TEST_NAME]]";
 
-fn F() {
-  class A {}
+fn F1() {
+  fn F2();
 
-  class B {
-    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+3]]:12: error: name `A` used before it was declared [NameUseBeforeDecl]
-    // CHECK:STDERR:     var v: A;
-    // CHECK:STDERR:            ^
-    var v: A;
+  class C {
+    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+3]]:16: error: name `F2` used before it was declared [NameUseBeforeDecl]
+    // CHECK:STDERR:     alias F3 = F2;
+    // CHECK:STDERR:                ^~
+    alias F3 = F2;
 
-    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+4]]:11: note: declared here [NameUseBeforeDeclNote]
-    // CHECK:STDERR:     class A {}
-    // CHECK:STDERR:           ^
+    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+4]]:8: note: declared here [NameUseBeforeDeclNote]
+    // CHECK:STDERR:     fn F2();
+    // CHECK:STDERR:        ^~
     // CHECK:STDERR:
-    class A {}
+    fn F2();
   }
 }
 
 // CHECK:STDOUT: --- no_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
-// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.75d: type = fn_type @F1.1 [concrete]
+// CHECK:STDOUT:   %F1.afe: %F1.type.75d = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.fe6: type = fn_type @F1.2 [concrete]
+// CHECK:STDOUT:   %F1.cc1: %F1.type.fe6 = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .F1 = %F1.decl.loc4
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %F1.decl.loc4: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl.loc8
-// CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:     .F2 = %F2.decl
-// CHECK:STDOUT:     .N = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl.loc8
+// CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc8: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C.9f4 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.9f4 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.9f4 = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc8 [concrete = constants.%C.9f4]
-// CHECK:STDOUT:     %x: %C.9f4 = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
-// CHECK:STDOUT:     %x.patt: %C.9f4 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.9f4 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.9f4 = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc8 [concrete = constants.%C.9f4]
-// CHECK:STDOUT:     %x: %C.9f4 = bind_name x, %x.param
-// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl.loc8: %F1.type.fe6 = fn_decl @F1.2 [concrete = constants.%F1.cc1] {} {}
+// CHECK:STDOUT:   %F1.ref: %F1.type.fe6 = name_ref F1, %F1.decl.loc8 [concrete = constants.%F1.cc1]
+// CHECK:STDOUT:   %F2: %F1.type.fe6 = bind_alias F2, %F1.decl.loc8 [concrete = constants.%F1.cc1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C.1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT: fn @F1.1();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.f79
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.9f4
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C.9f4);
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F2(%x.param_patt: %C.9f4) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
-// CHECK:STDOUT:   %F1.ref: %F1.type = name_ref F1, file.%F1.decl [concrete = constants.%F1]
-// CHECK:STDOUT:   %x.ref: %C.9f4 = name_ref x, %x
-// CHECK:STDOUT:   %F1.call: init %empty_tuple.type = call %F1.ref(%x.ref)
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
+// CHECK:STDOUT: fn @F1.2();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .F1 = %F1.decl
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
-// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.ref: %F1.type = name_ref F1, %F1.decl [concrete = constants.%F1]
+// CHECK:STDOUT:   %F2: %F1.type = bind_alias F2, %F1.decl [concrete = constants.%F1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT: fn @F1();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_class_without_usage.carbon
+// CHECK:STDOUT: --- fail_declare_after_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
+// CHECK:STDOUT:   %F1.type.75d: type = fn_type @F1.1 [concrete]
+// CHECK:STDOUT:   %F1.afe: %F1.type.75d = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.fe6: type = fn_type @F1.2 [concrete]
+// CHECK:STDOUT:   %F1.cc1: %F1.type.fe6 = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .F1 = %F1.decl.loc4
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %F1.decl.loc4: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
-// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc19: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
+// CHECK:STDOUT:   %F1.ref: %F1.type.75d = name_ref F1, %F1.decl.loc4 [concrete = constants.%F1.afe]
+// CHECK:STDOUT:   %F2: %F1.type.75d = bind_alias F2, %F1.decl.loc4 [concrete = constants.%F1.afe]
+// CHECK:STDOUT:   %F1.decl.loc18: %F1.type.fe6 = fn_decl @F1.2 [concrete = constants.%F1.cc1] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C.1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT: fn @F1.1();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.f79
-// CHECK:STDOUT: }
+// CHECK:STDOUT: fn @F1.2();
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.9f4
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_interface_without_usage.carbon
+// CHECK:STDOUT: --- fail_use_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
-// CHECK:STDOUT:   %Self.826: %I.type.733 = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
-// CHECK:STDOUT:   %Self.f85: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I = %I.decl.loc4
+// CHECK:STDOUT:     .F1 = %F1.decl
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.decl.loc4: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %I.type.733 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
-// CHECK:STDOUT:     %x: %I.type.733 = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.decl.loc19: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I.1 {
-// CHECK:STDOUT:   %Self: %I.type.733 = bind_symbolic_name Self, 0 [symbolic = constants.%Self.826]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I.2 {
-// CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic = constants.%Self.f85]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type.733);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_namespace_without_usage.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl
-// CHECK:STDOUT:     .N = %N
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
-// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %x: %C = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C: <namespace> = namespace [concrete] {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_member_without_usage.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C1: type = class_type @C1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %D: type = class_type @D [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %C2: type = class_type @C2 [concrete]
-// CHECK:STDOUT:   %D.elem: type = unbound_element_type %D, %C2 [concrete]
-// CHECK:STDOUT:   %struct_type.C1: type = struct_type {.C1: %C2} [concrete]
-// CHECK:STDOUT:   %complete_type.ec1: <witness> = complete_type_witness %struct_type.C1 [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C1 = %C1.decl
-// CHECK:STDOUT:     .D = %D.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C1.decl: type = class_decl @C1 [concrete = constants.%C1] {} {}
-// CHECK:STDOUT:   %D.decl: type = class_decl @D [concrete = constants.%D] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C1
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @D {
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C1 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C1 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C1 = value_param runtime_param0
-// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1]
-// CHECK:STDOUT:     %x: %C1 = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [concrete = constants.%C2] {} {}
-// CHECK:STDOUT:   %.loc20_9: %D.elem = field_decl C1, element0 [concrete]
-// CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %.loc20_3: %D.elem = var_pattern %.loc20_9
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %D.elem = var <none>
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.C1 [concrete = constants.%complete_type.ec1]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%D
-// CHECK:STDOUT:   .C1 = <poisoned>
-// CHECK:STDOUT:   .F1 = %F1.decl
-// CHECK:STDOUT:   .C2 = %C2.decl
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C1);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_function_without_usage.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C.f79: type = class_type @C.2 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %C.type: type = fn_type @C.1 [concrete]
-// CHECK:STDOUT:   %C.3f2: %C.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl.loc4
-// CHECK:STDOUT:     .N = %N
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.2 [concrete = constants.%C.f79] {} {}
-// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
-// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc19: %C.type = fn_decl @C.1 [concrete = constants.%C.3f2] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.f79
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @C.1();
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_use_undefined_poisoned_name.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
-// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl
-// CHECK:STDOUT:     .N = %N
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
-// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:     .N = <poisoned>
-// CHECK:STDOUT:     .F2 = %F2.decl
+// CHECK:STDOUT:     .F3 = %F3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %return.patt: %C = return_slot_pattern
-// CHECK:STDOUT:     %return.param_patt: %C = out_param_pattern %return.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %return.param: ref %C = out_param runtime_param0
-// CHECK:STDOUT:     %return: ref %C = return_slot %return.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
-// CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern
-// CHECK:STDOUT:     %return.param_patt: <error> = out_param_pattern %return.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
-// CHECK:STDOUT:     %C.ref: <error> = name_ref C, <error> [concrete = <error>]
-// CHECK:STDOUT:     %return.param: ref <error> = out_param runtime_param0
-// CHECK:STDOUT:     %return: ref <error> = return_slot %return.param
-// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.ref.loc8: %F1.type = name_ref F1, %F1.decl [concrete = constants.%F1]
+// CHECK:STDOUT:   %F2: %F1.type = bind_alias F2, %F1.decl [concrete = constants.%F1]
+// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, %N [concrete = %N]
+// CHECK:STDOUT:   %F1.ref.loc14: <error> = name_ref F1, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F3: <error> = bind_alias F3, <error> [concrete = <error>]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT: fn @F1();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1() -> %C;
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F2() -> <error>;
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_with_usage.carbon
+// CHECK:STDOUT: --- fail_use_declaration_after_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
-// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
-// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.75d: type = fn_type @F1.1 [concrete]
+// CHECK:STDOUT:   %F1.afe: %F1.type.75d = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.fe6: type = fn_type @F1.2 [concrete]
+// CHECK:STDOUT:   %F1.cc1: %F1.type.fe6 = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .F1 = %F1.decl.loc4
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %F1.decl.loc4: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:     .F2 = %F2.decl
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:     .N = <poisoned>
+// CHECK:STDOUT:     .F3 = %F3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
-// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc19: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
-// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
-// CHECK:STDOUT:     %x.patt: %C.f79 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.f79 = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
-// CHECK:STDOUT:     %x: %C.f79 = bind_name x, %x.param
-// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.ref.loc11: %F1.type.75d = name_ref F1, %F1.decl.loc4 [concrete = constants.%F1.afe]
+// CHECK:STDOUT:   %F2: %F1.type.75d = bind_alias F2, %F1.decl.loc4 [concrete = constants.%F1.afe]
+// CHECK:STDOUT:   %F1.decl.loc18: %F1.type.fe6 = fn_decl @F1.2 [concrete = constants.%F1.cc1] {} {}
+// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, %N [concrete = %N]
+// CHECK:STDOUT:   %F1.ref.loc25: <error> = name_ref F1, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F3: <error> = bind_alias F3, <error> [concrete = <error>]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C.1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT: fn @F1.1();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.f79
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.9f4
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C.f79);
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F2(%x.param_patt: %C.f79) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
-// CHECK:STDOUT:   %F1.ref: %F1.type = name_ref F1, file.%F1.decl [concrete = constants.%F1]
-// CHECK:STDOUT:   %x.ref: %C.f79 = name_ref x, %x
-// CHECK:STDOUT:   %F1.call: init %empty_tuple.type = call %F1.ref(%x.ref)
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
+// CHECK:STDOUT: fn @F1.2();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_poison_multiple_scopes.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %D1: type = class_type @D1 [concrete]
-// CHECK:STDOUT:   %D2.type: type = facet_type <@D2> [concrete]
-// CHECK:STDOUT:   %Self.8cf: %D2.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %D3.b65: type = class_type @D3 [concrete]
-// CHECK:STDOUT:   %D3.68e: type = class_type @D3, @D3(%Self.8cf) [symbolic]
-// CHECK:STDOUT:   %F.type: type = fn_type @F, @D3(%Self.8cf) [symbolic]
-// CHECK:STDOUT:   %F: %F.type = struct_value () [symbolic]
-// CHECK:STDOUT:   %C.fef: type = class_type @C.2 [concrete]
-// CHECK:STDOUT:   %C.5a3: type = class_type @C.2, @C.2(%Self.8cf) [symbolic]
-// CHECK:STDOUT:   %C.2fa: type = class_type @C.3 [concrete]
-// CHECK:STDOUT:   %C.4bd: type = class_type @C.3, @C.3(%Self.8cf) [symbolic]
-// CHECK:STDOUT:   %C.6f6: type = class_type @C.4 [concrete]
-// CHECK:STDOUT:   %C.0b8: type = class_type @C.5 [concrete]
-// CHECK:STDOUT:   %C.type: type = facet_type <@C.7> [concrete]
-// CHECK:STDOUT:   %Self.b2a: %C.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %C.6f1: type = class_type @C.6 [concrete]
+// CHECK:STDOUT:   %F1.type.75d: type = fn_type @F1.1 [concrete]
+// CHECK:STDOUT:   %F1.afe: %F1.type.75d = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.1f8: type = fn_type @F1.2 [concrete]
+// CHECK:STDOUT:   %F1.19a: %F1.type.1f8 = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.73a: type = fn_type @F1.3 [concrete]
+// CHECK:STDOUT:   %F1.727: %F1.type.73a = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.fe3: type = fn_type @F1.4 [concrete]
+// CHECK:STDOUT:   %F1.6a8: %F1.type.fe3 = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl.loc4
+// CHECK:STDOUT:     .F1 = %F1.decl.loc4
 // CHECK:STDOUT:     .N1 = %N1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc4: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
+// CHECK:STDOUT:   %F1.decl.loc4: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {} {}
 // CHECK:STDOUT:   %N1: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .N2 = %N2
-// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F1 = <poisoned>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .N3 = %N3
-// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F1 = <poisoned>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N3: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .D1 = %D1.decl
-// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %D1.decl: type = class_decl @D1 [concrete = constants.%D1] {} {}
-// CHECK:STDOUT:   %C.decl.loc59: type = class_decl @C.5 [concrete = constants.%C.0b8] {} {}
-// CHECK:STDOUT:   %C.decl.loc68: type = interface_decl @C.7 [concrete = constants.%C.type] {} {}
-// CHECK:STDOUT:   %C.decl.loc74: type = class_decl @C.6 [concrete = constants.%C.6f1] {} {}
+// CHECK:STDOUT:   %F1.ref: %F1.type.75d = name_ref F1, %F1.decl.loc4 [concrete = constants.%F1.afe]
+// CHECK:STDOUT:   %F2: %F1.type.75d = bind_alias F2, %F1.decl.loc4 [concrete = constants.%F1.afe]
+// CHECK:STDOUT:   %F1.decl.loc25: %F1.type.1f8 = fn_decl @F1.2 [concrete = constants.%F1.19a] {} {}
+// CHECK:STDOUT:   %F1.decl.loc33: %F1.type.73a = fn_decl @F1.3 [concrete = constants.%F1.727] {} {}
+// CHECK:STDOUT:   %F1.decl.loc38: %F1.type.fe3 = fn_decl @F1.4 [concrete = constants.%F1.6a8] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @D2 {
-// CHECK:STDOUT:   %Self: %D2.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.8cf]
-// CHECK:STDOUT:   %D3.decl: type = class_decl @D3 [concrete = constants.%D3.b65] {} {}
-// CHECK:STDOUT:   %C.decl: type = class_decl @C.3 [concrete = constants.%C.2fa] {} {}
+// CHECK:STDOUT: fn @F1.1();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .D3 = %D3.decl
-// CHECK:STDOUT:   .C = <poisoned>
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
+// CHECK:STDOUT: fn @F1.2();
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @C.7 {
-// CHECK:STDOUT:   %Self: %C.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.b2a]
+// CHECK:STDOUT: fn @F1.3();
 // CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.f79
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @D1 {
-// CHECK:STDOUT:   %D2.decl: type = interface_decl @D2 [concrete = constants.%D2.type] {} {}
-// CHECK:STDOUT:   %C.decl: type = class_decl @C.4 [concrete = constants.%C.6f6] {} {}
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%D1
-// CHECK:STDOUT:   .D2 = %D2.decl
-// CHECK:STDOUT:   .C = <poisoned>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic class @D3(@D2.%Self: %D2.type) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Self: %D2.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.8cf)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F, @D3(%Self) [symbolic = %F.type (constants.%F.type)]
-// CHECK:STDOUT:   %F: @D3.%F.type (%F.type) = struct_value () [symbolic = %F (constants.%F)]
-// CHECK:STDOUT:
-// CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %F.decl: @D3.%F.type (%F.type) = fn_decl @F [symbolic = @D3.%F (constants.%F)] {
-// CHECK:STDOUT:       %x.patt: %C.f79 = binding_pattern x
-// CHECK:STDOUT:       %x.param_patt: %C.f79 = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %x.param: %C.f79 = value_param runtime_param0
-// CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl.loc4 [concrete = constants.%C.f79]
-// CHECK:STDOUT:       %x: %C.f79 = bind_name x, %x.param
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %C.decl: type = class_decl @C.2 [concrete = constants.%C.fef] {} {}
-// CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:     complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     .Self = constants.%D3.68e
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F = %F.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic class @C.2(@D2.%Self: %D2.type) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:
-// CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:     complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     .Self = constants.%C.5a3
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic class @C.3(@D2.%Self: %D2.type) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:
-// CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:     complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     .Self = constants.%C.4bd
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.4 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.6f6
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.5 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.0b8
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.6 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.6f1
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(@D2.%Self: %D2.type) {
-// CHECK:STDOUT:   fn(%x.param_patt: %C.f79);
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @D3(constants.%Self.8cf) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(constants.%Self.8cf) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @C.2(constants.%Self.8cf) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @D3(%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @C.3(constants.%Self.8cf) {}
+// CHECK:STDOUT: fn @F1.4();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_alias.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
+// CHECK:STDOUT:     .F = <poisoned>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.ref: type = name_ref C, %C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %C: type = bind_alias C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, %F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %F: %F.type = bind_alias F, %F.decl [concrete = constants.%F]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT: }
+// CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- ignored_poison_in_import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %Main.C = import_ref Main//poison, C, unloaded
+// CHECK:STDOUT:   %Main.F1 = import_ref Main//poison, F1, unloaded
 // CHECK:STDOUT:   %Main.N: <namespace> = import_ref Main//poison, N, loaded
 // CHECK:STDOUT:   %N: <namespace> = namespace %Main.N, [concrete] {
-// CHECK:STDOUT:     .F1 = %Main.F1
-// CHECK:STDOUT:     .C = file.%C.decl
+// CHECK:STDOUT:     .F2 = %Main.F2
+// CHECK:STDOUT:     .F1 = file.%F1.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = imports.%Main.C
+// CHECK:STDOUT:     .F1 = imports.%Main.F1
 // CHECK:STDOUT:     .N = imports.%N
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %default.import = import <none>
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT: }
+// CHECK:STDOUT: fn @F1();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %Main.C = import_ref Main//poison, C, unloaded
+// CHECK:STDOUT:   %Main.F1 = import_ref Main//poison, F1, unloaded
 // CHECK:STDOUT:   %Main.N: <namespace> = import_ref Main//poison, N, loaded
 // CHECK:STDOUT:   %N: <namespace> = namespace %Main.N, [concrete] {
-// CHECK:STDOUT:     .F1 = %Main.F1
-// CHECK:STDOUT:     .C = file.%C.decl
+// CHECK:STDOUT:     .F2 = %Main.F2
+// CHECK:STDOUT:     .F1 = file.%F1.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = imports.%Main.C
+// CHECK:STDOUT:     .F1 = imports.%Main.F1
 // CHECK:STDOUT:     .N = imports.%N
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
 // CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_when_lookup_fails.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F1.type.75d: type = fn_type @F1.1 [concrete]
+// CHECK:STDOUT:   %F1.afe: %F1.type.75d = struct_value () [concrete]
+// CHECK:STDOUT:   %F1.type.fe6: type = fn_type @F1.2 [concrete]
+// CHECK:STDOUT:   %F1.cc1: %F1.type.fe6 = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .F1 = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.ref: <error> = name_ref F1, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F2: <error> = bind_alias F2, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F1.decl.loc23: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {} {}
+// CHECK:STDOUT:   %F1.decl.loc28: %F1.type.fe6 = fn_decl @F1.2 [concrete = constants.%F1.cc1] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1.1();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1.2();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_with_lexical_result.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F2.type.028: type = fn_type @F2.1 [concrete]
+// CHECK:STDOUT:   %F2.18a: %F2.type.028 = struct_value () [concrete]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %F2.type.c9e: type = fn_type @F2.2 [concrete]
+// CHECK:STDOUT:   %F2.c1c: %F2.type.c9e = struct_value () [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %F2.ref: %F2.type.028 = name_ref F2, @F1.%F2.decl [concrete = constants.%F2.18a]
+// CHECK:STDOUT:   %F3: %F2.type.028 = bind_alias F3, @F1.%F2.decl [concrete = constants.%F2.18a]
+// CHECK:STDOUT:   %F2.decl: %F2.type.c9e = fn_decl @F2.2 [concrete = constants.%F2.c1c] {} {}
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .F2 = <poisoned>
+// CHECK:STDOUT:   .F3 = %F3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- using_poisoned_name_in_impl.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C.type: type = facet_type <@C> [concrete]
-// CHECK:STDOUT:   %Self: %C.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
-// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %X: type = class_type @X [concrete]
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl
-// CHECK:STDOUT:     .N = %N
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl: type = interface_decl @C [concrete = constants.%C.type] {} {}
-// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:     .X = %X.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C.type = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C.type = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C.type = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C.type]
-// CHECK:STDOUT:     %x: %C.type = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %X.decl: type = class_decl @X [concrete = constants.%X] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @C {
-// CHECK:STDOUT:   %Self: %C.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %Self.ref as %C.ref {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = @X.%impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @X {
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%X [concrete = constants.%X]
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C.type]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [concrete = constants.%impl_witness]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%X
-// CHECK:STDOUT:   .C = <poisoned>
-// CHECK:STDOUT:   extend @impl.%C.ref
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C.type);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_when_lookup_fails.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
-// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
-// CHECK:STDOUT:   %C.f79: type = class_type @C.1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %C.9f4: type = class_type @C.2 [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .N = %N
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = <poisoned>
-// CHECK:STDOUT:     .F = %F.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %C.ref: <error> = name_ref C, <error> [concrete = <error>]
-// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.decl.loc22: type = class_decl @C.1 [concrete = constants.%C.f79] {} {}
-// CHECK:STDOUT:   %C.decl.loc27: type = class_decl @C.2 [concrete = constants.%C.9f4] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.f79
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @C.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C.9f4
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: <error>);
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_poison_with_lexical_result.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
-// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
-// CHECK:STDOUT:   %A.666: type = class_type @A.1 [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %B: type = class_type @B [concrete]
-// CHECK:STDOUT:   %B.elem: type = unbound_element_type %B, %A.666 [concrete]
-// CHECK:STDOUT:   %A.9b6: type = class_type @A.2 [concrete]
-// CHECK:STDOUT:   %struct_type.v: type = struct_type {.v: %A.666} [concrete]
-// CHECK:STDOUT:   %complete_type.57e: <witness> = complete_type_witness %struct_type.v [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .F = %F.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @A.1 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%A.666
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %.loc11_10: %B.elem = field_decl v, element0 [concrete]
-// CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %.loc11_5: %B.elem = var_pattern %.loc11_10
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.var: ref %B.elem = var <none>
-// CHECK:STDOUT:   %A.decl: type = class_decl @A.2 [concrete = constants.%A.9b6] {} {}
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [concrete = constants.%complete_type.57e]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%B
-// CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   .v = %.loc11_10
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @A.2 {
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%A.9b6
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: fn @F1() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.decl: type = class_decl @A.1 [concrete = constants.%A.666] {} {}
-// CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
+// CHECK:STDOUT:   %F2.decl: %F2.type.028 = fn_decl @F2.1 [concrete = constants.%F2.18a] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F2.1();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F2.2();
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/name_poisoning.carbon
@@ -12,12 +12,20 @@
 
 library "[[@TEST_NAME]]";
 
-fn F1();
+class C1 {}
+class C2 {}
 
-// N.F2 uses N.F1 and not F1.
+fn F1(x: C1);
+
+// `N.F2` uses `N.F1` and not `package.F1`.
 namespace N;
-fn N.F1();
+fn N.F1(x: C2);
 alias N.F2 = F1;
+
+fn TestCall(x: C2) {
+  // `N.F2` accepts a `C2` not a `C1`.
+  N.F2(x);
+}
 
 // --- poison.carbon
 
@@ -25,7 +33,7 @@ library "[[@TEST_NAME]]";
 
 fn F1();
 
-// Use F1 and poison N.F1.
+// Use `package.F1` and poison `N.F1`.
 namespace N;
 alias N.F2 = F1;
 
@@ -36,13 +44,13 @@ library "[[@TEST_NAME]]";
 fn F1();
 
 namespace N;
-// Use F1 and poison N.F1.
+// Use `package.F1` and poison `N.F1`.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:14: error: name `F1` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: alias N.F2 = F1;
 // CHECK:STDERR:              ^~
 alias N.F2 = F1;
 
-// Failure: N.F1 declared after it was poisoned.
+// Failure: `N.F1` declared after it was poisoned.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: fn N.F1();
 // CHECK:STDERR:      ^~
@@ -55,7 +63,7 @@ library "[[@TEST_NAME]]";
 
 fn F1();
 
-// Use F1 and poison N.F1.
+// Use `package.F1` and poison `N.F1`.
 namespace N;
 alias N.F2 = F1;
 
@@ -72,20 +80,20 @@ library "[[@TEST_NAME]]";
 fn F1();
 
 namespace N;
-// Use F1 and poison N.F1.
+// Use `package.F1` and poison `N.F1`.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:14: error: name `F1` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: alias N.F2 = F1;
 // CHECK:STDERR:              ^~
 alias N.F2 = F1;
 
-// Failure: N.F1 declared after it was poisoned.
+// Failure: `N.F1` declared after it was poisoned.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:6: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: fn N.F1();
 // CHECK:STDERR:      ^~
 // CHECK:STDERR:
 fn N.F1();
 
-// Failure: N.F1 used after declaration failed.
+// Failure: `N.F1` used after declaration failed.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:14: error: member name `F1` not found in `N` [MemberNameNotFoundInScope]
 // CHECK:STDERR: alias N.F3 = N.F1;
 // CHECK:STDERR:              ^~~~
@@ -101,10 +109,10 @@ fn F1();
 namespace N1;
 namespace N1.N2;
 namespace N1.N2.N3;
-// Use F1 and poison:
-// * N1.F1
-// * N1.N2.F1
-// * N1.N2.N3.F1
+// Use `package.F1` and poison:
+// * `N1.F1`
+// * `N1.N2.F1`
+// * `N1.N2.N3.F1`
 // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:21: error: name `F1` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: alias N1.N2.N3.F2 = F1;
 // CHECK:STDERR:                     ^~
@@ -160,7 +168,7 @@ fn N.F1();
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: #4622 This should fail since N.F1 was poisoned in the api.
+// TODO: #4622 This should fail since `N.F1` was poisoned in the api.
 fn N.F1() {}
 
 // --- fail_poison_when_lookup_fails.carbon
@@ -168,7 +176,7 @@ fn N.F1() {}
 library "[[@TEST_NAME]]";
 
 namespace N;
-// N.F1 poisoned when not found.
+// `N.F1` poisoned when not found.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:14: error: name `F1` not found [NameNotFound]
 // CHECK:STDERR: alias N.F2 = F1;
 // CHECK:STDERR:              ^~
@@ -217,30 +225,90 @@ fn F1() {
 // CHECK:STDOUT: --- no_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C1: type = class_type @C1 [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C2: type = class_type @C2 [concrete]
 // CHECK:STDOUT:   %F1.type.75d: type = fn_type @F1.1 [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %F1.afe: %F1.type.75d = struct_value () [concrete]
 // CHECK:STDOUT:   %F1.type.fe6: type = fn_type @F1.2 [concrete]
 // CHECK:STDOUT:   %F1.cc1: %F1.type.fe6 = struct_value () [concrete]
+// CHECK:STDOUT:   %TestCall.type: type = fn_type @TestCall [concrete]
+// CHECK:STDOUT:   %TestCall: %TestCall.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .F1 = %F1.decl.loc4
+// CHECK:STDOUT:     .C1 = %C1.decl
+// CHECK:STDOUT:     .C2 = %C2.decl
+// CHECK:STDOUT:     .F1 = %F1.decl.loc7
 // CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:     .TestCall = %TestCall.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl.loc4: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {} {}
+// CHECK:STDOUT:   %C1.decl: type = class_decl @C1 [concrete = constants.%C1] {} {}
+// CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [concrete = constants.%C2] {} {}
+// CHECK:STDOUT:   %F1.decl.loc7: %F1.type.75d = fn_decl @F1.1 [concrete = constants.%F1.afe] {
+// CHECK:STDOUT:     %x.patt: %C1 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C1 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C1 = value_param runtime_param0
+// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1]
+// CHECK:STDOUT:     %x: %C1 = bind_name x, %x.param
+// CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .F1 = %F1.decl.loc8
+// CHECK:STDOUT:     .C2 = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl.loc11
 // CHECK:STDOUT:     .F2 = %F2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F1.decl.loc8: %F1.type.fe6 = fn_decl @F1.2 [concrete = constants.%F1.cc1] {} {}
-// CHECK:STDOUT:   %F1.ref: %F1.type.fe6 = name_ref F1, %F1.decl.loc8 [concrete = constants.%F1.cc1]
-// CHECK:STDOUT:   %F2: %F1.type.fe6 = bind_alias F2, %F1.decl.loc8 [concrete = constants.%F1.cc1]
+// CHECK:STDOUT:   %F1.decl.loc11: %F1.type.fe6 = fn_decl @F1.2 [concrete = constants.%F1.cc1] {
+// CHECK:STDOUT:     %x.patt: %C2 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C2 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C2 = value_param runtime_param0
+// CHECK:STDOUT:     %C2.ref: type = name_ref C2, file.%C2.decl [concrete = constants.%C2]
+// CHECK:STDOUT:     %x: %C2 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.ref: %F1.type.fe6 = name_ref F1, %F1.decl.loc11 [concrete = constants.%F1.cc1]
+// CHECK:STDOUT:   %F2: %F1.type.fe6 = bind_alias F2, %F1.decl.loc11 [concrete = constants.%F1.cc1]
+// CHECK:STDOUT:   %TestCall.decl: %TestCall.type = fn_decl @TestCall [concrete = constants.%TestCall] {
+// CHECK:STDOUT:     %x.patt: %C2 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C2 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C2 = value_param runtime_param0
+// CHECK:STDOUT:     %C2.ref: type = name_ref C2, file.%C2.decl [concrete = constants.%C2]
+// CHECK:STDOUT:     %x: %C2 = bind_name x, %x.param
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1.1();
+// CHECK:STDOUT: class @C1 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1.2();
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C2 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1.1(%x.param_patt: %C1);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1.2(%x.param_patt: %C2);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @TestCall(%x.param_patt: %C2) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:   %F2.ref: %F1.type.fe6 = name_ref F2, file.%F2 [concrete = constants.%F1.cc1]
+// CHECK:STDOUT:   %x.ref: %C2 = name_ref x, %x
+// CHECK:STDOUT:   %F1.call: init %empty_tuple.type = call %F2.ref(%x.ref)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.carbon
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -1,0 +1,808 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+
+// --- no_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I;
+
+// N.F uses N.I and not I.
+namespace N;
+interface N.I {}
+fn N.F(x: I);
+
+// --- poison.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I;
+
+namespace N;
+// Use I and poison N.I.
+fn N.F(x: I);
+
+// --- fail_declare_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I;
+
+namespace N;
+// Use I and poison N.I.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR:           ^
+fn N.F(x: I);
+
+// Failure: N.I declared after it was poisoned.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: interface N.I {}
+// CHECK:STDERR:             ^
+// CHECK:STDERR:
+interface N.I {}
+
+// --- fail_use_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I;
+
+namespace N;
+// Use I and poison N.I.
+fn N.F1(x: I);
+
+// CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: fn N.F2(x: N.I);
+// CHECK:STDERR:            ^~~
+// CHECK:STDERR:
+fn N.F2(x: N.I);
+
+// --- fail_use_declaration_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I;
+
+namespace N;
+// Use I and poison N.I.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F1(x: I);
+// CHECK:STDERR:            ^
+fn N.F1(x: I);
+
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: interface N.I;
+// CHECK:STDERR:             ^
+// CHECK:STDERR:
+interface N.I;
+
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: fn N.F2(x: N.I);
+// CHECK:STDERR:            ^~~
+// CHECK:STDERR:
+fn N.F2(x: N.I);
+
+// --- fail_alias.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I;
+namespace N;
+
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+7]]:13: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N.I = I;
+// CHECK:STDERR:             ^
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+4]]:9: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: alias N.I = I;
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+alias N.I = I;
+
+// --- fail_poison_multiple_scopes.carbon
+
+library "[[@TEST_NAME]]";
+
+interface I1;
+
+interface I2 {
+  interface I3 {
+    interface I4 {
+      // Use I1 and poison:
+      // * I2.I1
+      // * I2.I3.I1
+      // * I2.I3.I4.I1
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
+      // CHECK:STDERR:       fn F(x: I1);
+      // CHECK:STDERR:               ^~
+      fn F(x: I1);
+
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:17: note: declared here [NameUseBeforeDeclNote]
+      // CHECK:STDERR:       interface I1;
+      // CHECK:STDERR:                 ^~
+      // CHECK:STDERR:
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
+      // CHECK:STDERR:       fn F(x: I1);
+      // CHECK:STDERR:               ^~
+      interface I1;
+    }
+    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:15: note: declared here [NameUseBeforeDeclNote]
+    // CHECK:STDERR:     interface I1;
+    // CHECK:STDERR:               ^~
+    // CHECK:STDERR:
+    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-15]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
+    // CHECK:STDERR:       fn F(x: I1);
+    // CHECK:STDERR:               ^~
+    interface I1;
+  }
+  // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
+  // CHECK:STDERR:   interface I1;
+  // CHECK:STDERR:             ^~
+  // CHECK:STDERR:
+  interface I1;
+}
+
+// --- ignored_poison_in_import.carbon
+
+library "[[@TEST_NAME]]";
+import library "poison";
+
+// This doesn't fail.
+interface N.I;
+
+// --- poison.impl.carbon
+
+impl library "[[@TEST_NAME]]";
+
+// TODO: This should fail since N.F1 was poisoned in the api.
+interface N.I;
+
+// --- fail_poison_when_lookup_fails.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N;
+// N.I1 poisoned when not found.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `I1` not found [NameNotFound]
+// CHECK:STDERR: fn N.F(x: I1);
+// CHECK:STDERR:           ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `I1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: I1);
+// CHECK:STDERR:           ^~
+fn N.F(x: I1);
+
+// TODO: We should ideally only produce one diagnostic here.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: interface I1;
+// CHECK:STDERR:           ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `I1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: I1);
+// CHECK:STDERR:           ^~
+interface I1;
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: interface N.I1;
+// CHECK:STDERR:             ^~
+// CHECK:STDERR:
+interface N.I1;
+
+// --- fail_poison_with_lexical_result.carbon
+
+library "[[@TEST_NAME]]";
+
+fn F() {
+  interface I1 {}
+
+  class C {
+    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+3]]:12: error: name `I1` used before it was declared [NameUseBeforeDecl]
+    // CHECK:STDERR:     var v: I1;
+    // CHECK:STDERR:            ^~
+    var v: I1;
+
+    // CHECK:STDERR: fail_poison_with_lexical_result.carbon:[[@LINE+4]]:15: note: declared here [NameUseBeforeDeclNote]
+    // CHECK:STDERR:     interface I1;
+    // CHECK:STDERR:               ^~
+    // CHECK:STDERR:
+    interface I1;
+  }
+}
+
+// --- using_poisoned_name_in_impl.carbon
+
+library "[[@TEST_NAME]]";
+
+interface C1 {};
+
+namespace N;
+// Use C1 and poison N.C1.
+fn N.F1(x: C1);
+
+class N.C2 {
+  extend impl as C1 {
+  }
+}
+
+// CHECK:STDOUT: --- no_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
+// CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
+// CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl.loc4
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl.loc4: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl.loc8
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl.loc8: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %I.type.4da = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type.4da = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %I.type.4da = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
+// CHECK:STDOUT:     %x: %I.type.4da = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I.2 {
+// CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %I.type.4da);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %I.type);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_declare_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
+// CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl.loc4
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl.loc4: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: %I.type.733 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
+// CHECK:STDOUT:     %x: %I.type.733 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl.loc18: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I.2 {
+// CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: %I.type.733);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_use_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
+// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .N = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
+// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
+// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
+// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
+// CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_use_declaration_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
+// CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
+// CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl.loc4
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl.loc4: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .N = <poisoned>
+// CHECK:STDOUT:     .F2 = %F2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
+// CHECK:STDOUT:     %x.patt: %I.type.733 = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
+// CHECK:STDOUT:     %x: %I.type.733 = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl.loc17: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
+// CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
+// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
+// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
+// CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type.733);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_alias.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.ref: type = name_ref I, %I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:   %I: type = bind_alias I, %I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_multiple_scopes.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I1.type.80c: type = facet_type <@I1.1> [concrete]
+// CHECK:STDOUT:   %I2.type: type = facet_type <@I2> [concrete]
+// CHECK:STDOUT:   %Self.c7b: %I2.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %I3.type.07a: type = facet_type <@I3> [concrete]
+// CHECK:STDOUT:   %I3.type.b2f: type = facet_type <@I3, @I3(%Self.c7b)> [symbolic]
+// CHECK:STDOUT:   %Self.60c: %I3.type.b2f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %I4.type.451: type = facet_type <@I4> [concrete]
+// CHECK:STDOUT:   %I4.type.78e: type = facet_type <@I4, @I4(%Self.c7b, %Self.60c)> [symbolic]
+// CHECK:STDOUT:   %Self.a4d: %I4.type.78e = bind_symbolic_name Self, 2 [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F, @I4(%Self.c7b, %Self.60c) [symbolic]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [symbolic]
+// CHECK:STDOUT:   %I4.assoc_type: type = assoc_entity_type %I4.type.78e [symbolic]
+// CHECK:STDOUT:   %assoc0: %I4.assoc_type = assoc_entity element0, @I4.%F.decl [symbolic]
+// CHECK:STDOUT:   %I1.type.f4e: type = facet_type <@I1.2> [concrete]
+// CHECK:STDOUT:   %I1.type.575: type = facet_type <@I1.3> [concrete]
+// CHECK:STDOUT:   %I1.type.e5b: type = facet_type <@I1.4> [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I1 = %I1.decl
+// CHECK:STDOUT:     .I2 = %I2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I1.decl: type = interface_decl @I1.1 [concrete = constants.%I1.type.80c] {} {}
+// CHECK:STDOUT:   %I2.decl: type = interface_decl @I2 [concrete = constants.%I2.type] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I1.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I2 {
+// CHECK:STDOUT:   %Self: %I2.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.c7b]
+// CHECK:STDOUT:   %I3.decl: type = interface_decl @I3 [concrete = constants.%I3.type.07a] {} {}
+// CHECK:STDOUT:   %I1.decl: type = interface_decl @I1.4 [concrete = constants.%I1.type.e5b] {} {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .I3 = %I3.decl
+// CHECK:STDOUT:   .I1 = <poisoned>
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I3(@I2.%Self: %I2.type) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Self.2: %I2.type = bind_symbolic_name Self, 0 [symbolic = %Self.2 (constants.%Self.c7b)]
+// CHECK:STDOUT:   %I3.type: type = facet_type <@I3, @I3(%Self.2)> [symbolic = %I3.type (constants.%I3.type.b2f)]
+// CHECK:STDOUT:   %Self.3: %I3.type.b2f = bind_symbolic_name Self, 1 [symbolic = %Self.3 (constants.%Self.60c)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @I3.%I3.type (%I3.type.b2f) = bind_symbolic_name Self, 1 [symbolic = %Self.3 (constants.%Self.60c)]
+// CHECK:STDOUT:     %I4.decl: type = interface_decl @I4 [concrete = constants.%I4.type.451] {} {}
+// CHECK:STDOUT:     %I1.decl: type = interface_decl @I1.3 [concrete = constants.%I1.type.575] {} {}
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .I4 = %I4.decl
+// CHECK:STDOUT:     .I1 = <poisoned>
+// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I4(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f)) {
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Self.2: %I2.type = bind_symbolic_name Self, 0 [symbolic = %Self.2 (constants.%Self.c7b)]
+// CHECK:STDOUT:   %Self.3: %I3.type.b2f = bind_symbolic_name Self, 1 [symbolic = %Self.3 (constants.%Self.60c)]
+// CHECK:STDOUT:   %I4.type: type = facet_type <@I4, @I4(%Self.2, %Self.3)> [symbolic = %I4.type (constants.%I4.type.78e)]
+// CHECK:STDOUT:   %Self.4: %I4.type.78e = bind_symbolic_name Self, 2 [symbolic = %Self.4 (constants.%Self.a4d)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F, @I4(%Self.2, %Self.3) [symbolic = %F.type (constants.%F.type)]
+// CHECK:STDOUT:   %F: @I4.%F.type (%F.type) = struct_value () [symbolic = %F (constants.%F)]
+// CHECK:STDOUT:   %I4.assoc_type: type = assoc_entity_type @I4.%I4.type (%I4.type.78e) [symbolic = %I4.assoc_type (constants.%I4.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc16_18.2: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_18.2 (constants.%assoc0)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @I4.%I4.type (%I4.type.78e) = bind_symbolic_name Self, 2 [symbolic = %Self.4 (constants.%Self.a4d)]
+// CHECK:STDOUT:     %F.decl: @I4.%F.type (%F.type) = fn_decl @F [symbolic = @I4.%F (constants.%F)] {
+// CHECK:STDOUT:       %x.patt: %I1.type.80c = binding_pattern x
+// CHECK:STDOUT:       %x.param_patt: %I1.type.80c = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %x.param: %I1.type.80c = value_param runtime_param0
+// CHECK:STDOUT:       %I1.ref: type = name_ref I1, file.%I1.decl [concrete = constants.%I1.type.80c]
+// CHECK:STDOUT:       %x: %I1.type.80c = bind_name x, %x.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc16_18.1: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_18.2 (constants.%assoc0)]
+// CHECK:STDOUT:     %I1.decl: type = interface_decl @I1.2 [concrete = constants.%I1.type.f4e] {} {}
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .I1 = <poisoned>
+// CHECK:STDOUT:     .F = %assoc0.loc16_18.1
+// CHECK:STDOUT:     witness = (%F.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I1.2(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f), @I4.%Self.1: @I4.%I4.type (%I4.type.78e)) {
+// CHECK:STDOUT:   interface;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I1.3(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f)) {
+// CHECK:STDOUT:   interface;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I1.4(@I2.%Self: %I2.type) {
+// CHECK:STDOUT:   interface;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f), @I4.%Self.1: @I4.%I4.type (%I4.type.78e)) {
+// CHECK:STDOUT:   fn(%x.param_patt: %I1.type.80c);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I3(constants.%Self.c7b) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I4(constants.%Self.c7b, constants.%Self.60c) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%Self.c7b, constants.%Self.60c, constants.%Self.a4d) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I1.2(constants.%Self.c7b, constants.%Self.60c, constants.%Self.a4d) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I4(%Self.2, %Self.3) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I1.3(constants.%Self.c7b, constants.%Self.60c) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I3(%Self.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I1.4(constants.%Self.c7b) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- ignored_poison_in_import.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.I = import_ref Main//poison, I, unloaded
+// CHECK:STDOUT:   %Main.N: <namespace> = import_ref Main//poison, N, loaded
+// CHECK:STDOUT:   %N: <namespace> = namespace %Main.N, [concrete] {
+// CHECK:STDOUT:     .F = %Main.F
+// CHECK:STDOUT:     .I = file.%I.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = imports.%Main.I
+// CHECK:STDOUT:     .N = imports.%N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import = import <none>
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- poison.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.I = import_ref Main//poison, I, unloaded
+// CHECK:STDOUT:   %Main.N: <namespace> = import_ref Main//poison, N, loaded
+// CHECK:STDOUT:   %N: <namespace> = namespace %Main.N, [concrete] {
+// CHECK:STDOUT:     .F = %Main.F
+// CHECK:STDOUT:     .I = file.%I.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = imports.%Main.I
+// CHECK:STDOUT:     .N = imports.%N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I;
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_when_lookup_fails.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %I1.type.80c: type = facet_type <@I1.1> [concrete]
+// CHECK:STDOUT:   %I1.type.46a: type = facet_type <@I1.2> [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:     .I1 = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I1 = <poisoned>
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
+// CHECK:STDOUT:     %I1.ref: <error> = name_ref I1, <error> [concrete = <error>]
+// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I1.decl.loc23: type = interface_decl @I1.1 [concrete = constants.%I1.type.80c] {} {}
+// CHECK:STDOUT:   %I1.decl.loc28: type = interface_decl @I1.2 [concrete = constants.%I1.type.46a] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I1.1;
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I1.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%x.param_patt: <error>);
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_with_lexical_result.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %I1.type.06a: type = facet_type <@I1.1> [concrete]
+// CHECK:STDOUT:   %Self: %I1.type.06a = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %C.elem: type = unbound_element_type %C, %I1.type.06a [concrete]
+// CHECK:STDOUT:   %I1.type.8ea: type = facet_type <@I1.2> [concrete]
+// CHECK:STDOUT:   %struct_type.v: type = struct_type {.v: %I1.type.06a} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I1.1 {
+// CHECK:STDOUT:   %Self: %I1.type.06a = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I1.2;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %.loc11_10: %C.elem = field_decl v, element0 [concrete]
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %.loc11_5: %C.elem = var_pattern %.loc11_10
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.var: ref %C.elem = var <none>
+// CHECK:STDOUT:   %I1.decl: type = interface_decl @I1.2 [concrete = constants.%I1.type.8ea] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.v [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .I1 = <poisoned>
+// CHECK:STDOUT:   .v = %.loc11_10
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %I1.decl: type = interface_decl @I1.1 [concrete = constants.%I1.type.06a] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- using_poisoned_name_in_impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C1.type: type = facet_type <@C1> [concrete]
+// CHECK:STDOUT:   %Self: %C1.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
+// CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C2: type = class_type @C2 [concrete]
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C1 = %C1.decl
+// CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C1.decl: type = interface_decl @C1 [concrete = constants.%C1.type] {} {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C1 = <poisoned>
+// CHECK:STDOUT:     .F1 = %F1.decl
+// CHECK:STDOUT:     .C2 = %C2.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
+// CHECK:STDOUT:     %x.patt: %C1.type = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %C1.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %C1.type = value_param runtime_param0
+// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1.type]
+// CHECK:STDOUT:     %x: %C1.type = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [concrete = constants.%C2] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @C1 {
+// CHECK:STDOUT:   %Self: %C1.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: %Self.ref as %C1.ref {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = @C2.%impl_witness
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C2 {
+// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C2 [concrete = constants.%C2]
+// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1.type]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [concrete = constants.%impl_witness]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C2
+// CHECK:STDOUT:   .C1 = <poisoned>
+// CHECK:STDOUT:   extend @impl.%C1.ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F1(%x.param_patt: %C1.type);
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -161,7 +161,7 @@ interface N.I;
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should fail since N.F1 was poisoned in the api.
+// TODO: #4622 This should fail since N.F1 was poisoned in the api.
 interface N.I;
 
 // --- fail_poison_when_lookup_fails.carbon

--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -17,10 +17,10 @@ interface I;
 // `N.F` uses `N.I` and not `package.I`.
 namespace N;
 interface N.I {}
-fn N.F(x: I);
+fn N.F(x: I*);
 
-fn TestCall(x: N.I) {
-  // `N.F` accepts an `N.I` not a `package.I`.
+fn TestCall(x: N.I*) {
+  // `N.F` accepts an `N.I*` not a `package.I*`.
   N.F(x);
 }
 
@@ -32,7 +32,7 @@ interface I;
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-fn N.F(x: I);
+fn N.F(x: I*);
 
 // --- fail_declare_after_poison.carbon
 
@@ -43,9 +43,9 @@ interface I;
 namespace N;
 // Use `package.I` and poison `N.I`.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR: fn N.F(x: I*);
 // CHECK:STDERR:           ^
-fn N.F(x: I);
+fn N.F(x: I*);
 
 // Failure: N.I declared after it was poisoned.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
@@ -62,13 +62,13 @@ interface I;
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-fn N.F1(x: I);
+fn N.F1(x: I*);
 
 // CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
-// CHECK:STDERR: fn N.F2(x: N.I);
+// CHECK:STDERR: fn N.F2(x: N.I*);
 // CHECK:STDERR:            ^~~
 // CHECK:STDERR:
-fn N.F2(x: N.I);
+fn N.F2(x: N.I*);
 
 // --- fail_use_declaration_after_poison.carbon
 
@@ -79,9 +79,9 @@ interface I;
 namespace N;
 // Use `package.I` and poison `N.I`.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: I);
+// CHECK:STDERR: fn N.F1(x: I*);
 // CHECK:STDERR:            ^
-fn N.F1(x: I);
+fn N.F1(x: I*);
 
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: interface N.I;
@@ -90,10 +90,10 @@ fn N.F1(x: I);
 interface N.I;
 
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
-// CHECK:STDERR: fn N.F2(x: N.I);
+// CHECK:STDERR: fn N.F2(x: N.I*);
 // CHECK:STDERR:            ^~~
 // CHECK:STDERR:
-fn N.F2(x: N.I);
+fn N.F2(x: N.I*);
 
 // --- fail_alias.carbon
 
@@ -125,16 +125,16 @@ interface I2 {
       // * `I2.I3.I1`
       // * `I2.I3.I4.I1`
       // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
-      // CHECK:STDERR:       fn F(x: I1);
+      // CHECK:STDERR:       fn F(x: I1*);
       // CHECK:STDERR:               ^~
-      fn F(x: I1);
+      fn F(x: I1*);
 
       // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:17: note: declared here [NameUseBeforeDeclNote]
       // CHECK:STDERR:       interface I1;
       // CHECK:STDERR:                 ^~
       // CHECK:STDERR:
       // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
-      // CHECK:STDERR:       fn F(x: I1);
+      // CHECK:STDERR:       fn F(x: I1*);
       // CHECK:STDERR:               ^~
       interface I1;
     }
@@ -143,7 +143,7 @@ interface I2 {
     // CHECK:STDERR:               ^~
     // CHECK:STDERR:
     // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-15]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
-    // CHECK:STDERR:       fn F(x: I1);
+    // CHECK:STDERR:       fn F(x: I1*);
     // CHECK:STDERR:               ^~
     interface I1;
   }
@@ -176,13 +176,13 @@ library "[[@TEST_NAME]]";
 namespace N;
 // `package.I` and `N.I` poisoned when not found.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `I` not found [NameNotFound]
-// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR: fn N.F(x: I*);
 // CHECK:STDERR:           ^
 // CHECK:STDERR:
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR: fn N.F(x: I*);
 // CHECK:STDERR:           ^
-fn N.F(x: I);
+fn N.F(x: I*);
 
 // TODO: We should ideally only produce one diagnostic here.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
@@ -190,7 +190,7 @@ fn N.F(x: I);
 // CHECK:STDERR:           ^
 // CHECK:STDERR:
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR: fn N.F(x: I*);
 // CHECK:STDERR:           ^
 interface I;
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
@@ -228,7 +228,7 @@ interface I {};
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-fn N.F1(x: I);
+fn N.F1(x: I*);
 
 class N.C {
   extend impl as I {
@@ -241,6 +241,7 @@ class N.C {
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
 // CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I.type.4da [concrete]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
@@ -261,23 +262,27 @@ class N.C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc8: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: %I.type.4da = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type.4da = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type.4da = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
-// CHECK:STDOUT:     %x: %I.type.4da = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc9: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.4da [concrete = constants.%ptr]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestCall.decl: %TestCall.type = fn_decl @TestCall [concrete = constants.%TestCall] {
-// CHECK:STDOUT:     %x.patt: %I.type.4da = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type.4da = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type.4da = value_param runtime_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %I.ref [concrete = constants.%I.type.4da] {
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc11: type = splice_block %ptr [concrete = constants.%ptr] {
 // CHECK:STDOUT:       %N.ref.loc11: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.4da [concrete = constants.%ptr]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %I.type.4da = bind_name x, %x.param
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -291,13 +296,13 @@ class N.C {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: %I.type.4da);
+// CHECK:STDOUT: fn @F(%x.param_patt: %ptr);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @TestCall(%x.param_patt: %I.type.4da) {
+// CHECK:STDOUT: fn @TestCall(%x.param_patt: %ptr) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %N.ref.loc13: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %x.ref: %I.type.4da = name_ref x, %x
+// CHECK:STDOUT:   %x.ref: %ptr = name_ref x, %x
 // CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.ref(%x.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -306,6 +311,7 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I.type [concrete]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -321,23 +327,27 @@ class N.C {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc8: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type [concrete = constants.%ptr]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: %I.type);
+// CHECK:STDOUT: fn @F(%x.param_patt: %ptr);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_declare_after_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I.type.733 [concrete]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
@@ -355,12 +365,15 @@ class N.C {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: %I.type.733 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
-// CHECK:STDOUT:     %x: %I.type.733 = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc11: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.733 [concrete = constants.%ptr]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc18: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT: }
@@ -375,12 +388,13 @@ class N.C {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: %I.type.733);
+// CHECK:STDOUT: fn @F(%x.param_patt: %ptr);
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_use_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I.type [concrete]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
@@ -400,21 +414,25 @@ class N.C {
 // CHECK:STDOUT:     .F2 = %F2.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc8: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type [concrete = constants.%ptr]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
 // CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
 // CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
+// CHECK:STDOUT:     %.loc14: type = splice_block %ptr [concrete = <error>] {
 // CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:       %ptr: type = ptr_type <error> [concrete = <error>]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
 // CHECK:STDOUT:   }
@@ -422,7 +440,7 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %ptr);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
 // CHECK:STDOUT:
@@ -430,6 +448,7 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I.type.733 [concrete]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
@@ -450,12 +469,15 @@ class N.C {
 // CHECK:STDOUT:     .F2 = %F2.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %I.type.733 = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
-// CHECK:STDOUT:     %x: %I.type.733 = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc11: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.733 [concrete = constants.%ptr]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc17: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
@@ -463,9 +485,10 @@ class N.C {
 // CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
+// CHECK:STDOUT:     %.loc23: type = splice_block %ptr [concrete = <error>] {
 // CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:       %ptr: type = ptr_type <error> [concrete = <error>]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
 // CHECK:STDOUT:   }
@@ -475,7 +498,7 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.2;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type.733);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %ptr);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
 // CHECK:STDOUT:
@@ -512,6 +535,7 @@ class N.C {
 // CHECK:STDOUT:   %I4.type.451: type = facet_type <@I4> [concrete]
 // CHECK:STDOUT:   %I4.type.78e: type = facet_type <@I4, @I4(%Self.c7b, %Self.60c)> [symbolic]
 // CHECK:STDOUT:   %Self.a4d: %I4.type.78e = bind_symbolic_name Self, 2 [symbolic]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I1.type.80c [concrete]
 // CHECK:STDOUT:   %F.type: type = fn_type @F, @I4(%Self.c7b, %Self.60c) [symbolic]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [symbolic]
 // CHECK:STDOUT:   %I4.assoc_type: type = assoc_entity_type %I4.type.78e [symbolic]
@@ -572,25 +596,28 @@ class N.C {
 // CHECK:STDOUT:   %F.type: type = fn_type @F, @I4(%Self.2, %Self.3) [symbolic = %F.type (constants.%F.type)]
 // CHECK:STDOUT:   %F: @I4.%F.type (%F.type) = struct_value () [symbolic = %F (constants.%F)]
 // CHECK:STDOUT:   %I4.assoc_type: type = assoc_entity_type @I4.%I4.type (%I4.type.78e) [symbolic = %I4.assoc_type (constants.%I4.assoc_type)]
-// CHECK:STDOUT:   %assoc0.loc16_18.2: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_18.2 (constants.%assoc0)]
+// CHECK:STDOUT:   %assoc0.loc16_19.2: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_19.2 (constants.%assoc0)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.1: @I4.%I4.type (%I4.type.78e) = bind_symbolic_name Self, 2 [symbolic = %Self.4 (constants.%Self.a4d)]
 // CHECK:STDOUT:     %F.decl: @I4.%F.type (%F.type) = fn_decl @F [symbolic = @I4.%F (constants.%F)] {
-// CHECK:STDOUT:       %x.patt: %I1.type.80c = binding_pattern x
-// CHECK:STDOUT:       %x.param_patt: %I1.type.80c = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:       %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:       %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %x.param: %I1.type.80c = value_param runtime_param0
-// CHECK:STDOUT:       %I1.ref: type = name_ref I1, file.%I1.decl [concrete = constants.%I1.type.80c]
-// CHECK:STDOUT:       %x: %I1.type.80c = bind_name x, %x.param
+// CHECK:STDOUT:       %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:       %.loc16: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:         %I1.ref: type = name_ref I1, file.%I1.decl [concrete = constants.%I1.type.80c]
+// CHECK:STDOUT:         %ptr: type = ptr_type %I1.type.80c [concrete = constants.%ptr]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %assoc0.loc16_18.1: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_18.2 (constants.%assoc0)]
+// CHECK:STDOUT:     %assoc0.loc16_19.1: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_19.2 (constants.%assoc0)]
 // CHECK:STDOUT:     %I1.decl: type = interface_decl @I1.2 [concrete = constants.%I1.type.f4e] {} {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.1
 // CHECK:STDOUT:     .I1 = <poisoned>
-// CHECK:STDOUT:     .F = %assoc0.loc16_18.1
+// CHECK:STDOUT:     .F = %assoc0.loc16_19.1
 // CHECK:STDOUT:     witness = (%F.decl)
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -608,7 +635,7 @@ class N.C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f), @I4.%Self.1: @I4.%I4.type (%I4.type.78e)) {
-// CHECK:STDOUT:   fn(%x.param_patt: %I1.type.80c);
+// CHECK:STDOUT:   fn(%x.param_patt: %ptr);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I3(constants.%Self.c7b) {}
@@ -703,7 +730,10 @@ class N.C {
 // CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:     %.loc13: type = splice_block %ptr [concrete = <error>] {
+// CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:       %ptr: type = ptr_type <error> [concrete = <error>]
+// CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc23: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
@@ -775,6 +805,7 @@ class N.C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
 // CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %ptr: type = ptr_type %I.type [concrete]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
@@ -795,12 +826,15 @@ class N.C {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
+// CHECK:STDOUT:     %.loc8: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:       %ptr: type = ptr_type %I.type [concrete = constants.%ptr]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
@@ -833,5 +867,5 @@ class N.C {
 // CHECK:STDOUT:   extend @impl.%I.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %ptr);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -14,10 +14,15 @@ library "[[@TEST_NAME]]";
 
 interface I;
 
-// N.F uses N.I and not I.
+// `N.F` uses `N.I` and not `package.I`.
 namespace N;
 interface N.I {}
 fn N.F(x: I);
+
+fn TestCall(x: N.I) {
+  // `N.F` accepts an `N.I` not a `package.I`.
+  N.F(x);
+}
 
 // --- poison.carbon
 
@@ -26,7 +31,7 @@ library "[[@TEST_NAME]]";
 interface I;
 
 namespace N;
-// Use I and poison N.I.
+// Use `package.I` and poison `N.I`.
 fn N.F(x: I);
 
 // --- fail_declare_after_poison.carbon
@@ -36,7 +41,7 @@ library "[[@TEST_NAME]]";
 interface I;
 
 namespace N;
-// Use I and poison N.I.
+// Use `package.I` and poison `N.I`.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: fn N.F(x: I);
 // CHECK:STDERR:           ^
@@ -56,7 +61,7 @@ library "[[@TEST_NAME]]";
 interface I;
 
 namespace N;
-// Use I and poison N.I.
+// Use `package.I` and poison `N.I`.
 fn N.F1(x: I);
 
 // CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
@@ -72,7 +77,7 @@ library "[[@TEST_NAME]]";
 interface I;
 
 namespace N;
-// Use I and poison N.I.
+// Use `package.I` and poison `N.I`.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: fn N.F1(x: I);
 // CHECK:STDERR:            ^
@@ -115,10 +120,10 @@ interface I1;
 interface I2 {
   interface I3 {
     interface I4 {
-      // Use I1 and poison:
-      // * I2.I1
-      // * I2.I3.I1
-      // * I2.I3.I4.I1
+      // Use `package.I1` and poison:
+      // * `I2.I1`
+      // * `I2.I3.I1`
+      // * `I2.I3.I4.I1`
       // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
       // CHECK:STDERR:       fn F(x: I1);
       // CHECK:STDERR:               ^~
@@ -161,7 +166,7 @@ interface N.I;
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: #4622 This should fail since N.F1 was poisoned in the api.
+// TODO: #4622 This should fail since `N.I` was poisoned in the api.
 interface N.I;
 
 // --- fail_poison_when_lookup_fails.carbon
@@ -169,30 +174,30 @@ interface N.I;
 library "[[@TEST_NAME]]";
 
 namespace N;
-// N.I1 poisoned when not found.
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `I1` not found [NameNotFound]
-// CHECK:STDERR: fn N.F(x: I1);
-// CHECK:STDERR:           ^~
+// `package.I` and `N.I` poisoned when not found.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `I` not found [NameNotFound]
+// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR:           ^
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `I1` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I1);
-// CHECK:STDERR:           ^~
-fn N.F(x: I1);
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR:           ^
+fn N.F(x: I);
 
 // TODO: We should ideally only produce one diagnostic here.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: interface I1;
-// CHECK:STDERR:           ^~
+// CHECK:STDERR: interface I;
+// CHECK:STDERR:           ^
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `I1` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I1);
-// CHECK:STDERR:           ^~
-interface I1;
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x: I);
+// CHECK:STDERR:           ^
+interface I;
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
-// CHECK:STDERR: interface N.I1;
-// CHECK:STDERR:             ^~
+// CHECK:STDERR: interface N.I;
+// CHECK:STDERR:             ^
 // CHECK:STDERR:
-interface N.I1;
+interface N.I;
 
 // --- fail_poison_with_lexical_result.carbon
 
@@ -219,14 +224,14 @@ fn F() {
 
 library "[[@TEST_NAME]]";
 
-interface C1 {};
+interface I {};
 
 namespace N;
-// Use C1 and poison N.C1.
-fn N.F1(x: C1);
+// Use `package.I` and poison `N.I`.
+fn N.F1(x: I);
 
-class N.C2 {
-  extend impl as C1 {
+class N.C {
+  extend impl as I {
   }
 }
 
@@ -237,13 +242,17 @@ class N.C2 {
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
 // CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %TestCall.type: type = fn_type @TestCall [concrete]
+// CHECK:STDOUT:   %TestCall: %TestCall.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .I = %I.decl.loc4
 // CHECK:STDOUT:     .N = %N
+// CHECK:STDOUT:     .TestCall = %TestCall.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc4: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
@@ -259,6 +268,17 @@ class N.C2 {
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
 // CHECK:STDOUT:     %x: %I.type.4da = bind_name x, %x.param
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %TestCall.decl: %TestCall.type = fn_decl @TestCall [concrete = constants.%TestCall] {
+// CHECK:STDOUT:     %x.patt: %I.type.4da = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type.4da = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %x.param: %I.type.4da = value_param runtime_param0
+// CHECK:STDOUT:     %.loc11: type = splice_block %I.ref [concrete = constants.%I.type.4da] {
+// CHECK:STDOUT:       %N.ref.loc11: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: %I.type.4da = bind_name x, %x.param
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.1;
@@ -272,6 +292,15 @@ class N.C2 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%x.param_patt: %I.type.4da);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @TestCall(%x.param_patt: %I.type.4da) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %N.ref.loc13: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %x.ref: %I.type.4da = name_ref x, %x
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.ref(%x.ref)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.carbon
 // CHECK:STDOUT:
@@ -656,17 +685,17 @@ class N.C2 {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
-// CHECK:STDOUT:   %I1.type.80c: type = facet_type <@I1.1> [concrete]
-// CHECK:STDOUT:   %I1.type.46a: type = facet_type <@I1.2> [concrete]
+// CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
+// CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .N = %N
-// CHECK:STDOUT:     .I1 = <poisoned>
+// CHECK:STDOUT:     .I = <poisoned>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I1 = <poisoned>
+// CHECK:STDOUT:     .I = <poisoned>
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
@@ -674,16 +703,16 @@ class N.C2 {
 // CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %I1.ref: <error> = name_ref I1, <error> [concrete = <error>]
+// CHECK:STDOUT:     %I.ref: <error> = name_ref I, <error> [concrete = <error>]
 // CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I1.decl.loc23: type = interface_decl @I1.1 [concrete = constants.%I1.type.80c] {} {}
-// CHECK:STDOUT:   %I1.decl.loc28: type = interface_decl @I1.2 [concrete = constants.%I1.type.46a] {} {}
+// CHECK:STDOUT:   %I.decl.loc23: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
+// CHECK:STDOUT:   %I.decl.loc28: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @I1.1;
+// CHECK:STDOUT: interface @I.1;
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @I1.2;
+// CHECK:STDOUT: interface @I.2;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%x.param_patt: <error>);
 // CHECK:STDOUT:
@@ -744,11 +773,11 @@ class N.C2 {
 // CHECK:STDOUT: --- using_poisoned_name_in_impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C1.type: type = facet_type <@C1> [concrete]
-// CHECK:STDOUT:   %Self: %C1.type = bind_symbolic_name Self, 0 [symbolic]
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
-// CHECK:STDOUT:   %C2: type = class_type @C2 [concrete]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
@@ -756,53 +785,53 @@ class N.C2 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C1 = %C1.decl
+// CHECK:STDOUT:     .I = %I.decl
 // CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C1.decl: type = interface_decl @C1 [concrete = constants.%C1.type] {} {}
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
 // CHECK:STDOUT:   %N: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C1 = <poisoned>
+// CHECK:STDOUT:     .I = <poisoned>
 // CHECK:STDOUT:     .F1 = %F1.decl
-// CHECK:STDOUT:     .C2 = %C2.decl
+// CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %C1.type = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %C1.type = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt: %I.type = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt, runtime_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %C1.type = value_param runtime_param0
-// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1.type]
-// CHECK:STDOUT:     %x: %C1.type = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param0
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %x: %I.type = bind_name x, %x.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C2.decl: type = class_decl @C2 [concrete = constants.%C2] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: interface @C1 {
-// CHECK:STDOUT:   %Self: %C1.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
+// CHECK:STDOUT: interface @I {
+// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %Self.ref as %C1.ref {
+// CHECK:STDOUT: impl @impl: %Self.ref as %I.ref {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = @C2.%impl_witness
+// CHECK:STDOUT:   witness = @C.%impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C2 {
+// CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C2 [concrete = constants.%C2]
-// CHECK:STDOUT:     %C1.ref: type = name_ref C1, file.%C1.decl [concrete = constants.%C1.type]
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [concrete = constants.%C]
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl_witness: <witness> = impl_witness () [concrete = constants.%impl_witness]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C2
-// CHECK:STDOUT:   .C1 = <poisoned>
-// CHECK:STDOUT:   extend @impl.%C1.ref
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .I = <poisoned>
+// CHECK:STDOUT:   extend @impl.%I.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %C1.type);
+// CHECK:STDOUT: fn @F1(%x.param_patt: %I.type);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
@@ -1,0 +1,386 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+
+// --- no_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+
+// N2.N3 uses N2.N1 and not N1.
+namespace N2;
+namespace N2.N1;
+alias N2.N3 = N1;
+
+// --- poison.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+
+// Use N1 and poison N2.N1.
+namespace N2;
+alias N2.N3 = N1;
+
+// --- fail_declare_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+
+// Use N1 and poison N2.N1.
+namespace N2;
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:15: error: name `N1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N2.N3 = N1;
+// CHECK:STDERR:               ^~
+alias N2.N3 = N1;
+
+// Failure: N2.N1 declared after it was poisoned.
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:14: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N2.N1;
+// CHECK:STDERR:              ^~
+// CHECK:STDERR:
+namespace N2.N1;
+
+// --- fail_use_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+
+// Use N1 and poison N2.N1.
+namespace N2;
+alias N2.N3 = N1;
+
+// CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:15: error: member name `N1` not found in `N2` [MemberNameNotFoundInScope]
+// CHECK:STDERR: alias N2.N4 = N2.N1;
+// CHECK:STDERR:               ^~~~~
+// CHECK:STDERR:
+alias N2.N4 = N2.N1;
+
+// --- fail_use_declaration_after_poison.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+
+// Use N1 and poison N2.N1.
+namespace N2;
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:15: error: name `N1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N2.N3 = N1;
+// CHECK:STDERR:               ^~
+alias N2.N3 = N1;
+
+// Failure: N2.N1 declared after it was poisoned.
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:14: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N2.N1;
+// CHECK:STDERR:              ^~
+// CHECK:STDERR:
+namespace N2.N1;
+
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:15: error: member name `N1` not found in `N2` [MemberNameNotFoundInScope]
+// CHECK:STDERR: alias N2.N4 = N2.N1;
+// CHECK:STDERR:               ^~~~~
+// CHECK:STDERR:
+alias N2.N4 = N2.N1;
+
+// --- fail_alias.carbon
+
+namespace N1;
+
+namespace N2;
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+7]]:15: error: name `N1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N2.N1 = N1;
+// CHECK:STDERR:               ^~
+// CHECK:STDERR: fail_alias.carbon:[[@LINE+4]]:10: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: alias N2.N1 = N1;
+// CHECK:STDERR:          ^~
+// CHECK:STDERR:
+alias N2.N1 = N1;
+
+// --- fail_poison_multiple_scopes.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+namespace N2;
+namespace N2.N3;
+namespace N2.N3.N4;
+// Use N1 and poison:
+// * N2.N1
+// * N2.N3.N1
+// * N2.N3.N4.N1
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:21: error: name `N1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N2.N3.N4.N5 = N1;
+// CHECK:STDERR:                     ^~
+alias N2.N3.N4.N5 = N1;
+
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:20: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N2.N3.N4.N1;
+// CHECK:STDERR:                    ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:21: error: name `N1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N2.N3.N4.N5 = N1;
+// CHECK:STDERR:                     ^~
+namespace N2.N3.N4.N1;
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:17: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N2.N3.N1;
+// CHECK:STDERR:                 ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-14]]:21: error: name `N1` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N2.N3.N4.N5 = N1;
+// CHECK:STDERR:                     ^~
+namespace N2.N3.N1;
+// CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:14: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N2.N1;
+// CHECK:STDERR:              ^~
+// CHECK:STDERR:
+namespace N2.N1;
+
+// --- ignored_poison_in_import.carbon
+
+library "[[@TEST_NAME]]";
+import library "poison";
+
+// This doesn't fail.
+namespace N2.N1;
+
+// --- poison.impl.carbon
+
+impl library "[[@TEST_NAME]]";
+
+// TODO: This should fail since N2.N1 was poisoned in the api.
+namespace N2.N1;
+
+// --- fail_poison_when_lookup_fails.carbon
+
+library "[[@TEST_NAME]]";
+
+namespace N1;
+// N1.N3 poisoned when not found.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:15: error: name `N3` not found [NameNotFound]
+// CHECK:STDERR: alias N1.N2 = N3;
+// CHECK:STDERR:               ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:15: error: name `N3` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N1.N2 = N3;
+// CHECK:STDERR:               ^~
+alias N1.N2 = N3;
+
+// TODO: We should ideally only produce one diagnostic here.
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N3;
+// CHECK:STDERR:           ^~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:15: error: name `N3` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: alias N1.N2 = N3;
+// CHECK:STDERR:               ^~
+namespace N3;
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:14: note: declared here [NameUseBeforeDeclNote]
+// CHECK:STDERR: namespace N1.N3;
+// CHECK:STDERR:              ^~
+// CHECK:STDERR:
+namespace N1.N3;
+
+// CHECK:STDOUT: --- no_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1.loc4
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1.loc8
+// CHECK:STDOUT:     .N3 = %N3
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.loc8: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc8 [concrete = %N1.loc8]
+// CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1.loc8 [concrete = %N1.loc8]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:     .N3 = %N3
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1 [concrete = %N1]
+// CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1 [concrete = %N1]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_declare_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1.loc4
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:     .N3 = %N3
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc4 [concrete = %N1.loc4]
+// CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1.loc4 [concrete = %N1.loc4]
+// CHECK:STDOUT:   %N1.loc18: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_use_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:     .N3 = %N3
+// CHECK:STDOUT:     .N2 = <poisoned>
+// CHECK:STDOUT:     .N4 = %N4
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.ref.loc8: <namespace> = name_ref N1, %N1 [concrete = %N1]
+// CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1 [concrete = %N1]
+// CHECK:STDOUT:   %N2.ref: <namespace> = name_ref N2, %N2 [concrete = %N2]
+// CHECK:STDOUT:   %N1.ref.loc14: <error> = name_ref N1, <error> [concrete = <error>]
+// CHECK:STDOUT:   %N4: <error> = bind_alias N4, <error> [concrete = <error>]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_use_declaration_after_poison.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1.loc4
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:     .N3 = %N3
+// CHECK:STDOUT:     .N2 = <poisoned>
+// CHECK:STDOUT:     .N4 = %N4
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.ref.loc11: <namespace> = name_ref N1, %N1.loc4 [concrete = %N1.loc4]
+// CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1.loc4 [concrete = %N1.loc4]
+// CHECK:STDOUT:   %N1.loc18: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2.ref: <namespace> = name_ref N2, %N2 [concrete = %N2]
+// CHECK:STDOUT:   %N1.ref.loc24: <error> = name_ref N1, <error> [concrete = <error>]
+// CHECK:STDOUT:   %N4: <error> = bind_alias N4, <error> [concrete = <error>]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_alias.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1.loc2
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.loc2: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc2 [concrete = %N1.loc2]
+// CHECK:STDOUT:   %N1.loc12: <namespace> = bind_alias N1, %N1.loc2 [concrete = %N1.loc2]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_multiple_scopes.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1.loc4
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N3 = %N3
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N3: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N4 = %N4
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N4: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = <poisoned>
+// CHECK:STDOUT:     .N5 = %N5
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc4 [concrete = %N1.loc4]
+// CHECK:STDOUT:   %N5: <namespace> = bind_alias N5, %N1.loc4 [concrete = %N1.loc4]
+// CHECK:STDOUT:   %N1.loc24: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N1.loc32: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N1.loc37: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- ignored_poison_in_import.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.N1: <namespace> = import_ref Main//poison, N1, loaded
+// CHECK:STDOUT:   %N1: <namespace> = namespace %Main.N1, [concrete] {}
+// CHECK:STDOUT:   %Main.N2: <namespace> = import_ref Main//poison, N2, loaded
+// CHECK:STDOUT:   %N2: <namespace> = namespace %Main.N2, [concrete] {
+// CHECK:STDOUT:     .N3 = %Main.N3
+// CHECK:STDOUT:     .N1 = file.%N1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = imports.%N1
+// CHECK:STDOUT:     .N2 = imports.%N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import = import <none>
+// CHECK:STDOUT:   %N1: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- poison.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.N2: <namespace> = import_ref Main//poison, N2, loaded
+// CHECK:STDOUT:   %N2: <namespace> = namespace %Main.N2, [concrete] {
+// CHECK:STDOUT:     .N3 = %Main.N3
+// CHECK:STDOUT:     .N1 = file.%N1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Main.N1: <namespace> = import_ref Main//poison, N1, loaded
+// CHECK:STDOUT:   %N1: <namespace> = namespace %Main.N1, [concrete] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N2 = imports.%N2
+// CHECK:STDOUT:     .N1 = imports.%N1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %N1: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_poison_when_lookup_fails.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N1 = %N1
+// CHECK:STDOUT:     .N3 = <poisoned>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N1: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .N3 = <poisoned>
+// CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N3.ref: <error> = name_ref N3, <error> [concrete = <error>]
+// CHECK:STDOUT:   %N2: <error> = bind_alias N2, <error> [concrete = <error>]
+// CHECK:STDOUT:   %N3.loc23: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N3.loc28: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
@@ -156,7 +156,7 @@ namespace N2.N1;
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should fail since N2.N1 was poisoned in the api.
+// TODO: #4622 This should fail since N2.N1 was poisoned in the api.
 namespace N2.N1;
 
 // --- fail_poison_when_lookup_fails.carbon

--- a/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
@@ -20,6 +20,7 @@ namespace N2.N1;
 alias N2.N3 = N1;
 
 class N2.N1.C {}
+class N1.C {}
 fn TestNamespaces() {
   var x: N2.N1.C;
   var y: N2.N3.C* = &x;
@@ -198,12 +199,13 @@ namespace N1.N3;
 // CHECK:STDOUT: --- no_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %C.2a3: type = class_type @C.1 [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %C.0b8: type = class_type @C.2 [concrete]
 // CHECK:STDOUT:   %TestNamespaces.type: type = fn_type @TestNamespaces [concrete]
 // CHECK:STDOUT:   %TestNamespaces: %TestNamespaces.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ptr.33b: type = ptr_type %C [concrete]
+// CHECK:STDOUT:   %ptr.33b: type = ptr_type %C.2a3 [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -212,54 +214,65 @@ namespace N1.N3;
 // CHECK:STDOUT:     .N2 = %N2
 // CHECK:STDOUT:     .TestNamespaces = %TestNamespaces.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl.loc12
+// CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .N1 = %N1.loc8
 // CHECK:STDOUT:     .N3 = %N3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N1.loc8: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .C = %C.decl.loc11
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc8 [concrete = %N1.loc8]
 // CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1.loc8 [concrete = %N1.loc8]
-// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc11: type = class_decl @C.1 [concrete = constants.%C.2a3] {} {}
+// CHECK:STDOUT:   %C.decl.loc12: type = class_decl @C.2 [concrete = constants.%C.0b8] {} {}
 // CHECK:STDOUT:   %TestNamespaces.decl: %TestNamespaces.type = fn_decl @TestNamespaces [concrete = constants.%TestNamespaces] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @C {
+// CHECK:STDOUT: class @C.1 {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT:   .Self = constants.%C.2a3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C.2 {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C.0b8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestNamespaces() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
-// CHECK:STDOUT:     %.loc13_3: %C = var_pattern %x.patt
+// CHECK:STDOUT:     %x.patt: %C.2a3 = binding_pattern x
+// CHECK:STDOUT:     %.loc14_3: %C.2a3 = var_pattern %x.patt
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %x.var: ref %C = var x
-// CHECK:STDOUT:   %.loc13_15: type = splice_block %C.ref.loc13 [concrete = constants.%C] {
-// CHECK:STDOUT:     %N2.ref.loc13: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
+// CHECK:STDOUT:   %x.var: ref %C.2a3 = var x
+// CHECK:STDOUT:   %.loc14_15: type = splice_block %C.ref.loc14 [concrete = constants.%C.2a3] {
+// CHECK:STDOUT:     %N2.ref.loc14: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
 // CHECK:STDOUT:     %N1.ref: <namespace> = name_ref N1, file.%N1.loc8 [concrete = file.%N1.loc8]
-// CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc14: type = name_ref C, file.%C.decl.loc11 [concrete = constants.%C.2a3]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %x: ref %C = bind_name x, %x.var
+// CHECK:STDOUT:   %x: ref %C.2a3 = bind_name x, %x.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %y.patt: %ptr.33b = binding_pattern y
-// CHECK:STDOUT:     %.loc14_3: %ptr.33b = var_pattern %y.patt
+// CHECK:STDOUT:     %.loc15_3: %ptr.33b = var_pattern %y.patt
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %y.var: ref %ptr.33b = var y
-// CHECK:STDOUT:   %x.ref: ref %C = name_ref x, %x
+// CHECK:STDOUT:   %x.ref: ref %C.2a3 = name_ref x, %x
 // CHECK:STDOUT:   %addr: %ptr.33b = addr_of %x.ref
 // CHECK:STDOUT:   assign %y.var, %addr
-// CHECK:STDOUT:   %.loc14_17: type = splice_block %ptr [concrete = constants.%ptr.33b] {
-// CHECK:STDOUT:     %N2.ref.loc14: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
+// CHECK:STDOUT:   %.loc15_17: type = splice_block %ptr [concrete = constants.%ptr.33b] {
+// CHECK:STDOUT:     %N2.ref.loc15: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
 // CHECK:STDOUT:     %N3.ref: <namespace> = name_ref N3, file.%N3 [concrete = file.%N1.loc8]
-// CHECK:STDOUT:     %C.ref.loc14: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %ptr: type = ptr_type %C [concrete = constants.%ptr.33b]
+// CHECK:STDOUT:     %C.ref.loc15: type = name_ref C, file.%C.decl.loc11 [concrete = constants.%C.2a3]
+// CHECK:STDOUT:     %ptr: type = ptr_type %C.2a3 [concrete = constants.%ptr.33b]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %y: ref %ptr.33b = bind_name y, %y.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
@@ -14,10 +14,16 @@ library "[[@TEST_NAME]]";
 
 namespace N1;
 
-// N2.N3 uses N2.N1 and not N1.
+// `N2.N3` uses `N2.N1` and not `package.N1`.
 namespace N2;
 namespace N2.N1;
 alias N2.N3 = N1;
+
+class N2.N1.S {}
+fn TestNamespaces() {
+  var x: N2.N1.S;
+  var y: N2.N3.S* = &x;
+}
 
 // --- poison.carbon
 
@@ -25,7 +31,7 @@ library "[[@TEST_NAME]]";
 
 namespace N1;
 
-// Use N1 and poison N2.N1.
+// Use `package.N1` and poison `N2.N1`.
 namespace N2;
 alias N2.N3 = N1;
 
@@ -35,7 +41,7 @@ library "[[@TEST_NAME]]";
 
 namespace N1;
 
-// Use N1 and poison N2.N1.
+// Use `package.N1` and poison `N2.N1`.
 namespace N2;
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:15: error: name `N1` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: alias N2.N3 = N1;
@@ -55,7 +61,7 @@ library "[[@TEST_NAME]]";
 
 namespace N1;
 
-// Use N1 and poison N2.N1.
+// Use `package.N1` and poison `N2.N1`.
 namespace N2;
 alias N2.N3 = N1;
 
@@ -71,14 +77,14 @@ library "[[@TEST_NAME]]";
 
 namespace N1;
 
-// Use N1 and poison N2.N1.
+// Use `package.N1` and poison `N2.N1`.
 namespace N2;
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:15: error: name `N1` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: alias N2.N3 = N1;
 // CHECK:STDERR:               ^~
 alias N2.N3 = N1;
 
-// Failure: N2.N1 declared after it was poisoned.
+// Failure: `N2.N1` declared after it was poisoned.
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:14: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: namespace N2.N1;
 // CHECK:STDERR:              ^~
@@ -113,10 +119,10 @@ namespace N1;
 namespace N2;
 namespace N2.N3;
 namespace N2.N3.N4;
-// Use N1 and poison:
-// * N2.N1
-// * N2.N3.N1
-// * N2.N3.N4.N1
+// Use `package.N1` and poison:
+// * `N2.N1`
+// * `N2.N3.N1`
+// * `N2.N3.N4.N1`
 // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:21: error: name `N1` used before it was declared [NameUseBeforeDecl]
 // CHECK:STDERR: alias N2.N3.N4.N5 = N1;
 // CHECK:STDERR:                     ^~
@@ -156,7 +162,7 @@ namespace N2.N1;
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: #4622 This should fail since N2.N1 was poisoned in the api.
+// TODO: #4622 This should fail since `N2.N1` was poisoned in the api.
 namespace N2.N1;
 
 // --- fail_poison_when_lookup_fails.carbon
@@ -164,7 +170,7 @@ namespace N2.N1;
 library "[[@TEST_NAME]]";
 
 namespace N1;
-// N1.N3 poisoned when not found.
+// `N1.N3` poisoned when not found.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:15: error: name `N3` not found [NameNotFound]
 // CHECK:STDERR: alias N1.N2 = N3;
 // CHECK:STDERR:               ^~
@@ -191,19 +197,72 @@ namespace N1.N3;
 
 // CHECK:STDOUT: --- no_poison.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %S: type = class_type @S [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %TestNamespaces.type: type = fn_type @TestNamespaces [concrete]
+// CHECK:STDOUT:   %TestNamespaces: %TestNamespaces.type = struct_value () [concrete]
+// CHECK:STDOUT:   %ptr.251: type = ptr_type %S [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .N1 = %N1.loc4
 // CHECK:STDOUT:     .N2 = %N2
+// CHECK:STDOUT:     .TestNamespaces = %TestNamespaces.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N1.loc4: <namespace> = namespace [concrete] {}
 // CHECK:STDOUT:   %N2: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .N1 = %N1.loc8
 // CHECK:STDOUT:     .N3 = %N3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %N1.loc8: <namespace> = namespace [concrete] {}
+// CHECK:STDOUT:   %N1.loc8: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .S = %S.decl
+// CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc8 [concrete = %N1.loc8]
 // CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1.loc8 [concrete = %N1.loc8]
+// CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
+// CHECK:STDOUT:   %TestNamespaces.decl: %TestNamespaces.type = fn_decl @TestNamespaces [concrete = constants.%TestNamespaces] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @S {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%S
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @TestNamespaces() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %x.patt: %S = binding_pattern x
+// CHECK:STDOUT:     %.loc13_3: %S = var_pattern %x.patt
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %x.var: ref %S = var x
+// CHECK:STDOUT:   %.loc13_15: type = splice_block %S.ref.loc13 [concrete = constants.%S] {
+// CHECK:STDOUT:     %N2.ref.loc13: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
+// CHECK:STDOUT:     %N1.ref: <namespace> = name_ref N1, file.%N1.loc8 [concrete = file.%N1.loc8]
+// CHECK:STDOUT:     %S.ref.loc13: type = name_ref S, file.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %x: ref %S = bind_name x, %x.var
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %y.patt: %ptr.251 = binding_pattern y
+// CHECK:STDOUT:     %.loc14_3: %ptr.251 = var_pattern %y.patt
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %y.var: ref %ptr.251 = var y
+// CHECK:STDOUT:   %x.ref: ref %S = name_ref x, %x
+// CHECK:STDOUT:   %addr: %ptr.251 = addr_of %x.ref
+// CHECK:STDOUT:   assign %y.var, %addr
+// CHECK:STDOUT:   %.loc14_17: type = splice_block %ptr [concrete = constants.%ptr.251] {
+// CHECK:STDOUT:     %N2.ref.loc14: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
+// CHECK:STDOUT:     %N3.ref: <namespace> = name_ref N3, file.%N3 [concrete = file.%N1.loc8]
+// CHECK:STDOUT:     %S.ref.loc14: type = name_ref S, file.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:     %ptr: type = ptr_type %S [concrete = constants.%ptr.251]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %y: ref %ptr.251 = bind_name y, %y.var
+// CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.carbon

--- a/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/namespace/no_prelude/name_poisoning.carbon
@@ -19,10 +19,10 @@ namespace N2;
 namespace N2.N1;
 alias N2.N3 = N1;
 
-class N2.N1.S {}
+class N2.N1.C {}
 fn TestNamespaces() {
-  var x: N2.N1.S;
-  var y: N2.N3.S* = &x;
+  var x: N2.N1.C;
+  var y: N2.N3.C* = &x;
 }
 
 // --- poison.carbon
@@ -198,12 +198,12 @@ namespace N1.N3;
 // CHECK:STDOUT: --- no_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %S: type = class_type @S [concrete]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
 // CHECK:STDOUT:   %TestNamespaces.type: type = fn_type @TestNamespaces [concrete]
 // CHECK:STDOUT:   %TestNamespaces: %TestNamespaces.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ptr.251: type = ptr_type %S [concrete]
+// CHECK:STDOUT:   %ptr.33b: type = ptr_type %C [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -218,50 +218,50 @@ namespace N1.N3;
 // CHECK:STDOUT:     .N3 = %N3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N1.loc8: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .S = %S.decl
+// CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %N1.ref: <namespace> = name_ref N1, %N1.loc8 [concrete = %N1.loc8]
 // CHECK:STDOUT:   %N3: <namespace> = bind_alias N3, %N1.loc8 [concrete = %N1.loc8]
-// CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   %TestNamespaces.decl: %TestNamespaces.type = fn_decl @TestNamespaces [concrete = constants.%TestNamespaces] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @S {
+// CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%S
+// CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestNamespaces() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %x.patt: %S = binding_pattern x
-// CHECK:STDOUT:     %.loc13_3: %S = var_pattern %x.patt
+// CHECK:STDOUT:     %x.patt: %C = binding_pattern x
+// CHECK:STDOUT:     %.loc13_3: %C = var_pattern %x.patt
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %x.var: ref %S = var x
-// CHECK:STDOUT:   %.loc13_15: type = splice_block %S.ref.loc13 [concrete = constants.%S] {
+// CHECK:STDOUT:   %x.var: ref %C = var x
+// CHECK:STDOUT:   %.loc13_15: type = splice_block %C.ref.loc13 [concrete = constants.%C] {
 // CHECK:STDOUT:     %N2.ref.loc13: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
 // CHECK:STDOUT:     %N1.ref: <namespace> = name_ref N1, file.%N1.loc8 [concrete = file.%N1.loc8]
-// CHECK:STDOUT:     %S.ref.loc13: type = name_ref S, file.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %x: ref %S = bind_name x, %x.var
+// CHECK:STDOUT:   %x: ref %C = bind_name x, %x.var
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %y.patt: %ptr.251 = binding_pattern y
-// CHECK:STDOUT:     %.loc14_3: %ptr.251 = var_pattern %y.patt
+// CHECK:STDOUT:     %y.patt: %ptr.33b = binding_pattern y
+// CHECK:STDOUT:     %.loc14_3: %ptr.33b = var_pattern %y.patt
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %y.var: ref %ptr.251 = var y
-// CHECK:STDOUT:   %x.ref: ref %S = name_ref x, %x
-// CHECK:STDOUT:   %addr: %ptr.251 = addr_of %x.ref
+// CHECK:STDOUT:   %y.var: ref %ptr.33b = var y
+// CHECK:STDOUT:   %x.ref: ref %C = name_ref x, %x
+// CHECK:STDOUT:   %addr: %ptr.33b = addr_of %x.ref
 // CHECK:STDOUT:   assign %y.var, %addr
-// CHECK:STDOUT:   %.loc14_17: type = splice_block %ptr [concrete = constants.%ptr.251] {
+// CHECK:STDOUT:   %.loc14_17: type = splice_block %ptr [concrete = constants.%ptr.33b] {
 // CHECK:STDOUT:     %N2.ref.loc14: <namespace> = name_ref N2, file.%N2 [concrete = file.%N2]
 // CHECK:STDOUT:     %N3.ref: <namespace> = name_ref N3, file.%N3 [concrete = file.%N1.loc8]
-// CHECK:STDOUT:     %S.ref.loc14: type = name_ref S, file.%S.decl [concrete = constants.%S]
-// CHECK:STDOUT:     %ptr: type = ptr_type %S [concrete = constants.%ptr.251]
+// CHECK:STDOUT:     %C.ref.loc14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %ptr: type = ptr_type %C [concrete = constants.%ptr.33b]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %y: ref %ptr.251 = bind_name y, %y.var
+// CHECK:STDOUT:   %y: ref %ptr.33b = bind_name y, %y.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
This is also following https://github.com/carbon-language/carbon-lang/pull/4900#discussion_r1945606053, which points that name poisoning tests are not in the correct place.
Part of #4622.