### PR TITLE
Factor out fuzzing disablement in the driver

### DIFF
--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -23,13 +23,12 @@
 
 CARBON_DIAGNOSTIC_KIND(DriverInstallInvalid)
 CARBON_DIAGNOSTIC_KIND(DriverCommandLineParseFailed)
-CARBON_DIAGNOSTIC_KIND(ClangFuzzingDisallowed)
 CARBON_DIAGNOSTIC_KIND(CompilePhaseFlagConflict)
 CARBON_DIAGNOSTIC_KIND(CompilePreludeManifestError)
 CARBON_DIAGNOSTIC_KIND(CompileInputNotRegularFile)
 CARBON_DIAGNOSTIC_KIND(CompileOutputFileOpenError)
 CARBON_DIAGNOSTIC_KIND(FormatMultipleFilesToOneOutput)
-CARBON_DIAGNOSTIC_KIND(LLDFuzzingDisallowed)
+CARBON_DIAGNOSTIC_KIND(ToolFuzzingDisallowed)
 
 // ============================================================================
 // SourceBuffer diagnostics

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -95,6 +95,7 @@ cc_library(
         "compile_subcommand.h",
         "driver.cpp",
         "driver_env.h",
+        "driver_subcommand.cpp",
         "format_subcommand.cpp",
         "format_subcommand.h",
         "language_server_subcommand.cpp",

--- a/toolchain/driver/clang_subcommand.cpp
+++ b/toolchain/driver/clang_subcommand.cpp
@@ -50,11 +50,7 @@ auto ClangSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Don't run Clang when fuzzing, it is known to not be reliable under fuzzing
   // due to many unfixed issues.
-  if (driver_env.fuzzing) {
-    CARBON_DIAGNOSTIC(
-        ClangFuzzingDisallowed, Error,
-        "preventing fuzzing of `clang` subcommand due to library crashes");
-    driver_env.emitter.Emit(ClangFuzzingDisallowed);
+  if (!DisableFuzzingExternalLibraries(driver_env, "clang")) {
     return {.success = false};
   }
 

--- a/toolchain/driver/driver_subcommand.cpp
+++ b/toolchain/driver/driver_subcommand.cpp
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/driver/driver_subcommand.h"
+
+#include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
+#include "toolchain/driver/lld_runner.h"
+
+namespace Carbon {
+
+auto DriverSubcommand::DisableFuzzingExternalLibraries(DriverEnv& driver_env,
+                                                       llvm::StringRef name)
+    -> bool {
+  // Only need to do anything when fuzzing.
+  if (!driver_env.fuzzing) {
+    return true;
+  }
+
+  CARBON_DIAGNOSTIC(
+      ToolFuzzingDisallowed, Error,
+      "preventing fuzzing of `{0}` subcommand due to external library",
+      std::string);
+  driver_env.emitter.Emit(ToolFuzzingDisallowed, name.str());
+  return false;
+}
+
+}  // namespace Carbon

--- a/toolchain/driver/driver_subcommand.h
+++ b/toolchain/driver/driver_subcommand.h
@@ -45,6 +45,15 @@ class DriverSubcommand {
   // Runs the command.
   virtual auto Run(DriverEnv& driver_env) -> DriverResult = 0;
 
+ protected:
+  // Diagnoses and returns false if currently fuzzing.
+  //
+  // This should be used in subcommands to check and diagnose rather than
+  // entering them during fuzzing when they use external libraries that we can't
+  // keep fuzz-clean.
+  auto DisableFuzzingExternalLibraries(DriverEnv& driver_env,
+                                       llvm::StringRef name) -> bool;
+
  private:
   // Subcommand information.
   CommandLine::CommandInfo info_;

--- a/toolchain/driver/lld_subcommand.cpp
+++ b/toolchain/driver/lld_subcommand.cpp
@@ -93,11 +93,7 @@ auto LldSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Don't run LLD when fuzzing, as we're not currently in a good position to
   // debug and fix fuzzer-found bugs within LLD.
-  if (driver_env.fuzzing) {
-    CARBON_DIAGNOSTIC(
-        LLDFuzzingDisallowed, Error,
-        "preventing fuzzing of `lld` subcommand due to external library");
-    driver_env.emitter.Emit(LLDFuzzingDisallowed);
+  if (!DisableFuzzingExternalLibraries(driver_env, "lld")) {
     return {.success = false};
   }
 

--- a/toolchain/driver/testdata/fail_clang_fuzzing.cpp
+++ b/toolchain/driver/testdata/fail_clang_fuzzing.cpp
@@ -11,5 +11,5 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/fail_clang_fuzzing.cpp
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/fail_clang_fuzzing.cpp
-// CHECK:STDERR: error: preventing fuzzing of `clang` subcommand due to library crashes [ClangFuzzingDisallowed]
+// CHECK:STDERR: error: preventing fuzzing of `clang` subcommand due to external library [ToolFuzzingDisallowed]
 // CHECK:STDERR:

--- a/toolchain/driver/testdata/fail_lld_fuzzing.carbon
+++ b/toolchain/driver/testdata/fail_lld_fuzzing.carbon
@@ -11,5 +11,5 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/fail_lld_fuzzing.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/fail_lld_fuzzing.carbon
-// CHECK:STDERR: error: preventing fuzzing of `lld` subcommand due to external library [LLDFuzzingDisallowed]
+// CHECK:STDERR: error: preventing fuzzing of `lld` subcommand due to external library [ToolFuzzingDisallowed]
 // CHECK:STDERR:


### PR DESCRIPTION
We end up needing to do this in any driver subcommand that reaches into external code that may not be fully fuzz-clean. No need to grow multiple different diagnostics for each, we can use a common diagnostic.