### PR TITLE
Append the source-map configs for lldb

### DIFF
--- a/.vscode/lldb_launch.json
+++ b/.vscode/lldb_launch.json
@@ -10,8 +10,8 @@
       "debuggerRoot": "${workspaceFolder}",
       "initCommands": [
         "command script import external/+llvm_project+llvm-project/llvm/utils/lldbDataFormatters.py",
-        "settings set target.source-map \".\" \"${workspaceFolder}\"",
-        "settings set target.source-map \"/proc/self/cwd\" \"${workspaceFolder}\"",
+        "settings append target.source-map \".\" \"${workspaceFolder}\"",
+        "settings append target.source-map \"/proc/self/cwd\" \"${workspaceFolder}\"",
         "env TEST_TARGET=//toolchain/testing:file_test",
         "env TEST_TMPDIR=/tmp"
       ]
@@ -31,8 +31,8 @@
       "debuggerRoot": "${workspaceFolder}",
       "initCommands": [
         "command script import external/+llvm_project+llvm-project/llvm/utils/lldbDataFormatters.py",
-        "settings set target.source-map \".\" \"${workspaceFolder}\"",
-        "settings set target.source-map \"/proc/self/cwd\" \"${workspaceFolder}\""
+        "settings append target.source-map \".\" \"${workspaceFolder}\"",
+        "settings append target.source-map \"/proc/self/cwd\" \"${workspaceFolder}\""
       ]
     }
   ]


### PR DESCRIPTION
Currently we do `settings set` twice which means the second one overrides the first one, instead of ending up with a source-map that has both entries in it.
