### PR TITLE
Use Generics in `no_poison` test instead of pointers.

### DIFF
--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -32,7 +32,7 @@ interface I;
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-fn N.F(x: I*);
+fn N.F(x:! I);
 
 // --- fail_declare_after_poison.carbon
 
@@ -42,10 +42,10 @@ interface I;
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I*);
-// CHECK:STDERR:           ^
-fn N.F(x: I*);
+// CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x:! I);
+// CHECK:STDERR:            ^
+fn N.F(x:! I);
 
 // Failure: N.I declared after it was poisoned.
 // CHECK:STDERR: fail_declare_after_poison.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
@@ -62,13 +62,13 @@ interface I;
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-fn N.F1(x: I*);
+fn N.F1(x:! I);
 
-// CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
-// CHECK:STDERR: fn N.F2(x: N.I*);
-// CHECK:STDERR:            ^~~
+// CHECK:STDERR: fail_use_poison.carbon:[[@LINE+4]]:13: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: fn N.F2(x:! N.I);
+// CHECK:STDERR:             ^~~
 // CHECK:STDERR:
-fn N.F2(x: N.I*);
+fn N.F2(x:! N.I);
 
 // --- fail_use_declaration_after_poison.carbon
 
@@ -78,10 +78,10 @@ interface I;
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F1(x: I*);
-// CHECK:STDERR:            ^
-fn N.F1(x: I*);
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+3]]:13: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F1(x:! I);
+// CHECK:STDERR:             ^
+fn N.F1(x:! I);
 
 // CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: interface N.I;
@@ -89,11 +89,11 @@ fn N.F1(x: I*);
 // CHECK:STDERR:
 interface N.I;
 
-// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:12: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
-// CHECK:STDERR: fn N.F2(x: N.I*);
-// CHECK:STDERR:            ^~~
+// CHECK:STDERR: fail_use_declaration_after_poison.carbon:[[@LINE+4]]:13: error: member name `I` not found in `N` [MemberNameNotFoundInScope]
+// CHECK:STDERR: fn N.F2(x:! N.I);
+// CHECK:STDERR:             ^~~
 // CHECK:STDERR:
-fn N.F2(x: N.I*);
+fn N.F2(x:! N.I);
 
 // --- fail_alias.carbon
 
@@ -124,27 +124,27 @@ interface I2 {
       // * `I2.I1`
       // * `I2.I3.I1`
       // * `I2.I3.I4.I1`
-      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
-      // CHECK:STDERR:       fn F(x: I1*);
-      // CHECK:STDERR:               ^~
-      fn F(x: I1*);
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+3]]:16: error: name `I1` used before it was declared [NameUseBeforeDecl]
+      // CHECK:STDERR:       fn F(x:! I1);
+      // CHECK:STDERR:                ^~
+      fn F(x:! I1);
 
       // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:17: note: declared here [NameUseBeforeDeclNote]
       // CHECK:STDERR:       interface I1;
       // CHECK:STDERR:                 ^~
       // CHECK:STDERR:
-      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
-      // CHECK:STDERR:       fn F(x: I1*);
-      // CHECK:STDERR:               ^~
+      // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-6]]:16: error: name `I1` used before it was declared [NameUseBeforeDecl]
+      // CHECK:STDERR:       fn F(x:! I1);
+      // CHECK:STDERR:                ^~
       interface I1;
     }
     // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+7]]:15: note: declared here [NameUseBeforeDeclNote]
     // CHECK:STDERR:     interface I1;
     // CHECK:STDERR:               ^~
     // CHECK:STDERR:
-    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-15]]:15: error: name `I1` used before it was declared [NameUseBeforeDecl]
-    // CHECK:STDERR:       fn F(x: I1*);
-    // CHECK:STDERR:               ^~
+    // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE-15]]:16: error: name `I1` used before it was declared [NameUseBeforeDecl]
+    // CHECK:STDERR:       fn F(x:! I1);
+    // CHECK:STDERR:                ^~
     interface I1;
   }
   // CHECK:STDERR: fail_poison_multiple_scopes.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
