### PR TITLE
Minor clang-tidy recommended cleanup

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -122,7 +122,7 @@ class ExplorerFileTest : public FileTestBase {
 auto GetFileTestManifest() -> llvm::SmallVector<std::string> {
   llvm::SmallVector<std::string> manifest;
   auto content = ReadFile(absl::GetFlag(FLAGS_explorer_test_targets_file));
-  for (const auto& line : absl::StrSplit(*content, "\n", absl::SkipEmpty())) {
+  for (const auto& line : absl::StrSplit(*content, '\n', absl::SkipEmpty())) {
     manifest.push_back(std::string(line));
   }
   return manifest;

--- a/explorer/interpreter/matching_impl_set.cpp
+++ b/explorer/interpreter/matching_impl_set.cpp
@@ -50,7 +50,7 @@ class MatchingImplSet::LeafCollector {
 
   void VisitValue(const StructType* struct_type) {
     Collect(Label::StructType);
-    for (auto [name, type] : struct_type->fields()) {
+    for (const auto& [name, type] : struct_type->fields()) {
       Collect(type);
     }
   }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2095,15 +2095,15 @@ class TypeChecker::SubstitutedGenericBindings {
 };
 
 auto TypeChecker::Substitute(const Bindings& bindings,
-                             Nonnull<const Value*> type) const
+                             Nonnull<const Value*> value) const
     -> ErrorOr<Nonnull<const Value*>> {
   // Don't waste time recursively rebuilding a type if we have nothing to
   // substitute.
   if (bindings.empty()) {
-    return type;
+    return value;
   }
 
-  CARBON_ASSIGN_OR_RETURN(const auto* result, SubstituteImpl(bindings, type));
+  CARBON_ASSIGN_OR_RETURN(const auto* result, SubstituteImpl(bindings, value));
 
   if (trace_stream_->is_enabled()) {
     trace_stream_->Substitute() << "substitution of [";
@@ -2114,7 +2114,7 @@ auto TypeChecker::Substitute(const Bindings& bindings,
     for (const auto& [name, value] : bindings.witnesses()) {
       *trace_stream_ << sep << "`" << *name << "` -> `" << *value << "`";
     }
-    *trace_stream_ << "]\n -  old: `" << *type << "`\n +  new: `" << *result
+    *trace_stream_ << "]\n -  old: `" << *value << "`\n +  new: `" << *result
                    << "`\n";
   }
   return result;


### PR DESCRIPTION
Some minor code health improvements discovered by clang-tidy:

* avoid copying; use const reference
* harmonize parameter names
* use more efficient absl::StrSplit-by-character