### PR TITLE
Small rephrasing of 'partial' interaction with final classes

### DIFF
--- a/docs/design/classes.md
+++ b/docs/design/classes.md
@@ -1409,15 +1409,14 @@ The partial class type for a base class type like `MyBaseType` is written
     `partial MyBaseClass` to `MyBaseClass`. It changes the value by filling in
     the hidden vptr slot. If `MyBaseClass` is abstract, then attempting that
     conversion is an error.
--   `partial MyBaseClass` is considered final, even if `MyBaseClass` is not.
-    This is despite the fact that from a data layout perspective,
-    `partial MyDerivedClass` will have `partial MyBaseClass` as a prefix if
-    `MyDerivedClass` extends `MyBaseClass`. The type `partial MyBaseClass`
-    specifically means "exactly this and no more." This means we don't need to
-    look at the hidden vptr slot, and we can instantiate it even if it doesn't
-    have a virtual [destructor](#destructors).
--   The keyword `partial` may only be applied to a base class. For final
-    classes, there is no need for a second type.
+-   `partial MyBaseClass` is considered final. This is despite the fact that
+    from a data layout perspective, `partial MyDerivedClass` will have
+    `partial MyBaseClass` as a prefix if `MyDerivedClass` extends `MyBaseClass`.
+    The type `partial MyBaseClass` specifically means "exactly this and no
+    more." This means we don't need to look at the hidden vptr slot, and we can
+    instantiate it even if it doesn't have a virtual [destructor](#destructors).
+-   The keyword `partial` is only valid for a `base` or `abstract` class. For
+    final classes, there is no need for a second type.
 
 ##### Usage
 


### PR DESCRIPTION
I believe this reflects the intent, but the phrasing of "even if `MyBaseClass` is not" implies that `MyBaseClass` _can_ be final in `partial MyBaseClass`. Also, make clear it's allowed on `abstract` classes, not only `base` (this seems explicitly intended from the `MyAbstractClass` example around line 1482).