### PR TITLE
Don't re-evaluate imported constants. 

### DIFF
--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -11,6 +11,13 @@
 
 namespace Carbon::Check {
 
+// Adds a `ConstantId` for a constant that has been imported from another IR.
+// Does not evaluate the instruction, instead trusting that it is already in a
+// suitable form, but does canonicalize the operands if necessary.
+// TODO: Rely on import to canonicalize the operands to avoid this work.
+auto AddImportedConstant(Context& context, SemIR::Inst inst)
+    -> SemIR::ConstantId;
+
 // Determines the phase of the instruction `inst`, and returns its constant
 // value if it has constant phase. If it has runtime phase, returns
 // `SemIR::ConstantId::NotConstant`.

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1332,7 +1332,7 @@ static auto RetryOrDone(ImportRefResolver& resolver, SemIR::ConstantId const_id)
 // that there is no new work.
 static auto ResolveAsUntyped(ImportContext& context, SemIR::Inst inst)
     -> ResolveResult {
-  auto result = TryEvalInst(context.local_context(), SemIR::InstId::None, inst);
+  auto result = AddImportedConstant(context.local_context(), inst);
   CARBON_CHECK(result.is_constant(), "{0} is not constant", inst);
   return ResolveResult::Done(result);
 }


### PR DESCRIPTION
Trust that import_ref produces constants that are already in their
evaluated form. We still do one pass over the operands to map them into
their canonical constant values. Even that is mostly unnecessary, but
there are a few instructions produced by importing that still need it
for now.