### PR TITLE
Fix handling of null StringRef file buffers

### DIFF
--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -691,7 +691,7 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
     // Incomplete ranges will use the next token for their end; we want that to
     // be `FileEnd` in this case, so check before adding `FileEnd`. The argument
     // is just the final character for diagnostic locations.
-    lexer.EndDumpSemIRRangeIfIncomplete(source_text.end() - 1);
+    lexer.EndDumpSemIRRangeIfIncomplete(source_text.end());
   }
 
   // When we finish the source text, stop recursing. We also hint this so that

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -216,6 +216,10 @@ class [[clang::internal_linkage]] Lexer {
   // marker.
   auto EndDumpSemIRRangeIfIncomplete(const char* diag_loc) -> void;
 
+  auto has_dump_sem_ir_ranges() -> bool {
+    return buffer_.has_dump_sem_ir_ranges();
+  }
+
  private:
   class ErrorRecoveryBuffer;
 
@@ -683,10 +687,12 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
         source_text[position])](lexer, source_text, position);
   }
 
-  // Incomplete ranges will use the next token for their end; we want that to be
-  // `FileEnd` in this case, so check before adding `FileEnd`. The argument is
-  // just the final character for diagnostic locations.
-  lexer.EndDumpSemIRRangeIfIncomplete(source_text.end() - 1);
+  if (lexer.has_dump_sem_ir_ranges()) {
+    // Incomplete ranges will use the next token for their end; we want that to
+    // be `FileEnd` in this case, so check before adding `FileEnd`. The argument
+    // is just the final character for diagnostic locations.
+    lexer.EndDumpSemIRRangeIfIncomplete(source_text.end() - 1);
+  }
 
   // When we finish the source text, stop recursing. We also hint this so that
   // the tail-dispatch is optimized as that's essentially the loop back-edge
@@ -768,6 +774,13 @@ auto Lexer::Lex() && -> TokenizedBuffer {
 }
 
 auto Lexer::MakeLines(llvm::StringRef source_text) -> void {
+  if (source_text.empty()) {
+    // Construct a single line for empty input.
+    buffer_.AddLine(TokenizedBuffer::LineInfo(0));
+    line_index_ = 0;
+    return;
+  }
+
   // We currently use `memchr` here which typically is well optimized to use
   // SIMD or other significantly faster than byte-wise scanning. We also use
   // carefully selected variables and the `ssize_t` type for performance and

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -691,7 +691,9 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
     // Incomplete ranges will use the next token for their end; we want that to
     // be `FileEnd` in this case, so check before adding `FileEnd`. The argument
     // is just the final character for diagnostic locations.
-    lexer.EndDumpSemIRRangeIfIncomplete(source_text.end());
+    // TODO: This offset may not be needed if `file_test` handled diagnostics
+    // pointing at `.end()`.
+    lexer.EndDumpSemIRRangeIfIncomplete(source_text.end() - 1);
   }
 
   // When we finish the source text, stop recursing. We also hint this so that
