### PR TITLE
Clean up `KeywordModifierSet` after #5345

### DIFF
--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -54,7 +54,7 @@ class KeywordModifierSet {
     Method = Abstract | Impl | Virtual,
     ImplDecl = Extend | Final,
     Interface = Default | Final,
-    Decl = Class | Method | Impl | Interface | Export | Returned,
+    Decl = Class | Method | Interface | Export | Returned,
     None = 0,
 
     LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/Returned)


### PR DESCRIPTION
See comment https://github.com/carbon-language/carbon-lang/pull/5345#discussion_r2074260967

> `Impl` is already a part of `Method` and refers to using `impl` as a modifier keyword on virtual methods (to be replaced by `override`, see #5253 ), as opposed to `ImplDecl` which is the modifiers allowed on an `impl` declaration. It would make more sense to delete this than use `Impl` here.