### PR TITLE
Change `NodeIdTraversal.context_` from reference to pointer

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -351,7 +351,7 @@ auto CheckUnit::ImportOtherPackages(SemIR::TypeId namespace_type_id) -> void {
 // for example if an unrecoverable state is encountered.
 // NOLINTNEXTLINE(readability-function-size)
 auto CheckUnit::ProcessNodeIds() -> bool {
-  NodeIdTraversal traversal(context_, vlog_stream_);
+  NodeIdTraversal traversal(&context_, vlog_stream_);
 
   Parse::NodeId node_id = Parse::NodeId::None;
 

--- a/toolchain/check/node_id_traversal.h
+++ b/toolchain/check/node_id_traversal.h
@@ -17,7 +17,8 @@ namespace Carbon::Check {
 // to check them.
 class NodeIdTraversal {
  public:
-  explicit NodeIdTraversal(Context& context, llvm::raw_ostream* vlog_stream);
+  // `context` must not be null.
+  explicit NodeIdTraversal(Context* context, llvm::raw_ostream* vlog_stream);
 
   // Finds the next `NodeId` to type-check. Returns nullopt if the traversal is
   // complete.
@@ -76,7 +77,7 @@ class NodeIdTraversal {
       DeferredDefinitionWorklist::CheckSkippedDefinition&& parse_definition)
       -> void;
 
-  Context& context_;
+  Context* context_;
   NextDeferredDefinitionCache next_deferred_definition_;
   DeferredDefinitionWorklist worklist_;
   llvm::SmallVector<Chunk> chunks_;


### PR DESCRIPTION
Per [the style guide](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/cpp_style_guide.md#syntax-and-formatting):
* If it is captured and must outlive the call expression itself, use a pointer and document that it must not be null (unless it is also optional).
* When storing an object's address as a non-owned member, prefer storing a pointer.