### PR TITLE
Rename `Parse::State` to `Parse::StateKind`

### DIFF
--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -436,14 +436,14 @@ auto Context::DiagnoseExpectedDeclSemiOrDefinition(Lex::TokenKind expected_kind)
 // definitions are deferred, such as a class or interface.
 static auto ParsingInDeferredDefinitionScope(Context& context) -> bool {
   auto& stack = context.state_stack();
-  if (stack.size() < 2 || stack.back().state != State::DeclScopeLoop) {
+  if (stack.size() < 2 || stack.back().kind != StateKind::DeclScopeLoop) {
     return false;
   }
-  auto state = stack[stack.size() - 2].state;
-  return state == State::DeclDefinitionFinishAsClass ||
-         state == State::DeclDefinitionFinishAsImpl ||
-         state == State::DeclDefinitionFinishAsInterface ||
-         state == State::DeclDefinitionFinishAsNamedConstraint;
+  auto kind = stack[stack.size() - 2].kind;
+  return kind == StateKind::DeclDefinitionFinishAsClass ||
+         kind == StateKind::DeclDefinitionFinishAsImpl ||
+         kind == StateKind::DeclDefinitionFinishAsInterface ||
+         kind == StateKind::DeclDefinitionFinishAsNamedConstraint;
 }
 
 auto Context::AddFunctionDefinitionStart(Lex::TokenIndex token, bool has_error)
@@ -470,7 +470,7 @@ auto Context::AddFunctionDefinition(Lex::TokenIndex token, bool has_error)
 auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {
   output << "Parser stack:\n";
   for (auto [i, entry] : llvm::enumerate(state_stack_)) {
-    output << "\t" << i << ".\t" << entry.state;
+    output << "\t" << i << ".\t" << entry.kind;
     PrintTokenForStackDump(output, entry.token);
   }
   output << "\tcursor\tposition_";

--- a/toolchain/parse/handle_adapt.cpp
+++ b/toolchain/parse/handle_adapt.cpp
@@ -10,9 +10,9 @@ namespace Carbon::Parse {
 // Handles processing of a complete `adapt T` declaration.
 auto HandleAdaptAfterIntroducer(Context& context) -> void {
   auto state = context.PopState();
-  state.state = State::AdaptDecl;
+  state.kind = StateKind::AdaptDecl;
   context.PushState(state);
-  context.PushState(State::Expr);
+  context.PushState(StateKind::Expr);
 }
 
 // Handles processing of a complete `adapt T` declaration.

--- a/toolchain/parse/handle_alias.cpp
+++ b/toolchain/parse/handle_alias.cpp
@@ -14,8 +14,8 @@ namespace Carbon::Parse {
 auto HandleAlias(Context& context) -> void {
   auto state = context.PopState();
 
-  context.PushState(state, State::AliasAfterName);
-  context.PushState(State::DeclNameAndParams, state.token);
+  context.PushState(state, StateKind::AliasAfterName);
+  context.PushState(StateKind::DeclNameAndParams, state.token);
 }
 
 auto HandleAliasAfterName(Context& context) -> void {
@@ -29,8 +29,8 @@ auto HandleAliasAfterName(Context& context) -> void {
 
   if (auto equal = context.ConsumeIf(Lex::TokenKind::Equal)) {
     context.AddLeafNode(NodeKind::AliasInitializer, *equal);
-    context.PushState(state, State::AliasFinish);
-    context.PushState(State::Expr);
+    context.PushState(state, StateKind::AliasFinish);
+    context.PushState(StateKind::Expr);
   } else {
     CARBON_DIAGNOSTIC(ExpectedAliasInitializer, Error,
                       "`alias` requires a `=` for the source");

--- a/toolchain/parse/handle_array_expr.cpp
+++ b/toolchain/parse/handle_array_expr.cpp
@@ -21,8 +21,8 @@ auto HandleArrayExpr(Context& context) -> void {
   } else {
     state.has_error = true;
   }
-  context.PushState(state, State::ArrayExprComma);
-  context.PushState(State::Expr);
+  context.PushState(state, StateKind::ArrayExprComma);
+  context.PushState(StateKind::Expr);
 }
 
 auto HandleArrayExprComma(Context& context) -> void {
@@ -35,8 +35,8 @@ auto HandleArrayExprComma(Context& context) -> void {
     context.emitter().Emit(*context.position(), ExpectedArrayComma);
     state.has_error = true;
   }
-  context.PushState(state, State::ArrayExprFinish);
-  context.PushState(State::Expr);
+  context.PushState(state, StateKind::ArrayExprFinish);
+  context.PushState(StateKind::Expr);
 }
 
 auto HandleArrayExprFinish(Context& context) -> void {

--- a/toolchain/parse/handle_base.cpp
+++ b/toolchain/parse/handle_base.cpp
@@ -24,9 +24,9 @@ auto HandleBaseAfterIntroducer(Context& context) -> void {
     return;
   }
 
-  state.state = State::BaseDecl;
+  state.kind = StateKind::BaseDecl;
   context.PushState(state);
-  context.PushState(State::Expr);
+  context.PushState(StateKind::Expr);
 }
 
 // Handles processing of a complete `base: B` declaration.

--- a/toolchain/parse/handle_call_expr.cpp
+++ b/toolchain/parse/handle_call_expr.cpp
@@ -9,12 +9,12 @@ namespace Carbon::Parse {
 
 auto HandleCallExpr(Context& context) -> void {
   auto state = context.PopState();
-  context.PushState(state, State::CallExprFinish);
+  context.PushState(state, StateKind::CallExprFinish);
 
   context.AddNode(NodeKind::CallExprStart, context.Consume(), state.has_error);
   if (!context.PositionIs(Lex::TokenKind::CloseParen)) {
-    context.PushState(State::CallExprParamFinish);
-    context.PushState(State::Expr);
+    context.PushState(StateKind::CallExprParamFinish);
+    context.PushState(StateKind::Expr);
   }
 }
 
@@ -28,8 +28,8 @@ auto HandleCallExprParamFinish(Context& context) -> void {
   if (context.ConsumeListToken(NodeKind::CallExprComma,
                                Lex::TokenKind::CloseParen, state.has_error) ==
       Context::ListTokenKind::Comma) {
-    context.PushState(State::CallExprParamFinish);
-    context.PushState(State::Expr);
+    context.PushState(StateKind::CallExprParamFinish);
+    context.PushState(StateKind::Expr);
   }
 }
 

--- a/toolchain/parse/handle_choice.cpp
+++ b/toolchain/parse/handle_choice.cpp
@@ -9,8 +9,8 @@ namespace Carbon::Parse {
 auto HandleChoiceIntroducer(Context& context) -> void {
   auto state = context.PopState();
 
-  context.PushState(state, State::ChoiceDefinitionStart);
-  context.PushState(State::DeclNameAndParams, state.token);
+  context.PushState(state, StateKind::ChoiceDefinitionStart);
+  context.PushState(StateKind::DeclNameAndParams, state.token);
 }
 
 auto HandleChoiceDefinitionStart(Context& context) -> void {
@@ -37,18 +37,18 @@ auto HandleChoiceDefinitionStart(Context& context) -> void {
                   state.has_error);
 
   state.has_error = false;
-  state.state = State::ChoiceDefinitionFinish;
+  state.kind = StateKind::ChoiceDefinitionFinish;
   context.PushState(state);
 
   if (!context.PositionIs(Lex::TokenKind::CloseCurlyBrace)) {
-    context.PushState(State::ChoiceAlternative);
+    context.PushState(StateKind::ChoiceAlternative);
   }
 }
 
 auto HandleChoiceAlternative(Context& context) -> void {
   auto state = context.PopState();
 
-  context.PushState(State::ChoiceAlternativeFinish);
+  context.PushState(StateKind::ChoiceAlternativeFinish);
 
   auto token = context.ConsumeIf(Lex::TokenKind::Identifier);
   if (!token) {
@@ -68,7 +68,7 @@ auto HandleChoiceAlternative(Context& context) -> void {
 
   if (context.PositionIs(Lex::TokenKind::OpenParen)) {
     context.AddLeafNode(NodeKind::IdentifierNameBeforeParams, *token);
-    context.PushState(State::PatternListAsExplicit);
+    context.PushState(StateKind::PatternListAsExplicit);
   } else {
     context.AddLeafNode(NodeKind::IdentifierNameNotBeforeParams, *token);
   }
@@ -80,7 +80,7 @@ auto HandleChoiceAlternativeFinish(Context& context) -> void {
   if (state.has_error) {
     context.ReturnErrorOnState();
     if (!context.PositionIs(Lex::TokenKind::CloseCurlyBrace)) {
-      context.PushState(State::ChoiceAlternative);
+      context.PushState(StateKind::ChoiceAlternative);
     }
     return;
   }
@@ -88,7 +88,7 @@ auto HandleChoiceAlternativeFinish(Context& context) -> void {
   if (context.ConsumeListToken(
           NodeKind::ChoiceAlternativeListComma, Lex::TokenKind::CloseCurlyBrace,
           state.has_error) == Context::ListTokenKind::Comma) {
-    context.PushState(State::ChoiceAlternative);
+    context.PushState(StateKind::ChoiceAlternative);
   }
 }
 

--- a/toolchain/parse/handle_code_block.cpp
+++ b/toolchain/parse/handle_code_block.cpp
@@ -10,10 +10,10 @@ namespace Carbon::Parse {
 auto HandleCodeBlock(Context& context) -> void {
   context.PopAndDiscardState();
 
-  context.PushState(State::CodeBlockFinish);
+  context.PushState(StateKind::CodeBlockFinish);
   if (context.ConsumeAndAddLeafNodeIf(Lex::TokenKind::OpenCurlyBrace,
                                       NodeKind::CodeBlockStart)) {
-    context.PushState(State::StatementScopeLoop);
+    context.PushState(StateKind::StatementScopeLoop);
   } else {
     context.AddLeafNode(NodeKind::CodeBlockStart, *context.position(),
                         /*has_error=*/true);
@@ -22,7 +22,7 @@ auto HandleCodeBlock(Context& context) -> void {
     CARBON_DIAGNOSTIC(ExpectedCodeBlock, Error, "expected braced code block");
     context.emitter().Emit(*context.position(), ExpectedCodeBlock);
 
-    context.PushState(State::Statement);
+    context.PushState(StateKind::Statement);
   }
 }
 

--- a/toolchain/parse/handle_decl_definition.cpp
+++ b/toolchain/parse/handle_decl_definition.cpp
@@ -11,7 +11,7 @@ namespace Carbon::Parse {
 // definition.
 static auto HandleDeclOrDefinition(Context& context, NodeKind decl_kind,
                                    NodeKind definition_start_kind,
-                                   State definition_finish_state) -> void {
+                                   StateKind definition_finish_state) -> void {
   auto state = context.PopState();
 
   if (state.has_error || !context.PositionIs(Lex::TokenKind::OpenCurlyBrace)) {
@@ -22,32 +22,32 @@ static auto HandleDeclOrDefinition(Context& context, NodeKind decl_kind,
   }
 
   context.PushState(state, definition_finish_state);
-  context.PushState(State::DeclScopeLoop);
+  context.PushState(StateKind::DeclScopeLoop);
   context.AddNode(definition_start_kind, context.Consume(), state.has_error);
 }
 
 auto HandleDeclOrDefinitionAsClass(Context& context) -> void {
   HandleDeclOrDefinition(context, NodeKind::ClassDecl,
                          NodeKind::ClassDefinitionStart,
-                         State::DeclDefinitionFinishAsClass);
+                         StateKind::DeclDefinitionFinishAsClass);
 }
 
 auto HandleDeclOrDefinitionAsImpl(Context& context) -> void {
   HandleDeclOrDefinition(context, NodeKind::ImplDecl,
                          NodeKind::ImplDefinitionStart,
-                         State::DeclDefinitionFinishAsImpl);
+                         StateKind::DeclDefinitionFinishAsImpl);
 }
 
 auto HandleDeclOrDefinitionAsInterface(Context& context) -> void {
   HandleDeclOrDefinition(context, NodeKind::InterfaceDecl,
                          NodeKind::InterfaceDefinitionStart,
-                         State::DeclDefinitionFinishAsInterface);
+                         StateKind::DeclDefinitionFinishAsInterface);
 }
 
 auto HandleDeclOrDefinitionAsNamedConstraint(Context& context) -> void {
   HandleDeclOrDefinition(context, NodeKind::NamedConstraintDecl,
                          NodeKind::NamedConstraintDefinitionStart,
-                         State::DeclDefinitionFinishAsNamedConstraint);
+                         StateKind::DeclDefinitionFinishAsNamedConstraint);
 }
 
 // Handles parsing after the declaration scope of a type.

--- a/toolchain/parse/handle_decl_name_and_params.cpp
+++ b/toolchain/parse/handle_decl_name_and_params.cpp
@@ -21,21 +21,21 @@ static auto HandleName(Context& context, Context::StateStackEntry state,
       context.AddNode(not_before_params_qualifier_kind,
                       context.ConsumeChecked(Lex::TokenKind::Period),
                       state.has_error);
-      context.PushState(State::DeclNameAndParams);
+      context.PushState(StateKind::DeclNameAndParams);
       break;
 
     case Lex::TokenKind::OpenSquareBracket:
       context.AddLeafNode(before_params_kind, name_token);
-      state.state = State::DeclNameAndParamsAfterImplicit;
+      state.kind = StateKind::DeclNameAndParamsAfterImplicit;
       context.PushState(state);
-      context.PushState(State::PatternListAsImplicit);
+      context.PushState(StateKind::PatternListAsImplicit);
       break;
 
     case Lex::TokenKind::OpenParen:
       context.AddLeafNode(before_params_kind, name_token);
-      state.state = State::DeclNameAndParamsAfterParams;
+      state.kind = StateKind::DeclNameAndParamsAfterParams;
       context.PushState(state);
-      context.PushState(State::PatternListAsExplicit);
+      context.PushState(StateKind::PatternListAsExplicit);
       break;
 
     default:
@@ -86,14 +86,14 @@ auto HandleDeclNameAndParams(Context& context) -> void {
 auto HandleDeclNameAndParamsAfterImplicit(Context& context) -> void {
   auto state = context.PopState();
 
-  state.state = State::DeclNameAndParamsAfterParams;
+  state.kind = StateKind::DeclNameAndParamsAfterParams;
   context.PushState(state);
 
   if (!context.PositionIs(Lex::TokenKind::OpenParen)) {
     return;
   }
 
-  context.PushState(State::PatternListAsExplicit);
+  context.PushState(StateKind::PatternListAsExplicit);
 }
 
 auto HandleDeclNameAndParamsAfterParams(Context& context) -> void {
@@ -105,7 +105,7 @@ auto HandleDeclNameAndParamsAfterParams(Context& context) -> void {
                          ? NodeKind::IdentifierNameQualifierWithParams
                          : NodeKind::KeywordNameQualifierWithParams;
     context.AddNode(node_kind, *period, state.has_error);
-    context.PushState(State::DeclNameAndParams);
+    context.PushState(StateKind::DeclNameAndParams);
   }
 }
 

--- a/toolchain/parse/handle_function.cpp
+++ b/toolchain/parse/handle_function.cpp
@@ -9,20 +9,20 @@ namespace Carbon::Parse {
 
 auto HandleFunctionIntroducer(Context& context) -> void {
   auto state = context.PopState();
-  context.PushState(state, State::FunctionAfterParams);
-  context.PushState(State::DeclNameAndParams, state.token);
+  context.PushState(state, StateKind::FunctionAfterParams);
+  context.PushState(StateKind::DeclNameAndParams, state.token);
 }
 
 auto HandleFunctionAfterParams(Context& context) -> void {
   auto state = context.PopState();
 
   // Regardless of whether there's a return type, we'll finish the signature.
-  context.PushState(state, State::FunctionSignatureFinish);
+  context.PushState(state, StateKind::FunctionSignatureFinish);
 
   // If there is a return type, parse the expression before adding the return
   // type node.
   if (context.PositionIs(Lex::TokenKind::MinusGreater)) {
-    context.PushState(State::FunctionReturnTypeFinish);
+    context.PushState(StateKind::FunctionReturnTypeFinish);
     context.ConsumeAndDiscard();
     context.PushStateForExpr(PrecedenceGroup::ForType());
   }
@@ -47,8 +47,8 @@ auto HandleFunctionSignatureFinish(Context& context) -> void {
       context.AddFunctionDefinitionStart(context.Consume(), state.has_error);
       // Any error is recorded on the FunctionDefinitionStart.
       state.has_error = false;
-      context.PushState(state, State::FunctionDefinitionFinish);
-      context.PushState(State::StatementScopeLoop);
+      context.PushState(state, StateKind::FunctionDefinitionFinish);
+      context.PushState(StateKind::StatementScopeLoop);
       break;
     }
     case Lex::TokenKind::Equal: {

--- a/toolchain/parse/handle_if_expr.cpp
+++ b/toolchain/parse/handle_if_expr.cpp
@@ -14,7 +14,7 @@ auto HandleIfExprFinishCondition(Context& context) -> void {
   context.AddNode(NodeKind::IfExprIf, state.token, state.has_error);
 
   if (context.PositionIs(Lex::TokenKind::Then)) {
-    context.PushState(State::IfExprFinishThen);
+    context.PushState(StateKind::IfExprFinishThen);
     context.ConsumeChecked(Lex::TokenKind::Then);
     context.PushStateForExpr(*PrecedenceGroup::ForLeading(Lex::TokenKind::If));
   } else {
@@ -37,7 +37,7 @@ auto HandleIfExprFinishThen(Context& context) -> void {
   context.AddNode(NodeKind::IfExprThen, state.token, state.has_error);
 
   if (context.PositionIs(Lex::TokenKind::Else)) {
-    context.PushState(State::IfExprFinishElse);
+    context.PushState(StateKind::IfExprFinishElse);
     context.ConsumeChecked(Lex::TokenKind::Else);
     context.PushStateForExpr(*PrecedenceGroup::ForLeading(Lex::TokenKind::If));
   } else {

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -201,8 +201,8 @@ auto HandleExportName(Context& context) -> void {
 
   RestrictExportToApi(context, state);
 
-  context.PushState(state, State::ExportNameFinish);
-  context.PushState(State::DeclNameAndParams, state.token);
+  context.PushState(state, StateKind::ExportNameFinish);
+  context.PushState(StateKind::DeclNameAndParams, state.token);
 }
 
 auto HandleExportNameFinish(Context& context) -> void {

--- a/toolchain/parse/handle_index_expr.cpp
+++ b/toolchain/parse/handle_index_expr.cpp
@@ -10,11 +10,11 @@ namespace Carbon::Parse {
 
 auto HandleIndexExpr(Context& context) -> void {
   auto state = context.PopState();
-  context.PushState(state, State::IndexExprFinish);
+  context.PushState(state, StateKind::IndexExprFinish);
   context.AddNode(NodeKind::IndexExprStart,
                   context.ConsumeChecked(Lex::TokenKind::OpenSquareBracket),
                   state.has_error);
-  context.PushState(State::Expr);
+  context.PushState(StateKind::Expr);
 }
 
 auto HandleIndexExprFinish(Context& context) -> void {

--- a/toolchain/parse/handle_let.cpp
+++ b/toolchain/parse/handle_let.cpp
@@ -11,11 +11,11 @@ auto HandleLet(Context& context) -> void {
   auto state = context.PopState();
 
   // These will start at the `let`.
-  context.PushState(state, State::LetFinish);
-  context.PushState(state, State::LetAfterPattern);
+  context.PushState(state, StateKind::LetFinish);
+  context.PushState(state, StateKind::LetAfterPattern);
 
   // This will start at the pattern.
-  context.PushState(State::Pattern);
+  context.PushState(StateKind::Pattern);
 }
 
 auto HandleLetAfterPattern(Context& context) -> void {
@@ -30,7 +30,7 @@ auto HandleLetAfterPattern(Context& context) -> void {
 
   if (auto equals = context.ConsumeIf(Lex::TokenKind::Equal)) {
     context.AddLeafNode(NodeKind::LetInitializer, *equals);
-    context.PushState(State::Expr);
+    context.PushState(StateKind::Expr);
   }
 }
 

--- a/toolchain/parse/handle_namespace.cpp
+++ b/toolchain/parse/handle_namespace.cpp
@@ -9,8 +9,8 @@ namespace Carbon::Parse {
 
 auto HandleNamespace(Context& context) -> void {
   auto state = context.PopState();
-  context.PushState(state, State::NamespaceFinish);
-  context.PushState(State::DeclNameAndParams, state.token);
+  context.PushState(state, StateKind::NamespaceFinish);
+  context.PushState(StateKind::DeclNameAndParams, state.token);
 }
 
 auto HandleNamespaceFinish(Context& context) -> void {

--- a/toolchain/parse/handle_paren_condition.cpp
+++ b/toolchain/parse/handle_paren_condition.cpp
@@ -9,7 +9,7 @@ namespace Carbon::Parse {
 
 // Handles ParenConditionAs(If|While|Match).
 static auto HandleParenCondition(Context& context, NodeKind start_kind,
-                                 State finish_state) -> void {
+                                 StateKind finish_state_kind) -> void {
   auto state = context.PopState();
 
   std::optional<Lex::TokenIndex> open_paren =
@@ -17,7 +17,7 @@ static auto HandleParenCondition(Context& context, NodeKind start_kind,
   if (open_paren) {
     state.token = *open_paren;
   }
-  context.PushState(state, finish_state);
+  context.PushState(state, finish_state_kind);
 
   if (!open_paren && context.PositionIs(Lex::TokenKind::OpenCurlyBrace)) {
     // For an open curly, assume the condition was completely omitted.
@@ -25,23 +25,23 @@ static auto HandleParenCondition(Context& context, NodeKind start_kind,
     // a code block and just emit an invalid parse.
     context.AddInvalidParse(*context.position());
   } else {
-    context.PushState(State::Expr);
+    context.PushState(StateKind::Expr);
   }
 }
 
 auto HandleParenConditionAsIf(Context& context) -> void {
   HandleParenCondition(context, NodeKind::IfConditionStart,
-                       State::ParenConditionFinishAsIf);
+                       StateKind::ParenConditionFinishAsIf);
 }
 
 auto HandleParenConditionAsWhile(Context& context) -> void {
   HandleParenCondition(context, NodeKind::WhileConditionStart,
-                       State::ParenConditionFinishAsWhile);
+                       StateKind::ParenConditionFinishAsWhile);
 }
 
 auto HandleParenConditionAsMatch(Context& context) -> void {
   HandleParenCondition(context, NodeKind::MatchConditionStart,
-                       State::ParenConditionFinishAsMatch);
+                       StateKind::ParenConditionFinishAsMatch);
 }
 
 auto HandleParenConditionFinishAsIf(Context& context) -> void {

--- a/toolchain/parse/handle_pattern.cpp
+++ b/toolchain/parse/handle_pattern.cpp
@@ -11,14 +11,16 @@ auto HandlePattern(Context& context) -> void {
   auto state = context.PopState();
   switch (context.PositionKind()) {
     case Lex::TokenKind::OpenParen:
-      context.PushStateForPattern(State::PatternListAsTuple,
+      context.PushStateForPattern(StateKind::PatternListAsTuple,
                                   state.in_var_pattern);
       break;
     case Lex::TokenKind::Var:
-      context.PushStateForPattern(State::VariablePattern, state.in_var_pattern);
+      context.PushStateForPattern(StateKind::VariablePattern,
+                                  state.in_var_pattern);
       break;
     default:
-      context.PushStateForPattern(State::BindingPattern, state.in_var_pattern);
+      context.PushStateForPattern(StateKind::BindingPattern,
+                                  state.in_var_pattern);
       break;
   }
 }

--- a/toolchain/parse/handle_pattern_list.cpp
+++ b/toolchain/parse/handle_pattern_list.cpp
@@ -8,33 +8,33 @@
 namespace Carbon::Parse {
 
 // Handles PatternListElementAs(Tuple|Explicit|Implicit).
-static auto HandlePatternListElement(Context& context, State pattern_state,
-                                     State finish_state) -> void {
+static auto HandlePatternListElement(Context& context, StateKind pattern_state,
+                                     StateKind finish_state_kind) -> void {
   auto state = context.PopState();
 
-  context.PushStateForPattern(finish_state, state.in_var_pattern);
+  context.PushStateForPattern(finish_state_kind, state.in_var_pattern);
   context.PushStateForPattern(pattern_state, state.in_var_pattern);
 }
 
 auto HandlePatternListElementAsTuple(Context& context) -> void {
-  HandlePatternListElement(context, State::Pattern,
-                           State::PatternListElementFinishAsTuple);
+  HandlePatternListElement(context, StateKind::Pattern,
+                           StateKind::PatternListElementFinishAsTuple);
 }
 
 auto HandlePatternListElementAsExplicit(Context& context) -> void {
-  HandlePatternListElement(context, State::Pattern,
-                           State::PatternListElementFinishAsExplicit);
+  HandlePatternListElement(context, StateKind::Pattern,
+                           StateKind::PatternListElementFinishAsExplicit);
 }
 
 auto HandlePatternListElementAsImplicit(Context& context) -> void {
-  HandlePatternListElement(context, State::Pattern,
-                           State::PatternListElementFinishAsImplicit);
+  HandlePatternListElement(context, StateKind::Pattern,
+                           StateKind::PatternListElementFinishAsImplicit);
 }
 
 // Handles PatternListElementFinishAs(Tuple|Explicit|Implicit).
 static auto HandlePatternListElementFinish(Context& context,
                                            Lex::TokenKind close_token,
-                                           State param_state) -> void {
+                                           StateKind param_state_kind) -> void {
   auto state = context.PopState();
 
   if (state.has_error) {
@@ -44,30 +44,31 @@ static auto HandlePatternListElementFinish(Context& context,
   if (context.ConsumeListToken(NodeKind::PatternListComma, close_token,
                                state.has_error) ==
       Context::ListTokenKind::Comma) {
-    context.PushStateForPattern(param_state, state.in_var_pattern);
+    context.PushStateForPattern(param_state_kind, state.in_var_pattern);
   }
 }
 
 auto HandlePatternListElementFinishAsTuple(Context& context) -> void {
   HandlePatternListElementFinish(context, Lex::TokenKind::CloseParen,
-                                 State::PatternListElementAsTuple);
+                                 StateKind::PatternListElementAsTuple);
 }
 
 auto HandlePatternListElementFinishAsExplicit(Context& context) -> void {
   HandlePatternListElementFinish(context, Lex::TokenKind::CloseParen,
-                                 State::PatternListElementAsExplicit);
+                                 StateKind::PatternListElementAsExplicit);
 }
 
 auto HandlePatternListElementFinishAsImplicit(Context& context) -> void {
   HandlePatternListElementFinish(context, Lex::TokenKind::CloseSquareBracket,
-                                 State::PatternListElementAsImplicit);
+                                 StateKind::PatternListElementAsImplicit);
 }
 
 // Handles PatternListAs(Tuple|Explicit|Implicit).
 static auto HandlePatternList(Context& context, NodeKind node_kind,
                               Lex::TokenKind open_token_kind,
                               Lex::TokenKind close_token_kind,
-                              State param_state, State finish_state) -> void {
+                              StateKind param_state, StateKind finish_state)
+    -> void {
   auto state = context.PopState();
 
   context.PushStateForPattern(finish_state, state.in_var_pattern);
@@ -81,22 +82,23 @@ static auto HandlePatternList(Context& context, NodeKind node_kind,
 auto HandlePatternListAsTuple(Context& context) -> void {
   HandlePatternList(context, NodeKind::TuplePatternStart,
                     Lex::TokenKind::OpenParen, Lex::TokenKind::CloseParen,
-                    State::PatternListElementAsTuple,
-                    State::PatternListFinishAsTuple);
+                    StateKind::PatternListElementAsTuple,
+                    StateKind::PatternListFinishAsTuple);
 }
 
 auto HandlePatternListAsExplicit(Context& context) -> void {
   HandlePatternList(context, NodeKind::ExplicitParamListStart,
                     Lex::TokenKind::OpenParen, Lex::TokenKind::CloseParen,
-                    State::PatternListElementAsExplicit,
-                    State::PatternListFinishAsExplicit);
+                    StateKind::PatternListElementAsExplicit,
+                    StateKind::PatternListFinishAsExplicit);
 }
 
 auto HandlePatternListAsImplicit(Context& context) -> void {
-  HandlePatternList(
-      context, NodeKind::ImplicitParamListStart,
-      Lex::TokenKind::OpenSquareBracket, Lex::TokenKind::CloseSquareBracket,
-      State::PatternListElementAsImplicit, State::PatternListFinishAsImplicit);
+  HandlePatternList(context, NodeKind::ImplicitParamListStart,
+                    Lex::TokenKind::OpenSquareBracket,
+                    Lex::TokenKind::CloseSquareBracket,
+                    StateKind::PatternListElementAsImplicit,
+                    StateKind::PatternListFinishAsImplicit);
 }
 
 // Handles PatternListFinishAs(Tuple|Explicit|Implicit).

--- a/toolchain/parse/handle_period.cpp
+++ b/toolchain/parse/handle_period.cpp
@@ -12,7 +12,8 @@ namespace Carbon::Parse {
 // TODO: This currently only supports identifiers on the rhs, but will in the
 // future need to handle things like `object.(Interface.member)` for qualifiers.
 static auto HandlePeriodOrArrow(Context& context, NodeKind node_kind,
-                                State paren_state, bool is_arrow) -> void {
+                                StateKind paren_state_kind, bool is_arrow)
+    -> void {
   auto state = context.PopState();
 
   // We're handling `.something` or `->something`.
@@ -30,11 +31,11 @@ static auto HandlePeriodOrArrow(Context& context, NodeKind node_kind,
              context.ConsumeAndAddLeafNodeIf(Lex::TokenKind::IntLiteral,
                                              NodeKind::IntLiteral)) {
     // OK, '.42'.
-  } else if (paren_state != State::Invalid &&
+  } else if (paren_state_kind != StateKind::Invalid &&
              context.PositionIs(Lex::TokenKind::OpenParen)) {
-    state.state = paren_state;
+    state.kind = paren_state_kind;
     context.PushState(state);
-    context.PushState(State::OnlyParenExpr);
+    context.PushState(StateKind::OnlyParenExpr);
     return;
   } else {
     CARBON_DIAGNOSTIC(ExpectedIdentifierAfterPeriodOrArrow, Error,
@@ -61,18 +62,19 @@ static auto HandlePeriodOrArrow(Context& context, NodeKind node_kind,
 
 auto HandlePeriodAsExpr(Context& context) -> void {
   HandlePeriodOrArrow(context, NodeKind::MemberAccessExpr,
-                      State::CompoundMemberAccess,
+                      StateKind::CompoundMemberAccess,
                       /*is_arrow=*/false);
 }
 
 auto HandlePeriodAsStruct(Context& context) -> void {
-  HandlePeriodOrArrow(context, NodeKind::StructFieldDesignator, State::Invalid,
+  HandlePeriodOrArrow(context, NodeKind::StructFieldDesignator,
+                      StateKind::Invalid,
                       /*is_arrow=*/false);
 }
 
 auto HandleArrowExpr(Context& context) -> void {
   HandlePeriodOrArrow(context, NodeKind::PointerMemberAccessExpr,
-                      State::CompoundPointerMemberAccess,
+                      StateKind::CompoundPointerMemberAccess,
                       /*is_arrow=*/true);
 }
 

--- a/toolchain/parse/handle_requirement.cpp
+++ b/toolchain/parse/handle_requirement.cpp
@@ -22,9 +22,9 @@ auto HandleRequirementBegin(Context& context) -> void {
                     /*has_error=*/false);
     context.AddNode(NodeKind::DesignatorExpr, period, /*has_error=*/false);
     state.token = context.Consume();
-    context.PushState(state, State::RequirementOperatorFinish);
+    context.PushState(state, StateKind::RequirementOperatorFinish);
   } else {
-    context.PushState(State::RequirementOperator);
+    context.PushState(StateKind::RequirementOperator);
   }
   context.PushStateForExpr(PrecedenceGroup::ForRequirements());
 }
@@ -63,7 +63,7 @@ auto HandleRequirementOperator(Context& context) -> void {
     }
   }
   state.token = context.Consume();
-  context.PushState(state, State::RequirementOperatorFinish);
+  context.PushState(state, StateKind::RequirementOperatorFinish);
   context.PushStateForExpr(PrecedenceGroup::ForRequirements());
 }
 
@@ -97,7 +97,7 @@ auto HandleRequirementOperatorFinish(Context& context) -> void {
   }
   if (auto token = context.ConsumeIf(Lex::TokenKind::And)) {
     context.AddNode(NodeKind::RequirementAnd, *token, /*has_error=*/false);
-    context.PushState(State::RequirementBegin);
+    context.PushState(StateKind::RequirementBegin);
   }
 }
 

--- a/toolchain/parse/handle_type.cpp
+++ b/toolchain/parse/handle_type.cpp
@@ -9,22 +9,24 @@ namespace Carbon::Parse {
 
 // Handles processing of a type declaration or definition after its introducer.
 static auto HandleTypeAfterIntroducer(Context& context,
-                                      State after_params_state) -> void {
+                                      StateKind after_params_state_kind)
+    -> void {
   auto state = context.PopState();
-  context.PushState(state, after_params_state);
-  context.PushState(State::DeclNameAndParams, state.token);
+  context.PushState(state, after_params_state_kind);
+  context.PushState(StateKind::DeclNameAndParams, state.token);
 }
 
 auto HandleTypeAfterIntroducerAsClass(Context& context) -> void {
-  HandleTypeAfterIntroducer(context, State::DeclOrDefinitionAsClass);
+  HandleTypeAfterIntroducer(context, StateKind::DeclOrDefinitionAsClass);
 }
 
 auto HandleTypeAfterIntroducerAsInterface(Context& context) -> void {
-  HandleTypeAfterIntroducer(context, State::DeclOrDefinitionAsInterface);
+  HandleTypeAfterIntroducer(context, StateKind::DeclOrDefinitionAsInterface);
 }
 
 auto HandleTypeAfterIntroducerAsNamedConstraint(Context& context) -> void {
-  HandleTypeAfterIntroducer(context, State::DeclOrDefinitionAsNamedConstraint);
+  HandleTypeAfterIntroducer(context,
+                            StateKind::DeclOrDefinitionAsNamedConstraint);
 }
 
 }  // namespace Carbon::Parse

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -28,12 +28,12 @@ auto Parse(Lex::TokenizedBuffer& tokens, Diagnostics::Consumer& consumer,
   context.AddLeafNode(NodeKind::FileStart,
                       context.ConsumeChecked(Lex::TokenKind::FileStart));
 
-  context.PushState(State::DeclScopeLoop);
+  context.PushState(StateKind::DeclScopeLoop);
 
   while (!context.state_stack().empty()) {
-    switch (context.state_stack().back().state) {
+    switch (context.state_stack().back().kind) {
 #define CARBON_PARSE_STATE(Name) \
-  case State::Name:              \
+  case StateKind::Name:          \
     Handle##Name(context);       \
     break;
 #include "toolchain/parse/state.def"

--- a/toolchain/parse/state.cpp
+++ b/toolchain/parse/state.cpp
@@ -6,7 +6,7 @@
 
 namespace Carbon::Parse {
 
-CARBON_DEFINE_ENUM_CLASS_NAMES(State) = {
+CARBON_DEFINE_ENUM_CLASS_NAMES(StateKind) = {
 #define CARBON_PARSE_STATE(Name) CARBON_ENUM_CLASS_NAME_STRING(Name)
 #include "toolchain/parse/state.def"
 };

--- a/toolchain/parse/state.def
+++ b/toolchain/parse/state.def
@@ -39,20 +39,20 @@
 #define CARBON_PARSE_STATE(Name)
 #endif
 
-// Use CARBON_PARSE_STATE_VARIANTSN(State, Variant1, Variant2, ...) to generate
-// StateAsVariant1, StateAsVariant2, ... states.
-#define CARBON_PARSE_STATE_VARIANT(State, Variant) \
-  CARBON_PARSE_STATE(State##As##Variant)
-#define CARBON_PARSE_STATE_VARIANTS2(State, Variant1, Variant2) \
-  CARBON_PARSE_STATE_VARIANT(State, Variant1)                   \
-  CARBON_PARSE_STATE_VARIANT(State, Variant2)
-#define CARBON_PARSE_STATE_VARIANTS3(State, Variant1, Variant2, Variant3) \
-  CARBON_PARSE_STATE_VARIANT(State, Variant1)                             \
-  CARBON_PARSE_STATE_VARIANTS2(State, Variant2, Variant3)
-#define CARBON_PARSE_STATE_VARIANTS4(State, Variant1, Variant2, Variant3, \
-                                     Variant4)                            \
-  CARBON_PARSE_STATE_VARIANT(State, Variant1)                             \
-  CARBON_PARSE_STATE_VARIANTS3(State, Variant2, Variant3, Variant4)
+// Use CARBON_PARSE_STATE_VARIANTSN(Kind, Variant1, Variant2, ...) to generate
+// KindAsVariant1, KindAsVariant2, ... states.
+#define CARBON_PARSE_STATE_VARIANT(Kind, Variant) \
+  CARBON_PARSE_STATE(Kind##As##Variant)
+#define CARBON_PARSE_STATE_VARIANTS2(Kind, Variant1, Variant2) \
+  CARBON_PARSE_STATE_VARIANT(Kind, Variant1)                   \
+  CARBON_PARSE_STATE_VARIANT(Kind, Variant2)
+#define CARBON_PARSE_STATE_VARIANTS3(Kind, Variant1, Variant2, Variant3) \
+  CARBON_PARSE_STATE_VARIANT(Kind, Variant1)                             \
+  CARBON_PARSE_STATE_VARIANTS2(Kind, Variant2, Variant3)
+#define CARBON_PARSE_STATE_VARIANTS4(Kind, Variant1, Variant2, Variant3, \
+                                     Variant4)                           \
+  CARBON_PARSE_STATE_VARIANT(Kind, Variant1)                             \
+  CARBON_PARSE_STATE_VARIANTS3(Kind, Variant2, Variant3, Variant4)
 
 // Used as a default for StateStackEntry initialization in some cases. Should
 // not be put on the state stack.

--- a/toolchain/parse/state.h
+++ b/toolchain/parse/state.h
@@ -11,22 +11,23 @@
 
 namespace Carbon::Parse {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(State, uint8_t) {
+CARBON_DEFINE_RAW_ENUM_CLASS(StateKind, uint8_t) {
 #define CARBON_PARSE_STATE(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/parse/state.def"
 };
 
-class State : public CARBON_ENUM_BASE(State) {
+class StateKind : public CARBON_ENUM_BASE(StateKind) {
  public:
 #define CARBON_PARSE_STATE(Name) CARBON_ENUM_CONSTANT_DECL(Name)
 #include "toolchain/parse/state.def"
 };
 
-#define CARBON_PARSE_STATE(Name) CARBON_ENUM_CONSTANT_DEFINITION(State, Name)
+#define CARBON_PARSE_STATE(Name) \
+  CARBON_ENUM_CONSTANT_DEFINITION(StateKind, Name)
 #include "toolchain/parse/state.def"
 
 // We expect State to fit compactly into 8 bits.
-static_assert(sizeof(State) == 1, "State includes padding!");
+static_assert(sizeof(StateKind) == 1, "State includes padding!");
 
 }  // namespace Carbon::Parse
 


### PR DESCRIPTION
Also renames variables of that type to match. A follow-up PR will rename `Parse::StateStackEntry` to `Parse::State`. This is more consistent with the naming of similar enums elsewhere in the toolchain, and with the prevailing practice of using `state` rather than e.g. `entry` as the name of a `StateStackEntry`.

See also discussion [here](https://discord.com/channels/655572317891461132/963846118964350976/1326280585592700990)
