### PR TITLE
Adjust patch indent for buildifier

### DIFF
--- a/bazel/llvm_project/0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch
+++ b/bazel/llvm_project/0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch
@@ -26,9 +26,9 @@ index 9bdd454e1e36..0f30c21f63dc 100644
 +        "lib/fuzzer/Fuzzer*.def",
 +    ]),
 +    copts = [
-+      # Not using no-sanitize=address per https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
-+      "-fno-sanitize=memory,thread,undefined",
-+      "-fsanitize-coverage=0",
++        # Not using no-sanitize=address per https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
++        "-fno-sanitize=memory,thread,undefined",
++        "-fsanitize-coverage=0",
 +    ],
 +    includes = ["lib/fuzzer"],
 +)


### PR DESCRIPTION
Noticed from https://github.com/carbon-language/carbon-lang/pull/5338/files/5bac558d8d9bd8adbfdd5e9e44bf7a24d75e1d8d..e0d2089c86df1fb2e97c58d727b7f531f952829b#diff-bab6d9fe4c98e775b8a74edf0079d3052a11faf16c133b69172181744e537d81R25