### PR TITLE
Rename `StateStackEntry` to `State`

### DIFF
--- a/toolchain/docs/parse.md
+++ b/toolchain/docs/parse.md
@@ -462,9 +462,9 @@ switches to the expression-statement state.
 Depending on the introducer, different actions can be taken. The most common
 case is to:
 
--   Call `context.PushState(State::___);` to mark the beginning of the statement
-    or declaration and indicate the state that will handle the tokens after the
-    introducer.
+-   Call `context.PushState(StateKind::___);` to mark the beginning of the
+    statement or declaration and indicate the state that will handle the tokens
+    after the introducer.
 
 -   Call `context.AddLeafNode(NodeKind::___, context.Consume());` to output a
     bracketing node for this introducer.
@@ -513,8 +513,8 @@ declaration or statement.
 
 -   **Step 1**: Save the current value of `context.tree().size()`. This could be
     accomplished by calling `context.PushState()`, which saves that value in the
-    `subtree_start` field of `Context::StateStackEntry`; or by constructing a
-    `Context::StateStackEntry` value directly, as is done in
+    `subtree_start` field of `Context::State`; or by constructing a
+    `Context::State` value directly, as is done in
     [parse/handle_decl_scope_loop.cpp](/toolchain/parse/handle_decl_scope_loop.cpp).
     This marks the position of the placeholder node we are going to replace, as
     well as the beginning of the subtree we are eventually going to emit for
@@ -701,10 +701,10 @@ This is handled by the `ExpectAsOrTypeExpression` code from
 if (context.PositionIs(Lex::TokenKind::As)) {
   // as <expression> ...
   context.AddLeafNode(NodeKind::DefaultSelfImplAs, context.Consume());
-  context.PushState(State::Expr);
+  context.PushState(StateKind::Expr);
 } else {
   // <expression> as <expression>...
-  context.PushState(State::ImplBeforeAs);
+  context.PushState(StateKind::ImplBeforeAs);
   context.PushStateForExpr(PrecedenceGroup::ForImplAs());
 }
 ```
@@ -716,7 +716,7 @@ auto state = context.PopState();
 if (auto as = context.ConsumeIf(Lex::TokenKind::As)) {
   context.AddNode(NodeKind::TypeImplAs, *as, state.subtree_start,
                   state.has_error);
-  context.PushState(State::Expr);
+  context.PushState(StateKind::Expr);
 } else {
   if (!state.has_error) {
     CARBON_DIAGNOSTIC(ImplExpectedAs, Error,
@@ -728,9 +728,9 @@ if (auto as = context.ConsumeIf(Lex::TokenKind::As)) {
 ```
 
 Note (1) that the `state.subtree_start` value comes from the
