### PR TITLE
Reduce explicit SemIR::LocIdAndInst construction

### DIFF
--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -63,18 +63,16 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
           is_template);
       if (is_generic) {
         bind_id = AddInstInNoBlock(
-            context, SemIR::LocIdAndInst(name_node,
-                                         SemIR::BindSymbolicName{
-                                             .type_id = cast_type_id,
-                                             .entity_name_id = entity_name_id,
-                                             .value_id = SemIR::InstId::None}));
+            context, name_node,
+            SemIR::BindSymbolicName{.type_id = cast_type_id,
+                                    .entity_name_id = entity_name_id,
+                                    .value_id = SemIR::InstId::None});
       } else {
-        bind_id = AddInstInNoBlock(
-            context,
-            SemIR::LocIdAndInst(
-                name_node, SemIR::BindName{.type_id = cast_type_id,
-                                           .entity_name_id = entity_name_id,
-                                           .value_id = SemIR::InstId::None}));
+        bind_id =
+            AddInstInNoBlock(context, name_node,
+                             SemIR::BindName{.type_id = cast_type_id,
+                                             .entity_name_id = entity_name_id,
+                                             .value_id = SemIR::InstId::None});
       }
     }
 
@@ -195,10 +193,8 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
         .decl_block_id = SemIR::InstBlockId::None};
     auto decl_id = AddPlaceholderInstInNoBlock(
         context,
-        SemIR::LocIdAndInst(
-            context.parse_tree().As<Parse::CompileTimeBindingPatternId>(
-                node_id),
-            assoc_const_decl));
+        context.parse_tree().As<Parse::CompileTimeBindingPatternId>(node_id),
+        assoc_const_decl);
     assoc_const_decl.assoc_const_id = context.associated_constants().Add(
         {.name_id = name_id,
          .parent_scope_id = context.scope_stack().PeekNameScopeId(),

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -222,8 +222,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
       SemIR::ClassDecl{.type_id = SemIR::TypeType::SingletonTypeId,
                        .class_id = SemIR::ClassId::None,
                        .decl_block_id = decl_block_id};
-  auto class_decl_id =
-      AddPlaceholderInst(context, SemIR::LocIdAndInst(node_id, class_decl));
+  auto class_decl_id = AddPlaceholderInst(context, node_id, class_decl);
 
   // TODO: Store state regarding is_extern.
   SemIR::Class class_info = {

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -464,8 +464,7 @@ static auto BuildFunctionDecl(Context& context,
   SemIR::FunctionDecl function_decl = {SemIR::TypeId::None,
                                        SemIR::FunctionId::None,
                                        context.inst_block_stack().Pop()};
-  auto decl_id =
-      AddPlaceholderInst(context, SemIR::LocIdAndInst(node_id, function_decl));
+  auto decl_id = AddPlaceholderInst(context, node_id, function_decl);
   RequestVtableIfVirtual(context, node_id, virtual_modifier, parent_scope_inst,
                          decl_id);
 

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -380,8 +380,7 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
   // Add the impl declaration.
   SemIR::ImplDecl impl_decl = {.impl_id = SemIR::ImplId::None,
                                .decl_block_id = decl_block_id};
-  auto impl_decl_id =
-      AddPlaceholderInst(context, SemIR::LocIdAndInst(node_id, impl_decl));
+  auto impl_decl_id = AddPlaceholderInst(context, node_id, impl_decl);
 
   SemIR::Impl impl_info = {name_context.MakeEntityWithParamsBase(
                                name, impl_decl_id,

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -55,8 +55,7 @@ static auto BuildInterfaceDecl(Context& context,
   auto interface_decl =
       SemIR::InterfaceDecl{SemIR::TypeType::SingletonTypeId,
                            SemIR::InterfaceId::None, decl_block_id};
-  auto interface_decl_id =
-      AddPlaceholderInst(context, SemIR::LocIdAndInst(node_id, interface_decl));
+  auto interface_decl_id = AddPlaceholderInst(context, node_id, interface_decl);
 
   SemIR::Interface interface_info = {name_context.MakeEntityWithParamsBase(
       name, interface_decl_id, /*is_extern=*/false,

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -119,15 +119,12 @@ static auto GetOrAddStorage(Context& context, SemIR::InstId var_pattern_id)
   }
   auto pattern = context.insts().GetWithLocId(var_pattern_id);
 
-  return AddInst(
-      context,
-      SemIR::LocIdAndInst(
-          pattern.loc_id,
-          SemIR::VarStorage{
-              .type_id = pattern.inst.type_id(),
-              .pretty_name_id = SemIR::GetPrettyNameFromPatternId(
-                  context.sem_ir(),
-                  pattern.inst.As<SemIR::VarPattern>().subpattern_id)}));
+  return AddInst(context, pattern.loc_id,
+                 SemIR::VarStorage{
+                     .type_id = pattern.inst.type_id(),
+                     .pretty_name_id = SemIR::GetPrettyNameFromPatternId(
+                         context.sem_ir(),
+                         pattern.inst.As<SemIR::VarPattern>().subpattern_id)});
 }
 
 auto HandleParseNode(Context& context, Parse::VariablePatternId node_id)

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -42,8 +42,7 @@ auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
   auto namespace_inst = SemIR::Namespace{
       GetSingletonType(context, SemIR::NamespaceType::SingletonInstId),
       SemIR::NameScopeId::None, SemIR::InstId::None};
-  auto namespace_id =
-      AddPlaceholderInst(context, SemIR::LocIdAndInst(node_id, namespace_inst));
+  auto namespace_id = AddPlaceholderInst(context, node_id, namespace_inst);
 
   SemIR::ScopeLookupResult lookup_result =
       context.decl_name_stack().LookupOrAddName(name_context, namespace_id,

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -223,8 +223,8 @@ static auto ImportFunctionDecl(Context& context, SemIR::LocId loc_id,
 
   auto function_decl = SemIR::FunctionDecl{
       SemIR::TypeId::None, SemIR::FunctionId::None, SemIR::InstBlockId::Empty};
-  auto decl_id = AddPlaceholderInst(
-      context, SemIR::LocIdAndInst(Parse::NodeId::None, function_decl));
+  auto decl_id =
+      AddPlaceholderInst(context, Parse::NodeId::None, function_decl);
 
   auto function_info = SemIR::Function{
       {.name_id = name_id,

--- a/toolchain/check/inst.h
+++ b/toolchain/check/inst.h
@@ -90,12 +90,26 @@ auto AddPatternInst(Context& context,
 auto AddPlaceholderInst(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::InstId;
 
+// Convenience for AddPlaceholderInst with typed nodes.
+template <typename InstT, typename LocT>
+auto AddPlaceholderInst(Context& context, LocT loc, InstT inst)
+    -> SemIR::InstId {
+  return AddPlaceholderInst(context, SemIR::LocIdAndInst(loc, inst));
+}
+
 // Adds an instruction in no block, returning the produced ID. Should be used
 // rarely. The instruction is a placeholder that is expected to be replaced by
 // `ReplaceInstBeforeConstantUse`.
 auto AddPlaceholderInstInNoBlock(Context& context,
                                  SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::InstId;
+
+// Convenience for AddPlaceholderInstInNoBlock with typed nodes.
+template <typename InstT, typename LocT>
+auto AddPlaceholderInstInNoBlock(Context& context, LocT loc, InstT inst)
+    -> SemIR::InstId {
+  return AddPlaceholderInstInNoBlock(context, SemIR::LocIdAndInst(loc, inst));
+}
 
 // Replaces the instruction at `inst_id` with `loc_id_and_inst`. The
 // instruction is required to not have been used in any constant evaluation,

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -62,21 +62,16 @@ class PendingBlock {
   auto MergeReplacing(SemIR::InstId target_id, SemIR::InstId value_id) -> void {
     SemIR::LocIdAndInst value = context_.insts().GetWithLocId(value_id);
 
-    // There are three cases here:
-
     if (insts_.size() == 1 && insts_[0] == value_id) {
-      // 1) The block is {value_id}. Replace `target_id` with the instruction
-      //    referred to by `value_id`. This is intended to be the common case.
+      // The block is {value_id}. Replace `target_id` with the instruction
+      // referred to by `value_id`. This is intended to be the common case.
     } else {
-      // 2) The block is empty. Replace `target_id` with an empty splice
-      //    pointing at `value_id`.
-      // 3) Anything else: splice it into the IR, replacing `target_id`.
-      SemIR::InstBlockId block_id = insts_.empty()
-                                        ? SemIR::InstBlockId::Empty
-                                        : context_.inst_blocks().Add(insts_);
-      value.inst = SemIR::SpliceBlock{.type_id = value.inst.type_id(),
-                                      .block_id = block_id,
-                                      .result_id = value_id};
+      // Anything else: splice it into the IR, replacing `target_id`. This
+      // includes empty blocks, which `Add` handles.
+      value.inst =
+          SemIR::SpliceBlock{.type_id = value.inst.type_id(),
+                             .block_id = context_.inst_blocks().Add(insts_),
+                             .result_id = value_id};
     }
 
     ReplaceLocIdAndInstBeforeConstantUse(context_, target_id, value);

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -8,6 +8,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/inst.h"
+#include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
@@ -59,34 +60,26 @@ class PendingBlock {
   // Replace the instruction at target_id with the instructions in this block.
   // The new value for target_id should be value_id.
   auto MergeReplacing(SemIR::InstId target_id, SemIR::InstId value_id) -> void {
-    auto value = context_.insts().GetWithLocId(value_id);
+    SemIR::LocIdAndInst value = context_.insts().GetWithLocId(value_id);
 
     // There are three cases here:
 
-    if (insts_.empty()) {
-      // 1) The block is empty. Replace `target_id` with an empty splice
-      // pointing at `value_id`.
-      ReplaceLocIdAndInstBeforeConstantUse(
-          context_, target_id,
-          SemIR::LocIdAndInst(
-              value.loc_id,
-              SemIR::SpliceBlock{.type_id = value.inst.type_id(),
-                                 .block_id = SemIR::InstBlockId::Empty,
-                                 .result_id = value_id}));
-    } else if (insts_.size() == 1 && insts_[0] == value_id) {
-      // 2) The block is {value_id}. Replace `target_id` with the instruction
-      // referred to by `value_id`. This is intended to be the common case.
-      ReplaceLocIdAndInstBeforeConstantUse(context_, target_id, value);
+    if (insts_.size() == 1 && insts_[0] == value_id) {
+      // 1) The block is {value_id}. Replace `target_id` with the instruction
+      //    referred to by `value_id`. This is intended to be the common case.
     } else {
+      // 2) The block is empty. Replace `target_id` with an empty splice
+      //    pointing at `value_id`.
       // 3) Anything else: splice it into the IR, replacing `target_id`.
-      ReplaceLocIdAndInstBeforeConstantUse(
-          context_, target_id,
-          SemIR::LocIdAndInst(
-              value.loc_id,
-              SemIR::SpliceBlock{.type_id = value.inst.type_id(),
-                                 .block_id = context_.inst_blocks().Add(insts_),
-                                 .result_id = value_id}));
+      SemIR::InstBlockId block_id = insts_.empty()
+                                        ? SemIR::InstBlockId::Empty
+                                        : context_.inst_blocks().Add(insts_);
+      value.inst = SemIR::SpliceBlock{.type_id = value.inst.type_id(),
+                                      .block_id = block_id,
+                                      .result_id = value_id};
     }
+
+    ReplaceLocIdAndInstBeforeConstantUse(context_, target_id, value);
 
     // Prepare to stash more pending instructions.
     insts_.clear();

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -557,13 +557,11 @@ auto RequireCompleteType(Context& context, SemIR::TypeId type_id,
   // specific type to be complete.
   if (type_id.is_symbolic()) {
     // TODO: Deduplicate these.
-    AddInstInNoBlock(
-        context,
-        SemIR::LocIdAndInst(
-            loc_id, SemIR::RequireCompleteType{
-                        .type_id = GetSingletonType(
-                            context, SemIR::WitnessType::SingletonInstId),
-                        .complete_type_id = type_id}));
+    AddInstInNoBlock(context, loc_id,
+                     SemIR::RequireCompleteType{
+                         .type_id = GetSingletonType(
+                             context, SemIR::WitnessType::SingletonInstId),
+                         .complete_type_id = type_id});
   }
 
   return true;


### PR DESCRIPTION
Building on #5151 reducing `UncheckedLoc` use, further remove uses of the `SemIR::LocIdAndInst` constructor where we typically have overloads that don't need it. Add parallel convenience wrappers for placeholder insts.

Also refactors `MergeReplacing`. I don't think it makes sense to add an overload for `ReplaceLocIdAndInstBeforeConstantUse`, but we can still reduce the `LocIdAndInst` construction there.