### PR TITLE
Do a stable sort when splitting up impls by interface

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -578,7 +578,7 @@ auto CheckUnit::CheckOverlappingImpls() -> void {
   // interface. We only need to compare impls within each such segment.
   llvm::SmallVector<SemIR::Impl> impls_by_interface(
       context_.impls().array_ref());
-  llvm::sort(
+  llvm::stable_sort(
       impls_by_interface, [](const SemIR::Impl& a, const SemIR::Impl& b) {
         return a.interface.interface_id.index < b.interface.interface_id.index;
       });


### PR DESCRIPTION
Keep the impls for each interface in the order that they were declared. This ensures that the resulting diagnostics will be deterministic.