-`context.PushState(State::ImplBeforeAs);` before parsing the type expression,
-and that is how that type expression ends up as the child of the created
-`TypeImplAs` node. Unlike
+`context.PushState(StateKind::ImplBeforeAs);` before parsing the type
+expression, and that is how that type expression ends up as the child of the
+created `TypeImplAs` node. Unlike
 [the previous case 1](#case-1-introducer-to-optional-clause-is-used-as-parent-node),
 though, the parent node uses the token after the optional expression, rather
 than an introducer token for the optional clause.
@@ -784,10 +784,10 @@ This is handled by the `ExpectAsOrTypeExpression` code from
 if (context.PositionIs(Lex::TokenKind::As)) {
   // as <expression> ...
   context.AddLeafNode(NodeKind::ImplAs, context.Consume());
-  context.PushState(State::Expr);
+  context.PushState(StateKind::Expr);
 } else {
   // <expression> as <expression>...
-  context.PushState(State::ImplBeforeAs);
+  context.PushState(StateKind::ImplBeforeAs);
   context.PushStateForExpr(PrecedenceGroup::ForImplAs());
 }
 ```

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -68,8 +68,8 @@ auto Context::ConsumeAndAddOpenParen(Lex::TokenIndex default_token,
 }
 
 auto Context::ConsumeAndAddCloseSymbol(Lex::TokenIndex expected_open,
-                                       StateStackEntry state,
-                                       NodeKind close_kind) -> void {
+                                       State state, NodeKind close_kind)
+    -> void {
   Lex::TokenKind open_token_kind = tokens().GetKind(expected_open);
 
   if (!open_token_kind.is_opening_symbol()) {
@@ -346,8 +346,7 @@ auto Context::ConsumeListToken(NodeKind comma_kind, Lex::TokenKind close_kind,
   }
 }
 
-auto Context::AddNodeExpectingDeclSemi(StateStackEntry state,
-                                       NodeKind node_kind,
+auto Context::AddNodeExpectingDeclSemi(State state, NodeKind node_kind,
                                        Lex::TokenKind decl_kind,
                                        bool is_def_allowed) -> void {
   // TODO: This could better handle things like:
@@ -373,7 +372,7 @@ auto Context::AddNodeExpectingDeclSemi(StateStackEntry state,
   }
 }
 
-auto Context::RecoverFromDeclError(StateStackEntry state, NodeKind node_kind,
+auto Context::RecoverFromDeclError(State state, NodeKind node_kind,
                                    bool skip_past_likely_end) -> void {
   auto token = state.token;
   if (skip_past_likely_end) {

--- a/toolchain/parse/handle_brace_expr.cpp
+++ b/toolchain/parse/handle_brace_expr.cpp
@@ -20,8 +20,7 @@ auto HandleBraceExpr(Context& context) -> void {
 }
 
 // Prints a diagnostic for brace expression syntax errors.
-static auto HandleBraceExprParamError(Context& context,
-                                      Context::StateStackEntry state,
+static auto HandleBraceExprParamError(Context& context, Context::State state,
                                       StateKind param_finish_state_kind)
     -> void {
   Diagnostics::IntAsSelect mode(0);

--- a/toolchain/parse/handle_decl_name_and_params.cpp
+++ b/toolchain/parse/handle_decl_name_and_params.cpp
@@ -10,7 +10,7 @@ namespace Carbon::Parse {
 
 // Adds a leaf node for the name, and updates the state stack for parameter
 // handling.
-static auto HandleName(Context& context, Context::StateStackEntry state,
+static auto HandleName(Context& context, Context::State state,
                        Lex::TokenIndex name_token,
                        NodeKind not_before_params_kind,
                        NodeKind not_before_params_qualifier_kind,

--- a/toolchain/parse/handle_decl_scope_loop.cpp
+++ b/toolchain/parse/handle_decl_scope_loop.cpp
@@ -32,7 +32,7 @@ static auto HandleUnrecognizedDecl(Context& context, int32_t subtree_start)
 
 // Replaces the introducer placeholder node, and pushes the introducer state for
 // processing.
-static auto ApplyIntroducer(Context& context, Context::StateStackEntry state,
+static auto ApplyIntroducer(Context& context, Context::State state,
                             NodeKind introducer_kind, StateKind next_state_kind)
     -> void {
   context.ReplacePlaceholderNode(state.subtree_start, introducer_kind,
@@ -118,7 +118,7 @@ static constexpr auto DeclIntroducers = [] {
 // Returns true if the current position is a declaration. If we see a
 // declaration introducer keyword token, replace the placeholder node and switch
 // to a state to parse the rest of the declaration.
-static auto TryHandleAsDecl(Context& context, Context::StateStackEntry state,
+static auto TryHandleAsDecl(Context& context, Context::State state,
                             bool saw_modifier) -> bool {
   const auto& info = DeclIntroducers[context.PositionKind().AsInt()];
 

--- a/toolchain/parse/handle_expr.cpp
+++ b/toolchain/parse/handle_expr.cpp
@@ -374,8 +374,7 @@ auto HandleExprLoop(Context& context) -> void {
 }
 
 // Adds the operator node and returns the main expression loop.
-static auto HandleExprLoopForOperator(Context& context,
-                                      Context::StateStackEntry state,
+static auto HandleExprLoopForOperator(Context& context, Context::State state,
                                       NodeKind node_kind) -> void {
   context.AddNode(node_kind, state.token, state.has_error);
   state.has_error = false;

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -13,7 +13,7 @@
 namespace Carbon::Parse {
 
 // Provides common error exiting logic that skips to the semi, if present.
-static auto OnParseError(Context& context, Context::StateStackEntry state,
+static auto OnParseError(Context& context, Context::State state,
                          NodeKind declaration) -> void {
   context.AddNode(declaration, context.SkipPastLikelyEnd(state.token),
                   /*has_error=*/true);
@@ -23,7 +23,7 @@ static auto OnParseError(Context& context, Context::StateStackEntry state,
 // the given declaration.
 // TODO: Restructure how we handle packaging declarations to avoid the need to
 // do this.
-static auto HasModifier(Context& context, Context::StateStackEntry state,
+static auto HasModifier(Context& context, Context::State state,
                         Lex::TokenKind modifier) -> bool {
   for (Lex::TokenIterator it(state.token); it != context.position(); ++it) {
     if (context.tokens().GetKind(*it) == modifier) {
@@ -35,7 +35,7 @@ static auto HasModifier(Context& context, Context::StateStackEntry state,
 
 // Handles everything after the declaration's introducer.
 template <const Parse::NodeKind& DeclKind>
-static auto HandleDeclContent(Context& context, Context::StateStackEntry state,
+static auto HandleDeclContent(Context& context, Context::State state,
                               bool is_export, bool is_impl,
                               llvm::function_ref<auto()->void> on_parse_error)
     -> void {
@@ -163,8 +163,8 @@ static auto VerifyInImports(Context& context, Lex::TokenIndex intro_token)
 }
 
 // Diagnoses if `export` is used in an `impl` file.
-static auto RestrictExportToApi(Context& context,
-                                Context::StateStackEntry& state) -> void {
+static auto RestrictExportToApi(Context& context, Context::State& state)
+    -> void {
   // Error for both Main//default and every implementation file.
   auto packaging = context.tree().packaging_decl();
   if (!packaging || packaging->is_impl) {

--- a/toolchain/parse/handle_paren_expr.cpp
+++ b/toolchain/parse/handle_paren_expr.cpp
@@ -19,8 +19,8 @@ auto HandleOnlyParenExpr(Context& context) -> void {
   context.PushState(StateKind::Expr);
 }
 
-static auto FinishParenExpr(Context& context,
-                            const Context::StateStackEntry& state) -> void {
+static auto FinishParenExpr(Context& context, const Context::State& state)
+    -> void {
   context.AddNode(NodeKind::ParenExpr, context.Consume(), state.has_error);
 }
 

--- a/toolchain/parse/state.def
+++ b/toolchain/parse/state.def
@@ -54,7 +54,7 @@
   CARBON_PARSE_STATE_VARIANT(Kind, Variant1)                             \
   CARBON_PARSE_STATE_VARIANTS3(Kind, Variant2, Variant3, Variant4)
 
-// Used as a default for StateStackEntry initialization in some cases. Should
+// Used as a default for State initialization in some cases. Should
 // not be put on the state stack.
 CARBON_PARSE_STATE(Invalid)
 


### PR DESCRIPTION
Also clean up `State` -> `StateKind` in the toolchain docs, which was missed in #5249.

