### PR TITLE
Change `CodeGen::Make()` to take `module` and `errors` as pointers and not references

### DIFF
--- a/toolchain/codegen/codegen.cpp
+++ b/toolchain/codegen/codegen.cpp
@@ -13,17 +13,17 @@
 
 namespace Carbon {
 
-auto CodeGen::Make(llvm::Module& module, llvm::StringRef target_triple,
-                   llvm::raw_pwrite_stream& errors) -> std::optional<CodeGen> {
+auto CodeGen::Make(llvm::Module* module, llvm::StringRef target_triple,
+                   llvm::raw_pwrite_stream* errors) -> std::optional<CodeGen> {
   std::string error;
   const llvm::Target* target =
       llvm::TargetRegistry::lookupTarget(target_triple, error);
 
   if (!target) {
-    errors << "error: invalid target: " << error << "\n";
+    *errors << "error: invalid target: " << error << "\n";
     return {};
   }
-  module.setTargetTriple(llvm::Triple(target_triple));
+  module->setTargetTriple(llvm::Triple(target_triple));
 
   constexpr llvm::StringLiteral CPU = "generic";
   constexpr llvm::StringLiteral Features = "";
@@ -45,7 +45,7 @@ auto CodeGen::EmitObject(llvm::raw_pwrite_stream& out) -> bool {
 
 auto CodeGen::EmitCode(llvm::raw_pwrite_stream& out,
                        llvm::CodeGenFileType file_type) -> bool {
-  module_.setDataLayout(target_machine_->createDataLayout());
+  module_->setDataLayout(target_machine_->createDataLayout());
 
   // Using the legacy PM to generate the assembly since the new PM
   // does not work with this yet.
@@ -53,11 +53,11 @@ auto CodeGen::EmitCode(llvm::raw_pwrite_stream& out,
   llvm::legacy::PassManager pass;
   // Note that this returns true on an error.
   if (target_machine_->addPassesToEmitFile(pass, out, nullptr, file_type)) {
-    errors_ << "error: unable to emit to this file\n";
+    *errors_ << "error: unable to emit to this file\n";
     return false;
   }
 
-  pass.run(module_);
+  pass.run(*module_);
   return true;
 }
 

--- a/toolchain/codegen/codegen.h
+++ b/toolchain/codegen/codegen.h
@@ -12,8 +12,9 @@ namespace Carbon {
 
 class CodeGen {
  public:
-  static auto Make(llvm::Module& module, llvm::StringRef target_triple,
-                   llvm::raw_pwrite_stream& errors) -> std::optional<CodeGen>;
+  // `module` and `errors` must not be null.
+  static auto Make(llvm::Module* module, llvm::StringRef target_triple,
+                   llvm::raw_pwrite_stream* errors) -> std::optional<CodeGen>;
 
   // Generates the object code file.
   // Returns false in case of failure, and any information about the failure is
@@ -32,7 +33,8 @@ class CodeGen {
   auto EmitAssembly(llvm::raw_pwrite_stream& out) -> bool;
 
  private:
-  explicit CodeGen(llvm::Module& module, llvm::raw_pwrite_stream& errors)
+  // `module` and `errors` must not be null.
+  explicit CodeGen(llvm::Module* module, llvm::raw_pwrite_stream* errors)
       : module_(module), errors_(errors) {}
 
   // Using the llvm pass emits either assembly or object code to dest.
@@ -41,8 +43,8 @@ class CodeGen {
   auto EmitCode(llvm::raw_pwrite_stream& out, llvm::CodeGenFileType file_type)
       -> bool;
 
-  llvm::Module& module_;
-  llvm::raw_pwrite_stream& errors_;
+  llvm::Module* module_;
+  llvm::raw_pwrite_stream* errors_;
   std::unique_ptr<llvm::TargetMachine> target_machine_;
 };
 

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -641,8 +641,9 @@ auto CompilationUnit::PostCompile() -> void {
 }
 
 auto CompilationUnit::RunCodeGenHelper() -> bool {
-  std::optional<CodeGen> codegen = CodeGen::Make(
-      *module_, options_.codegen_options.target, *driver_env_->error_stream);
+  std::optional<CodeGen> codegen =
+      CodeGen::Make(module_.get(), options_.codegen_options.target,
+                    driver_env_->error_stream);
   if (!codegen) {
     return false;
   }


### PR DESCRIPTION
Per [the style guide](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/cpp_style_guide.md#syntax-and-formatting):
* If it is captured and must outlive the call expression itself, use a pointer and document that it must not be null (unless it is also optional).
* When storing an object's address as a non-owned member, prefer storing a pointer.