### PR TITLE
Rename singleton InstId constants to TypeInstId

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -154,7 +154,7 @@ static auto BuildCalleeSpecificFunction(
         GetOrAddInst(context, context.insts().GetLocId(generic_callee_id),
                      SemIR::SpecificImplFunction{
                          .type_id = GetSingletonType(
-                             context, SemIR::SpecificFunctionType::InstId),
+                             context, SemIR::SpecificFunctionType::TypeInstId),
                          .callee_id = generic_callee_id,
                          .specific_id = callee_specific_id});
   } else {
@@ -164,7 +164,7 @@ static auto BuildCalleeSpecificFunction(
         GetOrAddInst(context, context.insts().GetLocId(generic_callee_id),
                      SemIR::SpecificFunction{
                          .type_id = GetSingletonType(
-                             context, SemIR::SpecificFunctionType::InstId),
+                             context, SemIR::SpecificFunctionType::TypeInstId),
                          .callee_id = generic_callee_id,
                          .specific_id = callee_specific_id});
   }

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -89,7 +89,7 @@ auto CheckUnit::Run() -> void {
 auto CheckUnit::InitPackageScopeAndImports() -> void {
   // Importing makes many namespaces, so only canonicalize the type once.
   auto namespace_type_id =
-      GetSingletonType(context_, SemIR::NamespaceType::InstId);
+      GetSingletonType(context_, SemIR::NamespaceType::TypeInstId);
 
   // Define the package scope, with an instruction for `package` expressions to
   // reference.

--- a/toolchain/check/class.cpp
+++ b/toolchain/check/class.cpp
@@ -97,7 +97,7 @@ static auto CheckCompleteAdapterClassType(
 
   return AddInst<SemIR::CompleteTypeWitness>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
        // TODO: Use InstId from the adapt declaration.
        .object_repr_type_inst_id = context.types().GetInstId(object_repr_id)});
 }
@@ -184,7 +184,7 @@ static auto BuildVtable(Context& context, Parse::NodeId node_id,
   }
   return AddInst<SemIR::Vtable>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::VtableType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::VtableType::TypeInstId),
        .virtual_functions_id = context.inst_blocks().Add(vtable)});
 }
 