@@ -911,8 +913,8 @@ auto Lexer::LexCommentOrSlash(llvm::StringRef source_text, ssize_t& position)
 auto Lexer::BeginDumpSemIRRange(const char* diag_loc) -> void {
   EndDumpSemIRRangeIfIncomplete(diag_loc);
 
-  // The begin here will be the next token, which may be FileEnd. The end will
-  // be assigned by either AddDumpSemIREnd or, if invalid,
+  // The begin here will be the next token, which may be dump-sem-ir-begin. The
+  // end will be assigned by either AddDumpSemIREnd or, if invalid,
   // EndDumpSemIRRangeIfIncomplete.
   buffer_.dump_sem_ir_ranges_.push_back(
       {.begin = TokenIndex(buffer_.size()), .end = TokenIndex::None});

--- a/toolchain/lex/testdata/dump_sem_ir_range.carbon
+++ b/toolchain/lex/testdata/dump_sem_ir_range.carbon
@@ -76,11 +76,11 @@ e
 // CHECK:STDOUT:   - {begin: 1, end: 0}
 
 //@dump-sem-ir-begin
-// CHECK:STDERR: fail_start_only.carbon:[[@LINE+4]]:1: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
+
+// CHECK:STDERR: fail_start_only.carbon:[[@LINE+3]]:1: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
 // CHECK:STDERR:
 // CHECK:STDERR: ^
 // CHECK:STDERR:
-
 // --- fail_end_only.carbon
 // CHECK:STDOUT: - filename: fail_end_only.carbon
 // CHECK:STDOUT:   tokens:
@@ -140,7 +140,7 @@ d
 // CHECK:STDOUT:   - {begin: 2, end: 2}
 // CHECK:STDOUT:   - {begin: 4, end: 4}
 
-// CHECK:STDERR: fail_count_mismatch.carbon:[[@LINE+3]]:17: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
-// CHECK:STDERR: // CHECK:STDERR:
-// CHECK:STDERR:                 ^
+// CHECK:STDERR: fail_count_mismatch.carbon:[[@LINE+3]]:1: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
+// CHECK:STDERR:
+// CHECK:STDERR: ^
 // CHECK:STDERR:

--- a/toolchain/lex/testdata/dump_sem_ir_range.carbon
+++ b/toolchain/lex/testdata/dump_sem_ir_range.carbon
@@ -77,9 +77,9 @@ e
 
 //@dump-sem-ir-begin
 
-// CHECK:STDERR: fail_start_only.carbon:[[@LINE+3]]:1: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
-// CHECK:STDERR:
-// CHECK:STDERR: ^
+// CHECK:STDERR: fail_start_only.carbon:[[@LINE+3]]:17: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
+// CHECK:STDERR: // CHECK:STDERR:
+// CHECK:STDERR:                 ^
 // CHECK:STDERR:
 // --- fail_end_only.carbon
 // CHECK:STDOUT: - filename: fail_end_only.carbon
@@ -140,7 +140,7 @@ d
 // CHECK:STDOUT:   - {begin: 2, end: 2}
 // CHECK:STDOUT:   - {begin: 4, end: 4}
 
-// CHECK:STDERR: fail_count_mismatch.carbon:[[@LINE+3]]:1: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
-// CHECK:STDERR:
-// CHECK:STDERR: ^
+// CHECK:STDERR: fail_count_mismatch.carbon:[[@LINE+3]]:17: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
+// CHECK:STDERR: // CHECK:STDERR:
+// CHECK:STDERR:                 ^
 // CHECK:STDERR:

--- a/toolchain/lex/testdata/dump_sem_ir_range.carbon
+++ b/toolchain/lex/testdata/dump_sem_ir_range.carbon
@@ -76,11 +76,11 @@ e
 // CHECK:STDOUT:   - {begin: 1, end: 0}
 
 //@dump-sem-ir-begin
-
-// CHECK:STDERR: fail_start_only.carbon:[[@LINE+3]]:17: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
-// CHECK:STDERR: // CHECK:STDERR:
-// CHECK:STDERR:                 ^
+// CHECK:STDERR: fail_start_only.carbon:[[@LINE+4]]:1: error: missing `//@dump-sem-ir-end` to match `//@dump-sem-ir-begin` [DumpSemIRRangeMissingEnd]
 // CHECK:STDERR:
+// CHECK:STDERR: ^
+// CHECK:STDERR:
+
 // --- fail_end_only.carbon
 // CHECK:STDOUT: - filename: fail_end_only.carbon
 // CHECK:STDOUT:   tokens:

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -50,6 +50,14 @@ TEST_F(LexerTest, HandlesEmptyBuffer) {
                           {.kind = TokenKind::FileEnd}}));
 }
 
+TEST_F(LexerTest, NullStringRef) {
+  auto& buffer = compile_helper_.GetTokenizedBuffer(llvm::StringRef());
+  EXPECT_FALSE(buffer.has_errors());
+  EXPECT_THAT(buffer, HasTokens(llvm::ArrayRef<ExpectedToken>{
+                          {.kind = TokenKind::FileStart},
+                          {.kind = TokenKind::FileEnd}}));
+}
+
 TEST_F(LexerTest, TracksLinesAndColumns) {
   auto& buffer = compile_helper_.GetTokenizedBuffer(
       "\n  ;;\n   ;;;\n   x\"foo\" '''baz\n  a\n ''' y");

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -40,6 +40,11 @@ TEST_F(TreeTest, IsValid) {
   EXPECT_TRUE((*tree.postorder().begin()).has_value());
 }
 
+TEST_F(TreeTest, NullStringRef) {
+  Tree& tree = compile_helper_.GetTree(llvm::StringRef());
+  EXPECT_TRUE((*tree.postorder().begin()).has_value());
+}
+
 TEST_F(TreeTest, AsAndTryAs) {
   auto [tokens, tree_and_subtrees] =
       compile_helper_.GetTokenizedBufferWithTreeAndSubtrees("fn F();");

--- a/toolchain/testing/compile_helper.cpp
+++ b/toolchain/testing/compile_helper.cpp
@@ -50,8 +50,10 @@ auto CompileHelper::GetTokenizedBufferWithTreeAndSubtrees(llvm::StringRef text)
 
 auto CompileHelper::GetSourceBuffer(llvm::StringRef text) -> SourceBuffer& {
   std::string filename = llvm::formatv("test{0}.carbon", ++file_index_);
-  CARBON_CHECK(fs_.addFile(filename, /*ModificationTime=*/0,
-                           llvm::MemoryBuffer::getMemBuffer(text)));
+  CARBON_CHECK(
+      fs_.addFile(filename, /*ModificationTime=*/0,
+                  llvm::MemoryBuffer::getMemBuffer(
+                      text, filename, /*RequiresNullTerminator=*/false)));
   source_storage_.push_front(
       std::move(*SourceBuffer::MakeFromFile(fs_, filename, consumer_)));
   return source_storage_.front();


### PR DESCRIPTION
The current behavior hits UBSAN and ASAN issues.

Note, `RequiresNullTerminator` is already set to `false` in `source_buffer.cpp`; setting it in `compile_helper.cpp` is making things more consistent. The related logic is an [assert fail](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Support/MemoryBuffer.cpp#L52).

This was fuzzer-discovered.