### PR TITLE
Add missing trailing return types

### DIFF
--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -61,7 +61,7 @@ auto ConvertFormatValue(T&& t) -> T&& {
 // without the user writing a cast.
 template <typename T>
   requires(std::is_enum_v<std::remove_reference_t<T>>)
-auto ConvertFormatValue(T&& t) {
+auto ConvertFormatValue(T&& t) -> auto {
   if constexpr (std::is_signed_v<
                     std::underlying_type_t<std::remove_reference_t<T>>>) {
     return static_cast<int64_t>(t);

--- a/testing/base/capture_std_streams.h
+++ b/testing/base/capture_std_streams.h
@@ -25,7 +25,7 @@ auto EndStdStreamCapture(std::string& out, std::string& err) -> void;
 // that are needed when debugging.
 template <typename FnT>
 static auto CallWithCapturedOutput(std::string& out, std::string& err,
-                                   FnT function) {
+                                   FnT function) -> auto {
   Internal::BeginStdStreamCapture();
   auto result = function();
   Internal::EndStdStreamCapture(out, err);

--- a/testing/file_test/test_file.cpp
+++ b/testing/file_test/test_file.cpp
@@ -301,7 +301,7 @@ static auto TryConsumeSplit(llvm::StringRef line, llvm::StringRef line_trimmed,
 // Converts a `FileCheck`-style expectation string into a single complete regex
 // string by escaping all regex characters outside of the designated `{{...}}`
 // regex sequences, and switching those to a normal regex sub-pattern syntax.
-static void ConvertExpectationStringToRegex(std::string& str) {
+static auto ConvertExpectationStringToRegex(std::string& str) -> void {
   for (int pos = 0; pos < static_cast<int>(str.size());) {
     switch (str[pos]) {
       case '(':

--- a/testing/file_test/test_file.h
+++ b/testing/file_test/test_file.h
@@ -23,7 +23,7 @@ namespace Carbon::Testing {
 struct TestFile {
   // Represents a split within the test file.
   struct Split {
-    friend void PrintTo(const Split& f, std::ostream* os) {
+    friend auto PrintTo(const Split& f, std::ostream* os) -> void {
       // Print content escaped.
       llvm::raw_os_ostream os_wrap(*os);
       os_wrap << "Split(" << f.filename << ", \"" << FormatEscaped(f.content)

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -79,7 +79,8 @@ static auto GetImportName(const SemIR::File& import_sem_ir,
 // could also be a builtin name ID which is equivalent cross-IR.
 static auto CopyNameFromImportIR(Context& context,
                                  const SemIR::File& import_sem_ir,
-                                 SemIR::NameId import_name_id) {
+                                 SemIR::NameId import_name_id)
+    -> SemIR::NameId {
   if (auto import_identifier_id = import_name_id.AsIdentifierId();
       import_identifier_id.has_value()) {
     auto name = import_sem_ir.identifiers().Get(import_identifier_id);

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -72,7 +72,7 @@ class ConstantContext {
 
   // Sets the index of the constant we most recently lowered. This is used to
   // check we don't look at constants that we've not lowered yet.
-  auto SetLastLoweredConstantIndex(int32_t index) {
+  auto SetLastLoweredConstantIndex(int32_t index) -> void {
     last_lowered_constant_index_ = index;
   }
 

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -64,7 +64,7 @@ auto FunctionContext::LowerBlockContents(SemIR::InstBlockId block_id) -> void {
 // types, which would make getting the right overload resolution complex.
 template <typename InstT>
 static auto LowerInstHelper(FunctionContext& context, SemIR::InstId inst_id,
-                            InstT inst) {
+                            InstT inst) -> void {
   if constexpr (!InstT::Kind.is_lowered()) {
     CARBON_FATAL(
         "Encountered an instruction that isn't expected to lower. It's "

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -62,7 +62,7 @@ class FunctionContext {
   }
 
   // Sets the value for the given instruction.
-  auto SetLocal(SemIR::InstId inst_id, llvm::Value* value) {
+  auto SetLocal(SemIR::InstId inst_id, llvm::Value* value) -> void {
     bool added = locals_.Insert(inst_id, value).is_inserted();
     CARBON_CHECK(added, "Duplicate local insert: {0} {1}", inst_id,
                  sem_ir().insts().Get(inst_id));
@@ -102,7 +102,7 @@ class FunctionContext {
 
   // Sets the instruction after static allocas. This should be called once,
   // after the first alloca is created.
-  auto SetInstructionAfterAllocas(llvm::Instruction* after_allocas) {
+  auto SetInstructionAfterAllocas(llvm::Instruction* after_allocas) -> void {
     CARBON_CHECK(!after_allocas_);
     after_allocas_ = after_allocas;
   }

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -48,7 +48,9 @@ class NodeExtractor {
   // Saves a checkpoint of our current position so we can return later if
   // extraction of a child node fails.
   auto Checkpoint() const -> CheckpointState { return {.it = it_}; }
-  auto RestoreCheckpoint(CheckpointState checkpoint) { it_ = checkpoint.it; }
+  auto RestoreCheckpoint(CheckpointState checkpoint) -> void {
+    it_ = checkpoint.it;
+  }
 
   // Determines whether the current position matches the specified node kind. If
   // not, produces a suitable trace message.

--- a/toolchain/parse/node_kind.h
+++ b/toolchain/parse/node_kind.h
@@ -196,7 +196,7 @@ class NodeKind::Definition : public NodeKind {
 
   // This is factored out and non-constexpr to improve the compile-time error
   // message if the check below fails.
-  auto MustSpecifyEitherBracketingNodeOrChildCount() {
+  auto MustSpecifyEitherBracketingNodeOrChildCount() -> void {
     CARBON_FATAL("Must specify either bracketing node or fixed child count.");
   }
 

--- a/toolchain/parse/precedence.cpp
+++ b/toolchain/parse/precedence.cpp
@@ -51,9 +51,9 @@ struct PrecedenceGroup::OperatorPriorityTable {
     ConsistencyCheck();
   }
 
-  constexpr void MarkHigherThan(
+  constexpr auto MarkHigherThan(
       std::initializer_list<PrecedenceLevel> higher_group,
-      std::initializer_list<PrecedenceLevel> lower_group) {
+      std::initializer_list<PrecedenceLevel> lower_group) -> void {
     for (auto higher : higher_group) {
       for (auto lower : lower_group) {
         table[higher][lower] = OperatorPriority::LeftFirst;
@@ -61,7 +61,7 @@ struct PrecedenceGroup::OperatorPriorityTable {
     }
   }
 
-  constexpr void MakeTransitivelyClosed() {
+  constexpr auto MakeTransitivelyClosed() -> void {
     // A naive algorithm compiles acceptably fast for now (~0.5s). This should
     // be revisited if we see compile time problems after adding precedence
     // groups; it's easy to do this faster.
@@ -85,7 +85,7 @@ struct PrecedenceGroup::OperatorPriorityTable {
     } while (changed);
   }
 
-  constexpr void MakeSymmetric() {
+  constexpr auto MakeSymmetric() -> void {
     for (int8_t a = 0; a != NumPrecedenceLevels; ++a) {
       for (int8_t b = 0; b != NumPrecedenceLevels; ++b) {
         if (table[a][b] == OperatorPriority::LeftFirst) {
@@ -97,7 +97,7 @@ struct PrecedenceGroup::OperatorPriorityTable {
     }
   }
 
-  constexpr void AddAssociativityRules() {
+  constexpr auto AddAssociativityRules() -> void {
     // Associativity rules occupy the diagonal
 
     // For prefix operators, RightFirst would mean `@@x` is `@(@x)` and
@@ -122,7 +122,7 @@ struct PrecedenceGroup::OperatorPriorityTable {
     // For other operators, we require explicit parentheses.
   }
 
-  constexpr void ConsistencyCheck() {
+  constexpr auto ConsistencyCheck() -> void {
     for (int8_t level = 0; level != NumPrecedenceLevels; ++level) {
       if (level != Highest) {
         CARBON_CHECK(table[Highest][level] == OperatorPriority::LeftFirst &&

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -251,7 +251,7 @@ class Inst : public Printable<Inst> {
   auto SetType(TypeId type_id) -> void { type_id_ = type_id; }
 
   // Sets the arguments of this instruction.
-  auto SetArgs(int32_t arg0, int32_t arg1) {
+  auto SetArgs(int32_t arg0, int32_t arg1) -> void {
     arg0_ = arg0;
     arg1_ = arg1;
   }


### PR DESCRIPTION
Noted CopyNameFromImportIR while glancing around (this one's interesting because it's NameId, not void nor auto), did a scan just for a few other cases. Not an exhaustive fix, and TBH assuming we'd prefer `auto ... -> auto` since equivalent Carbon syntax would probably be `fn ... -> auto`