### PR TITLE
Make the regex for line number replacements stricter so that line numbers in the middle of the line won't be captured

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -272,7 +272,7 @@ auto FileTestBase::GetLineNumberReplacements(
     -> llvm::SmallVector<LineNumberReplacement> {
   return {{.has_file = true,
            .re = std::make_shared<RE2>(
-               llvm::formatv(R"(({0}):(\d+)?)", llvm::join(filenames, "|"))),
+               llvm::formatv(R"(:\ ({0}):(\d+)?)", llvm::join(filenames, "|"))),
            .line_formatv = R"({0})"}};
 }
 

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -98,13 +98,13 @@ static auto TestAlternatingFiles(TestParams& params)
     -> ErrorOr<FileTestBaseTest::RunResult> {
   params.output_stream << "unattached message 1\n"
                        << "a.carbon:2: message 2\n"
-                       << "b.carbon:5: message 3\n"
+                       << "b.carbon:5: message 3 with location a.carbon:2\n"
                        << "a.carbon:2: message 4\n"
                        << "b.carbon:5: message 5\n"
                        << "unattached message 6\n";
   params.error_stream << "unattached message 1\n"
                       << "a.carbon:2: message 2\n"
-                      << "b.carbon:5: message 3\n"
+                      << "b.carbon:5: message 3 with location a.carbon:2\n"
                       << "a.carbon:2: message 4\n"
                       << "b.carbon:5: message 5\n"
                       << "unattached message 6\n";

--- a/testing/file_test/testdata/alternating_files.carbon
+++ b/testing/file_test/testdata/alternating_files.carbon
@@ -17,12 +17,12 @@ aaa
 // CHECK:STDOUT: a.carbon:[[@LINE-1]]: message 2
 
 // --- b.carbon
-// CHECK:STDERR: b.carbon:[[@LINE+4]]: message 3
+// CHECK:STDERR: b.carbon:[[@LINE+4]]: message 3 with location a.carbon:2
 // CHECK:STDERR: a.carbon:2: message 4
 // CHECK:STDERR: b.carbon:[[@LINE+2]]: message 5
 // CHECK:STDERR: unattached message 6
 bbb
-// CHECK:STDOUT: b.carbon:[[@LINE-1]]: message 3
+// CHECK:STDOUT: b.carbon:[[@LINE-1]]: message 3 with location a.carbon:2
 // CHECK:STDOUT: a.carbon:2: message 4
 // CHECK:STDOUT: b.carbon:[[@LINE-3]]: message 5
 // CHECK:STDOUT: unattached message 6


### PR DESCRIPTION
This has no impact on existing tests file tests.

However, this has an impact on a potential change that adds instructions formatted to include line numbers.

Part of #5245.