### PR TITLE
Add a newline to the end of Printable::Dump()

### DIFF
--- a/common/ostream.h
+++ b/common/ostream.h
@@ -24,6 +24,7 @@ class Printable {
   // Provides simple printing for debuggers.
   LLVM_DUMP_METHOD void Dump() const {
     static_cast<const DerivedT*>(this)->Print(llvm::errs());
+    llvm::errs() << '\n';
   }
 
   // Supports printing to llvm::raw_ostream.


### PR DESCRIPTION
This makes it friendlier in interactive debuggers. If you want to print a value without a newline from code, you will have to be calling Print() anyway since Dump() is private, and Print() does not add a newline.
