### PR TITLE
Add missing standard library header inclusions

### DIFF
--- a/common/check_internal.cpp
+++ b/common/check_internal.cpp
@@ -4,6 +4,9 @@
 
 #include "common/check_internal.h"
 
+#include <cstdlib>
+#include <string>
+
 #include "common/ostream.h"
 #include "llvm/Support/Signals.h"
 

--- a/common/command_line.cpp
+++ b/common/command_line.cpp
@@ -4,7 +4,11 @@
 
 #include "common/command_line.h"
 
+#include <array>
 #include <memory>
+#include <optional>
+#include <string>
+#include <utility>
 
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/DenseMap.h"

--- a/common/exe_path.cpp
+++ b/common/exe_path.cpp
@@ -4,6 +4,9 @@
 
 #include "common/exe_path.h"
 
+#include <string>
+#include <utility>
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Program.h"

--- a/common/exe_path_test.cpp
+++ b/common/exe_path_test.cpp
@@ -5,6 +5,7 @@
 #include "common/exe_path.h"
 
 #include <gtest/gtest.h>
+
 #include <string>
 #include <system_error>
 

--- a/common/exe_path_test.cpp
+++ b/common/exe_path_test.cpp
@@ -5,6 +5,8 @@
 #include "common/exe_path.h"
 
 #include <gtest/gtest.h>
+#include <string>
+#include <system_error>
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"

--- a/common/hashing.cpp
+++ b/common/hashing.cpp
@@ -4,6 +4,8 @@
 
 #include "common/hashing.h"
 
