### PR TITLE
Configure lldb to support /proc/self/cwd paths

### DIFF
--- a/.vscode/lldb_launch.json
+++ b/.vscode/lldb_launch.json
@@ -12,7 +12,10 @@
         "command script import external/+llvm_project+llvm-project/llvm/utils/lldbDataFormatters.py",
         "settings set target.source-map \".\" \"${workspaceFolder}\""
       ],
-      "env": { "TEST_TMPDIR": "/tmp" }
+      "env": { "TEST_TMPDIR": "/tmp" },
+      "sourceMap": {
+        "/proc/self/cwd/": "${workspaceFolder}"
+      }
     },
     {
       "type": "lldb-dap",


### PR DESCRIPTION
On my machine, the LLVM debug information seems to use source file paths relative to `/proc/self/cwd`, which is the current working directory of whatever process refers to it. Consequently, VSCode can't find those files, because it has a different current working directory. This change enables VSCode to rewrite those paths to a usable form.