### PR TITLE
Add `TypeId::is_symbolic` and `is_concrete`.

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -549,7 +549,7 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
     // that incorrectly.
     auto arg_type_id = context().insts().Get(deduced_arg_id).type_id();
     auto binding_type_id = context().insts().Get(binding_id).type_id();
-    if (!arg_type_id.is_symbolic() && binding_type_id.is_symbolic()) {
+    if (arg_type_id.is_concrete() && binding_type_id.is_symbolic()) {
       auto param_type_const_id = SubstConstant(
           context(), binding_type_id.AsConstantId(), substitutions_);
       CARBON_CHECK(param_type_const_id.has_value());

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -323,7 +323,7 @@ auto DeductionContext::Deduce() -> bool {
 
     auto param_type_id = context().insts().Get(param_id).type_id();
     // If the parameter has a symbolic type, deduce against that.
-    if (param_type_id.AsConstantId().is_symbolic()) {
+    if (param_type_id.is_symbolic()) {
       Add(context().types().GetInstId(param_type_id),
           context().types().GetInstId(context().insts().Get(arg_id).type_id()),
           needs_substitution);
@@ -549,8 +549,7 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
     // that incorrectly.
     auto arg_type_id = context().insts().Get(deduced_arg_id).type_id();
     auto binding_type_id = context().insts().Get(binding_id).type_id();
-    if (!arg_type_id.AsConstantId().is_symbolic() &&
-        binding_type_id.AsConstantId().is_symbolic()) {
+    if (!arg_type_id.is_symbolic() && binding_type_id.is_symbolic()) {
       auto param_type_const_id = SubstConstant(
           context(), binding_type_id.AsConstantId(), substitutions_);
       CARBON_CHECK(param_type_const_id.has_value());

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -134,7 +134,7 @@ auto ResolveFacetTypeImplWitness(
       // If the associated constant has a symbolic type, convert the rewrite
       // value to that type now we know the value of `Self`.
       SemIR::TypeId assoc_const_type_id = decl->type_id;
-      if (context.types().GetConstantId(assoc_const_type_id).is_symbolic()) {
+      if (assoc_const_type_id.is_symbolic()) {
         // Get the type of the associated constant in this interface with this
         // value for `Self`.
         assoc_const_type_id = GetTypeForSpecificAssociatedEntity(

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -62,7 +62,7 @@ auto HandleParseNode(Context& context, Parse::RequirementEqualId node_id)
 
   // Convert rhs to type of lhs.
   auto lhs_type_id = context.insts().Get(lhs).type_id();
-  if (context.types().GetConstantId(lhs_type_id).is_symbolic()) {
+  if (lhs_type_id.is_symbolic()) {
     // If the type of the associated constant is symbolic, we defer conversion
     // until the constraint is resolved, in case it depends on `Self` (which
     // will now be a reference to `.Self`).

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -557,7 +557,7 @@ auto RequireCompleteType(Context& context, SemIR::TypeId type_id,
 
   // For a symbolic type, create an instruction to require the corresponding
   // specific type to be complete.
-  if (type_id.AsConstantId().is_symbolic()) {
+  if (type_id.is_symbolic()) {
     // TODO: Deduplicate these.
     AddInstInNoBlock(
         context,

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -735,6 +735,11 @@ struct TypeId : public IdBase<TypeId> {
   // Returns the constant ID that defines the type.
   auto AsConstantId() const -> ConstantId { return ConstantId(index); }
 
+  // Returns whether this represents a symbolic type. Requires has_value.
+  auto is_symbolic() const -> bool { return AsConstantId().is_symbolic(); }
+  // Returns whether this represents a concrete type. Requires has_value.
+  auto is_concrete() const -> bool { return AsConstantId().is_concrete(); }
+
   auto Print(llvm::raw_ostream& out) const -> void;
 };
 


### PR DESCRIPTION
These just forward to the corresponding members of `TypeId`.