### PR TITLE
Writeup for why we don't do deeply restrictive parsing

### DIFF
--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -25,6 +25,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         -   [Case 2: parent node is required token after optional clause, with different parent node kinds for different options](#case-2-parent-node-is-required-token-after-optional-clause-with-different-parent-node-kinds-for-different-options)
         -   [Case 3: optional sibling](#case-3-optional-sibling)
     -   [Operators](#operators)
+-   [Alternatives considered](#alternatives-considered)
+    -   [Restrictive parsing](#restrictive-parsing)
 
 <!-- tocstop -->
 
@@ -800,3 +802,60 @@ TODO
 
 An independent description of our approach:
 ["Better operator precedence" on scattered-thoughts.net](https://www.scattered-thoughts.net/writing/better-operator-precedence/)
+
+## Alternatives considered
+
+### Restrictive parsing
+
+The toolchain will often parse code that could theoretically be rejected,
+instead allowing the check phase to reject incorrect structures.
+
+For example, consider the code `abstract var x: i32 = 0;`. When parsing the
+`abstract` modifier, parse could do lookahead to see `var`, and error in the
+parse (`abstract var` is never valid). Instead, we save the modifier and
+diagnose it with check.
+
+The problem with diagnosing this example during parse is there could be other
+modifiers, such as `abstract private returned var x: i32 = 0;`, so additional
+lookahead would be required to determine the entity for `abstract`. Some
+modifiers are also contextually valid; for example, `abstract fn` is only valid
+inside an `abstract class` scope. As a consequence, a form of either arbitrary
+lookahead or additional context would be necessary in parse in order to reliably
+diagnose incorrect uses of `abstract`, and it may miss cases. In contrast with
+parse, check will have the necessary context and semantic understanding to issue
+all necessary modifier diagnostics.
+
+Rejecting incorrect code during parsing can also have negative consequences for
+diagnostics. The check phase collects more context about invalid code, and might
+produce either better diagnostics specific to semantics, or even if the error is
+similar to what parse could produce, might do it with less work.
+
+As a consequence, at times we will defer to the check phase to produce
+diagnostics instead of trying to produce those same diagnostics during parse. A
+couple examples of why we might diagnose in check instead of parse are:
+
+-   To issue better diagnostics based on semantic information.
+-   To diagnose similar invalid uses in one place, versus partly in check and
+    partly in parse.
+-   To support syntax highlighting for IDEs in near-correct code, still being
+    typed.
+
+A few examples of parse designs to avoid are:
+
+-   Using arbitrary lookahead.
+    -   Looking ahead one or two tokens is okay. However, we should never have
+        arbitrary lookahead.
+    -   This includes approaches which would require using the mapping of
+        opening brackets to closing brackets that is produced by
+        `TokenizedBuffer`. Those are helpful for error recovery.
+-   Building complex context.
+    -   We want parsing to be fast and lightweight.
+-   Duplicating diagnostics between parse and check.
+    -   When there are closely related invalid variants of syntax, only some of
+        which can be diagnosed during parse, consider diagnosing all variants
+        during check.
+
+This is a balance. We don't want to unnecessarily shift costs from parse onto
+check, and we don't try to allow clearly invalid constructs. Parse still tries
+to produce a reasonable parse tree. However, parse leans more towards a
+permissive parse.

--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -858,5 +858,5 @@ A few examples of parse designs to avoid are:
 This is a balance. We don't want to unnecessarily shift costs from parse onto
 check, and we don't try to allow clearly invalid constructs. Parse still tries
 to produce a reasonable parse tree. However, parse leans more towards a
-permissive parse, and a valid parse tree does not mean the code is grammatically
-correct.
+permissive parse, and an error-free parse tree does not mean the code is
+grammatically correct.

--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -858,4 +858,5 @@ A few examples of parse designs to avoid are:
 This is a balance. We don't want to unnecessarily shift costs from parse onto
 check, and we don't try to allow clearly invalid constructs. Parse still tries
 to produce a reasonable parse tree. However, parse leans more towards a
-permissive parse.
+permissive parse, and a valid parse tree does not mean the code is grammatically
+correct.

--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -811,24 +811,23 @@ The toolchain will often parse code that could theoretically be rejected,
 instead allowing the check phase to reject incorrect structures.
 
 For example, consider the code `abstract var x: i32 = 0;`. When parsing the
-`abstract` modifier, parse could do lookahead to see `var`, and error in the
-parse (`abstract var` is never valid). Instead, we save the modifier and
-diagnose it with check.
+`abstract` modifier, parse could do single-token lookahead to see `var`, and
+error in the parse (`abstract var` is never valid). Instead, we save the
+modifier and diagnose it during check.
 
-The problem with diagnosing this example during parse is there could be other
-modifiers, such as `abstract private returned var x: i32 = 0;`, so additional
-lookahead would be required to determine the entity for `abstract`. Some
-modifiers are also contextually valid; for example, `abstract fn` is only valid
-inside an `abstract class` scope. As a consequence, a form of either arbitrary
-lookahead or additional context would be necessary in parse in order to reliably
-diagnose incorrect uses of `abstract`, and it may miss cases. In contrast with
-parse, check will have the necessary context and semantic understanding to issue
-all necessary modifier diagnostics.
+The problem is that code isn't always this simple. Considering the above
+example, there could be other modifiers, such as
+`abstract private returned var x: i32 = 0;`, so single-token lookahead isn't a
+general solution. Some modifiers are also contextually valid; for example,
+`abstract fn` is only valid inside an `abstract class` scope. As a consequence,
+a form of either arbitrary lookahead or additional context would be necessary in
+parse in order to reliably diagnose incorrect uses of `abstract`. In contrast
+with parse, check will have that additional context.
 
 Rejecting incorrect code during parsing can also have negative consequences for
-diagnostics. The check phase collects more context about invalid code, and might
-produce either better diagnostics specific to semantics, or even if the error is
-similar to what parse could produce, might do it with less work.
+diagnostics. The additional information that check has about semantics may
+produce better diagnostics. Alternately, sometimes check will produce
+diagnostics equivalent to what parse could, but with less work overall.
 
 As a consequence, at times we will defer to the check phase to produce
 diagnostics instead of trying to produce those same diagnostics during parse. A
@@ -839,6 +838,7 @@ couple examples of why we might diagnose in check instead of parse are:
     partly in parse.
 -   To support syntax highlighting for IDEs in near-correct code, still being
     typed.
+-   When it's important to distinguish between multiple possible syntaxes.
 
 A few examples of parse designs to avoid are:
 

--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -849,7 +849,7 @@ A few examples of parse designs to avoid are:
         opening brackets to closing brackets that is produced by
         `TokenizedBuffer`. Those are helpful for error recovery.
 -   Building complex context.
-    -   We want parsing to be fast and lightweight.
+    -   We want parsing to be faster and lighter weight than check.
 -   Duplicating diagnostics between parse and check.
     -   When there are closely related invalid variants of syntax, only some of
         which can be diagnosed during parse, consider diagnosing all variants

--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -830,15 +830,19 @@ produce better diagnostics. Alternately, sometimes check will produce
 diagnostics equivalent to what parse could, but with less work overall.
 
 As a consequence, at times we will defer to the check phase to produce
-diagnostics instead of trying to produce those same diagnostics during parse. A
-couple examples of why we might diagnose in check instead of parse are:
+diagnostics instead of trying to produce those same diagnostics during parse.
+Some examples of why we might diagnose in check instead of parse are:
 
 -   To issue better diagnostics based on semantic information.
 -   To diagnose similar invalid uses in one place, versus partly in check and
     partly in parse.
 -   To support syntax highlighting for IDEs in near-correct code, still being
     typed.
+
+Some examples of why we might diagnose in parse are:
+
 -   When it's important to distinguish between multiple possible syntaxes.
+-   When permitting the syntax would require more work than rejecting it.
 
 A few examples of parse designs to avoid are:
 


### PR DESCRIPTION
Modifiers came to mind since we had a bit of discussion way back when, about whether parse or check was the best place to do validation. Trying to capture the tradeoffs to consider here.

Note, I'm writing this up mainly because I was asked why I don't reject `fn destroy;` in parse twice (but still allowing things like `fn destroy();` or `fn destroy[]();`), so I've been thinking a reference of the higher-level parsing philosophy would be helpful.