### PR TITLE
Add a typed node return to AddNode

### DIFF
--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -447,27 +447,23 @@ static auto ParsingInDeferredDefinitionScope(Context& context) -> bool {
 
 auto Context::AddFunctionDefinitionStart(Lex::TokenIndex token, bool has_error)
     -> void {
+  auto start_id = AddNode<NodeKind::FunctionDefinitionStart>(token, has_error);
   if (ParsingInDeferredDefinitionScope(*this)) {
-    deferred_definition_stack_.push_back(tree_->deferred_definitions_.Add(
-        {.start_id = FunctionDefinitionStartId::UnsafeMake(
-             NodeId(tree_->node_impls_.size()))}));
+    deferred_definition_stack_.push_back(
+        tree_->deferred_definitions_.Add({.start_id = start_id}));
   }
-
-  AddNode(NodeKind::FunctionDefinitionStart, token, has_error);
 }
 
 auto Context::AddFunctionDefinition(Lex::TokenIndex token, bool has_error)
     -> void {
+  auto definition_id = AddNode<NodeKind::FunctionDefinition>(token, has_error);
   if (ParsingInDeferredDefinitionScope(*this)) {
     auto definition_index = deferred_definition_stack_.pop_back_val();
     auto& definition = tree_->deferred_definitions_.Get(definition_index);
-    definition.definition_id =
-        FunctionDefinitionId::UnsafeMake(NodeId(tree_->node_impls_.size()));
+    definition.definition_id = definition_id;
     definition.next_definition_index =
         DeferredDefinitionIndex(tree_->deferred_definitions().size());
   }
-
-  AddNode(NodeKind::FunctionDefinition, token, has_error);
 }
 
 auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -132,14 +132,20 @@ class Context {
   }
 
   // Adds a node to the parse tree that has children.
-  // TODO: Look into switching to a typed node return.
-  auto AddNode(NodeKind kind, Lex::TokenIndex token, bool has_error) -> NodeId {
+  auto AddNode(NodeKind kind, Lex::TokenIndex token, bool has_error) -> void {
     CARBON_CHECK(has_error || (kind != NodeKind::InvalidParse &&
                                kind != NodeKind::InvalidParseStart &&
                                kind != NodeKind::InvalidParseSubtree),
                  "{0} nodes must always have an error", kind);
     tree_->node_impls_.push_back(Tree::NodeImpl(kind, has_error, token));
-    return NodeId(tree_->node_impls_.size() - 1);
+  }
+
+  // Adds a node and returns its typed NodeId.
+  template <const Parse::NodeKind& Kind>
+  auto AddNode(Lex::TokenIndex token, bool has_error) -> NodeIdForKind<Kind> {
+    AddNode(Kind, token, has_error);
+    return NodeIdForKind<Kind>::UnsafeMake(
+        NodeId(tree_->node_impls_.size() - 1));
   }
 
   // Adds an invalid parse node.

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -88,6 +88,8 @@ class NodeExtractor {
     }
   }
 
+  auto tree() -> const Tree& { return tree_->tree(); }
+
  private:
   const TreeAndSubtrees* tree_;
   const Lex::TokenizedBuffer* tokens_;
@@ -155,7 +157,7 @@ struct Extractable<NodeIdForKind<Kind>> {
   static auto Extract(NodeExtractor& extractor)
       -> std::optional<NodeIdForKind<Kind>> {
     if (extractor.MatchesNodeIdForKind(Kind)) {
-      return NodeIdForKind<Kind>::UnsafeMake(extractor.ExtractNode());
+      return extractor.tree().As<NodeIdForKind<Kind>>(extractor.ExtractNode());
     } else {
       return std::nullopt;
     }
@@ -182,7 +184,8 @@ struct Extractable<NodeIdInCategory<Category>> {
   static auto Extract(NodeExtractor& extractor)
       -> std::optional<NodeIdInCategory<Category>> {
     if (extractor.MatchesNodeIdInCategory(Category)) {
-      return NodeIdInCategory<Category>::UnsafeMake(extractor.ExtractNode());
+      return extractor.tree().As<NodeIdInCategory<Category>>(
+          extractor.ExtractNode());
     } else {
       return std::nullopt;
     }
@@ -227,7 +230,7 @@ struct Extractable<NodeIdOneOf<T...>> {
   static auto Extract(NodeExtractor& extractor)
       -> std::optional<NodeIdOneOf<T...>> {
     if (extractor.MatchesNodeIdOneOf({T::Kind...})) {
-      return NodeIdOneOf<T...>::UnsafeMake(extractor.ExtractNode());
+      return extractor.tree().As<NodeIdOneOf<T...>>(extractor.ExtractNode());
     } else {
       return std::nullopt;
     }


### PR DESCRIPTION
Building on #5120, make a variant of `AddNode` that returns typed nodes, and replace `UnsafeMake` uses with it. This switches to templating in import parsing so that we can get type validation.

With this change, `UnsafeMake` ends up used in three places: `Tree::As`, `Tree::TryAs`, and `Context::AddNode`. That should mean that all typed nodes are verified.