### PR TITLE
Delete the GetConstantValue overload for AbsoluteInstId

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -348,6 +348,12 @@ static auto MakeFacetTypeResult(Context& context,
 // with constant phase, and if so, returns the corresponding constant value.
 // Overloads are provided for different kinds of ID.
 
+// AbsoluteInstId can not have its values substituted, so this overload is
+// deleted. This prevents conversion to InstId.
+static auto GetConstantValue(EvalContext& eval_context,
+                             SemIR::AbsoluteInstId inst_id, Phase* phase)
+    -> SemIR::InstBlockId = delete;
+
 // If the given instruction is constant, returns its constant value.
 static auto GetConstantValue(EvalContext& eval_context, SemIR::InstId inst_id,
                              Phase* phase) -> SemIR::InstId {
@@ -375,7 +381,8 @@ static auto GetConstantValue(EvalContext& eval_context, SemIR::TypeId type_id,
   return eval_context.context().types().GetTypeIdForTypeConstantId(const_id);
 }
 
-// AbsoluteInstBlockId can not have its values substituted.
+// AbsoluteInstBlockId can not have its values substituted, so this overload is
+// deleted. This prevents conversion to InstBlockId.
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::AbsoluteInstBlockId inst_block_id,
                              Phase* phase) -> SemIR::InstBlockId = delete;

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -352,7 +352,7 @@ static auto MakeFacetTypeResult(Context& context,
 // deleted. This prevents conversion to InstId.
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::AbsoluteInstId inst_id, Phase* phase)
-    -> SemIR::InstBlockId = delete;
+    -> SemIR::InstId = delete;
 
 // If the given instruction is constant, returns its constant value.
 static auto GetConstantValue(EvalContext& eval_context, SemIR::InstId inst_id,


### PR DESCRIPTION
This prevents conversion from an InstId which is its base class, and documents that this is invalid in the code.

Also expand the comment on the AbsoluteInstBlockId, which I had locally but seem to have not saved and included in #5141.
