### PR TITLE
Don't compare witnesses when deducing through FacetValue

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -471,8 +471,10 @@ auto DeductionContext::Deduce() -> bool {
           auto [kind0, kind1] = param_inst.ArgKinds();
           worklist_.AddInstArg(kind0, param_inst.arg0(), arg_inst.arg0(),
                                needs_substitution);
-          worklist_.AddInstArg(kind1, param_inst.arg1(), arg_inst.arg1(),
-                               needs_substitution);
+          if (arg_inst.kind() != SemIR::InstKind::FacetValue) {
+            worklist_.AddInstArg(kind1, param_inst.arg1(), arg_inst.arg1(),
+                                 needs_substitution);
+          }
           continue;
         }
         break;


### PR DESCRIPTION
As long as the types (FacetTypes) of the FacetValue match, any witnesses that are present should be accepted for deduce.

If the parameter's witnesses are concrete, the argument's will also be concrete and the exact same values. This is what we have relied on so far.

If the parameter's witnesses are symbolic, the argument may have either symbolic or concrete witnesses. If they are symbolic then they are equal. If they are concrete then they are not equal (and will fail deduction if compared. But the argument FacetValue with a concrete witness brings more information than the parameter has, and can be used in place of the parameter's FacetValue.

All FacetValues have _some_ witness for every interface in the facet's type (FacetType), so there's no question of whether a witness is present or not between the parameter and argument.

This ensures that the deduction test with a nested FacetValue in a specific block continues to pass when generic witness resolution can produce a FacetValue with a symbolic witness in #5169.

See issue #5178 for more details.
