### PR TITLE
Dump the inst block with the specific

### DIFF
--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -247,6 +247,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file,
 LLVM_DUMP_METHOD auto Dump(const File& file, SpecificId specific_id) -> void {
   DumpNoNewline(file, specific_id);
   llvm::errs() << '\n';
+  Dump(file, file.specifics().Get(specific_id).args_id);
 }
 
 LLVM_DUMP_METHOD auto Dump(const File& file,


### PR DESCRIPTION
Every time I dump a specific id, the next thing I do is dump the inst block. This saves typing `SemIR::MakeInstBlockId(x)` all the time.
