### PR TITLE
Collapse GetAbsoluteNodeId overload

### DIFF
--- a/toolchain/sem_ir/absolute_node_id.cpp
+++ b/toolchain/sem_ir/absolute_node_id.cpp
@@ -118,13 +118,6 @@ static auto GetAbsoluteNodeIdImpl(
                                .node_id = Parse::NodeId::None});
 }
 
-auto GetAbsoluteNodeId(const File* sem_ir, InstId inst_id)
-    -> llvm::SmallVector<AbsoluteNodeId> {
-  llvm::SmallVector<AbsoluteNodeId> absolute_node_ids;
-  GetAbsoluteNodeIdImpl(absolute_node_ids, sem_ir, inst_id);
-  return absolute_node_ids;
-}
-
 auto GetAbsoluteNodeId(const File* sem_ir, LocId loc_id)
     -> llvm::SmallVector<AbsoluteNodeId> {
   llvm::SmallVector<AbsoluteNodeId> absolute_node_ids;
@@ -135,7 +128,7 @@ auto GetAbsoluteNodeId(const File* sem_ir, LocId loc_id)
       break;
 
     case SemIR::LocId::Kind::InstId:
-      absolute_node_ids = GetAbsoluteNodeId(sem_ir, loc_id.inst_id());
+      GetAbsoluteNodeIdImpl(absolute_node_ids, sem_ir, loc_id.inst_id());
       break;
 
     case SemIR::LocId::Kind::ImportIRInstId:

--- a/toolchain/sem_ir/absolute_node_id.h
+++ b/toolchain/sem_ir/absolute_node_id.h
@@ -17,14 +17,10 @@ struct AbsoluteNodeId {
   Parse::NodeId node_id;
 };
 
-// Resolves the `InstId` to a series of `NodeId`s, which may be in different
+// Resolves the `LocId` to a series of `NodeId`s, which may be in different
 // files. The vector will have one entry if there were no imports, and multiple
 // entries when imports are traversed. The final entry is the actual
 // declaration.
-auto GetAbsoluteNodeId(const File* sem_ir, InstId inst_id)
-    -> llvm::SmallVector<AbsoluteNodeId>;
-
-// Similar to to above overload, but starting at a `LocId`.
 auto GetAbsoluteNodeId(const File* sem_ir, LocId loc_id)
     -> llvm::SmallVector<AbsoluteNodeId>;
 


### PR DESCRIPTION
Since LocId can handle a NodeId, this overload isn't really needed anymore. Probably helpful to simplify.