### PR TITLE
Import function call_param_ids.

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1138,47 +1138,15 @@ static auto GetLocalCallParamsId(ImportContext& context,
     auto any_param = context.import_insts().GetAs<SemIR::AnyParam>(call_param);
     auto type_id = context.local_context().types().GetTypeIdForTypeConstantId(
         GetLocalConstantIdChecked(context, any_param.type_id));
-    SemIR::InstId new_param_id = SemIR::InstId::None;
-
-    // TODO: Remove code duplication
-    auto out_param =
-        context.import_insts().TryGetAs<SemIR::OutParam>(call_param);
-    if (out_param) {
-      auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::OutParam>(
-          context.local_context(), AddImportIRInst(context, call_param),
-          {.type_id = type_id,
-           .index = out_param->index,
-           .pretty_name_id =
-               GetLocalNameId(context, out_param->pretty_name_id)});
-      new_param_id = AddInstInNoBlock(context.local_context(), loc_id_inst);
-    }
-
-    auto ref_param =
-        context.import_insts().TryGetAs<SemIR::RefParam>(call_param);
-    if (ref_param) {
-      auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::RefParam>(
-          context.local_context(), AddImportIRInst(context, call_param),
-          {.type_id = type_id,
-           .index = ref_param->index,
-           .pretty_name_id =
-               GetLocalNameId(context, ref_param->pretty_name_id)});
-      new_param_id = AddInstInNoBlock(context.local_context(), loc_id_inst);
-    }
-
-    auto value_param =
-        context.import_insts().TryGetAs<SemIR::ValueParam>(call_param);
-    if (value_param) {
-      auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::ValueParam>(
-          context.local_context(), AddImportIRInst(context, call_param),
-          {.type_id = type_id,
-           .index = value_param->index,
-           .pretty_name_id =
-               GetLocalNameId(context, value_param->pretty_name_id)});
-      new_param_id = AddInstInNoBlock(context.local_context(), loc_id_inst);
-    }
-
-    // Params are of one the above types, so a new param id must exist now.
-    CARBON_CHECK(new_param_id.has_value());
+    auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::AnyParam>(
+        context.local_context(), AddImportIRInst(context, call_param),
+        {.kind = any_param.kind,
+         .type_id = type_id,
+         .index = any_param.index,
+         .pretty_name_id = GetLocalNameId(context, any_param.pretty_name_id)});
+    SemIR::InstId new_param_id =
+        AddInstInNoBlock(context.local_context(), loc_id_inst);
+    CARBON_CHECK(new_param_id.has_value() && "Expected valid new_param_id");
     new_call_params.push_back(new_param_id);
   }
   return context.local_inst_blocks().Add(new_call_params);

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -11,6 +11,7 @@
 #include "toolchain/check/generic.h"
 #include "toolchain/check/inst.h"
 #include "toolchain/check/name_lookup.h"
+#include "toolchain/check/pattern_match.h"
 #include "toolchain/check/type.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/constant.h"
@@ -19,6 +20,7 @@
 #include "toolchain/sem_ir/import_ir.h"
 #include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/inst_kind.h"
+#include "toolchain/sem_ir/pattern.h"
 #include "toolchain/sem_ir/type_info.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
@@ -1121,6 +1123,67 @@ static auto GetLocalReturnSlotPatternId(
            .index = param_pattern.index}));
 }
 
