### PR TITLE
Allow a struct/tuple type literal to implicitly convert into a facet value

### DIFF
--- a/toolchain/check/testdata/facet/min_prelude/tuple_and_struct_type_literal.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/tuple_and_struct_type_literal.carbon
@@ -1,0 +1,100 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
+// EXTRA-ARGS: --custom-core --no-dump-sem-ir
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/min_prelude/tuple_and_struct_type_literal.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/min_prelude/tuple_and_struct_type_literal.carbon
+
+// --- tuple_literal_to_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let X:! Y;
+}
+
+impl () as Y {}
+
+// The tuple literal converts implicitly to a type, and then to a facet value
+// satisfying `Y`.
+impl forall [T:! type] T as Z where .X = () {}
+
+// --- complex_tuple_literal_to_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let X:! Y;
+}
+
+impl ((), {}) as Y {}
+
+// The tuple literal converts implicitly to a type, and then to a facet value
+// satisfying `Y`.
+impl forall [T:! type] T as Z where .X = ((), {}) {}
+
+// --- fail_mismatch_tuple_literal_to_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let X:! Y;
+}
+
+impl ((), {}) as Y {}
+
+// CHECK:STDERR: fail_mismatch_tuple_literal_to_facet_value.carbon:[[@LINE+4]]:42: error: cannot convert type `({}, {})` into type implementing `Y` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: impl forall [T:! type] T as Z where .X = ({}, {}) {}
+// CHECK:STDERR:                                          ^~~~~~~~
+// CHECK:STDERR:
+impl forall [T:! type] T as Z where .X = ({}, {}) {}
+
+// --- struct_literal_to_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let X:! Y;
+}
+
+impl {} as Y {}
+
+// The struct literal converts implicitly to a type, and then to a facet value
+// satisfying `Y`.
+impl forall [T:! type] T as Z where .X = {} {}
+
+// --- complex_struct_literal_to_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let X:! Y;
+}
+
+impl {.a: (), .b: {}} as Y {}
+
+// The struct literal converts implicitly to a type, and then to a facet value
+// satisfying `Y`.
+impl forall [T:! type] T as Z where .X = {.a: (), .b: {}} {}
+
+// --- fail_mismatch_struct_literal_to_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let X:! Y;
+}
+
+impl {.a: (), .b: {}} as Y {}
+
+// CHECK:STDERR: fail_mismatch_struct_literal_to_facet_value.carbon:[[@LINE+4]]:42: error: cannot convert type `{.a: {}, .b: {}}` into type implementing `Y` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: impl forall [T:! type] T as Z where .X = {.a: {}, .b: {}} {}
+// CHECK:STDERR:                                          ^~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl forall [T:! type] T as Z where .X = {.a: {}, .b: {}} {}

--- a/toolchain/check/testdata/impl/assoc_const_self.carbon
+++ b/toolchain/check/testdata/impl/assoc_const_self.carbon
@@ -86,13 +86,10 @@ fn F(T:! I where {} impls Core.ImplicitAs(.Self) and .V = {});
 
 fn CallF() {
   // TODO: This call should eventually work.
-  // CHECK:STDERR: fail_todo_constrained_fn.carbon:[[@LINE+10]]:3: error: cannot implicitly convert non-type value of type `{}` into type implementing `I where .(I.V) = {} and...` [ConversionFailureNonTypeToFacet]
+  // CHECK:STDERR: fail_todo_constrained_fn.carbon:[[@LINE+7]]:3: error: cannot convert type `{}` into type implementing `I where .(I.V) = {} and...` [ConversionFailureTypeToFacet]
   // CHECK:STDERR:   F({});
   // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_todo_constrained_fn.carbon:[[@LINE+7]]:3: note: type `{}` does not implement interface `Core.ImplicitAs(I where .(I.V) = {} and...)` [MissingImplInMemberAccessNote]
-  // CHECK:STDERR:   F({});
-  // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_todo_constrained_fn.carbon:[[@LINE-10]]:6: note: initializing generic parameter `T` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fail_todo_constrained_fn.carbon:[[@LINE-7]]:6: note: initializing generic parameter `T` declared here [InitializingGenericParam]
   // CHECK:STDERR: fn F(T:! I where {} impls Core.ImplicitAs(.Self) and .V = {});
   // CHECK:STDERR:      ^
   // CHECK:STDERR:
@@ -822,8 +819,7 @@ fn CallF() {
 // CHECK:STDOUT: fn @CallF() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %.loc22_6: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc22_7: %I_where.type = converted %.loc22_6, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc22: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/assoc_const_self.carbon
+++ b/toolchain/check/testdata/impl/assoc_const_self.carbon
@@ -819,7 +819,7 @@ fn CallF() {
 // CHECK:STDOUT: fn @CallF() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %.loc22: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc19: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
We already had conversion in place to implicitly convert these literals to `type`. Now they can also convert to `FacetType`. This is done by first doing a conversion to `type` and then converting that type value to `FacetType`.