### PR TITLE
Change `StringLexHelper.context_` from reference to pointer

### DIFF
--- a/explorer/syntax/lex_scan_helper.cpp
+++ b/explorer/syntax/lex_scan_helper.cpp
@@ -14,7 +14,7 @@ auto StringLexHelper::Advance() -> bool {
   CARBON_CHECK(is_eof_ == false);
   const char c = YyinputWrapper(yyscanner_);
   if (c <= 0) {
-    context_.RecordSyntaxError("Unexpected end of file");
+    context_->RecordSyntaxError("Unexpected end of file");
     is_eof_ = true;
     return false;
   }

--- a/explorer/syntax/lex_scan_helper.h
+++ b/explorer/syntax/lex_scan_helper.h
@@ -17,8 +17,9 @@ namespace Carbon {
 
 class StringLexHelper {
  public:
+  // `context` must not be null.
   StringLexHelper(const char* text, yyscan_t yyscanner,
-                  Carbon::ParseAndLexContext& context)
+                  Carbon::ParseAndLexContext* context)
       : str_(text), yyscanner_(yyscanner), context_(context), is_eof_(false) {}
   // Advances yyscanner by one char. Sets is_eof to true and returns false on
   // EOF.
@@ -33,7 +34,7 @@ class StringLexHelper {
  private:
   std::string str_;
   yyscan_t yyscanner_;
-  Carbon::ParseAndLexContext& context_;
+  Carbon::ParseAndLexContext* context_;
   // Skips reading next char.
   bool is_eof_;
 };

--- a/explorer/syntax/lexer.lpp
+++ b/explorer/syntax/lexer.lpp
@@ -332,7 +332,7 @@ operand_start         [(A-Za-z0-9_\"]
 
 #*\" {
   // Found a double quote character.
-  Carbon::StringLexHelper str_lex_helper(yytext, yyscanner, context);
+  Carbon::StringLexHelper str_lex_helper(yytext, yyscanner, &context);
   const std::string& s = str_lex_helper.str();
   const int hashtag_num = s.find_first_of('"');
 
@@ -377,7 +377,7 @@ operand_start         [(A-Za-z0-9_\"]
 
 #*\'\'\' {
   // Multi-line string literal.
-  Carbon::StringLexHelper str_lex_helper(yytext, yyscanner, context);
+  Carbon::StringLexHelper str_lex_helper(yytext, yyscanner, &context);
   const std::string& s = str_lex_helper.str();
   const int hashtag_num = s.find_first_of('\'');
 


### PR DESCRIPTION
Per [the style guide](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/cpp_style_guide.md#syntax-and-formatting):
* If it is captured and must outlive the call expression itself, use a pointer and document that it must not be null (unless it is also optional).
* When storing an object's address as a non-owned member, prefer storing a pointer.