### PR TITLE
Continue: emit function definitions for specifics.

### DIFF
--- a/toolchain/check/testdata/generic/call_basic_depth.carbon
+++ b/toolchain/check/testdata/generic/call_basic_depth.carbon
@@ -1,0 +1,288 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/call_basic_depth.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/generic/call_basic_depth.carbon
+
+fn F[T:! type](x: T) {
+}
+
+fn H[T:! type](x: T) -> T {
+  // TODO: Definition should be emitted for H for this to work in lowering.
+  F(x);
+  return x;
+}
+
+fn G[T:! type](x: T) -> T {
+  H(x);
+  F(x);
+  return x;
+}
+
+fn M() {
+  var n: i32 = 0;
+  var m: i32;
+
+  F(n);
+  m = G(n);
+}
+
+// CHECK:STDOUT: --- call_basic_depth.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %T.patt: type = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %T [symbolic]
+// CHECK:STDOUT:   %H.type: type = fn_type @H [concrete]
+// CHECK:STDOUT:   %H: %H.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F.specific_fn.ef1: <specific function> = specific_function %F, @F(%T) [symbolic]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [concrete]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [concrete]
+// CHECK:STDOUT:   %H.specific_fn.1ed: <specific function> = specific_function %H, @H(%T) [symbolic]
+// CHECK:STDOUT:   %M.type: type = fn_type @M [concrete]
+// CHECK:STDOUT:   %M: %M.type = struct_value () [concrete]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %i32.builtin: type = int_type signed, %int_32 [concrete]
+// CHECK:STDOUT:   %complete_type.f8a: <witness> = complete_type_witness %i32.builtin [concrete]
+// CHECK:STDOUT:   %int_0.5c6: Core.IntLiteral = int_value 0 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.205: type = facet_type <@ImplicitAs, @ImplicitAs(%i32)> [concrete]
+// CHECK:STDOUT:   %Convert.type.1b6: type = fn_type @Convert.1, @ImplicitAs(%i32) [concrete]
+// CHECK:STDOUT:   %impl_witness.d39: <witness> = impl_witness (imports.%Core.import_ref.a5b), @impl.4f9(%int_32) [concrete]
+// CHECK:STDOUT:   %Convert.type.035: type = fn_type @Convert.2, @impl.4f9(%int_32) [concrete]
+// CHECK:STDOUT:   %Convert.956: %Convert.type.035 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.205 = facet_value Core.IntLiteral, %impl_witness.d39 [concrete]
+// CHECK:STDOUT:   %.a0b: type = fn_type_with_self_type %Convert.type.1b6, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Convert.bound: <bound method> = bound_method %int_0.5c6, %Convert.956 [concrete]
+// CHECK:STDOUT:   %Convert.specific_fn: <specific function> = specific_function %Convert.bound, @Convert.2(%int_32) [concrete]
+// CHECK:STDOUT:   %int_0.6a9: %i32 = int_value 0 [concrete]
+// CHECK:STDOUT:   %F.specific_fn.501: <specific function> = specific_function %F, @F(%i32) [concrete]
+// CHECK:STDOUT:   %G.specific_fn: <specific function> = specific_function %G, @G(%i32) [concrete]
+// CHECK:STDOUT:   %H.specific_fn.aac: <specific function> = specific_function %H, @H(%i32) [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [concrete] {
+// CHECK:STDOUT:     .Int = %Core.Int
+// CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:     import Core//prelude/...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:     .H = %H.decl
+// CHECK:STDOUT:     .G = %G.decl
+// CHECK:STDOUT:     .M = %M.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %x.patt: @F.%T.loc11_6.2 (%T) = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: @F.%T.loc11_6.2 (%T) = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @F.%T.loc11_6.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_6.1 [symbolic = %T.loc11_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x: @F.%T.loc11_6.2 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {
+// CHECK:STDOUT:     %T.patt.loc14_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_6.1, runtime_param<none> [symbolic = %T.patt.loc14_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %x.patt: @H.%T.loc14_6.2 (%T) = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: @H.%T.loc14_6.2 (%T) = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %return.patt: @H.%T.loc14_6.2 (%T) = return_slot_pattern
+// CHECK:STDOUT:     %return.param_patt: @H.%T.loc14_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.ref.loc14_25: type = name_ref T, %T.loc14_6.1 [symbolic = %T.loc14_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc14_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc14_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @H.%T.loc14_6.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.ref.loc14_19: type = name_ref T, %T.loc14_6.1 [symbolic = %T.loc14_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x: @H.%T.loc14_6.2 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:     %return.param: ref @H.%T.loc14_6.2 (%T) = out_param runtime_param1
+// CHECK:STDOUT:     %return: ref @H.%T.loc14_6.2 (%T) = return_slot %return.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
+// CHECK:STDOUT:     %T.patt.loc20_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_6.1, runtime_param<none> [symbolic = %T.patt.loc20_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %x.patt: @G.%T.loc20_6.2 (%T) = binding_pattern x
+// CHECK:STDOUT:     %x.param_patt: @G.%T.loc20_6.2 (%T) = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %return.patt: @G.%T.loc20_6.2 (%T) = return_slot_pattern
+// CHECK:STDOUT:     %return.param_patt: @G.%T.loc20_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.ref.loc20_25: type = name_ref T, %T.loc20_6.1 [symbolic = %T.loc20_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
+// CHECK:STDOUT:     %T.loc20_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc20_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @G.%T.loc20_6.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.ref.loc20_19: type = name_ref T, %T.loc20_6.1 [symbolic = %T.loc20_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x: @G.%T.loc20_6.2 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:     %return.param: ref @G.%T.loc20_6.2 (%T) = out_param runtime_param1
+// CHECK:STDOUT:     %return: ref @G.%T.loc20_6.2 (%T) = return_slot %return.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %M.decl: %M.type = fn_decl @M [concrete = constants.%M] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(%T.loc11_6.1: type) {
+// CHECK:STDOUT:   %T.loc11_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_6.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc11_6.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @F.%T.loc11_6.2 (%T) [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: type](%x.param_patt: @F.%T.loc11_6.2 (%T)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @H(%T.loc14_6.1: type) {
+// CHECK:STDOUT:   %T.loc14_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_6.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc14_6.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @H.%T.loc14_6.2 (%T) [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %F.specific_fn.loc16_3.2: <specific function> = specific_function constants.%F, @F(%T.loc14_6.2) [symbolic = %F.specific_fn.loc16_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: type](%x.param_patt: @H.%T.loc14_6.2 (%T)) -> @H.%T.loc14_6.2 (%T) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:     %x.ref.loc16: @H.%T.loc14_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %F.specific_fn.loc16_3.1: <specific function> = specific_function %F.ref, @F(constants.%T) [symbolic = %F.specific_fn.loc16_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc16_3.1(%x.ref.loc16)
+// CHECK:STDOUT:     %x.ref.loc17: @H.%T.loc14_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     return %x.ref.loc17
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @G(%T.loc20_6.1: type) {
+// CHECK:STDOUT:   %T.loc20_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc20_6.2 (constants.%T)]
+// CHECK:STDOUT:   %T.patt.loc20_6.2: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_6.2 (constants.%T.patt)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @G.%T.loc20_6.2 (%T) [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %H.specific_fn.loc21_3.2: <specific function> = specific_function constants.%H, @H(%T.loc20_6.2) [symbolic = %H.specific_fn.loc21_3.2 (constants.%H.specific_fn.1ed)]
+// CHECK:STDOUT:   %F.specific_fn.loc22_3.2: <specific function> = specific_function constants.%F, @F(%T.loc20_6.2) [symbolic = %F.specific_fn.loc22_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn[%T.param_patt: type](%x.param_patt: @G.%T.loc20_6.2 (%T)) -> @G.%T.loc20_6.2 (%T) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %H.ref: %H.type = name_ref H, file.%H.decl [concrete = constants.%H]
+// CHECK:STDOUT:     %x.ref.loc21: @G.%T.loc20_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %H.specific_fn.loc21_3.1: <specific function> = specific_function %H.ref, @H(constants.%T) [symbolic = %H.specific_fn.loc21_3.2 (constants.%H.specific_fn.1ed)]
+// CHECK:STDOUT:     %H.call: init @G.%T.loc20_6.2 (%T) = call %H.specific_fn.loc21_3.1(%x.ref.loc21)
+// CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:     %x.ref.loc22: @G.%T.loc20_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %F.specific_fn.loc22_3.1: <specific function> = specific_function %F.ref, @F(constants.%T) [symbolic = %F.specific_fn.loc22_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc22_3.1(%x.ref.loc22)
+// CHECK:STDOUT:     %x.ref.loc23: @G.%T.loc20_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     return %x.ref.loc23
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @M() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %n.patt: %i32 = binding_pattern n
+// CHECK:STDOUT:     %.loc27_3.1: %i32 = var_pattern %n.patt
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %n.var: ref %i32 = var n
+// CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
+// CHECK:STDOUT:   %impl.elem0: %.a0b = impl_witness_access constants.%impl_witness.d39, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %bound_method, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %specific_fn(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc27_3.2: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   assign %n.var, %.loc27_3.2
+// CHECK:STDOUT:   %.loc27_10: type = splice_block %i32.loc27 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc27: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc27: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %n: ref %i32 = bind_name n, %n.var
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %m.patt: %i32 = binding_pattern m
+// CHECK:STDOUT:     %.loc28_3: %i32 = var_pattern %m.patt
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %m.var: ref %i32 = var m
+// CHECK:STDOUT:   %.loc28_10: type = splice_block %i32.loc28 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc28: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc28: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %m: ref %i32 = bind_name m, %m.var
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %n.ref.loc30: ref %i32 = name_ref n, %n
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F.ref, @F(constants.%i32) [concrete = constants.%F.specific_fn.501]
+// CHECK:STDOUT:   %.loc30: %i32 = bind_value %n.ref.loc30
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc30)
+// CHECK:STDOUT:   %m.ref: ref %i32 = name_ref m, %m
+// CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%G.decl [concrete = constants.%G]
+// CHECK:STDOUT:   %n.ref.loc31: ref %i32 = name_ref n, %n
+// CHECK:STDOUT:   %G.specific_fn: <specific function> = specific_function %G.ref, @G(constants.%i32) [concrete = constants.%G.specific_fn]
+// CHECK:STDOUT:   %.loc31: %i32 = bind_value %n.ref.loc31
+// CHECK:STDOUT:   %G.call: init %i32 = call %G.specific_fn(%.loc31)
+// CHECK:STDOUT:   assign %m.ref, %G.call
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%T) {
+// CHECK:STDOUT:   %T.loc11_6.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc11_6.2 => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.4ae
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @H(constants.%T) {
+// CHECK:STDOUT:   %T.loc14_6.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc14_6.2 => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.4ae
+// CHECK:STDOUT:   %F.specific_fn.loc16_3.2 => constants.%F.specific_fn.ef1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(@H.%T.loc14_6.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @G(constants.%T) {
+// CHECK:STDOUT:   %T.loc20_6.2 => constants.%T
+// CHECK:STDOUT:   %T.patt.loc20_6.2 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @H(@G.%T.loc20_6.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(@G.%T.loc20_6.2) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%i32) {
+// CHECK:STDOUT:   %T.loc11_6.2 => constants.%i32
+// CHECK:STDOUT:   %T.patt.loc11_6.2 => constants.%i32
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @G(constants.%i32) {
+// CHECK:STDOUT:   %T.loc20_6.2 => constants.%i32
+// CHECK:STDOUT:   %T.patt.loc20_6.2 => constants.%i32
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
+// CHECK:STDOUT:   %H.specific_fn.loc21_3.2 => constants.%H.specific_fn.aac
+// CHECK:STDOUT:   %F.specific_fn.loc22_3.2 => constants.%F.specific_fn.501
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @H(constants.%i32) {
+// CHECK:STDOUT:   %T.loc14_6.2 => constants.%i32
+// CHECK:STDOUT:   %T.patt.loc14_6.2 => constants.%i32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/generic/call_basic_depth.carbon
+++ b/toolchain/check/testdata/generic/call_basic_depth.carbon
@@ -88,48 +88,42 @@ fn M() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc11_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc11_6.1, runtime_param<none> [symbolic = %T.patt.loc11_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @F.%T.loc11_6.2 (%T) = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: @F.%T.loc11_6.2 (%T) = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.param_patt: @F.%T.loc11_6.2 (%T) = value_param_pattern %x.patt, call_param0
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
-// CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc11_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @F.%T.loc11_6.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.loc11_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @F.%T.loc11_6.2 (%T) = value_param call_param0
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_6.1 [symbolic = %T.loc11_6.2 (constants.%T)]
 // CHECK:STDOUT:     %x: @F.%T.loc11_6.2 (%T) = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {
 // CHECK:STDOUT:     %T.patt.loc14_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc14_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc14_6.1, runtime_param<none> [symbolic = %T.patt.loc14_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @H.%T.loc14_6.2 (%T) = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: @H.%T.loc14_6.2 (%T) = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.param_patt: @H.%T.loc14_6.2 (%T) = value_param_pattern %x.patt, call_param0
 // CHECK:STDOUT:     %return.patt: @H.%T.loc14_6.2 (%T) = return_slot_pattern
-// CHECK:STDOUT:     %return.param_patt: @H.%T.loc14_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     %return.param_patt: @H.%T.loc14_6.2 (%T) = out_param_pattern %return.patt, call_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc14_25: type = name_ref T, %T.loc14_6.1 [symbolic = %T.loc14_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
-// CHECK:STDOUT:     %T.loc14_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc14_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @H.%T.loc14_6.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.loc14_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @H.%T.loc14_6.2 (%T) = value_param call_param0
 // CHECK:STDOUT:     %T.ref.loc14_19: type = name_ref T, %T.loc14_6.1 [symbolic = %T.loc14_6.2 (constants.%T)]
 // CHECK:STDOUT:     %x: @H.%T.loc14_6.2 (%T) = bind_name x, %x.param
-// CHECK:STDOUT:     %return.param: ref @H.%T.loc14_6.2 (%T) = out_param runtime_param1
+// CHECK:STDOUT:     %return.param: ref @H.%T.loc14_6.2 (%T) = out_param call_param1
 // CHECK:STDOUT:     %return: ref @H.%T.loc14_6.2 (%T) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %T.patt.loc20_6.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_6.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %T.param_patt: type = value_param_pattern %T.patt.loc20_6.1, runtime_param<none> [symbolic = %T.patt.loc20_6.2 (constants.%T.patt)]
 // CHECK:STDOUT:     %x.patt: @G.%T.loc20_6.2 (%T) = binding_pattern x
-// CHECK:STDOUT:     %x.param_patt: @G.%T.loc20_6.2 (%T) = value_param_pattern %x.patt, runtime_param0
+// CHECK:STDOUT:     %x.param_patt: @G.%T.loc20_6.2 (%T) = value_param_pattern %x.patt, call_param0
 // CHECK:STDOUT:     %return.patt: @G.%T.loc20_6.2 (%T) = return_slot_pattern
-// CHECK:STDOUT:     %return.param_patt: @G.%T.loc20_6.2 (%T) = out_param_pattern %return.patt, runtime_param1
+// CHECK:STDOUT:     %return.param_patt: @G.%T.loc20_6.2 (%T) = out_param_pattern %return.patt, call_param1
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %T.ref.loc20_25: type = name_ref T, %T.loc20_6.1 [symbolic = %T.loc20_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.param: type = value_param runtime_param<none>
-// CHECK:STDOUT:     %T.loc20_6.1: type = bind_symbolic_name T, 0, %T.param [symbolic = %T.loc20_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @G.%T.loc20_6.2 (%T) = value_param runtime_param0
+// CHECK:STDOUT:     %T.loc20_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc20_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @G.%T.loc20_6.2 (%T) = value_param call_param0
 // CHECK:STDOUT:     %T.ref.loc20_19: type = name_ref T, %T.loc20_6.1 [symbolic = %T.loc20_6.2 (constants.%T)]
 // CHECK:STDOUT:     %x: @G.%T.loc20_6.2 (%T) = bind_name x, %x.param
-// CHECK:STDOUT:     %return.param: ref @G.%T.loc20_6.2 (%T) = out_param runtime_param1
+// CHECK:STDOUT:     %return.param: ref @G.%T.loc20_6.2 (%T) = out_param call_param1
 // CHECK:STDOUT:     %return: ref @G.%T.loc20_6.2 (%T) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %M.decl: %M.type = fn_decl @M [concrete = constants.%M] {} {}
@@ -142,7 +136,7 @@ fn M() {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @F.%T.loc11_6.2 (%T) [symbolic = %require_complete (constants.%require_complete.4ae)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn[%T.param_patt: type](%x.param_patt: @F.%T.loc11_6.2 (%T)) {
+// CHECK:STDOUT:   fn[%T.patt.loc11_6.1: type](%x.param_patt: @F.%T.loc11_6.2 (%T)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
@@ -156,7 +150,7 @@ fn M() {
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type @H.%T.loc14_6.2 (%T) [symbolic = %require_complete (constants.%require_complete.4ae)]
 // CHECK:STDOUT:   %F.specific_fn.loc16_3.2: <specific function> = specific_function constants.%F, @F(%T.loc14_6.2) [symbolic = %F.specific_fn.loc16_3.2 (constants.%F.specific_fn.ef1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn[%T.param_patt: type](%x.param_patt: @H.%T.loc14_6.2 (%T)) -> @H.%T.loc14_6.2 (%T) {
+// CHECK:STDOUT:   fn[%T.patt.loc14_6.1: type](%x.param_patt: @H.%T.loc14_6.2 (%T)) -> @H.%T.loc14_6.2 (%T) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:     %x.ref.loc16: @H.%T.loc14_6.2 (%T) = name_ref x, %x
@@ -176,7 +170,7 @@ fn M() {
 // CHECK:STDOUT:   %H.specific_fn.loc21_3.2: <specific function> = specific_function constants.%H, @H(%T.loc20_6.2) [symbolic = %H.specific_fn.loc21_3.2 (constants.%H.specific_fn.1ed)]
 // CHECK:STDOUT:   %F.specific_fn.loc22_3.2: <specific function> = specific_function constants.%F, @F(%T.loc20_6.2) [symbolic = %F.specific_fn.loc22_3.2 (constants.%F.specific_fn.ef1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn[%T.param_patt: type](%x.param_patt: @G.%T.loc20_6.2 (%T)) -> @G.%T.loc20_6.2 (%T) {
+// CHECK:STDOUT:   fn[%T.patt.loc20_6.1: type](%x.param_patt: @G.%T.loc20_6.2 (%T)) -> @G.%T.loc20_6.2 (%T) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %H.ref: %H.type = name_ref H, file.%H.decl [concrete = constants.%H]
 // CHECK:STDOUT:     %x.ref.loc21: @G.%T.loc20_6.2 (%T) = name_ref x, %x

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -128,17 +128,7 @@ auto FileContext::BuildDICompileUnit(llvm::StringRef module_name,
 
 auto FileContext::GetGlobal(SemIR::InstId inst_id,
                             SemIR::SpecificId specific_id) -> llvm::Value* {
-  auto inst = sem_ir().insts().Get(inst_id);
-
-  if (specific_id.has_value()) {
-    inst_id = sem_ir().constant_values().GetInstIdIfValid(
-        GetConstantValueInSpecific(sem_ir(), specific_id, inst_id));
-    CARBON_CHECK(inst_id.has_value(),
-                 "Expected to find an instruction id for a specific in the "
-                 "file context");
-  }
-
-  auto const_id = sem_ir().constant_values().Get(inst_id);
+  auto const_id = GetConstantValueInSpecific(sem_ir(), specific_id, inst_id);
   if (const_id.is_concrete()) {
     auto const_inst_id = sem_ir().constant_values().GetInstId(const_id);
 
@@ -151,7 +141,8 @@ auto FileContext::GetGlobal(SemIR::InstId inst_id,
     // If we want a pointer to the constant, materialize a global to hold it.
     // TODO: We could reuse the same global if the constant is used more than
     // once.
-    auto value_rep = SemIR::ValueRepr::ForType(sem_ir(), inst.type_id());
+    auto value_rep = SemIR::ValueRepr::ForType(
+        sem_ir(), sem_ir().insts().Get(const_inst_id).type_id());
     if (value_rep.kind == SemIR::ValueRepr::Pointer) {
       // Include both the name of the constant, if any, and the point of use in
       // the name of the variable.
@@ -182,9 +173,7 @@ auto FileContext::GetGlobal(SemIR::InstId inst_id,
     return const_value;
   }
 
-  // TODO: For generics, handle references to symbolic constants.
-
-  CARBON_FATAL("Missing value: {0} {1}", inst_id,
+  CARBON_FATAL("Missing value: {0} {1} {2}", inst_id, specific_id,
                sem_ir().insts().Get(inst_id));
 }
 

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -126,8 +126,17 @@ auto FileContext::BuildDICompileUnit(llvm::StringRef module_name,
                                       /*RV=*/0);
 }
 
-auto FileContext::GetGlobal(SemIR::InstId inst_id) -> llvm::Value* {
+auto FileContext::GetGlobal(SemIR::InstId inst_id,
+                            SemIR::SpecificId specific_id) -> llvm::Value* {
   auto inst = sem_ir().insts().Get(inst_id);
+
+  if (specific_id.has_value()) {
+    inst_id = sem_ir().constant_values().GetInstIdIfValid(
+        GetConstantValueInSpecific(sem_ir(), specific_id, inst_id));
+    CARBON_CHECK(inst_id.has_value(),
+                 "Expected to find an instruction id for a specific in the "
+                 "file context");
+  }
 
   auto const_id = sem_ir().constant_values().Get(inst_id);
   if (const_id.is_concrete()) {

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -76,7 +76,8 @@ class FileContext {
   }
 
   // Returns a global value for the given instruction.
-  auto GetGlobal(SemIR::InstId inst_id) -> llvm::Value*;
+  auto GetGlobal(SemIR::InstId inst_id, SemIR::SpecificId specific_id)
+      -> llvm::Value*;
 
   // Returns the empty LLVM struct type used to represent the type `type`.
   auto GetTypeType() -> llvm::StructType* {

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -46,8 +46,6 @@ class FunctionContext {
 
   // Returns a value for the given instruction.
   auto GetValue(SemIR::InstId inst_id) -> llvm::Value* {
-    // TODO: if(specific_id_.has_value()) may need to update inst_id first.
-
     // All builtins are types, with the same empty lowered value.
     if (SemIR::IsSingletonInstId(inst_id)) {
       return GetTypeAsValue();
@@ -61,7 +59,7 @@ class FunctionContext {
       return result.value();
     }
 
-    return file_context_->GetGlobal(inst_id);
+    return file_context_->GetGlobal(inst_id, specific_id_);
   }
 
   // Sets the value for the given instruction.

--- a/toolchain/lower/handle_call.cpp
+++ b/toolchain/lower/handle_call.cpp
@@ -443,7 +443,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
   std::vector<llvm::Value*> args;
 
   auto inst_type_id = SemIR::GetTypeInSpecific(
-      context.sem_ir(), callee_function.resolved_specific_id, inst.type_id);
+      context.sem_ir(), context.specific_id(), inst.type_id);
 
   if (SemIR::ReturnTypeInfo::ForType(context.sem_ir(), inst_type_id)
           .has_return_slot()) {

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -11,16 +11,22 @@
 fn F[T:! type](x: T) {
 }
 
-fn H[T:! type](x: T) {
-}
-
-fn G[T:! type](x: T) -> T {
-  H(x);
-  // TODO: Call crashes, see TODO in FunctionContext::GetValue()
-  // H(T);
+fn H[T:! type](x: T) -> T {
   return x;
 }
 
+fn G[T:! type](x: T) -> T {
+  // small stress test for single depth of calls with change in types
+  H(x);
+  H(T);
+  H(i32);
+  H(G(x));
+  G(T);
+  var a: f64;
+  G(a);
+  H(a);
+  return x;
+}
 
 fn M() {
   var n: i32 = 0;
@@ -37,6 +43,8 @@ fn M() {
 // CHECK:STDOUT: ; ModuleID = 'call_basic.carbon'
 // CHECK:STDOUT: source_filename = "call_basic.carbon"
 // CHECK:STDOUT:
+// CHECK:STDOUT: %type = type {}
+// CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
@@ -49,16 +57,16 @@ fn M() {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %p.var), !dbg !7
 // CHECK:STDOUT:   store double 1.000000e+00, ptr %p.var, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %q.var), !dbg !7
-// CHECK:STDOUT:   %.loc31 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc31), !dbg !10
-// CHECK:STDOUT:   %.loc32 = load i32, ptr %n.var, align 4, !dbg !11
-// CHECK:STDOUT:   %G.call.loc32 = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc32), !dbg !12
-// CHECK:STDOUT:   store i32 %G.call.loc32, ptr %m.var, align 4, !dbg !13
-// CHECK:STDOUT:   %.loc33 = load double, ptr %p.var, align 8, !dbg !14
-// CHECK:STDOUT:   call void @_CF.Main.66be507887ceee78(double %.loc33), !dbg !15
-// CHECK:STDOUT:   %.loc34 = load double, ptr %p.var, align 8, !dbg !16
-// CHECK:STDOUT:   %G.call.loc34 = call double @_CG.Main.66be507887ceee78(double %.loc34), !dbg !17
-// CHECK:STDOUT:   store double %G.call.loc34, ptr %q.var, align 8, !dbg !18
+// CHECK:STDOUT:   %.loc37 = load i32, ptr %n.var, align 4, !dbg !9
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc37), !dbg !10
+// CHECK:STDOUT:   %.loc38 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %G.call.loc38 = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc38), !dbg !12
+// CHECK:STDOUT:   store i32 %G.call.loc38, ptr %m.var, align 4, !dbg !13
+// CHECK:STDOUT:   %.loc39 = load double, ptr %p.var, align 8, !dbg !14
+// CHECK:STDOUT:   call void @_CF.Main.66be507887ceee78(double %.loc39), !dbg !15
+// CHECK:STDOUT:   %.loc40 = load double, ptr %p.var, align 8, !dbg !16
+// CHECK:STDOUT:   %G.call.loc40 = call double @_CG.Main.66be507887ceee78(double %.loc40), !dbg !17
+// CHECK:STDOUT:   store double %G.call.loc40, ptr %q.var, align 8, !dbg !18
 // CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -72,33 +80,82 @@ fn M() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !22 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !23
-// CHECK:STDOUT:   ret i32 %x, !dbg !24
+// CHECK:STDOUT:   %a.var = alloca double, align 8, !dbg !23
+// CHECK:STDOUT:   %H.call.loc20 = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !24
+// CHECK:STDOUT:   %H.call.loc21 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !25
+// CHECK:STDOUT:   %H.call.loc22 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !26
+// CHECK:STDOUT:   %G.call.loc23 = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x), !dbg !27
+// CHECK:STDOUT:   %H.call.loc23 = call i32 @_CH.Main.b88d1103f417c6d4(i32 %G.call.loc23), !dbg !28
+// CHECK:STDOUT:   %G.call.loc24 = call %type @_CG.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !29
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !23
+// CHECK:STDOUT:   %.loc26 = load double, ptr %a.var, align 8, !dbg !30
+// CHECK:STDOUT:   %G.call.loc26 = call double @_CG.Main.66be507887ceee78(double %.loc26), !dbg !31
+// CHECK:STDOUT:   %.loc27 = load double, ptr %a.var, align 8, !dbg !32
+// CHECK:STDOUT:   %H.call.loc27 = call double @_CH.Main.66be507887ceee78(double %.loc27), !dbg !33
+// CHECK:STDOUT:   ret i32 %x, !dbg !34
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !25 {
+// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !35 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !26
+// CHECK:STDOUT:   ret void, !dbg !36
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !27 {
+// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !37 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CH.Main.66be507887ceee78(double %x), !dbg !28
-// CHECK:STDOUT:   ret double %x, !dbg !29
+// CHECK:STDOUT:   %a.var = alloca double, align 8, !dbg !38
+// CHECK:STDOUT:   %H.call.loc20 = call double @_CH.Main.66be507887ceee78(double %x), !dbg !39
+// CHECK:STDOUT:   %H.call.loc21 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !40
+// CHECK:STDOUT:   %H.call.loc22 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !41
+// CHECK:STDOUT:   %G.call.loc23 = call double @_CG.Main.66be507887ceee78(double %x), !dbg !42
+// CHECK:STDOUT:   %H.call.loc23 = call double @_CH.Main.66be507887ceee78(double %G.call.loc23), !dbg !43
+// CHECK:STDOUT:   %G.call.loc24 = call %type @_CG.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !44
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !38
+// CHECK:STDOUT:   %.loc26 = load double, ptr %a.var, align 8, !dbg !45
+// CHECK:STDOUT:   %G.call.loc26 = call double @_CG.Main.66be507887ceee78(double %.loc26), !dbg !46
+// CHECK:STDOUT:   %.loc27 = load double, ptr %a.var, align 8, !dbg !47
+// CHECK:STDOUT:   %H.call.loc27 = call double @_CH.Main.66be507887ceee78(double %.loc27), !dbg !48
+// CHECK:STDOUT:   ret double %x, !dbg !49
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !30 {
+// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !50 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !31
+// CHECK:STDOUT:   ret i32 %x, !dbg !51
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CH.Main.66be507887ceee78(double %x) !dbg !32 {
+// CHECK:STDOUT: define %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !52 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !33
+// CHECK:STDOUT:   ret %type %x, !dbg !53
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !54 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca double, align 8, !dbg !55
+// CHECK:STDOUT:   %H.call.loc20 = call %type @_CH.Main.5754c7a55c7cbe4a(%type %x), !dbg !56
+// CHECK:STDOUT:   %H.call.loc21 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !57
+// CHECK:STDOUT:   %H.call.loc22 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !58
+// CHECK:STDOUT:   %G.call.loc23 = call %type @_CG.Main.5754c7a55c7cbe4a(%type %x), !dbg !59
+// CHECK:STDOUT:   %H.call.loc23 = call %type @_CH.Main.5754c7a55c7cbe4a(%type %G.call.loc23), !dbg !60
+// CHECK:STDOUT:   %G.call.loc24 = call %type @_CG.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !61
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !55
+// CHECK:STDOUT:   %.loc26 = load double, ptr %a.var, align 8, !dbg !62
+// CHECK:STDOUT:   %G.call.loc26 = call double @_CG.Main.66be507887ceee78(double %.loc26), !dbg !63
+// CHECK:STDOUT:   %.loc27 = load double, ptr %a.var, align 8, !dbg !64
+// CHECK:STDOUT:   %H.call.loc27 = call double @_CH.Main.66be507887ceee78(double %.loc27), !dbg !65
+// CHECK:STDOUT:   ret %type %x, !dbg !66
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define double @_CH.Main.66be507887ceee78(double %x) !dbg !67 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret double %x, !dbg !68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 1, 2, 6, 5, 4, 3 }
+// CHECK:STDOUT: uselistorder ptr @_CG.Main.66be507887ceee78, { 0, 1, 2, 4, 3 }
+// CHECK:STDOUT: uselistorder ptr @_CH.Main.b88d1103f417c6d4, { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @_CH.Main.5754c7a55c7cbe4a, { 0, 1, 2, 3, 7, 6, 5, 4 }
+// CHECK:STDOUT: uselistorder ptr @_CG.Main.5754c7a55c7cbe4a, { 0, 1, 3, 2 }
+// CHECK:STDOUT: uselistorder ptr @_CH.Main.66be507887ceee78, { 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT:
@@ -109,33 +166,68 @@ fn M() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "call_basic.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "M", linkageName: "_CM.Main", scope: null, file: !3, line: 25, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "M", linkageName: "_CM.Main", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 26, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 28, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 31, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 31, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 32, column: 9, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 32, column: 7, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 32, column: 3, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 33, column: 5, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 33, column: 3, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 34, column: 9, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 34, column: 7, scope: !4)
-// CHECK:STDOUT: !18 = !DILocation(line: 34, column: 3, scope: !4)
-// CHECK:STDOUT: !19 = !DILocation(line: 25, column: 1, scope: !4)
+// CHECK:STDOUT: !7 = !DILocation(line: 32, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 34, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 37, column: 5, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 37, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 38, column: 9, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 38, column: 7, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 38, column: 3, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 39, column: 5, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 39, column: 3, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 40, column: 9, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 40, column: 7, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 40, column: 3, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 31, column: 1, scope: !4)
 // CHECK:STDOUT: !20 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !21 = !DILocation(line: 11, column: 1, scope: !20)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !23 = !DILocation(line: 18, column: 3, scope: !22)
-// CHECK:STDOUT: !24 = !DILocation(line: 21, column: 3, scope: !22)
-// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !26 = !DILocation(line: 11, column: 1, scope: !25)
-// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !28 = !DILocation(line: 18, column: 3, scope: !27)
-// CHECK:STDOUT: !29 = !DILocation(line: 21, column: 3, scope: !27)
-// CHECK:STDOUT: !30 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !31 = !DILocation(line: 14, column: 1, scope: !30)
-// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.66be507887ceee78", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !33 = !DILocation(line: 14, column: 1, scope: !32)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 18, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = !DILocation(line: 25, column: 3, scope: !22)
+// CHECK:STDOUT: !24 = !DILocation(line: 20, column: 3, scope: !22)
+// CHECK:STDOUT: !25 = !DILocation(line: 21, column: 3, scope: !22)
+// CHECK:STDOUT: !26 = !DILocation(line: 22, column: 3, scope: !22)
+// CHECK:STDOUT: !27 = !DILocation(line: 23, column: 5, scope: !22)
+// CHECK:STDOUT: !28 = !DILocation(line: 23, column: 3, scope: !22)
+// CHECK:STDOUT: !29 = !DILocation(line: 24, column: 3, scope: !22)
+// CHECK:STDOUT: !30 = !DILocation(line: 26, column: 5, scope: !22)
+// CHECK:STDOUT: !31 = !DILocation(line: 26, column: 3, scope: !22)
+// CHECK:STDOUT: !32 = !DILocation(line: 27, column: 5, scope: !22)
+// CHECK:STDOUT: !33 = !DILocation(line: 27, column: 3, scope: !22)
+// CHECK:STDOUT: !34 = !DILocation(line: 28, column: 3, scope: !22)
+// CHECK:STDOUT: !35 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !36 = !DILocation(line: 11, column: 1, scope: !35)
+// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 18, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !38 = !DILocation(line: 25, column: 3, scope: !37)
+// CHECK:STDOUT: !39 = !DILocation(line: 20, column: 3, scope: !37)
+// CHECK:STDOUT: !40 = !DILocation(line: 21, column: 3, scope: !37)
+// CHECK:STDOUT: !41 = !DILocation(line: 22, column: 3, scope: !37)
+// CHECK:STDOUT: !42 = !DILocation(line: 23, column: 5, scope: !37)
+// CHECK:STDOUT: !43 = !DILocation(line: 23, column: 3, scope: !37)
+// CHECK:STDOUT: !44 = !DILocation(line: 24, column: 3, scope: !37)
+// CHECK:STDOUT: !45 = !DILocation(line: 26, column: 5, scope: !37)
+// CHECK:STDOUT: !46 = !DILocation(line: 26, column: 3, scope: !37)
+// CHECK:STDOUT: !47 = !DILocation(line: 27, column: 5, scope: !37)
+// CHECK:STDOUT: !48 = !DILocation(line: 27, column: 3, scope: !37)
+// CHECK:STDOUT: !49 = !DILocation(line: 28, column: 3, scope: !37)
+// CHECK:STDOUT: !50 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !51 = !DILocation(line: 15, column: 3, scope: !50)
+// CHECK:STDOUT: !52 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !53 = !DILocation(line: 15, column: 3, scope: !52)
+// CHECK:STDOUT: !54 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 18, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !55 = !DILocation(line: 25, column: 3, scope: !54)
+// CHECK:STDOUT: !56 = !DILocation(line: 20, column: 3, scope: !54)
+// CHECK:STDOUT: !57 = !DILocation(line: 21, column: 3, scope: !54)
+// CHECK:STDOUT: !58 = !DILocation(line: 22, column: 3, scope: !54)
+// CHECK:STDOUT: !59 = !DILocation(line: 23, column: 5, scope: !54)
+// CHECK:STDOUT: !60 = !DILocation(line: 23, column: 3, scope: !54)
+// CHECK:STDOUT: !61 = !DILocation(line: 24, column: 3, scope: !54)
+// CHECK:STDOUT: !62 = !DILocation(line: 26, column: 5, scope: !54)
+// CHECK:STDOUT: !63 = !DILocation(line: 26, column: 3, scope: !54)
+// CHECK:STDOUT: !64 = !DILocation(line: 27, column: 5, scope: !54)
+// CHECK:STDOUT: !65 = !DILocation(line: 27, column: 3, scope: !54)
+// CHECK:STDOUT: !66 = !DILocation(line: 28, column: 3, scope: !54)
+// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.66be507887ceee78", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !68 = !DILocation(line: 15, column: 3, scope: !67)

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -1,0 +1,105 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+
+fn F[T:! type](x: T) {
+}
+
+fn H[T:! type](x: T) -> T {
+  // This call crashes because check/eval does not emit a definition for H.
+  // In G below, the call to H can be typechecked without needing a definition.
+  // TODO: this needs to be resolved in check/eval.
+  // F(x);
+  return x;
+}
+
+fn G[T:! type](x: T) -> T {
+  H(x);
+  F(x);
+  return x;
+}
+
+fn M() {
+  var n: i32 = 0;
+  var m: i32;
+
+  F(n);
+  m = G(n);
+  // Adding something like this makes check/eval emit a definition for H, hence no crash.
+  // m = H(n);
+}
+
+// CHECK:STDOUT: ; ModuleID = 'call_basic_depth.carbon'
+// CHECK:STDOUT: source_filename = "call_basic_depth.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
+// CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %m.var), !dbg !7
+// CHECK:STDOUT:   %.loc32 = load i32, ptr %n.var, align 4, !dbg !8
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc32), !dbg !9
+// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !10
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !11
+// CHECK:STDOUT:   store i32 %G.call, ptr %m.var, align 4, !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !14 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !16 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !17
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !18
+// CHECK:STDOUT:   ret i32 %x, !dbg !19
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !20 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret i32 %x, !dbg !21
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "call_basic_depth.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "M", linkageName: "_CM.Main", scope: null, file: !3, line: 28, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 29, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 32, column: 5, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 32, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 33, column: 9, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 33, column: 7, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 33, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 28, column: 1, scope: !4)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !15 = !DILocation(line: 11, column: 1, scope: !14)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !17 = !DILocation(line: 23, column: 3, scope: !16)
+// CHECK:STDOUT: !18 = !DILocation(line: 24, column: 3, scope: !16)
+// CHECK:STDOUT: !19 = !DILocation(line: 25, column: 3, scope: !16)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = !DILocation(line: 19, column: 3, scope: !20)

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -21,6 +21,8 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id,
   if (specific_id.has_value()) {
     callee_id = sem_ir.constant_values().GetInstIdIfValid(
         GetConstantValueInSpecific(sem_ir, specific_id, callee_id));
+    CARBON_CHECK(callee_id.has_value(),
+                 "Invalid callee id in a specific context");
   }
 
   if (auto specific_function =


### PR DESCRIPTION
Resolve instruction id depending on the context from which a function is called.

Calling a function in a function context that does not have a definition emitted before reaching lowering will cause a crash. This needs a change in check/eval layer.

