### PR TITLE
Remove the SemIRLoc typedef

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -25,17 +25,18 @@ Context::Context(DiagnosticEmitterBase* emitter,
       scope_stack_(sem_ir_),
       vtable_stack_("vtable_stack_", *sem_ir, vlog_stream),
       global_init_(this),
-      region_stack_(
-          [this](SemIRLoc loc, std::string label) { TODO(loc, label); }) {
+      region_stack_([this](SemIR::LocId loc_id, std::string label) {
+        TODO(loc_id, label);
+      }) {
   // Prepare fields which relate to the number of IRs available for import.
   import_irs().Reserve(imported_ir_count);
   import_ir_constant_values_.reserve(imported_ir_count);
   check_ir_map_.resize(total_ir_count, SemIR::ImportIRId::None);
 }
 
-auto Context::TODO(SemIRLoc loc, std::string label) -> bool {
+auto Context::TODO(SemIR::LocId loc_id, std::string label) -> bool {
   CARBON_DIAGNOSTIC(SemanticsTodo, Error, "semantics TODO: `{0}`", std::string);
-  emitter_->Emit(loc, SemanticsTodo, std::move(label));
+  emitter_->Emit(loc_id, SemanticsTodo, std::move(label));
   return false;
 }
 

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -57,7 +57,7 @@ class Context {
                    int total_ir_count, llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
-  auto TODO(SemIRLoc loc, std::string label) -> bool;
+  auto TODO(SemIR::LocId loc_id, std::string label) -> bool;
 
   // Runs verification that the processing cleanly finished.
   auto VerifyOnFinish() const -> void;
@@ -152,7 +152,7 @@ class Context {
   }
 
   auto definitions_required_by_use()
-      -> llvm::SmallVector<std::pair<SemIRLoc, SemIR::SpecificId>>& {
+      -> llvm::SmallVector<std::pair<SemIR::LocId, SemIR::SpecificId>>& {
     return definitions_required_by_use_;
   }
 
@@ -350,7 +350,7 @@ class Context {
   // Entities that should have definitions by the end of the current source
   // file, because of a generic was used a concrete specific. This is currently
   // only tracking specific functions that should have a definition emitted.
-  llvm::SmallVector<std::pair<SemIRLoc, SemIR::SpecificId>>
+  llvm::SmallVector<std::pair<SemIR::LocId, SemIR::SpecificId>>
       definitions_required_by_use_;
 
   // State for global initialization.

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -609,14 +609,14 @@ using InheritancePath =
 
 // Computes the inheritance path from class `derived_id` to class `base_id`.
 // Returns nullopt if `derived_id` is not a class derived from `base_id`.
-static auto ComputeInheritancePath(Context& context, SemIRLoc loc,
+static auto ComputeInheritancePath(Context& context, SemIR::LocId loc_id,
                                    SemIR::TypeId derived_id,
                                    SemIR::TypeId base_id)
     -> std::optional<InheritancePath> {
   // We intend for NRVO to be applied to `result`. All `return` statements in
   // this function should `return result;`.
   std::optional<InheritancePath> result(std::in_place);
-  if (!TryToCompleteType(context, derived_id, loc)) {
+  if (!TryToCompleteType(context, derived_id, loc_id)) {
     // TODO: Should we give an error here? If we don't, and there is an
     // inheritance path when the class is defined, we may have a coherence
     // problem.

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -206,7 +206,7 @@ auto DeclNameStack::LookupOrAddName(NameContext name_context,
 // `fn Class(T:! type).F(n: i32)` we will push the scope for `Class(T:! type)`
 // between the scope containing the declaration of `T` and the scope
 // containing the declaration of `n`.
-static auto PushNameQualifierScope(Context& context, SemIRLoc loc,
+static auto PushNameQualifierScope(Context& context, SemIR::LocId loc_id,
                                    SemIR::InstId scope_inst_id,
                                    SemIR::NameScopeId scope_id,
                                    SemIR::GenericId generic_id,
@@ -219,7 +219,7 @@ static auto PushNameQualifierScope(Context& context, SemIRLoc loc,
   if (generic_id.has_value()) {
     self_specific_id = context.generics().GetSelfSpecific(generic_id);
     // When declaring a member of a generic, resolve the self specific.
-    ResolveSpecificDefinition(context, loc, self_specific_id);
+    ResolveSpecificDefinition(context, loc_id, self_specific_id);
   }
 
   // Close the generic stack scope and open a new one for whatever comes after
@@ -325,14 +325,14 @@ static auto CheckQualifierIsResolved(
 // Diagnose that a qualified declaration name specifies an incomplete class as
 // its scope.
 static auto DiagnoseQualifiedDeclInIncompleteClassScope(Context& context,
-                                                        SemIRLoc loc,
+                                                        SemIR::LocId loc_id,
                                                         SemIR::ClassId class_id)
     -> void {
   CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, Error,
                     "cannot declare a member of incomplete class {0}",
                     SemIR::TypeId);
   auto builder =
-      context.emitter().Build(loc, QualifiedDeclInIncompleteClassScope,
+      context.emitter().Build(loc_id, QualifiedDeclInIncompleteClassScope,
                               context.classes().Get(class_id).self_type_id);
   NoteIncompleteClass(context, class_id, builder);
   builder.Emit();
@@ -341,13 +341,13 @@ static auto DiagnoseQualifiedDeclInIncompleteClassScope(Context& context,
 // Diagnose that a qualified declaration name specifies an undefined interface
 // as its scope.
 static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
-    Context& context, SemIRLoc loc, SemIR::InterfaceId interface_id,
+    Context& context, SemIR::LocId loc_id, SemIR::InterfaceId interface_id,
     SemIR::InstId interface_inst_id) -> void {
   CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, Error,
                     "cannot declare a member of undefined interface {0}",
                     InstIdAsType);
   auto builder = context.emitter().Build(
-      loc, QualifiedDeclInUndefinedInterfaceScope, interface_inst_id);
+      loc_id, QualifiedDeclInUndefinedInterfaceScope, interface_inst_id);
   NoteIncompleteInterface(context, interface_id, builder);
   builder.Emit();
 }
@@ -355,32 +355,32 @@ static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
 // Diagnose that a qualified declaration name specifies a different package as
 // its scope.
 static auto DiagnoseQualifiedDeclInImportedPackage(Context& context,
-                                                   SemIRLoc use_loc,
-                                                   SemIRLoc import_loc)
+                                                   SemIR::LocId use_loc_id,
+                                                   SemIR::LocId import_loc_id)
     -> void {
   CARBON_DIAGNOSTIC(QualifiedDeclOutsidePackage, Error,
                     "imported packages cannot be used for declarations");
   CARBON_DIAGNOSTIC(QualifiedDeclOutsidePackageSource, Note,
                     "package imported here");
   context.emitter()
-      .Build(use_loc, QualifiedDeclOutsidePackage)
-      .Note(import_loc, QualifiedDeclOutsidePackageSource)
+      .Build(use_loc_id, QualifiedDeclOutsidePackage)
+      .Note(import_loc_id, QualifiedDeclOutsidePackageSource)
       .Emit();
 }
 
 // Diagnose that a qualified declaration name specifies a non-scope entity as
 // its scope.
-static auto DiagnoseQualifiedDeclInNonScope(Context& context, SemIRLoc use_loc,
-                                            SemIRLoc non_scope_entity_loc)
-    -> void {
+static auto DiagnoseQualifiedDeclInNonScope(
+    Context& context, SemIR::LocId use_loc_id,
+    SemIR::LocId non_scope_entity_loc_id) -> void {
   CARBON_DIAGNOSTIC(QualifiedNameInNonScope, Error,
                     "name qualifiers are only allowed for entities that "
                     "provide a scope");
   CARBON_DIAGNOSTIC(QualifiedNameNonScopeEntity, Note,
                     "referenced non-scope entity declared here");
   context.emitter()
-      .Build(use_loc, QualifiedNameInNonScope)
-      .Note(non_scope_entity_loc, QualifiedNameNonScopeEntity)
+      .Build(use_loc_id, QualifiedNameInNonScope)
+      .Note(non_scope_entity_loc_id, QualifiedNameNonScopeEntity)
       .Emit();
 }
 

--- a/toolchain/check/diagnostic_emitter.h
+++ b/toolchain/check/diagnostic_emitter.h
@@ -16,7 +16,7 @@
 
 namespace Carbon::Check {
 
-// Handles the transformation of a SemIRLoc to a DiagnosticLoc.
+// Handles the transformation of a SemIR::LocId to a DiagnosticLoc.
 class DiagnosticEmitter : public DiagnosticEmitterBase {
  public:
   explicit DiagnosticEmitter(

--- a/toolchain/check/diagnostic_helpers.h
+++ b/toolchain/check/diagnostic_helpers.h
@@ -11,17 +11,14 @@
 
 namespace Carbon::Check {
 
-// TODO: Update code to use LocId directly.
-using SemIRLoc = SemIR::LocId;
-
 // TODO: Consider instead changing calls to `SemIR::LocId::TokenOnly(...)`.
-inline auto TokenOnly(SemIR::LocId loc_id) -> SemIRLoc {
+inline auto TokenOnly(SemIR::LocId loc_id) -> SemIR::LocId {
   return loc_id.ToTokenOnly();
 }
 
 // We define the emitter separately for dependencies, so only provide a base
 // here.
-using DiagnosticEmitterBase = Diagnostics::Emitter<SemIRLoc>;
+using DiagnosticEmitterBase = Diagnostics::Emitter<SemIR::LocId>;
 
 using DiagnosticBuilder = DiagnosticEmitterBase::Builder;
 

--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -52,7 +52,7 @@ auto TryEvalInst(Context& context, InstT inst) -> SemIR::ConstantId {
 // Evaluates the eval block for a region of a specific. Produces a block
 // containing the evaluated constant values of the instructions in the eval
 // block.
-auto TryEvalBlockForSpecific(Context& context, SemIRLoc loc,
+auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
                              SemIR::SpecificId specific_id,
                              SemIR::GenericInstIndex::Region region)
     -> SemIR::InstBlockId;

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -39,20 +39,20 @@ static auto WitnessAccessMatchesInterface(
 }
 
 static auto IncompleteFacetTypeDiagnosticBuilder(
-    Context& context, SemIRLoc loc, SemIR::TypeInstId facet_type_inst_id,
+    Context& context, SemIR::LocId loc_id, SemIR::TypeInstId facet_type_inst_id,
     bool is_definition) -> DiagnosticBuilder {
   if (is_definition) {
     CARBON_DIAGNOSTIC(ImplAsIncompleteFacetTypeDefinition, Error,
                       "definition of impl as incomplete facet type {0}",
                       InstIdAsType);
-    return context.emitter().Build(loc, ImplAsIncompleteFacetTypeDefinition,
+    return context.emitter().Build(loc_id, ImplAsIncompleteFacetTypeDefinition,
                                    facet_type_inst_id);
   } else {
     CARBON_DIAGNOSTIC(
         ImplAsIncompleteFacetTypeRewrites, Error,
         "declaration of impl as incomplete facet type {0} with rewrites",
         InstIdAsType);
-    return context.emitter().Build(loc, ImplAsIncompleteFacetTypeRewrites,
+    return context.emitter().Build(loc_id, ImplAsIncompleteFacetTypeRewrites,
                                    facet_type_inst_id);
   }
 }
@@ -244,14 +244,14 @@ auto InitialFacetTypeImplWitness(
 }
 
 auto RequireCompleteFacetTypeForImplDefinition(
-    Context& context, SemIRLoc loc, SemIR::TypeInstId facet_type_inst_id)
+    Context& context, SemIR::LocId loc_id, SemIR::TypeInstId facet_type_inst_id)
     -> bool {
   auto facet_type_id =
       context.types().GetTypeIdForTypeInstId(facet_type_inst_id);
   return RequireCompleteType(context, facet_type_id,
                              context.insts().GetLocId(facet_type_inst_id), [&] {
                                return IncompleteFacetTypeDiagnosticBuilder(
-                                   context, loc, facet_type_inst_id,
+                                   context, loc_id, facet_type_inst_id,
                                    /*is_definition=*/true);
                              });
 }

--- a/toolchain/check/facet_type.h
+++ b/toolchain/check/facet_type.h
@@ -48,7 +48,7 @@ auto InitialFacetTypeImplWitness(
 // Returns `true` if the facet type is complete. Otherwise issues a diagnostic
 // and returns `false`.
 auto RequireCompleteFacetTypeForImplDefinition(
-    Context& context, SemIRLoc loc, SemIR::TypeInstId facet_type_inst_id)
+    Context& context, SemIR::LocId loc_id, SemIR::TypeInstId facet_type_inst_id)
     -> bool;
 
 // Replaces the placeholder created by `InitialFacetTypeImplWitness` with an

--- a/toolchain/check/generic.h
+++ b/toolchain/check/generic.h
@@ -28,7 +28,7 @@ auto DiscardGenericDecl(Context& context) -> void;
 auto BuildGeneric(Context& context, SemIR::InstId decl_id) -> SemIR::GenericId;
 
 // Builds eval block for the declaration.
-auto FinishGenericDecl(Context& context, SemIRLoc loc,
+auto FinishGenericDecl(Context& context, SemIR::LocId loc_id,
                        SemIR::GenericId generic_id) -> void;
 
 // BuildGeneric() and FinishGenericDecl() combined. Normally you would call this
@@ -55,31 +55,33 @@ auto RebuildGenericEvalBlock(Context& context, SemIR::GenericId generic_id,
 // Builds a new specific with a given argument list, or finds an existing one if
 // this generic has already been referenced with these arguments. Performs
 // substitution into the declaration, but not the definition, of the generic.
-auto MakeSpecific(Context& context, SemIRLoc loc, SemIR::GenericId generic_id,
+auto MakeSpecific(Context& context, SemIR::LocId loc_id,
+                  SemIR::GenericId generic_id,
                   llvm::ArrayRef<SemIR::InstId> args) -> SemIR::SpecificId;
 
 // Builds a new specific or finds an existing one in the case where the argument
 // list has already been converted into an instruction block. `args_id` should
 // be a canonical instruction block referring to constants.
-auto MakeSpecific(Context& context, SemIRLoc loc, SemIR::GenericId generic_id,
-                  SemIR::InstBlockId args_id) -> SemIR::SpecificId;
+auto MakeSpecific(Context& context, SemIR::LocId loc_id,
+                  SemIR::GenericId generic_id, SemIR::InstBlockId args_id)
+    -> SemIR::SpecificId;
 
 // Builds the specific that describes how the generic should refer to itself.
 // For example, for a generic `G(T:! type)`, this is the specific `G(T)`. If
 // `generic_id` is `None`, returns `None`.
-auto MakeSelfSpecific(Context& context, SemIRLoc loc,
+auto MakeSelfSpecific(Context& context, SemIR::LocId loc_id,
                       SemIR::GenericId generic_id) -> SemIR::SpecificId;
 
 // Resolve the declaration of the given specific, by evaluating the eval block
 // of the corresponding generic and storing a corresponding value block in the
 // specific.
-auto ResolveSpecificDeclaration(Context& context, SemIRLoc loc,
+auto ResolveSpecificDeclaration(Context& context, SemIR::LocId loc_id,
                                 SemIR::SpecificId specific_id) -> void;
 
 // Attempts to resolve the definition of the given specific, by evaluating the
 // eval block of the corresponding generic and storing a corresponding value
 // block in the specific. Returns false if a definition is not available.
-auto ResolveSpecificDefinition(Context& context, SemIRLoc loc,
+auto ResolveSpecificDefinition(Context& context, SemIR::LocId loc_id,
                                SemIR::SpecificId specific_id) -> bool;
 
 // Diagnoses if an entity has implicit parameters, indicating it's generic, but

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -608,7 +608,7 @@ static auto AddNamespaceFromOtherPackage(Context& context,
 }
 
 auto ImportNameFromOtherPackage(
-    Context& context, SemIRLoc loc, SemIR::NameScopeId scope_id,
+    Context& context, SemIR::LocId loc_id, SemIR::NameScopeId scope_id,
     llvm::ArrayRef<std::pair<SemIR::ImportIRId, SemIR::NameScopeId>>
         import_ir_scopes,
     SemIR::NameId name_id) -> SemIR::InstId {
@@ -626,7 +626,7 @@ auto ImportNameFromOtherPackage(
       &context.emitter(), [&](auto& builder) {
         CARBON_DIAGNOSTIC(InNameLookup, Note, "in name lookup for `{0}`",
                           SemIR::NameId);
-        builder.Note(loc, InNameLookup, name_id);
+        builder.Note(loc_id, InNameLookup, name_id);
       });
 
   // Although we track the result here and look in each IR, we pretty much use

--- a/toolchain/check/import.h
+++ b/toolchain/check/import.h
@@ -88,7 +88,7 @@ auto ImportLibrariesFromOtherPackage(Context& context,
 // Arguments are all in the context of the current IR. Scope lookup is expected
 // to be resolved first.
 auto ImportNameFromOtherPackage(
-    Context& context, SemIRLoc loc, SemIR::NameScopeId scope_id,
+    Context& context, SemIR::LocId loc_id, SemIR::NameScopeId scope_id,
     llvm::ArrayRef<std::pair<SemIR::ImportIRId, SemIR::NameScopeId>>
         import_ir_scopes,
     SemIR::NameId name_id) -> SemIR::InstId;

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -125,10 +125,10 @@ static auto GetGenericArgsWithSelfType(Context& context,
 }
 
 auto GetSelfSpecificForInterfaceMemberWithSelfType(
-    Context& context, SemIRLoc loc, SemIR::SpecificId interface_specific_id,
-    SemIR::GenericId generic_id, SemIR::SpecificId enclosing_specific_id,
-    SemIR::TypeId self_type_id, SemIR::InstId witness_inst_id)
-    -> SemIR::SpecificId {
+    Context& context, SemIR::LocId loc_id,
+    SemIR::SpecificId interface_specific_id, SemIR::GenericId generic_id,
+    SemIR::SpecificId enclosing_specific_id, SemIR::TypeId self_type_id,
+    SemIR::InstId witness_inst_id) -> SemIR::SpecificId {
   const auto& generic = context.generics().Get(generic_id);
   auto self_specific_args = context.inst_blocks().Get(
       context.specifics().Get(generic.self_specific_id).args_id);
@@ -169,10 +169,10 @@ auto GetSelfSpecificForInterfaceMemberWithSelfType(
     arg_ids.push_back(new_arg_id);
   }
 
-  return MakeSpecific(context, loc, generic_id, arg_ids);
+  return MakeSpecific(context, loc_id, generic_id, arg_ids);
 }
 
-auto GetTypeForSpecificAssociatedEntity(Context& context, SemIRLoc loc,
+auto GetTypeForSpecificAssociatedEntity(Context& context, SemIR::LocId loc_id,
                                         SemIR::SpecificId interface_specific_id,
                                         SemIR::InstId decl_id,
                                         SemIR::TypeId self_type_id,
@@ -189,7 +189,7 @@ auto GetTypeForSpecificAssociatedEntity(Context& context, SemIRLoc loc,
     auto arg_ids =
         GetGenericArgsWithSelfType(context, interface_specific_id, generic_id,
                                    self_type_id, self_witness_id);
-    auto const_specific_id = MakeSpecific(context, loc, generic_id, arg_ids);
+    auto const_specific_id = MakeSpecific(context, loc_id, generic_id, arg_ids);
     return SemIR::GetTypeOfInstInSpecific(context.sem_ir(), const_specific_id,
                                           decl_id);
   } else if (auto fn = context.types().TryGetAs<SemIR::FunctionType>(

--- a/toolchain/check/interface.h
+++ b/toolchain/check/interface.h
@@ -20,14 +20,14 @@ auto BuildAssociatedEntity(Context& context, SemIR::InterfaceId interface_id,
 // Gets the self specific of a generic declaration that is an interface member,
 // given a specific for the interface plus a type to use as `Self`.
 auto GetSelfSpecificForInterfaceMemberWithSelfType(
-    Context& context, SemIRLoc loc, SemIR::SpecificId interface_specific_id,
-    SemIR::GenericId generic_id, SemIR::SpecificId enclosing_specific_id,
-    SemIR::TypeId self_type_id, SemIR::InstId witness_inst_id)
-    -> SemIR::SpecificId;
+    Context& context, SemIR::LocId loc_id,
+    SemIR::SpecificId interface_specific_id, SemIR::GenericId generic_id,
+    SemIR::SpecificId enclosing_specific_id, SemIR::TypeId self_type_id,
+    SemIR::InstId witness_inst_id) -> SemIR::SpecificId;
 
 // Gets the type of the specified associated entity, given the specific for the
 // interface and the type of `Self`.
-auto GetTypeForSpecificAssociatedEntity(Context& context, SemIRLoc loc,
+auto GetTypeForSpecificAssociatedEntity(Context& context, SemIR::LocId loc_id,
                                         SemIR::SpecificId interface_specific_id,
                                         SemIR::InstId decl_id,
                                         SemIR::TypeId self_type_id,

--- a/toolchain/check/merge.h
+++ b/toolchain/check/merge.h
@@ -13,20 +13,20 @@ namespace Carbon::Check {
 
 // Diagnoses an `extern` declaration that was not preceded by a declaration in
 // the API file.
-auto DiagnoseExternRequiresDeclInApiFile(Context& context, SemIRLoc loc)
+auto DiagnoseExternRequiresDeclInApiFile(Context& context, SemIR::LocId loc_id)
     -> void;
 
 // Information on new and previous declarations for DiagnoseIfInvalidRedecl.
 struct RedeclInfo {
-  explicit RedeclInfo(SemIR::EntityWithParamsBase params, SemIRLoc loc,
+  explicit RedeclInfo(SemIR::EntityWithParamsBase params, SemIR::LocId loc_id,
                       bool is_definition)
-      : loc(loc),
+      : loc_id(loc_id),
         is_definition(is_definition),
         is_extern(params.is_extern),
         extern_library_id(params.extern_library_id) {}
 
   // The associated diagnostic location.
-  SemIRLoc loc;
+  SemIR::LocId loc_id;
   // True if a definition.
   bool is_definition;
   // True if an `extern` declaration.
@@ -60,24 +60,24 @@ auto ReplacePrevInstForMerge(Context& context, SemIR::NameScopeId scope_id,
 // different kinds of entity such as classes and functions.
 struct DeclParams {
   explicit DeclParams(const SemIR::EntityWithParamsBase& base)
-      : loc(base.latest_decl_id()),
+      : loc_id(base.latest_decl_id()),
         first_param_node_id(base.first_param_node_id),
         last_param_node_id(base.last_param_node_id),
         implicit_param_patterns_id(base.implicit_param_patterns_id),
         param_patterns_id(base.param_patterns_id) {}
 
-  DeclParams(SemIRLoc loc, Parse::NodeId first_param_node_id,
+  DeclParams(SemIR::LocId loc_id, Parse::NodeId first_param_node_id,
              Parse::NodeId last_param_node_id,
              SemIR::InstBlockId implicit_param_patterns_id,
              SemIR::InstBlockId param_patterns_id)
-      : loc(loc),
+      : loc_id(loc_id),
         first_param_node_id(first_param_node_id),
         last_param_node_id(last_param_node_id),
         implicit_param_patterns_id(implicit_param_patterns_id),
         param_patterns_id(param_patterns_id) {}
 
   // The location of the declaration of the entity.
-  SemIRLoc loc;
+  SemIR::LocId loc_id;
 
   // Parse tree bounds for the parameters, including both implicit and explicit
   // parameters. These will be compared to match between declaration and

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -191,12 +191,10 @@ auto LookupNameInExactScope(Context& context, SemIR::LocId loc_id,
 }
 
 // Prints diagnostics on invalid qualified name access.
-static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
-                                               SemIR::InstId scope_result_id,
-                                               SemIR::NameId name_id,
-                                               SemIR::AccessKind access_kind,
-                                               bool is_parent_access,
-                                               AccessInfo access_info) -> void {
+static auto DiagnoseInvalidQualifiedNameAccess(
+    Context& context, SemIR::LocId loc_id, SemIR::InstId scope_result_id,
+    SemIR::NameId name_id, SemIR::AccessKind access_kind, bool is_parent_access,
+    AccessInfo access_info) -> void {
   auto class_type = context.insts().TryGetAs<SemIR::ClassType>(
       context.constant_values().GetInstId(access_info.constant_id));
   if (!class_type) {
@@ -228,7 +226,7 @@ static auto DiagnoseInvalidQualifiedNameAccess(Context& context, SemIRLoc loc,
       Diagnostics::BoolAsSelect, SemIR::NameId, SemIR::TypeId);
   CARBON_DIAGNOSTIC(ClassMemberDeclaration, Note, "declared here");
   context.emitter()
-      .Build(loc, ClassInvalidMemberAccess,
+      .Build(loc_id, ClassInvalidMemberAccess,
              access_kind == SemIR::AccessKind::Private, name_id, parent_type_id)
       .Note(scope_result_id, ClassMemberDeclaration)
       .Emit();
@@ -351,7 +349,7 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
 
 // Prints a diagnostic for a missing qualified name.
 static auto DiagnoseMemberNameNotFound(
-    Context& context, SemIRLoc loc, SemIR::NameId name_id,
+    Context& context, SemIR::LocId loc_id, SemIR::NameId name_id,
     llvm::ArrayRef<LookupScope> lookup_scopes) -> void {
   if (lookup_scopes.size() == 1 &&
       lookup_scopes.front().name_scope_id.has_value()) {
@@ -360,7 +358,7 @@ static auto DiagnoseMemberNameNotFound(
       CARBON_DIAGNOSTIC(MemberNameNotFoundInSpecificScope, Error,
                         "member name `{0}` not found in {1}", SemIR::NameId,
                         SemIR::SpecificId);
-      context.emitter().Emit(loc, MemberNameNotFoundInSpecificScope, name_id,
+      context.emitter().Emit(loc_id, MemberNameNotFoundInSpecificScope, name_id,
                              specific_id);
     } else {
       auto scope_inst_id = context.name_scopes()
@@ -369,7 +367,7 @@ static auto DiagnoseMemberNameNotFound(
       CARBON_DIAGNOSTIC(MemberNameNotFoundInInstScope, Error,
                         "member name `{0}` not found in {1}", SemIR::NameId,
                         InstIdAsType);
-      context.emitter().Emit(loc, MemberNameNotFoundInInstScope, name_id,
+      context.emitter().Emit(loc_id, MemberNameNotFoundInInstScope, name_id,
                              scope_inst_id);
     }
     return;
@@ -377,7 +375,7 @@ static auto DiagnoseMemberNameNotFound(
 
   CARBON_DIAGNOSTIC(MemberNameNotFound, Error, "member name `{0}` not found",
                     SemIR::NameId);
-  context.emitter().Emit(loc, MemberNameNotFound, name_id);
+  context.emitter().Emit(loc_id, MemberNameNotFound, name_id);
 }
 
 auto LookupQualifiedName(Context& context, SemIR::LocId loc_id,
@@ -547,7 +545,8 @@ auto LookupNameInCore(Context& context, SemIR::LocId loc_id,
 }
 
 auto DiagnoseDuplicateName(Context& context, SemIR::NameId name_id,
-                           SemIRLoc dup_def, SemIRLoc prev_def) -> void {
+                           SemIR::LocId dup_def, SemIR::LocId prev_def)
+    -> void {
   CARBON_DIAGNOSTIC(NameDeclDuplicate, Error,
                     "duplicate name `{0}` being declared in the same scope",
                     SemIR::NameId);
@@ -572,10 +571,10 @@ auto DiagnosePoisonedName(Context& context, SemIR::NameId name_id,
       .Emit();
 }
 
-auto DiagnoseNameNotFound(Context& context, SemIRLoc loc, SemIR::NameId name_id)
-    -> void {
+auto DiagnoseNameNotFound(Context& context, SemIR::LocId loc_id,
+                          SemIR::NameId name_id) -> void {
   CARBON_DIAGNOSTIC(NameNotFound, Error, "name `{0}` not found", SemIR::NameId);
-  context.emitter().Emit(loc, NameNotFound, name_id);
+  context.emitter().Emit(loc_id, NameNotFound, name_id);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/name_lookup.h
+++ b/toolchain/check/name_lookup.h
@@ -101,7 +101,7 @@ auto LookupNameInCore(Context& context, SemIR::LocId loc_id,
 
 // Prints a diagnostic for a duplicate name.
 auto DiagnoseDuplicateName(Context& context, SemIR::NameId name_id,
-                           SemIRLoc dup_def, SemIRLoc prev_def) -> void;
+                           SemIR::LocId dup_def, SemIR::LocId prev_def) -> void;
 
 // Prints a diagnostic for a poisoned name when it's later declared.
 auto DiagnosePoisonedName(Context& context, SemIR::NameId name_id,
@@ -109,8 +109,8 @@ auto DiagnosePoisonedName(Context& context, SemIR::NameId name_id,
                           SemIR::LocId decl_name_loc_id) -> void;
 
 // Prints a diagnostic for a missing name.
-auto DiagnoseNameNotFound(Context& context, SemIRLoc loc, SemIR::NameId name_id)
-    -> void;
+auto DiagnoseNameNotFound(Context& context, SemIR::LocId loc_id,
+                          SemIR::NameId name_id) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/region_stack.h
+++ b/toolchain/check/region_stack.h
@@ -17,7 +17,7 @@ namespace Carbon::Check {
 class RegionStack {
  public:
   // A callback for Context::TODO.
-  using TodoFn = std::function<auto(SemIRLoc, std::string)->void>;
+  using TodoFn = std::function<auto(SemIR::LocId, std::string)->void>;
 
   explicit RegionStack(TodoFn todo_fn) : todo_fn_(std::move(todo_fn)) {}
 

--- a/toolchain/check/type.cpp
+++ b/toolchain/check/type.cpp
@@ -11,8 +11,8 @@
 namespace Carbon::Check {
 
 // Enforces that an integer type has a valid bit width.
-auto ValidateIntType(Context& context, SemIRLoc loc, SemIR::IntType result)
-    -> bool {
+auto ValidateIntType(Context& context, SemIR::LocId loc_id,
+                     SemIR::IntType result) -> bool {
   auto bit_width =
       context.insts().TryGetAs<SemIR::IntValue>(result.bit_width_id);
   if (!bit_width) {
@@ -26,7 +26,7 @@ auto ValidateIntType(Context& context, SemIRLoc loc, SemIR::IntType result)
     CARBON_DIAGNOSTIC(IntWidthNotPositive, Error,
                       "integer type width of {0} is not positive", TypedInt);
     context.emitter().Emit(
-        loc, IntWidthNotPositive,
+        loc_id, IntWidthNotPositive,
         {.type = bit_width->type_id, .value = bit_width_val});
     return false;
   }
@@ -35,7 +35,7 @@ auto ValidateIntType(Context& context, SemIRLoc loc, SemIR::IntType result)
                       "integer type width of {0} is greater than the "
                       "maximum supported width of {1}",
                       TypedInt, int);
-    context.emitter().Emit(loc, IntWidthTooLarge,
+    context.emitter().Emit(loc_id, IntWidthTooLarge,
                            {.type = bit_width->type_id, .value = bit_width_val},
                            IntStore::MaxIntWidth);
     return false;
@@ -44,7 +44,7 @@ auto ValidateIntType(Context& context, SemIRLoc loc, SemIR::IntType result)
 }
 
 // Enforces that the bit width is 64 for a float.
-auto ValidateFloatBitWidth(Context& context, SemIRLoc loc,
+auto ValidateFloatBitWidth(Context& context, SemIR::LocId loc_id,
                            SemIR::InstId inst_id) -> bool {
   auto inst = context.insts().GetAs<SemIR::IntValue>(inst_id);
   if (context.ints().Get(inst.int_id) == 64) {
@@ -52,20 +52,20 @@ auto ValidateFloatBitWidth(Context& context, SemIRLoc loc,
   }
 
   CARBON_DIAGNOSTIC(CompileTimeFloatBitWidth, Error, "bit width must be 64");
-  context.emitter().Emit(loc, CompileTimeFloatBitWidth);
+  context.emitter().Emit(loc_id, CompileTimeFloatBitWidth);
   return false;
 }
 
 // Enforces that a float type has a valid bit width.
-auto ValidateFloatType(Context& context, SemIRLoc loc, SemIR::FloatType result)
-    -> bool {
+auto ValidateFloatType(Context& context, SemIR::LocId loc_id,
+                       SemIR::FloatType result) -> bool {
   auto bit_width =
       context.insts().TryGetAs<SemIR::IntValue>(result.bit_width_id);
   if (!bit_width) {
     // Symbolic bit width.
     return true;
   }
-  return ValidateFloatBitWidth(context, loc, result.bit_width_id);
+  return ValidateFloatBitWidth(context, loc_id, result.bit_width_id);
 }
 
 // Gets or forms a type_id for a type, given the instruction kind and arguments.

--- a/toolchain/check/type.h
+++ b/toolchain/check/type.h
@@ -12,16 +12,16 @@
 namespace Carbon::Check {
 
 // Enforces that an integer type has a valid bit width.
-auto ValidateIntType(Context& context, SemIRLoc loc, SemIR::IntType result)
-    -> bool;
+auto ValidateIntType(Context& context, SemIR::LocId loc_id,
+                     SemIR::IntType result) -> bool;
 
 // Enforces that the bit width is 64 for a float.
-auto ValidateFloatBitWidth(Context& context, SemIRLoc loc,
+auto ValidateFloatBitWidth(Context& context, SemIR::LocId loc_id,
                            SemIR::InstId inst_id) -> bool;
 
 // Enforces that a float type has a valid bit width.
-auto ValidateFloatType(Context& context, SemIRLoc loc, SemIR::FloatType result)
-    -> bool;
+auto ValidateFloatType(Context& context, SemIR::LocId loc_id,
+                       SemIR::FloatType result) -> bool;
 
 // Gets the type to use for an unbound associated entity declared in this
 // interface. For example, this is the type of `I.T` after

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -30,9 +30,9 @@ namespace {
 class TypeCompleter {
  public:
   // `context` mut not be null.
-  TypeCompleter(Context* context, SemIRLoc loc,
+  TypeCompleter(Context* context, SemIR::LocId loc_id,
                 MakeDiagnosticBuilderFn diagnoser)
-      : context_(context), loc_(loc), diagnoser_(diagnoser) {}
+      : context_(context), loc_id_(loc_id), diagnoser_(diagnoser) {}
 
   // Attempts to complete the given type. Returns true if it is now complete,
   // false if it could not be completed.
@@ -165,7 +165,7 @@ class TypeCompleter {
 
   Context* context_;
   llvm::SmallVector<WorkItem> work_list_;
-  SemIRLoc loc_;
+  SemIR::LocId loc_id_;
   MakeDiagnosticBuilderFn diagnoser_;
 };
 }  // namespace
@@ -274,7 +274,7 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
         return false;
       }
       if (inst.specific_id.has_value()) {
-        ResolveSpecificDefinition(*context_, loc_, inst.specific_id);
+        ResolveSpecificDefinition(*context_, loc_id_, inst.specific_id);
       }
       if (auto adapted_type_id =
               class_info.GetAdaptedType(context_->sem_ir(), inst.specific_id);
@@ -307,7 +307,8 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
         }
 
         if (req_interface.specific_id.has_value()) {
-          ResolveSpecificDefinition(*context_, loc_, req_interface.specific_id);
+          ResolveSpecificDefinition(*context_, loc_id_,
+                                    req_interface.specific_id);
         }
       }
       break;
@@ -531,9 +532,10 @@ auto TypeCompleter::BuildInfo(SemIR::TypeId type_id, SemIR::Inst inst) const
   }
 }
 
-auto TryToCompleteType(Context& context, SemIR::TypeId type_id, SemIRLoc loc,
-                       MakeDiagnosticBuilderFn diagnoser) -> bool {
-  return TypeCompleter(&context, loc, diagnoser).Complete(type_id);
+auto TryToCompleteType(Context& context, SemIR::TypeId type_id,
+                       SemIR::LocId loc_id, MakeDiagnosticBuilderFn diagnoser)
+    -> bool {
+  return TypeCompleter(&context, loc_id, diagnoser).Complete(type_id);
 }
 
 auto CompleteTypeOrCheckFail(Context& context, SemIR::TypeId type_id) -> void {

--- a/toolchain/check/type_completion.h
+++ b/toolchain/check/type_completion.h
@@ -20,7 +20,8 @@ namespace Carbon::Check {
 // However, it's important that we use it during monomorphization, where we
 // don't want to trigger a request for more monomorphization.
 // TODO: Remove the other call to this function.
-auto TryToCompleteType(Context& context, SemIR::TypeId type_id, SemIRLoc loc,
+auto TryToCompleteType(Context& context, SemIR::TypeId type_id,
+                       SemIR::LocId loc_id,
                        MakeDiagnosticBuilderFn diagnoser = nullptr) -> bool;
 
 // Completes the type `type_id`. CHECK-fails if it can't be completed.


### PR DESCRIPTION
Replace SemIRLoc typedef uses with explicitly SemIR::LocId, loc -> loc_id for consistency.