### PR TITLE
Add mangling support for thunks.

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1956,6 +1956,7 @@ static auto MakeFunctionDecl(ImportContext& context,
       {GetIncompleteLocalEntityBase(context, function_decl_id, import_function),
        {.call_params_id = SemIR::InstBlockId::None,
         .return_slot_pattern_id = SemIR::InstId::None,
+        .special_function_kind = import_function.special_function_kind,
         .builtin_function_kind = import_function.builtin_function_kind}});
 
   function_decl.type_id = GetFunctionType(

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -189,25 +189,26 @@ static auto CloneFunctionDecl(Context& context, SemIR::LocId loc_id,
   // Create the `Function` object.
   auto& signature = context.functions().Get(signature_id);
   auto& callee = context.functions().Get(callee_id);
-  function_decl.function_id = context.functions().Add(
-      SemIR::Function{{.name_id = signature.name_id,
-                       .parent_scope_id = callee.parent_scope_id,
-                       .generic_id = generic_id,
-                       .first_param_node_id = signature.first_param_node_id,
-                       .last_param_node_id = signature.last_param_node_id,
-                       .pattern_block_id = pattern_block_id,
-                       .implicit_param_patterns_id = implicit_param_patterns_id,
-                       .param_patterns_id = param_patterns_id,
-                       .is_extern = false,
-                       .extern_library_id = SemIR::LibraryNameId::None,
-                       .non_owning_decl_id = SemIR::InstId::None,
-                       .first_owning_decl_id = decl_id,
-                       .definition_id = decl_id},
-                      {.call_params_id = call_params_id,
-                       .return_slot_pattern_id = return_slot_pattern_id,
-                       .virtual_modifier = callee.virtual_modifier,
-                       .virtual_index = callee.virtual_index,
-                       .self_param_id = self_param_id}});
+  function_decl.function_id = context.functions().Add(SemIR::Function{
+      {.name_id = signature.name_id,
+       .parent_scope_id = callee.parent_scope_id,
+       .generic_id = generic_id,
+       .first_param_node_id = signature.first_param_node_id,
+       .last_param_node_id = signature.last_param_node_id,
+       .pattern_block_id = pattern_block_id,
+       .implicit_param_patterns_id = implicit_param_patterns_id,
+       .param_patterns_id = param_patterns_id,
+       .is_extern = false,
+       .extern_library_id = SemIR::LibraryNameId::None,
+       .non_owning_decl_id = SemIR::InstId::None,
+       .first_owning_decl_id = decl_id,
+       .definition_id = decl_id},
+      {.call_params_id = call_params_id,
+       .return_slot_pattern_id = return_slot_pattern_id,
+       .special_function_kind = SemIR::Function::SpecialFunctionKind::Thunk,
+       .virtual_modifier = callee.virtual_modifier,
+       .virtual_index = callee.virtual_index,
+       .self_param_id = self_param_id}});
   function_decl.type_id =
       GetFunctionType(context, function_decl.function_id,
                       context.scope_stack().PeekSpecificId());

--- a/toolchain/lower/testdata/impl/import_thunk.carbon
+++ b/toolchain/lower/testdata/impl/import_thunk.carbon
@@ -1,0 +1,131 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/impl/import_thunk.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/impl/import_thunk.carbon
+
+// --- thunk.carbon
+
+library "[[@TEST_NAME]]";
+
+class A { var a: i32; }
+class B { var b: i32; }
+class C { var c: i32; }
+
+impl A as Core.ImplicitAs(B) {
+  fn Convert[self: A]() -> B { return {.b = self.a}; }
+}
+impl B as Core.ImplicitAs(C) {
+  fn Convert[self: B]() -> C { return {.c = self.b}; }
+}
+
+interface I {
+  fn F(a: A) -> C;
+}
+
+impl () as I {
+  fn F(b: B) -> B { return {.b = b.b}; }
+}
+
+// --- call.carbon
+
+library "[[@TEST_NAME]]";
+
+import library "thunk";
+
+fn Test(a: A) -> C {
+  return ().(I.F)(a);
+}
+
+// CHECK:STDOUT: ; ModuleID = 'thunk.carbon'
+// CHECK:STDOUT: source_filename = "thunk.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CConvert.A.Main:ImplicitAs.Core"(ptr sret({ i32 }) %return, ptr %self) !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc9_49.1.a = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0, !dbg !7
+// CHECK:STDOUT:   %.loc9_49.2 = load i32, ptr %.loc9_49.1.a, align 4, !dbg !7
+// CHECK:STDOUT:   %.loc9_51.2.b = getelementptr inbounds nuw { i32 }, ptr %return, i32 0, i32 0, !dbg !8
+// CHECK:STDOUT:   store i32 %.loc9_49.2, ptr %.loc9_51.2.b, align 4, !dbg !8
+// CHECK:STDOUT:   ret void, !dbg !9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CConvert.B.Main:ImplicitAs.Core"(ptr sret({ i32 }) %return, ptr %self) !dbg !10 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc12_49.1.b = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc12_49.2 = load i32, ptr %.loc12_49.1.b, align 4, !dbg !11
+// CHECK:STDOUT:   %.loc12_51.2.c = getelementptr inbounds nuw { i32 }, ptr %return, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   store i32 %.loc12_49.2, ptr %.loc12_51.2.c, align 4, !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CF.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %b) !dbg !14 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc20_35.1.b = getelementptr inbounds nuw { i32 }, ptr %b, i32 0, i32 0, !dbg !15
+// CHECK:STDOUT:   %.loc20_35.2 = load i32, ptr %.loc20_35.1.b, align 4, !dbg !15
+// CHECK:STDOUT:   %.loc20_37.2.b = getelementptr inbounds nuw { i32 }, ptr %return, i32 0, i32 0, !dbg !16
+// CHECK:STDOUT:   store i32 %.loc20_35.2, ptr %.loc20_37.2.b, align 4, !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CF:thunk.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) !dbg !18 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 8, !dbg !19
+// CHECK:STDOUT:   %.loc16_9.1.temp = alloca { i32 }, align 8, !dbg !20
+// CHECK:STDOUT:   call void @"_CConvert.A.Main:ImplicitAs.Core"(ptr %.loc16_9.1.temp, ptr %a), !dbg !20
+// CHECK:STDOUT:   call void @"_CF.61ea2aba74ab3bf1:I.Main"(ptr %.loc20_19.1.temp, ptr %.loc16_9.1.temp), !dbg !19
+// CHECK:STDOUT:   %.loc20_19.2.temp = alloca { i32 }, align 8, !dbg !19
+// CHECK:STDOUT:   call void @"_CConvert.B.Main:ImplicitAs.Core"(ptr %.loc20_19.2.temp, ptr %.loc20_19.1.temp), !dbg !19
+// CHECK:STDOUT:   ret void, !dbg !19
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "thunk.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.A.Main:ImplicitAs.Core", scope: null, file: !3, line: 9, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 9, column: 45, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 9, column: 39, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 9, column: 32, scope: !4)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.B.Main:ImplicitAs.Core", scope: null, file: !3, line: 12, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = !DILocation(line: 12, column: 45, scope: !10)
+// CHECK:STDOUT: !12 = !DILocation(line: 12, column: 39, scope: !10)
+// CHECK:STDOUT: !13 = !DILocation(line: 12, column: 32, scope: !10)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "F", linkageName: "_CF.61ea2aba74ab3bf1:I.Main", scope: null, file: !3, line: 20, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !15 = !DILocation(line: 20, column: 34, scope: !14)
+// CHECK:STDOUT: !16 = !DILocation(line: 20, column: 28, scope: !14)
+// CHECK:STDOUT: !17 = !DILocation(line: 20, column: 21, scope: !14)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "F", linkageName: "_CF:thunk.61ea2aba74ab3bf1:I.Main", scope: null, file: !3, line: 20, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !19 = !DILocation(line: 20, column: 3, scope: !18)
+// CHECK:STDOUT: !20 = !DILocation(line: 16, column: 8, scope: !18)
+// CHECK:STDOUT: ; ModuleID = 'call.carbon'
+// CHECK:STDOUT: source_filename = "call.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CTest.Main(ptr sret({ i32 }) %return, ptr %a) !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @"_CF:thunk.61ea2aba74ab3bf1:I.Main"(ptr %return, ptr %a), !dbg !7
+// CHECK:STDOUT:   ret void, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_CF:thunk.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }), ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "call.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Test", linkageName: "_CTest.Main", scope: null, file: !3, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 7, column: 10, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 3, scope: !4)

--- a/toolchain/lower/testdata/impl/thunk.carbon
+++ b/toolchain/lower/testdata/impl/thunk.carbon
@@ -1,0 +1,107 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/impl/thunk.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/impl/thunk.carbon
+
+class A { var a: i32; }
+class B { var b: i32; }
+class C { var c: i32; }
+
+impl A as Core.ImplicitAs(B) {
+  fn Convert[self: A]() -> B { return {.b = self.a}; }
+}
+impl B as Core.ImplicitAs(C) {
+  fn Convert[self: B]() -> C { return {.c = self.b}; }
+}
+
+interface I {
+  fn F(a: A) -> C;
+}
+
+impl () as I {
+  fn F(b: B) -> B { return {.b = b.b}; }
+}
+
+fn Test(a: A) -> C {
+  return ().(I.F)(a);
+}
+
+// CHECK:STDOUT: ; ModuleID = 'thunk.carbon'
+// CHECK:STDOUT: source_filename = "thunk.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CConvert.A.Main:ImplicitAs.Core"(ptr sret({ i32 }) %return, ptr %self) !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc16_49.1.a = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0, !dbg !7
+// CHECK:STDOUT:   %.loc16_49.2 = load i32, ptr %.loc16_49.1.a, align 4, !dbg !7
+// CHECK:STDOUT:   %.loc16_51.2.b = getelementptr inbounds nuw { i32 }, ptr %return, i32 0, i32 0, !dbg !8
+// CHECK:STDOUT:   store i32 %.loc16_49.2, ptr %.loc16_51.2.b, align 4, !dbg !8
+// CHECK:STDOUT:   ret void, !dbg !9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CConvert.B.Main:ImplicitAs.Core"(ptr sret({ i32 }) %return, ptr %self) !dbg !10 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc19_49.1.b = getelementptr inbounds nuw { i32 }, ptr %self, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc19_49.2 = load i32, ptr %.loc19_49.1.b, align 4, !dbg !11
+// CHECK:STDOUT:   %.loc19_51.2.c = getelementptr inbounds nuw { i32 }, ptr %return, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   store i32 %.loc19_49.2, ptr %.loc19_51.2.c, align 4, !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CF.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %b) !dbg !14 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc27_35.1.b = getelementptr inbounds nuw { i32 }, ptr %b, i32 0, i32 0, !dbg !15
+// CHECK:STDOUT:   %.loc27_35.2 = load i32, ptr %.loc27_35.1.b, align 4, !dbg !15
+// CHECK:STDOUT:   %.loc27_37.2.b = getelementptr inbounds nuw { i32 }, ptr %return, i32 0, i32 0, !dbg !16
+// CHECK:STDOUT:   store i32 %.loc27_35.2, ptr %.loc27_37.2.b, align 4, !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @"_CF:thunk.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) !dbg !18 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc27_19.1.temp = alloca { i32 }, align 8, !dbg !19
+// CHECK:STDOUT:   %.loc23_9.1.temp = alloca { i32 }, align 8, !dbg !20
+// CHECK:STDOUT:   call void @"_CConvert.A.Main:ImplicitAs.Core"(ptr %.loc23_9.1.temp, ptr %a), !dbg !20
+// CHECK:STDOUT:   call void @"_CF.61ea2aba74ab3bf1:I.Main"(ptr %.loc27_19.1.temp, ptr %.loc23_9.1.temp), !dbg !19
+// CHECK:STDOUT:   %.loc27_19.2.temp = alloca { i32 }, align 8, !dbg !19
+// CHECK:STDOUT:   call void @"_CConvert.B.Main:ImplicitAs.Core"(ptr %.loc27_19.2.temp, ptr %.loc27_19.1.temp), !dbg !19
+// CHECK:STDOUT:   ret void, !dbg !19
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CTest.Main(ptr sret({ i32 }) %return, ptr %a) !dbg !21 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @"_CF:thunk.61ea2aba74ab3bf1:I.Main"(ptr %return, ptr %a), !dbg !22
+// CHECK:STDOUT:   ret void, !dbg !23
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "thunk.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.A.Main:ImplicitAs.Core", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 16, column: 45, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 39, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 32, scope: !4)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.B.Main:ImplicitAs.Core", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 45, scope: !10)
+// CHECK:STDOUT: !12 = !DILocation(line: 19, column: 39, scope: !10)
+// CHECK:STDOUT: !13 = !DILocation(line: 19, column: 32, scope: !10)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "F", linkageName: "_CF.61ea2aba74ab3bf1:I.Main", scope: null, file: !3, line: 27, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !15 = !DILocation(line: 27, column: 34, scope: !14)
+// CHECK:STDOUT: !16 = !DILocation(line: 27, column: 28, scope: !14)
+// CHECK:STDOUT: !17 = !DILocation(line: 27, column: 21, scope: !14)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "F", linkageName: "_CF:thunk.61ea2aba74ab3bf1:I.Main", scope: null, file: !3, line: 27, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !19 = !DILocation(line: 27, column: 3, scope: !18)
+// CHECK:STDOUT: !20 = !DILocation(line: 23, column: 8, scope: !18)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "Test", linkageName: "_CTest.Main", scope: null, file: !3, line: 30, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = !DILocation(line: 31, column: 10, scope: !21)
+// CHECK:STDOUT: !23 = !DILocation(line: 31, column: 3, scope: !21)

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -15,6 +15,9 @@ namespace Carbon::SemIR {
 
 // Function-specific fields.
 struct FunctionFields {
+  // Kinds of special functions.
+  enum class SpecialFunctionKind : uint8_t { None, Thunk };
+
   // Kinds of virtual modifiers that can apply to functions.
   enum class VirtualModifier : uint8_t { None, Virtual, Abstract, Impl };
 
@@ -39,6 +42,11 @@ struct FunctionFields {
   // needs a return slot, but is always present if the function has a declared
   // return type.
   InstId return_slot_pattern_id;
+
+  // Which kind of special function this is, if any. This is used in cases where
+  // a special function would otherwise be indistinguishable from a normal
+  // function.
+  SpecialFunctionKind special_function_kind = SpecialFunctionKind::None;
 
   // Which, if any, virtual modifier (virtual, abstract, or impl) is applied to
   // this function.


### PR DESCRIPTION
A thunk may have the same mangling as the function that it's a thunk for, so add `:thunk` to the mangling to disambiguate.