### PR TITLE
Replace uses of "defined" with "complete"

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -446,7 +446,7 @@ auto CheckUnit::CheckRequiredDefinitions() -> void {
     SemIR::Inst decl_inst = context_.insts().Get(decl_inst_id);
     CARBON_KIND_SWITCH(context_.insts().Get(decl_inst_id)) {
       case CARBON_KIND(SemIR::ClassDecl class_decl): {
-        if (!context_.classes().Get(class_decl.class_id).is_defined()) {
+        if (!context_.classes().Get(class_decl.class_id).is_complete()) {
           emitter_.Emit(decl_inst_id, MissingDefinitionInImpl);
         }
         break;
@@ -460,7 +460,7 @@ auto CheckUnit::CheckRequiredDefinitions() -> void {
       }
       case CARBON_KIND(SemIR::ImplDecl impl_decl): {
         auto& impl = context_.impls().Get(impl_decl.impl_id);
-        if (!impl.is_defined()) {
+        if (!impl.is_complete()) {
           FillImplWitnessWithErrors(context_, impl);
           CARBON_DIAGNOSTIC(ImplMissingDefinition, Error,
                             "impl declared but not defined");

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -413,7 +413,7 @@ auto DeclNameStack::ResolveAsScope(const NameContext& name_context,
                                   DeclParams(class_info))) {
         return InvalidResult;
       }
-      if (!class_info.is_defined()) {
+      if (!class_info.is_complete()) {
         DiagnoseQualifiedDeclInIncompleteClassScope(
             *context_, name_context.loc_id, class_decl.class_id);
         return InvalidResult;
@@ -427,7 +427,7 @@ auto DeclNameStack::ResolveAsScope(const NameContext& name_context,
                                   DeclParams(interface_info))) {
         return InvalidResult;
       }
-      if (!interface_info.is_defined()) {
+      if (!interface_info.is_complete()) {
         DiagnoseQualifiedDeclInUndefinedInterfaceScope(
             *context_, name_context.loc_id, interface_decl.interface_id,
             name_context.resolved_inst_id);

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -348,7 +348,7 @@ static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
                     InstIdAsType);
   auto builder = context.emitter().Build(
       loc, QualifiedDeclInUndefinedInterfaceScope, interface_inst_id);
-  NoteUndefinedInterface(context, interface_id, builder);
+  NoteIncompleteInterface(context, interface_id, builder);
   builder.Emit();
 }
 

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -513,7 +513,7 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionId /*node_id*/)
       context.node_stack().Pop<Parse::NodeKind::ImplDefinitionStart>();
 
   auto& impl_info = context.impls().Get(impl_id);
-  CARBON_CHECK(!impl_info.is_defined());
+  CARBON_CHECK(!impl_info.is_complete());
   FinishImplWitness(context, impl_info);
   impl_info.defined = true;
   FinishGenericDefinition(context, impl_info.generic_id);

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1791,7 +1791,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver.local_context().types().GetTypeIdForTypeConstantId(
           self_const_id);
 
-  if (import_class.is_defined()) {
+  if (import_class.is_complete()) {
     auto complete_type_witness_id = AddLoadedImportRef(
         resolver,
         GetSingletonType(resolver.local_context(),
@@ -2242,7 +2242,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                          import_impl.constraint_id, constraint_const_id);
   new_impl.interface = GetLocalSpecificInterface(
       resolver, import_impl.interface.specific_id, specific_interface_data);
-  if (import_impl.is_defined()) {
+  if (import_impl.is_complete()) {
     AddImplDefinition(resolver, import_impl, new_impl);
   }
 
@@ -2392,7 +2392,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       GetLocalGenericData(resolver, import_interface.generic_id);
 
   std::optional<SemIR::InstId> self_param_id;
-  if (import_interface.is_defined()) {
+  if (import_interface.is_complete()) {
     self_param_id =
         GetLocalConstantInstId(resolver, import_interface.self_param_id);
   }
@@ -2411,7 +2411,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   SetGenericData(resolver, import_interface.generic_id,
                  new_interface.generic_id, generic_data);
 
-  if (import_interface.is_defined()) {
+  if (import_interface.is_complete()) {
     CARBON_CHECK(self_param_id);
     AddInterfaceDefinition(resolver, import_interface, new_interface,
                            *self_param_id);

--- a/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -13,7 +13,7 @@ interface I {
     // CHECK:STDERR: fail_extend_partially_defined_interface.carbon:[[@LINE+11]]:5: error: impl as incomplete facet type `I` [ImplAsIncompleteFacetType]
     // CHECK:STDERR:     extend impl as I;
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_extend_partially_defined_interface.carbon:[[@LINE-5]]:1: note: interface is currently being defined [InterfaceUndefinedWithinDefinition]
+    // CHECK:STDERR: fail_extend_partially_defined_interface.carbon:[[@LINE-5]]:1: note: interface is currently being defined [InterfaceIncompleteWithinDefinition]
     // CHECK:STDERR: interface I {
     // CHECK:STDERR: ^~~~~~~~~~~~~
     // CHECK:STDERR:

--- a/toolchain/check/testdata/impl/no_prelude/fail_extend_impl_scope.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_extend_impl_scope.carbon
@@ -45,7 +45,7 @@ interface Z {
   // CHECK:STDERR: fail_extend_impl_self_interface.carbon:[[@LINE+7]]:3: error: impl as incomplete facet type `Z` [ImplAsIncompleteFacetType]
   // CHECK:STDERR:   extend impl as Z {
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_extend_impl_self_interface.carbon:[[@LINE-10]]:1: note: interface is currently being defined [InterfaceUndefinedWithinDefinition]
+  // CHECK:STDERR: fail_extend_impl_self_interface.carbon:[[@LINE-10]]:1: note: interface is currently being defined [InterfaceIncompleteWithinDefinition]
   // CHECK:STDERR: interface Z {
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/impl/no_prelude/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_impl_as_scope.carbon
@@ -53,7 +53,7 @@ interface Z {
    // CHECK:STDERR: fail_impl_as_self_interface.carbon:[[@LINE+7]]:4: error: impl as incomplete facet type `Z` [ImplAsIncompleteFacetType]
    // CHECK:STDERR:    impl as Z {
    // CHECK:STDERR:    ^~~~~~~~~~~
-   // CHECK:STDERR: fail_impl_as_self_interface.carbon:[[@LINE-11]]:1: note: interface is currently being defined [InterfaceUndefinedWithinDefinition]
+   // CHECK:STDERR: fail_impl_as_self_interface.carbon:[[@LINE-11]]:1: note: interface is currently being defined [InterfaceIncompleteWithinDefinition]
    // CHECK:STDERR: interface Z {
    // CHECK:STDERR: ^~~~~~~~~~~~~
    // CHECK:STDERR:

--- a/toolchain/check/testdata/impl/use_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/use_assoc_const.carbon
@@ -174,14 +174,14 @@ interface J2 {
   // CHECK:STDERR: fail_todo_self_period_associated_type.carbon:[[@LINE+14]]:23: error: member access into object of incomplete type `J2` [IncompleteTypeInMemberAccess]
   // CHECK:STDERR:   fn F[self: Self](z: Self.U2) -> Self.U2;
   // CHECK:STDERR:                       ^~~~
-  // CHECK:STDERR: fail_todo_self_period_associated_type.carbon:[[@LINE-5]]:1: note: interface is currently being defined [InterfaceUndefinedWithinDefinition]
+  // CHECK:STDERR: fail_todo_self_period_associated_type.carbon:[[@LINE-5]]:1: note: interface is currently being defined [InterfaceIncompleteWithinDefinition]
   // CHECK:STDERR: interface J2 {
   // CHECK:STDERR: ^~~~~~~~~~~~~~
   // CHECK:STDERR:
   // CHECK:STDERR: fail_todo_self_period_associated_type.carbon:[[@LINE+7]]:35: error: member access into object of incomplete type `J2` [IncompleteTypeInMemberAccess]
   // CHECK:STDERR:   fn F[self: Self](z: Self.U2) -> Self.U2;
   // CHECK:STDERR:                                   ^~~~
-  // CHECK:STDERR: fail_todo_self_period_associated_type.carbon:[[@LINE-12]]:1: note: interface is currently being defined [InterfaceUndefinedWithinDefinition]
+  // CHECK:STDERR: fail_todo_self_period_associated_type.carbon:[[@LINE-12]]:1: note: interface is currently being defined [InterfaceIncompleteWithinDefinition]
   // CHECK:STDERR: interface J2 {
   // CHECK:STDERR: ^~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interface/no_prelude/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/fail_lookup_undefined.carbon
@@ -34,7 +34,7 @@ interface BeingDefined {
   // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+7]]:13: error: member access into incomplete facet type `BeingDefined` [QualifiedExprInIncompleteFacetTypeScope]
   // CHECK:STDERR:   fn H() -> BeingDefined.T;
   // CHECK:STDERR:             ^~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-4]]:1: note: interface is currently being defined [InterfaceUndefinedWithinDefinition]
+  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-4]]:1: note: interface is currently being defined [InterfaceIncompleteWithinDefinition]
   // CHECK:STDERR: interface BeingDefined {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -304,7 +304,7 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
         if (!interface.is_complete()) {
           if (diagnoser_) {
             auto builder = diagnoser_();
-            NoteUndefinedInterface(context_, interface_id, builder);
+            NoteIncompleteInterface(context_, interface_id, builder);
             builder.Emit();
           }
           return false;
@@ -669,15 +669,15 @@ auto NoteIncompleteClass(Context& context, SemIR::ClassId class_id,
   }
 }
 
-auto NoteUndefinedInterface(Context& context, SemIR::InterfaceId interface_id,
-                            DiagnosticBuilder& builder) -> void {
+auto NoteIncompleteInterface(Context& context, SemIR::InterfaceId interface_id,
+                             DiagnosticBuilder& builder) -> void {
   const auto& interface_info = context.interfaces().Get(interface_id);
   CARBON_CHECK(!interface_info.is_complete(), "Interface is not incomplete");
   if (interface_info.is_being_defined()) {
-    CARBON_DIAGNOSTIC(InterfaceUndefinedWithinDefinition, Note,
+    CARBON_DIAGNOSTIC(InterfaceIncompleteWithinDefinition, Note,
                       "interface is currently being defined");
     builder.Note(interface_info.definition_id,
-                 InterfaceUndefinedWithinDefinition);
+                 InterfaceIncompleteWithinDefinition);
   } else {
     CARBON_DIAGNOSTIC(InterfaceForwardDeclaredHere, Note,
                       "interface was forward declared here");

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -260,7 +260,7 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
     }
     case CARBON_KIND(SemIR::ClassType inst): {
       auto& class_info = context_.classes().Get(inst.class_id);
-      if (!class_info.is_defined()) {
+      if (!class_info.is_complete()) {
         if (diagnoser_) {
           auto builder = diagnoser_();
           NoteIncompleteClass(context_, inst.class_id, builder);
@@ -301,7 +301,7 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
         // TODO: expand named constraints
         auto interface_id = impl_interface.interface_id;
         const auto& interface = context_.interfaces().Get(interface_id);
-        if (!interface.is_defined()) {
+        if (!interface.is_complete()) {
           if (diagnoser_) {
             auto builder = diagnoser_();
             NoteUndefinedInterface(context_, interface_id, builder);
@@ -657,7 +657,7 @@ auto AsConcreteType(Context& context, SemIR::TypeId type_id,
 auto NoteIncompleteClass(Context& context, SemIR::ClassId class_id,
                          DiagnosticBuilder& builder) -> void {
   const auto& class_info = context.classes().Get(class_id);
-  CARBON_CHECK(!class_info.is_defined(), "Class is not incomplete");
+  CARBON_CHECK(!class_info.is_complete(), "Class is not incomplete");
   if (class_info.has_definition_started()) {
     CARBON_DIAGNOSTIC(ClassIncompleteWithinDefinition, Note,
                       "class is incomplete within its definition");
@@ -672,7 +672,7 @@ auto NoteIncompleteClass(Context& context, SemIR::ClassId class_id,
 auto NoteUndefinedInterface(Context& context, SemIR::InterfaceId interface_id,
                             DiagnosticBuilder& builder) -> void {
   const auto& interface_info = context.interfaces().Get(interface_id);
-  CARBON_CHECK(!interface_info.is_defined(), "Interface is not incomplete");
+  CARBON_CHECK(!interface_info.is_complete(), "Interface is not incomplete");
   if (interface_info.is_being_defined()) {
     CARBON_DIAGNOSTIC(InterfaceUndefinedWithinDefinition, Note,
                       "interface is currently being defined");

--- a/toolchain/check/type_completion.h
+++ b/toolchain/check/type_completion.h
@@ -81,8 +81,8 @@ auto NoteIncompleteClass(Context& context, SemIR::ClassId class_id,
                          DiagnosticBuilder& builder) -> void;
 
 // Adds a note to a diagnostic explaining that an interface is not defined.
-auto NoteUndefinedInterface(Context& context, SemIR::InterfaceId interface_id,
-                            DiagnosticBuilder& builder) -> void;
+auto NoteIncompleteInterface(Context& context, SemIR::InterfaceId interface_id,
+                             DiagnosticBuilder& builder) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -280,7 +280,7 @@ CARBON_DIAGNOSTIC_KIND(ExportPrevious)
 
 // Interface checking.
 CARBON_DIAGNOSTIC_KIND(InterfaceForwardDeclaredHere)
-CARBON_DIAGNOSTIC_KIND(InterfaceUndefinedWithinDefinition)
+CARBON_DIAGNOSTIC_KIND(InterfaceIncompleteWithinDefinition)
 CARBON_DIAGNOSTIC_KIND(VarInInterfaceDecl)
 
 // Impl checking.

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -75,9 +75,8 @@ struct Class : public EntityWithParamsBase,
     out << "}";
   }
 
-  // Determines whether this class has been fully defined. This is false until
-  // we reach the `}` of the class definition.
-  auto is_defined() const -> bool {
+  // This is false until we reach the `}` of the class definition.
+  auto is_complete() const -> bool {
     return complete_type_witness_id.has_value();
   }
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -379,7 +379,7 @@ class FormatterImpl {
     out_ << " as ";
     FormatName(impl_info.constraint_id);
 
-    if (impl_info.is_defined()) {
+    if (impl_info.is_complete()) {
       out_ << ' ';
       OpenBrace();
       FormatCodeBlock(impl_info.body_block_id);

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -52,13 +52,12 @@ struct Impl : public EntityWithParamsBase,
     out << "{self: " << self_id << ", constraint: " << constraint_id << "}";
   }
 
-  // Determines whether this impl has been fully defined. This is false until we
-  // reach the `}` of the impl definition.
-  auto is_defined() const -> bool { return defined; }
+  // This is false until we reach the `}` of the impl definition.
+  auto is_complete() const -> bool { return defined; }
 
   // Determines whether this impl's definition has begun but not yet ended.
   auto is_being_defined() const -> bool {
-    return has_definition_started() && !is_defined();
+    return has_definition_started() && !is_complete();
   }
 };
 

--- a/toolchain/sem_ir/interface.h
+++ b/toolchain/sem_ir/interface.h
@@ -36,14 +36,15 @@ struct Interface : public EntityWithParamsBase,
     out << "}";
   }
 
-  // Determines whether this interface has been fully defined. This is false
-  // until we reach the `}` of the interface definition.
-  auto is_defined() const -> bool { return associated_entities_id.has_value(); }
+  // This is false until we reach the `}` of the interface definition.
+  auto is_complete() const -> bool {
+    return associated_entities_id.has_value();
+  }
 
   // Determines whether we're currently defining the interface. This is true
   // between the braces of the interface.
   auto is_being_defined() const -> bool {
-    return has_definition_started() && !is_defined();
+    return has_definition_started() && !is_complete();
   }
 };
 

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -43,7 +43,7 @@ auto TypeStore::GetObjectRepr(TypeId type_id) const -> TypeId {
     return type_id;
   }
   const auto& class_info = file_->classes().Get(class_type->class_id);
-  if (!class_info.is_defined()) {
+  if (!class_info.is_complete()) {
     return TypeId::None;
   }
   return class_info.GetObjectRepr(*file_, class_type->specific_id);


### PR DESCRIPTION
As of #5087, these terms are no longer synonyms. This change preserves the original meaning.