### PR TITLE
Clean up node kind information for namespaces

### DIFF
--- a/toolchain/check/check_unit.h
+++ b/toolchain/check/check_unit.h
@@ -10,6 +10,7 @@
 #include "toolchain/check/check.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/sem_ir_loc_diagnostic_emitter.h"
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
@@ -27,15 +28,16 @@ struct PackageImports {
 
   // Use the constructor so that the SmallVector is only constructed
   // as-needed.
-  explicit PackageImports(PackageNameId package_id, Parse::ImportDeclId node_id)
+  explicit PackageImports(PackageNameId package_id,
+                          Parse::AnyPackagingDeclId node_id)
       : package_id(package_id), node_id(node_id) {}
 
   // The identifier of the imported package.
   PackageNameId package_id;
-  // The first `import` declaration in the file, which declared the package's
-  // identifier (even if the import failed). Used for associating diagnostics
-  // not specific to a single import.
-  Parse::ImportDeclId node_id;
+  // The first `package` or `import` declaration in the file, which declared the
+  // package's identifier (even if the import failed). Used for associating
+  // diagnostics not specific to a single import.
+  Parse::AnyPackagingDeclId node_id;
   // The associated `import` instruction. Has a value after a file is checked.
   SemIR::InstId import_decl_id = SemIR::InstId::None;
   // Whether there's an import that failed to load.

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -99,10 +99,10 @@ static auto MakeImportedNamespaceLocIdAndInst(
   }
 
   SemIR::LocId import_loc_id = context.insts().GetLocId(import_id);
-  //  if (!import_loc_id.has_value()) {
-  //   // TODO: Require a location.
-  //   return SemIR::LocIdAndInst::NoLoc(namespace_inst);
-  // }
+  if (!import_loc_id.has_value()) {
+    // TODO: Either document the use-case for this, or require a location.
+    return SemIR::LocIdAndInst::NoLoc(namespace_inst);
+  }
   if (import_loc_id.is_import_ir_inst_id()) {
     return MakeImportedLocIdAndInst(context, import_loc_id.import_ir_inst_id(),
                                     namespace_inst);

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -77,9 +77,10 @@ static auto GetImportName(const SemIR::File& import_sem_ir,
 
 // Translate the name to the current IR. It will usually be an identifier, but
 // could also be a builtin name ID which is equivalent cross-IR.
-static auto CopyNameFromImportIR(
-    Context& context, const SemIR::File& import_sem_ir,
-    SemIR::NameId import_name_id) -> SemIR::NameId {
+static auto CopyNameFromImportIR(Context& context,
+                                 const SemIR::File& import_sem_ir,
+                                 SemIR::NameId import_name_id)
+    -> SemIR::NameId {
   if (auto import_identifier_id = import_name_id.AsIdentifierId();
       import_identifier_id.has_value()) {
     auto name = import_sem_ir.identifiers().Get(import_identifier_id);
@@ -89,9 +90,10 @@ static auto CopyNameFromImportIR(
 }
 
 // Returns the LocIdAndInst for the namespace.
-static auto MakeImportedNamespaceLocIdAndInst(
-    Context& context, SemIR::InstId import_id,
-    SemIR::Namespace namespace_inst) -> SemIR::LocIdAndInst {
+static auto MakeImportedNamespaceLocIdAndInst(Context& context,
+                                              SemIR::InstId import_id,
+                                              SemIR::Namespace namespace_inst)
+    -> SemIR::LocIdAndInst {
   if (!import_id.has_value()) {
     // TODO: Associate the namespace with a proper location. This is related to:
     // https://github.com/carbon-language/carbon-lang/issues/4666.
@@ -193,8 +195,8 @@ auto AddImportNamespaceToScope(
 // Adds a copied namespace to the cache.
 static auto CacheCopiedNamespace(
     Map<SemIR::NameScopeId, SemIR::NameScopeId>& copied_namespaces,
-    SemIR::NameScopeId import_scope_id,
-    SemIR::NameScopeId to_scope_id) -> void {
+    SemIR::NameScopeId import_scope_id, SemIR::NameScopeId to_scope_id)
+    -> void {
   auto result = copied_namespaces.Insert(import_scope_id, to_scope_id);
   CARBON_CHECK(result.is_inserted() || result.value() == to_scope_id,
                "Copy result for namespace changed from {0} to {1}",
@@ -399,10 +401,12 @@ static auto AddScopedImportRef(Context& context,
 }
 
 // Imports entries in a specific scope into the current file.
-static auto ImportScopeFromApiFile(
-    Context& context, const SemIR::File& api_sem_ir,
-    SemIR::NameScopeId api_scope_id, SemIR::NameScopeId impl_scope_id,
-    llvm::SmallVector<TodoScope>& todo_scopes) -> void {
+static auto ImportScopeFromApiFile(Context& context,
+                                   const SemIR::File& api_sem_ir,
+                                   SemIR::NameScopeId api_scope_id,
+                                   SemIR::NameScopeId impl_scope_id,
+                                   llvm::SmallVector<TodoScope>& todo_scopes)
+    -> void {
   const auto& api_scope = api_sem_ir.name_scopes().Get(api_scope_id);
   auto& impl_scope = context.name_scopes().Get(impl_scope_id);
 
@@ -543,10 +547,11 @@ auto ImportLibrariesFromOtherPackage(Context& context,
 // Looks up a name in a scope imported from another package. An `identifier` is
 // provided if `name_id` corresponds to an identifier in the current file;
 // otherwise, `name_id` is file-agnostic and can be used directly.
-static auto LookupNameInImport(
-    const SemIR::File& import_ir, SemIR::NameScopeId import_scope_id,
-    SemIR::NameId name_id,
-    llvm::StringRef identifier) -> const Carbon::SemIR::NameScope::Entry* {
+static auto LookupNameInImport(const SemIR::File& import_ir,
+                               SemIR::NameScopeId import_scope_id,
+                               SemIR::NameId name_id,
+                               llvm::StringRef identifier)
+    -> const Carbon::SemIR::NameScope::Entry* {
   // Determine the NameId in the import IR.
   SemIR::NameId import_name_id = name_id;
   if (!identifier.empty()) {
@@ -578,11 +583,13 @@ static auto LookupNameInImport(
 }
 
 // Adds a namespace that points to one in another package.
-static auto AddNamespaceFromOtherPackage(
-    Context& context, SemIR::ImportIRId import_ir_id,
-    SemIR::InstId import_inst_id, SemIR::Namespace import_ns,
-    SemIR::NameScopeId parent_scope_id,
-    SemIR::NameId name_id) -> SemIR::InstId {
+static auto AddNamespaceFromOtherPackage(Context& context,
+                                         SemIR::ImportIRId import_ir_id,
+                                         SemIR::InstId import_inst_id,
+                                         SemIR::Namespace import_ns,
+                                         SemIR::NameScopeId parent_scope_id,
+                                         SemIR::NameId name_id)
+    -> SemIR::InstId {
   auto namespace_type_id =
       GetSingletonType(context, SemIR::NamespaceType::SingletonInstId);
   AddImportNamespaceToScopeResult result = CopySingleNameScopeFromImportIR(

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -77,10 +77,9 @@ static auto GetImportName(const SemIR::File& import_sem_ir,
 
 // Translate the name to the current IR. It will usually be an identifier, but
 // could also be a builtin name ID which is equivalent cross-IR.
-static auto CopyNameFromImportIR(Context& context,
-                                 const SemIR::File& import_sem_ir,
-                                 SemIR::NameId import_name_id)
-    -> SemIR::NameId {
+static auto CopyNameFromImportIR(
+    Context& context, const SemIR::File& import_sem_ir,
+    SemIR::NameId import_name_id) -> SemIR::NameId {
   if (auto import_identifier_id = import_name_id.AsIdentifierId();
       import_identifier_id.has_value()) {
     auto name = import_sem_ir.identifiers().Get(import_identifier_id);
@@ -89,25 +88,28 @@ static auto CopyNameFromImportIR(Context& context,
   return import_name_id;
 }
 
-// Returns the LocIdandInst for the namespace.
-static auto MakeImportedNamespaceLocIdAndInst(Context& context,
-                                              SemIR::InstId import_id,
-                                              SemIR::Namespace namespace_inst)
-    -> SemIR::LocIdAndInst {
-  if (import_id.has_value()) {
-    SemIR::LocId import_loc_id = context.insts().GetLocId(import_id);
-    return import_loc_id.is_import_ir_inst_id()
-               ? MakeImportedLocIdAndInst(
-                     context, import_loc_id.import_ir_inst_id(), namespace_inst)
-               // TODO: Check that this actually is an `AnyNamespaceId`.
-               : SemIR::LocIdAndInst(
-                     Parse::AnyNamespaceId::UnsafeMake(import_loc_id.node_id()),
-                     namespace_inst);
+// Returns the LocIdAndInst for the namespace.
+static auto MakeImportedNamespaceLocIdAndInst(
+    Context& context, SemIR::InstId import_id,
+    SemIR::Namespace namespace_inst) -> SemIR::LocIdAndInst {
+  if (!import_id.has_value()) {
+    // TODO: Associate the namespace with a proper location. This is related to:
+    // https://github.com/carbon-language/carbon-lang/issues/4666.
+    return SemIR::LocIdAndInst::NoLoc(namespace_inst);
   }
 
-  // TODO: Associate the namespace with a proper location. This is related to:
-  // https://github.com/carbon-language/carbon-lang/issues/4666.
-  return SemIR::LocIdAndInst::NoLoc(namespace_inst);
+  SemIR::LocId import_loc_id = context.insts().GetLocId(import_id);
+  //  if (!import_loc_id.has_value()) {
+  //   // TODO: Require a location.
+  //   return SemIR::LocIdAndInst::NoLoc(namespace_inst);
+  // }
+  if (import_loc_id.is_import_ir_inst_id()) {
+    return MakeImportedLocIdAndInst(context, import_loc_id.import_ir_inst_id(),
+                                    namespace_inst);
+  }
+  return SemIR::LocIdAndInst(
+      context.parse_tree().As<Parse::AnyNamespaceId>(import_loc_id.node_id()),
+      namespace_inst);
 }
 
 auto AddImportNamespace(Context& context, SemIR::TypeId namespace_type_id,
@@ -191,8 +193,8 @@ auto AddImportNamespaceToScope(
 // Adds a copied namespace to the cache.
 static auto CacheCopiedNamespace(
     Map<SemIR::NameScopeId, SemIR::NameScopeId>& copied_namespaces,
-    SemIR::NameScopeId import_scope_id, SemIR::NameScopeId to_scope_id)
-    -> void {
+    SemIR::NameScopeId import_scope_id,
+    SemIR::NameScopeId to_scope_id) -> void {
   auto result = copied_namespaces.Insert(import_scope_id, to_scope_id);
   CARBON_CHECK(result.is_inserted() || result.value() == to_scope_id,
                "Copy result for namespace changed from {0} to {1}",
@@ -397,12 +399,10 @@ static auto AddScopedImportRef(Context& context,
 }
 
 // Imports entries in a specific scope into the current file.
-static auto ImportScopeFromApiFile(Context& context,
-                                   const SemIR::File& api_sem_ir,
-                                   SemIR::NameScopeId api_scope_id,
-                                   SemIR::NameScopeId impl_scope_id,
-                                   llvm::SmallVector<TodoScope>& todo_scopes)
-    -> void {
+static auto ImportScopeFromApiFile(
+    Context& context, const SemIR::File& api_sem_ir,
+    SemIR::NameScopeId api_scope_id, SemIR::NameScopeId impl_scope_id,
+    llvm::SmallVector<TodoScope>& todo_scopes) -> void {
   const auto& api_scope = api_sem_ir.name_scopes().Get(api_scope_id);
   auto& impl_scope = context.name_scopes().Get(impl_scope_id);
 
@@ -543,11 +543,10 @@ auto ImportLibrariesFromOtherPackage(Context& context,
 // Looks up a name in a scope imported from another package. An `identifier` is
 // provided if `name_id` corresponds to an identifier in the current file;
 // otherwise, `name_id` is file-agnostic and can be used directly.
-static auto LookupNameInImport(const SemIR::File& import_ir,
-                               SemIR::NameScopeId import_scope_id,
-                               SemIR::NameId name_id,
-                               llvm::StringRef identifier)
-    -> const Carbon::SemIR::NameScope::Entry* {
+static auto LookupNameInImport(
+    const SemIR::File& import_ir, SemIR::NameScopeId import_scope_id,
+    SemIR::NameId name_id,
+    llvm::StringRef identifier) -> const Carbon::SemIR::NameScope::Entry* {
   // Determine the NameId in the import IR.
   SemIR::NameId import_name_id = name_id;
   if (!identifier.empty()) {
@@ -579,13 +578,11 @@ static auto LookupNameInImport(const SemIR::File& import_ir,
 }
 
 // Adds a namespace that points to one in another package.
-static auto AddNamespaceFromOtherPackage(Context& context,
-                                         SemIR::ImportIRId import_ir_id,
-                                         SemIR::InstId import_inst_id,
-                                         SemIR::Namespace import_ns,
-                                         SemIR::NameScopeId parent_scope_id,
-                                         SemIR::NameId name_id)
-    -> SemIR::InstId {
+static auto AddNamespaceFromOtherPackage(
+    Context& context, SemIR::ImportIRId import_ir_id,
+    SemIR::InstId import_inst_id, SemIR::Namespace import_ns,
+    SemIR::NameScopeId parent_scope_id,
+    SemIR::NameId name_id) -> SemIR::InstId {
   auto namespace_type_id =
       GetSingletonType(context, SemIR::NamespaceType::SingletonInstId);
   AddImportNamespaceToScopeResult result = CopySingleNameScopeFromImportIR(

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -99,8 +99,9 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
   auto& import_cpps = context.sem_ir().import_cpps();
   import_cpps.Reserve(imports.size());
   for (const Parse::Tree::PackagingNames& import : imports) {
-    import_cpps.Add(
-        {.node_id = import.node_id, .library_id = import.library_id});
+    import_cpps.Add({.node_id = context.parse_tree().As<Parse::ImportDeclId>(
+                         import.node_id),
+                     .library_id = import.library_id});
   }
 
   return AddImportNamespaceToScope(
@@ -111,7 +112,10 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
              /*diagnose_duplicate_namespace=*/false,
              [&]() {
                return AddInst<SemIR::ImportCppDecl>(
-                   context, imports.front().node_id, {});
+                   context,
+                   context.parse_tree().As<Parse::ImportDeclId>(
+                       imports.front().node_id),
+                   {});
              })
       .add_result.name_scope_id;
 }

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -3277,9 +3277,12 @@ static auto HasCompatibleImportedNodeKind(SemIR::InstKind imported_kind,
   }
   if (imported_kind == SemIR::ImportDecl::Kind &&
       local_kind == SemIR::Namespace::Kind) {
-    static_assert(
-        std::is_convertible_v<decltype(SemIR::ImportDecl::Kind)::TypedNodeId,
-                              decltype(SemIR::Namespace::Kind)::TypedNodeId>);
+    // TODO: Consider supporting NodeIdOneOf conversions to make the below work.
+    // But this extra validation is the primary use-case at present.
+    // static_assert(
+    //     std::is_convertible_v<
+    //         decltype(SemIR::ImportDecl::Kind)::TypedNodeId,
+    //         decltype(SemIR::Namespace::Kind)::TypedNodeId>);
     return true;
   }
   return false;

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -72,7 +72,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_foo.impl.carbon:[[@LINE+8]]:13: error: redeclaration differs at parameter 1 [RedeclParamDiffers]
 // CHECK:STDERR: class Class(U:! type) {
 // CHECK:STDERR:             ^
-// CHECK:STDERR: fail_foo.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_foo.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: foo.carbon:4:13: note: previous declaration's corresponding parameter here [RedeclParamPrevious]
 // CHECK:STDERR: class Class(T:! type);
 // CHECK:STDERR:             ^
@@ -313,8 +313,8 @@ class Class(U:! type) {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_19.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_19.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt.loc4: type = symbolic_binding_pattern T, 0 [symbolic = constants.%T.patt]
@@ -806,8 +806,8 @@ class Class(U:! type) {
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     .T = <poisoned>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_19.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_19.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: %Class.type.cf06d9.2 = class_decl @Class.2 [concrete = constants.%Class.generic.9545f5.2] {
 // CHECK:STDOUT:     %U.patt.loc12_13.1: type = symbolic_binding_pattern U, 0 [symbolic = %U.patt.loc12_13.2 (constants.%U.patt)]

--- a/toolchain/check/testdata/class/import_forward_decl.carbon
+++ b/toolchain/check/testdata/class/import_forward_decl.carbon
@@ -65,8 +65,8 @@ class ForwardDecl {
 // CHECK:STDOUT:     .ForwardDecl = %ForwardDecl.decl
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %ForwardDecl.decl: type = class_decl @ForwardDecl [concrete = constants.%ForwardDecl] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
@@ -33,7 +33,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `class C` is redundant [RedeclRedundant]
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: redecl_after_def.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: class C {}
 // CHECK:STDERR: ^~~~~~~~~
@@ -53,7 +53,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE+8]]:1: error: redefinition of `class C` [RedeclRedef]
 // CHECK:STDERR: class C {}
 // CHECK:STDERR: ^~~~~~~~~
-// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: redef_after_def.carbon:4:1: note: previously defined here [RedeclPrevDef]
 // CHECK:STDERR: class C {}
 // CHECK:STDERR: ^~~~~~~~~
@@ -74,7 +74,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_def_alias.impl.carbon:[[@LINE+8]]:7: error: duplicate name `B` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: class B {}
 // CHECK:STDERR:       ^
-// CHECK:STDERR: fail_def_alias.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_def_alias.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: def_alias.carbon:5:7: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: alias B = C;
 // CHECK:STDERR:       ^
@@ -111,8 +111,8 @@ class B {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_21.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_21.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -164,8 +164,8 @@ class B {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -218,8 +218,8 @@ class B {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C.2 [concrete = constants.%C.f794a0.2] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -275,8 +275,8 @@ class B {}
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_25.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_25.2 = import <none>
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
@@ -102,8 +102,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl.loc4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_46.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_46.2 = import <none>
 // CHECK:STDOUT:   %A.decl.loc4: type = class_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT:   %A.decl.loc6: type = class_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
@@ -132,8 +132,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_only_in_api.carbon
@@ -161,8 +161,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_in_api_decl_in_impl.carbon
@@ -193,8 +193,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_40.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_40.2 = import <none>
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -216,8 +216,8 @@ class D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.2 = import <none>
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [concrete = constants.%D] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
@@ -579,8 +579,8 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .Bar = %Bar.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.2 = import <none>
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [concrete = constants.%Foo.generic] {
 // CHECK:STDOUT:     %a.patt.loc4: %C = symbolic_binding_pattern a, 0 [symbolic = constants.%a.patt]
 // CHECK:STDOUT:   } {
@@ -950,8 +950,8 @@ fn Base.F[addr self: Base*]() {
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.2 = import <none>
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [concrete = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = class_decl @Foo [concrete = constants.%Foo.generic] {

--- a/toolchain/check/testdata/function/declaration/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/implicit_import.carbon
@@ -33,7 +33,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+12]]:1: error: redeclarations of `fn A` must match use of `extern` [RedeclExternMismatch]
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: extern_api.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: extern fn A();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
@@ -57,7 +57,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE+8]]:1: error: redeclarations of `fn A` must match use of `extern` [RedeclExternMismatch]
 // CHECK:STDERR: extern fn A();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
-// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: extern_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
@@ -94,8 +94,8 @@ extern fn A();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_21.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_21.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -134,8 +134,8 @@ extern fn A();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_26.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_26.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -171,8 +171,8 @@ extern fn A();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_27.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_27.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/function/declaration/no_prelude/no_definition_in_impl_file.carbon
@@ -102,8 +102,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl.loc4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_46.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_46.2 = import <none>
 // CHECK:STDOUT:   %A.decl.loc4: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT:   %A.decl.loc6: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
@@ -129,8 +129,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_only_in_api.carbon
@@ -159,8 +159,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- decl_in_api_decl_in_impl.carbon
@@ -193,8 +193,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_40.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_40.2 = import <none>
 // CHECK:STDOUT:   %C.decl: %C.type = fn_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -217,8 +217,8 @@ fn D();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.2 = import <none>
 // CHECK:STDOUT:   %D.decl: %D.type = fn_decl @D [concrete = constants.%D] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/extern.carbon
@@ -180,8 +180,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_29.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_29.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -288,8 +288,8 @@ extern fn F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/extern_library.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/extern_library.carbon
@@ -57,7 +57,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_two_file_impl_mismatch.impl.carbon:[[@LINE+8]]:1: error: redeclarations of `fn F` must match use of `extern` [RedeclExternMismatch]
 // CHECK:STDERR: fn F() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_two_file_impl_mismatch.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_two_file_impl_mismatch.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: two_file_impl_mismatch.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
@@ -249,8 +249,8 @@ extern fn ExternDecl();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -305,8 +305,8 @@ extern fn ExternDecl();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_38.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_38.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -341,8 +341,8 @@ extern fn ExternDecl();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_no_decl.carbon
@@ -415,8 +415,8 @@ extern fn ExternDecl();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -461,8 +461,8 @@ extern fn ExternDecl();
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.2 = import <none>
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/implicit_import.carbon
@@ -33,7 +33,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+8]]:1: error: redeclarations of `fn A` must match use of `extern` [RedeclExternMismatch]
 // CHECK:STDERR: fn A() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: extern_api.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: extern fn A();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
@@ -53,7 +53,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE+8]]:1: error: redeclarations of `fn A` must match use of `extern` [RedeclExternMismatch]
 // CHECK:STDERR: extern fn A() {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: extern_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
@@ -73,7 +73,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `fn A` is redundant [RedeclRedundant]
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: redecl_after_def.carbon:4:1: note: previously declared here [RedeclPrevDecl]
 // CHECK:STDERR: fn A() {}
 // CHECK:STDERR: ^~~~~~~~
@@ -93,7 +93,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE+8]]:1: error: redefinition of `fn A` [RedeclRedef]
 // CHECK:STDERR: fn A() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: redef_after_def.carbon:4:1: note: previously defined here [RedeclPrevDef]
 // CHECK:STDERR: fn A() {}
 // CHECK:STDERR: ^~~~~~~~
@@ -114,7 +114,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_def_alias.impl.carbon:[[@LINE+8]]:4: error: duplicate name `B` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: fn B() {}
 // CHECK:STDERR:    ^
-// CHECK:STDERR: fail_def_alias.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_def_alias.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: def_alias.carbon:5:7: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: alias B = A;
 // CHECK:STDERR:       ^
@@ -151,8 +151,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_21.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_21.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -191,8 +191,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_26.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_26.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -231,8 +231,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_27.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_27.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -274,8 +274,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type = fn_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -317,8 +317,8 @@ fn B() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.2 = import <none>
 // CHECK:STDOUT:   %A.decl: %A.type.00d7e7.2 = fn_decl @A.2 [concrete = constants.%A.1db889.2] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -367,8 +367,8 @@ fn B() {}
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_25.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_25.2 = import <none>
 // CHECK:STDOUT:   %B.decl: %B.type = fn_decl @B [concrete = constants.%B] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/syntactic_merge.carbon
@@ -466,8 +466,8 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .Bar = %Bar.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.2 = import <none>
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = fn_decl @Foo [concrete = constants.%Foo] {
 // CHECK:STDOUT:     %a.patt: %C = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %C = value_param_pattern %a.patt, call_param0
@@ -797,8 +797,8 @@ fn Foo(a: const (const C)) {}
 // CHECK:STDOUT:     .Foo = %Foo.decl
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.2 = import <none>
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [concrete = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type = fn_decl @Foo [concrete = constants.%Foo] {

--- a/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
@@ -307,8 +307,8 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .I = imports.%Main.I
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.08450a.2 [concrete] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
@@ -742,8 +742,8 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .J = imports.%Main.J
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_35.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_35.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.199bba.2 [concrete] {
 // CHECK:STDOUT:     %T.patt.loc8_14.1: type = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_14.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {

--- a/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/interface_args.carbon
@@ -472,8 +472,8 @@ fn InstanceC(a: A) -> C {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.2 = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %a.patt: %A = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %A = value_param_pattern %a.patt, call_param0
@@ -646,8 +646,8 @@ fn InstanceC(a: A) -> C {
 // CHECK:STDOUT:     .F = imports.%Main.F
 // CHECK:STDOUT:     .G = %G.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.2 = import <none>
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %a.patt: %A = binding_pattern a
 // CHECK:STDOUT:     %a.param_patt: %A = value_param_pattern %a.patt, call_param0
@@ -1073,8 +1073,8 @@ fn InstanceC(a: A) -> C {
 // CHECK:STDOUT:     .MakeB = %MakeB.decl
 // CHECK:STDOUT:     .InstanceB = %InstanceB.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.2 = import <none>
 // CHECK:STDOUT:   %MakeB.decl: %MakeB.type = fn_decl @MakeB [concrete = constants.%MakeB] {
 // CHECK:STDOUT:     %return.patt: %B = return_slot_pattern
 // CHECK:STDOUT:     %return.param_patt: %B = out_param_pattern %return.patt, call_param0
@@ -1339,8 +1339,8 @@ fn InstanceC(a: A) -> C {
 // CHECK:STDOUT:     .MakeC = %MakeC.decl
 // CHECK:STDOUT:     .InstanceC = %InstanceC.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_23.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   %MakeC.decl: %MakeC.type = fn_decl @MakeC [concrete = constants.%MakeC] {

--- a/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
@@ -151,8 +151,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_46.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_46.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.064930.2 [concrete] {} {
 // CHECK:STDOUT:     %.loc8_7.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc8_7.2: type = converted %.loc8_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
@@ -198,8 +198,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_31.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_decl_only_in_api.carbon
@@ -252,8 +252,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_32.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @B [from "fail_decl_only_in_api.carbon"] {
@@ -315,8 +315,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_40.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_40.2 = import <none>
 // CHECK:STDOUT:   impl_decl @impl.590fe9.2 [concrete] {} {
 // CHECK:STDOUT:     %.loc8_7.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc8_7.2: type = converted %.loc8_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
@@ -354,8 +354,8 @@ impl () as D;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_33.2 = import <none>
 // CHECK:STDOUT:   %D.decl: type = interface_decl @D [concrete = constants.%D.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
 // CHECK:STDOUT:     %.loc10_7.1: %empty_tuple.type = tuple_literal ()

--- a/toolchain/check/testdata/interface/no_prelude/import_interface_decl.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/import_interface_decl.carbon
@@ -52,8 +52,8 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc1_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc1_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_17.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_b.carbon
@@ -106,8 +106,8 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc1_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc1_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_17.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @B [from "fail_b.carbon"] {

--- a/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/syntactic_merge.carbon
@@ -72,7 +72,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR: fail_todo_two_file.impl.carbon:[[@LINE+8]]:11: error: duplicate name `Foo` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: interface Foo(a:! C) {}
 // CHECK:STDERR:           ^~~
-// CHECK:STDERR: fail_todo_two_file.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_todo_two_file.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: two_file.carbon:7:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: interface Foo(a:! C);
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
@@ -81,7 +81,7 @@ interface Foo(a:! C) {}
 // CHECK:STDERR: fail_todo_two_file.impl.carbon:[[@LINE+8]]:11: error: duplicate name `Bar` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: interface Bar(a:! D) {}
 // CHECK:STDERR:           ^~~
-// CHECK:STDERR: fail_todo_two_file.impl.carbon:[[@LINE-14]]:6: in import [InImport]
+// CHECK:STDERR: fail_todo_two_file.impl.carbon:[[@LINE-14]]:1: in import [InImport]
 // CHECK:STDERR: two_file.carbon:8:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: interface Bar(a:! D);
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
@@ -159,7 +159,7 @@ alias D = C;
 // CHECK:STDERR: fail_alias_two_file.impl.carbon:[[@LINE+8]]:11: error: duplicate name `Foo` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: interface Foo(a:! D) {}
 // CHECK:STDERR:           ^~~
-// CHECK:STDERR: fail_alias_two_file.impl.carbon:[[@LINE-10]]:6: in import [InImport]
+// CHECK:STDERR: fail_alias_two_file.impl.carbon:[[@LINE-10]]:1: in import [InImport]
 // CHECK:STDERR: alias_two_file.carbon:6:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: interface Foo(a:! C);
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
@@ -618,8 +618,8 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:     .Foo = imports.%Main.Foo
 // CHECK:STDOUT:     .Bar = imports.%Main.Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.2 = import <none>
 // CHECK:STDOUT:   %Foo.decl: %Foo.type.5380b8.2 = interface_decl @Foo.2 [concrete = constants.%Foo.generic.ec3175.2] {
 // CHECK:STDOUT:     %a.patt.loc12_15.1: %C = symbolic_binding_pattern a, 0 [symbolic = %a.patt.loc12_15.2 (constants.%a.patt)]
 // CHECK:STDOUT:   } {
@@ -1040,8 +1040,8 @@ interface Foo(a:! const (const C)) {}
 // CHECK:STDOUT:     .Foo = imports.%Main.Foo
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_30.2 = import <none>
 // CHECK:STDOUT:   %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, imports.%Main.C [concrete = constants.%C]
 // CHECK:STDOUT:   %Foo.decl: %Foo.type.5380b8.2 = interface_decl @Foo.2 [concrete = constants.%Foo.generic.ec3175.2] {

--- a/toolchain/check/testdata/interop/cpp/no_prelude/bad_import.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/bad_import.carbon
@@ -14,7 +14,7 @@ library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_import_cpp.carbon:[[@LINE+4]]:1: error: `Cpp` import missing library [CppInteropMissingLibrary]
 // CHECK:STDERR: import Cpp;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp;
 
@@ -24,7 +24,7 @@ library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_import_cpp_library_empty.carbon:[[@LINE+4]]:1: error: `Cpp` import missing library [CppInteropMissingLibrary]
 // CHECK:STDERR: import Cpp library "";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "";
 
@@ -38,7 +38,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |          ^~~~~~~~~~~
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "\"foo.h\"";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "\"foo.h\"";
 

--- a/toolchain/check/testdata/interop/cpp/no_prelude/cpp_diagnostics.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/cpp_diagnostics.carbon
@@ -23,7 +23,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "one_error.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "one_error.h";
 
@@ -46,7 +46,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "multiple_errors.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "multiple_errors.h";
 
@@ -65,7 +65,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseWarning]
 // CHECK:STDERR: import Cpp library "one_warning.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "one_warning.h";
 
@@ -92,7 +92,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseWarning]
 // CHECK:STDERR: import Cpp library "multiple_warnings.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "multiple_warnings.h";
 
@@ -115,7 +115,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "one_error_and_one_warning.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "one_error_and_one_warning.h";
 
@@ -150,7 +150,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "multiple_errors_and_multiple_warnings.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "multiple_errors_and_multiple_warnings.h";
 
@@ -176,7 +176,7 @@ import Cpp library "one_warning.h";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseWarning]
 // CHECK:STDERR: import Cpp library "multiple_warnings.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "multiple_warnings.h";
 
@@ -211,7 +211,7 @@ import Cpp library "one_error_and_one_warning.h";
 // CHECK:STDERR:       |  ^
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "multiple_errors_and_multiple_warnings.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "multiple_errors_and_multiple_warnings.h";
 

--- a/toolchain/check/testdata/interop/cpp/no_prelude/cpp_namespace.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/cpp_namespace.carbon
@@ -21,7 +21,7 @@ import Cpp library "header.h";
 // CHECK:STDERR:           ^~~
 // CHECK:STDERR: fail_duplicate_cpp_name.carbon:[[@LINE-5]]:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: import Cpp library "header.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 namespace Cpp;
 
@@ -53,7 +53,7 @@ import Cpp library "header.h";
 // CHECK:STDERR:       ^~~
 // CHECK:STDERR: fail_add_name_to_cpp_namespace.carbon:[[@LINE-5]]:1: note: package imported here [QualifiedDeclOutsidePackageSource]
 // CHECK:STDERR: import Cpp library "header.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 class Cpp.C {};
 
@@ -194,7 +194,7 @@ import Cpp library "header.h";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Cpp = imports.%Cpp
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_28.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_28.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/no_prelude/fail_fuzzing.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/fail_fuzzing.carbon
@@ -12,6 +12,6 @@
 
 // CHECK:STDERR: fail_fuzzing.carbon:[[@LINE+4]]:1: error: `Cpp` import found during fuzzing [CppInteropFuzzing]
 // CHECK:STDERR: import Cpp library "file.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "file.h";

--- a/toolchain/check/testdata/interop/cpp/no_prelude/file_not_found.carbon
+++ b/toolchain/check/testdata/interop/cpp/no_prelude/file_not_found.carbon
@@ -18,7 +18,7 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:       |          ^~~~~~~~~~~~~
 // CHECK:STDERR:  [CppInteropParseError]
 // CHECK:STDERR: import Cpp library "not_found.h";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Cpp library "not_found.h";
 

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_nested.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_nested.carbon
@@ -21,7 +21,7 @@ import Other;
 // CHECK:STDERR:           ^~~~~
 // CHECK:STDERR: fail_conflict.carbon:[[@LINE-4]]:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: import Other;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR:
 namespace Other;
 // CHECK:STDERR: fail_conflict.carbon:[[@LINE+8]]:10: error: imported packages cannot be used for declarations [QualifiedDeclOutsidePackage]

--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -10,25 +10,25 @@
 
 // --- fail_no_api.impl.carbon
 
-// CHECK:STDERR: fail_no_api.impl.carbon:[[@LINE+4]]:6: error: corresponding API for 'Foo' not found [LibraryApiNotFound]
+// CHECK:STDERR: fail_no_api.impl.carbon:[[@LINE+4]]:1: error: corresponding API for 'Foo' not found [LibraryApiNotFound]
 // CHECK:STDERR: impl package Foo;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Foo;
 
 // --- fail_no_api_lib.impl.carbon
 
-// CHECK:STDERR: fail_no_api_lib.impl.carbon:[[@LINE+4]]:6: error: corresponding API for 'Foo//no_api_lib' not found [LibraryApiNotFound]
+// CHECK:STDERR: fail_no_api_lib.impl.carbon:[[@LINE+4]]:1: error: corresponding API for 'Foo//no_api_lib' not found [LibraryApiNotFound]
 // CHECK:STDERR: impl package Foo library "no_api_lib";
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Foo library "[[@TEST_NAME]]";
 
 // --- fail_no_api_main_lib.impl.carbon
 
-// CHECK:STDERR: fail_no_api_main_lib.impl.carbon:[[@LINE+4]]:6: error: corresponding API for 'Main//no_api_main_lib' not found [LibraryApiNotFound]
+// CHECK:STDERR: fail_no_api_main_lib.impl.carbon:[[@LINE+4]]:1: error: corresponding API for 'Main//no_api_main_lib' not found [LibraryApiNotFound]
 // CHECK:STDERR: impl library "no_api_main_lib";
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl library "[[@TEST_NAME]]";
 

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -14,7 +14,7 @@ package A;
 
 // CHECK:STDERR: fail_a.carbon:[[@LINE+4]]:1: error: import cannot be used due to a cycle; cycle must be fixed to import [ImportCycleDetected]
 // CHECK:STDERR: import B;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR:
 import B;
 
@@ -24,7 +24,7 @@ package B;
 
 // CHECK:STDERR: fail_b.carbon:[[@LINE+4]]:1: error: import cannot be used due to a cycle; cycle must be fixed to import [ImportCycleDetected]
 // CHECK:STDERR: import C;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR:
 import C;
 
@@ -34,15 +34,15 @@ package C;
 
 // CHECK:STDERR: fail_c.carbon:[[@LINE+4]]:1: error: import cannot be used due to a cycle; cycle must be fixed to import [ImportCycleDetected]
 // CHECK:STDERR: import A;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR:
 import A;
 
 // --- fail_c.impl.carbon
 
-// CHECK:STDERR: fail_c.impl.carbon:[[@LINE+4]]:6: error: import cannot be used due to a cycle; cycle must be fixed to import [ImportCycleDetected]
+// CHECK:STDERR: fail_c.impl.carbon:[[@LINE+4]]:1: error: import cannot be used due to a cycle; cycle must be fixed to import [ImportCycleDetected]
 // CHECK:STDERR: impl package C;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package C;
 
@@ -52,7 +52,7 @@ package CycleChild;
 
 // CHECK:STDERR: fail_cycle_child.carbon:[[@LINE+4]]:1: error: import cannot be used due to a cycle; cycle must be fixed to import [ImportCycleDetected]
 // CHECK:STDERR: import B;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR:
 import B;
 

--- a/toolchain/check/testdata/packages/fail_duplicate_api.carbon
+++ b/toolchain/check/testdata/packages/fail_duplicate_api.carbon
@@ -22,7 +22,7 @@ library "lib";
 
 // CHECK:STDERR: fail_main_lib2.carbon:[[@LINE+4]]:1: error: library's API previously provided by `main_lib1.carbon` [DuplicateLibraryApi]
 // CHECK:STDERR: library "lib";
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR:
 library "lib";
 
@@ -34,7 +34,7 @@ package Package;
 
 // CHECK:STDERR: fail_package2.carbon:[[@LINE+4]]:1: error: library's API previously provided by `package1.carbon` [DuplicateLibraryApi]
 // CHECK:STDERR: package Package;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package Package;
 
@@ -46,7 +46,7 @@ package Package library "lib";
 
 // CHECK:STDERR: fail_package_lib2.carbon:[[@LINE+4]]:1: error: library's API previously provided by `package_lib1.carbon` [DuplicateLibraryApi]
 // CHECK:STDERR: package Package library "lib";
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package Package library "lib";
 

--- a/toolchain/check/testdata/packages/fail_extension.carbon
+++ b/toolchain/check/testdata/packages/fail_extension.carbon
@@ -23,15 +23,15 @@
 
 // CHECK:STDERR: fail_main_lib.incorrect:[[@LINE+4]]:1: error: file extension of `.carbon` required for api [IncorrectExtension]
 // CHECK:STDERR: library "main_lib";
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 library "[[@TEST_NAME]]";
 
 // --- fail_main_lib.impl.incorrect
 
-// CHECK:STDERR: fail_main_lib.impl.incorrect:[[@LINE+4]]:6: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
+// CHECK:STDERR: fail_main_lib.impl.incorrect:[[@LINE+4]]:1: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
 // CHECK:STDERR: impl library "main_lib";
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl library "[[@TEST_NAME]]";
 
@@ -39,15 +39,15 @@ impl library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_package.incorrect:[[@LINE+4]]:1: error: file extension of `.carbon` required for api [IncorrectExtension]
 // CHECK:STDERR: package Package;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package Package;
 
 // --- fail_package_impl.incorrect
 
-// CHECK:STDERR: fail_package_impl.incorrect:[[@LINE+4]]:6: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
+// CHECK:STDERR: fail_package_impl.incorrect:[[@LINE+4]]:1: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
 // CHECK:STDERR: impl package Package;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Package;
 
@@ -55,15 +55,15 @@ impl package Package;
 
 // CHECK:STDERR: fail_package_lib.incorrect:[[@LINE+4]]:1: error: file extension of `.carbon` required for api [IncorrectExtension]
 // CHECK:STDERR: package Package library "package_lib";
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package Package library "[[@TEST_NAME]]";
 
 // --- fail_package_lib.impl.incorrect
 
-// CHECK:STDERR: fail_package_lib.impl.incorrect:[[@LINE+4]]:6: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
+// CHECK:STDERR: fail_package_lib.impl.incorrect:[[@LINE+4]]:1: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
 // CHECK:STDERR: impl package Package library "package_lib";
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Package library "[[@TEST_NAME]]";
 
@@ -71,16 +71,16 @@ impl package Package library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_swapped_ext.impl.carbon:[[@LINE+5]]:1: error: file extension of `.carbon` required for api [IncorrectExtension]
 // CHECK:STDERR: package SwappedExt;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_swapped_ext.impl.carbon: note: file extension of `.impl.carbon` only allowed for `impl` [IncorrectExtensionImplNote]
 // CHECK:STDERR:
 package SwappedExt;
 
 // --- fail_swapped_ext.carbon
 
-// CHECK:STDERR: fail_swapped_ext.carbon:[[@LINE+4]]:6: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
+// CHECK:STDERR: fail_swapped_ext.carbon:[[@LINE+4]]:1: error: file extension of `.impl.carbon` required for `impl` [IncorrectExtension]
 // CHECK:STDERR: impl package SwappedExt;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package SwappedExt;
 
@@ -146,8 +146,8 @@ impl package SwappedExt;
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc6_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc6_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc6_24.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc6_24.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_default.carbon
+++ b/toolchain/check/testdata/packages/fail_import_default.carbon
@@ -14,7 +14,7 @@ package A;
 
 // CHECK:STDERR: fail_default_api.carbon:[[@LINE+4]]:1: error: file cannot import itself [ImportSelf]
 // CHECK:STDERR: import library default;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library default;
 
@@ -24,7 +24,7 @@ impl package A;
 
 // CHECK:STDERR: fail_default.impl.carbon:[[@LINE+4]]:1: error: explicit import of `api` from `impl` file is redundant with implicit import [ExplicitImportApi]
 // CHECK:STDERR: import library default;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library default;
 
@@ -32,7 +32,7 @@ import library default;
 
 // CHECK:STDERR: fail_main_import_default.carbon:[[@LINE+4]]:1: error: explicit import of `api` from `impl` file is redundant with implicit import [ExplicitImportApi]
 // CHECK:STDERR: import library default;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library default;
 
@@ -42,7 +42,7 @@ library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_main_lib_import_default.carbon:[[@LINE+4]]:1: error: cannot import `Main//default` [ImportMainDefaultLibrary]
 // CHECK:STDERR: import library default;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library default;
 

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -12,13 +12,13 @@
 
 // CHECK:STDERR: fail_main.carbon:[[@LINE+4]]:1: error: imports from the current package must omit the package name [ImportCurrentPackageByName]
 // CHECK:STDERR: import Main;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
 import Main;
 
 // CHECK:STDERR: fail_main.carbon:[[@LINE+4]]:1: error: imports from the current package must omit the package name [ImportCurrentPackageByName]
 // CHECK:STDERR: import Main library "lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Main library "lib";
 
@@ -28,13 +28,13 @@ package NotMain;
 
 // CHECK:STDERR: fail_not_main.carbon:[[@LINE+4]]:1: error: cannot import `Main` from other packages [ImportMainPackage]
 // CHECK:STDERR: import Main;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
 import Main;
 
 // CHECK:STDERR: fail_not_main.carbon:[[@LINE+4]]:1: error: cannot import `Main` from other packages [ImportMainPackage]
 // CHECK:STDERR: import Main library "lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Main library "lib";
 
@@ -44,7 +44,7 @@ package This;
 
 // CHECK:STDERR: fail_this.carbon:[[@LINE+4]]:1: error: file cannot import itself [ImportSelf]
 // CHECK:STDERR: import This;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
 import This;
 
@@ -54,7 +54,7 @@ package This library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_this_lib.carbon:[[@LINE+4]]:1: error: file cannot import itself [ImportSelf]
 // CHECK:STDERR: import library "this_lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library "this_lib";
 
@@ -68,7 +68,7 @@ impl package Implicit;
 
 // CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+4]]:1: error: explicit import of `api` from `impl` file is redundant with implicit import [ExplicitImportApi]
 // CHECK:STDERR: import Implicit;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Implicit;
 
@@ -82,7 +82,7 @@ impl package Implicit library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_implicit_lib.impl.carbon:[[@LINE+4]]:1: error: explicit import of `api` from `impl` file is redundant with implicit import [ExplicitImportApi]
 // CHECK:STDERR: import Implicit library "implicit_lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Implicit library "implicit_lib";
 
@@ -91,7 +91,7 @@ package NotFound;
 
 // CHECK:STDERR: fail_not_found.carbon:[[@LINE+4]]:1: error: imported API 'ImportNotFound' not found [ImportNotFound]
 // CHECK:STDERR: import ImportNotFound;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import ImportNotFound;
 

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -25,30 +25,30 @@ library "[[@TEST_NAME]]";
 import Api;
 // CHECK:STDERR: fail_import.carbon:[[@LINE+7]]:1: error: library imported more than once [RepeatedImport]
 // CHECK:STDERR: import Api;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-4]]:1: note: first import here [FirstImported]
 // CHECK:STDERR: import Api;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~
 // CHECK:STDERR:
 import Api;
 
 import Api library "api_lib";
 // CHECK:STDERR: fail_import.carbon:[[@LINE+7]]:1: error: library imported more than once [RepeatedImport]
 // CHECK:STDERR: import Api library "api_lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-4]]:1: note: first import here [FirstImported]
 // CHECK:STDERR: import Api library "api_lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Api library "api_lib";
 
 import library "main_lib";
 // CHECK:STDERR: fail_import.carbon:[[@LINE+7]]:1: error: library imported more than once [RepeatedImport]
 // CHECK:STDERR: import library "main_lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-4]]:1: note: first import here [FirstImported]
 // CHECK:STDERR: import library "main_lib";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library "main_lib";
 
@@ -59,10 +59,10 @@ package Api library "[[@TEST_NAME]]";
 import library default;
 // CHECK:STDERR: fail_default_import.carbon:[[@LINE+7]]:1: error: library imported more than once [RepeatedImport]
 // CHECK:STDERR: import library default;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_default_import.carbon:[[@LINE-4]]:1: note: first import here [FirstImported]
 // CHECK:STDERR: import library default;
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import library default;
 

--- a/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
+++ b/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
@@ -10,9 +10,9 @@
 
 // --- fail_implicit.impl.carbon
 
-// CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+4]]:6: error: corresponding API for 'Implicit' not found [LibraryApiNotFound]
+// CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+4]]:1: error: corresponding API for 'Implicit' not found [LibraryApiNotFound]
 // CHECK:STDERR: impl package Implicit;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Implicit;
 

--- a/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
+++ b/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
@@ -103,8 +103,8 @@ var b: i32 = a;
 // CHECK:STDOUT:     .Core = imports.%Core
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_19.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_19.2 = import <none>
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %i32 = binding_pattern b

--- a/toolchain/check/testdata/packages/no_prelude/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/cross_package_import.carbon
@@ -126,7 +126,7 @@ library "[[@TEST_NAME]]";
 import library "main_other_ns";
 // CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+8]]:1: error: duplicate name `Other` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: import Other library "other_fn";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE-4]]:1: in import [InImport]
 // CHECK:STDERR: main_other_ns.carbon:4:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: namespace Other;
@@ -155,7 +155,7 @@ import Other library "other_fn";
 // CHECK:STDERR:           ^~~~~
 // CHECK:STDERR: fail_main_reopen_other.carbon:[[@LINE-5]]:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: import Other library "other_fn";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 namespace Other;
 
@@ -173,7 +173,7 @@ import Other library "other_fn";
 // CHECK:STDERR:           ^~~~~
 // CHECK:STDERR: fail_main_reopen_other_nested.carbon:[[@LINE-5]]:1: note: package imported here [QualifiedDeclOutsidePackageSource]
 // CHECK:STDERR: import Other library "other_fn";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 namespace Other.Nested;
 
@@ -191,7 +191,7 @@ import Other library "other_fn";
 // CHECK:STDERR:    ^~~~~
 // CHECK:STDERR: fail_main_add_to_other.carbon:[[@LINE-5]]:1: note: package imported here [QualifiedDeclOutsidePackageSource]
 // CHECK:STDERR: import Other library "other_fn";
-// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn Other.G() {}
 

--- a/toolchain/check/testdata/packages/no_prelude/export_import.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_import.carbon
@@ -369,8 +369,8 @@ export Poison;
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_29.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_29.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc4: %C = var_pattern %c.patt

--- a/toolchain/check/testdata/packages/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_name.carbon
@@ -516,8 +516,8 @@ private export C;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .nsc = %nsc
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_29.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_29.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc4: %C = var_pattern %c.patt

--- a/toolchain/check/testdata/packages/no_prelude/fail_modifiers.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_modifiers.carbon
@@ -50,9 +50,9 @@ export library "export_library";
 
 // --- fail_import_modifiers.carbon
 
-// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:6: error: imported API 'ImplImport' not found [ImportNotFound]
+// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:1: error: imported API 'ImplImport' not found [ImportNotFound]
 // CHECK:STDERR: impl import ImplImport;
-// CHECK:STDERR:      ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+4]]:1: error: `impl` not allowed on `import` declaration [ModifierNotAllowedOnDeclaration]
 // CHECK:STDERR: impl import ImplImport;
@@ -60,9 +60,9 @@ export library "export_library";
 // CHECK:STDERR:
 impl import ImplImport;
 
-// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:8: error: imported API 'ExtendImport' not found [ImportNotFound]
+// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:1: error: imported API 'ExtendImport' not found [ImportNotFound]
 // CHECK:STDERR: extend import ExtendImport;
-// CHECK:STDERR:        ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+4]]:1: error: `extend` not allowed on `import` declaration [ModifierNotAllowedOnDeclaration]
 // CHECK:STDERR: extend import ExtendImport;
@@ -70,9 +70,9 @@ impl import ImplImport;
 // CHECK:STDERR:
 extend import ExtendImport;
 
-// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:9: error: imported API 'VirtualImport' not found [ImportNotFound]
+// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:1: error: imported API 'VirtualImport' not found [ImportNotFound]
 // CHECK:STDERR: virtual import VirtualImport;
-// CHECK:STDERR:         ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+4]]:1: error: `virtual` not allowed on `import` declaration [ModifierNotAllowedOnDeclaration]
 // CHECK:STDERR: virtual import VirtualImport;
@@ -80,9 +80,9 @@ extend import ExtendImport;
 // CHECK:STDERR:
 virtual import VirtualImport;
 
-// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:6: error: imported API 'BaseImport' not found [ImportNotFound]
+// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:1: error: imported API 'BaseImport' not found [ImportNotFound]
 // CHECK:STDERR: base import BaseImport;
-// CHECK:STDERR:      ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+4]]:1: error: `base` not allowed on `import` declaration [ModifierNotAllowedOnDeclaration]
 // CHECK:STDERR: base import BaseImport;
@@ -90,9 +90,9 @@ virtual import VirtualImport;
 // CHECK:STDERR:
 base import BaseImport;
 
-// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:9: error: imported API 'PrivateImport' not found [ImportNotFound]
+// CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+8]]:1: error: imported API 'PrivateImport' not found [ImportNotFound]
 // CHECK:STDERR: private import PrivateImport;
-// CHECK:STDERR:         ^~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_import_modifiers.carbon:[[@LINE+4]]:1: error: `private` not allowed on `import` declaration [ModifierNotAllowedOnDeclaration]
 // CHECK:STDERR: private import PrivateImport;

--- a/toolchain/check/testdata/packages/no_prelude/implicit_imports_empty.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/implicit_imports_empty.carbon
@@ -111,7 +111,7 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {}
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_24.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/implicit_imports_entities.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/implicit_imports_entities.carbon
@@ -131,11 +131,11 @@ import Other library "o1";
 
 // --- fail_import_conflict.impl.carbon
 
-// CHECK:STDERR: fail_import_conflict.impl.carbon:[[@LINE+9]]:6: in import [InImport]
+// CHECK:STDERR: fail_import_conflict.impl.carbon:[[@LINE+9]]:1: in import [InImport]
 // CHECK:STDERR: import_conflict.carbon:4:1: error: duplicate name `Other` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: import Other library "o1";
-// CHECK:STDERR: ^~~~~~
-// CHECK:STDERR: fail_import_conflict.impl.carbon:[[@LINE+5]]:6: in import [InImport]
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_import_conflict.impl.carbon:[[@LINE+5]]:1: in import [InImport]
 // CHECK:STDERR: local_other.carbon:4:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: class Other {}
 // CHECK:STDERR: ^~~~~~~~~~~~~
@@ -156,8 +156,8 @@ impl library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_import_conflict_reverse.impl.carbon:[[@LINE+9]]:1: error: duplicate name `Other` being declared in the same scope [NameDeclDuplicate]
 // CHECK:STDERR: import Other library "o1";
-// CHECK:STDERR: ^~~~~~
-// CHECK:STDERR: fail_import_conflict_reverse.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_import_conflict_reverse.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: import_conflict_reverse.carbon:4:1: in import [InImport]
 // CHECK:STDERR: local_other.carbon:4:1: note: name is previously declared here [NameDeclPrevious]
 // CHECK:STDERR: class Other {}
@@ -346,8 +346,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .c1 = %c1
 // CHECK:STDOUT:     .c2 = %c2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_35.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_35.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c1.patt: %C1 = binding_pattern c1
 // CHECK:STDOUT:     %.loc6: %C1 = var_pattern %c1.patt
@@ -424,8 +424,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .C1 = imports.%Main.C1
 // CHECK:STDOUT:     .c1 = %c1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c1.patt: %C1 = binding_pattern c1
 // CHECK:STDOUT:     %.loc6: %C1 = var_pattern %c1.patt
@@ -491,8 +491,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .NS = imports.%NS
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.2 = import <none>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %C = binding_pattern c
 // CHECK:STDOUT:     %.loc4_1: %C = var_pattern %c.patt
@@ -568,8 +568,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .o1 = %o1
 // CHECK:STDOUT:     .o2 = %o2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_25.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_25.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %o1.patt: %O1 = binding_pattern o1
@@ -659,8 +659,8 @@ import Other library "o1";
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:     .o1 = %o1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_22.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %o1.patt: %O1 = binding_pattern o1
@@ -717,8 +717,8 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc11_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc11_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc11_31.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc11_31.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -747,8 +747,8 @@ import Other library "o1";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Other = imports.%Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc2_6.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc2_6.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_39.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_39.2 = import <none>
 // CHECK:STDOUT:   %Other.import = import Other
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/no_prelude/restricted_package_names.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/restricted_package_names.carbon
@@ -17,15 +17,15 @@ package main;
 
 // CHECK:STDERR: fail_main.carbon:[[@LINE+4]]:1: error: `Main//default` must omit `package` declaration [ExplicitMainPackage]
 // CHECK:STDERR: package Main;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR:
 package Main;
 
 // --- fail_main_impl.carbon
 
-// CHECK:STDERR: fail_main_impl.carbon:[[@LINE+4]]:6: error: `Main//default` must omit `package` declaration [ExplicitMainPackage]
+// CHECK:STDERR: fail_main_impl.carbon:[[@LINE+4]]:1: error: `Main//default` must omit `package` declaration [ExplicitMainPackage]
 // CHECK:STDERR: impl package Main;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Main;
 
@@ -34,7 +34,7 @@ impl package Main;
 // `Main` isn't a keyword, so this fails the same way.
 // CHECK:STDERR: fail_raw_main.carbon:[[@LINE+4]]:1: error: `Main//default` must omit `package` declaration [ExplicitMainPackage]
 // CHECK:STDERR: package r#Main;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package r#Main;
 
@@ -42,7 +42,7 @@ package r#Main;
 
 // CHECK:STDERR: fail_main_lib.carbon:[[@LINE+4]]:1: error: use `library` declaration in `Main` package libraries [ExplicitMainLibrary]
 // CHECK:STDERR: package Main library "main_lib";
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package Main library "[[@TEST_NAME]]";
 
@@ -55,19 +55,19 @@ package cpp;
 
 // CHECK:STDERR: fail_cpp.carbon:[[@LINE+4]]:1: error: `Cpp` cannot be used by a `package` declaration [CppPackageDeclaration]
 // CHECK:STDERR: package Cpp;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
 package Cpp;
 
 // --- fail_cpp.impl.carbon
 
-// CHECK:STDERR: fail_cpp.impl.carbon:[[@LINE+8]]:6: error: `Cpp` cannot be used by a `package` declaration [CppPackageDeclaration]
+// CHECK:STDERR: fail_cpp.impl.carbon:[[@LINE+8]]:1: error: `Cpp` cannot be used by a `package` declaration [CppPackageDeclaration]
 // CHECK:STDERR: impl package Cpp;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
-// CHECK:STDERR: fail_cpp.impl.carbon:[[@LINE+4]]:6: error: `Cpp` import missing library [CppInteropMissingLibrary]
+// CHECK:STDERR: fail_cpp.impl.carbon:[[@LINE+4]]:1: error: `Cpp` import missing library [CppInteropMissingLibrary]
 // CHECK:STDERR: impl package Cpp;
-// CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl package Cpp;
 
@@ -76,7 +76,7 @@ impl package Cpp;
 // `cpp` isn't a keyword, so this fails the same way.
 // CHECK:STDERR: fail_raw_cpp.carbon:[[@LINE+4]]:1: error: `Cpp` cannot be used by a `package` declaration [CppPackageDeclaration]
 // CHECK:STDERR: package r#Cpp;
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR:
 package r#Cpp;
 
@@ -84,7 +84,7 @@ package r#Cpp;
 
 // CHECK:STDERR: fail_cpp_lib.carbon:[[@LINE+4]]:1: error: `Cpp` cannot be used by a `package` declaration [CppPackageDeclaration]
 // CHECK:STDERR: package Cpp library "cpp_lib";
-// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 package Cpp library "[[@TEST_NAME]]";
 

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -33,7 +33,7 @@ impl package Implicit;
 // CHECK:STDERR: fail_bad_type.impl.carbon:[[@LINE+8]]:14: error: missing value for field `a` in struct initialization [StructInitMissingFieldInLiteral]
 // CHECK:STDERR: var c_bad: C({.c = 1, .d = 2}) = F();
 // CHECK:STDERR:              ^~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_bad_type.impl.carbon:[[@LINE-4]]:6: in import [InImport]
+// CHECK:STDERR: fail_bad_type.impl.carbon:[[@LINE-4]]:1: in import [InImport]
 // CHECK:STDERR: implicit.carbon:8:9: note: initializing generic parameter `S` declared here [InitializingGenericParam]
 // CHECK:STDERR: class C(S:! {.a: i32, .b: i32}) {}
 // CHECK:STDERR:         ^

--- a/toolchain/check/testdata/tuple/import.carbon
+++ b/toolchain/check/testdata/tuple/import.carbon
@@ -34,7 +34,7 @@ impl package Implicit;
 // CHECK:STDERR: fail_bad_type.impl.carbon:[[@LINE+8]]:14: error: cannot initialize tuple of 2 elements from tuple with 3 elements [TupleInitElementCountMismatch]
 // CHECK:STDERR: var c_bad: C((1, 2, 3)) = F();
 // CHECK:STDERR:              ^~~~~~~~~
-// CHECK:STDERR: fail_bad_type.impl.carbon:[[@LINE-5]]:6: in import [InImport]
+// CHECK:STDERR: fail_bad_type.impl.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: implicit.carbon:7:9: note: initializing generic parameter `X` declared here [InitializingGenericParam]
 // CHECK:STDERR: class C(X:! (i32, i32)) {}
 // CHECK:STDERR:         ^

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -132,6 +132,7 @@ class Context {
   }
 
   // Adds a node to the parse tree that has children.
+  // TODO: Look into switching to a typed node return.
   auto AddNode(NodeKind kind, Lex::TokenIndex token, bool has_error) -> NodeId {
     CARBON_CHECK(has_error || (kind != NodeKind::InvalidParse &&
                                kind != NodeKind::InvalidParseStart &&
@@ -142,8 +143,8 @@ class Context {
   }
 
   // Adds an invalid parse node.
-  auto AddInvalidParse(Lex::TokenIndex token) -> NodeId {
-    return AddNode(NodeKind::InvalidParse, token, /*has_error=*/true);
+  auto AddInvalidParse(Lex::TokenIndex token) -> void {
+    AddNode(NodeKind::InvalidParse, token, /*has_error=*/true);
   }
 
   // Replaces the placeholder node at the indicated position with a leaf node.

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -11,6 +11,7 @@
 #include "common/vlog.h"
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/lex/tokenized_buffer.h"
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/precedence.h"
 #include "toolchain/parse/state.h"
@@ -131,17 +132,18 @@ class Context {
   }
 
   // Adds a node to the parse tree that has children.
-  auto AddNode(NodeKind kind, Lex::TokenIndex token, bool has_error) -> void {
+  auto AddNode(NodeKind kind, Lex::TokenIndex token, bool has_error) -> NodeId {
     CARBON_CHECK(has_error || (kind != NodeKind::InvalidParse &&
                                kind != NodeKind::InvalidParseStart &&
                                kind != NodeKind::InvalidParseSubtree),
                  "{0} nodes must always have an error", kind);
     tree_->node_impls_.push_back(Tree::NodeImpl(kind, has_error, token));
+    return NodeId(tree_->node_impls_.size() - 1);
   }
 
   // Adds an invalid parse node.
-  auto AddInvalidParse(Lex::TokenIndex token) -> void {
-    AddNode(NodeKind::InvalidParse, token, /*has_error=*/true);
+  auto AddInvalidParse(Lex::TokenIndex token) -> NodeId {
+    return AddNode(NodeKind::InvalidParse, token, /*has_error=*/true);
   }
 
   // Replaces the placeholder node at the indicated position with a leaf node.

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -115,13 +115,14 @@ static auto HandleDeclContent(Context& context, Context::StateStackEntry state,
   }
 
   if (auto semi = context.ConsumeIf(Lex::TokenKind::Semi)) {
+    auto node_id = context.AddNode(declaration, *semi, state.has_error);
+    names.node_id = context.tree().As<AnyPackagingDeclId>(node_id);
+
     if (declaration == NodeKind::ImportDecl) {
       context.AddImport(names);
     } else {
       context.set_packaging_decl(names, is_impl);
     }
-
-    context.AddNode(declaration, *semi, state.has_error);
   } else {
     context.DiagnoseExpectedDeclSemi(context.tokens().GetKind(state.token));
     on_parse_error();

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -39,9 +39,7 @@ static auto HandleDeclContent(Context& context, Context::StateStackEntry state,
                               bool is_impl,
                               llvm::function_ref<auto()->void> on_parse_error)
     -> void {
-  Tree::PackagingNames names{
-      .node_id = ImportDeclId::UnsafeMake(NodeId(state.subtree_start)),
-      .is_export = is_export};
+  Tree::PackagingNames names = {.is_export = is_export};
 
   // Parse the package name.
   if (declaration == NodeKind::LibraryDecl ||

--- a/toolchain/parse/node_ids.h
+++ b/toolchain/parse/node_ids.h
@@ -138,7 +138,10 @@ using AnyFunctionDeclId = NodeIdOneOf<FunctionDeclId, FunctionDefinitionStartId,
 using AnyImplDeclId = NodeIdOneOf<ImplDeclId, ImplDefinitionStartId>;
 using AnyInterfaceDeclId =
     NodeIdOneOf<InterfaceDeclId, InterfaceDefinitionStartId>;
-using AnyNamespaceId = NodeIdOneOf<NamespaceId, ImportDeclId>;
+using AnyNamespaceId =
+    NodeIdOneOf<NamespaceId, ImportDeclId, LibraryDeclId, PackageDeclId>;
+using AnyPackagingDeclId =
+    NodeIdOneOf<ImportDeclId, LibraryDeclId, PackageDeclId>;
 using AnyPointerDeferenceExprId =
     NodeIdOneOf<PrefixOperatorStarId, PointerMemberAccessExprId>;
 

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -78,7 +78,7 @@ class Tree : public Printable<Tree> {
   // Names in packaging, whether the file's packaging or an import. Links back
   // to the node for diagnostics.
   struct PackagingNames {
-    ImportDeclId node_id;
+    AnyPackagingDeclId node_id;
     PackageNameId package_id = PackageNameId::None;
     // TODO: Move LibraryNameId to Base and use it here.
     StringLiteralValueId library_id = StringLiteralValueId::None;

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -157,7 +157,8 @@ class Tree : public Printable<Tree> {
   template <typename T>
   auto As(NodeId n) const -> T {
     CARBON_DCHECK(n.has_value());
-    CARBON_DCHECK(ConvertTo<T>::AllowedFor(node_kind(n)));
+    CARBON_DCHECK(ConvertTo<T>::AllowedFor(node_kind(n)),
+                  "cannot convert {0} to {1}", node_kind(n), typeid(T).name());
     return T::UnsafeMake(n);
   }
 

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -78,7 +78,7 @@ class Tree : public Printable<Tree> {
   // Names in packaging, whether the file's packaging or an import. Links back
   // to the node for diagnostics.
   struct PackagingNames {
-    AnyPackagingDeclId node_id;
+    AnyPackagingDeclId node_id = AnyPackagingDeclId::None;
     PackageNameId package_id = PackageNameId::None;
     // TODO: Move LibraryNameId to Base and use it here.
     StringLiteralValueId library_id = StringLiteralValueId::None;

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -876,10 +876,11 @@ struct ImportCppDecl {
 // An `import` declaration. This is mainly for `import` diagnostics, and a 1:1
 // correspondence with actual `import`s isn't guaranteed.
 struct ImportDecl {
-  static constexpr auto Kind = InstKind::ImportDecl.Define<Parse::ImportDeclId>(
-      {.ir_name = "import",
-       .constant_kind = InstConstantKind::Never,
-       .is_lowered = false});
+  static constexpr auto Kind =
+      InstKind::ImportDecl.Define<Parse::AnyPackagingDeclId>(
+          {.ir_name = "import",
+           .constant_kind = InstConstantKind::Never,
+           .is_lowered = false});
 
   NameId package_id;
 };


### PR DESCRIPTION
This flows out of #5084 and trying to reduce UnsafeMake use. It turns out imports and namespaces were using unexpected node kinds (previously ImportIntroducer instead of ImportDecl, for example). This fixes and adds validation.

I was uncertain about whether to just remove the is_convertible check, since I don't see it as motivating creation of a conversion between NodeIdOneOf types. So I've just left a TODO for now.