### PR TITLE
Dump the LocId with the InstId from Check

### DIFF
--- a/toolchain/check/dump.cpp
+++ b/toolchain/check/dump.cpp
@@ -109,6 +109,10 @@ LLVM_DUMP_METHOD static auto Dump(const Context& context,
 LLVM_DUMP_METHOD static auto Dump(const Context& context, SemIR::InstId inst_id)
     -> void {
   SemIR::Dump(context.sem_ir(), inst_id);
+  auto loc_id = context.sem_ir().insts().GetLocId(inst_id);
+  llvm::errs() << "  - ";
+  DumpNoNewline(context, loc_id);
+  llvm::errs() << '\n';
 }
 
 LLVM_DUMP_METHOD static auto Dump(const Context& context,


### PR DESCRIPTION
Check can print the full location for a LocId properly, but SemIR can not since File doesn't have access to Lex.

So when dumping InstId from Check, include the LocId, to avoid making us type `call Dump(context, context.insts().GetLocId(x))` all the time.