@@ -223,7 +223,7 @@ static auto CheckCompleteClassType(
     struct_type_fields.push_back(
         {.name_id = SemIR::NameId::Vptr,
          .type_inst_id = context.types().GetInstId(
-             GetPointerType(context, SemIR::VtableType::InstId))});
+             GetPointerType(context, SemIR::VtableType::TypeInstId))});
   }
   if (base_type_id.has_value()) {
     auto base_decl = context.insts().GetAs<SemIR::BaseDecl>(class_info.base_id);
@@ -249,7 +249,7 @@ static auto CheckCompleteClassType(
 
   return AddInst<SemIR::CompleteTypeWitness>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
        .object_repr_type_inst_id = struct_type_inst_id});
 }
 

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -126,9 +126,9 @@ static auto MakeElementAccessInst(Context& context, SemIR::LocId loc_id,
     // index so that we don't need an integer literal instruction here, and
     // remove this special case.
     auto index_id = block.template AddInst<SemIR::IntValue>(
-        loc_id,
-        {.type_id = GetSingletonType(context, SemIR::IntLiteralType::InstId),
-         .int_id = context.ints().Add(static_cast<int64_t>(i))});
+        loc_id, {.type_id = GetSingletonType(context,
+                                             SemIR::IntLiteralType::TypeInstId),
+                 .int_id = context.ints().Add(static_cast<int64_t>(i))});
     return AddInst<AccessInstT>(block, loc_id,
                                 {elem_type_id, aggregate_id, index_id});
   } else {
@@ -1422,7 +1422,7 @@ auto ConvertToBoolValue(Context& context, SemIR::LocId loc_id,
                         SemIR::InstId value_id) -> SemIR::InstId {
   return ConvertToValueOfType(
       context, loc_id, value_id,
-      GetSingletonType(context, SemIR::BoolType::InstId));
+      GetSingletonType(context, SemIR::BoolType::TypeInstId));
 }
 
 auto ConvertForExplicitAs(Context& context, Parse::NodeId as_node,

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -827,7 +827,7 @@ static auto MakeIntTypeResult(Context& context, SemIR::LocId loc_id,
                               SemIR::IntKind int_kind, SemIR::InstId width_id,
                               Phase phase) -> SemIR::ConstantId {
   auto result = SemIR::IntType{
-      .type_id = GetSingletonType(context, SemIR::TypeType::InstId),
+      .type_id = GetSingletonType(context, SemIR::TypeType::TypeInstId),
       .int_kind = int_kind,
       .bit_width_id = width_id};
   if (!ValidateIntType(context, loc_id, result)) {
@@ -1441,7 +1441,7 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
     }
 
     case SemIR::BuiltinFunctionKind::IntLiteralMakeType: {
-      return context.constant_values().Get(SemIR::IntLiteralType::InstId);
+      return context.constant_values().Get(SemIR::IntLiteralType::TypeInstId);
     }
 
     case SemIR::BuiltinFunctionKind::IntMakeTypeSigned: {
@@ -1462,11 +1462,11 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (!ValidateFloatBitWidth(context, loc_id, arg_ids[0])) {
         return SemIR::ErrorInst::ConstantId;
       }
-      return context.constant_values().Get(SemIR::LegacyFloatType::InstId);
+      return context.constant_values().Get(SemIR::LegacyFloatType::TypeInstId);
     }
 
     case SemIR::BuiltinFunctionKind::BoolMakeType: {
-      return context.constant_values().Get(SemIR::BoolType::InstId);
+      return context.constant_values().Get(SemIR::BoolType::TypeInstId);
     }
 
     // Integer conversions.
@@ -1910,7 +1910,7 @@ auto TryEvalTypedInst<SemIR::WhereExpr>(EvalContext& eval_context,
         if (rhs != SemIR::ErrorInst::ConstantId &&
             IsPeriodSelf(eval_context, lhs)) {
           auto rhs_inst_id = eval_context.constant_values().GetInstId(rhs);
-          if (rhs_inst_id == SemIR::TypeType::InstId) {
+          if (rhs_inst_id == SemIR::TypeType::TypeInstId) {
             // `.Self impls type` -> nothing to do.
           } else {
             auto facet_type =

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -311,7 +311,8 @@ auto EvalConstantInst(Context& context, SemIR::NameRef inst)
 
 auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                       SemIR::RequireCompleteType inst) -> ConstantEvalResult {
-  auto witness_type_id = GetSingletonType(context, SemIR::WitnessType::InstId);
+  auto witness_type_id =
+      GetSingletonType(context, SemIR::WitnessType::TypeInstId);
 
   // If the type is a concrete constant, require it to be complete now.
   auto complete_type_id =

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -81,7 +81,7 @@ auto InitialFacetTypeImplWitness(
          .impl_id = SemIR::ImplId::None});
     return AddInst<SemIR::ImplWitness>(
         context, witness_loc_id,
-        {.type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+        {.type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
          .witness_table_id = witness_table_inst_id,
          .specific_id = self_specific_id});
   }
@@ -113,7 +113,7 @@ auto InitialFacetTypeImplWitness(
         context.inst_blocks().AddUninitialized(assoc_entities.size());
     table = context.inst_blocks().GetMutable(elements_id);
     for (auto& uninit : table) {
-      uninit = SemIR::ImplWitnessTablePlaceholder::InstId;
+      uninit = SemIR::ImplWitnessTablePlaceholder::TypeInstId;
     }
 
     auto witness_table_inst_id = AddInst<SemIR::ImplWitnessTable>(
@@ -122,7 +122,7 @@ auto InitialFacetTypeImplWitness(
 
     witness_inst_id = AddInst<SemIR::ImplWitness>(
         context, witness_loc_id,
-        {.type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+        {.type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
          .witness_table_id = witness_table_inst_id,
          .specific_id = self_specific_id});
   }
@@ -171,7 +171,7 @@ auto InitialFacetTypeImplWitness(
       continue;
     }
 
-    if (table_entry != SemIR::ImplWitnessTablePlaceholder::InstId) {
+    if (table_entry != SemIR::ImplWitnessTablePlaceholder::TypeInstId) {
       if (table_entry != rewrite_inst_id) {
         // TODO: Figure out how to print the two different values
         // `const_id` & `rewrite_inst_id` in the diagnostic
@@ -265,7 +265,7 @@ auto AllocateFacetTypeImplWitness(Context& context,
   }
 
   llvm::SmallVector<SemIR::InstId> empty_table(
-      assoc_entities.size(), SemIR::ImplWitnessTablePlaceholder::InstId);
+      assoc_entities.size(), SemIR::ImplWitnessTablePlaceholder::TypeInstId);
   context.inst_blocks().ReplacePlaceholder(witness_id, empty_table);
 }
 

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -49,7 +49,7 @@ auto HandleParseNode(Context& context, Parse::ArrayExprId node_id) -> bool {
 
   bound_inst_id = ConvertToValueOfType(
       context, context.insts().GetLocId(bound_inst_id), bound_inst_id,
-      GetSingletonType(context, SemIR::IntLiteralType::InstId));
+      GetSingletonType(context, SemIR::IntLiteralType::TypeInstId));
   AddInstAndPush<SemIR::ArrayType>(
       context, node_id,
       {.type_id = SemIR::TypeType::TypeId,

--- a/toolchain/check/handle_choice.cpp
+++ b/toolchain/check/handle_choice.cpp
@@ -280,7 +280,7 @@ auto HandleParseNode(Context& context, Parse::ChoiceDefinitionId node_id)
   auto choice_witness_id = AddInst(
       context, node_id,
       SemIR::CompleteTypeWitness{
-          .type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+          .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
           .object_repr_type_inst_id =
               context.types().GetInstId(GetStructType(context, fields_id))});
   // Note: avoid storing a reference to the returned Class, since it may be

--- a/toolchain/check/handle_if_expr.cpp
+++ b/toolchain/check/handle_if_expr.cpp
@@ -38,7 +38,7 @@ static auto DecayIntLiteralToSizedInt(Context& context, Parse::NodeId node_id,
                                       SemIR::InstId operand_id)
     -> SemIR::InstId {
   if (context.types().GetInstId(context.insts().Get(operand_id).type_id()) ==
-      SemIR::IntLiteralType::InstId) {
+      SemIR::IntLiteralType::TypeInstId) {
     operand_id = ConvertToValueOfType(
         context, node_id, operand_id,
         MakeIntType(context, node_id, SemIR::IntKind::Signed,

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -20,7 +20,7 @@ auto HandleParseNode(Context& context, Parse::BoolLiteralFalseId node_id)
     -> bool {
   AddInstAndPush<SemIR::BoolLiteral>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::BoolType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::BoolType::TypeInstId),
        .value = SemIR::BoolValue::False});
   return true;
 }
@@ -29,7 +29,7 @@ auto HandleParseNode(Context& context, Parse::BoolLiteralTrueId node_id)
     -> bool {
   AddInstAndPush<SemIR::BoolLiteral>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::BoolType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::BoolType::TypeInstId),
        .value = SemIR::BoolValue::True});
   return true;
 }
@@ -81,7 +81,7 @@ auto HandleParseNode(Context& context, Parse::RealLiteralId node_id) -> bool {
   auto float_id = context.sem_ir().floats().Add(llvm::APFloat(double_val));
   AddInstAndPush<SemIR::FloatLiteral>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::LegacyFloatType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::LegacyFloatType::TypeInstId),
        .float_id = float_id});
   return true;
 }
@@ -89,7 +89,7 @@ auto HandleParseNode(Context& context, Parse::RealLiteralId node_id) -> bool {
 auto HandleParseNode(Context& context, Parse::StringLiteralId node_id) -> bool {
   AddInstAndPush<SemIR::StringLiteral>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::StringType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::StringType::TypeInstId),
        .string_literal_id = context.tokens().GetStringLiteralValue(
            context.parse_tree().node_token(node_id))});
   return true;
@@ -156,13 +156,13 @@ auto HandleParseNode(Context& context, Parse::FloatTypeLiteralId node_id)
 
 auto HandleParseNode(Context& context, Parse::StringTypeLiteralId node_id)
     -> bool {
-  context.node_stack().Push(node_id, SemIR::StringType::InstId);
+  context.node_stack().Push(node_id, SemIR::StringType::TypeInstId);
   return true;
 }
 
 auto HandleParseNode(Context& context, Parse::TypeTypeLiteralId node_id)
     -> bool {
-  context.node_stack().Push(node_id, SemIR::TypeType::InstId);
+  context.node_stack().Push(node_id, SemIR::TypeType::TypeInstId);
   return true;
 }
 

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -286,7 +286,7 @@ auto HandleParseNode(Context& context, Parse::DesignatorExprId node_id)
 auto HandleParseNode(Context& context, Parse::PackageExprId node_id) -> bool {
   AddInstAndPush<SemIR::NameRef>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::NamespaceType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::NamespaceType::TypeInstId),
        .name_id = SemIR::NameId::PackageNamespace,
        .value_id = SemIR::Namespace::PackageInstId});
   return true;

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -39,9 +39,9 @@ auto HandleParseNode(Context& context, Parse::NamespaceId node_id) -> bool {
       context.decl_introducer_state_stack().Pop<Lex::TokenKind::Namespace>();
   LimitModifiersOnDecl(context, introducer, KeywordModifierSet::None);
 
-  auto namespace_inst =
-      SemIR::Namespace{GetSingletonType(context, SemIR::NamespaceType::InstId),
-                       SemIR::NameScopeId::None, SemIR::InstId::None};
+  auto namespace_inst = SemIR::Namespace{
+      GetSingletonType(context, SemIR::NamespaceType::TypeInstId),
+      SemIR::NameScopeId::None, SemIR::InstId::None};
   auto namespace_id = AddPlaceholderInst(context, node_id, namespace_inst);
 
   SemIR::ScopeLookupResult lookup_result =

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -143,7 +143,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
     CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
     if (auto decl =
             context.insts().TryGetAs<SemIR::AssociatedConstantDecl>(decl_id)) {
-      if (witness_value == SemIR::ImplWitnessTablePlaceholder::InstId) {
+      if (witness_value == SemIR::ImplWitnessTablePlaceholder::TypeInstId) {
         CARBON_DIAGNOSTIC(ImplAssociatedConstantNeedsValue, Error,
                           "associated constant {0} not given a value in impl "
                           "of interface {1}",
@@ -251,7 +251,7 @@ auto FillImplWitnessWithErrors(Context& context, SemIR::Impl& impl) -> void {
     auto witness_block =
         context.inst_blocks().GetMutable(witness_table.elements_id);
     for (auto& elem : witness_block) {
-      if (elem == SemIR::ImplWitnessTablePlaceholder::InstId) {
+      if (elem == SemIR::ImplWitnessTablePlaceholder::TypeInstId) {
         elem = SemIR::ErrorInst::InstId;
       }
     }

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -330,12 +330,13 @@ static auto FindWitnessInFacet(
     for (auto [index, interface] :
          llvm::enumerate(identified.required_interfaces())) {
       if (interface == specific_interface) {
-        auto witness_id = GetOrAddInst(
-            context, loc_id,
-            SemIR::FacetAccessWitness{.type_id = GetSingletonType(
-                                          context, SemIR::WitnessType::InstId),
-                                      .facet_value_inst_id = facet_inst_id,
-                                      .index = SemIR::ElementIndex(index)});
+        auto witness_id =
+            GetOrAddInst(context, loc_id,
+                         SemIR::FacetAccessWitness{
+                             .type_id = GetSingletonType(
+                                 context, SemIR::WitnessType::TypeInstId),
+                             .facet_value_inst_id = facet_inst_id,
+                             .index = SemIR::ElementIndex(index)});
         return witness_id;
       }
     }
@@ -356,7 +357,7 @@ static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
   auto witness_const_id = EvalOrAddInst(
       context, loc_id.ToImplicit(),
       SemIR::LookupImplWitness{
-          .type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+          .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
           .query_self_inst_id =
               context.constant_values().GetInstId(query_self_const_id),
           .query_specific_interface_id =

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -599,7 +599,7 @@ static auto AddNamespaceFromOtherPackage(Context& context,
                                          SemIR::NameId name_id)
     -> SemIR::InstId {
   auto namespace_type_id =
-      GetSingletonType(context, SemIR::NamespaceType::InstId);
+      GetSingletonType(context, SemIR::NamespaceType::TypeInstId);
   AddImportNamespaceToScopeResult result = CopySingleNameScopeFromImportIR(
       context, namespace_type_id, /*copied_namespaces=*/nullptr, import_ir_id,
       import_inst_id, import_ns.name_scope_id, parent_scope_id, name_id);

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -173,7 +173,8 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
   }
 
   return AddImportNamespaceToScope(
-             context, GetSingletonType(context, SemIR::NamespaceType::InstId),
+             context,
+             GetSingletonType(context, SemIR::NamespaceType::TypeInstId),
              SemIR::NameId::ForPackageName(cpp_package_id),
              SemIR::NameScopeId::Package,
              /*diagnose_duplicate_namespace=*/false,
@@ -427,8 +428,8 @@ static auto ImportNamespaceDecl(Context& context,
                                 clang::NamespaceDecl* clang_decl)
     -> SemIR::InstId {
   auto result = AddImportNamespace(
-      context, GetSingletonType(context, SemIR::NamespaceType::InstId), name_id,
-      parent_scope_id, /*import_id=*/SemIR::InstId::None);
+      context, GetSingletonType(context, SemIR::NamespaceType::TypeInstId),
+      name_id, parent_scope_id, /*import_id=*/SemIR::InstId::None);
   context.name_scopes()
       .Get(result.name_scope_id)
       .set_cpp_decl_context(clang_decl);

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1700,7 +1700,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::BoundMethod inst) -> ResolveResult {
   CARBON_CHECK(resolver.import_types().GetInstId(inst.type_id) ==
-               SemIR::BoundMethodType::InstId);
+               SemIR::BoundMethodType::TypeInstId);
   auto object_id = GetLocalConstantInstId(resolver, inst.object_id);
   auto function_decl_id =
       GetLocalConstantInstId(resolver, inst.function_decl_id);
@@ -1710,10 +1710,11 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   }
 
   return ResolveAs<SemIR::BoundMethod>(
-      resolver, {.type_id = GetSingletonType(resolver.local_context(),
-                                             SemIR::BoundMethodType::InstId),
-                 .object_id = object_id,
-                 .function_decl_id = function_decl_id});
+      resolver,
+      {.type_id = GetSingletonType(resolver.local_context(),
+                                   SemIR::BoundMethodType::TypeInstId),
+       .object_id = object_id,
+       .function_decl_id = function_decl_id});
 }
 
 static auto TryResolveTypedInst(ImportRefResolver& resolver, SemIR::Call inst)
@@ -1886,7 +1887,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   if (import_class.is_complete()) {
     auto complete_type_witness_id = AddLoadedImportRef(
         resolver,
-        GetSingletonType(resolver.local_context(), SemIR::WitnessType::InstId),
+        GetSingletonType(resolver.local_context(),
+                         SemIR::WitnessType::TypeInstId),
         import_class.complete_type_witness_id, complete_type_witness_const_id);
     AddClassDefinition(resolver, import_class, new_class,
                        complete_type_witness_id, base_id, adapt_id, vtable_id);
@@ -1930,7 +1932,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::CompleteTypeWitness inst)
     -> ResolveResult {
   CARBON_CHECK(resolver.import_types().GetInstId(inst.type_id) ==
-               SemIR::WitnessType::InstId);
+               SemIR::WitnessType::TypeInstId);
   auto object_repr_type_inst_id =
       GetLocalTypeInstId(resolver, inst.object_repr_type_inst_id);
   if (resolver.HasNewWork()) {
@@ -1938,7 +1940,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   }
   return ResolveAs<SemIR::CompleteTypeWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
-                                             SemIR::WitnessType::InstId),
+                                             SemIR::WitnessType::TypeInstId),
                  .object_repr_type_inst_id = object_repr_type_inst_id});
 }
 
@@ -2461,7 +2463,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   return ResolveAs<SemIR::FacetAccessWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
-                                             SemIR::WitnessType::InstId),
+                                             SemIR::WitnessType::TypeInstId),
                  .facet_value_inst_id = facet_value_inst_id,
                  .index = inst.index});
 }