@@ -175,23 +175,23 @@ library "[[@TEST_NAME]]";
 
 namespace N;
 // `package.I` and `N.I` poisoned when not found.
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: error: name `I` not found [NameNotFound]
-// CHECK:STDERR: fn N.F(x: I*);
-// CHECK:STDERR:           ^
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:12: error: name `I` not found [NameNotFound]
+// CHECK:STDERR: fn N.F(x:! I);
+// CHECK:STDERR:            ^
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I*);
-// CHECK:STDERR:           ^
-fn N.F(x: I*);
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+3]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x:! I);
+// CHECK:STDERR:            ^
+fn N.F(x:! I);
 
 // TODO: We should ideally only produce one diagnostic here.
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+7]]:11: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: interface I;
 // CHECK:STDERR:           ^
 // CHECK:STDERR:
-// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:11: error: name `I` used before it was declared [NameUseBeforeDecl]
-// CHECK:STDERR: fn N.F(x: I*);
-// CHECK:STDERR:           ^
+// CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE-7]]:12: error: name `I` used before it was declared [NameUseBeforeDecl]
+// CHECK:STDERR: fn N.F(x:! I);
+// CHECK:STDERR:            ^
 interface I;
 // CHECK:STDERR: fail_poison_when_lookup_fails.carbon:[[@LINE+4]]:13: note: declared here [NameUseBeforeDeclNote]
 // CHECK:STDERR: interface N.I;
@@ -228,7 +228,7 @@ interface I {};
 
 namespace N;
 // Use `package.I` and poison `N.I`.
