### PR TITLE
Remove SemIR:: from most sem_ir files

### DIFF
--- a/toolchain/sem_ir/absolute_node_id.cpp
+++ b/toolchain/sem_ir/absolute_node_id.cpp
@@ -22,10 +22,10 @@ static auto FollowImportRef(
 
   auto import_loc_id = cursor_ir->insts().GetLocId(import_ir.decl_id);
   switch (import_loc_id.kind()) {
-    case SemIR::LocId::Kind::None:
+    case LocId::Kind::None:
       break;
 
-    case SemIR::LocId::Kind::ImportIRInstId: {
+    case LocId::Kind::ImportIRInstId: {
       // For implicit imports, we need to unravel the location a little
       // further.
       auto implicit_import_ir_inst =
@@ -34,7 +34,7 @@ static auto FollowImportRef(
           cursor_ir->import_irs().Get(implicit_import_ir_inst.ir_id);
       auto implicit_loc_id =
           implicit_ir.sem_ir->insts().GetLocId(implicit_import_ir_inst.inst_id);
-      CARBON_CHECK(implicit_loc_id.kind() == SemIR::LocId::Kind::NodeId,
+      CARBON_CHECK(implicit_loc_id.kind() == LocId::Kind::NodeId,
                    "Should only be one layer of implicit imports");
       absolute_node_ids.push_back(
           {.check_ir_id = implicit_ir.sem_ir->check_ir_id(),
@@ -42,10 +42,10 @@ static auto FollowImportRef(
       break;
     }
 
-    case SemIR::LocId::Kind::InstId:
+    case LocId::Kind::InstId:
       CARBON_FATAL("Unexpected LocId: {0}", import_loc_id);
 
-    case SemIR::LocId::Kind::NodeId: {
+    case LocId::Kind::NodeId: {
       // For imports in the current file, the location is simple.
       absolute_node_ids.push_back({.check_ir_id = cursor_ir->check_ir_id(),
                                    .node_id = import_loc_id.node_id()});
@@ -63,21 +63,21 @@ static auto HandleLocId(llvm::SmallVector<AbsoluteNodeId>& absolute_node_ids,
                         const File*& cursor_ir, InstId& cursor_inst_id,
                         LocId loc_id) -> bool {
   switch (loc_id.kind()) {
-    case SemIR::LocId::Kind::ImportIRInstId: {
+    case LocId::Kind::ImportIRInstId: {
       FollowImportRef(absolute_node_ids, cursor_ir, cursor_inst_id,
                       loc_id.import_ir_inst_id());
       return false;
     }
 
-    case SemIR::LocId::Kind::NodeId: {
+    case LocId::Kind::NodeId: {
       // Parse nodes always refer to the current IR.
       absolute_node_ids.push_back({.check_ir_id = cursor_ir->check_ir_id(),
                                    .node_id = loc_id.node_id()});
       return true;
     }
 
-    case SemIR::LocId::Kind::None:
-    case SemIR::LocId::Kind::InstId:
+    case LocId::Kind::None:
+    case LocId::Kind::InstId:
       CARBON_FATAL("Unexpected LocId: {0}", loc_id);
   }
 }
@@ -122,17 +122,17 @@ auto GetAbsoluteNodeId(const File* sem_ir, LocId loc_id)
     -> llvm::SmallVector<AbsoluteNodeId> {
   llvm::SmallVector<AbsoluteNodeId> absolute_node_ids;
   switch (loc_id.kind()) {
-    case SemIR::LocId::Kind::None:
+    case LocId::Kind::None:
       absolute_node_ids.push_back({.check_ir_id = sem_ir->check_ir_id(),
                                    .node_id = Parse::NodeId::None});
       break;
 
-    case SemIR::LocId::Kind::InstId:
+    case LocId::Kind::InstId:
       GetAbsoluteNodeIdImpl(absolute_node_ids, sem_ir, loc_id.inst_id());
       break;
 
-    case SemIR::LocId::Kind::ImportIRInstId:
-    case SemIR::LocId::Kind::NodeId: {
+    case LocId::Kind::ImportIRInstId:
+    case LocId::Kind::NodeId: {
       const File* cursor_ir = sem_ir;
       InstId cursor_inst_id = InstId::None;
       if (HandleLocId(absolute_node_ids, cursor_ir, cursor_inst_id, loc_id)) {

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -72,11 +72,10 @@ template <typename PointeeT>
 struct PointerTo {
   static auto Check(const File& sem_ir, ValidateState& state, TypeId type_id)
       -> bool {
-    if (!sem_ir.types().Is<SemIR::PointerType>(type_id)) {
+    if (!sem_ir.types().Is<PointerType>(type_id)) {
       return false;
     }
-    return SemIR::Check<PointeeT>(sem_ir, state,
-                                  sem_ir.GetPointeeType(type_id));
+    return Check<PointeeT>(sem_ir, state, sem_ir.GetPointeeType(type_id));
   }
 };
 
@@ -85,7 +84,7 @@ struct PointerTo {
 struct NoReturn {
   static auto Check(const File& sem_ir, ValidateState& /*state*/,
                     TypeId type_id) -> bool {
-    auto tuple = sem_ir.types().TryGetAs<SemIR::TupleType>(type_id);
+    auto tuple = sem_ir.types().TryGetAs<TupleType>(type_id);
     if (!tuple) {
       return false;
     }
@@ -575,11 +574,11 @@ auto BuiltinFunctionKind::IsValidType(const File& sem_ir,
 static auto AnyIntLiteralTypes(const File& sem_ir,
                                llvm::ArrayRef<InstId> arg_ids,
                                TypeId return_type_id) -> bool {
-  if (sem_ir.types().Is<SemIR::IntLiteralType>(return_type_id)) {
+  if (sem_ir.types().Is<IntLiteralType>(return_type_id)) {
     return true;
   }
   for (auto arg_id : arg_ids) {
-    if (sem_ir.types().Is<SemIR::IntLiteralType>(
+    if (sem_ir.types().Is<IntLiteralType>(
             sem_ir.insts().Get(arg_id).type_id())) {
       return true;
     }

--- a/toolchain/sem_ir/class.cpp
+++ b/toolchain/sem_ir/class.cpp
@@ -16,7 +16,7 @@ static auto GetFoundationType(const File& file, SpecificId specific_id,
   if (!inst_id.has_value()) {
     return TypeId::None;
   }
-  if (inst_id == SemIR::ErrorInst::InstId) {
+  if (inst_id == ErrorInst::InstId) {
     return ErrorInst::TypeId;
   }
   return TypeId::ForTypeConstant(GetConstantValueInSpecific(

--- a/toolchain/sem_ir/constant.cpp
+++ b/toolchain/sem_ir/constant.cpp
@@ -14,7 +14,7 @@ auto ConstantStore::GetOrAdd(Inst inst, ConstantDependence dependence)
     auto inst_id = sem_ir_->insts().AddInNoBlock(LocIdAndInst::NoLoc(inst));
     ConstantId const_id = ConstantId::None;
     if (dependence == ConstantDependence::None) {
-      const_id = SemIR::ConstantId::ForConcreteConstant(inst_id);
+      const_id = ConstantId::ForConcreteConstant(inst_id);
     } else {
       // The instruction in the constants store is an abstract symbolic
       // constant, not associated with any particular generic.

--- a/toolchain/sem_ir/copy_on_write_block.h
+++ b/toolchain/sem_ir/copy_on_write_block.h
@@ -19,7 +19,7 @@ namespace Carbon::SemIR {
 //
 // This is intended to avoid an unnecessary block allocation in the case where
 // the new block ends up being exactly the same as the original block.
-template <typename BlockIdType, auto (SemIR::File::*ValueStore)()>
+template <typename BlockIdType, auto (File::*ValueStore)()>
 class CopyOnWriteBlock {
  public:
   struct UninitializedBlock {
@@ -28,12 +28,12 @@ class CopyOnWriteBlock {
 
   // Constructs the block. `source_id` is used as the initial value of the
   // block. `file` must not be null.
-  explicit CopyOnWriteBlock(SemIR::File* file, BlockIdType source_id)
+  explicit CopyOnWriteBlock(File* file, BlockIdType source_id)
       : file_(file), source_id_(source_id) {}
 
   // Constructs the block, treating the original block as an uninitialized block
   // with `size` elements. `file` must not be null.
-  explicit CopyOnWriteBlock(SemIR::File* file, UninitializedBlock uninit)
+  explicit CopyOnWriteBlock(File* file, UninitializedBlock uninit)
       : file_(file),
         source_id_(BlockIdType::None),
         id_((file_->*ValueStore)().AddUninitialized(uninit.size)) {}
@@ -62,7 +62,7 @@ class CopyOnWriteBlock {
   }
 
  private:
-  SemIR::File* file_;
+  File* file_;
   BlockIdType source_id_;
   BlockIdType id_ = source_id_;
 };

--- a/toolchain/sem_ir/entity_with_params_base.h
+++ b/toolchain/sem_ir/entity_with_params_base.h
@@ -57,7 +57,7 @@ struct EntityWithParamsBase {
   }
 
   // Returns the instruction for the first declaration.
-  auto first_decl_id() const -> SemIR::InstId {
+  auto first_decl_id() const -> InstId {
     if (non_owning_decl_id.has_value()) {
       return non_owning_decl_id;
     }
@@ -66,7 +66,7 @@ struct EntityWithParamsBase {
   }
 
   // Returns the instruction for the latest declaration.
-  auto latest_decl_id() const -> SemIR::InstId {
+  auto latest_decl_id() const -> InstId {
     if (has_definition_started()) {
       return definition_id;
     }
@@ -115,7 +115,7 @@ struct EntityWithParamsBase {
   bool is_extern;
 
   // For an `extern library` declaration, the library name.
-  SemIR::LibraryNameId extern_library_id;
+  LibraryNameId extern_library_id;
 
   // The non-owning declaration of the entity, if present. This will be a
   // <entity>Decl.

--- a/toolchain/sem_ir/entry_point.cpp
+++ b/toolchain/sem_ir/entry_point.cpp
@@ -10,8 +10,7 @@ namespace Carbon::SemIR {
 
 static constexpr llvm::StringLiteral EntryPointFunction = "Run";
 
-auto IsEntryPoint(const SemIR::File& file, SemIR::FunctionId function_id)
-    -> bool {
+auto IsEntryPoint(const File& file, FunctionId function_id) -> bool {
   // TODO: Check if `file` is in the `Main` package.
   const auto& function = file.functions().Get(function_id);
   // TODO: Check if `function` is in a namespace.

--- a/toolchain/sem_ir/entry_point.h
+++ b/toolchain/sem_ir/entry_point.h
@@ -11,8 +11,7 @@ namespace Carbon::SemIR {
 
 // Returns whether the specified function is the entry point function for the
 // program, `Main.Run`.
-auto IsEntryPoint(const SemIR::File& file, SemIR::FunctionId function_id)
-    -> bool;
+auto IsEntryPoint(const File& file, FunctionId function_id) -> bool;
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/expr_info.cpp
+++ b/toolchain/sem_ir/expr_info.cpp
@@ -49,7 +49,7 @@ auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
       case ImportRefUnloaded::Kind:
       case ImportRefLoaded::Kind: {
         auto import_ir_inst = ir->import_ir_insts().Get(
-            untyped_inst.As<SemIR::AnyImportRef>().import_ir_inst_id);
+            untyped_inst.As<AnyImportRef>().import_ir_inst_id);
         ir = ir->import_irs().Get(import_ir_inst.ir_id).sem_ir;
         inst_id = import_ir_inst.inst_id;
         continue;

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -59,7 +59,7 @@ struct ExprRegion {
 class File : public Printable<File> {
  public:
   using IdentifiedFacetTypeStore =
-      RelationalValueStore<SemIR::FacetTypeId, SemIR::IdentifiedFacetTypeId>;
+      RelationalValueStore<FacetTypeId, IdentifiedFacetTypeId>;
 
   // Starts a new file for Check::CheckParseTree.
   explicit File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
@@ -103,12 +103,12 @@ class File : public Printable<File> {
 
   // Returns true if this file is an `impl`.
   auto is_impl() -> bool {
-    return import_irs().Get(SemIR::ImportIRId::ApiForImpl).sem_ir != nullptr;
+    return import_irs().Get(ImportIRId::ApiForImpl).sem_ir != nullptr;
   }
 
   auto check_ir_id() const -> CheckIRId { return check_ir_id_; }
   auto package_id() const -> PackageNameId { return package_id_; }
-  auto library_id() const -> SemIR::LibraryNameId { return library_id_; }
+  auto library_id() const -> LibraryNameId { return library_id_; }
 
   // Directly expose SharedValueStores members.
   auto identifiers() -> SharedValueStores::IdentifierStore& {

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -190,7 +190,7 @@ class FormatterImpl {
 
   // Determines whether the specified entity should be included in the formatted
   // output.
-  auto ShouldFormatEntity(SemIR::InstId decl_id) -> bool {
+  auto ShouldFormatEntity(InstId decl_id) -> bool {
     if (!decl_id.has_value()) {
       return true;
     }
@@ -564,7 +564,7 @@ class FormatterImpl {
     // that IR in the output before the `{` or `;`.
     if (first_owning_decl_id.has_value()) {
       auto loc_id = sem_ir_->insts().GetLocId(first_owning_decl_id);
-      if (loc_id.kind() == SemIR::LocId::Kind::ImportIRInstId) {
+      if (loc_id.kind() == LocId::Kind::ImportIRInstId) {
         auto import_ir_id =
             sem_ir_->import_ir_insts().Get(loc_id.import_ir_inst_id()).ir_id;
         const auto* import_file =
@@ -691,12 +691,12 @@ class FormatterImpl {
       out_ << ".";
       FormatName(name_id);
       switch (result.access_kind()) {
-        case SemIR::AccessKind::Public:
+        case AccessKind::Public:
           break;
-        case SemIR::AccessKind::Protected:
+        case AccessKind::Protected:
           out_ << " [protected]";
           break;
-        case SemIR::AccessKind::Private:
+        case AccessKind::Private:
           out_ << " [private]";
           break;
       }
@@ -914,7 +914,7 @@ class FormatterImpl {
       // don't include it in the argument list if there is no corresponding
       // specific, that is, when we're not in a generic context.
       if constexpr (std::is_same_v<typename Info::template ArgType<1>,
-                                   SemIR::SpecificId>) {
+                                   SpecificId>) {
         if (!Info::template Get<1>(inst).has_value()) {
           FormatArgs(Info::template Get<0>(inst));
           return;
@@ -1160,17 +1160,17 @@ class FormatterImpl {
       const auto& import_ir = sem_ir_->import_irs().Get(import_ir_inst.ir_id);
       auto loc_id = import_ir.sem_ir->insts().GetLocId(import_ir_inst.inst_id);
       switch (loc_id.kind()) {
-        case SemIR::LocId::Kind::None: {
+        case LocId::Kind::None: {
           out_ << import_ir_inst.inst_id << " [no loc]";
           break;
         }
-        case SemIR::LocId::Kind::ImportIRInstId: {
+        case LocId::Kind::ImportIRInstId: {
           // TODO: Probably don't want to format each indirection, but maybe
           // reuse GetCanonicalImportIRInst?
           out_ << import_ir_inst.inst_id << " [indirect]";
           break;
         }
-        case SemIR::LocId::Kind::NodeId: {
+        case LocId::Kind::NodeId: {
           // Formats a NodeId from the import.
           const auto& tree = import_ir.sem_ir->parse_tree();
           auto token = tree.node_token(loc_id.node_id());
@@ -1178,7 +1178,7 @@ class FormatterImpl {
                << tree.tokens().GetColumnNumber(token);
           break;
         }
-        case SemIR::LocId::Kind::InstId:
+        case LocId::Kind::InstId:
           CARBON_FATAL("Unexpected LocId: {0}", loc_id);
       }
     }

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -55,7 +55,7 @@ auto GetCalleeFunction(const File& sem_ir, InstId callee_id,
 
   auto fn_type = fn_type_inst.TryAs<FunctionType>();
   if (!fn_type) {
-    result.is_error = fn_type_inst.Is<SemIR::ErrorInst>();
+    result.is_error = fn_type_inst.Is<ErrorInst>();
     return result;
   }
 
@@ -70,12 +70,12 @@ auto Function::GetParamPatternInfoFromPatternId(const File& sem_ir,
   auto inst_id = pattern_id;
   auto inst = sem_ir.insts().Get(inst_id);
 
-  if (auto addr_pattern = inst.TryAs<SemIR::AddrPattern>()) {
+  if (auto addr_pattern = inst.TryAs<AddrPattern>()) {
     inst_id = addr_pattern->inner_id;
     inst = sem_ir.insts().Get(inst_id);
   }
 
-  auto param_pattern_inst = inst.TryAs<SemIR::AnyParamPattern>();
+  auto param_pattern_inst = inst.TryAs<AnyParamPattern>();
   if (!param_pattern_inst) {
     return std::nullopt;
   }

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -50,7 +50,7 @@ struct FunctionFields {
 
   // The implicit self parameter, if any, in implicit_param_patterns_id from
   // EntityWithParamsBase.
-  InstId self_param_id = SemIR::InstId::None;
+  InstId self_param_id = InstId::None;
 
   // The following member is set on the first call to the function, or at the
   // point where the function is defined.
@@ -126,16 +126,16 @@ class File;
 
 struct CalleeFunction {
   // The function. `None` if not a function.
-  SemIR::FunctionId function_id;
+  FunctionId function_id;
   // The specific that contains the function.
-  SemIR::SpecificId enclosing_specific_id;
+  SpecificId enclosing_specific_id;
   // The specific for the callee itself, in a resolved call.
-  SemIR::SpecificId resolved_specific_id;
+  SpecificId resolved_specific_id;
   // The bound `Self` type or facet value. `None` if not a bound interface
   // member.
-  SemIR::InstId self_type_id;
+  InstId self_type_id;
   // The bound `self` parameter. `None` if not a method.
-  SemIR::InstId self_id;
+  InstId self_id;
   // True if an error instruction was found.
   bool is_error;
 };

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -135,7 +135,7 @@ class TypeEnum : public Printable<TypeEnum<Types...>> {
 //
 // As instruction operands, the types listed here can appear as fields of typed
 // instructions (`toolchain/sem_ir/typed_insts.h`) and must implement the
-// `FromRaw` and `ToRaw` protocol in `SemIR::Inst`. In most cases this is done
+// `FromRaw` and `ToRaw` protocol in `Inst`. In most cases this is done
 // by inheriting from `IdBase` or `IndexBase`.
 //
 // clang-format off: We want one per line.

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -135,8 +135,8 @@ class TypeEnum : public Printable<TypeEnum<Types...>> {
 //
 // As instruction operands, the types listed here can appear as fields of typed
 // instructions (`toolchain/sem_ir/typed_insts.h`) and must implement the
-// `FromRaw` and `ToRaw` protocol in `Inst`. In most cases this is done
-// by inheriting from `IdBase` or `IndexBase`.
+// `FromRaw` and `ToRaw` protocol in `Inst`. In most cases this is done by
+// inheriting from `IdBase` or `IndexBase`.
 //
 // clang-format off: We want one per line.
 using IdKind = TypeEnum<

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -622,11 +622,11 @@ constexpr InstBlockId InstBlockId::Unreachable = InstBlockId(NoneIndex - 1);
 class InstBlockIdOrError {
  public:
   // NOLINTNEXTLINE(google-explicit-constructor)
-  InstBlockIdOrError(SemIR::InstBlockId inst_block_id)
+  InstBlockIdOrError(InstBlockId inst_block_id)
       : InstBlockIdOrError(inst_block_id, false) {}
 
   static auto MakeError() -> InstBlockIdOrError {
-    return {SemIR::InstBlockId::None, true};
+    return {InstBlockId::None, true};
   }
 
   // Returns whether this class contains either an InstBlockId (other than
@@ -646,16 +646,16 @@ class InstBlockIdOrError {
   // false.
   //
   // Only valid to call if `has_error_value()` is false.
-  auto inst_block_id() const -> SemIR::InstBlockId {
+  auto inst_block_id() const -> InstBlockId {
     CARBON_CHECK(!has_error_value());
     return inst_block_id_;
   }
 
  private:
-  InstBlockIdOrError(SemIR::InstBlockId inst_block_id, bool error)
+  InstBlockIdOrError(InstBlockId inst_block_id, bool error)
       : inst_block_id_(inst_block_id), error_(error) {}
 
-  SemIR::InstBlockId inst_block_id_;
+  InstBlockId inst_block_id_;
   bool error_;
 };
 

--- a/toolchain/sem_ir/ids_test.cpp
+++ b/toolchain/sem_ir/ids_test.cpp
@@ -82,7 +82,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(LocIdAsNoneTestWithParam, Test) {
   auto [_, loc_id] = BuildIdAndLocId<Parse::NodeId>();
   EXPECT_FALSE(loc_id.has_value());
-  EXPECT_THAT(loc_id.kind(), Eq(SemIR::LocId::Kind::None));
+  EXPECT_THAT(loc_id.kind(), Eq(LocId::Kind::None));
   EXPECT_FALSE(loc_id.is_implicit());
   EXPECT_THAT(loc_id.import_ir_inst_id(), Eq(ImportIRInstId::None));
   EXPECT_THAT(loc_id.inst_id(), Eq(InstId::None));
@@ -99,7 +99,7 @@ INSTANTIATE_TEST_SUITE_P(Test, LocIdAsImportIRInstIdTest,
 TEST_P(LocIdAsImportIRInstIdTest, Test) {
   auto [import_ir_inst_id, loc_id] = BuildIdAndLocId<ImportIRInstId>();
   EXPECT_TRUE(loc_id.has_value());
-  ASSERT_THAT(loc_id.kind(), Eq(SemIR::LocId::Kind::ImportIRInstId));
+  ASSERT_THAT(loc_id.kind(), Eq(LocId::Kind::ImportIRInstId));
   EXPECT_THAT(loc_id.import_ir_inst_id(), import_ir_inst_id);
   EXPECT_FALSE(loc_id.is_implicit());
   EXPECT_THAT(loc_id.is_token_only(), Eq(is_token_only()));
@@ -115,7 +115,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(LocIdAsInstIdTest, Test) {
   auto [inst_id, loc_id] = BuildIdAndLocId<InstId>();
   EXPECT_TRUE(loc_id.has_value());
-  ASSERT_THAT(loc_id.kind(), Eq(SemIR::LocId::Kind::InstId));
+  ASSERT_THAT(loc_id.kind(), Eq(LocId::Kind::InstId));
   EXPECT_THAT(loc_id.inst_id(), inst_id);
   // Note that `is_implicit` and `is_token_only` are invalid to use with
   // `InstId`.
@@ -129,7 +129,7 @@ INSTANTIATE_TEST_SUITE_P(Test, LocIdAsNodeIdTest,
 TEST_P(LocIdAsNodeIdTest, Test) {
   auto [node_id, loc_id] = BuildIdAndLocId<Parse::NodeId>();
   EXPECT_TRUE(loc_id.has_value());
-  ASSERT_THAT(loc_id.kind(), Eq(SemIR::LocId::Kind::NodeId));
+  ASSERT_THAT(loc_id.kind(), Eq(LocId::Kind::NodeId));
   EXPECT_THAT(loc_id.node_id(), node_id);
   EXPECT_THAT(loc_id.is_implicit(), Eq(is_implicit()));
   EXPECT_THAT(loc_id.is_token_only(), Eq(is_token_only()));

--- a/toolchain/sem_ir/impl.cpp
+++ b/toolchain/sem_ir/impl.cpp
@@ -14,9 +14,8 @@ auto ImplStore::GetOrAddLookupBucket(const Impl& impl) -> LookupBucketRef {
   SpecificId specific_id = SpecificId::None;
   auto facet_type_id = TypeId::ForTypeConstant(
       sem_ir_.constant_values().Get(impl.constraint_id));
-  if (auto facet_type =
-          sem_ir_.types().TryGetAs<SemIR::FacetType>(facet_type_id)) {
-    const SemIR::FacetTypeInfo& facet_type_info =
+  if (auto facet_type = sem_ir_.types().TryGetAs<FacetType>(facet_type_id)) {
+    const FacetTypeInfo& facet_type_info =
         sem_ir_.facet_types().Get(facet_type->facet_type_id);
     if (auto interface_type = facet_type_info.TryAsSingleInterface()) {
       interface_id = interface_type->interface_id;

--- a/toolchain/sem_ir/impl.h
+++ b/toolchain/sem_ir/impl.h
@@ -24,7 +24,7 @@ struct ImplFields {
   // The single interface to implement from `constraint_id`.
   // The members are `None` if `constraint_id` isn't complete or doesn't
   // correspond to a single interface.
-  SemIR::SpecificInterface interface;
+  SpecificInterface interface;
 
   // The witness for the impl. This can be `BuiltinErrorInst` or an import
   // reference. Note that the entries in the witness are updated at the end of

--- a/toolchain/sem_ir/import_ir.h
+++ b/toolchain/sem_ir/import_ir.h
@@ -40,8 +40,7 @@ class ImportIRInst : public Printable<ImportIRInst> {
 
   // Constructor for a `Cpp` import.
   explicit ImportIRInst(ClangSourceLocId clang_source_loc_id)
-      : ir_id_(SemIR::ImportIRId::Cpp),
-        clang_source_loc_id_(clang_source_loc_id) {}
+      : ir_id_(ImportIRId::Cpp), clang_source_loc_id_(clang_source_loc_id) {}
 
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{ir_id: " << ir_id() << ", ";

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -136,14 +136,14 @@ class Inst : public Printable<Inst> {
     // Converts to `IdT`, validating the `kind` matches.
     template <typename IdT>
     auto As() const -> IdT {
-      CARBON_DCHECK(kind_ == SemIR::IdKind::For<IdT>);
+      CARBON_DCHECK(kind_ == IdKind::For<IdT>);
       return IdT(value_);
     }
 
     // Converts to `IdT`, returning nullopt if the kind is incorrect.
     template <typename IdT>
     auto TryAs() const -> std::optional<IdT> {
-      if (kind_ != SemIR::IdKind::For<IdT>) {
+      if (kind_ != IdKind::For<IdT>) {
         return std::nullopt;
       }
       return IdT(value_);
@@ -369,7 +369,7 @@ struct LocIdAndInst {
   // node.
   template <typename InstT>
     requires(Internal::HasUntypedNodeId<InstT>)
-  LocIdAndInst(SemIR::LocId loc_id, InstT inst) : loc_id(loc_id), inst(inst) {}
+  LocIdAndInst(LocId loc_id, InstT inst) : loc_id(loc_id), inst(inst) {}
 
   LocId loc_id;
   Inst inst;
@@ -504,7 +504,7 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
   // Sets the contents of a placeholder block to the given content.
   auto ReplacePlaceholder(InstBlockId block_id, llvm::ArrayRef<InstId> content)
       -> void {
-    CARBON_CHECK(block_id != SemIR::InstBlockId::Empty);
+    CARBON_CHECK(block_id != InstBlockId::Empty);
     CARBON_CHECK(Get(block_id).empty(),
                  "inst block content set more than once");
     values().Get(block_id) = AllocateCopy(content);

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -319,19 +319,19 @@ struct Worklist {
   // null IdKind as a parameter in order to get the type pack.
   template <typename... Types>
   static constexpr auto MakeAddTable(TypeEnum<Types...>* /*id_kind*/)
-      -> std::array<AddFnT*, SemIR::IdKind::NumValues> {
-    std::array<AddFnT*, SemIR::IdKind::NumValues> table = {};
-    ((table[SemIR::IdKind::template For<Types>.ToIndex()] =
+      -> std::array<AddFnT*, IdKind::NumValues> {
+    std::array<AddFnT*, IdKind::NumValues> table = {};
+    ((table[IdKind::template For<Types>.ToIndex()] =
           [](Worklist& worklist, int32_t arg) {
             worklist.Add(Inst::FromRaw<Types>(arg));
           }),
      ...);
-    table[SemIR::IdKind::Invalid.ToIndex()] = [](Worklist& /*worklist*/,
-                                                 int32_t /*arg*/) {
+    table[IdKind::Invalid.ToIndex()] = [](Worklist& /*worklist*/,
+                                          int32_t /*arg*/) {
       CARBON_FATAL("Unexpected invalid argument kind");
     };
-    table[SemIR::IdKind::None.ToIndex()] = [](Worklist& /*worklist*/,
-                                              int32_t /*arg*/) {};
+    table[IdKind::None.ToIndex()] = [](Worklist& /*worklist*/,
+                                       int32_t /*arg*/) {};
     return table;
   }
 

--- a/toolchain/sem_ir/inst_kind.cpp
+++ b/toolchain/sem_ir/inst_kind.cpp
@@ -15,7 +15,7 @@ CARBON_DEFINE_ENUM_CLASS_NAMES(InstKind) = {
 
 auto InstKind::definition_info(InstKind inst_kind) -> const DefinitionInfo& {
   static constexpr InstKind::DefinitionInfo DefinitionInfos[] = {
-#define CARBON_SEM_IR_INST_KIND(Name) Name::Kind.info_,
+#define CARBON_SEM_IR_INST_KIND(Name) SemIR::Name::Kind.info_,
 #include "toolchain/sem_ir/inst_kind.def"
   };
   return DefinitionInfos[inst_kind.AsInt()];
@@ -23,8 +23,9 @@ auto InstKind::definition_info(InstKind inst_kind) -> const DefinitionInfo& {
 
 auto InstKind::value_kind() const -> InstValueKind {
   static constexpr InstValueKind Table[] = {
-#define CARBON_SEM_IR_INST_KIND(Name) \
-  Internal::HasTypeIdMember<Name> ? InstValueKind::Typed : InstValueKind::None,
+#define CARBON_SEM_IR_INST_KIND(Name)                           \
+  Internal::HasTypeIdMember<SemIR::Name> ? InstValueKind::Typed \
+                                         : InstValueKind::None,
 #include "toolchain/sem_ir/inst_kind.def"
   };
   return Table[AsInt()];

--- a/toolchain/sem_ir/inst_kind.cpp
+++ b/toolchain/sem_ir/inst_kind.cpp
@@ -15,7 +15,7 @@ CARBON_DEFINE_ENUM_CLASS_NAMES(InstKind) = {
 
 auto InstKind::definition_info(InstKind inst_kind) -> const DefinitionInfo& {
   static constexpr InstKind::DefinitionInfo DefinitionInfos[] = {
-#define CARBON_SEM_IR_INST_KIND(Name) SemIR::Name::Kind.info_,
+#define CARBON_SEM_IR_INST_KIND(Name) Name::Kind.info_,
 #include "toolchain/sem_ir/inst_kind.def"
   };
   return DefinitionInfos[inst_kind.AsInt()];
@@ -23,9 +23,8 @@ auto InstKind::definition_info(InstKind inst_kind) -> const DefinitionInfo& {
 
 auto InstKind::value_kind() const -> InstValueKind {
   static constexpr InstValueKind Table[] = {
-#define CARBON_SEM_IR_INST_KIND(Name)                           \
-  Internal::HasTypeIdMember<SemIR::Name> ? InstValueKind::Typed \
-                                         : InstValueKind::None,
+#define CARBON_SEM_IR_INST_KIND(Name) \
+  Internal::HasTypeIdMember<Name> ? InstValueKind::Typed : InstValueKind::None,
 #include "toolchain/sem_ir/inst_kind.def"
   };
   return Table[AsInt()];

--- a/toolchain/sem_ir/inst_namer.h
+++ b/toolchain/sem_ir/inst_namer.h
@@ -136,10 +136,9 @@ class InstNamer {
       return Name(allocated.insert({name, NameResult()}).first);
     }
 
-    auto AllocateName(
-        const InstNamer& inst_namer,
-        std::variant<SemIR::LocId, uint64_t> loc_id_or_fingerprint,
-        std::string name) -> Name;
+    auto AllocateName(const InstNamer& inst_namer,
+                      std::variant<LocId, uint64_t> loc_id_or_fingerprint,
+                      std::string name) -> Name;
   };
 
   // A named scope that contains named entities.
@@ -157,15 +156,14 @@ class InstNamer {
     return scopes_[static_cast<int>(scope_id)];
   }
 
-  auto AddBlockLabel(ScopeId scope_id, InstBlockId block_id,
-                     std::string name = "",
-                     std::variant<SemIR::LocId, uint64_t>
-                         loc_id_or_fingerprint = SemIR::LocId::None) -> void;
+  auto AddBlockLabel(
+      ScopeId scope_id, InstBlockId block_id, std::string name = "",
+      std::variant<LocId, uint64_t> loc_id_or_fingerprint = LocId::None)
+      -> void;
 
   // Finds and adds a suitable block label for the given SemIR instruction that
   // represents some kind of branch.
-  auto AddBlockLabel(ScopeId scope_id, SemIR::LocId loc_id, AnyBranch branch)
-      -> void;
+  auto AddBlockLabel(ScopeId scope_id, LocId loc_id, AnyBranch branch) -> void;
 
   auto CollectNamesInBlock(ScopeId scope_id, InstBlockId block_id) -> void;
 

--- a/toolchain/sem_ir/name.h
+++ b/toolchain/sem_ir/name.h
@@ -18,7 +18,7 @@ namespace Carbon::SemIR {
 // as `NameId`s with the same non-negative index as the `IdentifierId` of the
 // identifier. Special names are represented as `NameId`s with a negative index.
 //
-// `SemIR::NameId` values should be obtained by using `NameId::ForIdentifier`
+// `NameId` values should be obtained by using `NameId::ForIdentifier`
 // or the named constants such as `NameId::SelfValue`.
 //
 // As we do not require any additional explicit storage for names, this is

--- a/toolchain/sem_ir/name.h
+++ b/toolchain/sem_ir/name.h
@@ -18,8 +18,8 @@ namespace Carbon::SemIR {
 // as `NameId`s with the same non-negative index as the `IdentifierId` of the
 // identifier. Special names are represented as `NameId`s with a negative index.
 //
-// `NameId` values should be obtained by using `NameId::ForIdentifier`
-// or the named constants such as `NameId::SelfValue`.
+// `NameId` values should be obtained by using `NameId::ForIdentifier` or the
+// named constants such as `NameId::SelfValue`.
 //
 // As we do not require any additional explicit storage for names, this is
 // currently a wrapper around an identifier store that has no state of its own.

--- a/toolchain/sem_ir/pattern.h
+++ b/toolchain/sem_ir/pattern.h
@@ -23,7 +23,7 @@ auto IsSelfPattern(const File& sem_ir, InstId pattern_id) -> bool;
 // This should only be used for decorative purposes such as SemIR
 // pretty-printing or LLVM parameter naming.
 auto GetPrettyNameFromPatternId(const File& sem_ir, InstId pattern_id)
-    -> SemIR::NameId;
+    -> NameId;
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/stringify.h
+++ b/toolchain/sem_ir/stringify.h
@@ -21,7 +21,7 @@ auto StringifyConstantInst(const File& sem_ir, InstId outer_inst_id)
 
 // Produces a string version of the name of a specific. Generally, this should
 // not be called directly. To format a string into a diagnostic, use a
-// diagnostic parameter of type `SemIR::SpecificId`.
+// diagnostic parameter of type `SpecificId`.
 auto StringifySpecific(const File& sem_ir, SpecificId specific_id)
     -> std::string;
 

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -68,7 +68,7 @@ class TypeStore : public Yaml::Printable<TypeStore> {
   // GetAsTypeInstId().
   auto GetBlockAsTypeInstIds(llvm::ArrayRef<InstId> array
                              [[clang::lifetimebound]]) const -> auto {
-    return llvm::map_range(array, [&](SemIR::InstId type_inst_id) {
+    return llvm::map_range(array, [&](InstId type_inst_id) {
       return GetAsTypeInstId(type_inst_id);
     });
   }
@@ -77,7 +77,7 @@ class TypeStore : public Yaml::Printable<TypeStore> {
   // GetTypeIdForTypeInstId().
   auto GetBlockAsTypeIds(llvm::ArrayRef<InstId> array
                          [[clang::lifetimebound]]) const -> auto {
-    return llvm::map_range(array, [&](SemIR::InstId type_inst_id) {
+    return llvm::map_range(array, [&](InstId type_inst_id) {
       return GetTypeIdForTypeInstId(type_inst_id);
     });
   }
@@ -166,8 +166,8 @@ class TypeStore : public Yaml::Printable<TypeStore> {
   auto GetIntTypeInfo(TypeId int_type_id) const -> IntTypeInfo;
 
   // Returns whether `type_id` represents a facet type.
-  auto IsFacetType(SemIR::TypeId type_id) const -> bool {
-    return type_id == SemIR::TypeType::TypeId || Is<SemIR::FacetType>(type_id);
+  auto IsFacetType(TypeId type_id) const -> bool {
+    return type_id == TypeType::TypeId || Is<FacetType>(type_id);
   }
 
   // Returns a list of types that were completed in this file, in the order in

--- a/toolchain/sem_ir/type_info.cpp
+++ b/toolchain/sem_ir/type_info.cpp
@@ -45,8 +45,8 @@ auto ValueRepr::IsCopyOfObjectRepr(const File& file, TypeId orig_type_id) const
     -> bool {
   // If aggregate_kind is ValueAggregate, then the representations are known to
   // be different in some way even, if they're represented by the same type.
-  return (kind == SemIR::ValueRepr::Copy || kind == SemIR::ValueRepr::None) &&
-         aggregate_kind != SemIR::ValueRepr::ValueAggregate &&
+  return (kind == ValueRepr::Copy || kind == ValueRepr::None) &&
+         aggregate_kind != ValueRepr::ValueAggregate &&
          type_id == file.types().GetObjectRepr(orig_type_id);
 }
 

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -80,7 +80,7 @@ struct CompleteTypeInfo : public Printable<CompleteTypeInfo> {
   ValueRepr value_repr = ValueRepr();
 
   // If this type is abstract, this is id of an abstract class it uses.
-  SemIR::ClassId abstract_class_id = SemIR::ClassId::None;
+  ClassId abstract_class_id = ClassId::None;
 };
 
 // The initializing representation to use when returning by value.

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -27,9 +27,9 @@
 //   listed in the `IdKind` type-enum, typically derived from `IdBase`.
 //
 // The field names here matter -- the fields must have the names specified
-// above, when present. When converting to a `Inst`, the `kind` and
-// `type_id` fields will become the kind and type associated with the
-// type-erased instruction.
+// above, when present. When converting to a `Inst`, the `kind` and `type_id`
+// fields will become the kind and type associated with the type-erased
+// instruction.
 //
 // Each type that describes a single kind of instructions provides a constant
 // `Kind` that associates the type with a particular member of the `InstKind`

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -24,10 +24,10 @@
 //   value. This includes instructions that produce an abstract value, such as a
 //   `Namespace`, for which a placeholder type should be used.
 // - Up to two members describing the contents of the struct. These are types
-//   listed in the `SemIR::IdKind` type-enum, typically derived from `IdBase`.
+//   listed in the `IdKind` type-enum, typically derived from `IdBase`.
 //
 // The field names here matter -- the fields must have the names specified
-// above, when present. When converting to a `SemIR::Inst`, the `kind` and
+// above, when present. When converting to a `Inst`, the `kind` and
 // `type_id` fields will become the kind and type associated with the
 // type-erased instruction.
 //

--- a/toolchain/sem_ir/typed_insts_test.cpp
+++ b/toolchain/sem_ir/typed_insts_test.cpp
@@ -11,7 +11,7 @@
 
 namespace Carbon::SemIR {
 
-// A friend of `SemIR::Inst` that is used to pierce the abstraction.
+// A friend of `Inst` that is used to pierce the abstraction.
 class InstTestHelper {
  public:
   static auto MakeInst(InstKind inst_kind, TypeId type_id, int32_t arg0,


### PR DESCRIPTION
This is just cleanup, at least some from LocId replacements.