### PR TITLE
Make the tests_file.tests manifest path relative to the binary

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -298,9 +298,10 @@ static auto RegisterTests(FileTestFactory* test_factory,
                           llvm::StringRef exe_path,
                           llvm::SmallVectorImpl<FileTestInfo>& tests)
     -> ErrorOr<Success> {
-  GetFileTestManifestPath();
-  CARBON_ASSIGN_OR_RETURN(auto test_manifest,
-                          ReadFile(GetFileTestManifestPath()));
+  auto manifest_path =
+      std::filesystem::path(std::string_view{exe_path}).parent_path() /
+      GetFileTestManifestPath();
+  CARBON_ASSIGN_OR_RETURN(auto test_manifest, ReadFile(manifest_path));
 
   // Prepare the vector first, so that the location of entries won't change.
   for (const auto& test_name :

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -133,9 +133,9 @@ struct FileTestFactory {
 // to implement this function.
 extern auto GetFileTestFactory() -> FileTestFactory;
 
-// Returns the manifest path, which is provided by rules.bzl and
-// file_test_manifest.cpp. This is exposed so that the explorer sharding
-// approach can use a different implementation.
+// Returns the manifest path relative to the file_test binary, which is provided
+// by rules.bzl and file_test_manifest.cpp. This is exposed so that the explorer
+// sharding approach can use a different implementation.
 auto GetFileTestManifestPath() -> std::filesystem::path;
 
 // Provides a standard GetFileTestFactory implementation.

--- a/testing/file_test/rules.bzl
+++ b/testing/file_test/rules.bzl
@@ -50,7 +50,7 @@ def file_test(
         # TODO: The prebuilt_binary support is only used by explorer. We should
         # remove this once explorer is removed, and think about better factoring
         # approaches if we need it later for toolchain.
-        args = ["--explorer_test_targets_file=$(rootpath :{0})".format(tests_file)] + args
+        args = ["--explorer_test_targets_file=$(execpath :{0})".format(tests_file)] + args
         native.sh_test(
             name = name,
             srcs = srcs + [prebuilt_binary],
@@ -66,6 +66,6 @@ def file_test(
             data = data,
             args = args,
             env = cc_env(),
-            local_defines = ["CARBON_FILE_TEST_MANIFEST='\"$(rootpath :{0})\"'".format(tests_file)],
+            local_defines = ["CARBON_FILE_TEST_MANIFEST='\"$(execpath :{0})\"'".format(tests_file)],
             **kwargs
         )

--- a/testing/file_test/rules.bzl
+++ b/testing/file_test/rules.bzl
@@ -50,7 +50,7 @@ def file_test(
         # TODO: The prebuilt_binary support is only used by explorer. We should
         # remove this once explorer is removed, and think about better factoring
         # approaches if we need it later for toolchain.
-        args = ["--explorer_test_targets_file=$(execpath :{0})".format(tests_file)] + args
+        args = ["--explorer_test_targets_file=$(rootpath :{0})".format(tests_file)] + args
         native.sh_test(
             name = name,
             srcs = srcs + [prebuilt_binary],
@@ -66,6 +66,6 @@ def file_test(
             data = data,
             args = args,
             env = cc_env(),
-            local_defines = ["CARBON_FILE_TEST_MANIFEST='\"$(execpath :{0})\"'".format(tests_file)],
+            local_defines = ["CARBON_FILE_TEST_MANIFEST='\"{0}\"'".format(tests_file)],
             **kwargs
         )


### PR DESCRIPTION
Neither rootpath nor execpath work for all cases that `file_test` is run
under.

The rootpath makes a path relative to output directory, such as
`toolchain/testing/file_test.tests`. When run in a debugger, the CWD is
at the repository root, so this path does not point to the file
correctly. It needs to include the root of the build directory.

The execpath makes a path relative to the repository root, such as
`bazel-bin/toolchain/testing/file_test.tests`. This works in a debugger
from the repository root (though not from arbitrary places). But it
fails under `bazel run`, which runs `file_test` with a CWD in the output
directory. https://stackoverflow.com/a/70265855 points out this is by
design and there's no good way to change the CWD for bazel run.

So this change makes the manifest file path relative to the binary
instead of either rootpath or execpath. The `file_test` binary takes the
path to the exe, moves to the parent path (drops the binary itself from
the path), and appends the manifest path specified from bazel. This
produces an absolute path to the tests_file.tests that is always correct.

This change attempts to make no change to explorer, assuming it is
working as-is.