+#include <cstddef>
+
 namespace Carbon {
 
 auto Hasher::HashSizedBytesLarge(llvm::ArrayRef<std::byte> bytes) -> void {

--- a/common/hashing_benchmark.cpp
+++ b/common/hashing_benchmark.cpp
@@ -5,6 +5,7 @@
 #include <benchmark/benchmark.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <numbers>
 

--- a/common/hashing_test.cpp
+++ b/common/hashing_test.cpp
@@ -8,7 +8,10 @@
 #include <gtest/gtest.h>
 
 #include <concepts>
+#include <string>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/Sequence.h"

--- a/common/raw_hashtable.cpp
+++ b/common/raw_hashtable.cpp
@@ -4,6 +4,8 @@
 
 #include "common/raw_hashtable.h"
 
+#include <cstddef>
+
 namespace Carbon::RawHashtable {
 
 volatile std::byte global_addr_seed{1};

--- a/common/raw_hashtable_benchmark_helpers.cpp
+++ b/common/raw_hashtable_benchmark_helpers.cpp
@@ -4,8 +4,11 @@
 
 #include "common/raw_hashtable_benchmark_helpers.h"
 
+#include <array>
 #include <cstddef>
 #include <forward_list>
+#include <utility>
+#include <vector>
 
 namespace Carbon::RawHashtable {
 

--- a/common/raw_hashtable_metadata_group_benchmark.cpp
+++ b/common/raw_hashtable_metadata_group_benchmark.cpp
@@ -5,6 +5,8 @@
 #include <benchmark/benchmark.h>
 
 #include <algorithm>
+#include <array>
+#include <numeric>
 
 #include "absl/random/random.h"
 #include "common/raw_hashtable_metadata_group.h"

--- a/common/set_benchmark.cpp
+++ b/common/set_benchmark.cpp
@@ -4,6 +4,8 @@
 
 #include <benchmark/benchmark.h>
 
+#include <type_traits>
+
 #include "absl/container/flat_hash_set.h"
 #include "common/raw_hashtable_benchmark_helpers.h"
 #include "common/set.h"

--- a/common/string_helpers.cpp
+++ b/common/string_helpers.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <string>
 
 #include "common/check.h"
 #include "llvm/ADT/StringExtras.h"

--- a/common/string_helpers_test.cpp
+++ b/common/string_helpers_test.cpp
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <string>
 
 using ::testing::Eq;

--- a/common/vlog_test.cpp
+++ b/common/vlog_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "common/raw_string_ostream.h"
 
 namespace Carbon::Testing {

--- a/testing/base/capture_std_streams.cpp
+++ b/testing/base/capture_std_streams.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <string>
 
 #include "common/ostream.h"
 

--- a/testing/base/file_helpers.cpp
+++ b/testing/base/file_helpers.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <string>
 #include <system_error>
 
 namespace Carbon::Testing {

--- a/testing/base/global_exe_path.cpp
+++ b/testing/base/global_exe_path.cpp
@@ -4,6 +4,7 @@
 
 #include "testing/base/global_exe_path.h"
 
+#include <optional>
 #include <string>
 
 #include "common/check.h"

--- a/testing/base/source_gen.cpp
+++ b/testing/base/source_gen.cpp
@@ -4,7 +4,11 @@
 
 #include "testing/base/source_gen.h"
 
+#include <algorithm>
+#include <array>
 #include <numeric>
+#include <string>
+#include <utility>
 
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/testing/base/source_gen_main.cpp
+++ b/testing/base/source_gen_main.cpp
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+#include <system_error>
+
 #include "common/bazel_working_dir.h"
 #include "common/command_line.h"
 #include "common/init_llvm.h"

--- a/testing/base/source_gen_test.cpp
+++ b/testing/base/source_gen_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "common/set.h"
 #include "testing/base/global_exe_path.h"
 #include "toolchain/driver/driver.h"

--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -5,6 +5,8 @@
 #include "testing/file_test/autoupdate.h"
 
 #include <fstream>
+#include <string>
+#include <utility>
 
 #include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -21,9 +21,16 @@
 
 #include "testing/file_test/file_test_base.h"
 
+#include <atomic>
+#include <cstdlib>
 #include <filesystem>
+#include <functional>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <utility>
 
 #include "absl/flags/flag.h"

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -7,6 +7,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
 #include "common/ostream.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"

--- a/testing/file_test/manifest.cpp
+++ b/testing/file_test/manifest.cpp
@@ -4,6 +4,8 @@
 
 #include "testing/file_test/manifest.h"
 
+#include <string>
+
 // The test manifest, produced by `manifest_as_cpp`.
 // NOLINTNEXTLINE(readability-identifier-naming): Constant in practice.
 extern const char* CarbonFileTestManifest[];

--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <utility>
+
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"

--- a/testing/file_test/test_file.cpp
+++ b/testing/file_test/test_file.cpp
@@ -5,6 +5,9 @@
 #include "testing/file_test/test_file.h"
 
 #include <fstream>
+#include <optional>
+#include <string>
+#include <utility>
 
 #include "common/check.h"
 #include "common/error.h"

--- a/toolchain/base/int.cpp
+++ b/toolchain/base/int.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/base/int.h"
 
+#include <algorithm>
+#include <string>
+
 namespace Carbon {
 
 auto IntStore::CanonicalBitWidth(int significant_bits) -> int {

--- a/toolchain/base/int_test.cpp
+++ b/toolchain/base/int_test.cpp
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <limits>
 
 namespace Carbon::Testing {

--- a/toolchain/base/value_store_test.cpp
+++ b/toolchain/base/value_store_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "toolchain/base/value_ids.h"
 
 namespace Carbon::Testing {

--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/call.h"
 
+#include <optional>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/control_flow.h"

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/check/check.h"
 
+#include <string>
+#include <utility>
+
 #include "common/check.h"
 #include "common/map.h"
 #include "toolchain/check/check_unit.h"

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/check_unit.h"
 
 #include <string>
+#include <utility>
 
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/check/context.h"
 
+#include <string>
+#include <utility>
+
 #include "common/check.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/control_flow.cpp
+++ b/toolchain/check/control_flow.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/control_flow.h"
 
+#include <initializer_list>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/call.h"
 #include "toolchain/check/inst.h"

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/convert.h"
 
+#include <optional>
 #include <string>
 #include <utility>
 

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/decl_name_stack.h"
 
+#include <utility>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/diagnostic_helpers.h"

--- a/toolchain/check/deferred_definition_worklist.cpp
+++ b/toolchain/check/deferred_definition_worklist.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/check/deferred_definition_worklist.h"
 
+#include <algorithm>
+#include <optional>
+
 #include "common/variant_helpers.h"
 #include "common/vlog.h"
 #include "toolchain/check/handle.h"

--- a/toolchain/check/diagnostic_emitter.cpp
+++ b/toolchain/check/diagnostic_emitter.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/check/diagnostic_emitter.h"
 
+#include <algorithm>
+#include <string>
+
 #include "common/raw_string_ostream.h"
 #include "toolchain/sem_ir/absolute_node_id.h"
 #include "toolchain/sem_ir/stringify.h"

--- a/toolchain/check/dump.cpp
+++ b/toolchain/check/dump.cpp
@@ -15,6 +15,8 @@
 
 #include "toolchain/lex/dump.h"
 
+#include <string>
+
 #include "common/check.h"
 #include "common/raw_string_ostream.h"
 #include "toolchain/check/context.h"

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -4,6 +4,11 @@
 
 #include "toolchain/check/eval.h"
 
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <utility>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/action.h"
 #include "toolchain/check/diagnostic_helpers.h"

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+#include <tuple>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/class.h"
 #include "toolchain/check/context.h"

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+#include <utility>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/control_flow.h"

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+#include <utility>
+
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/check/decl_name_stack.h"

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <tuple>
+
 #include "toolchain/check/context.h"
 #include "toolchain/check/eval.h"
 #include "toolchain/check/facet_type.h"

--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+
 #include "toolchain/check/context.h"
 #include "toolchain/check/control_flow.h"
 #include "toolchain/check/convert.h"

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cmath>
+
 #include "toolchain/check/call.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/handle.h"

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/impl_lookup.h"
 
 #include <algorithm>
+#include <utility>
 #include <variant>
 
 #include "toolchain/base/kind_switch.h"

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/check/import.h"
 
+#include <optional>
+#include <utility>
+
 #include "common/check.h"
 #include "common/map.h"
 #include "toolchain/base/kind_switch.h"

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
+#include <utility>
 
 #include "clang/Frontend/TextDiagnostic.h"
 #include "clang/Sema/Lookup.h"

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -4,6 +4,11 @@
 
 #include "toolchain/check/import_ref.h"
 
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
 #include "common/check.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/check/interface.h"
 
+#include <algorithm>
+#include <cstddef>
+
 #include "toolchain/check/context.h"
 #include "toolchain/check/eval.h"
 #include "toolchain/check/generic.h"

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/modifiers.h"
 
+#include <optional>
+
 #include "toolchain/check/decl_introducer_state.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/name_lookup.h"
 
+#include <optional>
+
 #include "toolchain/check/generic.h"
 #include "toolchain/check/import.h"
 #include "toolchain/check/import_cpp.h"

--- a/toolchain/check/node_id_traversal.cpp
+++ b/toolchain/check/node_id_traversal.cpp
@@ -4,6 +4,10 @@
 
 #include "toolchain/check/node_id_traversal.h"
 
+#include <optional>
+#include <utility>
+#include <variant>
+
 #include "toolchain/check/handle.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/pattern_match.h"
 
 #include <functional>
+#include <utility>
 #include <vector>
 
 #include "llvm/ADT/STLExtras.h"

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/scope_stack.h"
 
+#include <utility>
+
 #include "common/check.h"
 #include "toolchain/sem_ir/ids.h"
 

--- a/toolchain/codegen/codegen.cpp
+++ b/toolchain/codegen/codegen.cpp
@@ -5,6 +5,8 @@
 #include "toolchain/codegen/codegen.h"
 
 #include <memory>
+#include <optional>
+#include <string>
 
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/MC/TargetRegistry.h"

--- a/toolchain/diagnostics/mocks.cpp
+++ b/toolchain/diagnostics/mocks.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/diagnostics/mocks.h"
 
+#include <ostream>
+
 namespace Carbon::Diagnostics {
 
 auto PrintTo(const Diagnostic& diagnostic, std::ostream* os) -> void {

--- a/toolchain/driver/clang_runner.cpp
+++ b/toolchain/driver/clang_runner.cpp
@@ -8,6 +8,8 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <string>
+#include <utility>
 
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticOptions.h"

--- a/toolchain/driver/clang_runner_test.cpp
+++ b/toolchain/driver/clang_runner_test.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <utility>
 
 #include "common/check.h"

--- a/toolchain/driver/clang_subcommand.cpp
+++ b/toolchain/driver/clang_subcommand.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/driver/clang_subcommand.h"
 
+#include <string>
+
 #include "llvm/TargetParser/Host.h"
 #include "toolchain/driver/clang_runner.h"
 

--- a/toolchain/driver/compile_benchmark.cpp
+++ b/toolchain/driver/compile_benchmark.cpp
@@ -4,6 +4,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <algorithm>
 #include <string>
 
 #include "testing/base/global_exe_path.h"

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -4,6 +4,13 @@
 
 #include "toolchain/driver/compile_subcommand.h"
 
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <utility>
+
 #include "common/vlog.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -9,6 +9,8 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
+#include <system_error>
 #include <utility>
 
 #include "common/raw_string_ostream.h"

--- a/toolchain/driver/lld_runner.cpp
+++ b/toolchain/driver/lld_runner.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <string>
 
 #include "common/vlog.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/toolchain/driver/lld_runner_test.cpp
+++ b/toolchain/driver/lld_runner_test.cpp
@@ -9,6 +9,8 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
+#include <tuple>
 #include <utility>
 
 #include "common/check.h"

--- a/toolchain/driver/lld_subcommand.cpp
+++ b/toolchain/driver/lld_subcommand.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/driver/lld_subcommand.h"
 
+#include <string>
+
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #include "toolchain/driver/lld_runner.h"

--- a/toolchain/driver/llvm_runner.cpp
+++ b/toolchain/driver/llvm_runner.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <string>
 
 #include "common/vlog.h"
 #include "lld/Common/Driver.h"

--- a/toolchain/driver/llvm_runner_test.cpp
+++ b/toolchain/driver/llvm_runner_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "common/ostream.h"
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/ScopeExit.h"

--- a/toolchain/driver/tool_runner_base.cpp
+++ b/toolchain/driver/tool_runner_base.cpp
@@ -4,7 +4,9 @@
 
 #include "toolchain/driver/tool_runner_base.h"
 
+#include <array>
 #include <memory>
+#include <optional>
 
 #include "common/vlog.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/toolchain/install/busybox_info_test.cpp
+++ b/toolchain/install/busybox_info_test.cpp
@@ -9,6 +9,8 @@
 
 #include <cstdlib>
 #include <fstream>
+#include <optional>
+#include <system_error>
 
 #include "common/check.h"
 #include "llvm/ADT/ScopeExit.h"

--- a/toolchain/install/busybox_main.cpp
+++ b/toolchain/install/busybox_main.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <cstdlib>
+#include <string>
 
 #include "common/bazel_working_dir.h"
 #include "common/error.h"

--- a/toolchain/install/install_paths.cpp
+++ b/toolchain/install/install_paths.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/install/install_paths.h"
 
 #include <memory>
+#include <string>
 
 #include "common/check.h"
 #include "llvm/ADT/StringExtras.h"

--- a/toolchain/install/install_paths_test.cpp
+++ b/toolchain/install/install_paths_test.cpp
@@ -7,6 +7,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <string>
+
 #include "common/check.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"

--- a/toolchain/install/install_paths_test_helpers.cpp
+++ b/toolchain/install/install_paths_test_helpers.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/install/install_paths_test_helpers.h"
 
+#include <memory>
+#include <utility>
+
 #include "testing/base/global_exe_path.h"
 
 namespace Carbon::Testing {

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -5,6 +5,8 @@
 #include "toolchain/language_server/context.h"
 
 #include <memory>
+#include <optional>
+#include <utility>
 
 #include "common/check.h"
 #include "common/raw_string_ostream.h"

--- a/toolchain/language_server/handle_document_symbol.cpp
+++ b/toolchain/language_server/handle_document_symbol.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/check.h"
 #include "toolchain/language_server/handle.h"

--- a/toolchain/language_server/handle_initialize.cpp
+++ b/toolchain/language_server/handle_initialize.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <utility>
+
 #include "toolchain/language_server/handle.h"
 
 namespace Carbon::LanguageServer {

--- a/toolchain/language_server/handle_shutdown.cpp
+++ b/toolchain/language_server/handle_shutdown.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cstddef>
+
 #include "toolchain/language_server/handle.h"
 
 namespace Carbon::LanguageServer {

--- a/toolchain/language_server/handle_text_document.cpp
+++ b/toolchain/language_server/handle_text_document.cpp
@@ -2,6 +2,10 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <string>
+#include <tuple>
+#include <vector>
+
 #include "toolchain/language_server/handle.h"
 
 namespace Carbon::LanguageServer {

--- a/toolchain/language_server/incoming_messages.cpp
+++ b/toolchain/language_server/incoming_messages.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/language_server/incoming_messages.h"
 
+#include <utility>
+
 #include "common/ostream.h"
 #include "common/raw_string_ostream.h"
 #include "toolchain/language_server/handle.h"

--- a/toolchain/language_server/language_server.cpp
+++ b/toolchain/language_server/language_server.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/language_server/language_server.h"
 
+#include <memory>
+
 #include "clang-tools-extra/clangd/LSPBinder.h"
 #include "clang-tools-extra/clangd/Transport.h"
 #include "clang-tools-extra/clangd/support/Logger.h"

--- a/toolchain/lex/dump.cpp
+++ b/toolchain/lex/dump.cpp
@@ -6,6 +6,8 @@
 
 #include "toolchain/lex/dump.h"
 
+#include <string>
+
 #include "common/raw_string_ostream.h"
 
 namespace Carbon::Lex {

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <limits>
+#include <optional>
+#include <utility>
 
 #include "common/check.h"
 #include "common/variant_helpers.h"

--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -4,7 +4,10 @@
 
 #include "toolchain/lex/numeric_literal.h"
 
+#include <algorithm>
 #include <bitset>
+#include <iterator>
+#include <optional>
 
 #include "common/check.h"
 #include "llvm/ADT/StringExtras.h"

--- a/toolchain/lex/numeric_literal_test.cpp
+++ b/toolchain/lex/numeric_literal_test.cpp
@@ -7,6 +7,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
+#include <string>
+
 #include "common/check.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/test_helpers.h"

--- a/toolchain/lex/string_literal.cpp
+++ b/toolchain/lex/string_literal.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/lex/string_literal.h"
 
+#include <initializer_list>
+#include <optional>
+
 #include "common/check.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"

--- a/toolchain/lex/string_literal_benchmark.cpp
+++ b/toolchain/lex/string_literal_benchmark.cpp
@@ -4,6 +4,9 @@
 
 #include <benchmark/benchmark.h>
 
+#include <string>
+#include <string_view>
+
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/string_literal.h"
 

--- a/toolchain/lex/string_literal_test.cpp
+++ b/toolchain/lex/string_literal_test.cpp
@@ -7,6 +7,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
+#include <string>
+#include <utility>
+
 #include "common/check.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/test_helpers.h"

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -6,6 +6,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
+#include <optional>
+#include <utility>
 
 #include "common/check.h"
 #include "common/string_helpers.h"

--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -5,6 +5,8 @@
 #include <benchmark/benchmark.h>
 
 #include <algorithm>
+#include <array>
+#include <string>
 #include <utility>
 
 #include "absl/random/random.h"

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -7,9 +7,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <forward_list>
 #include <iterator>
+#include <string>
 
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -4,6 +4,11 @@
 
 #include "toolchain/lower/file_context.h"
 
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
 #include "common/check.h"
 #include "common/vlog.h"
 #include "llvm/ADT/STLExtras.h"

--- a/toolchain/lower/handle_call.cpp
+++ b/toolchain/lower/handle_call.cpp
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <algorithm>
+#include <vector>
+
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
 #include "toolchain/lower/function_context.h"

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/lower/lower.h"
 
+#include <memory>
+#include <optional>
+
 #include "toolchain/lower/file_context.h"
 
 namespace Carbon::Lower {

--- a/toolchain/lower/mangler.cpp
+++ b/toolchain/lower/mangler.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/lower/mangler.h"
 
+#include <string>
+
 #include "common/raw_string_ostream.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/sem_ir/entry_point.h"

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/parse/context.h"
 
+#include <initializer_list>
 #include <optional>
 
 #include "common/check.h"

--- a/toolchain/parse/dump.cpp
+++ b/toolchain/parse/dump.cpp
@@ -6,6 +6,8 @@
 
 #include "toolchain/parse/dump.h"
 
+#include <string>
+
 #include "common/raw_string_ostream.h"
 #include "toolchain/lex/dump.h"
 

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <initializer_list>
+#include <optional>
 #include <tuple>
 #include <typeinfo>
 #include <utility>

--- a/toolchain/parse/handle_decl_scope_loop.cpp
+++ b/toolchain/parse/handle_decl_scope_loop.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <array>
+
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/parse/context.h"
 #include "toolchain/parse/handle.h"

--- a/toolchain/parse/handle_paren_condition.cpp
+++ b/toolchain/parse/handle_paren_condition.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+
 #include "toolchain/parse/context.h"
 #include "toolchain/parse/handle.h"
 

--- a/toolchain/parse/handle_statement.cpp
+++ b/toolchain/parse/handle_statement.cpp
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <optional>
+
 #include "toolchain/parse/context.h"
 #include "toolchain/parse/handle.h"
 

--- a/toolchain/parse/precedence.cpp
+++ b/toolchain/parse/precedence.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/parse/precedence.h"
 
+#include <initializer_list>
+#include <optional>
+
 #include "common/check.h"
 
 namespace Carbon::Parse {

--- a/toolchain/parse/tree_and_subtrees.cpp
+++ b/toolchain/parse/tree_and_subtrees.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/parse/tree_and_subtrees.h"
 
+#include <tuple>
+#include <utility>
+
 #include "toolchain/lex/token_index.h"
 
 namespace Carbon::Parse {

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 
 #include <forward_list>
+#include <optional>
+#include <string>
 
 #include "common/raw_string_ostream.h"
 #include "toolchain/base/shared_value_stores.h"

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -6,6 +6,8 @@
 
 #include "toolchain/sem_ir/dump.h"
 
+#include <string>
+
 #include "common/raw_string_ostream.h"
 #include "toolchain/sem_ir/stringify.h"
 

--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/facet_type_info.h"
 
+#include <tuple>
+
 namespace Carbon::SemIR {
 
 template <typename VecT, typename CompareT>

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -4,6 +4,10 @@
 
 #include "toolchain/sem_ir/file.h"
 
+#include <optional>
+#include <string>
+#include <utility>
+
 #include "common/check.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/sem_ir/formatter.h"
 
+#include <string>
+#include <utility>
+
 #include "common/ostream.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/StringExtras.h"

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/function.h"
 
+#include <optional>
+
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/generic.h"
 #include "toolchain/sem_ir/ids.h"

--- a/toolchain/sem_ir/ids_test.cpp
+++ b/toolchain/sem_ir/ids_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <tuple>
 
 namespace Carbon::SemIR {
 namespace {

--- a/toolchain/sem_ir/inst.cpp
+++ b/toolchain/sem_ir/inst.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/inst.h"
 
+#include <utility>
+
 namespace Carbon::SemIR {
 
 auto Inst::Print(llvm::raw_ostream& out) const -> void {

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/inst_fingerprinter.h"
 
+#include <array>
+#include <utility>
 #include <variant>
 
 #include "common/ostream.h"

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -4,6 +4,10 @@
 
 #include "toolchain/sem_ir/inst_namer.h"
 
+#include <string>
+#include <utility>
+#include <variant>
+
 #include "common/ostream.h"
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/STLExtras.h"

--- a/toolchain/sem_ir/name_scope.cpp
+++ b/toolchain/sem_ir/name_scope.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/sem_ir/name_scope.h"
 
+#include <optional>
+#include <utility>
+
 #include "toolchain/sem_ir/file.h"
 
 namespace Carbon::SemIR {

--- a/toolchain/sem_ir/stringify.cpp
+++ b/toolchain/sem_ir/stringify.cpp
@@ -4,6 +4,11 @@
 
 #include "toolchain/sem_ir/stringify.h"
 
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
 #include "common/raw_string_ostream.h"
 #include "common/variant_helpers.h"
 #include "toolchain/base/kind_switch.h"

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/type.h"
 
+#include <optional>
+
 #include "toolchain/sem_ir/file.h"
 
 namespace Carbon::SemIR {

--- a/toolchain/sem_ir/type_info.cpp
+++ b/toolchain/sem_ir/type_info.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/type_info.h"
 
+#include <string>
+
 #include "common/raw_string_ostream.h"
 #include "toolchain/sem_ir/file.h"
 

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -5,6 +5,8 @@
 #include "toolchain/source/source_buffer.h"
 
 #include <limits>
+#include <memory>
+#include <optional>
 
 #include "llvm/Support/ErrorOr.h"
 #include "toolchain/diagnostics/file_diagnostics.h"

--- a/toolchain/testing/compile_helper.cpp
+++ b/toolchain/testing/compile_helper.cpp
@@ -4,6 +4,9 @@
 
 #include "toolchain/testing/compile_helper.h"
 
+#include <string>
+#include <utility>
+
 namespace Carbon::Testing {
 
 auto CompileHelper::GetTokenizedBuffer(llvm::StringRef text,

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -6,8 +6,10 @@
 #define CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_
 
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "absl/strings/str_replace.h"
 #include "common/error.h"

--- a/toolchain/testing/yaml_test_helpers.cpp
+++ b/toolchain/testing/yaml_test_helpers.cpp
@@ -4,6 +4,13 @@
 
 #include "toolchain/testing/yaml_test_helpers.h"
 
+#include <iomanip>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <variant>
+
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/YAMLParser.h"


### PR DESCRIPTION
Discovered by clang-tidy.