@@ -2543,7 +2545,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::LookupImplWitness inst)
     -> ResolveResult {
   CARBON_CHECK(resolver.import_types().GetInstId(inst.type_id) ==
-               SemIR::WitnessType::InstId);
+               SemIR::WitnessType::TypeInstId);
 
   auto query_self_inst_id =
       GetLocalConstantInstId(resolver, inst.query_self_inst_id);
@@ -2564,7 +2566,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver.local_specific_interfaces().Add(specific_interface);
   return ResolveAs<SemIR::LookupImplWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
-                                             SemIR::WitnessType::InstId),
+                                             SemIR::WitnessType::TypeInstId),
                  .query_self_inst_id = query_self_inst_id,
                  .query_specific_interface_id = query_specific_interface_id});
 }
@@ -2572,7 +2574,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::ImplWitness inst) -> ResolveResult {
   CARBON_CHECK(resolver.import_types().GetInstId(inst.type_id) ==
-               SemIR::WitnessType::InstId);
+               SemIR::WitnessType::TypeInstId);
 
   auto specific_data = GetLocalSpecificData(resolver, inst.specific_id);
   auto witness_table_id =
@@ -2585,7 +2587,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       GetOrAddLocalSpecific(resolver, inst.specific_id, specific_data);
   return ResolveAs<SemIR::ImplWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
