### PR TITLE
Update LLVM, picking up new `-disable-free` flag logic

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -113,8 +113,8 @@ bazel_dep(name = "zstd", version = "1.5.6", repo_name = "llvm_zstd")
 
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
-# HEAD as of 2025-03-07.
-llvm_project_version = "94c937d32195693bdcac34260d156b4ea55ca9d6"
+# HEAD as of 2025-04-17.
+llvm_project_version = "feb1fb5f0473eb949b35fb25e15c4d32465cd6d7"
 
 # Load a repository for the raw llvm-project, pre-overlay.
 http_archive(
@@ -126,7 +126,7 @@ http_archive(
         "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
         "@carbon//bazel/llvm_project:0003_Comment_out_unloaded_proto_library_dependencies.patch",
     ],
-    sha256 = "a39b09e3b1a5b0f48f250f8d4694f26298ebc67567c77d61bad785141a2d3bbe",
+    sha256 = "3d3621c8462e79713d0000778f1dc352c8596d904419c6a33a93a82e6dbe8b58",
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],
 )

--- a/toolchain/codegen/codegen.cpp
+++ b/toolchain/codegen/codegen.cpp
@@ -15,17 +15,18 @@
 
 namespace Carbon {
 
-auto CodeGen::Make(llvm::Module* module, llvm::StringRef target_triple,
+auto CodeGen::Make(llvm::Module* module, llvm::StringRef target_triple_str,
                    llvm::raw_pwrite_stream* errors) -> std::optional<CodeGen> {
   std::string error;
   const llvm::Target* target =
-      llvm::TargetRegistry::lookupTarget(target_triple, error);
+      llvm::TargetRegistry::lookupTarget(target_triple_str, error);
 
   if (!target) {
     *errors << "error: invalid target: " << error << "\n";
     return {};
   }
-  module->setTargetTriple(llvm::Triple(target_triple));
+  llvm::Triple target_triple(target_triple_str);
+  module->setTargetTriple(target_triple);
 
   constexpr llvm::StringLiteral CPU = "generic";
   constexpr llvm::StringLiteral Features = "";

--- a/toolchain/codegen/codegen.h
+++ b/toolchain/codegen/codegen.h
@@ -13,7 +13,7 @@ namespace Carbon {
 class CodeGen {
  public:
   // `module` and `errors` must not be null.
-  static auto Make(llvm::Module* module, llvm::StringRef target_triple,
+  static auto Make(llvm::Module* module, llvm::StringRef target_triple_str,
                    llvm::raw_pwrite_stream* errors) -> std::optional<CodeGen>;
 
   // Generates the object code file.

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -264,7 +264,7 @@ auto FileContext::BuildFunctionTypeInfo(const SemIR::Function& function,
   auto return_param_id = SemIR::InstId::None;
   if (return_info.has_return_slot()) {
     param_types.push_back(
-        llvm::PointerType::get(return_type, /*AddressSpace=*/0));
+        llvm::PointerType::get(llvm_context(), /*AddressSpace=*/0));
     return_param_id = function.return_slot_pattern_id;
     param_inst_ids.push_back(return_param_id);
   }


### PR DESCRIPTION
This requires fixing some uses of deprecated APIs.