+static auto GetLocalCallParamsId(ImportContext& context,
+                                 SemIR::InstBlockId call_params_id)
+    -> SemIR::InstBlockId {
+  if (!call_params_id.has_value() ||
+      call_params_id == SemIR::InstBlockId::Empty) {
+    return call_params_id;
+  }
+
+  const auto& call_params = context.import_inst_blocks().Get(call_params_id);
+  llvm::SmallVector<SemIR::InstId> new_call_params;
+
+  for (auto call_param : call_params) {
+    auto any_param = context.import_insts().GetAs<SemIR::AnyParam>(call_param);
+    auto type_id = context.local_context().types().GetTypeIdForTypeConstantId(
+        GetLocalConstantIdChecked(context, any_param.type_id));
+    SemIR::InstId new_param_id = SemIR::InstId::None;
+
+    // TODO: Remove code duplication
+    auto out_param =
+        context.import_insts().TryGetAs<SemIR::OutParam>(call_param);
+    if (out_param) {
+      auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::OutParam>(
+          context.local_context(), AddImportIRInst(context, call_param),
+          {.type_id = type_id,
+           .index = out_param->index,
+           .pretty_name_id =
+               GetLocalNameId(context, out_param->pretty_name_id)});
+      new_param_id = AddInstInNoBlock(context.local_context(), loc_id_inst);
+    }
+
+    auto ref_param =
+        context.import_insts().TryGetAs<SemIR::RefParam>(call_param);
+    if (ref_param) {
+      auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::RefParam>(
+          context.local_context(), AddImportIRInst(context, call_param),
+          {.type_id = type_id,
+           .index = ref_param->index,
+           .pretty_name_id =
+               GetLocalNameId(context, ref_param->pretty_name_id)});
+      new_param_id = AddInstInNoBlock(context.local_context(), loc_id_inst);
+    }
+
+    auto value_param =
+        context.import_insts().TryGetAs<SemIR::ValueParam>(call_param);
+    if (value_param) {
+      auto loc_id_inst = MakeImportedLocIdAndInst<SemIR::ValueParam>(
+          context.local_context(), AddImportIRInst(context, call_param),
+          {.type_id = type_id,
+           .index = value_param->index,
+           .pretty_name_id =
+               GetLocalNameId(context, value_param->pretty_name_id)});
+      new_param_id = AddInstInNoBlock(context.local_context(), loc_id_inst);
+    }
+
+    // Params are of one the above types, so a new param id must exist now.
+    CARBON_CHECK(new_param_id.has_value());
+    new_call_params.push_back(new_param_id);
+  }
+  return context.local_inst_blocks().Add(new_call_params);
+}
+
 // Translates a NameScopeId from the import IR to a local NameScopeId. Adds
 // unresolved constants to the resolver's work stack.
 static auto GetLocalNameScopeId(ImportRefResolver& resolver,
@@ -1987,6 +2050,9 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       GetLocalParamPatternsId(resolver, import_function.param_patterns_id);
   new_function.return_slot_pattern_id = GetLocalReturnSlotPatternId(
       resolver, import_function.return_slot_pattern_id);
+  new_function.call_params_id =
+      GetLocalCallParamsId(resolver, import_function.call_params_id);
+
   SetGenericData(resolver, import_function.generic_id, new_function.generic_id,
                  generic_data);
 

--- a/toolchain/check/import_ref.h
+++ b/toolchain/check/import_ref.h
@@ -8,6 +8,7 @@
 #include "toolchain/check/context.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
 
@@ -70,6 +71,21 @@ auto MakeImportedLocIdAndInst(Context& context,
     Internal::CheckCompatibleImportedNodeKind(context, imported_loc_id,
                                               InstT::Kind);
   }
+  return SemIR::LocIdAndInst::UncheckedLoc(imported_loc_id, inst);
+}
+
+// Returns a LocIdAndInst for an `Any*` instruction with an imported location.
+// `Any` instructions don't have a NodeId directly associated but have a `kind`
+// member as a field. Checks that the imported location is compatible with the
+// kind of instruction being created.
+template <typename InstT>
+  requires(!SemIR::Internal::HasNodeId<InstT> &&
+           SemIR::Internal::HasKindMemberAsField<InstT>)
+auto MakeImportedLocIdAndInst(Context& context,
+                              SemIR::ImportIRInstId imported_loc_id, InstT inst)
+    -> SemIR::LocIdAndInst {
+  Internal::CheckCompatibleImportedNodeKind(context, imported_loc_id,
+                                            inst.kind);
   return SemIR::LocIdAndInst::UncheckedLoc(imported_loc_id, inst);
 }
 

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -364,5 +364,5 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self.param_patt: %ForwardDeclared.7b34f2.1]() [from "a.carbon"];
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G[addr <unexpected>.inst1135: %ptr.6cf]() [from "a.carbon"];
+// CHECK:STDOUT: fn @G[addr <unexpected>.inst1202: %ptr.6cf]() [from "a.carbon"];
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -94,7 +94,7 @@ class C {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %x: %i32 = bind_name x, <unexpected>.inst1057.loc27_14
+// CHECK:STDOUT:   %x: %i32 = bind_name x, <unexpected>.inst1123.loc27_14
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %y.patt: %i32 = binding_pattern y
 // CHECK:STDOUT:     %.loc37: %i32 = var_pattern %y.patt

--- a/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
+++ b/toolchain/check/testdata/return/no_prelude/import_convert_function.carbon
@@ -1179,13 +1179,13 @@ fn F0(n: i32) -> P.D {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %P.D: type = import_ref P//library, D, loaded [concrete = constants.%D]
 // CHECK:STDOUT:   %P.import_ref.7e5: <witness> = import_ref P//library, loc7_35, loaded [concrete = constants.%complete_type.682]
-// CHECK:STDOUT:   %P.import_ref.cab = import_ref P//library, inst46 [no loc], unloaded
+// CHECK:STDOUT:   %P.import_ref.cab = import_ref P//library, inst48 [no loc], unloaded
 // CHECK:STDOUT:   %P.import_ref.a99 = import_ref P//library, loc7_16, unloaded
 // CHECK:STDOUT:   %P.import_ref.9d2 = import_ref P//library, loc7_28, unloaded
 // CHECK:STDOUT:   %P.C: %C.type = import_ref P//library, C, loaded [concrete = constants.%C.generic]
 // CHECK:STDOUT:   %P.import_ref.85e: %i32.builtin = import_ref P//library, loc6_9, loaded [symbolic = @C.%N (constants.%N)]
 // CHECK:STDOUT:   %P.import_ref.8f2: <witness> = import_ref P//library, loc6_19, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %P.import_ref.d9b = import_ref P//library, inst41 [no loc], unloaded
+// CHECK:STDOUT:   %P.import_ref.d9b = import_ref P//library, inst43 [no loc], unloaded
 // CHECK:STDOUT:   %Core.import_ref.5ab3ec.1: type = import_ref Core//default, loc8_22, loaded [symbolic = @ImplicitAs.%T (constants.%T)]
 // CHECK:STDOUT:   %Core.import_ref.ff5 = import_ref Core//default, inst48 [no loc], unloaded
 // CHECK:STDOUT:   %Core.import_ref.630: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.837) = import_ref Core//default, loc9_32, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.43d)]

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -328,7 +328,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.c81: %struct_type.a.b.5ca = import_ref Implicit//default, loc8_9, loaded [symbolic = @C.%S (constants.%S)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc8_34, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1132 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1198 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -505,7 +505,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.c81: %struct_type.a.b = import_ref Implicit//default, loc8_9, loaded [symbolic = @C.%S (constants.%S)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc8_34, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1132 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1198 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -622,7 +622,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.c81: %struct_type.a.b.5ca = import_ref Implicit//default, loc8_9, loaded [symbolic = @C.%S (constants.%S)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc8_34, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1132 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1198 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/tuple/import.carbon
+++ b/toolchain/check/testdata/tuple/import.carbon
@@ -358,7 +358,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.48d: %tuple.type.c2c = import_ref Implicit//default, loc7_9, loaded [symbolic = @C.%X (constants.%X)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc7_26, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1168 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1234 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -551,7 +551,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.48d: %tuple.type.c2c = import_ref Implicit//default, loc7_9, loaded [symbolic = @C.%X (constants.%X)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc7_26, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1168 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1234 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -669,7 +669,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.48d: %tuple.type.c2c = import_ref Implicit//default, loc7_9, loaded [symbolic = @C.%X (constants.%X)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc7_26, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1168 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1234 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/driver/testdata/compile/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/driver/testdata/compile/multifile_raw_and_textual_ir.carbon
@@ -118,7 +118,7 @@ fn B() {
 // CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: -1, is_template: 0}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, call_params_id: inst_block_empty, body: [inst_block5]}
-// CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1}
+// CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1, call_params_id: inst_block_empty}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}

--- a/toolchain/driver/testdata/compile/multifile_raw_ir.carbon
+++ b/toolchain/driver/testdata/compile/multifile_raw_ir.carbon
@@ -98,7 +98,7 @@ fn B() {
 // CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: -1, is_template: 0}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, parent_scope: name_scope0, call_params_id: inst_block_empty, body: [inst_block5]}
-// CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1}
+// CHECK:STDOUT:     function1:       {name: name1, parent_scope: name_scope1, call_params_id: inst_block_empty}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -223,16 +223,8 @@ auto FileContext::BuildFunctionTypeInfo(const SemIR::Function& function,
     return GetType(SemIR::GetTypeInSpecific(sem_ir(), specific_id, type_id));
   };
 
-  // TODO: expose the `Call` parameter patterns in `Function`, and use them here
-  // instead of reconstructing them via the syntactic parameter lists.
-  auto implicit_param_patterns =
-      sem_ir().inst_blocks().GetOrEmpty(function.implicit_param_patterns_id);
-  auto param_patterns =
-      sem_ir().inst_blocks().GetOrEmpty(function.param_patterns_id);
-
   auto* return_type = get_llvm_type(return_info.type_id);
 
-  llvm::SmallVector<llvm::Type*> param_types;
   // Compute the return type to use for the LLVM function. If the initializing
   // representation doesn't produce a value, set the return type to void.
   // TODO: For the `Run` entry point, remap return type to i32 if it doesn't
@@ -243,35 +235,44 @@ auto FileContext::BuildFunctionTypeInfo(const SemIR::Function& function,
           ? return_type
           : llvm::Type::getVoidTy(llvm_context());
 
+  auto call_param_ids =
+      sem_ir().inst_blocks().GetOrEmpty(function.call_params_id);
+
+  // In Carbon, the return is added at the end of the call_params, remove it.
+  // We treat the function return separately below.
+  if (function.return_slot_pattern_id.has_value()) {
+    call_param_ids = call_param_ids.drop_back();
+  }
+
   // TODO: Consider either storing `param_inst_ids` somewhere so that we can
   // reuse it from `BuildFunctionDefinition` and when building calls, or factor
   // out a mechanism to compute the mapping between parameters and arguments on
   // demand.
+  llvm::SmallVector<llvm::Type*> param_types;
   llvm::SmallVector<SemIR::InstId> param_inst_ids;
-  auto max_llvm_params = (return_info.has_return_slot() ? 1 : 0) +
-                         implicit_param_patterns.size() + param_patterns.size();
-  param_types.reserve(max_llvm_params);
-  param_inst_ids.reserve(max_llvm_params);
+  param_types.reserve(call_param_ids.size());
+  param_inst_ids.reserve(call_param_ids.size());
   auto return_param_id = SemIR::InstId::None;
+
+  // If in LLVM we use a return slot, this is added at the beginning of the
+  // param list according to LLVM calling convention. The function return type
+  // will then be void, as set by function_return_type above.
   if (return_info.has_return_slot()) {
     param_types.push_back(
         llvm::PointerType::get(return_type, /*AddressSpace=*/0));
     return_param_id = function.return_slot_pattern_id;
     param_inst_ids.push_back(return_param_id);
   }
-  for (auto param_pattern_id : llvm::concat<const SemIR::InstId>(
-           implicit_param_patterns, param_patterns)) {
-    auto param_pattern_info = SemIR::Function::GetParamPatternInfoFromPatternId(
-        sem_ir(), param_pattern_id);
-    if (!param_pattern_info) {
-      continue;
-    }
-    auto param_type_id = SemIR::GetTypeInSpecific(
-        sem_ir(), specific_id, param_pattern_info->inst.type_id);
+
+  // Generate the function parameters.
+  for (auto call_param_id : call_param_ids) {
+    auto param_inst = sem_ir().insts().GetAs<SemIR::AnyParam>(call_param_id);
+    auto param_type_id =
+        SemIR::GetTypeInSpecific(sem_ir(), specific_id, param_inst.type_id);
     CARBON_CHECK(
         !param_type_id.AsConstantId().is_symbolic(),
         "Found symbolic type id after resolution when lowering type {0}.",
-        param_pattern_info->inst.type_id);
+        param_inst.type_id);
     switch (auto value_rep = SemIR::ValueRepr::ForType(sem_ir(), param_type_id);
             value_rep.kind) {
       case SemIR::ValueRepr::Unknown:
@@ -287,7 +288,7 @@ auto FileContext::BuildFunctionTypeInfo(const SemIR::Function& function,
       case SemIR::ValueRepr::Pointer:
         auto* param_types_to_add = get_llvm_type(value_rep.type_id);
         param_types.push_back(param_types_to_add);
-        param_inst_ids.push_back(param_pattern_id);
+        param_inst_ids.push_back(call_param_id);
         break;
     }
   }
@@ -338,7 +339,7 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
       arg.addAttr(llvm::Attribute::getWithStructRetType(
           llvm_context(), function_type_info.return_type));
     } else {
-      name_id = SemIR::GetPrettyNameFromPatternId(sem_ir(), inst_id);
+      name_id = sem_ir().insts().GetAs<SemIR::AnyParam>(inst_id).pretty_name_id;
     }
     arg.setName(sem_ir().names().GetIRBaseName(name_id));
   }


### PR DESCRIPTION
Import the call parameters ids for functions. This is used in lowering to not recreate them using the patterns.
