### PR TITLE
Skip upfront emission of vtables for generic classes

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -732,6 +732,12 @@ auto FileContext::BuildVtable(const SemIR::Class& class_info)
     return nullptr;
   }
 
+  // Vtables can't be generated for generics, only for their specifics - and
+  // must be done lazily based on the use of those specifics.
+  if (class_info.generic_id != SemIR::GenericId::None) {
+    return nullptr;
+  }
+
   Mangler m(*this);
   std::string mangled_name = m.MangleVTable(class_info);
 

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -87,6 +87,13 @@ fn Use(b: Base) {
   b.F();
 }
 
+// --- generic.carbon
+
+library "[[@TEST_NAME]]";
+
+base class Base(T:! type) {
+  virtual fn F[self: Self]();
+}
 
 // CHECK:STDOUT: ; ModuleID = 'classes.carbon'
 // CHECK:STDOUT: source_filename = "classes.carbon"
@@ -316,3 +323,13 @@ fn Use(b: Base) {
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 9, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 8, column: 1, scope: !4)
+// CHECK:STDOUT: ; ModuleID = 'generic.carbon'
+// CHECK:STDOUT: source_filename = "generic.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "generic.carbon", directory: "")


### PR DESCRIPTION
These will need to be emitted lazily, as we do for functions - this
addresses the crash/removes the impossible (because we don't have a
specific) non-lazy path.
