### PR TITLE
Fix a compilation error with a recent Clang

### DIFF
--- a/common/set.h
+++ b/common/set.h
@@ -6,6 +6,7 @@
 #define CARBON_COMMON_SET_H_
 
 #include <concepts>
+#include <type_traits>
 
 #include "common/check.h"
 #include "common/hashtable_key_context.h"

--- a/common/set.h
+++ b/common/set.h
@@ -78,7 +78,7 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
 
   // Enable implicit conversions that add `const`-ness to the key type.
   // NOLINTNEXTLINE(google-explicit-constructor)
-  SetView(SetView<std::remove_const_t<KeyT>, KeyContextT> other_view)
+  SetView(const SetView<std::remove_const_t<KeyT>, KeyContextT>& other_view)
     requires(!std::same_as<KeyT, std::remove_const_t<KeyT>>)
       : ImplT(other_view) {}
 


### PR DESCRIPTION
This fixes a `copy constructor must pass its first argument by reference` compilation error when compiled with a recent enough Clang (after https://github.com/llvm/llvm-project/commit/fe0d3e3764961b62f43f1b129f30aaec5f30bc16, targeted for LLVM 21 release).

```
carbon/lang/common/set.h:81:59: error: copy constructor must pass its first argument by reference
   81 |   SetView(SetView<std::remove_const_t<KeyT>, KeyContextT> other_view)
      |                                                           ^
```