### PR TITLE
Refactor InstBlockStore's API, AddDefaultValue -> AddPlaceholder

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -62,13 +62,6 @@ class ValueStore
     return id;
   }
 
-  // Adds a default constructed value and returns an ID to reference it.
-  auto AddDefaultValue() -> IdT {
-    IdT id(values_.size());
-    values_.resize(id.index + 1);
-    return id;
-  }
-
   // Returns a mutable value for an ID.
   auto Get(IdT id) -> RefType {
     CARBON_DCHECK(id.index >= 0, "{0}", id);

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -515,10 +515,11 @@ auto CheckUnit::FinishRun() -> void {
   context_.scope_stack().Pop();
 
   // Finalizes the list of exports on the IR.
-  context_.inst_blocks().Set(SemIR::InstBlockId::Exports, context_.exports());
+  context_.inst_blocks().ReplacePlaceholder(SemIR::InstBlockId::Exports,
+                                            context_.exports());
   // Finalizes the ImportRef inst block.
-  context_.inst_blocks().Set(SemIR::InstBlockId::ImportRefs,
-                             context_.import_ref_ids());
+  context_.inst_blocks().ReplacePlaceholder(SemIR::InstBlockId::ImportRefs,
+                                            context_.import_ref_ids());
   // Finalizes __global_init.
   context_.global_init().Finalize();
 

--- a/toolchain/check/control_flow.cpp
+++ b/toolchain/check/control_flow.cpp
@@ -16,7 +16,7 @@ static auto AddDominatedBlockAndBranchImpl(Context& context,
   if (!context.inst_block_stack().is_current_block_reachable()) {
     return SemIR::InstBlockId::Unreachable;
   }
-  auto block_id = context.inst_blocks().AddDefaultValue();
+  auto block_id = context.inst_blocks().AddPlaceholder();
   AddInst<BranchNode>(context, node_id, {block_id, args...});
   return block_id;
 }
@@ -47,7 +47,7 @@ auto AddConvergenceBlockAndPush(Context& context, Parse::NodeId node_id,
   for ([[maybe_unused]] auto _ : llvm::seq(num_blocks)) {
     if (context.inst_block_stack().is_current_block_reachable()) {
       if (new_block_id == SemIR::InstBlockId::Unreachable) {
-        new_block_id = context.inst_blocks().AddDefaultValue();
+        new_block_id = context.inst_blocks().AddPlaceholder();
       }
       CARBON_CHECK(node_id.has_value());
       AddInst<SemIR::Branch>(context, node_id, {.target_id = new_block_id});
@@ -67,7 +67,7 @@ auto AddConvergenceBlockWithArgAndPush(
   for (auto arg_id : block_args) {
     if (context.inst_block_stack().is_current_block_reachable()) {
       if (new_block_id == SemIR::InstBlockId::Unreachable) {
-        new_block_id = context.inst_blocks().AddDefaultValue();
+        new_block_id = context.inst_blocks().AddPlaceholder();
       }
       AddInst<SemIR::BranchWithArg>(
           context, node_id, {.target_id = new_block_id, .arg_id = arg_id});

--- a/toolchain/check/inst_block_stack.cpp
+++ b/toolchain/check/inst_block_stack.cpp
@@ -29,7 +29,7 @@ auto InstBlockStack::PeekOrAdd(int depth) -> SemIR::InstBlockId {
   int index = id_stack_.size() - depth - 1;
   auto& slot = id_stack_[index];
   if (!slot.has_value()) {
-    slot = sem_ir_->inst_blocks().AddDefaultValue();
+    slot = sem_ir_->inst_blocks().AddPlaceholder();
   }
   return slot;
 }

--- a/toolchain/check/inst_block_stack.cpp
+++ b/toolchain/check/inst_block_stack.cpp
@@ -42,7 +42,7 @@ auto InstBlockStack::Pop() -> SemIR::InstBlockId {
   // Finalize the block.
   if (!insts.empty() && id != SemIR::InstBlockId::Unreachable) {
     if (id.has_value()) {
-      sem_ir_->inst_blocks().Set(id, insts);
+      sem_ir_->inst_blocks().ReplacePlaceholder(id, insts);
     } else {
       id = sem_ir_->inst_blocks().Add(insts);
     }

--- a/toolchain/check/subpattern.cpp
+++ b/toolchain/check/subpattern.cpp
@@ -20,7 +20,7 @@ auto EndSubpatternAsExpr(Context& context, SemIR::InstId result_id)
     // will be determined later.
     AddInst(context,
             SemIR::LocIdAndInst::NoLoc<SemIR::Branch>(
-                {.target_id = context.inst_blocks().AddDefaultValue()}));
+                {.target_id = context.inst_blocks().AddPlaceholder()}));
   } else {
     // This single-block region will be inserted as a SpliceBlock, so we don't
     // need control flow out of it.

--- a/toolchain/docs/idioms.md
+++ b/toolchain/docs/idioms.md
@@ -145,8 +145,6 @@ The indices typically use `IdBase`.
 `ValueStore`s APIs follow the shape of simple array access and mutation:
 
 -   `Add` which takes a value and returns the index.
--   `AddDefaultValue` which adds a default-constructed value and returns the
-    index.
 -   `Get` takes an index and returns a reference to the value (possibly a
     constant reference).
 -   Other vector-like functionality, including `size` or `Reserve`

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -474,7 +474,7 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
     return values().Add(llvm::MutableArrayRef<ElementType>());
   }
 
-  // Sets the contents of an empty block to the given content.
+  // Sets the contents of a placeholder block to the given content.
   auto ReplacePlaceholder(InstBlockId block_id, llvm::ArrayRef<InstId> content)
       -> void {
     CARBON_CHECK(Get(block_id).empty(),

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -462,20 +462,21 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
     CARBON_CHECK(global_init_id == InstBlockId::GlobalInit);
   }
 
-  // Reserves and returns a block ID. The contents of the block should be
-  // specified by calling Set, or similar.
-  auto AddPlaceholder() -> InstBlockId {
-    return values().Add(llvm::MutableArrayRef<ElementType>());
-  }
-
   // Adds an uninitialized block of the given size. The caller is expected to
   // modify values.
   auto AddUninitialized(size_t size) -> InstBlockId {
     return values().Add(AllocateUninitialized(size));
   }
 
+  // Reserves and returns a block ID. The contents of the block should be
+  // specified by calling ReplacePlaceholder.
+  auto AddPlaceholder() -> InstBlockId {
+    return values().Add(llvm::MutableArrayRef<ElementType>());
+  }
+
   // Sets the contents of an empty block to the given content.
-  auto Set(InstBlockId block_id, llvm::ArrayRef<InstId> content) -> void {
+  auto ReplacePlaceholder(InstBlockId block_id, llvm::ArrayRef<InstId> content)
+      -> void {
     CARBON_CHECK(Get(block_id).empty(),
                  "inst block content set more than once");
     values().Get(block_id) = AllocateCopy(content);

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -477,6 +477,7 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
   // Sets the contents of a placeholder block to the given content.
   auto ReplacePlaceholder(InstBlockId block_id, llvm::ArrayRef<InstId> content)
       -> void {
+    CARBON_CHECK(block_id != SemIR::InstBlockId::Empty);
     CARBON_CHECK(Get(block_id).empty(),
                  "inst block content set more than once");
     values().Get(block_id) = AllocateCopy(content);

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -452,22 +452,33 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
  public:
   using BaseType = BlockValueStore<InstBlockId>;
 
-  using BaseType::AddDefaultValue;
-  using BaseType::AddUninitialized;
-
   explicit InstBlockStore(llvm::BumpPtrAllocator& allocator)
       : BaseType(allocator) {
-    auto exports_id = AddDefaultValue();
+    auto exports_id = AddPlaceholder();
     CARBON_CHECK(exports_id == InstBlockId::Exports);
-    auto import_refs_id = AddDefaultValue();
+    auto import_refs_id = AddPlaceholder();
     CARBON_CHECK(import_refs_id == InstBlockId::ImportRefs);
-    auto global_init_id = AddDefaultValue();
+    auto global_init_id = AddPlaceholder();
     CARBON_CHECK(global_init_id == InstBlockId::GlobalInit);
   }
 
+  // Reserves and returns a block ID. The contents of the block should be
+  // specified by calling Set, or similar.
+  auto AddPlaceholder() -> InstBlockId {
+    return values().Add(llvm::MutableArrayRef<ElementType>());
+  }
+
+  // Adds an uninitialized block of the given size. The caller is expected to
+  // modify values.
+  auto AddUninitialized(size_t size) -> InstBlockId {
+    return values().Add(AllocateUninitialized(size));
+  }
+
+  // Sets the contents of an empty block to the given content.
   auto Set(InstBlockId block_id, llvm::ArrayRef<InstId> content) -> void {
-    CARBON_CHECK(block_id != InstBlockId::Unreachable);
-    BlockValueStore<InstBlockId>::SetContent(block_id, content);
+    CARBON_CHECK(Get(block_id).empty(),
+                 "inst block content set more than once");
+    values().Get(block_id) = AllocateCopy(content);
   }
 
   // Returns the contents of the specified block, or an empty array if the block


### PR DESCRIPTION
`AddDefaultValue` doesn't quite capture the intended semantics; it should typically be replaced with an actual value when dealing with control flows. Trying to indicate the "assign later" with `AddPlaceholder`, mirroring `AddPlaceholderInst`.

Shifting the `protected` functionality on `BlockValueStore` so that it's not providing functions just for `InstBlockStore` to use. Also hoping that seeing the comments next to the function name makes them easier to understand, whereas `using` buries that a little.