### PR TITLE
Lower a single specific for a type.

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -190,11 +190,6 @@ auto FileContext::GetOrCreateFunction(SemIR::FunctionId function_id,
   }
 
   auto* result = BuildFunctionDecl(function_id, specific_id);
-  // TODO: Add this function to a list of specific functions whose definitions
-  // we need to emit.
-  specific_functions_[specific_id.index] = result;
-  // TODO: Use this to generate definitions for these functions.
-  specific_function_definitions_.push_back({function_id, specific_id});
   return result;
 }
 
@@ -316,6 +311,48 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
 
   auto function_type_info = BuildFunctionTypeInfo(function, specific_id);
 
+  // TODO: Store just enough data to choose not to create a new llvm::Function
+  // if an identical one was created for another specific of the same generic.
+
+  if (!specific_id.has_value()) {
+    return CreateLlvmFunction(function_id, specific_id, function_type_info);
+  }
+
+  auto [existing_specifics, no_existing] =
+      GetLoweredSpecifics(function.generic_id);
+
+  if (no_existing) {
+    existing_specifics.push_back(specific_id);
+    lowered_specifics_types.Insert(specific_id, function_type_info);
+    auto* result =
+        CreateLlvmFunction(function_id, specific_id, function_type_info);
+    specific_functions_[specific_id.index] = result;
+    specific_function_definitions_.push_back({function_id, specific_id});
+    return result;
+  }
+
+  for (auto lowered_specific : existing_specifics) {
+    auto& prev_function_type_info =
+        lowered_specifics_types.Lookup(lowered_specific).value();
+    if (function_type_info.isEqual(prev_function_type_info)) {
+      deduplicate_specifics.Insert(lowered_specific, specific_id);
+      specific_functions_[specific_id.index] =
+          specific_functions_[lowered_specific.index];
+      return specific_functions_[lowered_specific.index];
+    }
+  }
+
+  auto* result =
+      CreateLlvmFunction(function_id, specific_id, function_type_info);
+  specific_functions_[specific_id.index] = result;
+  specific_function_definitions_.push_back({function_id, specific_id});
+  return result;
+}
+
+auto FileContext::CreateLlvmFunction(SemIR::FunctionId function_id,
+                                     SemIR::SpecificId specific_id,
+                                     FunctionTypeInfo& function_type_info)
+    -> llvm::Function* {
   Mangler m(*this);
   std::string mangled_name = m.Mangle(function_id, specific_id);
 

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -104,6 +104,30 @@ class FileContext {
     llvm::SmallVector<SemIR::InstId> param_inst_ids;
     llvm::Type* return_type = nullptr;
     SemIR::InstId return_param_id = SemIR::InstId::None;
+
+    // Compares the types of two functions. This is intended to be used for
+    // specifics of the same generic.
+    auto isEqual(FunctionTypeInfo other) -> bool {
+      // Two specifics of the same generic may not have the same number of
+      // params. It's possible one specific uses a return slot (so has one
+      // more param) while another does not.
+      if (param_inst_ids.size() != other.param_inst_ids.size() ||
+          return_param_id != other.return_param_id) {
+        return false;
+      }
+
+      if (type != other.type || return_type != other.return_type) {
+        return false;
+      }
+
+      for (const auto [param_id, other_param_id] :
+           llvm::zip_equal(param_inst_ids, other.param_inst_ids)) {
+        if (param_id != other_param_id) {
+          return false;
+        }
+      }
+      return true;
+    }
   };
 
   // Retrieve various features of the function's type useful for constructing
@@ -118,6 +142,13 @@ class FileContext {
   auto BuildFunctionDecl(SemIR::FunctionId function_id,
                          SemIR::SpecificId specific_id =
                              SemIR::SpecificId::None) -> llvm::Function*;
+
+  // Helper function for creating the LLVM function. Only used when building
+  // the function declaration.
+  auto CreateLlvmFunction(SemIR::FunctionId function_id,
+                          SemIR::SpecificId specific_id,
+                          FunctionTypeInfo& function_type_info)
+      -> llvm::Function*;
 
   // Builds the definition for the given function. If the function is only a
   // declaration with no definition, does nothing. If this is a generic it'll
@@ -146,6 +177,15 @@ class FileContext {
   // the caller.
   auto BuildGlobalVariableDecl(SemIR::VarStorage var_storage)
       -> llvm::GlobalVariable*;
+
+  auto GetLoweredSpecifics(SemIR::GenericId generic_id)
+      -> std::pair<llvm::SmallVector<SemIR::SpecificId>&, bool> {
+    llvm::SmallVector<SemIR::SpecificId> existing_specifics;
+    auto ls_entry = lowered_specifics.Insert(generic_id, existing_specifics);
+    llvm::SmallVector<SemIR::SpecificId>& ref_existing_specifics =
+        ls_entry.value();
+    return {ref_existing_specifics, ls_entry.is_inserted()};
+  }
 
   // State for building the LLVM IR.
   llvm::LLVMContext* llvm_context_;
@@ -206,6 +246,20 @@ class FileContext {
 
   // Maps global variables to their lowered variant.
   Map<SemIR::InstId, llvm::GlobalVariable*> global_variables_;
+
+  // For a generic function, keep track of the specifics for which LLVM
+  // function declarations were created. Those can be retrieved then via
+  // from specific_functions_, via specific_functions_[specific_id.index].
+  Map<SemIR::GenericId, llvm::SmallVector<SemIR::SpecificId>> lowered_specifics;
+  // For specifics that exist in lowered_specifics, store their function type
+  // information: return and parameter types.
+  // TODO: Storing all members of FunctionTypeInfo may not be necessary.
+  Map<SemIR::SpecificId, FunctionTypeInfo> lowered_specifics_types;
+  // For specific_id B we chose not to lower the function, because another
+  // specific_id A from the same generic was already lowered with params of the
+  // same type. Store a Map of <specific_idB, specific_idA> to retrieve the
+  // corresponding llvm function for B, found in specific_functions_.
+  Map<SemIR::SpecificId, SemIR::SpecificId> deduplicate_specifics;
 };
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/testdata/function/generic/call.carbon
+++ b/toolchain/lower/testdata/function/generic/call.carbon
@@ -50,7 +50,7 @@ fn G() {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !7
 // CHECK:STDOUT:   store double 0.000000e+00, ptr %m.var, align 8, !dbg !10
 // CHECK:STDOUT:   call void @_CF.Main.15b1f98bd9cc0c5b(ptr %c.var), !dbg !11
-// CHECK:STDOUT:   call void @_CF.Main.2cc450fc05045897(ptr %d.var), !dbg !12
+// CHECK:STDOUT:   call void @_CF.Main.15b1f98bd9cc0c5b(ptr %d.var), !dbg !12
 // CHECK:STDOUT:   %.loc25 = load i32, ptr %n.var, align 4, !dbg !13
 // CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc25), !dbg !14
 // CHECK:STDOUT:   %.loc26 = load double, ptr %m.var, align 8, !dbg !15
@@ -70,29 +70,25 @@ fn G() {
 // CHECK:STDOUT:   ret void, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.2cc450fc05045897(ptr %x) !dbg !21 {
+// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !23 {
+// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !25 {
+// CHECK:STDOUT: define void @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !26
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !27 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !28
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 3, 2, 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @llvm.memcpy.p0.p0.i64, { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @_CF.Main.15b1f98bd9cc0c5b, { 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT: attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
@@ -121,11 +117,9 @@ fn G() {
 // CHECK:STDOUT: !18 = !DILocation(line: 17, column: 1, scope: !4)
 // CHECK:STDOUT: !19 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.15b1f98bd9cc0c5b", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !20 = !DILocation(line: 11, column: 1, scope: !19)
-// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.2cc450fc05045897", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !22 = !DILocation(line: 11, column: 1, scope: !21)
-// CHECK:STDOUT: !23 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !24 = !DILocation(line: 11, column: 1, scope: !23)
-// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !26 = !DILocation(line: 11, column: 1, scope: !25)
-// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !28 = !DILocation(line: 11, column: 1, scope: !27)

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -97,10 +97,10 @@ fn M() {
 // CHECK:STDOUT:   %H.call.loc58 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc58), !dbg !20
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
 // CHECK:STDOUT:   %.loc60 = load ptr, ptr %ptr_f64.var, align 8, !dbg !21
-// CHECK:STDOUT:   %H.call.loc60 = call ptr @_CH.Main.04bf2edaaa84aa22(ptr %.loc60), !dbg !22
+// CHECK:STDOUT:   %H.call.loc60 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc60), !dbg !22
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !7
 // CHECK:STDOUT:   %.loc62 = load ptr, ptr %ptr_i8.var, align 8, !dbg !23
-// CHECK:STDOUT:   %H.call.loc62 = call ptr @_CH.Main.bda010de15e6a5ad(ptr %.loc62), !dbg !24
+// CHECK:STDOUT:   %H.call.loc62 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc62), !dbg !24
 // CHECK:STDOUT:   ret void, !dbg !25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -166,76 +166,67 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %x, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.04bf2edaaa84aa22(ptr %x) !dbg !62 {
+// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !62 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !63
+// CHECK:STDOUT:   ret i32 %x, !dbg !63
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.bda010de15e6a5ad(ptr %x) !dbg !64 {
+// CHECK:STDOUT: define %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !64 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !65
+// CHECK:STDOUT:   ret %type %x, !dbg !65
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !66 {
+// CHECK:STDOUT: define %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !66 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret i32 %x, !dbg !67
+// CHECK:STDOUT:   %a.var = alloca double, align 8, !dbg !67
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !68
+// CHECK:STDOUT:   %H.call.loc25 = call %type @_CH.Main.5754c7a55c7cbe4a(%type %x), !dbg !68
+// CHECK:STDOUT:   %H.call.loc26 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !69
+// CHECK:STDOUT:   %H.call.loc27 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !70
+// CHECK:STDOUT:   %G.call.loc28 = call %type @_CG.Main.5754c7a55c7cbe4a(%type %x), !dbg !71
+// CHECK:STDOUT:   %H.call.loc28 = call %type @_CH.Main.5754c7a55c7cbe4a(%type %G.call.loc28), !dbg !72
+// CHECK:STDOUT:   %G.call.loc29 = call %type @_CG.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !73
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !67
+// CHECK:STDOUT:   %.loc32 = load double, ptr %a.var, align 8, !dbg !74
+// CHECK:STDOUT:   %G.call.loc32 = call double @_CG.Main.66be507887ceee78(double %.loc32), !dbg !75
+// CHECK:STDOUT:   %.loc33 = load double, ptr %a.var, align 8, !dbg !76
+// CHECK:STDOUT:   %H.call.loc33 = call double @_CH.Main.66be507887ceee78(double %.loc33), !dbg !77
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !68
+// CHECK:STDOUT:   call void @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %c.var, %type %x), !dbg !78
+// CHECK:STDOUT:   %.loc39_6.1.temp = alloca {}, align 8, !dbg !79
+// CHECK:STDOUT:   call void @_CH.Main.15b1f98bd9cc0c5b(ptr %.loc39_6.1.temp, ptr %c.var), !dbg !79
+// CHECK:STDOUT:   ret %type %x, !dbg !80
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !68 {
+// CHECK:STDOUT: define double @_CH.Main.66be507887ceee78(double %x) !dbg !81 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret %type %x, !dbg !69
+// CHECK:STDOUT:   ret double %x, !dbg !82
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !70 {
+// CHECK:STDOUT: define void @_CCfn.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !83 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca double, align 8, !dbg !71
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !72
-// CHECK:STDOUT:   %H.call.loc25 = call %type @_CH.Main.5754c7a55c7cbe4a(%type %x), !dbg !72
-// CHECK:STDOUT:   %H.call.loc26 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !73
-// CHECK:STDOUT:   %H.call.loc27 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !74
-// CHECK:STDOUT:   %G.call.loc28 = call %type @_CG.Main.5754c7a55c7cbe4a(%type %x), !dbg !75
-// CHECK:STDOUT:   %H.call.loc28 = call %type @_CH.Main.5754c7a55c7cbe4a(%type %G.call.loc28), !dbg !76
-// CHECK:STDOUT:   %G.call.loc29 = call %type @_CG.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !77
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !71
-// CHECK:STDOUT:   %.loc32 = load double, ptr %a.var, align 8, !dbg !78
-// CHECK:STDOUT:   %G.call.loc32 = call double @_CG.Main.66be507887ceee78(double %.loc32), !dbg !79
-// CHECK:STDOUT:   %.loc33 = load double, ptr %a.var, align 8, !dbg !80
-// CHECK:STDOUT:   %H.call.loc33 = call double @_CH.Main.66be507887ceee78(double %.loc33), !dbg !81
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !72
-// CHECK:STDOUT:   call void @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %c.var, %type %x), !dbg !82
-// CHECK:STDOUT:   %.loc39_6.1.temp = alloca {}, align 8, !dbg !83
-// CHECK:STDOUT:   call void @_CH.Main.15b1f98bd9cc0c5b(ptr %.loc39_6.1.temp, ptr %c.var), !dbg !83
-// CHECK:STDOUT:   ret %type %x, !dbg !84
+// CHECK:STDOUT:   ret void, !dbg !84
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CH.Main.66be507887ceee78(double %x) !dbg !85 {
+// CHECK:STDOUT: define void @_CH.Main.15b1f98bd9cc0c5b(ptr sret({}) %return, ptr %x) !dbg !85 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret double %x, !dbg !86
+// CHECK:STDOUT:   ret ptr %x, !dbg !86
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CCfn.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !87 {
+// CHECK:STDOUT: define void @_CCfn.C.Main.66be507887ceee78(ptr %self, double %x) !dbg !87 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !88
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CH.Main.15b1f98bd9cc0c5b(ptr sret({}) %return, ptr %x) !dbg !89 {
+// CHECK:STDOUT: define void @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %self, %type %x) !dbg !89 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !90
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CCfn.C.Main.66be507887ceee78(ptr %self, double %x) !dbg !91 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !92
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %self, %type %x) !dbg !93 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !94
+// CHECK:STDOUT:   ret void, !dbg !90
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 1, 2, 3, 4, 5, 12, 11, 10, 9, 8, 7, 6 }
 // CHECK:STDOUT: uselistorder ptr @_CG.Main.66be507887ceee78, { 0, 1, 2, 4, 3 }
+// CHECK:STDOUT: uselistorder ptr @_CH.Main.e8193710fd35b608, { 2, 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @_CH.Main.b88d1103f417c6d4, { 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @_CH.Main.5754c7a55c7cbe4a, { 0, 1, 2, 3, 7, 6, 5, 4 }
 // CHECK:STDOUT: uselistorder ptr @_CG.Main.5754c7a55c7cbe4a, { 0, 1, 3, 2 }
@@ -309,36 +300,32 @@ fn M() {
 // CHECK:STDOUT: !59 = !DILocation(line: 41, column: 3, scope: !45)
 // CHECK:STDOUT: !60 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.e8193710fd35b608", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !61 = !DILocation(line: 20, column: 3, scope: !60)
-// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !63 = !DILocation(line: 20, column: 3, scope: !62)
-// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.bda010de15e6a5ad", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !65 = !DILocation(line: 20, column: 3, scope: !64)
-// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !67 = !DILocation(line: 20, column: 3, scope: !66)
-// CHECK:STDOUT: !68 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !69 = !DILocation(line: 20, column: 3, scope: !68)
-// CHECK:STDOUT: !70 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !71 = !DILocation(line: 31, column: 3, scope: !70)
-// CHECK:STDOUT: !72 = !DILocation(line: 25, column: 3, scope: !70)
-// CHECK:STDOUT: !73 = !DILocation(line: 26, column: 3, scope: !70)
-// CHECK:STDOUT: !74 = !DILocation(line: 27, column: 3, scope: !70)
-// CHECK:STDOUT: !75 = !DILocation(line: 28, column: 5, scope: !70)
-// CHECK:STDOUT: !76 = !DILocation(line: 28, column: 3, scope: !70)
-// CHECK:STDOUT: !77 = !DILocation(line: 29, column: 3, scope: !70)
-// CHECK:STDOUT: !78 = !DILocation(line: 32, column: 5, scope: !70)
-// CHECK:STDOUT: !79 = !DILocation(line: 32, column: 3, scope: !70)
-// CHECK:STDOUT: !80 = !DILocation(line: 33, column: 5, scope: !70)
-// CHECK:STDOUT: !81 = !DILocation(line: 33, column: 3, scope: !70)
-// CHECK:STDOUT: !82 = !DILocation(line: 36, column: 3, scope: !70)
-// CHECK:STDOUT: !83 = !DILocation(line: 39, column: 3, scope: !70)
-// CHECK:STDOUT: !84 = !DILocation(line: 41, column: 3, scope: !70)
-// CHECK:STDOUT: !85 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.66be507887ceee78", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !67 = !DILocation(line: 31, column: 3, scope: !66)
+// CHECK:STDOUT: !68 = !DILocation(line: 25, column: 3, scope: !66)
+// CHECK:STDOUT: !69 = !DILocation(line: 26, column: 3, scope: !66)
+// CHECK:STDOUT: !70 = !DILocation(line: 27, column: 3, scope: !66)
+// CHECK:STDOUT: !71 = !DILocation(line: 28, column: 5, scope: !66)
+// CHECK:STDOUT: !72 = !DILocation(line: 28, column: 3, scope: !66)
+// CHECK:STDOUT: !73 = !DILocation(line: 29, column: 3, scope: !66)
+// CHECK:STDOUT: !74 = !DILocation(line: 32, column: 5, scope: !66)
+// CHECK:STDOUT: !75 = !DILocation(line: 32, column: 3, scope: !66)
+// CHECK:STDOUT: !76 = !DILocation(line: 33, column: 5, scope: !66)
+// CHECK:STDOUT: !77 = !DILocation(line: 33, column: 3, scope: !66)
+// CHECK:STDOUT: !78 = !DILocation(line: 36, column: 3, scope: !66)
+// CHECK:STDOUT: !79 = !DILocation(line: 39, column: 3, scope: !66)
+// CHECK:STDOUT: !80 = !DILocation(line: 41, column: 3, scope: !66)
+// CHECK:STDOUT: !81 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.66be507887ceee78", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !82 = !DILocation(line: 20, column: 3, scope: !81)
+// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.b88d1103f417c6d4", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !84 = !DILocation(line: 12, column: 3, scope: !83)
+// CHECK:STDOUT: !85 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.15b1f98bd9cc0c5b", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !86 = !DILocation(line: 20, column: 3, scope: !85)
-// CHECK:STDOUT: !87 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.b88d1103f417c6d4", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !87 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.66be507887ceee78", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !88 = !DILocation(line: 12, column: 3, scope: !87)
-// CHECK:STDOUT: !89 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.15b1f98bd9cc0c5b", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !90 = !DILocation(line: 20, column: 3, scope: !89)
-// CHECK:STDOUT: !91 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.66be507887ceee78", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !92 = !DILocation(line: 12, column: 3, scope: !91)
-// CHECK:STDOUT: !93 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !94 = !DILocation(line: 12, column: 3, scope: !93)
+// CHECK:STDOUT: !89 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !90 = !DILocation(line: 12, column: 3, scope: !89)


### PR DESCRIPTION
Currently for functions only:
A specific_id is created for each new type (use) found for a generic. If the function's LLVM types are the same with another previously found specific of the same generic, do not create a new LLVM function and use the previously created one.

