### PR TITLE
Change `CopyOnWriteBlock::file_` from reference to pointer

### DIFF
--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -385,10 +385,10 @@ static auto ConvertTupleToTuple(Context& context, SemIR::TupleType src_type,
   // TODO: Annotate diagnostics coming from here with the element index.
   auto new_block =
       literal_elems_id.has_value()
-          ? SemIR::CopyOnWriteInstBlock(sem_ir, literal_elems_id)
+          ? SemIR::CopyOnWriteInstBlock(&sem_ir, literal_elems_id)
           : SemIR::CopyOnWriteInstBlock(
-                sem_ir, SemIR::CopyOnWriteInstBlock::UninitializedBlock{
-                            src_elem_types.size()});
+                &sem_ir, SemIR::CopyOnWriteInstBlock::UninitializedBlock{
+                             src_elem_types.size()});
   for (auto [i, src_type_id, dest_type_id] :
        llvm::enumerate(src_elem_types, dest_elem_types)) {
     // TODO: This call recurses back into conversion. Switch to an iterative
@@ -496,10 +496,10 @@ static auto ConvertStructToStructOrClass(Context& context,
   // TODO: Annotate diagnostics coming from here with the element index.
   auto new_block =
       literal_elems_id.has_value() && !dest_has_vptr
-          ? SemIR::CopyOnWriteInstBlock(sem_ir, literal_elems_id)
+          ? SemIR::CopyOnWriteInstBlock(&sem_ir, literal_elems_id)
           : SemIR::CopyOnWriteInstBlock(
-                sem_ir, SemIR::CopyOnWriteInstBlock::UninitializedBlock{
-                            dest_elem_fields.size()});
+                &sem_ir, SemIR::CopyOnWriteInstBlock::UninitializedBlock{
+                             dest_elem_fields.size()});
   for (auto [i, dest_field] : llvm::enumerate(dest_elem_fields)) {
     if (dest_field.name_id == SemIR::NameId::Vptr) {
       if constexpr (!ToClass) {

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -155,7 +155,7 @@ static auto PopOperand(Context& context, Worklist& worklist,
                        SemIR::Inst::ArgAndKind arg) -> int32_t {
   auto pop_block_id = [&](SemIR::InstBlockId old_inst_block_id) {
     auto size = context.inst_blocks().Get(old_inst_block_id).size();
-    SemIR::CopyOnWriteInstBlock new_inst_block(context.sem_ir(),
+    SemIR::CopyOnWriteInstBlock new_inst_block(&context.sem_ir(),
                                                old_inst_block_id);
     for (auto i : llvm::reverse(llvm::seq(size))) {
       new_inst_block.Set(i, worklist.Pop());
@@ -196,7 +196,7 @@ static auto PopOperand(Context& context, Worklist& worklist,
     }
     case CARBON_KIND(SemIR::StructTypeFieldsId old_fields_id): {
       auto old_fields = context.struct_type_fields().Get(old_fields_id);
-      SemIR::CopyOnWriteStructTypeFieldsBlock new_fields(context.sem_ir(),
+      SemIR::CopyOnWriteStructTypeFieldsBlock new_fields(&context.sem_ir(),
                                                          old_fields_id);
       for (auto i : llvm::reverse(llvm::seq(old_fields.size()))) {
         new_fields.Set(i, {.name_id = old_fields[i].name_id,
@@ -207,7 +207,7 @@ static auto PopOperand(Context& context, Worklist& worklist,
     }
     case CARBON_KIND(SemIR::TypeBlockId old_type_block_id): {
       auto size = context.type_blocks().Get(old_type_block_id).size();
-      SemIR::CopyOnWriteTypeBlock new_type_block(context.sem_ir(),
+      SemIR::CopyOnWriteTypeBlock new_type_block(&context.sem_ir(),
                                                  old_type_block_id);
       for (auto i : llvm::reverse(llvm::seq(size))) {
         new_type_block.Set(


### PR DESCRIPTION
Per [the style guide](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/cpp_style_guide.md#syntax-and-formatting):
* If it is captured and must outlive the call expression itself, use a pointer and document that it must not be null (unless it is also optional).
* When storing an object's address as a non-owned member, prefer storing a pointer.