### PR TITLE
Consolidate on @platforms//os:macos

### DIFF
--- a/bazel/cc_toolchains/BUILD
+++ b/bazel/cc_toolchains/BUILD
@@ -20,7 +20,7 @@ selects.config_setting_group(
 # Matches macOS platforms.
 config_setting(
     name = "is_macos",
-    constraint_values = ["@platforms//os:osx"],
+    constraint_values = ["@platforms//os:macos"],
 )
 
 # For use by rules.bzl.


### PR DESCRIPTION
Noticed because we have a new dep on @platforms//os:macos in https://github.com/carbon-language/carbon-lang/blob/trunk/toolchain/base/BUILD#L131

macos is preferred according to the definition at https://github.com/bazelbuild/platforms/blob/dd28c190c563531c06ba3bd64eca1cc9ca3e667f/os/BUILD#L70C1-L74C2