### PR TITLE
Fix single-threaded runs for single test

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -356,7 +356,7 @@ static auto SingleThreaded(llvm::ArrayRef<FileTestInfo> tests) -> bool {
     found_test_to_run = true;
   }
   // 0 or 1 test will be run, so single-threaded.
-  return false;
+  return true;
 }
 
 // Runs the test in the section that would be inside a lock, possibly inside a


### PR DESCRIPTION
Typo fix.

```
$ bazel test :file_test_base_test --test_output=all
...
Running tests with 128 thread(s)
...
$ bazel test :file_test_base_test --test_output=all --test_arg=--gtest_filter=FileTestBaseTest.testing/file_test/testdata/two_files.carbon
...
Running tests with 1 thread(s)
...
```
