### PR TITLE
Default FileTest to brief output

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -487,6 +487,11 @@ auto FileTestEventListener::OnTestProgramStart(
 
 // Implements main() within the Carbon::Testing namespace for convenience.
 static auto Main(int argc, char** argv) -> ErrorOr<int> {
+  // Default to brief because we expect lots of tests, and `FileTestBase`
+  // provides some summaries. Note `--test_arg=--gtest_brief=1` works to restore
+  // output.
+  absl::SetFlag(&FLAGS_gtest_brief, 1);
+
   Carbon::InitLLVM init_llvm(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   auto args = absl::ParseCommandLine(argc, argv);

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -488,7 +488,7 @@ auto FileTestEventListener::OnTestProgramStart(
 // Implements main() within the Carbon::Testing namespace for convenience.
 static auto Main(int argc, char** argv) -> ErrorOr<int> {
   // Default to brief because we expect lots of tests, and `FileTestBase`
-  // provides some summaries. Note `--test_arg=--gtest_brief=1` works to restore
+  // provides some summaries. Note `--test_arg=--gtest_brief=0` works to restore
   // output.
   absl::SetFlag(&FLAGS_gtest_brief, 1);
 


### PR DESCRIPTION
Trying to make it easier to skim test output for failures. Note this excludes all the RUN and OK. Failing tests may still be verbose due to the diff printed, but CHECK-fails should become short.

```
==================== Test output for //toolchain/testing:file_test:
Running tests with 128 thread(s)
...
Done!
[==========] 1272 tests from 1 test suite ran. (688 ms total)
[  PASSED  ] 1272 tests.
================================================================================
```