### PR TITLE
Clarify `ImportIRInstId` isn't expected in `GetAbsoluteNodeId()`

### DIFF
--- a/toolchain/sem_ir/absolute_node_id.cpp
+++ b/toolchain/sem_ir/absolute_node_id.cpp
@@ -133,6 +133,9 @@ auto GetAbsoluteNodeId(const File* sem_ir, LocId loc_id)
       break;
 
     case LocId::Kind::ImportIRInstId:
+      CARBON_FATAL("Unexpected ImportIRInstId location");
+      break;
+
     case LocId::Kind::NodeId: {
       const File* cursor_ir = sem_ir;
       InstId cursor_inst_id = InstId::None;


### PR DESCRIPTION
This is a preparation to handling this TODO: https://github.com/carbon-language/carbon-lang/blob/7c85397f8bfe4cc5137a056d99e3a8acc24cb42a/toolchain/check/diagnostic_emitter.cpp#L20-L22

Part of #5245.