### PR TITLE
Avoid copying `NameScope` and only allow moving it

### DIFF
--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -253,7 +253,7 @@ static auto CopyAncestorNameScopesFromImportIR(
 
   // Add ancestor namespace names, starting with the outermost.
   for (auto import_scope_id : llvm::reverse(new_namespaces)) {
-    auto import_scope = import_sem_ir.name_scopes().Get(import_scope_id);
+    const auto& import_scope = import_sem_ir.name_scopes().Get(import_scope_id);
     auto name_id =
         CopyNameFromImportIR(context, import_sem_ir, import_scope.name_id());
     scope_cursor =

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -135,6 +135,10 @@ class NameScope : public Printable<NameScope> {
     using IdBase::IdBase;
   };
 
+  // Disallow copy, allow move.
+  NameScope(NameScope&& other) = default;
+  auto operator=(NameScope&& other) -> NameScope& = default;
+
   explicit NameScope(InstId inst_id, NameId name_id,
                      NameScopeId parent_scope_id)
       : inst_id_(inst_id),


### PR DESCRIPTION
This class is not intended to be copied.
Part of #4622.