### PR TITLE
Remove references to explorer

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -18,7 +18,6 @@ changelog:
     - title: 'Toolchain and implementation changes :hammer_and_wrench:'
       labels:
         - toolchain
-        - explorer
       exclude.labels:
         - bot
     - title: 'Documentation changes :memo:'

--- a/.github/workflows/auto_assign_prs.yaml
+++ b/.github/workflows/auto_assign_prs.yaml
@@ -35,8 +35,6 @@ jobs:
               - 'docs/project/goals.md'
               - 'docs/project/roadmap.md'
               - 'proposals/*.md'
-            explorer:
-              - 'explorer/**'
             toolchain:
               - 'toolchain/**'
 
@@ -45,13 +43,6 @@ jobs:
         uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:
           reviewers: KateGregory, chandlerc, zygoloid
-          max-num-of-reviewers: 1
-
-      - id: assign-explorer
-        if: steps.filter.outputs.explorer == 'true'
-        uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
-        with:
-          reviewers: geoffromer, jonmeow, zygoloid
           max-num-of-reviewers: 1
 
       - id: assign-toolchain
@@ -65,7 +56,6 @@ jobs:
       - id: assign-fallback
         if: |
           steps.filter.outputs.leads != 'true' &&
-          steps.filter.outputs.explorer != 'true' &&
           steps.filter.outputs.toolchain != 'true'
         uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:

--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -33,10 +33,6 @@ jobs:
               - 'examples/**'
               - 'third_party/examples/**'
 
-            explorer:
-              - 'explorer/**'
-              - 'installers/**'
-
             infrastructure:
               - '*.bzl'
               - '*.cfg'
@@ -73,14 +69,6 @@ jobs:
         if: steps.filter.outputs.documentation == 'true'
         run: |
           gh pr edit "${PR}" --add-label "documentation"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.html_url }}
-
-      - id: explorer
-        if: steps.filter.outputs.explorer == 'true'
-        run: |
-          gh pr edit "${PR}" --add-label "explorer"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,13 +89,6 @@ repos:
         language: python
         args: ['-i']
         additional_dependencies: ['clang-format==17.0.1']
-      - id: explorer-format-grammar
-        name: Format the explorer grammar file
-        entry: explorer/syntax/format_grammar.py
-        language: python
-        files: ^explorer/syntax/(lexer.lpp|parser.ypp)$
-        pass_filenames: false
-        additional_dependencies: ['clang-format==17.0.1']
 
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ and the language:
 -   An under-development [compiler and toolchain](/toolchain/) that will compile
     Carbon (and eventually C++ code as well) into standard executable code. This
     is where most of our current implementation efforts are directed.
+    -   Historically, there was also a prototype
+        [explorer](https://github.com/carbon-language/explorer) interpreter that
+        is no longer under development, and has been archived.
 
 If you're interested in contributing, we're currently focused on developing the
 Carbon toolchain until it can

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ and the language:
     is where most of our current implementation efforts are directed.
     -   Historically, there was also a prototype
         [explorer](https://github.com/carbon-language/explorer) interpreter that
-        is no longer under development, and has been archived.
+        implemented an older version of the Carbon language design, but is no
+        longer under development and has been archived.
 
 If you're interested in contributing, we're currently focused on developing the
 Carbon toolchain until it can

--- a/README.md
+++ b/README.md
@@ -145,9 +145,6 @@ and the language:
     -   Operator overloading
     -   Lexical and syntactic structure
     -   Code organization and modular structure
--   A prototype interpreter demo that can both run isolated examples and gives a
-    detailed analysis of the specific semantic model and abstract machine of
-    Carbon. We call this the [Carbon Explorer](/explorer/).
 -   An under-development [compiler and toolchain](/toolchain/) that will compile
     Carbon (and eventually C++ code as well) into standard executable code. This
     is where most of our current implementation efforts are directed.
@@ -353,7 +350,6 @@ Learn more about the Carbon project:
 
 -   [Project goals](/docs/project/goals.md)
 -   [Language design overview](/docs/design)
--   [Carbon Explorer](/explorer)
 -   [Carbon Toolchain](/toolchain)
 -   [FAQ](/docs/project/faq.md)
 

--- a/bazel/check_deps/BUILD
+++ b/bazel/check_deps/BUILD
@@ -13,8 +13,6 @@ load("@rules_python//python:defs.bzl", "py_test")
 filegroup(
     name = "non_test_cc_rules",
     data = [
-        "//explorer",
-        "//installers/local:carbon",
         "//toolchain/install:carbon-busybox",
         # The tree sitter rules can't be queried; evaluation fails on
         # @platforms.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,5 +52,4 @@ documentation for developers writing programs in Carbon.
 
 The [`spec/` directory](spec/) contains the **to-be-written** formal
 specification of the Carbon language. This is for implementers of compilers or
-other tooling. This is intended to complement the interactive
-[language explorer tool](/explorer/).
+other tooling. This is intended to complement the [toolchain](/toolchain/).

--- a/proposals/p2107.md
+++ b/proposals/p2107.md
@@ -38,7 +38,9 @@ A number of smaller changes grouped together in one proposal:
 ## Problem
 
 There were a number of gaps found in the design when @zygoloid went to implement
-these features in [the explorer codebase](/explorer), for example
+these features in
+[the explorer codebase](https://github.com/carbon-language/carbon-lang/tree/76c68153a2cf5b35249be3e9b8097238f3dc1ee1/explorer),
+for example
 [#1311: Basic support for `.Self` within `:!` bindings and `where` expressions](https://github.com/carbon-language/carbon-lang/pull/1311).
 
 ## Background


### PR DESCRIPTION
I'm doing this separately from removing the explorer/ and installers/ directories so that it's easier to review the side-effects.

Note for the main README, I didn't think it was worth keeping a mention of "used to have a prototype interpreter, now archived" versus focusing on the existing toolchain (for "Currently, we have fleshed out").