### PR TITLE
Switch tree-sitter from explorer to toolchain testdata

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/codegen/BUILD
+++ b/toolchain/codegen/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob([
+    srcs = glob([
         "testdata/**/*.carbon",
         "testdata/**/*.cpp",
     ]),

--- a/toolchain/format/BUILD
+++ b/toolchain/format/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/language_server/BUILD
+++ b/toolchain/language_server/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/lower/BUILD
+++ b/toolchain/lower/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 cc_library(

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "testdata",
-    data = glob(["testdata/**/*.carbon"]),
+    srcs = glob(["testdata/**/*.carbon"]),
 )
 
 manifest(

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "all_testdata",
-    data = [
+    srcs = [
         "//toolchain/check:testdata",
         "//toolchain/codegen:testdata",
         "//toolchain/diagnostics:testdata",

--- a/utils/tree_sitter/BUILD
+++ b/utils/tree_sitter/BUILD
@@ -71,7 +71,7 @@ cc_binary(
 # these tests to work on improving support, but also, it may be worth improving
 # the test setup to:
 # - Support file_test's split files.
-# - Better understand when the toolchain doesn't a test file to parse.
+# - Better understand when the toolchain doesn't expect a test file to parse.
 cc_test(
     name = "toolchain_testdata_tests",
     size = "small",

--- a/utils/tree_sitter/BUILD
+++ b/utils/tree_sitter/BUILD
@@ -23,9 +23,9 @@ test_suite(
     name = "tests",
     tags = ["manual"],
     tests = [
-        ":explorer_tests",
         ":string_fail_tests",
         ":string_tests",
+        ":toolchain_testdata_tests",
     ],
 )
 
@@ -66,12 +66,18 @@ cc_binary(
     ],
 )
 
+# TODO: This test is expected to fail. tree-sitter support has fallen
+# significantly behind the toolchain. Anybody looking at this can still use
+# these tests to work on improving support, but also, it may be worth improving
+# the test setup to:
+# - Support file_test's split files.
+# - Better understand when the toolchain doesn't a test file to parse.
 cc_test(
-    name = "explorer_tests",
+    name = "toolchain_testdata_tests",
     size = "small",
     srcs = ["test_runner.cpp"],
-    args = ["$(locations //explorer:tree_sitter_testdata)"],
-    data = ["//explorer:tree_sitter_testdata"],
+    args = ["$(locations //toolchain/testing:all_testdata)"],
+    data = ["//toolchain/testing:all_testdata"],
     tags = ["manual"],
     deps = [
         ":parser",


### PR DESCRIPTION
Noticed as part of #5290; `srcs` is needed to make `$(locations)` work.