### PR TITLE
Support language-server arguments in the extension.

### DIFF
--- a/utils/vscode/package-lock.json
+++ b/utils/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carbon-vscode",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carbon-vscode",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
       },

--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-vscode",
   "displayName": "Carbon Language",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "carbon-lang",
   "description": "Carbon language support for Visual Studio Code.",
   "repository": {
@@ -42,8 +42,18 @@
       "properties": {
         "carbon.carbonPath": {
           "type": "string",
-          "description": "The path to the 'carbon' binary.",
+          "description": "The path to the `carbon` binary.",
           "default": "./bazel-bin/toolchain/carbon"
+        },
+        "carbon.carbonServerCommandArgs": {
+          "type": "string",
+          "description": "Extra flags to pass to `carbon` before the `language-server` subcommand, such as `-v` for debugging.",
+          "default": ""
+        },
+        "carbon.carbonServerSubcommandArgs": {
+          "type": "string",
+          "description": "Extra flags to pass to the `language-server` subcommand.",
+          "default": ""
         }
       }
     },

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -8,7 +8,12 @@
  * This is the main launcher for the LSP extension.
  */
 
-import { workspace, ExtensionContext, commands } from 'vscode';
+import {
+  workspace,
+  ExtensionContext,
+  commands,
+  WorkspaceConfiguration,
+} from 'vscode';
 
 import {
   LanguageClient,
@@ -17,6 +22,39 @@ import {
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
+
+/**
+ * Splits a CLI-style quoted string.
+ */
+function splitQuotedString(carbonArgs: string): string[] {
+  const regex = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  const result = [];
+  let match;
+
+  while ((match = regex.exec(carbonArgs)) !== null) {
+    if (match[1]) {
+      result.push(match[1]);
+    } else if (match[2]) {
+      result.push(match[2]);
+    } else if (match[3]) {
+      result.push(match[3]);
+    }
+  }
+  return result;
+}
+
+/**
+ * Combines the `language-server` command with args from settings.
+ */
+function buildServerArgs(settings: WorkspaceConfiguration): string[] {
+  const result: string[] = [];
+  result.push(...splitQuotedString(settings.get('carbonServerCommandArgs', '')));
+  result.push('language-server');
+  result.push(
+    ...splitQuotedString(settings.get('carbonServerSubcommandArgs', ''))
+  );
+  return result;
+}
 
 export function activate(context: ExtensionContext) {
   const settings = workspace.getConfiguration('carbon');
@@ -28,7 +66,7 @@ export function activate(context: ExtensionContext) {
       'carbonPath',
       context.asAbsolutePath('./bazel-bin/toolchain/carbon')
     ),
-    args: ['language-server'],
+    args: buildServerArgs(settings),
   };
 
   const clientOptions: LanguageClientOptions = {

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -18,22 +18,17 @@ import {
 import {
   LanguageClient,
   LanguageClientOptions,
-  ServerOptions,
-} from 'vscode-languageclient/node';
-
-let client: LanguageClient;
-
-/**
- * Splits a CLI-style quoted string.
- */
 function splitQuotedString(argsString: string): string[] {
   const args: string[] = [];
   let arg = '';
   let inSingleQuotes = false;
   let inDoubleQuotes = false;
   let escaped = false;
+  let empty = true;
 
   for (const char of argsString) {
+    const was_empty = empty;
+    empty = false;
     if (escaped) {
       arg += char;
       escaped = false;
@@ -57,15 +52,19 @@ function splitQuotedString(argsString: string): string[] {
         break;
       case ' ':
         if (!inSingleQuotes && !inDoubleQuotes) {
-          args.push(arg);
-          arg = '';
+          if (!was_empty) {
+            args.push(arg);
+            arg = '';
+          }
+          empty = true;
+          continue;
         }
         break;
     }
     arg += char;
   }
 
-  if (arg.length > 0) {
+  if (!empty) {
     args.push(arg);
   }
 

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -26,21 +26,50 @@ let client: LanguageClient;
 /**
  * Splits a CLI-style quoted string.
  */
-function splitQuotedString(carbonArgs: string): string[] {
-  const regex = /"([^"]*)"|'([^']*)'|(\S+)/g;
-  const result = [];
-  let match;
+function splitQuotedString(argsString: string): string[] {
+  const args: string[] = [];
+  let arg = '';
+  let inSingleQuotes = false;
+  let inDoubleQuotes = false;
+  let escaped = false;
 
-  while ((match = regex.exec(carbonArgs)) !== null) {
-    if (match[1]) {
-      result.push(match[1]);
-    } else if (match[2]) {
-      result.push(match[2]);
-    } else if (match[3]) {
-      result.push(match[3]);
+  for (const char of argsString) {
+    if (escaped) {
+      arg += char;
+      escaped = false;
+      continue;
     }
+    switch (char) {
+      case '\\':
+        escaped = true;
+        continue;
+      case "'":
+        if (!inDoubleQuotes) {
+          inSingleQuotes = !inSingleQuotes;
+          continue;
+        }
+        break;
+      case '"':
+        if (!inSingleQuotes) {
+          inDoubleQuotes = !inDoubleQuotes;
+          continue;
+        }
+        break;
+      case ' ':
+        if (!inSingleQuotes && !inDoubleQuotes) {
+          args.push(arg);
+          arg = '';
+        }
+        break;
+    }
+    arg += char;
   }
-  return result;
+
+  if (arg.length > 0) {
+    args.push(arg);
+  }
+
+  return args;
 }
 
 /**
@@ -48,7 +77,9 @@ function splitQuotedString(carbonArgs: string): string[] {
  */
 function buildServerArgs(settings: WorkspaceConfiguration): string[] {
   const result: string[] = [];
-  result.push(...splitQuotedString(settings.get('carbonServerCommandArgs', '')));
+  result.push(
+    ...splitQuotedString(settings.get('carbonServerCommandArgs', ''))
+  );
   result.push('language-server');
   result.push(
     ...splitQuotedString(settings.get('carbonServerSubcommandArgs', ''))

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -18,45 +18,63 @@ import {
 import {
   LanguageClient,
   LanguageClientOptions,
+  ServerOptions,
+} from 'vscode-languageclient/node';
+
+let client: LanguageClient;
+
+/**
+ * Splits a CLI-style quoted string.
+ */
 function splitQuotedString(argsString: string): string[] {
   const args: string[] = [];
   let arg = '';
+  // Track whether there's an arg to handle `""` and similar.
+  let hasArg = true;
+  // Whether this is in a quote-delimited section.
   let inSingleQuotes = false;
   let inDoubleQuotes = false;
-  let escaped = false;
-  let empty = true;
+  // Whether this is a `\`-escaped character.
+  let inEscape = false;
 
   for (const char of argsString) {
-    const was_empty = empty;
-    empty = false;
-    if (escaped) {
+    // While spaces can appear in arguments, they can only be an argument in
+    // combination with other characters.
+    hasArg = hasArg || char != ' ';
+
+    if (inEscape) {
+      // After an escape, directly append the character.
       arg += char;
-      escaped = false;
+      inEscape = false;
       continue;
     }
     switch (char) {
       case '\\':
-        escaped = true;
+        // First character of an escape.
+        inEscape = true;
         continue;
       case "'":
         if (!inDoubleQuotes) {
+          // Single-quoted section.
           inSingleQuotes = !inSingleQuotes;
           continue;
         }
         break;
       case '"':
         if (!inSingleQuotes) {
+          // Double-quoted section.
           inDoubleQuotes = !inDoubleQuotes;
           continue;
         }
         break;
       case ' ':
         if (!inSingleQuotes && !inDoubleQuotes) {
-          if (!was_empty) {
+          // Space between arguments (but possibly multiple spaces).
+          if (hasArg) {
             args.push(arg);
             arg = '';
+            hasArg = false;
           }
-          empty = true;
           continue;
         }
         break;
@@ -64,7 +82,8 @@ function splitQuotedString(argsString: string): string[] {
     arg += char;
   }
 
-  if (!empty) {
+  // Finish any pending argument.
+  if (hasArg) {
     args.push(arg);
   }
 


### PR DESCRIPTION
I was on the fence about just having a string which was "language-server", but was thinking split options might be less error-prone (e.g., changing options to just "-v" and trying to figure out why nothing worked).