### PR TITLE
Remove exceptions for `performance-enum-size`

### DIFF
--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -25,7 +25,6 @@ class KeywordModifierSet {
   // instances just due to the duplication of declarations that would cause.
   //
   // We expect this to grow, so are using a bigger size than needed.
-  // NOLINTNEXTLINE(performance-enum-size)
   enum RawEnumType : uint32_t {
     // At most one of these access modifiers allowed for a given declaration,
     // and if present it must be first:

--- a/toolchain/diagnostics/diagnostic_kind.h
+++ b/toolchain/diagnostics/diagnostic_kind.h
@@ -13,7 +13,6 @@ namespace Carbon::Diagnostics {
 
 // Although this currently fits into int8_t, it shouldn't be expected to
 // long-term.
-// NOLINTNEXTLINE(performance-enum-size)
 CARBON_DEFINE_RAW_ENUM_CLASS(Kind, uint16_t) {
 #define CARBON_DIAGNOSTIC_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/diagnostics/diagnostic_kind.def"

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -23,6 +23,8 @@ namespace Carbon::Parse {
 // used sparingly, and unbounded lookahead should be avoided.
 //
 // TODO: Decide whether we want to avoid lookahead altogether.
+//
+// The size of the enum deliberately matches the index size.
 enum class Lookahead : int32_t {
   CurrentToken = 0,
   NextToken = 1,

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -23,8 +23,6 @@ namespace Carbon::Parse {
 // used sparingly, and unbounded lookahead should be avoided.
 //
 // TODO: Decide whether we want to avoid lookahead altogether.
-//
-// NOLINTNEXTLINE(performance-enum-size): Deliberately matches index size.
 enum class Lookahead : int32_t {
   CurrentToken = 0,
   NextToken = 1,

--- a/toolchain/parse/node_category.h
+++ b/toolchain/parse/node_category.h
@@ -49,7 +49,6 @@ class NodeCategory : public Printable<NodeCategory> {
   // instances just due to the duplication of declarations that would cause.
   //
   // We expect this to grow, so are using a bigger size than needed.
-  // NOLINTNEXTLINE(performance-enum-size)
   enum RawEnumType : uint32_t {
 #define CARBON_NODE_CATEGORY_FOR_BIT_MASK(Name) \
   Name = 1 << static_cast<uint8_t>(BitShift::Name),

--- a/toolchain/sem_ir/inst_namer.h
+++ b/toolchain/sem_ir/inst_namer.h
@@ -18,7 +18,6 @@ namespace Carbon::SemIR {
 class InstNamer {
  public:
   // int32_t matches the input value size.
-  // NOLINTNEXTLINE(performance-enum-size)
   enum class ScopeId : int32_t {
     None = -1,
     File = 0,


### PR DESCRIPTION
This is a followup of `performance-enum-size` disablement in https://github.com/carbon-language/carbon-lang/pull/5368.