### PR TITLE
Avoid ToTokenOnly for the AddrSelfIsNonRef diagnostic

### DIFF
--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -261,9 +261,7 @@ auto MatchContext::DoEmitPatternMatch(Context& context,
     default:
       CARBON_DIAGNOSTIC(AddrSelfIsNonRef, Error,
                         "`addr self` method cannot be invoked on a value");
-      context.emitter().Emit(
-          context.insts().GetCanonicalLocId(entry.scrutinee_id).ToTokenOnly(),
-          AddrSelfIsNonRef);
+      context.emitter().Emit(entry.scrutinee_id, AddrSelfIsNonRef);
       // Add fake reference expression to preserve invariants.
       auto scrutinee = context.insts().GetWithLocId(entry.scrutinee_id);
       scrutinee_ref_id = AddInstWithCleanup<SemIR::TemporaryStorage>(

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -18,9 +18,9 @@ class B {
 
 fn F(s: {.a: A}, b: B) {
   // `s` has only a value representation, so this must be invalid.
-  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+7]]:4: error: `addr self` method cannot be invoked on a value [AddrSelfIsNonRef]
+  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+7]]:3: error: `addr self` method cannot be invoked on a value [AddrSelfIsNonRef]
   // CHECK:STDERR:   s.a.F();
-  // CHECK:STDERR:    ^
+  // CHECK:STDERR:   ^~~
   // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE-12]]:8: note: initializing function parameter [InCallToFunctionParam]
   // CHECK:STDERR:   fn F[addr self: A*]();
   // CHECK:STDERR:        ^~~~~~~~~~~~~
@@ -29,9 +29,9 @@ fn F(s: {.a: A}, b: B) {
 
   // `b` has an object representation for `A`, but this is still invalid for
   // consistency.
-  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+7]]:4: error: `addr self` method cannot be invoked on a value [AddrSelfIsNonRef]
+  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+7]]:3: error: `addr self` method cannot be invoked on a value [AddrSelfIsNonRef]
   // CHECK:STDERR:   b.a.F();
-  // CHECK:STDERR:    ^
+  // CHECK:STDERR:   ^~~
   // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE-23]]:8: note: initializing function parameter [InCallToFunctionParam]
   // CHECK:STDERR:   fn F[addr self: A*]();
   // CHECK:STDERR:        ^~~~~~~~~~~~~


### PR DESCRIPTION
The location of the diagnostic is an instruction id, not a parse node.
Converting to a parse node to call ToTokenOnly will drop the descendents
of the instruction being diagnosed, but the diagnostic is about the
whole instruction not just the root parse node of whatever instruction
it happens to be.
