### PR TITLE
Avoid crashing when a NamespaceType is in a type structure

### DIFF
--- a/toolchain/check/testdata/facet/min_prelude/fail_namespace_type.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_namespace_type.carbon
@@ -7,9 +7,9 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/min_prelude/namespace_type.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/min_prelude/fail_namespace_type.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/min_prelude/namespace_type.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/min_prelude/fail_namespace_type.carbon
 
 // --- fail_namespace_as.carbon
 library "[[@TEST_NAME]]";

--- a/toolchain/check/testdata/facet/min_prelude/namespace_type.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/namespace_type.carbon
@@ -1,0 +1,51 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
+// EXTRA-ARGS: --no-dump-sem-ir --custom-core
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/min_prelude/namespace_type.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/min_prelude/namespace_type.carbon
+
+// --- fail_namespace_as.carbon
+library "[[@TEST_NAME]]";
+
+namespace N;
+
+interface Z {}
+
+impl forall [T:! type] T as Z {}
+
+fn F() {
+  // CHECK:STDERR: fail_namespace_as.carbon:[[@LINE+4]]:3: error: expression cannot be used as a value [UseOfNonExprAsValue]
+  // CHECK:STDERR:   N as Z;
+  // CHECK:STDERR:   ^
+  // CHECK:STDERR:
+  N as Z;
+}
+
+// --- fail_namespace_argument.carbon
+library "[[@TEST_NAME]]";
+
+namespace N;
+
+interface Z {}
+
+impl forall [T:! type] T as Z {}
+
+fn G[T:! Z](a: T) {}
+
+fn F() {
+  // CHECK:STDERR: fail_namespace_argument.carbon:[[@LINE+7]]:5: error: expression cannot be used as a value [UseOfNonExprAsValue]
+  // CHECK:STDERR:   G(N);
+  // CHECK:STDERR:     ^
+  // CHECK:STDERR: fail_namespace_argument.carbon:[[@LINE-6]]:13: note: initializing function parameter [InCallToFunctionParam]
+  // CHECK:STDERR: fn G[T:! Z](a: T) {}
+  // CHECK:STDERR:             ^~~~
+  // CHECK:STDERR:
+  G(N);
+}

--- a/toolchain/check/type_structure.cpp
+++ b/toolchain/check/type_structure.cpp
@@ -210,6 +210,7 @@ class TypeStructureBuilder {
         case SemIR::ImplWitnessAccess::Kind:
         case SemIR::IntLiteralType::Kind:
         case SemIR::LegacyFloatType::Kind:
+        case SemIR::NamespaceType::Kind:
         case SemIR::StringType::Kind:
         case SemIR::TypeType::Kind:
         case SemIR::WitnessType::Kind: {


### PR DESCRIPTION
NamespaceType is not valid to use as an argument for generics, but when it's there handle it gracefully through to the diagnostic.

Found by fuzzer.