-fn N.F1(x: I*);
+fn N.F1(x:! I);
 
 class N.C {
   extend impl as I {
@@ -342,7 +342,8 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I.type [concrete]
+// CHECK:STDOUT:   %x: %I.type = bind_symbolic_name x, 0 [symbolic]
+// CHECK:STDOUT:   %x.patt: %I.type = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -358,27 +359,35 @@ class N.C {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc8_8.1: %I.type = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc8_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt.loc8_8.1, runtime_param<none> [symbolic = %x.patt.loc8_8.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc8: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type [concrete = constants.%ptr]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %x.loc8_8.1: %I.type = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc8_8.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F(%x.loc8_8.1: %I.type) {
+// CHECK:STDOUT:   %x.loc8_8.2: %I.type = bind_symbolic_name x, 0 [symbolic = %x.loc8_8.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc8_8.2: %I.type = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc8_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%x) {
+// CHECK:STDOUT:   %x.loc8_8.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc8_8.2 => constants.%x
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_declare_after_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I.type.733 [concrete]
+// CHECK:STDOUT:   %x: %I.type.733 = bind_symbolic_name x, 0 [symbolic]
+// CHECK:STDOUT:   %x.patt: %I.type.733 = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
@@ -396,15 +405,12 @@ class N.C {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc11_8.1: %I.type.733 = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc11_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt.loc11_8.1, runtime_param<none> [symbolic = %x.patt.loc11_8.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.733 [concrete = constants.%ptr]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
+// CHECK:STDOUT:     %x.loc11_8.1: %I.type.733 = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc11_8.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc18: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT: }
@@ -419,15 +425,27 @@ class N.C {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F(%x.loc11_8.1: %I.type.733) {
+// CHECK:STDOUT:   %x.loc11_8.2: %I.type.733 = bind_symbolic_name x, 0 [symbolic = %x.loc11_8.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc11_8.2: %I.type.733 = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc11_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type.733);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%x) {
+// CHECK:STDOUT:   %x.loc11_8.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc11_8.2 => constants.%x
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_use_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I.type [concrete]
+// CHECK:STDOUT:   %x: %I.type = bind_symbolic_name x, 0 [symbolic]
+// CHECK:STDOUT:   %x.patt.3ad: %I.type = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %x.patt.e01: <error> = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
 // CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -445,44 +463,60 @@ class N.C {
 // CHECK:STDOUT:     .F2 = %F2.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc8_9.1: %I.type = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc8_9.2 (constants.%x.patt.3ad)]
+// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt.loc8_9.1, runtime_param<none> [symbolic = %x.patt.loc8_9.2 (constants.%x.patt.3ad)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc8: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type [concrete = constants.%ptr]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %x.loc8_9.1: %I.type = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc8_9.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
-// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc14_9.1: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc14_9.2 (constants.%x.patt.e01)]
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt.loc14_9.1, runtime_param<none> [symbolic = %x.patt.loc14_9.2 (constants.%x.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %.loc14: type = splice_block %ptr [concrete = <error>] {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param<none>
+// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
 // CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
-// CHECK:STDOUT:       %ptr: type = ptr_type <error> [concrete = <error>]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:     %x: <error> = bind_symbolic_name x, 0, %x.param [concrete = <error>]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F1(%x.loc8_9.1: %I.type) {
+// CHECK:STDOUT:   %x.loc8_9.2: %I.type = bind_symbolic_name x, 0 [symbolic = %x.loc8_9.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc8_9.2: %I.type = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc8_9.2 (constants.%x.patt.3ad)]
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F2(%x: <error>) {
+// CHECK:STDOUT:   %x.patt.loc14_9.2: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc14_9.2 (constants.%x.patt.e01)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: <error>);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F1(constants.%x) {
+// CHECK:STDOUT:   %x.loc8_9.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc8_9.2 => constants.%x
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F2(<error>) {
+// CHECK:STDOUT:   %x.patt.loc14_9.2 => <error>
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_use_declaration_after_poison.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I.type.733 [concrete]
+// CHECK:STDOUT:   %x: %I.type.733 = bind_symbolic_name x, 0 [symbolic]
+// CHECK:STDOUT:   %x.patt.3ad: %I.type.733 = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
+// CHECK:STDOUT:   %x.patt.e01: <error> = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F2.type: type = fn_type @F2 [concrete]
 // CHECK:STDOUT:   %F2: %F2.type = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -500,28 +534,24 @@ class N.C {
 // CHECK:STDOUT:     .F2 = %F2.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc11_9.1: %I.type.733 = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc11_9.2 (constants.%x.patt.3ad)]
+// CHECK:STDOUT:     %x.param_patt: %I.type.733 = value_param_pattern %x.patt.loc11_9.1, runtime_param<none> [symbolic = %x.patt.loc11_9.2 (constants.%x.patt.3ad)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.733 [concrete = constants.%ptr]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type.733 = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc4 [concrete = constants.%I.type.733]
+// CHECK:STDOUT:     %x.loc11_9.1: %I.type.733 = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc11_9.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc17: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT:   %F2.decl: %F2.type = fn_decl @F2 [concrete = constants.%F2] {
-// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc23_9.1: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc23_9.2 (constants.%x.patt.e01)]
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt.loc23_9.1, runtime_param<none> [symbolic = %x.patt.loc23_9.2 (constants.%x.patt.e01)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %.loc23: type = splice_block %ptr [concrete = <error>] {
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param<none>
+// CHECK:STDOUT:     %.1: <error> = splice_block <error> [concrete = <error>] {
 // CHECK:STDOUT:       %N.ref: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
-// CHECK:STDOUT:       %ptr: type = ptr_type <error> [concrete = <error>]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:     %x: <error> = bind_symbolic_name x, 0, %x.param [concrete = <error>]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -529,9 +559,27 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.2;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F1(%x.loc11_9.1: %I.type.733) {
+// CHECK:STDOUT:   %x.loc11_9.2: %I.type.733 = bind_symbolic_name x, 0 [symbolic = %x.loc11_9.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc11_9.2: %I.type.733 = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc11_9.2 (constants.%x.patt.3ad)]
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F2(%x.param_patt: <error>);
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type.733);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F2(%x: <error>) {
+// CHECK:STDOUT:   %x.patt.loc23_9.2: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc23_9.2 (constants.%x.patt.e01)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: <error>);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F1(constants.%x) {
+// CHECK:STDOUT:   %x.loc11_9.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc11_9.2 => constants.%x
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F2(<error>) {
+// CHECK:STDOUT:   %x.patt.loc23_9.2 => <error>
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_alias.carbon
 // CHECK:STDOUT:
@@ -566,7 +614,8 @@ class N.C {
 // CHECK:STDOUT:   %I4.type.451: type = facet_type <@I4> [concrete]
 // CHECK:STDOUT:   %I4.type.78e: type = facet_type <@I4, @I4(%Self.c7b, %Self.60c)> [symbolic]
 // CHECK:STDOUT:   %Self.a4d: %I4.type.78e = bind_symbolic_name Self, 2 [symbolic]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I1.type.80c [concrete]
+// CHECK:STDOUT:   %x: %I1.type.80c = bind_symbolic_name x, 3 [symbolic]
+// CHECK:STDOUT:   %x.patt: %I1.type.80c = symbolic_binding_pattern x, 3 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F, @I4(%Self.c7b, %Self.60c) [symbolic]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [symbolic]
 // CHECK:STDOUT:   %I4.assoc_type: type = assoc_entity_type %I4.type.78e [symbolic]
@@ -632,15 +681,12 @@ class N.C {
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.1: @I4.%I4.type (%I4.type.78e) = bind_symbolic_name Self, 2 [symbolic = %Self.4 (constants.%Self.a4d)]
 // CHECK:STDOUT:     %F.decl: @I4.%F.type (%F.type) = fn_decl @F [symbolic = @I4.%F (constants.%F)] {
-// CHECK:STDOUT:       %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:       %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:       %x.patt.loc16_12.2: %I1.type.80c = symbolic_binding_pattern x, 3 [symbolic = %x.patt.loc16_12.1 (constants.%x.patt)]
+// CHECK:STDOUT:       %x.param_patt: %I1.type.80c = value_param_pattern %x.patt.loc16_12.2, runtime_param<none> [symbolic = %x.patt.loc16_12.1 (constants.%x.patt)]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:       %.loc16: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:         %I1.ref: type = name_ref I1, file.%I1.decl [concrete = constants.%I1.type.80c]
-// CHECK:STDOUT:         %ptr: type = ptr_type %I1.type.80c [concrete = constants.%ptr]
-// CHECK:STDOUT:       }
-// CHECK:STDOUT:       %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:       %x.param: %I1.type.80c = value_param runtime_param<none>
+// CHECK:STDOUT:       %I1.ref: type = name_ref I1, file.%I1.decl [concrete = constants.%I1.type.80c]
+// CHECK:STDOUT:       %x.loc16_12.2: %I1.type.80c = bind_symbolic_name x, 3, %x.param [symbolic = %x.loc16_12.1 (constants.%x)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %assoc0.loc16_19.1: @I4.%I4.assoc_type (%I4.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_19.2 (constants.%assoc0)]
 // CHECK:STDOUT:     %I1.decl: type = interface_decl @I1.2 [concrete = constants.%I1.type.f4e] {} {}
@@ -665,15 +711,21 @@ class N.C {
 // CHECK:STDOUT:   interface;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f), @I4.%Self.1: @I4.%I4.type (%I4.type.78e)) {
-// CHECK:STDOUT:   fn(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F(@I2.%Self: %I2.type, @I3.%Self.1: @I3.%I3.type (%I3.type.b2f), @I4.%Self.1: @I4.%I4.type (%I4.type.78e), %x.loc16_12.2: %I1.type.80c) {
+// CHECK:STDOUT:   %x.loc16_12.1: %I1.type.80c = bind_symbolic_name x, 3 [symbolic = %x.loc16_12.1 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc16_12.1: %I1.type.80c = symbolic_binding_pattern x, 3 [symbolic = %x.patt.loc16_12.1 (constants.%x.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: %I1.type.80c);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I3(constants.%Self.c7b) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I4(constants.%Self.c7b, constants.%Self.60c) {}
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(constants.%Self.c7b, constants.%Self.60c, constants.%Self.a4d) {}
+// CHECK:STDOUT: specific @F(constants.%Self.c7b, constants.%Self.60c, constants.%Self.a4d, constants.%x) {
+// CHECK:STDOUT:   %x.loc16_12.1 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc16_12.1 => constants.%x
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I1.2(constants.%Self.c7b, constants.%Self.60c, constants.%Self.a4d) {}
 // CHECK:STDOUT:
@@ -741,6 +793,7 @@ class N.C {
 // CHECK:STDOUT: --- fail_poison_when_lookup_fails.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %x.patt: <error> = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
@@ -757,15 +810,12 @@ class N.C {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: <error> = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc13_8.1: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc13_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: <error> = value_param_pattern %x.patt.loc13_8.1, runtime_param<none> [symbolic = %x.patt.loc13_8.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param0
-// CHECK:STDOUT:     %.loc13: type = splice_block %ptr [concrete = <error>] {
-// CHECK:STDOUT:       %I.ref: <error> = name_ref I, <error> [concrete = <error>]
-// CHECK:STDOUT:       %ptr: type = ptr_type <error> [concrete = <error>]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: <error> = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: <error> = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: <error> = name_ref I, <error> [concrete = <error>]
+// CHECK:STDOUT:     %x: <error> = bind_symbolic_name x, 0, %x.param [concrete = <error>]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc23: type = interface_decl @I.1 [concrete = constants.%I.type.733] {} {}
 // CHECK:STDOUT:   %I.decl.loc28: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
@@ -775,7 +825,15 @@ class N.C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.2;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: <error>);
+// CHECK:STDOUT: generic fn @F(%x: <error>) {
+// CHECK:STDOUT:   %x.patt.loc13_8.2: <error> = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc13_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: <error>);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(<error>) {
+// CHECK:STDOUT:   %x.patt.loc13_8.2 => <error>
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_poison_with_lexical_result.carbon
 // CHECK:STDOUT:
@@ -836,7 +894,8 @@ class N.C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
 // CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I.type [concrete]
+// CHECK:STDOUT:   %x: %I.type = bind_symbolic_name x, 0 [symbolic]
+// CHECK:STDOUT:   %x.patt: %I.type = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F1.type: type = fn_type @F1 [concrete]
 // CHECK:STDOUT:   %F1: %F1.type = struct_value () [concrete]
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
@@ -857,15 +916,12 @@ class N.C {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F1.decl: %F1.type = fn_decl @F1 [concrete = constants.%F1] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc8_9.1: %I.type = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc8_9.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: %I.type = value_param_pattern %x.patt.loc8_9.1, runtime_param<none> [symbolic = %x.patt.loc8_9.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc8: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type [concrete = constants.%ptr]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %x.loc8_9.1: %I.type = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc8_9.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
@@ -898,5 +954,15 @@ class N.C {
 // CHECK:STDOUT:   extend @impl.%I.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F1(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F1(%x.loc8_9.1: %I.type) {
+// CHECK:STDOUT:   %x.loc8_9.2: %I.type = bind_symbolic_name x, 0 [symbolic = %x.loc8_9.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc8_9.2: %I.type = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc8_9.2 (constants.%x.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F1(constants.%x) {
+// CHECK:STDOUT:   %x.loc8_9.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc8_9.2 => constants.%x
+// CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -17,10 +17,10 @@ interface I;
 // `N.F` uses `N.I` and not `package.I`.
 namespace N;
 interface N.I {}
-fn N.F(x: I*);
+fn N.F(x:! I) {}
 
-fn TestCall(x: N.I*) {
-  // `N.F` accepts an `N.I*` not a `package.I*`.
+fn TestCall(x:! N.I) {
+  // `N.F` accepts an `N.I` not a `package.I`.
   N.F(x);
 }
 
@@ -241,12 +241,14 @@ class N.C {
 // CHECK:STDOUT:   %I.type.733: type = facet_type <@I.1> [concrete]
 // CHECK:STDOUT:   %I.type.4da: type = facet_type <@I.2> [concrete]
 // CHECK:STDOUT:   %Self: %I.type.4da = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %ptr: type = ptr_type %I.type.4da [concrete]
+// CHECK:STDOUT:   %x: %I.type.4da = bind_symbolic_name x, 0 [symbolic]
+// CHECK:STDOUT:   %x.patt: %I.type.4da = symbolic_binding_pattern x, 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %TestCall.type: type = fn_type @TestCall [concrete]
 // CHECK:STDOUT:   %TestCall: %TestCall.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F, @F(%x) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -262,27 +264,23 @@ class N.C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl.loc8: type = interface_decl @I.2 [concrete = constants.%I.type.4da] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc9_8.1: %I.type.4da = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc9_8.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: %I.type.4da = value_param_pattern %x.patt.loc9_8.1, runtime_param<none> [symbolic = %x.patt.loc9_8.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc9: type = splice_block %ptr [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.4da [concrete = constants.%ptr]
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.param: %I.type.4da = value_param runtime_param<none>
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
+// CHECK:STDOUT:     %x.loc9_8.1: %I.type.4da = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc9_8.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestCall.decl: %TestCall.type = fn_decl @TestCall [concrete = constants.%TestCall] {
-// CHECK:STDOUT:     %x.patt: %ptr = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: %ptr = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.patt.loc11_13.1: %I.type.4da = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc11_13.2 (constants.%x.patt)]
+// CHECK:STDOUT:     %x.param_patt: %I.type.4da = value_param_pattern %x.patt.loc11_13.1, runtime_param<none> [symbolic = %x.patt.loc11_13.2 (constants.%x.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param: %ptr = value_param runtime_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:     %x.param: %I.type.4da = value_param runtime_param<none>
+// CHECK:STDOUT:     %.loc11: type = splice_block %I.ref [concrete = constants.%I.type.4da] {
 // CHECK:STDOUT:       %N.ref.loc11: <namespace> = name_ref N, file.%N [concrete = file.%N]
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl.loc8 [concrete = constants.%I.type.4da]
-// CHECK:STDOUT:       %ptr: type = ptr_type %I.type.4da [concrete = constants.%ptr]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: %ptr = bind_name x, %x.param
+// CHECK:STDOUT:     %x.loc11_13.1: %I.type.4da = bind_symbolic_name x, 0, %x.param [symbolic = %x.loc11_13.2 (constants.%x)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -296,16 +294,49 @@ class N.C {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%x.param_patt: %ptr);
+// CHECK:STDOUT: generic fn @F(%x.loc9_8.1: %I.type.4da) {
+// CHECK:STDOUT:   %x.loc9_8.2: %I.type.4da = bind_symbolic_name x, 0 [symbolic = %x.loc9_8.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc9_8.2: %I.type.4da = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc9_8.2 (constants.%x.patt)]
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @TestCall(%x.param_patt: %ptr) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %N.ref.loc13: <namespace> = name_ref N, file.%N [concrete = file.%N]
-// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %x.ref: %ptr = name_ref x, %x
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.ref(%x.ref)
-// CHECK:STDOUT:   return
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type.4da) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @TestCall(%x.loc11_13.1: %I.type.4da) {
+// CHECK:STDOUT:   %x.loc11_13.2: %I.type.4da = bind_symbolic_name x, 0 [symbolic = %x.loc11_13.2 (constants.%x)]
+// CHECK:STDOUT:   %x.patt.loc11_13.2: %I.type.4da = symbolic_binding_pattern x, 0 [symbolic = %x.patt.loc11_13.2 (constants.%x.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %F.specific_fn.loc13_4.2: <specific function> = specific_function constants.%F, @F(%x.loc11_13.2) [symbolic = %F.specific_fn.loc13_4.2 (constants.%F.specific_fn)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param_patt: %I.type.4da) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %N.ref.loc13: <namespace> = name_ref N, file.%N [concrete = file.%N]
+// CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:     %x.ref: %I.type.4da = name_ref x, %x.loc11_13.1 [symbolic = %x.loc11_13.2 (constants.%x)]
+// CHECK:STDOUT:     %F.specific_fn.loc13_4.1: <specific function> = specific_function %F.ref, @F(constants.%x) [symbolic = %F.specific_fn.loc13_4.2 (constants.%F.specific_fn)]
+// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc13_4.1()
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%x) {
+// CHECK:STDOUT:   %x.loc9_8.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc9_8.2 => constants.%x
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @TestCall(constants.%x) {
+// CHECK:STDOUT:   %x.loc11_13.2 => constants.%x
+// CHECK:STDOUT:   %x.patt.loc11_13.2 => constants.%x
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(@TestCall.%x.loc11_13.2) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- poison.carbon
 // CHECK:STDOUT:


### PR DESCRIPTION
Followup of [#4987 comment](https://github.com/carbon-language/carbon-lang/pull/4987/files/b015f99d0e86f5dfe3b1709bec8a426a584f7804#r1964119857).
Part of #4622.