### PR TITLE
Use the constant value unconditionally in deduce diagnostic

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -511,11 +511,10 @@ auto DeductionContext::Deduce() -> bool {
 static auto GetEntityNameForGenericBinding(Context& context,
                                            SemIR::InstId binding_id)
     -> SemIR::NameId {
-  // If `binding_id` is imported, it may not have an entity name. Get a
-  // canonical local instruction from its constant value which does.
-  if (context.insts().Is<SemIR::ImportRefLoaded>(binding_id)) {
-    binding_id = context.constant_values().GetConstantInstId(binding_id);
-  }
+  // If `binding_id` is imported (or referenced indirectly perhaps in the
+  // future), it may not have an entity name. Get a canonical local instruction
+  // from its constant value which does.
+  binding_id = context.constant_values().GetConstantInstId(binding_id);
 
   if (auto bind_name =
           context.insts().TryGetAs<SemIR::AnyBindName>(binding_id)) {


### PR DESCRIPTION
When finding the binding entity name, always go through the binding instruction's constant value to get a canonical instruction which will always have an entity name attached to it.

Currently the only instructions in this position without an entity name are ImportRefLoaded. But other indirect instructions may exist in the future, which evaluate to an AnyBindName but are not themselves one. So this makes the code more robust to change in the future.

