### PR TITLE
In C++ interop, stop referring to the diagnostics consumer before deleting it

### DIFF
--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -70,6 +70,9 @@ static auto GenerateAst(Context& context, llvm::StringRef importing_file_path,
       "clang-tool", std::make_shared<clang::PCHContainerOperations>(),
       clang::tooling::getClangStripDependencyFileAdjuster(),
       clang::tooling::FileContentMappings(), &diagnostics_consumer, fs);
+  // Remove link to the diagnostics consumer before its deletion.
+  ast->getDiagnostics().setClient(nullptr);
+
   // TODO: Implement and use a DynamicRecursiveASTVisitor to traverse the AST.
   int num_errors = diagnostics_consumer.getNumErrors();
   int num_warnings = diagnostics_consumer.getNumWarnings();
@@ -89,8 +92,6 @@ static auto GenerateAst(Context& context, llvm::StringRef importing_file_path,
     context.emitter().Emit(loc, CppInteropParseWarning, num_warnings,
                            num_imports, diagnostics_str);
   }
-  // Remove link to the diagnostics consumer before its deletion.
-  ast->getDiagnostics().setClient(nullptr);
   return {std::move(ast), !ast || num_errors > 0};
 }
 

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -89,6 +89,8 @@ static auto GenerateAst(Context& context, llvm::StringRef importing_file_path,
     context.emitter().Emit(loc, CppInteropParseWarning, num_warnings,
                            num_imports, diagnostics_str);
   }
+  // Remove link to the diagnostics consumer before its deletion.
+  ast->getDiagnostics().setClient(nullptr);
   return {std::move(ast), !ast || num_errors > 0};
 }
 


### PR DESCRIPTION
Part of #4666