### PR TITLE
Disable clang-tidy `performance-enum-size`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -81,6 +81,8 @@ WarningsAsErrors: '*'
 # - '-modernize-use-nodiscard'
 # # We aren't using the ranges library due to performance concerns.
 # - '-modernize-use-ranges'
+# # Low value compared to the engineering cost.
+# - '-performance-enum-size'
 # # Duplicates `modernize-pass-by-value`.
 # - '-performance-unnecessary-value-param'
 # # Warns on enums which use the `LastValue = Value` pattern if all the other
@@ -114,7 +116,7 @@ Checks:
   -google-readability-function-size, -google-readability-todo,
   -misc-confusable-identifiers, -misc-use-internal-linkage,
   -modernize-avoid-c-arrays, -modernize-use-designated-initializers,
-  -modernize-use-nodiscard, -modernize-use-ranges,
+  -modernize-use-nodiscard, -modernize-use-ranges, -performance-enum-size,
   -performance-unnecessary-value-param, -readability-enum-initial-value,
   -readability-function-cognitive-complexity, -readability-magic-numbers,
   -readability-redundant-member-init, -readability-suspicious-call-argument


### PR DESCRIPTION
See discussion in https://github.com/carbon-language/carbon-lang/pull/5352 and https://discord.com/channels/655572317891461132/655578254970716160/1365319438198378577