-                                             SemIR::WitnessType::InstId),
+                                             SemIR::WitnessType::TypeInstId),
                  .witness_table_id = witness_table_id,
                  .specific_id = specific_id});
 }
@@ -2676,8 +2678,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  auto namespace_type_id =
-      GetSingletonType(resolver.local_context(), SemIR::NamespaceType::InstId);
+  auto namespace_type_id = GetSingletonType(resolver.local_context(),
+                                            SemIR::NamespaceType::TypeInstId);
   auto namespace_decl =
       SemIR::Namespace{.type_id = namespace_type_id,
                        .name_scope_id = SemIR::NameScopeId::None,
@@ -2714,7 +2716,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::RequireCompleteType inst)
     -> ResolveResult {
   CARBON_CHECK(resolver.import_types().GetInstId(inst.type_id) ==
-               SemIR::WitnessType::InstId);
+               SemIR::WitnessType::TypeInstId);
 
   auto complete_type_inst_id =
       GetLocalTypeInstId(resolver, inst.complete_type_inst_id);
@@ -2724,7 +2726,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   return ResolveAs<SemIR::RequireCompleteType>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
-                                             SemIR::WitnessType::InstId),
+                                             SemIR::WitnessType::TypeInstId),
                  .complete_type_inst_id = complete_type_inst_id});
 }
 
