### PR TITLE
Move impl cycle tests to min-prelude

### DIFF
--- a/toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
@@ -7,9 +7,9 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/impl_cycle.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/no_prelude/impl_cycle.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
 
 // --- fail_impl_simple_cycle.carbon
 library "[[@TEST_NAME]]";

--- a/toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
@@ -2,7 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
+// EXTRA-ARGS: --no-dump-sem-ir --custom-core
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -10,29 +11,8 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/no_prelude/impl_cycle.carbon
 
-// --- core.carbon
-package Core;
-
-interface As(Dest:! type) {
-  fn Convert[self: Self]() -> Dest;
-}
-
-interface ImplicitAs(Dest:! type) {
-  fn Convert[self: Self]() -> Dest;
-}
-
-interface BitAnd {
-  fn Op[self: Self](other: Self) -> Self;
-}
-
-impl forall [T:! type] T as BitAnd {
-  fn Op[self: Self](other: Self) -> Self = "type.and";
-}
-
 // --- fail_impl_simple_cycle.carbon
 library "[[@TEST_NAME]]";
-
-import Core;
 
 interface Z {}
 
@@ -57,8 +37,6 @@ fn F() {
 // --- todo_fail_impl_simple_where_cycle.carbon
 library "[[@TEST_NAME]]";
 
-import Core;
-
 interface Z {}
 
 // This creates a dependency cycle with itself.
@@ -75,8 +53,6 @@ fn F() {
 
 // --- fail_impl_simple_two_interfaces.carbon
 library "[[@TEST_NAME]]";
-
-import Core;
 
 interface Z {}
 interface Y {}
@@ -102,8 +78,6 @@ fn F() {
 
 // --- fail_impl_long_cycle.carbon
 library "[[@TEST_NAME]]";
-
-import Core;
 
 interface X {}
 interface Y {}
@@ -136,8 +110,6 @@ fn F() {
 
 // --- fail_impl_cycle_one_generic_param.carbon
 library "[[@TEST_NAME]]";
-
-import Core;
 
 interface ComparableWith(T:! type) {}
 
@@ -208,8 +180,6 @@ fn F() {
 // --- impl_recurse_with_simpler_type_no_cycle.carbon
 library "[[@TEST_NAME]]";
 
-import Core;
-
 class Wraps(T:! type) {}
 
 interface Printable {}
@@ -227,8 +197,6 @@ fn F() {
 
 // --- impl_recurse_with_simpler_type_in_generic_param_no_cycle.carbon
 library "[[@TEST_NAME]]";
-
-import Core;
 
 class Wraps(T:! type) {}
 
@@ -252,8 +220,6 @@ fn F() {
 
 // --- impl_recurse_with_simpler_type_in_generic_param_bidirectional_no_cycle.carbon
 library "[[@TEST_NAME]]";
-
-import Core;
 
 // Implement this for a type in one direction.
 interface ComparableTo(T:! type) {}


### PR DESCRIPTION
Use the facet_types min-prelude instead of defining a Core package in the test file.
