### PR TITLE
Don't define an unscoped enumeration out of line.

### DIFF
--- a/toolchain/parse/precedence.h
+++ b/toolchain/parse/precedence.h
@@ -88,7 +88,43 @@ class PrecedenceGroup {
   }
 
  private:
-  enum PrecedenceLevel : int8_t;
+  enum PrecedenceLevel : int8_t {
+    // Sentinel representing the absence of any operator.
+    Highest,
+    // Terms.
+    TermPrefix,
+    // Numeric.
+    IncrementDecrement,
+    NumericPrefix,
+    Modulo,
+    Multiplicative,
+    Additive,
+    // Bitwise.
+    BitwisePrefix,
+    BitwiseAnd,
+    BitwiseOr,
+    BitwiseXor,
+    BitShift,
+    // Type formation.
+    TypePrefix,
+    TypePostfix,
+    // `where` keyword.
+    Where,
+    // Casts.
+    As,
+    // Logical.
+    LogicalPrefix,
+    Relational,
+    LogicalAnd,
+    LogicalOr,
+    // Conditional.
+    If,
+    // Assignment.
+    Assignment,
+    // Sentinel representing a context in which any operator can appear.
+    Lowest,
+  };
+
   struct OperatorPriorityTable;
 
   static const int8_t NumPrecedenceLevels;
@@ -116,43 +152,6 @@ struct PrecedenceGroup::Trailing {
 // Only implementation details below this point.
 //
 ////////////////////////////////////////////////////////////////////////////////
-
-enum PrecedenceGroup::PrecedenceLevel : int8_t {
-  // Sentinel representing the absence of any operator.
-  Highest,
-  // Terms.
-  TermPrefix,
-  // Numeric.
-  IncrementDecrement,
-  NumericPrefix,
-  Modulo,
-  Multiplicative,
-  Additive,
-  // Bitwise.
-  BitwisePrefix,
-  BitwiseAnd,
-  BitwiseOr,
-  BitwiseXor,
-  BitShift,
-  // Type formation.
-  TypePrefix,
-  TypePostfix,
-  // `where` keyword.
-  Where,
-  // Casts.
-  As,
-  // Logical.
-  LogicalPrefix,
-  Relational,
-  LogicalAnd,
-  LogicalOr,
-  // Conditional.
-  If,
-  // Assignment.
-  Assignment,
-  // Sentinel representing a context in which any operator can appear.
-  Lowest,
-};
 
 inline auto PrecedenceGroup::ForPostfixExpr() -> PrecedenceGroup {
   return PrecedenceGroup(Highest);


### PR DESCRIPTION
The C++ language semantics for doing so are weird and a bit broken. Under [CWG1485](https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1485) this code may become invalid in the future.