@@ -2756,7 +2758,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   }
 
   auto type_id = GetSingletonType(resolver.local_context(),
-                                  SemIR::SpecificFunctionType::InstId);
+                                  SemIR::SpecificFunctionType::TypeInstId);
   auto specific_id =
       GetOrAddLocalSpecific(resolver, inst.specific_id, specific_data);
   return ResolveAs<SemIR::SpecificImplFunction>(

--- a/toolchain/check/literal.cpp
+++ b/toolchain/check/literal.cpp
@@ -16,7 +16,7 @@ auto MakeIntLiteral(Context& context, Parse::NodeId node_id, IntId int_id)
     -> SemIR::InstId {
   return AddInst<SemIR::IntValue>(
       context, node_id,
-      {.type_id = GetSingletonType(context, SemIR::IntLiteralType::InstId),
+      {.type_id = GetSingletonType(context, SemIR::IntLiteralType::TypeInstId),
        .int_id = int_id});
 }
 

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -362,7 +362,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
                   GetOrAddInst(context, loc_id,
                                SemIR::FacetAccessWitness{
                                    .type_id = GetSingletonType(
-                                       context, SemIR::WitnessType::InstId),
+                                       context, SemIR::WitnessType::TypeInstId),
                                    .facet_value_inst_id = base_id,
                                    .index = SemIR::ElementIndex(index)});
               break;
@@ -417,7 +417,8 @@ static auto PerformInstanceBinding(Context& context, SemIR::LocId loc_id,
 
     return GetOrAddInst<SemIR::BoundMethod>(
         context, loc_id,
-        {.type_id = GetSingletonType(context, SemIR::BoundMethodType::InstId),
+        {.type_id =
+             GetSingletonType(context, SemIR::BoundMethodType::TypeInstId),
          .object_id = base_id,
          .function_decl_id = member_id});
   }
@@ -644,7 +645,7 @@ static auto GetAssociatedValueImpl(Context& context, SemIR::LocId loc_id,
   auto witness_id = GetOrAddInst(
       context, loc_id,
       SemIR::FacetAccessWitness{
-          .type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+          .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
           .facet_value_inst_id = facet_inst_id,
           // There's only one interface in this facet type.
           .index = SemIR::ElementIndex(0)});
@@ -785,7 +786,7 @@ auto PerformTupleAccess(Context& context, SemIR::LocId loc_id,
   auto index_node_id = context.insts().GetLocId(index_inst_id);
   index_inst_id = ConvertToValueOfType(
       context, index_node_id, index_inst_id,
-      GetSingletonType(context, SemIR::IntLiteralType::InstId));
+      GetSingletonType(context, SemIR::IntLiteralType::TypeInstId));
   auto index_const_id = context.constant_values().Get(index_inst_id);
   if (index_const_id == SemIR::ErrorInst::ConstantId) {
     return SemIR::ErrorInst::InstId;

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -561,7 +561,8 @@ auto RequireCompleteType(Context& context, SemIR::TypeId type_id,
     AddInstInNoBlock(
         context, loc_id,
         SemIR::RequireCompleteType{
-            .type_id = GetSingletonType(context, SemIR::WitnessType::InstId),
+            .type_id =
+                GetSingletonType(context, SemIR::WitnessType::TypeInstId),
             .complete_type_inst_id = context.types().GetInstId(type_id)});
   }
 

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -36,7 +36,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
   llvm::Value* index;
   if (context.sem_ir().types().GetInstId(
           context.sem_ir().insts().Get(inst.index_id).type_id()) ==
-      SemIR::IntLiteralType::InstId) {
+      SemIR::IntLiteralType::TypeInstId) {
     auto value = context.sem_ir().insts().GetAs<SemIR::IntValue>(
         context.sem_ir().constant_values().GetConstantInstId(inst.index_id));
     index = llvm::ConstantInt::get(context.llvm_context(),
@@ -73,7 +73,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::BindAlias inst) -> void {
   auto type_inst_id = context.sem_ir().types().GetInstId(inst.type_id);
-  if (type_inst_id == SemIR::NamespaceType::InstId) {
+  if (type_inst_id == SemIR::NamespaceType::TypeInstId) {
     return;
   }
 
@@ -83,7 +83,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::ExportDecl inst) -> void {
   auto type_inst_id = context.sem_ir().types().GetInstId(inst.type_id);
-  if (type_inst_id == SemIR::NamespaceType::InstId) {
+  if (type_inst_id == SemIR::NamespaceType::TypeInstId) {
     return;
   }
 
@@ -191,7 +191,7 @@ auto HandleInst(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::NameRef inst) -> void {
   auto type_inst_id = context.sem_ir().types().GetInstId(inst.type_id);
-  if (type_inst_id == SemIR::NamespaceType::InstId) {
+  if (type_inst_id == SemIR::NamespaceType::TypeInstId) {
     return;
   }
 

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -77,7 +77,7 @@ struct NoReturn {
 };
 
 // Constraint that a type is `bool`.
-using Bool = BuiltinType<BoolType::InstId>;
+using Bool = BuiltinType<BoolType::TypeInstId>;
 
 // Constraint that requires the type to be a sized integer type.
 struct AnySizedInt {
@@ -92,7 +92,8 @@ struct AnyInt {
   static auto Check(const File& sem_ir, ValidateState& state, TypeId type_id)
       -> bool {
     return AnySizedInt::Check(sem_ir, state, type_id) ||
-           BuiltinType<IntLiteralType::InstId>::Check(sem_ir, state, type_id);
+           BuiltinType<IntLiteralType::TypeInstId>::Check(sem_ir, state,
+                                                          type_id);
   }
 };
 
@@ -100,7 +101,8 @@ struct AnyInt {
 struct AnyFloat {
   static auto Check(const File& sem_ir, ValidateState& state, TypeId type_id)
       -> bool {
-    if (BuiltinType<LegacyFloatType::InstId>::Check(sem_ir, state, type_id)) {
+    if (BuiltinType<LegacyFloatType::TypeInstId>::Check(sem_ir, state,
+                                                        type_id)) {
       return true;
     }
     return sem_ir.types().Is<FloatType>(type_id);
@@ -108,14 +110,14 @@ struct AnyFloat {
 };
 
 // Constraint that requires the type to be the type type.
-using Type = BuiltinType<TypeType::InstId>;
+using Type = BuiltinType<TypeType::TypeInstId>;
 
 // Constraint that requires the type to be a type value, whose type is type
 // type. Also accepts symbolic constant value types.
 struct AnyType {
   static auto Check(const File& sem_ir, ValidateState& state, TypeId type_id)
       -> bool {
-    if (BuiltinType<TypeType::InstId>::Check(sem_ir, state, type_id)) {
+    if (BuiltinType<TypeType::TypeInstId>::Check(sem_ir, state, type_id)) {
       return true;
     }
     return sem_ir.types().GetAsInst(type_id).type_id() == TypeType::TypeId;

--- a/toolchain/sem_ir/singleton_insts.h
+++ b/toolchain/sem_ir/singleton_insts.h
@@ -32,11 +32,11 @@ static constexpr std::array SingletonInstKinds = {
 // Returns true if the InstKind is a singleton.
 constexpr auto IsSingletonInstKind(InstKind kind) -> bool;
 
-// Provides the InstId for singleton instructions. These are exposed as
-// `InstT::InstId` in `typed_insts.h`.
+// Provides the TypeInstId for singleton instructions. These are exposed as
+// `InstT::TypeInstId` in `typed_insts.h`.
 template <InstKind::RawEnumType Kind>
   requires(IsSingletonInstKind(InstKind::Make(Kind)))
-constexpr auto MakeSingletonInstId() -> TypeInstId;
+constexpr auto MakeSingletonTypeInstId() -> TypeInstId;
 
 // Returns true if the InstId corresponds to a singleton inst.
 constexpr auto IsSingletonInstId(InstId id) -> bool {
@@ -67,7 +67,7 @@ constexpr auto IsSingletonInstKind(InstKind kind) -> bool {
 
 template <InstKind::RawEnumType Kind>
   requires(IsSingletonInstKind(InstKind::Make(Kind)))
-constexpr auto MakeSingletonInstId() -> TypeInstId {
+constexpr auto MakeSingletonTypeInstId() -> TypeInstId {
   auto index = Internal::GetSingletonInstIndex(InstKind::Make(Kind));
   return TypeInstId(index);
 }

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -82,7 +82,7 @@ static auto TryGetIntTypeInfo(const File& file, TypeId type_id)
     return std::nullopt;
   }
   auto inst_id = file.types().GetInstId(object_repr_id);
-  if (inst_id == IntLiteralType::InstId) {
+  if (inst_id == IntLiteralType::TypeInstId) {
     // `Core.IntLiteral` has an unknown bit-width.
     return TypeStore::IntTypeInfo{.is_signed = true, .bit_width = IntId::None};
   }

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -273,9 +273,9 @@ struct AutoType {
       {.ir_name = "auto",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
   static constexpr auto TypeId =
-      TypeId::ForTypeConstant(ConstantId::ForConcreteConstant(InstId));
+      TypeId::ForTypeConstant(ConstantId::ForConcreteConstant(TypeInstId));
 
   SemIR::TypeId type_id;
 };
@@ -428,7 +428,7 @@ struct BoolType {
        .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -459,7 +459,7 @@ struct BoundMethodType {
            .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -661,10 +661,10 @@ struct ErrorInst {
       {.ir_name = "<error>",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
-  static constexpr SemIR::InstId InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
+  static constexpr SemIR::InstId InstId = TypeInstId;
   static constexpr auto ConstantId = ConstantId::ForConcreteConstant(InstId);
   static constexpr auto TypeId = TypeId::ForTypeConstant(ConstantId);
-  static constexpr auto TypeInstId = TypeInstId::UnsafeMake(InstId);
 
   SemIR::TypeId type_id;
 };
@@ -793,7 +793,7 @@ struct LegacyFloatType {
            .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -999,7 +999,7 @@ struct ImplWitnessTablePlaceholder {
           {.ir_name = "impl_witness_table_placeholder",
            .constant_kind = InstConstantKind::Unique,
            .is_lowered = false});
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -1078,9 +1078,9 @@ struct InstType {
       {.ir_name = "<instruction>",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
   static constexpr auto TypeId =
-      TypeId::ForTypeConstant(ConstantId::ForConcreteConstant(InstId));
+      TypeId::ForTypeConstant(ConstantId::ForConcreteConstant(TypeInstId));
 
   SemIR::TypeId type_id;
 };
@@ -1133,7 +1133,7 @@ struct IntLiteralType {
            .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -1233,7 +1233,7 @@ struct NamespaceType {
            .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -1538,7 +1538,7 @@ struct SpecificFunctionType {
            .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -1613,7 +1613,7 @@ struct StringType {
        .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -1790,9 +1790,9 @@ struct TypeType {
       {.ir_name = "type",
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Always});
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
   static constexpr auto TypeId =
-      TypeId::ForTypeConstant(ConstantId::ForConcreteConstant(InstId));
+      TypeId::ForTypeConstant(ConstantId::ForConcreteConstant(TypeInstId));
 
   SemIR::TypeId type_id;
 };
@@ -1885,7 +1885,7 @@ struct VtableType {
        .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };
@@ -1934,7 +1934,7 @@ struct WitnessType {
        .constant_kind = InstConstantKind::Always});
   // This is a singleton instruction. However, it may still evolve into a more
   // standard type and be removed.
-  static constexpr auto InstId = MakeSingletonInstId<Kind>();
+  static constexpr auto TypeInstId = MakeSingletonTypeInstId<Kind>();
 
   TypeId type_id;
 };


### PR DESCRIPTION
These constant instructions are all TypeInstId already in their type, and this makes their names match.

Change the name of MakeSingletonInstId as well and update its comment.