### PR TITLE
When import C++ names, add the note on the `ClangLookup()` as well

### DIFF
--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -293,17 +293,17 @@ static auto ImportNameDecl(Context& context, SemIR::LocId loc_id,
 auto ImportNameFromCpp(Context& context, SemIR::LocId loc_id,
                        SemIR::NameScopeId scope_id, SemIR::NameId name_id)
     -> SemIR::InstId {
-  auto lookup = ClangLookup(context, loc_id, scope_id, name_id);
-  if (!lookup) {
-    return SemIR::InstId::None;
-  }
-
   DiagnosticAnnotationScope annotate_diagnostics(
       &context.emitter(), [&](auto& builder) {
         CARBON_DIAGNOSTIC(InCppNameLookup, Note,
                           "in `Cpp` name lookup for `{0}`", SemIR::NameId);
         builder.Note(loc_id, InCppNameLookup, name_id);
       });
+
+  auto lookup = ClangLookup(context, loc_id, scope_id, name_id);
+  if (!lookup) {
+    return SemIR::InstId::None;
+  }
 
   if (!lookup->isSingleResult()) {
     context.TODO(loc_id,


### PR DESCRIPTION
Currently has no effect because we can't do lookup in classes, yet.

Part of #4666.