### PR TITLE
Bump clang version to 18

### DIFF
--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -22,48 +22,47 @@ runs:
         # to save time.
         large-packages: false
 
-    # Cache and install a recent version of LLVM. This uses the GitHub action
-    # cache to avoid directly downloading on each iteration and improve
-    # reliability.
-    - name: Cache LLVM and Clang installation
-      id: cache-llvm-ubuntu
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      env:
-        cache-name: cache-llvm
-      with:
-        path: ~/llvm
-        key: LLVM-16-Cache-ubuntu-${{ runner.arch }}
+    - name: Show system LLVM and Clang installation
+      shell: bash
+      run: |
+        dpkg -l|grep -E 'clang|llvm'
 
+    # Install a recent version of LLVM. We use LLVM's apt.llvm.org in order to
+    # have access to all released versions, instead of the GitHub releases which
+    # are often missing binaries for ubuntu x64.
     - name: Download LLVM and Clang installation
-      if: steps.cache-llvm-ubuntu.outputs.cache-hit != 'true'
+      env:
+        # We will use this clang version.
+        clang_version: 18
+        # The ubuntu 24.04 image has these versions installed:
+        # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+        installed_clang_version: '16,17,18'
+      if: env.clang_version != env.installed_clang_version
       shell: bash
       run: |
-        cd ~
-        LLVM_RELEASE=clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04
-        echo "*** Downloading $LLVM_RELEASE"
-        wget --show-progress=off "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.4/$LLVM_RELEASE.tar.xz"
-        echo "*** Extracting $LLVM_RELEASE"
-        tar -xJf "$LLVM_RELEASE.tar.xz"
-        echo "*** Moving to 'llvm'"
-        mv "$LLVM_RELEASE" llvm
-        echo "*** Testing `clang++ --version`"
-        ~/llvm/bin/clang++ --version
+        echo '*** Removing system clang packages'
+        for version in ${installed_clang_version//,/ }; do
+          sudo apt-get remove clang-${version} \
+            lldb-${version} \
+            lld-${version} \
+            clangd-${version} \
+            clang-tidy-${version} \
+            clang-format-${version} \
+            clang-tools-${version} \
+            llvm-${version}-dev \
+            lld-${version} \
+            lldb-${version} \
+            llvm-${version}-tools \
+            libomp-${version}-dev \
+            libc++-${version}-dev \
+            libc++abi-${version}-dev \
+            libclang-common-${version}-dev \
+            libclang-${version}-dev \
+            libclang-cpp${version}-dev \
+            libunwind-${version}-dev
+          done
 
-        # The installation contains *huge* parts of LLVM we don't need for the
-        # toolchain. Prune them here to keep our cache small.
-        echo "*** Cleaning the 'llvm' directory"
-        rm llvm/lib/{*.a,*.so,*.so.*,*.bc}
-        rm llvm/bin/{flang-*,mlir-*,clang-{scan-deps,check,repl},*-test,llvm-{lto*,reduce,bolt*,exegesis,jitlink},bugpoint,opt,llc}
-        echo "*** Size of the 'llvm' directory"
-        du -hs llvm
-
-    - name: Setup LLVM and Clang paths
-      shell: bash
-      run: |
-        LLVM_PATH=~/llvm
-        echo "Using ${LLVM_PATH}"
-        echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
-        echo '*** ls "${LLVM_PATH}"'
-        ls "${LLVM_PATH}"
-        echo '*** ls "${LLVM_PATH}/bin"'
-        ls "${LLVM_PATH}/bin"
+        echo '*** Installing upstream clang packages'
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh ${clang_version} all

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Harden Runner
@@ -51,7 +51,7 @@ jobs:
       - id: test-setup
         uses: ./.github/actions/test-setup
         with:
-          matrix_runner: 'ubuntu-22.04'
+          matrix_runner: 'ubuntu-24.04'
           base_sha:
             ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.base.sha ||

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -68,7 +68,7 @@ jobs:
 
       - uses: ./.github/actions/build-setup-common
         with:
-          matrix_runner: ubuntu-22.04
+          matrix_runner: ubuntu-24.04
           remote_cache_upload: ${{ env.remote_cache_upload }}
 
       - name: Get nightly date

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         # Test a recent version of each supported OS.
-        runner: ['ubuntu-22.04', 'macos-14']
+        runner: ['ubuntu-24.04', 'macos-14']
         build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.runner }}
 

--- a/proposals/p5366.md
+++ b/proposals/p5366.md
@@ -1,0 +1,327 @@
+# The name of an `impl` in `class` scope
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/5366)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+    -   [Optional `Self` before `as`](#optional-self-before-as)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [Use semantic match for the scope](#use-semantic-match-for-the-scope)
+
+<!-- tocstop -->
+
+## Abstract
+
+```
+class C {
+  impl as I;
+}
+```
+
+is redeclared
+
+```
+impl C.(as I)
+```
+
+for purposes of `match_first`/`impl_priority` blocks and definitions.
+
+## Problem
+
+An `impl` declaration can be declared in `class` scope:
+
+```
+class C {
+  alias T = bool;
+  impl as As(T);
+}
+```
+
+or in file scope:
+
+```
+class C {
+  alias T = bool;
+}
+alias T = i32;
+impl C as As(T);
+```
+
+These `impl` declarations need to be named so they may be redeclared in a
+definition or
+[`match_first`/`impl_priority` block](/docs/design/generics/details.md#prioritization-rule).
+Under the current rules introduced in
+[proposal #1084](https://github.com/carbon-language/carbon-lang/pull/1084) and
+modified in [#3763](https://github.com/carbon-language/carbon-lang/pull/3763),
+an `impl` redeclaration must match syntactically, and that only works if the
+redeclaration enters the same scope as the original declaration.
+
+This problem is demonstrated in the example above. We need some indication
+whether to lookup `T` in the file or the class scope, otherwise these both would
+be redeclared as `impl C as As(T)`.
+
+```carbon
+class C(T:! type) {
+  class E {}
+  impl E as I(C(T), E);
+}
+
+// No ability to do syntactic match
+// C(T) does not match C(T:! type)
+// C(T).E does not match E
+impl forall [T:! type] C(T).E as I(C(T), C(T).E);
+```
+
+## Background
+
+The need for forward declarations of entities comes from the
+[information accumulation principle](/docs/project/principles/information_accumulation.md).
+
+[Leads issue #1132](https://github.com/carbon-language/carbon-lang/issues/1132)
+defined the initial rules for matching forward declarations to their
+definitions. Those rules were partially incorporated into the design by
+[proposal #1084, "Generics details 9: forward declarations"](/proposals/p1084.md).
+
+A replacement approach was
+[discussed on 2024-03-11](https://docs.google.com/document/d/1s3mMCupmuSpWOFJGnvjoElcBIe2aoaysTIdyczvKX84/edit?resourcekey=0-G095Wc3sR6pW1hLJbGgE0g&tab=t.0#heading=h.p69b78lovqb7)
+and mentioned in [proposal #3763](/proposals/p3763.md#redeclarations). This is
+the approach of syntactic matching and re-entering the same scope. The syntax
+adopted by this proposal was first suggested in those.
+
+[Proposal #3762: Merging forward declarations](https://github.com/carbon-language/carbon-lang/pull/3762)
+and
+[proposal #3980: Singular `extern` declarations](https://github.com/carbon-language/carbon-lang/pull/3980)
+refined the rules for forward declarations, including the rules for `extern`
+declarations.
+
+[Leads issue #5251: `impl` declarations in a generic class context](https://github.com/carbon-language/carbon-lang/issues/5251)
+is (pending resolution) saying that an `impl` declaration in class scope must
+use `Self` in a deducible position.
+
+## Proposal
+
+An `impl` declaration is associated with the scope it is first declared in, and
+can only be redeclared in that scope, matching all other declarations. Consider
+how a function is redeclared outside the scope of a class in which it was
+originally defined:
+
+```
+class Z(T:! type) {
+  // Forward declaration of a function.
+  fn F();
+}
+
+// Definition of the function that was forward declared.
+fn Z(T:! type).F() { ... }
+```
+
+To redeclare an `impl` after the end of the scope it was declared in, that scope
+may be re-entered as part of the `impl` redeclaration, in the same way, except
+with parentheses around the name of the `impl`, as in:
+
+```carbon
+class X {
+  // Forward declaration that `X impls Y`:
+  impl as Y;
+}
+
+// Definition of the `impl` that `X impls Y`
+// that was forward declared in `X`:
+impl X.(as Y) { ... }
+```
+
+More generally, in a `class` scope
+
+```carbon
+class __X__ {
+  impl __Y__;
+}
+```
+
+is redeclared `impl __X__.(__Y__)` outside of that `class` scope. Here `__X__`
+is whatever sequence of tokens appears in that position in the `class`
+declaration, and `__Y__` is the sequence of tokens in the `impl` declaration.
+These declarations are matched syntactically, and anything in `__Y__` is
+interpreted as if it appeared in the scope of `__X__` like it was first
+declared.
+
+## Details
+
+Here are some examples of this in practice:
+
+```carbon
+class F {}
+
+class A {
+  impl as As(i32);
+  impl Self as As(bool);
+  impl A as As(f64);
+
+  impl F as As(A);
+
+  class G {}
+  impl G as As(A);
+}
+
+impl A.(as As(i32)) { ... }
+impl A.(Self as As(bool)) { ... }
+impl A.(A as As(f64)) { ... }
+impl A.(F as As(A)) { ... }
+impl A.(G as As(A)) { ... }
+```
+
+Parameterized classes:
+
+```carbon
+class B(T:! type) {
+  impl B(i32) as AddWith(A(T));
+}
+
+impl B(T:! type).(B(i32) as AddWith(A(T))) { ... }
+```
+
+Parameterized impl:
+
+```carbon
+class C {
+  impl forall [T:! type] as I(T);
+}
+
+impl C.(forall [T:! type] as I(T));
+```
+
+Putting the `forall` inside the parens both simplifies the syntactic match and
+means that any mentions of names in that clause are in scope. For example:
+
+```
+class D(T:! type) {
+  class E {}
+  impl forall [U:! J(E)] as I(U);
+}
+
+impl D(T:! type).(forall [U:! J(E)] as I(U));
+```
+
+Notice how the `E` in the constraint on `U` is found in the `D(T:! type)` scope.
+
+Nested classes:
+
+```
+class C1 {
+  class C2 {
+    class C3 {
+      impl as I;
+      class C4 {}
+    }
+  }
+}
+
+// Defining impl that was forward declared within the `C3` definition:
+impl C1.C2.C3.(as I) { ... }
+
+// Defining a new impl:
+impl C1.C2.C3.C4 as I { ... }
+```
+
+Notice that we don't know which form will be used until we see:
+
+-   the open paren (`(`) after a `.`,
+-   a parameter pattern,
+-   a non-parameter argument, or
+-   the `as`.
+
+### Optional `Self` before `as`
+
+The normalization to add `Self` before `as` when that type is omitted before
+performing syntactic match is preserved from proposals
+[#1084](https://github.com/carbon-language/carbon-lang/pull/1084) and
+[#3763](https://github.com/carbon-language/carbon-lang/pull/3763). Note that the
+`Self` is inserted in the parentheses when the `as` appears there. So:
+
+```
+class A {
+  // First impl declaration is equivalent
+  // to `impl Self as As(i32);`
+  impl as As(i32);
+
+  // Second impl declaration.
+  impl Self as As(bool);
+}
+
+// Redeclaration of the first impl declaration.
+impl A.(Self as As(i32)) { ... }
+
+// Since this is equivalent to
+// `impl A.(Self as As(bool)) { ... }`, is a
+// valid redeclaration of the second impl
+// declaration.
+impl A.(as As(bool)) { ... }
+```
+
+## Rationale
+
+The need for this proposal comes from supporting forward declarations for the
+[information accumulation principle](/docs/project/principles/information_accumulation.md).
+The specifics of this proposal were chosen comply with these
+[Carbon goals](/docs/project/goals.md):
+
+-   Unambiguous rules that are simple to implement benefit
+    [language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem).
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+    benefits by having rules that are simple to state and validate. The
+    syntactic match rule means redeclarations are close to a copy of the
+    original declaration, which makes authoring straightforward and automatable.
+
+## Alternatives considered
+
+### Use semantic match for the scope
+
+[Leads issue #5367: `impl` in `class` redeclaration syntax with parameterization](https://github.com/carbon-language/carbon-lang/issues/5367)
+considered an alternative where
+
+```carbon
+// Alternative
+impl forall [T:! type] B(T).(as I) { ... }
+```
+
+instead of:
+
+```carbon
+// This proposal
+impl B(T:! type).(as I) { ... }
+```
+
+It avoided putting a `forall` clause inside the parentheses, but that both
+greatly limited the syntactic matching that we could do, and meant examples
+like:
+
+```carbon
+// This proposal
+impl D(T:! type).(forall [U:! J(E)] as I(U));
+```
+
+had to instead be written with more qualfiers:
+
+```carbon
+// Alternative
+impl forall [T:! type, U:! J(D(T).E)] D(T).(as I(U));
+```
+
+It is not just helpful for the compiler: being able to make fewer and more
+mechanical changes after copy-pasting the `impl` declaration to make the
+redeclaration makes authoring the code easier, and simplifies tooling to
+automate the process.

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -129,6 +129,9 @@ class FunctionContext {
     return synthetic_block_ == block;
   }
 
+  // Returns the debug location to associate with the specified instruction.
+  auto GetDebugLoc(SemIR::InstId inst_id) -> llvm::DebugLoc;
+
   // After emitting an initializer `init_id`, finishes performing the
   // initialization of `dest_id` from that initializer. This is a no-op if the
   // initialization was performed in-place, and otherwise performs a store or a

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -27,43 +27,43 @@ fn Run() {
 // CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [1 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca [2 x double], align 8, !dbg !7
-// CHECK:STDOUT:   %c.var = alloca [5 x {}], align 8, !dbg !7
-// CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %e.var = alloca [3 x i32], align 4, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca [2 x double], align 8, !dbg !8
+// CHECK:STDOUT:   %c.var = alloca [5 x {}], align 8, !dbg !9
+// CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !10
+// CHECK:STDOUT:   %e.var = alloca [3 x i32], align 4, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %a.var), !dbg !7
-// CHECK:STDOUT:   %.loc12_29.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, i64 0, !dbg !8
+// CHECK:STDOUT:   %.loc12_29.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, i64 0, !dbg !12
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @array.237.loc12_3.2, i64 4, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %.loc13_37.2.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 0, !dbg !9
-// CHECK:STDOUT:   %.loc13_37.4.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 1, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b.var, ptr align 8 @array.6a2.loc13_3.2, i64 16, i1 false), !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !7
-// CHECK:STDOUT:   %.loc14_45.2.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 0, !dbg !11
-// CHECK:STDOUT:   %.loc14_45.4.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 1, !dbg !11
-// CHECK:STDOUT:   %.loc14_45.6.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 2, !dbg !11
-// CHECK:STDOUT:   %.loc14_45.8.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 3, !dbg !11
-// CHECK:STDOUT:   %.loc14_45.10.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 4, !dbg !11
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @array.1cb.loc14_3.2, i64 0, i1 false), !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %d.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !13
-// CHECK:STDOUT:   %tuple.elem1.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   %tuple.elem2.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !13
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @tuple.loc15_3.2, i64 12, i1 false), !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %e.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !15
-// CHECK:STDOUT:   %.loc16_26.1 = load i32, ptr %tuple.elem0.loc16.tuple.elem, align 4, !dbg !15
-// CHECK:STDOUT:   %.loc16_26.2.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 0, !dbg !15
-// CHECK:STDOUT:   store i32 %.loc16_26.1, ptr %.loc16_26.2.array.index, align 4, !dbg !15
-// CHECK:STDOUT:   %tuple.elem1.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !15
-// CHECK:STDOUT:   %.loc16_26.4 = load i32, ptr %tuple.elem1.loc16.tuple.elem, align 4, !dbg !15
-// CHECK:STDOUT:   %.loc16_26.5.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 1, !dbg !15
-// CHECK:STDOUT:   store i32 %.loc16_26.4, ptr %.loc16_26.5.array.index, align 4, !dbg !15
-// CHECK:STDOUT:   %tuple.elem2.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !15
-// CHECK:STDOUT:   %.loc16_26.7 = load i32, ptr %tuple.elem2.loc16.tuple.elem, align 4, !dbg !15
-// CHECK:STDOUT:   %.loc16_26.8.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 2, !dbg !15
-// CHECK:STDOUT:   store i32 %.loc16_26.7, ptr %.loc16_26.8.array.index, align 4, !dbg !15
-// CHECK:STDOUT:   ret void, !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %.loc13_37.2.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 0, !dbg !13
+// CHECK:STDOUT:   %.loc13_37.4.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 1, !dbg !13
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b.var, ptr align 8 @array.6a2.loc13_3.2, i64 16, i1 false), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !9
+// CHECK:STDOUT:   %.loc14_45.2.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 0, !dbg !14
+// CHECK:STDOUT:   %.loc14_45.4.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 1, !dbg !14
+// CHECK:STDOUT:   %.loc14_45.6.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 2, !dbg !14
+// CHECK:STDOUT:   %.loc14_45.8.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 3, !dbg !14
+// CHECK:STDOUT:   %.loc14_45.10.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @array.1cb.loc14_3.2, i64 0, i1 false), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %d.var), !dbg !10
+// CHECK:STDOUT:   %tuple.elem0.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !15
+// CHECK:STDOUT:   %tuple.elem1.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !15
+// CHECK:STDOUT:   %tuple.elem2.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !15
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @tuple.loc15_3.2, i64 12, i1 false), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %e.var), !dbg !11
+// CHECK:STDOUT:   %tuple.elem0.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !16
+// CHECK:STDOUT:   %.loc16_26.1 = load i32, ptr %tuple.elem0.loc16.tuple.elem, align 4, !dbg !16
+// CHECK:STDOUT:   %.loc16_26.2.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 0, !dbg !16
+// CHECK:STDOUT:   store i32 %.loc16_26.1, ptr %.loc16_26.2.array.index, align 4, !dbg !16
+// CHECK:STDOUT:   %tuple.elem1.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !16
+// CHECK:STDOUT:   %.loc16_26.4 = load i32, ptr %tuple.elem1.loc16.tuple.elem, align 4, !dbg !16
+// CHECK:STDOUT:   %.loc16_26.5.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 1, !dbg !16
+// CHECK:STDOUT:   store i32 %.loc16_26.4, ptr %.loc16_26.5.array.index, align 4, !dbg !16
+// CHECK:STDOUT:   %tuple.elem2.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !16
+// CHECK:STDOUT:   %.loc16_26.7 = load i32, ptr %tuple.elem2.loc16.tuple.elem, align 4, !dbg !16
+// CHECK:STDOUT:   %.loc16_26.8.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 2, !dbg !16
+// CHECK:STDOUT:   store i32 %.loc16_26.7, ptr %.loc16_26.8.array.index, align 4, !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -91,12 +91,13 @@ fn Run() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 26, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 26, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 14, column: 25, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 15, column: 28, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 16, column: 26, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 11, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 12, column: 26, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 13, column: 26, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 14, column: 25, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 15, column: 28, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 16, column: 26, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 11, column: 1, scope: !4)

--- a/toolchain/lower/testdata/basics/numeric_literals.carbon
+++ b/toolchain/lower/testdata/basics/numeric_literals.carbon
@@ -36,21 +36,21 @@ fn F() {
 // CHECK:STDOUT: define void @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %ints.var = alloca [4 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %floats.var = alloca [6 x double], align 8, !dbg !7
+// CHECK:STDOUT:   %floats.var = alloca [6 x double], align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %ints.var), !dbg !7
-// CHECK:STDOUT:   %.loc19_3.3.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 0, !dbg !8
-// CHECK:STDOUT:   %.loc19_3.6.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 1, !dbg !8
-// CHECK:STDOUT:   %.loc19_3.9.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 2, !dbg !8
-// CHECK:STDOUT:   %.loc19_3.12.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 3, !dbg !8
+// CHECK:STDOUT:   %.loc19_3.3.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 0, !dbg !9
+// CHECK:STDOUT:   %.loc19_3.6.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 1, !dbg !9
+// CHECK:STDOUT:   %.loc19_3.9.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 2, !dbg !9
+// CHECK:STDOUT:   %.loc19_3.12.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 3, !dbg !9
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %ints.var, ptr align 4 @array.712.loc14_3.2, i64 16, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 48, ptr %floats.var), !dbg !7
-// CHECK:STDOUT:   %.loc27_3.2.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 0, !dbg !9
-// CHECK:STDOUT:   %.loc27_3.4.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 1, !dbg !9
-// CHECK:STDOUT:   %.loc27_3.6.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 2, !dbg !9
-// CHECK:STDOUT:   %.loc27_3.8.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 3, !dbg !9
-// CHECK:STDOUT:   %.loc27_3.10.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 4, !dbg !9
-// CHECK:STDOUT:   %.loc27_3.12.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 5, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %floats.var, ptr align 8 @array.a2f.loc20_3.2, i64 48, i1 false), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 48, ptr %floats.var), !dbg !8
+// CHECK:STDOUT:   %.loc27_3.2.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 0, !dbg !10
+// CHECK:STDOUT:   %.loc27_3.4.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 1, !dbg !10
+// CHECK:STDOUT:   %.loc27_3.6.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 2, !dbg !10
+// CHECK:STDOUT:   %.loc27_3.8.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 3, !dbg !10
+// CHECK:STDOUT:   %.loc27_3.10.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 4, !dbg !10
+// CHECK:STDOUT:   %.loc27_3.12.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 5, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %floats.var, ptr align 8 @array.a2f.loc20_3.2, i64 48, i1 false), !dbg !8
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -78,7 +78,7 @@ fn F() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 29, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 20, column: 31, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 20, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 20, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 29, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 20, column: 31, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 11, column: 1, scope: !4)

--- a/toolchain/lower/testdata/builtins/no_prelude/types.carbon
+++ b/toolchain/lower/testdata/builtins/no_prelude/types.carbon
@@ -26,13 +26,13 @@ fn F() {
 // CHECK:STDOUT: define void @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %i.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %f.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca i1, align 1, !dbg !7
+// CHECK:STDOUT:   %f.var = alloca double, align 8, !dbg !8
+// CHECK:STDOUT:   %b.var = alloca i1, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %i.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %i.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %f.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %f.var), !dbg !8
 // CHECK:STDOUT:   store double 0.000000e+00, ptr %f.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 1, ptr %b.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 1, ptr %b.var), !dbg !9
 // CHECK:STDOUT:   store i1 false, ptr %b.var, align 1, !dbg !9
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/class/basic.carbon
+++ b/toolchain/lower/testdata/class/basic.carbon
@@ -28,11 +28,11 @@ fn Run() {
 // CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca { i32, ptr }, align 8, !dbg !7
-// CHECK:STDOUT:   %d.var = alloca { i32, ptr }, align 8, !dbg !7
+// CHECK:STDOUT:   %d.var = alloca { i32, ptr }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %c.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %d.var), !dbg !7
-// CHECK:STDOUT:   call void @_CF.Main(ptr %d.var, ptr %c.var), !dbg !8
-// CHECK:STDOUT:   ret void, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %d.var), !dbg !8
+// CHECK:STDOUT:   call void @_CF.Main(ptr %d.var, ptr %c.var), !dbg !9
+// CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -54,5 +54,6 @@ fn Run() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 19, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 20, column: 14, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 18, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 20, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 20, column: 14, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 18, column: 1, scope: !4)

--- a/toolchain/lower/testdata/class/field.carbon
+++ b/toolchain/lower/testdata/class/field.carbon
@@ -122,14 +122,14 @@ fn Run() {
 // CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %o.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %u.var = alloca { ptr, {} }, align 8, !dbg !7
+// CHECK:STDOUT:   %u.var = alloca { ptr, {} }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %o.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %u.var), !dbg !7
-// CHECK:STDOUT:   %.loc15_33.2.a = getelementptr inbounds nuw { ptr, {} }, ptr %u.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   store ptr %o.var, ptr %.loc15_33.2.a, align 8, !dbg !8
-// CHECK:STDOUT:   %.loc15_33.4.b = getelementptr inbounds nuw { ptr, {} }, ptr %u.var, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc15_33.4.b, ptr align 1 @Other.val.loc15_33.5, i64 0, i1 false), !dbg !8
-// CHECK:STDOUT:   ret void, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %u.var), !dbg !8
+// CHECK:STDOUT:   %.loc15_33.2.a = getelementptr inbounds nuw { ptr, {} }, ptr %u.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   store ptr %o.var, ptr %.loc15_33.2.a, align 8, !dbg !9
+// CHECK:STDOUT:   %.loc15_33.4.b = getelementptr inbounds nuw { ptr, {} }, ptr %u.var, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc15_33.4.b, ptr align 1 @Other.val.loc15_33.5, i64 0, i1 false), !dbg !9
+// CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -155,8 +155,9 @@ fn Run() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 16, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 11, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 15, column: 16, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 1, scope: !4)
 // CHECK:STDOUT: ; ModuleID = 'implicit_init_with_nonempty_nonconst.carbon'
 // CHECK:STDOUT: source_filename = "implicit_init_with_nonempty_nonconst.carbon"
 // CHECK:STDOUT:
@@ -165,15 +166,15 @@ fn Run() {
 // CHECK:STDOUT: define void @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %o.var = alloca { i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %u.var = alloca { ptr, { i32 } }, align 8, !dbg !7
+// CHECK:STDOUT:   %u.var = alloca { ptr, { i32 } }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %o.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %u.var), !dbg !7
-// CHECK:STDOUT:   %.loc17_40.2.a = getelementptr inbounds nuw { ptr, { i32 } }, ptr %u.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   store ptr %o.var, ptr %.loc17_40.2.a, align 8, !dbg !8
-// CHECK:STDOUT:   %.loc17_40.4.b = getelementptr inbounds nuw { ptr, { i32 } }, ptr %u.var, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   %.loc17_39.3.v = getelementptr inbounds nuw { i32 }, ptr %.loc17_40.4.b, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc17_40.4.b, ptr align 4 @Other.val.loc17_40.5, i64 4, i1 false), !dbg !8
-// CHECK:STDOUT:   ret void, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %u.var), !dbg !8
+// CHECK:STDOUT:   %.loc17_40.2.a = getelementptr inbounds nuw { ptr, { i32 } }, ptr %u.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   store ptr %o.var, ptr %.loc17_40.2.a, align 8, !dbg !9
+// CHECK:STDOUT:   %.loc17_40.4.b = getelementptr inbounds nuw { ptr, { i32 } }, ptr %u.var, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   %.loc17_39.3.v = getelementptr inbounds nuw { i32 }, ptr %.loc17_40.4.b, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc17_40.4.b, ptr align 4 @Other.val.loc17_40.5, i64 4, i1 false), !dbg !9
+// CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -199,6 +200,7 @@ fn Run() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 17, column: 16, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 17, column: 31, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 17, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 17, column: 16, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 31, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 13, column: 1, scope: !4)

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -134,30 +134,30 @@ base class Base(T:! type) {
 // CHECK:STDOUT: define void @_CCreate.Create() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %i.var = alloca { ptr, {} }, align 8, !dbg !7
-// CHECK:STDOUT:   %d.var = alloca { { ptr, {} } }, align 8, !dbg !7
-// CHECK:STDOUT:   %d2.var = alloca { { ptr, {} } }, align 8, !dbg !7
+// CHECK:STDOUT:   %i.var = alloca { ptr, {} }, align 8, !dbg !8
+// CHECK:STDOUT:   %d.var = alloca { { ptr, {} } }, align 8, !dbg !9
+// CHECK:STDOUT:   %d2.var = alloca { { ptr, {} } }, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %b.var), !dbg !7
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %b.var, ptr align 1 @Base.val.loc7_3.2, i64 0, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %i.var), !dbg !7
-// CHECK:STDOUT:   %.loc8_44.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %i.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   store ptr @"_CIntermediate.Classes.$vtable", ptr %.loc8_44.2.vptr, align 8, !dbg !8
-// CHECK:STDOUT:   %.loc8_44.5.base = getelementptr inbounds nuw { ptr, {} }, ptr %i.var, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc8_44.5.base, ptr align 1 @Base.val.loc7_3.2, i64 0, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %d.var), !dbg !7
-// CHECK:STDOUT:   %.loc9_49.2.base = getelementptr inbounds nuw { { ptr, {} } }, ptr %d.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %.loc9_48.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %.loc9_49.2.base, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   store ptr @"_CDerived.Classes.$vtable", ptr %.loc9_48.2.vptr, align 8, !dbg !10
-// CHECK:STDOUT:   %.loc9_48.5.base = getelementptr inbounds nuw { ptr, {} }, ptr %.loc9_49.2.base, i32 0, i32 1, !dbg !10
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc9_48.5.base, ptr align 1 @Base.val.loc7_3.2, i64 0, i1 false), !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %d2.var), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %i.var), !dbg !8
+// CHECK:STDOUT:   %.loc8_44.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %i.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   store ptr @"_CIntermediate.Classes.$vtable", ptr %.loc8_44.2.vptr, align 8, !dbg !11
+// CHECK:STDOUT:   %.loc8_44.5.base = getelementptr inbounds nuw { ptr, {} }, ptr %i.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc8_44.5.base, ptr align 1 @Base.val.loc7_3.2, i64 0, i1 false), !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %d.var), !dbg !9
+// CHECK:STDOUT:   %.loc9_49.2.base = getelementptr inbounds nuw { { ptr, {} } }, ptr %d.var, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   %.loc9_48.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %.loc9_49.2.base, i32 0, i32 0, !dbg !13
+// CHECK:STDOUT:   store ptr @"_CDerived.Classes.$vtable", ptr %.loc9_48.2.vptr, align 8, !dbg !13
+// CHECK:STDOUT:   %.loc9_48.5.base = getelementptr inbounds nuw { ptr, {} }, ptr %.loc9_49.2.base, i32 0, i32 1, !dbg !13
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc9_48.5.base, ptr align 1 @Base.val.loc7_3.2, i64 0, i1 false), !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %d2.var), !dbg !10
+// CHECK:STDOUT:   ret void, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CUse.Create(ptr %v) !dbg !12 {
+// CHECK:STDOUT: define void @_CUse.Create(ptr %v) !dbg !15 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CFn.Intermediate.Classes(ptr %v), !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT:   call void @_CFn.Intermediate.Classes(ptr %v), !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_CFn.Intermediate.Classes(ptr)
@@ -187,13 +187,16 @@ base class Base(T:! type) {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 7, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 8, column: 33, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 9, column: 28, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 9, column: 37, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 6, column: 1, scope: !4)
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Use", linkageName: "_CUse.Create", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !13 = !DILocation(line: 15, column: 3, scope: !12)
-// CHECK:STDOUT: !14 = !DILocation(line: 14, column: 1, scope: !12)
+// CHECK:STDOUT: !8 = !DILocation(line: 8, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 9, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 8, column: 33, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 9, column: 28, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 9, column: 37, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 6, column: 1, scope: !4)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "Use", linkageName: "_CUse.Create", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = !DILocation(line: 15, column: 3, scope: !15)
+// CHECK:STDOUT: !17 = !DILocation(line: 14, column: 1, scope: !15)
 // CHECK:STDOUT: ; ModuleID = 'member_init.carbon'
 // CHECK:STDOUT: source_filename = "member_init.carbon"
 // CHECK:STDOUT:
@@ -207,24 +210,24 @@ base class Base(T:! type) {
 // CHECK:STDOUT: define void @_CFn.MemberInit() !dbg !8 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %i.var = alloca i32, align 4, !dbg !9
-// CHECK:STDOUT:   %v.var = alloca { ptr, i32 }, align 8, !dbg !9
-// CHECK:STDOUT:   %u.var = alloca { ptr, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %v.var = alloca { ptr, i32 }, align 8, !dbg !10
+// CHECK:STDOUT:   %u.var = alloca { ptr, i32 }, align 8, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %i.var), !dbg !9
 // CHECK:STDOUT:   store i32 3, ptr %i.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %v.var), !dbg !9
-// CHECK:STDOUT:   %.loc11_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   store ptr @"_CBase.MemberInit.$vtable", ptr %.loc11_24.2.vptr, align 8, !dbg !10
-// CHECK:STDOUT:   %.loc11_23 = load i32, ptr %i.var, align 4, !dbg !11
-// CHECK:STDOUT:   %.loc11_24.5.m = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 1, !dbg !10
-// CHECK:STDOUT:   store i32 %.loc11_23, ptr %.loc11_24.5.m, align 4, !dbg !10
-// CHECK:STDOUT:   %.loc12_4.m = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 1, !dbg !12
-// CHECK:STDOUT:   store i32 5, ptr %.loc12_4.m, align 4, !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %u.var), !dbg !9
-// CHECK:STDOUT:   %.loc13_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %u.var, i32 0, i32 0, !dbg !13
-// CHECK:STDOUT:   store ptr @"_CBase.MemberInit.$vtable", ptr %.loc13_24.2.vptr, align 8, !dbg !13
-// CHECK:STDOUT:   %.loc13_24.6.m = getelementptr inbounds nuw { ptr, i32 }, ptr %u.var, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   store i32 3, ptr %.loc13_24.6.m, align 4, !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %v.var), !dbg !10
+// CHECK:STDOUT:   %.loc11_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   store ptr @"_CBase.MemberInit.$vtable", ptr %.loc11_24.2.vptr, align 8, !dbg !12
+// CHECK:STDOUT:   %.loc11_23 = load i32, ptr %i.var, align 4, !dbg !13
+// CHECK:STDOUT:   %.loc11_24.5.m = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 1, !dbg !12
+// CHECK:STDOUT:   store i32 %.loc11_23, ptr %.loc11_24.5.m, align 4, !dbg !12
+// CHECK:STDOUT:   %.loc12_4.m = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 1, !dbg !14
+// CHECK:STDOUT:   store i32 5, ptr %.loc12_4.m, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %u.var), !dbg !11
+// CHECK:STDOUT:   %.loc13_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %u.var, i32 0, i32 0, !dbg !15
+// CHECK:STDOUT:   store ptr @"_CBase.MemberInit.$vtable", ptr %.loc13_24.2.vptr, align 8, !dbg !15
+// CHECK:STDOUT:   %.loc13_24.6.m = getelementptr inbounds nuw { ptr, i32 }, ptr %u.var, i32 0, i32 1, !dbg !15
+// CHECK:STDOUT:   store i32 3, ptr %.loc13_24.6.m, align 4, !dbg !15
+// CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -249,11 +252,13 @@ base class Base(T:! type) {
 // CHECK:STDOUT: !7 = !DILocation(line: 6, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Fn", linkageName: "_CFn.MemberInit", scope: null, file: !3, line: 9, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !9 = !DILocation(line: 10, column: 3, scope: !8)
-// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 17, scope: !8)
-// CHECK:STDOUT: !11 = !DILocation(line: 11, column: 23, scope: !8)
-// CHECK:STDOUT: !12 = !DILocation(line: 12, column: 3, scope: !8)
-// CHECK:STDOUT: !13 = !DILocation(line: 13, column: 17, scope: !8)
-// CHECK:STDOUT: !14 = !DILocation(line: 9, column: 1, scope: !8)
+// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 3, scope: !8)
+// CHECK:STDOUT: !11 = !DILocation(line: 13, column: 3, scope: !8)
+// CHECK:STDOUT: !12 = !DILocation(line: 11, column: 17, scope: !8)
+// CHECK:STDOUT: !13 = !DILocation(line: 11, column: 23, scope: !8)
+// CHECK:STDOUT: !14 = !DILocation(line: 12, column: 3, scope: !8)
+// CHECK:STDOUT: !15 = !DILocation(line: 13, column: 17, scope: !8)
+// CHECK:STDOUT: !16 = !DILocation(line: 9, column: 1, scope: !8)
 // CHECK:STDOUT: ; ModuleID = 'member_brace_init.carbon'
 // CHECK:STDOUT: source_filename = "member_brace_init.carbon"
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call.carbon
+++ b/toolchain/lower/testdata/function/generic/call.carbon
@@ -38,16 +38,16 @@ fn G() {
 // CHECK:STDOUT: define void @_CG.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %d.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !7
+// CHECK:STDOUT:   %d.var = alloca {}, align 8, !dbg !8
+// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !9
+// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !7
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @C.val.loc18_3.2, i64 0, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %d.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %d.var), !dbg !8
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %d.var, ptr align 1 @D.val.loc19_3.2, i64 0, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !9
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !10
 // CHECK:STDOUT:   store double 0.000000e+00, ptr %m.var, align 8, !dbg !10
 // CHECK:STDOUT:   call void @_CF.Main.15b1f98bd9cc0c5b(ptr %c.var), !dbg !11
 // CHECK:STDOUT:   call void @_CF.Main.2cc450fc05045897(ptr %d.var), !dbg !12

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -60,134 +60,134 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %p.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %q.var = alloca double, align 8, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   %p.var = alloca double, align 8, !dbg !9
+// CHECK:STDOUT:   %q.var = alloca double, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %m.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %p.var), !dbg !7
-// CHECK:STDOUT:   store double 1.000000e+00, ptr %p.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %q.var), !dbg !7
-// CHECK:STDOUT:   %.loc49 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc49), !dbg !10
-// CHECK:STDOUT:   %.loc50 = load i32, ptr %n.var, align 4, !dbg !11
-// CHECK:STDOUT:   %G.call.loc50 = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc50), !dbg !12
-// CHECK:STDOUT:   store i32 %G.call.loc50, ptr %m.var, align 4, !dbg !13
-// CHECK:STDOUT:   %.loc51 = load double, ptr %p.var, align 8, !dbg !14
-// CHECK:STDOUT:   call void @_CF.Main.66be507887ceee78(double %.loc51), !dbg !15
-// CHECK:STDOUT:   %.loc52 = load double, ptr %p.var, align 8, !dbg !16
-// CHECK:STDOUT:   %G.call.loc52 = call double @_CG.Main.66be507887ceee78(double %.loc52), !dbg !17
-// CHECK:STDOUT:   store double %G.call.loc52, ptr %q.var, align 8, !dbg !18
-// CHECK:STDOUT:   ret void, !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %m.var), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %p.var), !dbg !9
+// CHECK:STDOUT:   store double 1.000000e+00, ptr %p.var, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %q.var), !dbg !10
+// CHECK:STDOUT:   %.loc49 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc49), !dbg !12
+// CHECK:STDOUT:   %.loc50 = load i32, ptr %n.var, align 4, !dbg !13
+// CHECK:STDOUT:   %G.call.loc50 = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc50), !dbg !14
+// CHECK:STDOUT:   store i32 %G.call.loc50, ptr %m.var, align 4, !dbg !15
+// CHECK:STDOUT:   %.loc51 = load double, ptr %p.var, align 8, !dbg !16
+// CHECK:STDOUT:   call void @_CF.Main.66be507887ceee78(double %.loc51), !dbg !17
+// CHECK:STDOUT:   %.loc52 = load double, ptr %p.var, align 8, !dbg !18
+// CHECK:STDOUT:   %G.call.loc52 = call double @_CG.Main.66be507887ceee78(double %.loc52), !dbg !19
+// CHECK:STDOUT:   store double %G.call.loc52, ptr %q.var, align 8, !dbg !20
+// CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !20 {
+// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !22 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT:   ret void, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !22 {
+// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !24 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !23
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !24
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !24
-// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !24
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !24
-// CHECK:STDOUT:   %H.call.loc23 = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !24
-// CHECK:STDOUT:   %H.call.loc24 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !25
-// CHECK:STDOUT:   %H.call.loc25 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !26
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x), !dbg !27
-// CHECK:STDOUT:   %H.call.loc26 = call i32 @_CH.Main.b88d1103f417c6d4(i32 %G.call), !dbg !28
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %var_f64.var), !dbg !23
-// CHECK:STDOUT:   %.loc30 = load double, ptr %var_f64.var, align 8, !dbg !29
-// CHECK:STDOUT:   %H.call.loc30 = call double @_CH.Main.66be507887ceee78(double %.loc30), !dbg !30
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !24
-// CHECK:STDOUT:   %.loc32 = load ptr, ptr %ptr_i32.var, align 8, !dbg !31
-// CHECK:STDOUT:   %H.call.loc32 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc32), !dbg !32
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !24
-// CHECK:STDOUT:   %.loc34 = load ptr, ptr %ptr_f64.var, align 8, !dbg !33
-// CHECK:STDOUT:   %H.call.loc34 = call ptr @_CH.Main.04bf2edaaa84aa22(ptr %.loc34), !dbg !34
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !24
-// CHECK:STDOUT:   %.loc36 = load ptr, ptr %ptr_i8.var, align 8, !dbg !35
-// CHECK:STDOUT:   %H.call.loc36 = call ptr @_CH.Main.bda010de15e6a5ad(ptr %.loc36), !dbg !36
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !24
-// CHECK:STDOUT:   %.loc38_6.1.temp = alloca {}, align 8, !dbg !37
-// CHECK:STDOUT:   call void @_CH.Main.15b1f98bd9cc0c5b(ptr %.loc38_6.1.temp, ptr %c.var), !dbg !37
-// CHECK:STDOUT:   ret i32 %x, !dbg !38
+// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !25
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !26
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !27
+// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !28
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !29
+// CHECK:STDOUT:   %H.call.loc23 = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !30
+// CHECK:STDOUT:   %H.call.loc24 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !31
+// CHECK:STDOUT:   %H.call.loc25 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !32
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x), !dbg !33
+// CHECK:STDOUT:   %H.call.loc26 = call i32 @_CH.Main.b88d1103f417c6d4(i32 %G.call), !dbg !34
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %var_f64.var), !dbg !25
+// CHECK:STDOUT:   %.loc30 = load double, ptr %var_f64.var, align 8, !dbg !35
+// CHECK:STDOUT:   %H.call.loc30 = call double @_CH.Main.66be507887ceee78(double %.loc30), !dbg !36
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !26
+// CHECK:STDOUT:   %.loc32 = load ptr, ptr %ptr_i32.var, align 8, !dbg !37
+// CHECK:STDOUT:   %H.call.loc32 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc32), !dbg !38
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !27
+// CHECK:STDOUT:   %.loc34 = load ptr, ptr %ptr_f64.var, align 8, !dbg !39
+// CHECK:STDOUT:   %H.call.loc34 = call ptr @_CH.Main.04bf2edaaa84aa22(ptr %.loc34), !dbg !40
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !28
+// CHECK:STDOUT:   %.loc36 = load ptr, ptr %ptr_i8.var, align 8, !dbg !41
+// CHECK:STDOUT:   %H.call.loc36 = call ptr @_CH.Main.bda010de15e6a5ad(ptr %.loc36), !dbg !42
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !29
+// CHECK:STDOUT:   %.loc38_6.1.temp = alloca {}, align 8, !dbg !43
+// CHECK:STDOUT:   call void @_CH.Main.15b1f98bd9cc0c5b(ptr %.loc38_6.1.temp, ptr %c.var), !dbg !43
+// CHECK:STDOUT:   ret i32 %x, !dbg !44
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !39 {
+// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !45 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !40
+// CHECK:STDOUT:   ret void, !dbg !46
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !41 {
+// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !47 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !42
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !43
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !43
-// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !43
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !43
-// CHECK:STDOUT:   %H.call.loc23 = call double @_CH.Main.66be507887ceee78(double %x), !dbg !43
-// CHECK:STDOUT:   %H.call.loc24 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !44
-// CHECK:STDOUT:   %H.call.loc25 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !45
-// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x), !dbg !46
-// CHECK:STDOUT:   %H.call.loc26 = call double @_CH.Main.66be507887ceee78(double %G.call), !dbg !47
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %var_f64.var), !dbg !42
-// CHECK:STDOUT:   %.loc30 = load double, ptr %var_f64.var, align 8, !dbg !48
-// CHECK:STDOUT:   %H.call.loc30 = call double @_CH.Main.66be507887ceee78(double %.loc30), !dbg !49
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !43
-// CHECK:STDOUT:   %.loc32 = load ptr, ptr %ptr_i32.var, align 8, !dbg !50
-// CHECK:STDOUT:   %H.call.loc32 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc32), !dbg !51
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !43
-// CHECK:STDOUT:   %.loc34 = load ptr, ptr %ptr_f64.var, align 8, !dbg !52
-// CHECK:STDOUT:   %H.call.loc34 = call ptr @_CH.Main.04bf2edaaa84aa22(ptr %.loc34), !dbg !53
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !43
-// CHECK:STDOUT:   %.loc36 = load ptr, ptr %ptr_i8.var, align 8, !dbg !54
-// CHECK:STDOUT:   %H.call.loc36 = call ptr @_CH.Main.bda010de15e6a5ad(ptr %.loc36), !dbg !55
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !43
-// CHECK:STDOUT:   %.loc38_6.1.temp = alloca {}, align 8, !dbg !56
-// CHECK:STDOUT:   call void @_CH.Main.15b1f98bd9cc0c5b(ptr %.loc38_6.1.temp, ptr %c.var), !dbg !56
-// CHECK:STDOUT:   ret double %x, !dbg !57
+// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !48
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !49
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !50
+// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !51
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !52
+// CHECK:STDOUT:   %H.call.loc23 = call double @_CH.Main.66be507887ceee78(double %x), !dbg !53
+// CHECK:STDOUT:   %H.call.loc24 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !54
+// CHECK:STDOUT:   %H.call.loc25 = call %type @_CH.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !55
+// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x), !dbg !56
+// CHECK:STDOUT:   %H.call.loc26 = call double @_CH.Main.66be507887ceee78(double %G.call), !dbg !57
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %var_f64.var), !dbg !48
+// CHECK:STDOUT:   %.loc30 = load double, ptr %var_f64.var, align 8, !dbg !58
+// CHECK:STDOUT:   %H.call.loc30 = call double @_CH.Main.66be507887ceee78(double %.loc30), !dbg !59
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !49
+// CHECK:STDOUT:   %.loc32 = load ptr, ptr %ptr_i32.var, align 8, !dbg !60
+// CHECK:STDOUT:   %H.call.loc32 = call ptr @_CH.Main.e8193710fd35b608(ptr %.loc32), !dbg !61
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !50
+// CHECK:STDOUT:   %.loc34 = load ptr, ptr %ptr_f64.var, align 8, !dbg !62
+// CHECK:STDOUT:   %H.call.loc34 = call ptr @_CH.Main.04bf2edaaa84aa22(ptr %.loc34), !dbg !63
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !51
+// CHECK:STDOUT:   %.loc36 = load ptr, ptr %ptr_i8.var, align 8, !dbg !64
+// CHECK:STDOUT:   %H.call.loc36 = call ptr @_CH.Main.bda010de15e6a5ad(ptr %.loc36), !dbg !65
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !52
+// CHECK:STDOUT:   %.loc38_6.1.temp = alloca {}, align 8, !dbg !66
+// CHECK:STDOUT:   call void @_CH.Main.15b1f98bd9cc0c5b(ptr %.loc38_6.1.temp, ptr %c.var), !dbg !66
+// CHECK:STDOUT:   ret double %x, !dbg !67
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !58 {
+// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !68 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret i32 %x, !dbg !59
+// CHECK:STDOUT:   ret i32 %x, !dbg !69
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !60 {
+// CHECK:STDOUT: define %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !70 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret %type %x, !dbg !61
+// CHECK:STDOUT:   ret %type %x, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CH.Main.66be507887ceee78(double %x) !dbg !62 {
+// CHECK:STDOUT: define double @_CH.Main.66be507887ceee78(double %x) !dbg !72 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret double %x, !dbg !63
+// CHECK:STDOUT:   ret double %x, !dbg !73
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.e8193710fd35b608(ptr %x) !dbg !64 {
+// CHECK:STDOUT: define ptr @_CH.Main.e8193710fd35b608(ptr %x) !dbg !74 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !65
+// CHECK:STDOUT:   ret ptr %x, !dbg !75
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.04bf2edaaa84aa22(ptr %x) !dbg !66 {
+// CHECK:STDOUT: define ptr @_CH.Main.04bf2edaaa84aa22(ptr %x) !dbg !76 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !67
+// CHECK:STDOUT:   ret ptr %x, !dbg !77
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.bda010de15e6a5ad(ptr %x) !dbg !68 {
+// CHECK:STDOUT: define ptr @_CH.Main.bda010de15e6a5ad(ptr %x) !dbg !78 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !69
+// CHECK:STDOUT:   ret ptr %x, !dbg !79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CH.Main.15b1f98bd9cc0c5b(ptr sret({}) %return, ptr %x) !dbg !70 {
+// CHECK:STDOUT: define void @_CH.Main.15b1f98bd9cc0c5b(ptr sret({}) %return, ptr %x) !dbg !80 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !71
+// CHECK:STDOUT:   ret ptr %x, !dbg !81
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -213,67 +213,77 @@ fn M() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 44, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 46, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 49, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 49, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 50, column: 9, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 50, column: 7, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 50, column: 3, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 51, column: 5, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 51, column: 3, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 52, column: 9, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 52, column: 7, scope: !4)
-// CHECK:STDOUT: !18 = !DILocation(line: 52, column: 3, scope: !4)
-// CHECK:STDOUT: !19 = !DILocation(line: 43, column: 1, scope: !4)
-// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !21 = !DILocation(line: 13, column: 1, scope: !20)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !23 = !DILocation(line: 29, column: 3, scope: !22)
-// CHECK:STDOUT: !24 = !DILocation(line: 23, column: 3, scope: !22)
-// CHECK:STDOUT: !25 = !DILocation(line: 24, column: 3, scope: !22)
-// CHECK:STDOUT: !26 = !DILocation(line: 25, column: 3, scope: !22)
-// CHECK:STDOUT: !27 = !DILocation(line: 26, column: 5, scope: !22)
-// CHECK:STDOUT: !28 = !DILocation(line: 26, column: 3, scope: !22)
-// CHECK:STDOUT: !29 = !DILocation(line: 30, column: 5, scope: !22)
-// CHECK:STDOUT: !30 = !DILocation(line: 30, column: 3, scope: !22)
-// CHECK:STDOUT: !31 = !DILocation(line: 32, column: 5, scope: !22)
-// CHECK:STDOUT: !32 = !DILocation(line: 32, column: 3, scope: !22)
-// CHECK:STDOUT: !33 = !DILocation(line: 34, column: 5, scope: !22)
-// CHECK:STDOUT: !34 = !DILocation(line: 34, column: 3, scope: !22)
-// CHECK:STDOUT: !35 = !DILocation(line: 36, column: 5, scope: !22)
-// CHECK:STDOUT: !36 = !DILocation(line: 36, column: 3, scope: !22)
-// CHECK:STDOUT: !37 = !DILocation(line: 38, column: 3, scope: !22)
-// CHECK:STDOUT: !38 = !DILocation(line: 40, column: 3, scope: !22)
-// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !40 = !DILocation(line: 13, column: 1, scope: !39)
-// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !42 = !DILocation(line: 29, column: 3, scope: !41)
-// CHECK:STDOUT: !43 = !DILocation(line: 23, column: 3, scope: !41)
-// CHECK:STDOUT: !44 = !DILocation(line: 24, column: 3, scope: !41)
-// CHECK:STDOUT: !45 = !DILocation(line: 25, column: 3, scope: !41)
-// CHECK:STDOUT: !46 = !DILocation(line: 26, column: 5, scope: !41)
-// CHECK:STDOUT: !47 = !DILocation(line: 26, column: 3, scope: !41)
-// CHECK:STDOUT: !48 = !DILocation(line: 30, column: 5, scope: !41)
-// CHECK:STDOUT: !49 = !DILocation(line: 30, column: 3, scope: !41)
-// CHECK:STDOUT: !50 = !DILocation(line: 32, column: 5, scope: !41)
-// CHECK:STDOUT: !51 = !DILocation(line: 32, column: 3, scope: !41)
-// CHECK:STDOUT: !52 = !DILocation(line: 34, column: 5, scope: !41)
-// CHECK:STDOUT: !53 = !DILocation(line: 34, column: 3, scope: !41)
-// CHECK:STDOUT: !54 = !DILocation(line: 36, column: 5, scope: !41)
-// CHECK:STDOUT: !55 = !DILocation(line: 36, column: 3, scope: !41)
-// CHECK:STDOUT: !56 = !DILocation(line: 38, column: 3, scope: !41)
-// CHECK:STDOUT: !57 = !DILocation(line: 40, column: 3, scope: !41)
-// CHECK:STDOUT: !58 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !59 = !DILocation(line: 17, column: 3, scope: !58)
-// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !61 = !DILocation(line: 17, column: 3, scope: !60)
-// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.66be507887ceee78", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !63 = !DILocation(line: 17, column: 3, scope: !62)
-// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.e8193710fd35b608", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !65 = !DILocation(line: 17, column: 3, scope: !64)
-// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !67 = !DILocation(line: 17, column: 3, scope: !66)
-// CHECK:STDOUT: !68 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.bda010de15e6a5ad", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = !DILocation(line: 45, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 46, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 47, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 49, column: 5, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 49, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 50, column: 9, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 50, column: 7, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 50, column: 3, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 51, column: 5, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 51, column: 3, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 52, column: 9, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 52, column: 7, scope: !4)
+// CHECK:STDOUT: !20 = !DILocation(line: 52, column: 3, scope: !4)
+// CHECK:STDOUT: !21 = !DILocation(line: 43, column: 1, scope: !4)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = !DILocation(line: 13, column: 1, scope: !22)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !25 = !DILocation(line: 29, column: 3, scope: !24)
+// CHECK:STDOUT: !26 = !DILocation(line: 31, column: 3, scope: !24)
+// CHECK:STDOUT: !27 = !DILocation(line: 33, column: 3, scope: !24)
+// CHECK:STDOUT: !28 = !DILocation(line: 35, column: 3, scope: !24)
+// CHECK:STDOUT: !29 = !DILocation(line: 37, column: 3, scope: !24)
+// CHECK:STDOUT: !30 = !DILocation(line: 23, column: 3, scope: !24)
+// CHECK:STDOUT: !31 = !DILocation(line: 24, column: 3, scope: !24)
+// CHECK:STDOUT: !32 = !DILocation(line: 25, column: 3, scope: !24)
+// CHECK:STDOUT: !33 = !DILocation(line: 26, column: 5, scope: !24)
+// CHECK:STDOUT: !34 = !DILocation(line: 26, column: 3, scope: !24)
+// CHECK:STDOUT: !35 = !DILocation(line: 30, column: 5, scope: !24)
+// CHECK:STDOUT: !36 = !DILocation(line: 30, column: 3, scope: !24)
+// CHECK:STDOUT: !37 = !DILocation(line: 32, column: 5, scope: !24)
+// CHECK:STDOUT: !38 = !DILocation(line: 32, column: 3, scope: !24)
+// CHECK:STDOUT: !39 = !DILocation(line: 34, column: 5, scope: !24)
+// CHECK:STDOUT: !40 = !DILocation(line: 34, column: 3, scope: !24)
+// CHECK:STDOUT: !41 = !DILocation(line: 36, column: 5, scope: !24)
+// CHECK:STDOUT: !42 = !DILocation(line: 36, column: 3, scope: !24)
+// CHECK:STDOUT: !43 = !DILocation(line: 38, column: 3, scope: !24)
+// CHECK:STDOUT: !44 = !DILocation(line: 40, column: 3, scope: !24)
+// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !46 = !DILocation(line: 13, column: 1, scope: !45)
+// CHECK:STDOUT: !47 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !48 = !DILocation(line: 29, column: 3, scope: !47)
+// CHECK:STDOUT: !49 = !DILocation(line: 31, column: 3, scope: !47)
+// CHECK:STDOUT: !50 = !DILocation(line: 33, column: 3, scope: !47)
+// CHECK:STDOUT: !51 = !DILocation(line: 35, column: 3, scope: !47)
+// CHECK:STDOUT: !52 = !DILocation(line: 37, column: 3, scope: !47)
+// CHECK:STDOUT: !53 = !DILocation(line: 23, column: 3, scope: !47)
+// CHECK:STDOUT: !54 = !DILocation(line: 24, column: 3, scope: !47)
+// CHECK:STDOUT: !55 = !DILocation(line: 25, column: 3, scope: !47)
+// CHECK:STDOUT: !56 = !DILocation(line: 26, column: 5, scope: !47)
+// CHECK:STDOUT: !57 = !DILocation(line: 26, column: 3, scope: !47)
+// CHECK:STDOUT: !58 = !DILocation(line: 30, column: 5, scope: !47)
+// CHECK:STDOUT: !59 = !DILocation(line: 30, column: 3, scope: !47)
+// CHECK:STDOUT: !60 = !DILocation(line: 32, column: 5, scope: !47)
+// CHECK:STDOUT: !61 = !DILocation(line: 32, column: 3, scope: !47)
+// CHECK:STDOUT: !62 = !DILocation(line: 34, column: 5, scope: !47)
+// CHECK:STDOUT: !63 = !DILocation(line: 34, column: 3, scope: !47)
+// CHECK:STDOUT: !64 = !DILocation(line: 36, column: 5, scope: !47)
+// CHECK:STDOUT: !65 = !DILocation(line: 36, column: 3, scope: !47)
+// CHECK:STDOUT: !66 = !DILocation(line: 38, column: 3, scope: !47)
+// CHECK:STDOUT: !67 = !DILocation(line: 40, column: 3, scope: !47)
+// CHECK:STDOUT: !68 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !69 = !DILocation(line: 17, column: 3, scope: !68)
-// CHECK:STDOUT: !70 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.15b1f98bd9cc0c5b", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !70 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !71 = !DILocation(line: 17, column: 3, scope: !70)
+// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.66be507887ceee78", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !73 = !DILocation(line: 17, column: 3, scope: !72)
+// CHECK:STDOUT: !74 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.e8193710fd35b608", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !75 = !DILocation(line: 17, column: 3, scope: !74)
+// CHECK:STDOUT: !76 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !77 = !DILocation(line: 17, column: 3, scope: !76)
+// CHECK:STDOUT: !78 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.bda010de15e6a5ad", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !79 = !DILocation(line: 17, column: 3, scope: !78)
+// CHECK:STDOUT: !80 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.15b1f98bd9cc0c5b", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !81 = !DILocation(line: 17, column: 3, scope: !80)

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -39,37 +39,37 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %m.var), !dbg !7
-// CHECK:STDOUT:   %.loc32 = load i32, ptr %n.var, align 4, !dbg !8
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc32), !dbg !9
-// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !10
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !11
-// CHECK:STDOUT:   store i32 %G.call, ptr %m.var, align 4, !dbg !12
-// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %m.var), !dbg !8
+// CHECK:STDOUT:   %.loc32 = load i32, ptr %n.var, align 4, !dbg !9
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc32), !dbg !10
+// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !12
+// CHECK:STDOUT:   store i32 %G.call, ptr %m.var, align 4, !dbg !13
+// CHECK:STDOUT:   ret void, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !14 {
+// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !15 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !16 {
+// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !17 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !17
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !18
-// CHECK:STDOUT:   ret i32 %x, !dbg !19
+// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !18
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !19
+// CHECK:STDOUT:   ret i32 %x, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !20 {
+// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !21 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !21
-// CHECK:STDOUT:   ret i32 %x, !dbg !22
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !22
+// CHECK:STDOUT:   ret i32 %x, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -88,18 +88,19 @@ fn M() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 29, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 32, column: 5, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 32, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 33, column: 9, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 33, column: 7, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 33, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 28, column: 1, scope: !4)
-// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !15 = !DILocation(line: 14, column: 1, scope: !14)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !17 = !DILocation(line: 23, column: 3, scope: !16)
-// CHECK:STDOUT: !18 = !DILocation(line: 24, column: 3, scope: !16)
-// CHECK:STDOUT: !19 = !DILocation(line: 25, column: 3, scope: !16)
-// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 3, scope: !20)
-// CHECK:STDOUT: !22 = !DILocation(line: 19, column: 3, scope: !20)
+// CHECK:STDOUT: !8 = !DILocation(line: 30, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 32, column: 5, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 32, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 33, column: 9, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 33, column: 7, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 33, column: 3, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 28, column: 1, scope: !4)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = !DILocation(line: 14, column: 1, scope: !15)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !18 = !DILocation(line: 23, column: 3, scope: !17)
+// CHECK:STDOUT: !19 = !DILocation(line: 24, column: 3, scope: !17)
+// CHECK:STDOUT: !20 = !DILocation(line: 25, column: 3, scope: !17)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.b88d1103f417c6d4", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = !DILocation(line: 18, column: 3, scope: !21)
+// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 3, scope: !21)

--- a/toolchain/lower/testdata/function/generic/call_dedup_ptr.carbon
+++ b/toolchain/lower/testdata/function/generic/call_dedup_ptr.carbon
@@ -30,36 +30,36 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !7
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !8
+// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !7
-// CHECK:STDOUT:   %.loc20 = load ptr, ptr %ptr_i32.var, align 8, !dbg !8
-// CHECK:STDOUT:   %F.call.loc20 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc20), !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
-// CHECK:STDOUT:   %.loc22 = load ptr, ptr %ptr_f64.var, align 8, !dbg !10
-// CHECK:STDOUT:   %F.call.loc22 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc22), !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !7
-// CHECK:STDOUT:   %.loc24 = load ptr, ptr %ptr_i8.var, align 8, !dbg !12
-// CHECK:STDOUT:   %F.call.loc24 = call ptr @_CF.Main.bda010de15e6a5ad(ptr %.loc24), !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT:   %.loc20 = load ptr, ptr %ptr_i32.var, align 8, !dbg !10
+// CHECK:STDOUT:   %F.call.loc20 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc20), !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !8
+// CHECK:STDOUT:   %.loc22 = load ptr, ptr %ptr_f64.var, align 8, !dbg !12
+// CHECK:STDOUT:   %F.call.loc22 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc22), !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !9
+// CHECK:STDOUT:   %.loc24 = load ptr, ptr %ptr_i8.var, align 8, !dbg !14
+// CHECK:STDOUT:   %F.call.loc24 = call ptr @_CF.Main.bda010de15e6a5ad(ptr %.loc24), !dbg !15
+// CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !15 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !16
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !17 {
+// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !19 {
+// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !20
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !21 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret ptr %x, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -78,16 +78,18 @@ fn M() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 19, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 20, column: 5, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 20, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 22, column: 5, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 22, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 24, column: 5, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 24, column: 3, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 15, column: 1, scope: !4)
-// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !16 = !DILocation(line: 12, column: 3, scope: !15)
-// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = !DILocation(line: 21, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 23, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 20, column: 5, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 20, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 22, column: 5, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 22, column: 3, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 24, column: 5, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 24, column: 3, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !4)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !18 = !DILocation(line: 12, column: 3, scope: !17)
-// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.bda010de15e6a5ad", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !20 = !DILocation(line: 12, column: 3, scope: !19)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.bda010de15e6a5ad", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = !DILocation(line: 12, column: 3, scope: !21)

--- a/toolchain/lower/testdata/function/generic/call_method.carbon
+++ b/toolchain/lower/testdata/function/generic/call_method.carbon
@@ -28,10 +28,10 @@ fn CallF() -> i32 {
 // CHECK:STDOUT: define i32 @_CCallF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !7
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @C.val.loc18_3.2, i64 0, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !8
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !8
 // CHECK:STDOUT:   %.loc20_14 = load i32, ptr %n.var, align 4, !dbg !9
 // CHECK:STDOUT:   %F.call = call i32 @_CF.C.Main.b88d1103f417c6d4(ptr %c.var, i32 %.loc20_14), !dbg !10

--- a/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
@@ -43,83 +43,83 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !8
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !9
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !8
 // CHECK:STDOUT:   store double 1.000000e+00, ptr %m.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
-// CHECK:STDOUT:   %.loc28_5 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   %F.call.loc28 = call i32 @_CF.Main.b88d1103f417c6d4(i32 %.loc28_5, i32 0), !dbg !10
-// CHECK:STDOUT:   %.loc29_5 = load double, ptr %m.var, align 8, !dbg !11
-// CHECK:STDOUT:   %F.call.loc29 = call double @_CF.Main.66be507887ceee78(double %.loc29_5, i32 0), !dbg !12
-// CHECK:STDOUT:   %.loc30_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !13
-// CHECK:STDOUT:   %F.call.loc30 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc30_5, i32 0), !dbg !14
-// CHECK:STDOUT:   %.loc31_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !15
-// CHECK:STDOUT:   %F.call.loc31 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc31_5, i32 0), !dbg !16
-// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !10
+// CHECK:STDOUT:   %.loc28_5 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %F.call.loc28 = call i32 @_CF.Main.b88d1103f417c6d4(i32 %.loc28_5, i32 0), !dbg !12
+// CHECK:STDOUT:   %.loc29_5 = load double, ptr %m.var, align 8, !dbg !13
+// CHECK:STDOUT:   %F.call.loc29 = call double @_CF.Main.66be507887ceee78(double %.loc29_5, i32 0), !dbg !14
+// CHECK:STDOUT:   %.loc30_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !15
+// CHECK:STDOUT:   %F.call.loc30 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc30_5, i32 0), !dbg !16
+// CHECK:STDOUT:   %.loc31_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !17
+// CHECK:STDOUT:   %F.call.loc31 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc31_5, i32 0), !dbg !18
+// CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !18 {
+// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !19
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !20
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !21
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !22
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret i32 %x, !dbg !21
+// CHECK:STDOUT:   ret i32 %x, !dbg !23
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !22
-// CHECK:STDOUT:   %F.call = call i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !23
-// CHECK:STDOUT:   ret i32 %F.call, !dbg !24
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !24
+// CHECK:STDOUT:   %F.call = call i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !25
+// CHECK:STDOUT:   ret i32 %F.call, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !25 {
+// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !27 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !26
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !27
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !28
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !29
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret double %x, !dbg !28
+// CHECK:STDOUT:   ret double %x, !dbg !30
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !29
-// CHECK:STDOUT:   %F.call = call double @_CF.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !30
-// CHECK:STDOUT:   ret double %F.call, !dbg !31
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !31
+// CHECK:STDOUT:   %F.call = call double @_CF.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !32
+// CHECK:STDOUT:   ret double %F.call, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !32 {
+// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !34 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !33
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !34
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !35
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !36
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !35
+// CHECK:STDOUT:   ret ptr %x, !dbg !37
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !36
-// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !37
-// CHECK:STDOUT:   ret ptr %F.call, !dbg !38
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !38
+// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !39
+// CHECK:STDOUT:   ret ptr %F.call, !dbg !40
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !39 {
+// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !41 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !40
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !41
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !42
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !43
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !42
+// CHECK:STDOUT:   ret ptr %x, !dbg !44
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !43
-// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !44
-// CHECK:STDOUT:   ret ptr %F.call, !dbg !45
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !45
+// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !46
+// CHECK:STDOUT:   ret ptr %F.call, !dbg !47
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -139,40 +139,42 @@ fn M() {
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 23, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 24, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 28, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 28, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 29, column: 5, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 29, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 30, column: 5, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 30, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 31, column: 5, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 31, column: 3, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 22, column: 1, scope: !4)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !19 = !DILocation(line: 16, column: 7, scope: !18)
-// CHECK:STDOUT: !20 = !DILocation(line: 16, column: 6, scope: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 17, column: 5, scope: !18)
-// CHECK:STDOUT: !22 = !DILocation(line: 19, column: 15, scope: !18)
-// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 10, scope: !18)
-// CHECK:STDOUT: !24 = !DILocation(line: 19, column: 3, scope: !18)
-// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !26 = !DILocation(line: 16, column: 7, scope: !25)
-// CHECK:STDOUT: !27 = !DILocation(line: 16, column: 6, scope: !25)
-// CHECK:STDOUT: !28 = !DILocation(line: 17, column: 5, scope: !25)
-// CHECK:STDOUT: !29 = !DILocation(line: 19, column: 15, scope: !25)
-// CHECK:STDOUT: !30 = !DILocation(line: 19, column: 10, scope: !25)
-// CHECK:STDOUT: !31 = !DILocation(line: 19, column: 3, scope: !25)
-// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !33 = !DILocation(line: 16, column: 7, scope: !32)
-// CHECK:STDOUT: !34 = !DILocation(line: 16, column: 6, scope: !32)
-// CHECK:STDOUT: !35 = !DILocation(line: 17, column: 5, scope: !32)
-// CHECK:STDOUT: !36 = !DILocation(line: 19, column: 15, scope: !32)
-// CHECK:STDOUT: !37 = !DILocation(line: 19, column: 10, scope: !32)
-// CHECK:STDOUT: !38 = !DILocation(line: 19, column: 3, scope: !32)
-// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !40 = !DILocation(line: 16, column: 7, scope: !39)
-// CHECK:STDOUT: !41 = !DILocation(line: 16, column: 6, scope: !39)
-// CHECK:STDOUT: !42 = !DILocation(line: 17, column: 5, scope: !39)
-// CHECK:STDOUT: !43 = !DILocation(line: 19, column: 15, scope: !39)
-// CHECK:STDOUT: !44 = !DILocation(line: 19, column: 10, scope: !39)
-// CHECK:STDOUT: !45 = !DILocation(line: 19, column: 3, scope: !39)
+// CHECK:STDOUT: !9 = !DILocation(line: 25, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 26, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 28, column: 5, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 28, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 29, column: 5, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 29, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 30, column: 5, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 30, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 31, column: 5, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 31, column: 3, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 22, column: 1, scope: !4)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = !DILocation(line: 16, column: 7, scope: !20)
+// CHECK:STDOUT: !22 = !DILocation(line: 16, column: 6, scope: !20)
+// CHECK:STDOUT: !23 = !DILocation(line: 17, column: 5, scope: !20)
+// CHECK:STDOUT: !24 = !DILocation(line: 19, column: 15, scope: !20)
+// CHECK:STDOUT: !25 = !DILocation(line: 19, column: 10, scope: !20)
+// CHECK:STDOUT: !26 = !DILocation(line: 19, column: 3, scope: !20)
+// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !28 = !DILocation(line: 16, column: 7, scope: !27)
+// CHECK:STDOUT: !29 = !DILocation(line: 16, column: 6, scope: !27)
+// CHECK:STDOUT: !30 = !DILocation(line: 17, column: 5, scope: !27)
+// CHECK:STDOUT: !31 = !DILocation(line: 19, column: 15, scope: !27)
+// CHECK:STDOUT: !32 = !DILocation(line: 19, column: 10, scope: !27)
+// CHECK:STDOUT: !33 = !DILocation(line: 19, column: 3, scope: !27)
+// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !35 = !DILocation(line: 16, column: 7, scope: !34)
+// CHECK:STDOUT: !36 = !DILocation(line: 16, column: 6, scope: !34)
+// CHECK:STDOUT: !37 = !DILocation(line: 17, column: 5, scope: !34)
+// CHECK:STDOUT: !38 = !DILocation(line: 19, column: 15, scope: !34)
+// CHECK:STDOUT: !39 = !DILocation(line: 19, column: 10, scope: !34)
+// CHECK:STDOUT: !40 = !DILocation(line: 19, column: 3, scope: !34)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !42 = !DILocation(line: 16, column: 7, scope: !41)
+// CHECK:STDOUT: !43 = !DILocation(line: 16, column: 6, scope: !41)
+// CHECK:STDOUT: !44 = !DILocation(line: 17, column: 5, scope: !41)
+// CHECK:STDOUT: !45 = !DILocation(line: 19, column: 15, scope: !41)
+// CHECK:STDOUT: !46 = !DILocation(line: 19, column: 10, scope: !41)
+// CHECK:STDOUT: !47 = !DILocation(line: 19, column: 3, scope: !41)

--- a/toolchain/lower/testdata/function/generic/call_recursive_diamond.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_diamond.carbon
@@ -62,201 +62,201 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !8
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !9
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !8
 // CHECK:STDOUT:   store double 1.000000e+00, ptr %m.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
-// CHECK:STDOUT:   %.loc51_5 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   %A.call.loc51 = call i32 @_CA.Main.b88d1103f417c6d4(i32 %.loc51_5, i32 0), !dbg !10
-// CHECK:STDOUT:   %.loc52_5 = load double, ptr %m.var, align 8, !dbg !11
-// CHECK:STDOUT:   %A.call.loc52 = call double @_CA.Main.66be507887ceee78(double %.loc52_5, i32 0), !dbg !12
-// CHECK:STDOUT:   %.loc53_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !13
-// CHECK:STDOUT:   %A.call.loc53 = call ptr @_CA.Main.e8193710fd35b608(ptr %.loc53_5, i32 0), !dbg !14
-// CHECK:STDOUT:   %.loc54_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !15
-// CHECK:STDOUT:   %A.call.loc54 = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %.loc54_5, i32 0), !dbg !16
-// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !10
+// CHECK:STDOUT:   %.loc51_5 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %A.call.loc51 = call i32 @_CA.Main.b88d1103f417c6d4(i32 %.loc51_5, i32 0), !dbg !12
+// CHECK:STDOUT:   %.loc52_5 = load double, ptr %m.var, align 8, !dbg !13
+// CHECK:STDOUT:   %A.call.loc52 = call double @_CA.Main.66be507887ceee78(double %.loc52_5, i32 0), !dbg !14
+// CHECK:STDOUT:   %.loc53_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !15
+// CHECK:STDOUT:   %A.call.loc53 = call ptr @_CA.Main.e8193710fd35b608(ptr %.loc53_5, i32 0), !dbg !16
+// CHECK:STDOUT:   %.loc54_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !17
+// CHECK:STDOUT:   %A.call.loc54 = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %.loc54_5, i32 0), !dbg !18
+// CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !18 {
+// CHECK:STDOUT: define i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !19
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !20
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !21
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !22
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   ret i32 %x, !dbg !21
+// CHECK:STDOUT:   ret i32 %x, !dbg !23
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !22
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !22
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !23
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !24
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !24
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !25
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %B.call = call i32 @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !24
-// CHECK:STDOUT:   ret i32 %B.call, !dbg !25
+// CHECK:STDOUT:   %B.call = call i32 @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !26
+// CHECK:STDOUT:   ret i32 %B.call, !dbg !27
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %C.call = call i32 @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !26
-// CHECK:STDOUT:   ret i32 %C.call, !dbg !27
+// CHECK:STDOUT:   %C.call = call i32 @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !28
+// CHECK:STDOUT:   ret i32 %C.call, !dbg !29
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !28 {
+// CHECK:STDOUT: define double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !30 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !29
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !30
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !31
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !32
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   ret double %x, !dbg !31
+// CHECK:STDOUT:   ret double %x, !dbg !33
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !32
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !32
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !33
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !34
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !34
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !35
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %B.call = call double @_CB.Main.66be507887ceee78(double %x, i32 %count), !dbg !34
-// CHECK:STDOUT:   ret double %B.call, !dbg !35
+// CHECK:STDOUT:   %B.call = call double @_CB.Main.66be507887ceee78(double %x, i32 %count), !dbg !36
+// CHECK:STDOUT:   ret double %B.call, !dbg !37
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %C.call = call double @_CC.Main.66be507887ceee78(double %x, i32 %count), !dbg !36
-// CHECK:STDOUT:   ret double %C.call, !dbg !37
+// CHECK:STDOUT:   %C.call = call double @_CC.Main.66be507887ceee78(double %x, i32 %count), !dbg !38
+// CHECK:STDOUT:   ret double %C.call, !dbg !39
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !38 {
+// CHECK:STDOUT: define ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !40 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !39
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !40
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !41
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !42
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !41
+// CHECK:STDOUT:   ret ptr %x, !dbg !43
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !42
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !42
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !43
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !44
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !44
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !45
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %B.call = call ptr @_CB.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !44
-// CHECK:STDOUT:   ret ptr %B.call, !dbg !45
+// CHECK:STDOUT:   %B.call = call ptr @_CB.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !46
+// CHECK:STDOUT:   ret ptr %B.call, !dbg !47
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %C.call = call ptr @_CC.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !46
-// CHECK:STDOUT:   ret ptr %C.call, !dbg !47
+// CHECK:STDOUT:   %C.call = call ptr @_CC.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !48
+// CHECK:STDOUT:   ret ptr %C.call, !dbg !49
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !48 {
+// CHECK:STDOUT: define ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !50 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !49
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !50
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !51
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !52
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !51
+// CHECK:STDOUT:   ret ptr %x, !dbg !53
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc20:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !52
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !52
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !53
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !54
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !54
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc23, label %if.else.loc23, !dbg !55
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %B.call = call ptr @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !54
-// CHECK:STDOUT:   ret ptr %B.call, !dbg !55
+// CHECK:STDOUT:   %B.call = call ptr @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !56
+// CHECK:STDOUT:   ret ptr %B.call, !dbg !57
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc23:                                    ; preds = %if.else.loc20
-// CHECK:STDOUT:   %C.call = call ptr @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !56
-// CHECK:STDOUT:   ret ptr %C.call, !dbg !57
+// CHECK:STDOUT:   %C.call = call ptr @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !58
+// CHECK:STDOUT:   ret ptr %C.call, !dbg !59
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !58 {
+// CHECK:STDOUT: define i32 @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !60 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !59
-// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !60
-// CHECK:STDOUT:   ret i32 %D.call, !dbg !61
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !61
+// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !62
+// CHECK:STDOUT:   ret i32 %D.call, !dbg !63
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !62 {
+// CHECK:STDOUT: define i32 @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !64 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !63
-// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !64
-// CHECK:STDOUT:   ret i32 %D.call, !dbg !65
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !65
+// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !66
+// CHECK:STDOUT:   ret i32 %D.call, !dbg !67
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !66 {
+// CHECK:STDOUT: define double @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !68 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !67
-// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !68
-// CHECK:STDOUT:   ret double %D.call, !dbg !69
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !69
+// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !70
+// CHECK:STDOUT:   ret double %D.call, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !70 {
+// CHECK:STDOUT: define double @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !72 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !71
-// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !72
-// CHECK:STDOUT:   ret double %D.call, !dbg !73
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !73
+// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !74
+// CHECK:STDOUT:   ret double %D.call, !dbg !75
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !74 {
+// CHECK:STDOUT: define ptr @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !76 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !75
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !76
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !77
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !77
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !78
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !78 {
+// CHECK:STDOUT: define ptr @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !80 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !79
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !80
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !81
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !81
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !82
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !83
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !82 {
+// CHECK:STDOUT: define ptr @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !84 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !83
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !84
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !85
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !85
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !86
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !87
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !86 {
+// CHECK:STDOUT: define ptr @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !88 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !87
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !88
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !89
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !89
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !90
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !91
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !90 {
+// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !92 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !91
-// CHECK:STDOUT:   %A.call = call i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !92
-// CHECK:STDOUT:   ret i32 %A.call, !dbg !93
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !93
+// CHECK:STDOUT:   %A.call = call i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !94
+// CHECK:STDOUT:   ret i32 %A.call, !dbg !95
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !94 {
+// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !96 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !95
-// CHECK:STDOUT:   %A.call = call double @_CA.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !96
-// CHECK:STDOUT:   ret double %A.call, !dbg !97
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !97
+// CHECK:STDOUT:   %A.call = call double @_CA.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !98
+// CHECK:STDOUT:   ret double %A.call, !dbg !99
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !98 {
+// CHECK:STDOUT: define ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !100 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !99
-// CHECK:STDOUT:   %A.call = call ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !100
-// CHECK:STDOUT:   ret ptr %A.call, !dbg !101
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !101
+// CHECK:STDOUT:   %A.call = call ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !102
+// CHECK:STDOUT:   ret ptr %A.call, !dbg !103
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !102 {
+// CHECK:STDOUT: define ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !104 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !103
-// CHECK:STDOUT:   %A.call = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !104
-// CHECK:STDOUT:   ret ptr %A.call, !dbg !105
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !105
+// CHECK:STDOUT:   %A.call = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !106
+// CHECK:STDOUT:   ret ptr %A.call, !dbg !107
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -281,100 +281,102 @@ fn M() {
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 46, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 47, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 51, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 51, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 52, column: 5, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 52, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 53, column: 5, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 53, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 54, column: 5, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 54, column: 3, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 45, column: 1, scope: !4)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.b88d1103f417c6d4", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !19 = !DILocation(line: 20, column: 7, scope: !18)
-// CHECK:STDOUT: !20 = !DILocation(line: 20, column: 6, scope: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 21, column: 5, scope: !18)
-// CHECK:STDOUT: !22 = !DILocation(line: 23, column: 7, scope: !18)
-// CHECK:STDOUT: !23 = !DILocation(line: 23, column: 6, scope: !18)
-// CHECK:STDOUT: !24 = !DILocation(line: 24, column: 12, scope: !18)
-// CHECK:STDOUT: !25 = !DILocation(line: 24, column: 5, scope: !18)
-// CHECK:STDOUT: !26 = !DILocation(line: 26, column: 12, scope: !18)
-// CHECK:STDOUT: !27 = !DILocation(line: 26, column: 5, scope: !18)
-// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.66be507887ceee78", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !29 = !DILocation(line: 20, column: 7, scope: !28)
-// CHECK:STDOUT: !30 = !DILocation(line: 20, column: 6, scope: !28)
-// CHECK:STDOUT: !31 = !DILocation(line: 21, column: 5, scope: !28)
-// CHECK:STDOUT: !32 = !DILocation(line: 23, column: 7, scope: !28)
-// CHECK:STDOUT: !33 = !DILocation(line: 23, column: 6, scope: !28)
-// CHECK:STDOUT: !34 = !DILocation(line: 24, column: 12, scope: !28)
-// CHECK:STDOUT: !35 = !DILocation(line: 24, column: 5, scope: !28)
-// CHECK:STDOUT: !36 = !DILocation(line: 26, column: 12, scope: !28)
-// CHECK:STDOUT: !37 = !DILocation(line: 26, column: 5, scope: !28)
-// CHECK:STDOUT: !38 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.e8193710fd35b608", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !39 = !DILocation(line: 20, column: 7, scope: !38)
-// CHECK:STDOUT: !40 = !DILocation(line: 20, column: 6, scope: !38)
-// CHECK:STDOUT: !41 = !DILocation(line: 21, column: 5, scope: !38)
-// CHECK:STDOUT: !42 = !DILocation(line: 23, column: 7, scope: !38)
-// CHECK:STDOUT: !43 = !DILocation(line: 23, column: 6, scope: !38)
-// CHECK:STDOUT: !44 = !DILocation(line: 24, column: 12, scope: !38)
-// CHECK:STDOUT: !45 = !DILocation(line: 24, column: 5, scope: !38)
-// CHECK:STDOUT: !46 = !DILocation(line: 26, column: 12, scope: !38)
-// CHECK:STDOUT: !47 = !DILocation(line: 26, column: 5, scope: !38)
-// CHECK:STDOUT: !48 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !49 = !DILocation(line: 20, column: 7, scope: !48)
-// CHECK:STDOUT: !50 = !DILocation(line: 20, column: 6, scope: !48)
-// CHECK:STDOUT: !51 = !DILocation(line: 21, column: 5, scope: !48)
-// CHECK:STDOUT: !52 = !DILocation(line: 23, column: 7, scope: !48)
-// CHECK:STDOUT: !53 = !DILocation(line: 23, column: 6, scope: !48)
-// CHECK:STDOUT: !54 = !DILocation(line: 24, column: 12, scope: !48)
-// CHECK:STDOUT: !55 = !DILocation(line: 24, column: 5, scope: !48)
-// CHECK:STDOUT: !56 = !DILocation(line: 26, column: 12, scope: !48)
-// CHECK:STDOUT: !57 = !DILocation(line: 26, column: 5, scope: !48)
-// CHECK:STDOUT: !58 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.b88d1103f417c6d4", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !59 = !DILocation(line: 32, column: 3, scope: !58)
-// CHECK:STDOUT: !60 = !DILocation(line: 33, column: 10, scope: !58)
-// CHECK:STDOUT: !61 = !DILocation(line: 33, column: 3, scope: !58)
-// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.b88d1103f417c6d4", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !63 = !DILocation(line: 37, column: 3, scope: !62)
-// CHECK:STDOUT: !64 = !DILocation(line: 38, column: 10, scope: !62)
-// CHECK:STDOUT: !65 = !DILocation(line: 38, column: 3, scope: !62)
-// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.66be507887ceee78", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !67 = !DILocation(line: 32, column: 3, scope: !66)
-// CHECK:STDOUT: !68 = !DILocation(line: 33, column: 10, scope: !66)
-// CHECK:STDOUT: !69 = !DILocation(line: 33, column: 3, scope: !66)
-// CHECK:STDOUT: !70 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.66be507887ceee78", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !71 = !DILocation(line: 37, column: 3, scope: !70)
-// CHECK:STDOUT: !72 = !DILocation(line: 38, column: 10, scope: !70)
-// CHECK:STDOUT: !73 = !DILocation(line: 38, column: 3, scope: !70)
-// CHECK:STDOUT: !74 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.e8193710fd35b608", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !75 = !DILocation(line: 32, column: 3, scope: !74)
-// CHECK:STDOUT: !76 = !DILocation(line: 33, column: 10, scope: !74)
-// CHECK:STDOUT: !77 = !DILocation(line: 33, column: 3, scope: !74)
-// CHECK:STDOUT: !78 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.e8193710fd35b608", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !79 = !DILocation(line: 37, column: 3, scope: !78)
-// CHECK:STDOUT: !80 = !DILocation(line: 38, column: 10, scope: !78)
-// CHECK:STDOUT: !81 = !DILocation(line: 38, column: 3, scope: !78)
-// CHECK:STDOUT: !82 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !83 = !DILocation(line: 32, column: 3, scope: !82)
-// CHECK:STDOUT: !84 = !DILocation(line: 33, column: 10, scope: !82)
-// CHECK:STDOUT: !85 = !DILocation(line: 33, column: 3, scope: !82)
-// CHECK:STDOUT: !86 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !87 = !DILocation(line: 37, column: 3, scope: !86)
-// CHECK:STDOUT: !88 = !DILocation(line: 38, column: 10, scope: !86)
-// CHECK:STDOUT: !89 = !DILocation(line: 38, column: 3, scope: !86)
-// CHECK:STDOUT: !90 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.b88d1103f417c6d4", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !91 = !DILocation(line: 42, column: 15, scope: !90)
-// CHECK:STDOUT: !92 = !DILocation(line: 42, column: 10, scope: !90)
-// CHECK:STDOUT: !93 = !DILocation(line: 42, column: 3, scope: !90)
-// CHECK:STDOUT: !94 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.66be507887ceee78", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !95 = !DILocation(line: 42, column: 15, scope: !94)
-// CHECK:STDOUT: !96 = !DILocation(line: 42, column: 10, scope: !94)
-// CHECK:STDOUT: !97 = !DILocation(line: 42, column: 3, scope: !94)
-// CHECK:STDOUT: !98 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.e8193710fd35b608", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !99 = !DILocation(line: 42, column: 15, scope: !98)
-// CHECK:STDOUT: !100 = !DILocation(line: 42, column: 10, scope: !98)
-// CHECK:STDOUT: !101 = !DILocation(line: 42, column: 3, scope: !98)
-// CHECK:STDOUT: !102 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !103 = !DILocation(line: 42, column: 15, scope: !102)
-// CHECK:STDOUT: !104 = !DILocation(line: 42, column: 10, scope: !102)
-// CHECK:STDOUT: !105 = !DILocation(line: 42, column: 3, scope: !102)
+// CHECK:STDOUT: !9 = !DILocation(line: 48, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 49, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 51, column: 5, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 51, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 52, column: 5, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 52, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 53, column: 5, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 53, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 54, column: 5, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 54, column: 3, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 45, column: 1, scope: !4)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.b88d1103f417c6d4", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = !DILocation(line: 20, column: 7, scope: !20)
+// CHECK:STDOUT: !22 = !DILocation(line: 20, column: 6, scope: !20)
+// CHECK:STDOUT: !23 = !DILocation(line: 21, column: 5, scope: !20)
+// CHECK:STDOUT: !24 = !DILocation(line: 23, column: 7, scope: !20)
+// CHECK:STDOUT: !25 = !DILocation(line: 23, column: 6, scope: !20)
+// CHECK:STDOUT: !26 = !DILocation(line: 24, column: 12, scope: !20)
+// CHECK:STDOUT: !27 = !DILocation(line: 24, column: 5, scope: !20)
+// CHECK:STDOUT: !28 = !DILocation(line: 26, column: 12, scope: !20)
+// CHECK:STDOUT: !29 = !DILocation(line: 26, column: 5, scope: !20)
+// CHECK:STDOUT: !30 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.66be507887ceee78", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !31 = !DILocation(line: 20, column: 7, scope: !30)
+// CHECK:STDOUT: !32 = !DILocation(line: 20, column: 6, scope: !30)
+// CHECK:STDOUT: !33 = !DILocation(line: 21, column: 5, scope: !30)
+// CHECK:STDOUT: !34 = !DILocation(line: 23, column: 7, scope: !30)
+// CHECK:STDOUT: !35 = !DILocation(line: 23, column: 6, scope: !30)
+// CHECK:STDOUT: !36 = !DILocation(line: 24, column: 12, scope: !30)
+// CHECK:STDOUT: !37 = !DILocation(line: 24, column: 5, scope: !30)
+// CHECK:STDOUT: !38 = !DILocation(line: 26, column: 12, scope: !30)
+// CHECK:STDOUT: !39 = !DILocation(line: 26, column: 5, scope: !30)
+// CHECK:STDOUT: !40 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.e8193710fd35b608", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !41 = !DILocation(line: 20, column: 7, scope: !40)
+// CHECK:STDOUT: !42 = !DILocation(line: 20, column: 6, scope: !40)
+// CHECK:STDOUT: !43 = !DILocation(line: 21, column: 5, scope: !40)
+// CHECK:STDOUT: !44 = !DILocation(line: 23, column: 7, scope: !40)
+// CHECK:STDOUT: !45 = !DILocation(line: 23, column: 6, scope: !40)
+// CHECK:STDOUT: !46 = !DILocation(line: 24, column: 12, scope: !40)
+// CHECK:STDOUT: !47 = !DILocation(line: 24, column: 5, scope: !40)
+// CHECK:STDOUT: !48 = !DILocation(line: 26, column: 12, scope: !40)
+// CHECK:STDOUT: !49 = !DILocation(line: 26, column: 5, scope: !40)
+// CHECK:STDOUT: !50 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !51 = !DILocation(line: 20, column: 7, scope: !50)
+// CHECK:STDOUT: !52 = !DILocation(line: 20, column: 6, scope: !50)
+// CHECK:STDOUT: !53 = !DILocation(line: 21, column: 5, scope: !50)
+// CHECK:STDOUT: !54 = !DILocation(line: 23, column: 7, scope: !50)
+// CHECK:STDOUT: !55 = !DILocation(line: 23, column: 6, scope: !50)
+// CHECK:STDOUT: !56 = !DILocation(line: 24, column: 12, scope: !50)
+// CHECK:STDOUT: !57 = !DILocation(line: 24, column: 5, scope: !50)
+// CHECK:STDOUT: !58 = !DILocation(line: 26, column: 12, scope: !50)
+// CHECK:STDOUT: !59 = !DILocation(line: 26, column: 5, scope: !50)
+// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.b88d1103f417c6d4", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !61 = !DILocation(line: 32, column: 3, scope: !60)
+// CHECK:STDOUT: !62 = !DILocation(line: 33, column: 10, scope: !60)
+// CHECK:STDOUT: !63 = !DILocation(line: 33, column: 3, scope: !60)
+// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.b88d1103f417c6d4", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !65 = !DILocation(line: 37, column: 3, scope: !64)
+// CHECK:STDOUT: !66 = !DILocation(line: 38, column: 10, scope: !64)
+// CHECK:STDOUT: !67 = !DILocation(line: 38, column: 3, scope: !64)
+// CHECK:STDOUT: !68 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.66be507887ceee78", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !69 = !DILocation(line: 32, column: 3, scope: !68)
+// CHECK:STDOUT: !70 = !DILocation(line: 33, column: 10, scope: !68)
+// CHECK:STDOUT: !71 = !DILocation(line: 33, column: 3, scope: !68)
+// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.66be507887ceee78", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !73 = !DILocation(line: 37, column: 3, scope: !72)
+// CHECK:STDOUT: !74 = !DILocation(line: 38, column: 10, scope: !72)
+// CHECK:STDOUT: !75 = !DILocation(line: 38, column: 3, scope: !72)
+// CHECK:STDOUT: !76 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.e8193710fd35b608", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !77 = !DILocation(line: 32, column: 3, scope: !76)
+// CHECK:STDOUT: !78 = !DILocation(line: 33, column: 10, scope: !76)
+// CHECK:STDOUT: !79 = !DILocation(line: 33, column: 3, scope: !76)
+// CHECK:STDOUT: !80 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.e8193710fd35b608", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !81 = !DILocation(line: 37, column: 3, scope: !80)
+// CHECK:STDOUT: !82 = !DILocation(line: 38, column: 10, scope: !80)
+// CHECK:STDOUT: !83 = !DILocation(line: 38, column: 3, scope: !80)
+// CHECK:STDOUT: !84 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !85 = !DILocation(line: 32, column: 3, scope: !84)
+// CHECK:STDOUT: !86 = !DILocation(line: 33, column: 10, scope: !84)
+// CHECK:STDOUT: !87 = !DILocation(line: 33, column: 3, scope: !84)
+// CHECK:STDOUT: !88 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !89 = !DILocation(line: 37, column: 3, scope: !88)
+// CHECK:STDOUT: !90 = !DILocation(line: 38, column: 10, scope: !88)
+// CHECK:STDOUT: !91 = !DILocation(line: 38, column: 3, scope: !88)
+// CHECK:STDOUT: !92 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.b88d1103f417c6d4", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !93 = !DILocation(line: 42, column: 15, scope: !92)
+// CHECK:STDOUT: !94 = !DILocation(line: 42, column: 10, scope: !92)
+// CHECK:STDOUT: !95 = !DILocation(line: 42, column: 3, scope: !92)
+// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.66be507887ceee78", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !97 = !DILocation(line: 42, column: 15, scope: !96)
+// CHECK:STDOUT: !98 = !DILocation(line: 42, column: 10, scope: !96)
+// CHECK:STDOUT: !99 = !DILocation(line: 42, column: 3, scope: !96)
+// CHECK:STDOUT: !100 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.e8193710fd35b608", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !101 = !DILocation(line: 42, column: 15, scope: !100)
+// CHECK:STDOUT: !102 = !DILocation(line: 42, column: 10, scope: !100)
+// CHECK:STDOUT: !103 = !DILocation(line: 42, column: 3, scope: !100)
+// CHECK:STDOUT: !104 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !105 = !DILocation(line: 42, column: 15, scope: !104)
+// CHECK:STDOUT: !106 = !DILocation(line: 42, column: 10, scope: !104)
+// CHECK:STDOUT: !107 = !DILocation(line: 42, column: 3, scope: !104)

--- a/toolchain/lower/testdata/function/generic/call_recursive_mutual.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_mutual.carbon
@@ -45,139 +45,139 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !8
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !9
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !8
 // CHECK:STDOUT:   store double 1.000000e+00, ptr %m.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
-// CHECK:STDOUT:   %.loc36_5 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   %F.call.loc36 = call i32 @_CF.Main.b88d1103f417c6d4(i32 %.loc36_5, i32 0), !dbg !10
-// CHECK:STDOUT:   %.loc37_5 = load double, ptr %m.var, align 8, !dbg !11
-// CHECK:STDOUT:   %F.call.loc37 = call double @_CF.Main.66be507887ceee78(double %.loc37_5, i32 0), !dbg !12
-// CHECK:STDOUT:   %.loc38_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !13
-// CHECK:STDOUT:   %F.call.loc38 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc38_5, i32 0), !dbg !14
-// CHECK:STDOUT:   %.loc39_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !15
-// CHECK:STDOUT:   %F.call.loc39 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc39_5, i32 0), !dbg !16
-// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !10
+// CHECK:STDOUT:   %.loc36_5 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %F.call.loc36 = call i32 @_CF.Main.b88d1103f417c6d4(i32 %.loc36_5, i32 0), !dbg !12
+// CHECK:STDOUT:   %.loc37_5 = load double, ptr %m.var, align 8, !dbg !13
+// CHECK:STDOUT:   %F.call.loc37 = call double @_CF.Main.66be507887ceee78(double %.loc37_5, i32 0), !dbg !14
+// CHECK:STDOUT:   %.loc38_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !15
+// CHECK:STDOUT:   %F.call.loc38 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc38_5, i32 0), !dbg !16
+// CHECK:STDOUT:   %.loc39_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !17
+// CHECK:STDOUT:   %F.call.loc39 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc39_5, i32 0), !dbg !18
+// CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !18 {
+// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !19
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !20
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !21
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !22
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret i32 %x, !dbg !21
+// CHECK:STDOUT:   ret i32 %x, !dbg !23
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !22
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !23
-// CHECK:STDOUT:   ret i32 %G.call, !dbg !24
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !24
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !25
+// CHECK:STDOUT:   ret i32 %G.call, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !25 {
+// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !27 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !26
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !27
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !28
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !29
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret double %x, !dbg !28
+// CHECK:STDOUT:   ret double %x, !dbg !30
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !29
-// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !30
-// CHECK:STDOUT:   ret double %G.call, !dbg !31
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !31
+// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !32
+// CHECK:STDOUT:   ret double %G.call, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !32 {
+// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !34 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !33
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !34
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !35
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !36
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !35
+// CHECK:STDOUT:   ret ptr %x, !dbg !37
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !36
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !37
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !38
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !38
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !39
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !40
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !39 {
+// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !41 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !40
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !41
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !42
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !43
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !42
+// CHECK:STDOUT:   ret ptr %x, !dbg !44
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !43
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !44
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !45
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !45
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !46
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !47
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !46 {
+// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !48 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !47
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !48
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !49
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !50
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret i32 %x, !dbg !49
+// CHECK:STDOUT:   ret i32 %x, !dbg !51
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !50
-// CHECK:STDOUT:   %F.call = call i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !51
-// CHECK:STDOUT:   ret i32 %F.call, !dbg !52
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !52
+// CHECK:STDOUT:   %F.call = call i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !53
+// CHECK:STDOUT:   ret i32 %F.call, !dbg !54
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !53 {
+// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !55 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !54
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !55
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !56
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !57
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret double %x, !dbg !56
+// CHECK:STDOUT:   ret double %x, !dbg !58
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !57
-// CHECK:STDOUT:   %F.call = call double @_CF.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !58
-// CHECK:STDOUT:   ret double %F.call, !dbg !59
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !59
+// CHECK:STDOUT:   %F.call = call double @_CF.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !60
+// CHECK:STDOUT:   ret double %F.call, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !60 {
+// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !62 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !61
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !62
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !63
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !64
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !63
+// CHECK:STDOUT:   ret ptr %x, !dbg !65
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !64
-// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !65
-// CHECK:STDOUT:   ret ptr %F.call, !dbg !66
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !66
+// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !67
+// CHECK:STDOUT:   ret ptr %F.call, !dbg !68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !67 {
+// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !69 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !68
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !69
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !70
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !71
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !70
+// CHECK:STDOUT:   ret ptr %x, !dbg !72
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !71
-// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !72
-// CHECK:STDOUT:   ret ptr %F.call, !dbg !73
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !73
+// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !74
+// CHECK:STDOUT:   ret ptr %F.call, !dbg !75
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -197,68 +197,70 @@ fn M() {
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 31, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 32, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 36, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 36, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 37, column: 5, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 37, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 38, column: 5, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 38, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 39, column: 5, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 39, column: 3, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 30, column: 1, scope: !4)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !19 = !DILocation(line: 17, column: 7, scope: !18)
-// CHECK:STDOUT: !20 = !DILocation(line: 17, column: 6, scope: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 5, scope: !18)
-// CHECK:STDOUT: !22 = !DILocation(line: 20, column: 15, scope: !18)
-// CHECK:STDOUT: !23 = !DILocation(line: 20, column: 10, scope: !18)
-// CHECK:STDOUT: !24 = !DILocation(line: 20, column: 3, scope: !18)
-// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !26 = !DILocation(line: 17, column: 7, scope: !25)
-// CHECK:STDOUT: !27 = !DILocation(line: 17, column: 6, scope: !25)
-// CHECK:STDOUT: !28 = !DILocation(line: 18, column: 5, scope: !25)
-// CHECK:STDOUT: !29 = !DILocation(line: 20, column: 15, scope: !25)
-// CHECK:STDOUT: !30 = !DILocation(line: 20, column: 10, scope: !25)
-// CHECK:STDOUT: !31 = !DILocation(line: 20, column: 3, scope: !25)
-// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !33 = !DILocation(line: 17, column: 7, scope: !32)
-// CHECK:STDOUT: !34 = !DILocation(line: 17, column: 6, scope: !32)
-// CHECK:STDOUT: !35 = !DILocation(line: 18, column: 5, scope: !32)
-// CHECK:STDOUT: !36 = !DILocation(line: 20, column: 15, scope: !32)
-// CHECK:STDOUT: !37 = !DILocation(line: 20, column: 10, scope: !32)
-// CHECK:STDOUT: !38 = !DILocation(line: 20, column: 3, scope: !32)
-// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !40 = !DILocation(line: 17, column: 7, scope: !39)
-// CHECK:STDOUT: !41 = !DILocation(line: 17, column: 6, scope: !39)
-// CHECK:STDOUT: !42 = !DILocation(line: 18, column: 5, scope: !39)
-// CHECK:STDOUT: !43 = !DILocation(line: 20, column: 15, scope: !39)
-// CHECK:STDOUT: !44 = !DILocation(line: 20, column: 10, scope: !39)
-// CHECK:STDOUT: !45 = !DILocation(line: 20, column: 3, scope: !39)
-// CHECK:STDOUT: !46 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !47 = !DILocation(line: 24, column: 7, scope: !46)
-// CHECK:STDOUT: !48 = !DILocation(line: 24, column: 6, scope: !46)
-// CHECK:STDOUT: !49 = !DILocation(line: 25, column: 5, scope: !46)
-// CHECK:STDOUT: !50 = !DILocation(line: 27, column: 15, scope: !46)
-// CHECK:STDOUT: !51 = !DILocation(line: 27, column: 10, scope: !46)
-// CHECK:STDOUT: !52 = !DILocation(line: 27, column: 3, scope: !46)
-// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !54 = !DILocation(line: 24, column: 7, scope: !53)
-// CHECK:STDOUT: !55 = !DILocation(line: 24, column: 6, scope: !53)
-// CHECK:STDOUT: !56 = !DILocation(line: 25, column: 5, scope: !53)
-// CHECK:STDOUT: !57 = !DILocation(line: 27, column: 15, scope: !53)
-// CHECK:STDOUT: !58 = !DILocation(line: 27, column: 10, scope: !53)
-// CHECK:STDOUT: !59 = !DILocation(line: 27, column: 3, scope: !53)
-// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e8193710fd35b608", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !61 = !DILocation(line: 24, column: 7, scope: !60)
-// CHECK:STDOUT: !62 = !DILocation(line: 24, column: 6, scope: !60)
-// CHECK:STDOUT: !63 = !DILocation(line: 25, column: 5, scope: !60)
-// CHECK:STDOUT: !64 = !DILocation(line: 27, column: 15, scope: !60)
-// CHECK:STDOUT: !65 = !DILocation(line: 27, column: 10, scope: !60)
-// CHECK:STDOUT: !66 = !DILocation(line: 27, column: 3, scope: !60)
-// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !68 = !DILocation(line: 24, column: 7, scope: !67)
-// CHECK:STDOUT: !69 = !DILocation(line: 24, column: 6, scope: !67)
-// CHECK:STDOUT: !70 = !DILocation(line: 25, column: 5, scope: !67)
-// CHECK:STDOUT: !71 = !DILocation(line: 27, column: 15, scope: !67)
-// CHECK:STDOUT: !72 = !DILocation(line: 27, column: 10, scope: !67)
-// CHECK:STDOUT: !73 = !DILocation(line: 27, column: 3, scope: !67)
+// CHECK:STDOUT: !9 = !DILocation(line: 33, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 34, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 36, column: 5, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 36, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 37, column: 5, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 37, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 38, column: 5, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 38, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 39, column: 5, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 39, column: 3, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 30, column: 1, scope: !4)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = !DILocation(line: 17, column: 7, scope: !20)
+// CHECK:STDOUT: !22 = !DILocation(line: 17, column: 6, scope: !20)
+// CHECK:STDOUT: !23 = !DILocation(line: 18, column: 5, scope: !20)
+// CHECK:STDOUT: !24 = !DILocation(line: 20, column: 15, scope: !20)
+// CHECK:STDOUT: !25 = !DILocation(line: 20, column: 10, scope: !20)
+// CHECK:STDOUT: !26 = !DILocation(line: 20, column: 3, scope: !20)
+// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !28 = !DILocation(line: 17, column: 7, scope: !27)
+// CHECK:STDOUT: !29 = !DILocation(line: 17, column: 6, scope: !27)
+// CHECK:STDOUT: !30 = !DILocation(line: 18, column: 5, scope: !27)
+// CHECK:STDOUT: !31 = !DILocation(line: 20, column: 15, scope: !27)
+// CHECK:STDOUT: !32 = !DILocation(line: 20, column: 10, scope: !27)
+// CHECK:STDOUT: !33 = !DILocation(line: 20, column: 3, scope: !27)
+// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !35 = !DILocation(line: 17, column: 7, scope: !34)
+// CHECK:STDOUT: !36 = !DILocation(line: 17, column: 6, scope: !34)
+// CHECK:STDOUT: !37 = !DILocation(line: 18, column: 5, scope: !34)
+// CHECK:STDOUT: !38 = !DILocation(line: 20, column: 15, scope: !34)
+// CHECK:STDOUT: !39 = !DILocation(line: 20, column: 10, scope: !34)
+// CHECK:STDOUT: !40 = !DILocation(line: 20, column: 3, scope: !34)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !42 = !DILocation(line: 17, column: 7, scope: !41)
+// CHECK:STDOUT: !43 = !DILocation(line: 17, column: 6, scope: !41)
+// CHECK:STDOUT: !44 = !DILocation(line: 18, column: 5, scope: !41)
+// CHECK:STDOUT: !45 = !DILocation(line: 20, column: 15, scope: !41)
+// CHECK:STDOUT: !46 = !DILocation(line: 20, column: 10, scope: !41)
+// CHECK:STDOUT: !47 = !DILocation(line: 20, column: 3, scope: !41)
+// CHECK:STDOUT: !48 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !49 = !DILocation(line: 24, column: 7, scope: !48)
+// CHECK:STDOUT: !50 = !DILocation(line: 24, column: 6, scope: !48)
+// CHECK:STDOUT: !51 = !DILocation(line: 25, column: 5, scope: !48)
+// CHECK:STDOUT: !52 = !DILocation(line: 27, column: 15, scope: !48)
+// CHECK:STDOUT: !53 = !DILocation(line: 27, column: 10, scope: !48)
+// CHECK:STDOUT: !54 = !DILocation(line: 27, column: 3, scope: !48)
+// CHECK:STDOUT: !55 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !56 = !DILocation(line: 24, column: 7, scope: !55)
+// CHECK:STDOUT: !57 = !DILocation(line: 24, column: 6, scope: !55)
+// CHECK:STDOUT: !58 = !DILocation(line: 25, column: 5, scope: !55)
+// CHECK:STDOUT: !59 = !DILocation(line: 27, column: 15, scope: !55)
+// CHECK:STDOUT: !60 = !DILocation(line: 27, column: 10, scope: !55)
+// CHECK:STDOUT: !61 = !DILocation(line: 27, column: 3, scope: !55)
+// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e8193710fd35b608", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !63 = !DILocation(line: 24, column: 7, scope: !62)
+// CHECK:STDOUT: !64 = !DILocation(line: 24, column: 6, scope: !62)
+// CHECK:STDOUT: !65 = !DILocation(line: 25, column: 5, scope: !62)
+// CHECK:STDOUT: !66 = !DILocation(line: 27, column: 15, scope: !62)
+// CHECK:STDOUT: !67 = !DILocation(line: 27, column: 10, scope: !62)
+// CHECK:STDOUT: !68 = !DILocation(line: 27, column: 3, scope: !62)
+// CHECK:STDOUT: !69 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !70 = !DILocation(line: 24, column: 7, scope: !69)
+// CHECK:STDOUT: !71 = !DILocation(line: 24, column: 6, scope: !69)
+// CHECK:STDOUT: !72 = !DILocation(line: 25, column: 5, scope: !69)
+// CHECK:STDOUT: !73 = !DILocation(line: 27, column: 15, scope: !69)
+// CHECK:STDOUT: !74 = !DILocation(line: 27, column: 10, scope: !69)
+// CHECK:STDOUT: !75 = !DILocation(line: 27, column: 3, scope: !69)

--- a/toolchain/lower/testdata/function/generic/call_recursive_sccs_deep.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_sccs_deep.carbon
@@ -89,305 +89,305 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !7
+// CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !8
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !9
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %m.var), !dbg !8
 // CHECK:STDOUT:   store double 1.000000e+00, ptr %m.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
-// CHECK:STDOUT:   %.loc77_5 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   %A.call.loc77 = call i32 @_CA.Main.b88d1103f417c6d4(i32 %.loc77_5, i32 0), !dbg !10
-// CHECK:STDOUT:   %.loc78_5 = load double, ptr %m.var, align 8, !dbg !11
-// CHECK:STDOUT:   %A.call.loc78 = call double @_CA.Main.66be507887ceee78(double %.loc78_5, i32 0), !dbg !12
-// CHECK:STDOUT:   %.loc79_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !13
-// CHECK:STDOUT:   %A.call.loc79 = call ptr @_CA.Main.e8193710fd35b608(ptr %.loc79_5, i32 0), !dbg !14
-// CHECK:STDOUT:   %.loc80_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !15
-// CHECK:STDOUT:   %A.call.loc80 = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %.loc80_5, i32 0), !dbg !16
-// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !10
+// CHECK:STDOUT:   %.loc77_5 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %A.call.loc77 = call i32 @_CA.Main.b88d1103f417c6d4(i32 %.loc77_5, i32 0), !dbg !12
+// CHECK:STDOUT:   %.loc78_5 = load double, ptr %m.var, align 8, !dbg !13
+// CHECK:STDOUT:   %A.call.loc78 = call double @_CA.Main.66be507887ceee78(double %.loc78_5, i32 0), !dbg !14
+// CHECK:STDOUT:   %.loc79_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !15
+// CHECK:STDOUT:   %A.call.loc79 = call ptr @_CA.Main.e8193710fd35b608(ptr %.loc79_5, i32 0), !dbg !16
+// CHECK:STDOUT:   %.loc80_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !17
+// CHECK:STDOUT:   %A.call.loc80 = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %.loc80_5, i32 0), !dbg !18
+// CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !18 {
+// CHECK:STDOUT: define i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !19
-// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !20
-// CHECK:STDOUT:   ret i32 %D.call, !dbg !21
+// CHECK:STDOUT:   call void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !21
+// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !22
+// CHECK:STDOUT:   ret i32 %D.call, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !22 {
+// CHECK:STDOUT: define double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !24 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CB.Main.66be507887ceee78(double %x, i32 %count), !dbg !23
-// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !24
-// CHECK:STDOUT:   ret double %D.call, !dbg !25
+// CHECK:STDOUT:   call void @_CB.Main.66be507887ceee78(double %x, i32 %count), !dbg !25
+// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !26
+// CHECK:STDOUT:   ret double %D.call, !dbg !27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !26 {
+// CHECK:STDOUT: define ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !28 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !27
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !28
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !29
+// CHECK:STDOUT:   call void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !29
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !30
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !30 {
+// CHECK:STDOUT: define ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !32 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !31
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !32
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !33
+// CHECK:STDOUT:   call void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !33
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !34
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !35
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !34 {
+// CHECK:STDOUT: define void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !36 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !35
-// CHECK:STDOUT:   ret void, !dbg !36
+// CHECK:STDOUT:   call void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !37
+// CHECK:STDOUT:   ret void, !dbg !38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !37 {
+// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !39 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !38
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !39
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !40
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !41
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   ret i32 %x, !dbg !40
+// CHECK:STDOUT:   ret i32 %x, !dbg !42
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !41
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !41
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !42
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !43
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !43
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !44
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %E.call = call i32 @_CE.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !43
-// CHECK:STDOUT:   ret i32 %E.call, !dbg !44
+// CHECK:STDOUT:   %E.call = call i32 @_CE.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !45
+// CHECK:STDOUT:   ret i32 %E.call, !dbg !46
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %F.call = call i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !45
-// CHECK:STDOUT:   ret i32 %F.call, !dbg !46
+// CHECK:STDOUT:   %F.call = call i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !47
+// CHECK:STDOUT:   ret i32 %F.call, !dbg !48
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !47 {
+// CHECK:STDOUT: define void @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !49 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CC.Main.66be507887ceee78(double %x, i32 %count), !dbg !48
-// CHECK:STDOUT:   ret void, !dbg !49
+// CHECK:STDOUT:   call void @_CC.Main.66be507887ceee78(double %x, i32 %count), !dbg !50
+// CHECK:STDOUT:   ret void, !dbg !51
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !50 {
+// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !52 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !51
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !52
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !53
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !54
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   ret double %x, !dbg !53
+// CHECK:STDOUT:   ret double %x, !dbg !55
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !54
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !54
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !55
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !56
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !56
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !57
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %E.call = call double @_CE.Main.66be507887ceee78(double %x, i32 %count), !dbg !56
-// CHECK:STDOUT:   ret double %E.call, !dbg !57
+// CHECK:STDOUT:   %E.call = call double @_CE.Main.66be507887ceee78(double %x, i32 %count), !dbg !58
+// CHECK:STDOUT:   ret double %E.call, !dbg !59
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %F.call = call double @_CF.Main.66be507887ceee78(double %x, i32 %count), !dbg !58
-// CHECK:STDOUT:   ret double %F.call, !dbg !59
+// CHECK:STDOUT:   %F.call = call double @_CF.Main.66be507887ceee78(double %x, i32 %count), !dbg !60
+// CHECK:STDOUT:   ret double %F.call, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !60 {
+// CHECK:STDOUT: define void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !62 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !61
-// CHECK:STDOUT:   ret void, !dbg !62
+// CHECK:STDOUT:   call void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !63
+// CHECK:STDOUT:   ret void, !dbg !64
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !63 {
+// CHECK:STDOUT: define ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !65 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !64
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !65
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !66
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !67
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !66
+// CHECK:STDOUT:   ret ptr %x, !dbg !68
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !67
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !67
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !68
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !69
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !69
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !70
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %E.call = call ptr @_CE.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !69
-// CHECK:STDOUT:   ret ptr %E.call, !dbg !70
+// CHECK:STDOUT:   %E.call = call ptr @_CE.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !71
+// CHECK:STDOUT:   ret ptr %E.call, !dbg !72
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !71
-// CHECK:STDOUT:   ret ptr %F.call, !dbg !72
+// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !73
+// CHECK:STDOUT:   ret ptr %F.call, !dbg !74
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !73 {
+// CHECK:STDOUT: define void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !75 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !74
-// CHECK:STDOUT:   ret void, !dbg !75
+// CHECK:STDOUT:   call void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !76
+// CHECK:STDOUT:   ret void, !dbg !77
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !76 {
+// CHECK:STDOUT: define ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !78 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !77
-// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !78
+// CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !79
+// CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !80
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   ret ptr %x, !dbg !79
+// CHECK:STDOUT:   ret ptr %x, !dbg !81
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc46:                                    ; preds = %entry
-// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !80
-// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !80
-// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !81
+// CHECK:STDOUT:   %int.smod = srem i32 %count, 2, !dbg !82
+// CHECK:STDOUT:   %int.eq = icmp eq i32 %int.smod, 0, !dbg !82
+// CHECK:STDOUT:   br i1 %int.eq, label %if.then.loc49, label %if.else.loc49, !dbg !83
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %E.call = call ptr @_CE.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !82
-// CHECK:STDOUT:   ret ptr %E.call, !dbg !83
+// CHECK:STDOUT:   %E.call = call ptr @_CE.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !84
+// CHECK:STDOUT:   ret ptr %E.call, !dbg !85
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else.loc49:                                    ; preds = %if.else.loc46
-// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !84
-// CHECK:STDOUT:   ret ptr %F.call, !dbg !85
+// CHECK:STDOUT:   %F.call = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !86
+// CHECK:STDOUT:   ret ptr %F.call, !dbg !87
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !86 {
+// CHECK:STDOUT: define void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !88 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !87
-// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !88
+// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !89
+// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !90
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !89
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !90
-// CHECK:STDOUT:   call void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !91
-// CHECK:STDOUT:   br label %if.else, !dbg !92
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !91
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !92
+// CHECK:STDOUT:   call void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !93
+// CHECK:STDOUT:   br label %if.else, !dbg !94
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %if.then, %entry
-// CHECK:STDOUT:   ret void, !dbg !93
+// CHECK:STDOUT:   ret void, !dbg !95
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CE.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !94 {
+// CHECK:STDOUT: define i32 @_CE.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !96 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !95
-// CHECK:STDOUT:   ret i32 %G.call, !dbg !96
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !97
+// CHECK:STDOUT:   ret i32 %G.call, !dbg !98
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !97 {
+// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !99 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !98
-// CHECK:STDOUT:   ret i32 %G.call, !dbg !99
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !100
+// CHECK:STDOUT:   ret i32 %G.call, !dbg !101
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !100 {
+// CHECK:STDOUT: define void @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !102 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !101
-// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !102
+// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !103
+// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !104
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !103
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !104
-// CHECK:STDOUT:   call void @_CB.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !105
-// CHECK:STDOUT:   br label %if.else, !dbg !106
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !105
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !106
+// CHECK:STDOUT:   call void @_CB.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !107
+// CHECK:STDOUT:   br label %if.else, !dbg !108
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %if.then, %entry
-// CHECK:STDOUT:   ret void, !dbg !107
+// CHECK:STDOUT:   ret void, !dbg !109
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CE.Main.66be507887ceee78(double %x, i32 %count) !dbg !108 {
+// CHECK:STDOUT: define double @_CE.Main.66be507887ceee78(double %x, i32 %count) !dbg !110 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %count), !dbg !109
-// CHECK:STDOUT:   ret double %G.call, !dbg !110
+// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %count), !dbg !111
+// CHECK:STDOUT:   ret double %G.call, !dbg !112
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !111 {
+// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !113 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %count), !dbg !112
-// CHECK:STDOUT:   ret double %G.call, !dbg !113
+// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %count), !dbg !114
+// CHECK:STDOUT:   ret double %G.call, !dbg !115
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !114 {
+// CHECK:STDOUT: define void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !116 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !115
-// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !116
+// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !117
+// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !118
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !117
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !118
-// CHECK:STDOUT:   call void @_CB.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !119
-// CHECK:STDOUT:   br label %if.else, !dbg !120
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !119
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !120
+// CHECK:STDOUT:   call void @_CB.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !121
+// CHECK:STDOUT:   br label %if.else, !dbg !122
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %if.then, %entry
-// CHECK:STDOUT:   ret void, !dbg !121
+// CHECK:STDOUT:   ret void, !dbg !123
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CE.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !122 {
+// CHECK:STDOUT: define ptr @_CE.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !124 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !123
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !124
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !125
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !126
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !125 {
+// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !127 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !126
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !127
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !128
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !129
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !128 {
+// CHECK:STDOUT: define void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !130 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !129
-// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !130
+// CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !131
+// CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !132
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !131
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !132
-// CHECK:STDOUT:   call void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !133
-// CHECK:STDOUT:   br label %if.else, !dbg !134
+// CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 %count), !dbg !133
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !134
+// CHECK:STDOUT:   call void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !135
+// CHECK:STDOUT:   br label %if.else, !dbg !136
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %if.then, %entry
-// CHECK:STDOUT:   ret void, !dbg !135
+// CHECK:STDOUT:   ret void, !dbg !137
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CE.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !136 {
+// CHECK:STDOUT: define ptr @_CE.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !138 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !137
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !138
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !139
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !140
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !139 {
+// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !141 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !140
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !141
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !142
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !143
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !142 {
+// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !144 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !143
-// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !144
-// CHECK:STDOUT:   ret i32 %D.call, !dbg !145
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !145
+// CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !146
+// CHECK:STDOUT:   ret i32 %D.call, !dbg !147
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !146 {
+// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !148 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !147
-// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !148
-// CHECK:STDOUT:   ret double %D.call, !dbg !149
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !149
+// CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !150
+// CHECK:STDOUT:   ret double %D.call, !dbg !151
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !150 {
+// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !152 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !151
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !152
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !153
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !153
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !154
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !155
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !154 {
+// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !156 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !155
-// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !156
-// CHECK:STDOUT:   ret ptr %D.call, !dbg !157
+// CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !157
+// CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !158
+// CHECK:STDOUT:   ret ptr %D.call, !dbg !159
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -412,152 +412,154 @@ fn M() {
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 72, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 73, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 77, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 77, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 78, column: 5, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 78, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 79, column: 5, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 79, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 80, column: 5, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 80, column: 3, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 71, column: 1, scope: !4)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.b88d1103f417c6d4", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !19 = !DILocation(line: 30, column: 3, scope: !18)
-// CHECK:STDOUT: !20 = !DILocation(line: 31, column: 10, scope: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 31, column: 3, scope: !18)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.66be507887ceee78", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !23 = !DILocation(line: 30, column: 3, scope: !22)
-// CHECK:STDOUT: !24 = !DILocation(line: 31, column: 10, scope: !22)
-// CHECK:STDOUT: !25 = !DILocation(line: 31, column: 3, scope: !22)
-// CHECK:STDOUT: !26 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.e8193710fd35b608", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !27 = !DILocation(line: 30, column: 3, scope: !26)
-// CHECK:STDOUT: !28 = !DILocation(line: 31, column: 10, scope: !26)
-// CHECK:STDOUT: !29 = !DILocation(line: 31, column: 3, scope: !26)
-// CHECK:STDOUT: !30 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !31 = !DILocation(line: 30, column: 3, scope: !30)
-// CHECK:STDOUT: !32 = !DILocation(line: 31, column: 10, scope: !30)
-// CHECK:STDOUT: !33 = !DILocation(line: 31, column: 3, scope: !30)
-// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.b88d1103f417c6d4", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !35 = !DILocation(line: 35, column: 3, scope: !34)
-// CHECK:STDOUT: !36 = !DILocation(line: 34, column: 1, scope: !34)
-// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.b88d1103f417c6d4", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !38 = !DILocation(line: 46, column: 7, scope: !37)
-// CHECK:STDOUT: !39 = !DILocation(line: 46, column: 6, scope: !37)
-// CHECK:STDOUT: !40 = !DILocation(line: 47, column: 5, scope: !37)
-// CHECK:STDOUT: !41 = !DILocation(line: 49, column: 7, scope: !37)
-// CHECK:STDOUT: !42 = !DILocation(line: 49, column: 6, scope: !37)
-// CHECK:STDOUT: !43 = !DILocation(line: 50, column: 12, scope: !37)
-// CHECK:STDOUT: !44 = !DILocation(line: 50, column: 5, scope: !37)
-// CHECK:STDOUT: !45 = !DILocation(line: 52, column: 12, scope: !37)
-// CHECK:STDOUT: !46 = !DILocation(line: 52, column: 5, scope: !37)
-// CHECK:STDOUT: !47 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.66be507887ceee78", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !48 = !DILocation(line: 35, column: 3, scope: !47)
-// CHECK:STDOUT: !49 = !DILocation(line: 34, column: 1, scope: !47)
-// CHECK:STDOUT: !50 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.66be507887ceee78", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !51 = !DILocation(line: 46, column: 7, scope: !50)
-// CHECK:STDOUT: !52 = !DILocation(line: 46, column: 6, scope: !50)
-// CHECK:STDOUT: !53 = !DILocation(line: 47, column: 5, scope: !50)
-// CHECK:STDOUT: !54 = !DILocation(line: 49, column: 7, scope: !50)
-// CHECK:STDOUT: !55 = !DILocation(line: 49, column: 6, scope: !50)
-// CHECK:STDOUT: !56 = !DILocation(line: 50, column: 12, scope: !50)
-// CHECK:STDOUT: !57 = !DILocation(line: 50, column: 5, scope: !50)
-// CHECK:STDOUT: !58 = !DILocation(line: 52, column: 12, scope: !50)
-// CHECK:STDOUT: !59 = !DILocation(line: 52, column: 5, scope: !50)
-// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.e8193710fd35b608", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !61 = !DILocation(line: 35, column: 3, scope: !60)
-// CHECK:STDOUT: !62 = !DILocation(line: 34, column: 1, scope: !60)
-// CHECK:STDOUT: !63 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.e8193710fd35b608", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !64 = !DILocation(line: 46, column: 7, scope: !63)
-// CHECK:STDOUT: !65 = !DILocation(line: 46, column: 6, scope: !63)
-// CHECK:STDOUT: !66 = !DILocation(line: 47, column: 5, scope: !63)
-// CHECK:STDOUT: !67 = !DILocation(line: 49, column: 7, scope: !63)
-// CHECK:STDOUT: !68 = !DILocation(line: 49, column: 6, scope: !63)
-// CHECK:STDOUT: !69 = !DILocation(line: 50, column: 12, scope: !63)
-// CHECK:STDOUT: !70 = !DILocation(line: 50, column: 5, scope: !63)
-// CHECK:STDOUT: !71 = !DILocation(line: 52, column: 12, scope: !63)
-// CHECK:STDOUT: !72 = !DILocation(line: 52, column: 5, scope: !63)
-// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !74 = !DILocation(line: 35, column: 3, scope: !73)
-// CHECK:STDOUT: !75 = !DILocation(line: 34, column: 1, scope: !73)
-// CHECK:STDOUT: !76 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !77 = !DILocation(line: 46, column: 7, scope: !76)
-// CHECK:STDOUT: !78 = !DILocation(line: 46, column: 6, scope: !76)
-// CHECK:STDOUT: !79 = !DILocation(line: 47, column: 5, scope: !76)
-// CHECK:STDOUT: !80 = !DILocation(line: 49, column: 7, scope: !76)
-// CHECK:STDOUT: !81 = !DILocation(line: 49, column: 6, scope: !76)
-// CHECK:STDOUT: !82 = !DILocation(line: 50, column: 12, scope: !76)
-// CHECK:STDOUT: !83 = !DILocation(line: 50, column: 5, scope: !76)
-// CHECK:STDOUT: !84 = !DILocation(line: 52, column: 12, scope: !76)
-// CHECK:STDOUT: !85 = !DILocation(line: 52, column: 5, scope: !76)
-// CHECK:STDOUT: !86 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.b88d1103f417c6d4", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !87 = !DILocation(line: 39, column: 7, scope: !86)
-// CHECK:STDOUT: !88 = !DILocation(line: 39, column: 6, scope: !86)
-// CHECK:STDOUT: !89 = !DILocation(line: 40, column: 5, scope: !86)
-// CHECK:STDOUT: !90 = !DILocation(line: 41, column: 10, scope: !86)
-// CHECK:STDOUT: !91 = !DILocation(line: 41, column: 5, scope: !86)
-// CHECK:STDOUT: !92 = !DILocation(line: 39, column: 3, scope: !86)
-// CHECK:STDOUT: !93 = !DILocation(line: 38, column: 1, scope: !86)
-// CHECK:STDOUT: !94 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.b88d1103f417c6d4", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !95 = !DILocation(line: 59, column: 10, scope: !94)
-// CHECK:STDOUT: !96 = !DILocation(line: 59, column: 3, scope: !94)
-// CHECK:STDOUT: !97 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !98 = !DILocation(line: 63, column: 10, scope: !97)
-// CHECK:STDOUT: !99 = !DILocation(line: 63, column: 3, scope: !97)
-// CHECK:STDOUT: !100 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.66be507887ceee78", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !101 = !DILocation(line: 39, column: 7, scope: !100)
-// CHECK:STDOUT: !102 = !DILocation(line: 39, column: 6, scope: !100)
-// CHECK:STDOUT: !103 = !DILocation(line: 40, column: 5, scope: !100)
-// CHECK:STDOUT: !104 = !DILocation(line: 41, column: 10, scope: !100)
-// CHECK:STDOUT: !105 = !DILocation(line: 41, column: 5, scope: !100)
-// CHECK:STDOUT: !106 = !DILocation(line: 39, column: 3, scope: !100)
-// CHECK:STDOUT: !107 = !DILocation(line: 38, column: 1, scope: !100)
-// CHECK:STDOUT: !108 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.66be507887ceee78", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !109 = !DILocation(line: 59, column: 10, scope: !108)
-// CHECK:STDOUT: !110 = !DILocation(line: 59, column: 3, scope: !108)
-// CHECK:STDOUT: !111 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !112 = !DILocation(line: 63, column: 10, scope: !111)
-// CHECK:STDOUT: !113 = !DILocation(line: 63, column: 3, scope: !111)
-// CHECK:STDOUT: !114 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.e8193710fd35b608", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !115 = !DILocation(line: 39, column: 7, scope: !114)
-// CHECK:STDOUT: !116 = !DILocation(line: 39, column: 6, scope: !114)
-// CHECK:STDOUT: !117 = !DILocation(line: 40, column: 5, scope: !114)
-// CHECK:STDOUT: !118 = !DILocation(line: 41, column: 10, scope: !114)
-// CHECK:STDOUT: !119 = !DILocation(line: 41, column: 5, scope: !114)
-// CHECK:STDOUT: !120 = !DILocation(line: 39, column: 3, scope: !114)
-// CHECK:STDOUT: !121 = !DILocation(line: 38, column: 1, scope: !114)
-// CHECK:STDOUT: !122 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.e8193710fd35b608", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !123 = !DILocation(line: 59, column: 10, scope: !122)
-// CHECK:STDOUT: !124 = !DILocation(line: 59, column: 3, scope: !122)
-// CHECK:STDOUT: !125 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !126 = !DILocation(line: 63, column: 10, scope: !125)
-// CHECK:STDOUT: !127 = !DILocation(line: 63, column: 3, scope: !125)
-// CHECK:STDOUT: !128 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !129 = !DILocation(line: 39, column: 7, scope: !128)
-// CHECK:STDOUT: !130 = !DILocation(line: 39, column: 6, scope: !128)
-// CHECK:STDOUT: !131 = !DILocation(line: 40, column: 5, scope: !128)
-// CHECK:STDOUT: !132 = !DILocation(line: 41, column: 10, scope: !128)
-// CHECK:STDOUT: !133 = !DILocation(line: 41, column: 5, scope: !128)
-// CHECK:STDOUT: !134 = !DILocation(line: 39, column: 3, scope: !128)
-// CHECK:STDOUT: !135 = !DILocation(line: 38, column: 1, scope: !128)
-// CHECK:STDOUT: !136 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !137 = !DILocation(line: 59, column: 10, scope: !136)
-// CHECK:STDOUT: !138 = !DILocation(line: 59, column: 3, scope: !136)
-// CHECK:STDOUT: !139 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !140 = !DILocation(line: 63, column: 10, scope: !139)
-// CHECK:STDOUT: !141 = !DILocation(line: 63, column: 3, scope: !139)
-// CHECK:STDOUT: !142 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !143 = !DILocation(line: 67, column: 15, scope: !142)
-// CHECK:STDOUT: !144 = !DILocation(line: 67, column: 10, scope: !142)
-// CHECK:STDOUT: !145 = !DILocation(line: 67, column: 3, scope: !142)
-// CHECK:STDOUT: !146 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !147 = !DILocation(line: 67, column: 15, scope: !146)
-// CHECK:STDOUT: !148 = !DILocation(line: 67, column: 10, scope: !146)
-// CHECK:STDOUT: !149 = !DILocation(line: 67, column: 3, scope: !146)
-// CHECK:STDOUT: !150 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e8193710fd35b608", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !151 = !DILocation(line: 67, column: 15, scope: !150)
-// CHECK:STDOUT: !152 = !DILocation(line: 67, column: 10, scope: !150)
-// CHECK:STDOUT: !153 = !DILocation(line: 67, column: 3, scope: !150)
-// CHECK:STDOUT: !154 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !155 = !DILocation(line: 67, column: 15, scope: !154)
-// CHECK:STDOUT: !156 = !DILocation(line: 67, column: 10, scope: !154)
-// CHECK:STDOUT: !157 = !DILocation(line: 67, column: 3, scope: !154)
+// CHECK:STDOUT: !9 = !DILocation(line: 74, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 75, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 77, column: 5, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 77, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 78, column: 5, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 78, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 79, column: 5, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 79, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 80, column: 5, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 80, column: 3, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 71, column: 1, scope: !4)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.b88d1103f417c6d4", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !21 = !DILocation(line: 30, column: 3, scope: !20)
+// CHECK:STDOUT: !22 = !DILocation(line: 31, column: 10, scope: !20)
+// CHECK:STDOUT: !23 = !DILocation(line: 31, column: 3, scope: !20)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.66be507887ceee78", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !25 = !DILocation(line: 30, column: 3, scope: !24)
+// CHECK:STDOUT: !26 = !DILocation(line: 31, column: 10, scope: !24)
+// CHECK:STDOUT: !27 = !DILocation(line: 31, column: 3, scope: !24)
+// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.e8193710fd35b608", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !29 = !DILocation(line: 30, column: 3, scope: !28)
+// CHECK:STDOUT: !30 = !DILocation(line: 31, column: 10, scope: !28)
+// CHECK:STDOUT: !31 = !DILocation(line: 31, column: 3, scope: !28)
+// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "A", linkageName: "_CA.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !33 = !DILocation(line: 30, column: 3, scope: !32)
+// CHECK:STDOUT: !34 = !DILocation(line: 31, column: 10, scope: !32)
+// CHECK:STDOUT: !35 = !DILocation(line: 31, column: 3, scope: !32)
+// CHECK:STDOUT: !36 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.b88d1103f417c6d4", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !37 = !DILocation(line: 35, column: 3, scope: !36)
+// CHECK:STDOUT: !38 = !DILocation(line: 34, column: 1, scope: !36)
+// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.b88d1103f417c6d4", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !40 = !DILocation(line: 46, column: 7, scope: !39)
+// CHECK:STDOUT: !41 = !DILocation(line: 46, column: 6, scope: !39)
+// CHECK:STDOUT: !42 = !DILocation(line: 47, column: 5, scope: !39)
+// CHECK:STDOUT: !43 = !DILocation(line: 49, column: 7, scope: !39)
+// CHECK:STDOUT: !44 = !DILocation(line: 49, column: 6, scope: !39)
+// CHECK:STDOUT: !45 = !DILocation(line: 50, column: 12, scope: !39)
+// CHECK:STDOUT: !46 = !DILocation(line: 50, column: 5, scope: !39)
+// CHECK:STDOUT: !47 = !DILocation(line: 52, column: 12, scope: !39)
+// CHECK:STDOUT: !48 = !DILocation(line: 52, column: 5, scope: !39)
+// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.66be507887ceee78", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !50 = !DILocation(line: 35, column: 3, scope: !49)
+// CHECK:STDOUT: !51 = !DILocation(line: 34, column: 1, scope: !49)
+// CHECK:STDOUT: !52 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.66be507887ceee78", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !53 = !DILocation(line: 46, column: 7, scope: !52)
+// CHECK:STDOUT: !54 = !DILocation(line: 46, column: 6, scope: !52)
+// CHECK:STDOUT: !55 = !DILocation(line: 47, column: 5, scope: !52)
+// CHECK:STDOUT: !56 = !DILocation(line: 49, column: 7, scope: !52)
+// CHECK:STDOUT: !57 = !DILocation(line: 49, column: 6, scope: !52)
+// CHECK:STDOUT: !58 = !DILocation(line: 50, column: 12, scope: !52)
+// CHECK:STDOUT: !59 = !DILocation(line: 50, column: 5, scope: !52)
+// CHECK:STDOUT: !60 = !DILocation(line: 52, column: 12, scope: !52)
+// CHECK:STDOUT: !61 = !DILocation(line: 52, column: 5, scope: !52)
+// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.e8193710fd35b608", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !63 = !DILocation(line: 35, column: 3, scope: !62)
+// CHECK:STDOUT: !64 = !DILocation(line: 34, column: 1, scope: !62)
+// CHECK:STDOUT: !65 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.e8193710fd35b608", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !66 = !DILocation(line: 46, column: 7, scope: !65)
+// CHECK:STDOUT: !67 = !DILocation(line: 46, column: 6, scope: !65)
+// CHECK:STDOUT: !68 = !DILocation(line: 47, column: 5, scope: !65)
+// CHECK:STDOUT: !69 = !DILocation(line: 49, column: 7, scope: !65)
+// CHECK:STDOUT: !70 = !DILocation(line: 49, column: 6, scope: !65)
+// CHECK:STDOUT: !71 = !DILocation(line: 50, column: 12, scope: !65)
+// CHECK:STDOUT: !72 = !DILocation(line: 50, column: 5, scope: !65)
+// CHECK:STDOUT: !73 = !DILocation(line: 52, column: 12, scope: !65)
+// CHECK:STDOUT: !74 = !DILocation(line: 52, column: 5, scope: !65)
+// CHECK:STDOUT: !75 = distinct !DISubprogram(name: "B", linkageName: "_CB.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !76 = !DILocation(line: 35, column: 3, scope: !75)
+// CHECK:STDOUT: !77 = !DILocation(line: 34, column: 1, scope: !75)
+// CHECK:STDOUT: !78 = distinct !DISubprogram(name: "D", linkageName: "_CD.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 45, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !79 = !DILocation(line: 46, column: 7, scope: !78)
+// CHECK:STDOUT: !80 = !DILocation(line: 46, column: 6, scope: !78)
+// CHECK:STDOUT: !81 = !DILocation(line: 47, column: 5, scope: !78)
+// CHECK:STDOUT: !82 = !DILocation(line: 49, column: 7, scope: !78)
+// CHECK:STDOUT: !83 = !DILocation(line: 49, column: 6, scope: !78)
+// CHECK:STDOUT: !84 = !DILocation(line: 50, column: 12, scope: !78)
+// CHECK:STDOUT: !85 = !DILocation(line: 50, column: 5, scope: !78)
+// CHECK:STDOUT: !86 = !DILocation(line: 52, column: 12, scope: !78)
+// CHECK:STDOUT: !87 = !DILocation(line: 52, column: 5, scope: !78)
+// CHECK:STDOUT: !88 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.b88d1103f417c6d4", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !89 = !DILocation(line: 39, column: 7, scope: !88)
+// CHECK:STDOUT: !90 = !DILocation(line: 39, column: 6, scope: !88)
+// CHECK:STDOUT: !91 = !DILocation(line: 40, column: 5, scope: !88)
+// CHECK:STDOUT: !92 = !DILocation(line: 41, column: 10, scope: !88)
+// CHECK:STDOUT: !93 = !DILocation(line: 41, column: 5, scope: !88)
+// CHECK:STDOUT: !94 = !DILocation(line: 39, column: 3, scope: !88)
+// CHECK:STDOUT: !95 = !DILocation(line: 38, column: 1, scope: !88)
+// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.b88d1103f417c6d4", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !97 = !DILocation(line: 59, column: 10, scope: !96)
+// CHECK:STDOUT: !98 = !DILocation(line: 59, column: 3, scope: !96)
+// CHECK:STDOUT: !99 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !100 = !DILocation(line: 63, column: 10, scope: !99)
+// CHECK:STDOUT: !101 = !DILocation(line: 63, column: 3, scope: !99)
+// CHECK:STDOUT: !102 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.66be507887ceee78", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !103 = !DILocation(line: 39, column: 7, scope: !102)
+// CHECK:STDOUT: !104 = !DILocation(line: 39, column: 6, scope: !102)
+// CHECK:STDOUT: !105 = !DILocation(line: 40, column: 5, scope: !102)
+// CHECK:STDOUT: !106 = !DILocation(line: 41, column: 10, scope: !102)
+// CHECK:STDOUT: !107 = !DILocation(line: 41, column: 5, scope: !102)
+// CHECK:STDOUT: !108 = !DILocation(line: 39, column: 3, scope: !102)
+// CHECK:STDOUT: !109 = !DILocation(line: 38, column: 1, scope: !102)
+// CHECK:STDOUT: !110 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.66be507887ceee78", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !111 = !DILocation(line: 59, column: 10, scope: !110)
+// CHECK:STDOUT: !112 = !DILocation(line: 59, column: 3, scope: !110)
+// CHECK:STDOUT: !113 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !114 = !DILocation(line: 63, column: 10, scope: !113)
+// CHECK:STDOUT: !115 = !DILocation(line: 63, column: 3, scope: !113)
+// CHECK:STDOUT: !116 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.e8193710fd35b608", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !117 = !DILocation(line: 39, column: 7, scope: !116)
+// CHECK:STDOUT: !118 = !DILocation(line: 39, column: 6, scope: !116)
+// CHECK:STDOUT: !119 = !DILocation(line: 40, column: 5, scope: !116)
+// CHECK:STDOUT: !120 = !DILocation(line: 41, column: 10, scope: !116)
+// CHECK:STDOUT: !121 = !DILocation(line: 41, column: 5, scope: !116)
+// CHECK:STDOUT: !122 = !DILocation(line: 39, column: 3, scope: !116)
+// CHECK:STDOUT: !123 = !DILocation(line: 38, column: 1, scope: !116)
+// CHECK:STDOUT: !124 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.e8193710fd35b608", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !125 = !DILocation(line: 59, column: 10, scope: !124)
+// CHECK:STDOUT: !126 = !DILocation(line: 59, column: 3, scope: !124)
+// CHECK:STDOUT: !127 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !128 = !DILocation(line: 63, column: 10, scope: !127)
+// CHECK:STDOUT: !129 = !DILocation(line: 63, column: 3, scope: !127)
+// CHECK:STDOUT: !130 = distinct !DISubprogram(name: "C", linkageName: "_CC.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !131 = !DILocation(line: 39, column: 7, scope: !130)
+// CHECK:STDOUT: !132 = !DILocation(line: 39, column: 6, scope: !130)
+// CHECK:STDOUT: !133 = !DILocation(line: 40, column: 5, scope: !130)
+// CHECK:STDOUT: !134 = !DILocation(line: 41, column: 10, scope: !130)
+// CHECK:STDOUT: !135 = !DILocation(line: 41, column: 5, scope: !130)
+// CHECK:STDOUT: !136 = !DILocation(line: 39, column: 3, scope: !130)
+// CHECK:STDOUT: !137 = !DILocation(line: 38, column: 1, scope: !130)
+// CHECK:STDOUT: !138 = distinct !DISubprogram(name: "E", linkageName: "_CE.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 58, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !139 = !DILocation(line: 59, column: 10, scope: !138)
+// CHECK:STDOUT: !140 = !DILocation(line: 59, column: 3, scope: !138)
+// CHECK:STDOUT: !141 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 62, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !142 = !DILocation(line: 63, column: 10, scope: !141)
+// CHECK:STDOUT: !143 = !DILocation(line: 63, column: 3, scope: !141)
+// CHECK:STDOUT: !144 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !145 = !DILocation(line: 67, column: 15, scope: !144)
+// CHECK:STDOUT: !146 = !DILocation(line: 67, column: 10, scope: !144)
+// CHECK:STDOUT: !147 = !DILocation(line: 67, column: 3, scope: !144)
+// CHECK:STDOUT: !148 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !149 = !DILocation(line: 67, column: 15, scope: !148)
+// CHECK:STDOUT: !150 = !DILocation(line: 67, column: 10, scope: !148)
+// CHECK:STDOUT: !151 = !DILocation(line: 67, column: 3, scope: !148)
+// CHECK:STDOUT: !152 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e8193710fd35b608", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !153 = !DILocation(line: 67, column: 15, scope: !152)
+// CHECK:STDOUT: !154 = !DILocation(line: 67, column: 10, scope: !152)
+// CHECK:STDOUT: !155 = !DILocation(line: 67, column: 3, scope: !152)
+// CHECK:STDOUT: !156 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 66, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !157 = !DILocation(line: 67, column: 15, scope: !156)
+// CHECK:STDOUT: !158 = !DILocation(line: 67, column: 10, scope: !156)
+// CHECK:STDOUT: !159 = !DILocation(line: 67, column: 3, scope: !156)

--- a/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
+++ b/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
@@ -50,148 +50,148 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %var_i32.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !7
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !8
+// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !9
+// CHECK:STDOUT:   %var_i32.var = alloca i32, align 4, !dbg !10
+// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !11
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i32.var), !dbg !7
-// CHECK:STDOUT:   %.loc32 = load ptr, ptr %ptr_i32.var, align 8, !dbg !8
-// CHECK:STDOUT:   %F.call.loc32 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc32), !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !7
-// CHECK:STDOUT:   %.loc34 = load ptr, ptr %ptr_f64.var, align 8, !dbg !10
-// CHECK:STDOUT:   %F.call.loc34 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc34), !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !7
-// CHECK:STDOUT:   %.loc36 = load ptr, ptr %ptr_i8.var, align 8, !dbg !12
-// CHECK:STDOUT:   %F.call.loc36 = call ptr @_CF.Main.bda010de15e6a5ad(ptr %.loc36), !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %var_i32.var), !dbg !7
-// CHECK:STDOUT:   store i32 0, ptr %var_i32.var, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc38 = load i32, ptr %var_i32.var, align 4, !dbg !15
-// CHECK:STDOUT:   %F.call.loc38 = call i32 @_CF.Main.b88d1103f417c6d4(i32 %.loc38), !dbg !16
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %var_f64.var), !dbg !7
-// CHECK:STDOUT:   store double 0.000000e+00, ptr %var_f64.var, align 8, !dbg !17
-// CHECK:STDOUT:   %.loc40 = load double, ptr %var_f64.var, align 8, !dbg !18
-// CHECK:STDOUT:   %F.call.loc40 = call double @_CF.Main.66be507887ceee78(double %.loc40), !dbg !19
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !7
-// CHECK:STDOUT:   %F.call.loc42 = call %type @_CF.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !20
-// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT:   %.loc32 = load ptr, ptr %ptr_i32.var, align 8, !dbg !13
+// CHECK:STDOUT:   %F.call.loc32 = call ptr @_CF.Main.e8193710fd35b608(ptr %.loc32), !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_f64.var), !dbg !8
+// CHECK:STDOUT:   %.loc34 = load ptr, ptr %ptr_f64.var, align 8, !dbg !15
+// CHECK:STDOUT:   %F.call.loc34 = call ptr @_CF.Main.04bf2edaaa84aa22(ptr %.loc34), !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %ptr_i8.var), !dbg !9
+// CHECK:STDOUT:   %.loc36 = load ptr, ptr %ptr_i8.var, align 8, !dbg !17
+// CHECK:STDOUT:   %F.call.loc36 = call ptr @_CF.Main.bda010de15e6a5ad(ptr %.loc36), !dbg !18
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %var_i32.var), !dbg !10
+// CHECK:STDOUT:   store i32 0, ptr %var_i32.var, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc38 = load i32, ptr %var_i32.var, align 4, !dbg !19
+// CHECK:STDOUT:   %F.call.loc38 = call i32 @_CF.Main.b88d1103f417c6d4(i32 %.loc38), !dbg !20
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %var_f64.var), !dbg !11
+// CHECK:STDOUT:   store double 0.000000e+00, ptr %var_f64.var, align 8, !dbg !11
+// CHECK:STDOUT:   %.loc40 = load double, ptr %var_f64.var, align 8, !dbg !21
+// CHECK:STDOUT:   %F.call.loc40 = call double @_CF.Main.66be507887ceee78(double %.loc40), !dbg !22
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !12
+// CHECK:STDOUT:   %F.call.loc42 = call %type @_CF.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !23
+// CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !22 {
+// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !25 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x), !dbg !23
-// CHECK:STDOUT:   ret ptr %G.call, !dbg !24
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !25 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x), !dbg !26
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x), !dbg !26
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !28 {
+// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !28 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.bda010de15e6a5ad(ptr %x), !dbg !29
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x), !dbg !29
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !30
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !31 {
+// CHECK:STDOUT: define ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !31 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x), !dbg !32
-// CHECK:STDOUT:   ret i32 %G.call, !dbg !33
+// CHECK:STDOUT:   %G.call = call ptr @_CG.Main.bda010de15e6a5ad(ptr %x), !dbg !32
+// CHECK:STDOUT:   ret ptr %G.call, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x) !dbg !34 {
+// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !34 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x), !dbg !35
-// CHECK:STDOUT:   ret double %G.call, !dbg !36
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x), !dbg !35
+// CHECK:STDOUT:   ret i32 %G.call, !dbg !36
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !37 {
+// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x) !dbg !37 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call %type @_CG.Main.5754c7a55c7cbe4a(%type %x), !dbg !38
-// CHECK:STDOUT:   ret %type %G.call, !dbg !39
+// CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x), !dbg !38
+// CHECK:STDOUT:   ret double %G.call, !dbg !39
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x) !dbg !40 {
+// CHECK:STDOUT: define %type @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !40 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !41
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !41
-// CHECK:STDOUT:   %Cfn.call = call ptr @_CCfn.C.Main.e8193710fd35b608(ptr %c.var, ptr %x), !dbg !42
-// CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !43
+// CHECK:STDOUT:   %G.call = call %type @_CG.Main.5754c7a55c7cbe4a(%type %x), !dbg !41
+// CHECK:STDOUT:   ret %type %G.call, !dbg !42
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x) !dbg !44 {
+// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x) !dbg !43 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !45
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !45
-// CHECK:STDOUT:   %Cfn.call = call ptr @_CCfn.C.Main.04bf2edaaa84aa22(ptr %c.var, ptr %x), !dbg !46
-// CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !47
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !44
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !44
+// CHECK:STDOUT:   %Cfn.call = call ptr @_CCfn.C.Main.e8193710fd35b608(ptr %c.var, ptr %x), !dbg !45
+// CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !46
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.bda010de15e6a5ad(ptr %x) !dbg !48 {
+// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x) !dbg !47 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !49
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !49
-// CHECK:STDOUT:   %Cfn.call = call ptr @_CCfn.C.Main.bda010de15e6a5ad(ptr %c.var, ptr %x), !dbg !50
-// CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !51
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !48
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !48
+// CHECK:STDOUT:   %Cfn.call = call ptr @_CCfn.C.Main.04bf2edaaa84aa22(ptr %c.var, ptr %x), !dbg !49
+// CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !50
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !52 {
+// CHECK:STDOUT: define ptr @_CG.Main.bda010de15e6a5ad(ptr %x) !dbg !51 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !53
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !53
-// CHECK:STDOUT:   %Cfn.call = call i32 @_CCfn.C.Main.b88d1103f417c6d4(ptr %c.var, i32 %x), !dbg !54
-// CHECK:STDOUT:   ret i32 %Cfn.call, !dbg !55
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !52
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !52
+// CHECK:STDOUT:   %Cfn.call = call ptr @_CCfn.C.Main.bda010de15e6a5ad(ptr %c.var, ptr %x), !dbg !53
+// CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !54
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !56 {
+// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !55 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !57
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !57
-// CHECK:STDOUT:   %Cfn.call = call double @_CCfn.C.Main.66be507887ceee78(ptr %c.var, double %x), !dbg !58
-// CHECK:STDOUT:   ret double %Cfn.call, !dbg !59
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !56
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !56
+// CHECK:STDOUT:   %Cfn.call = call i32 @_CCfn.C.Main.b88d1103f417c6d4(ptr %c.var, i32 %x), !dbg !57
+// CHECK:STDOUT:   ret i32 %Cfn.call, !dbg !58
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !60 {
+// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !59 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !61
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !61
-// CHECK:STDOUT:   %Cfn.call = call %type @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %c.var, %type %x), !dbg !62
-// CHECK:STDOUT:   ret %type %Cfn.call, !dbg !63
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !60
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !60
+// CHECK:STDOUT:   %Cfn.call = call double @_CCfn.C.Main.66be507887ceee78(ptr %c.var, double %x), !dbg !61
+// CHECK:STDOUT:   ret double %Cfn.call, !dbg !62
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CCfn.C.Main.e8193710fd35b608(ptr %self, ptr %x) !dbg !64 {
+// CHECK:STDOUT: define %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !63 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !65
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !64
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !64
+// CHECK:STDOUT:   %Cfn.call = call %type @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %c.var, %type %x), !dbg !65
+// CHECK:STDOUT:   ret %type %Cfn.call, !dbg !66
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CCfn.C.Main.04bf2edaaa84aa22(ptr %self, ptr %x) !dbg !66 {
+// CHECK:STDOUT: define ptr @_CCfn.C.Main.e8193710fd35b608(ptr %self, ptr %x) !dbg !67 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !67
+// CHECK:STDOUT:   ret ptr %x, !dbg !68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CCfn.C.Main.bda010de15e6a5ad(ptr %self, ptr %x) !dbg !68 {
+// CHECK:STDOUT: define ptr @_CCfn.C.Main.04bf2edaaa84aa22(ptr %self, ptr %x) !dbg !69 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !69
+// CHECK:STDOUT:   ret ptr %x, !dbg !70
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CCfn.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !70 {
+// CHECK:STDOUT: define ptr @_CCfn.C.Main.bda010de15e6a5ad(ptr %self, ptr %x) !dbg !71 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret i32 %x, !dbg !71
+// CHECK:STDOUT:   ret ptr %x, !dbg !72
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CCfn.C.Main.66be507887ceee78(ptr %self, double %x) !dbg !72 {
+// CHECK:STDOUT: define i32 @_CCfn.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !73 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret double %x, !dbg !73
+// CHECK:STDOUT:   ret i32 %x, !dbg !74
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %self, %type %x) !dbg !74 {
+// CHECK:STDOUT: define double @_CCfn.C.Main.66be507887ceee78(ptr %self, double %x) !dbg !75 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret %type %x, !dbg !75
+// CHECK:STDOUT:   ret double %x, !dbg !76
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %type @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %self, %type %x) !dbg !77 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret %type %x, !dbg !78
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -210,71 +210,74 @@ fn M() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 31, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 32, column: 5, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 32, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 34, column: 5, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 34, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 36, column: 5, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 36, column: 3, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 37, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 38, column: 5, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 38, column: 3, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 39, column: 3, scope: !4)
-// CHECK:STDOUT: !18 = !DILocation(line: 40, column: 5, scope: !4)
-// CHECK:STDOUT: !19 = !DILocation(line: 40, column: 3, scope: !4)
-// CHECK:STDOUT: !20 = !DILocation(line: 42, column: 3, scope: !4)
-// CHECK:STDOUT: !21 = !DILocation(line: 30, column: 1, scope: !4)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !23 = !DILocation(line: 27, column: 10, scope: !22)
-// CHECK:STDOUT: !24 = !DILocation(line: 27, column: 3, scope: !22)
-// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !8 = !DILocation(line: 33, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 35, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 37, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 39, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 41, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 32, column: 5, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 32, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 34, column: 5, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 34, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 36, column: 5, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 36, column: 3, scope: !4)
+// CHECK:STDOUT: !19 = !DILocation(line: 38, column: 5, scope: !4)
+// CHECK:STDOUT: !20 = !DILocation(line: 38, column: 3, scope: !4)
+// CHECK:STDOUT: !21 = !DILocation(line: 40, column: 5, scope: !4)
+// CHECK:STDOUT: !22 = !DILocation(line: 40, column: 3, scope: !4)
+// CHECK:STDOUT: !23 = !DILocation(line: 42, column: 3, scope: !4)
+// CHECK:STDOUT: !24 = !DILocation(line: 30, column: 1, scope: !4)
+// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.e8193710fd35b608", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !26 = !DILocation(line: 27, column: 10, scope: !25)
 // CHECK:STDOUT: !27 = !DILocation(line: 27, column: 3, scope: !25)
-// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.bda010de15e6a5ad", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !29 = !DILocation(line: 27, column: 10, scope: !28)
 // CHECK:STDOUT: !30 = !DILocation(line: 27, column: 3, scope: !28)
-// CHECK:STDOUT: !31 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !31 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.bda010de15e6a5ad", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !32 = !DILocation(line: 27, column: 10, scope: !31)
 // CHECK:STDOUT: !33 = !DILocation(line: 27, column: 3, scope: !31)
-// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !35 = !DILocation(line: 27, column: 10, scope: !34)
 // CHECK:STDOUT: !36 = !DILocation(line: 27, column: 3, scope: !34)
-// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.66be507887ceee78", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !38 = !DILocation(line: 27, column: 10, scope: !37)
 // CHECK:STDOUT: !39 = !DILocation(line: 27, column: 3, scope: !37)
-// CHECK:STDOUT: !40 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e8193710fd35b608", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !41 = !DILocation(line: 22, column: 3, scope: !40)
-// CHECK:STDOUT: !42 = !DILocation(line: 23, column: 10, scope: !40)
-// CHECK:STDOUT: !43 = !DILocation(line: 23, column: 3, scope: !40)
-// CHECK:STDOUT: !44 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !45 = !DILocation(line: 22, column: 3, scope: !44)
-// CHECK:STDOUT: !46 = !DILocation(line: 23, column: 10, scope: !44)
-// CHECK:STDOUT: !47 = !DILocation(line: 23, column: 3, scope: !44)
-// CHECK:STDOUT: !48 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.bda010de15e6a5ad", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !49 = !DILocation(line: 22, column: 3, scope: !48)
-// CHECK:STDOUT: !50 = !DILocation(line: 23, column: 10, scope: !48)
-// CHECK:STDOUT: !51 = !DILocation(line: 23, column: 3, scope: !48)
-// CHECK:STDOUT: !52 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !53 = !DILocation(line: 22, column: 3, scope: !52)
-// CHECK:STDOUT: !54 = !DILocation(line: 23, column: 10, scope: !52)
-// CHECK:STDOUT: !55 = !DILocation(line: 23, column: 3, scope: !52)
-// CHECK:STDOUT: !56 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !57 = !DILocation(line: 22, column: 3, scope: !56)
-// CHECK:STDOUT: !58 = !DILocation(line: 23, column: 10, scope: !56)
-// CHECK:STDOUT: !59 = !DILocation(line: 23, column: 3, scope: !56)
-// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !61 = !DILocation(line: 22, column: 3, scope: !60)
-// CHECK:STDOUT: !62 = !DILocation(line: 23, column: 10, scope: !60)
-// CHECK:STDOUT: !63 = !DILocation(line: 23, column: 3, scope: !60)
-// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.e8193710fd35b608", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !65 = !DILocation(line: 17, column: 5, scope: !64)
-// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !67 = !DILocation(line: 17, column: 5, scope: !66)
-// CHECK:STDOUT: !68 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.bda010de15e6a5ad", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !69 = !DILocation(line: 17, column: 5, scope: !68)
-// CHECK:STDOUT: !70 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !71 = !DILocation(line: 17, column: 5, scope: !70)
-// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.66be507887ceee78", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !73 = !DILocation(line: 17, column: 5, scope: !72)
-// CHECK:STDOUT: !74 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !75 = !DILocation(line: 17, column: 5, scope: !74)
+// CHECK:STDOUT: !40 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !41 = !DILocation(line: 27, column: 10, scope: !40)
+// CHECK:STDOUT: !42 = !DILocation(line: 27, column: 3, scope: !40)
+// CHECK:STDOUT: !43 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e8193710fd35b608", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !44 = !DILocation(line: 22, column: 3, scope: !43)
+// CHECK:STDOUT: !45 = !DILocation(line: 23, column: 10, scope: !43)
+// CHECK:STDOUT: !46 = !DILocation(line: 23, column: 3, scope: !43)
+// CHECK:STDOUT: !47 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !48 = !DILocation(line: 22, column: 3, scope: !47)
+// CHECK:STDOUT: !49 = !DILocation(line: 23, column: 10, scope: !47)
+// CHECK:STDOUT: !50 = !DILocation(line: 23, column: 3, scope: !47)
+// CHECK:STDOUT: !51 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.bda010de15e6a5ad", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !52 = !DILocation(line: 22, column: 3, scope: !51)
+// CHECK:STDOUT: !53 = !DILocation(line: 23, column: 10, scope: !51)
+// CHECK:STDOUT: !54 = !DILocation(line: 23, column: 3, scope: !51)
+// CHECK:STDOUT: !55 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.b88d1103f417c6d4", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !56 = !DILocation(line: 22, column: 3, scope: !55)
+// CHECK:STDOUT: !57 = !DILocation(line: 23, column: 10, scope: !55)
+// CHECK:STDOUT: !58 = !DILocation(line: 23, column: 3, scope: !55)
+// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.66be507887ceee78", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !60 = !DILocation(line: 22, column: 3, scope: !59)
+// CHECK:STDOUT: !61 = !DILocation(line: 23, column: 10, scope: !59)
+// CHECK:STDOUT: !62 = !DILocation(line: 23, column: 3, scope: !59)
+// CHECK:STDOUT: !63 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 21, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !64 = !DILocation(line: 22, column: 3, scope: !63)
+// CHECK:STDOUT: !65 = !DILocation(line: 23, column: 10, scope: !63)
+// CHECK:STDOUT: !66 = !DILocation(line: 23, column: 3, scope: !63)
+// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.e8193710fd35b608", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !68 = !DILocation(line: 17, column: 5, scope: !67)
+// CHECK:STDOUT: !69 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.04bf2edaaa84aa22", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !70 = !DILocation(line: 17, column: 5, scope: !69)
+// CHECK:STDOUT: !71 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.bda010de15e6a5ad", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !72 = !DILocation(line: 17, column: 5, scope: !71)
+// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !74 = !DILocation(line: 17, column: 5, scope: !73)
+// CHECK:STDOUT: !75 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.66be507887ceee78", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !76 = !DILocation(line: 17, column: 5, scope: !75)
+// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Cfn", linkageName: "_CCfn.C.Main.5754c7a55c7cbe4a", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !78 = !DILocation(line: 17, column: 5, scope: !77)

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -43,33 +43,33 @@ fn Run() {
 // CHECK:STDOUT: define void @main() !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [2 x i32], align 4, !dbg !13
-// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !13
-// CHECK:STDOUT:   %c.var = alloca i32, align 4, !dbg !13
-// CHECK:STDOUT:   %d.var = alloca i32, align 4, !dbg !13
+// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !14
+// CHECK:STDOUT:   %c.var = alloca i32, align 4, !dbg !15
+// CHECK:STDOUT:   %d.var = alloca i32, align 4, !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !13
-// CHECK:STDOUT:   %.loc15_28.1.temp = alloca { i32, i32 }, align 8, !dbg !14
-// CHECK:STDOUT:   call void @_CA.Main(ptr %.loc15_28.1.temp), !dbg !14
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc15_28.1.temp, i32 0, i32 0, !dbg !14
-// CHECK:STDOUT:   %.loc15_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc15_28.4.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 0, !dbg !14
-// CHECK:STDOUT:   store i32 %.loc15_28.3, ptr %.loc15_28.4.array.index, align 4, !dbg !14
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc15_28.1.temp, i32 0, i32 1, !dbg !14
-// CHECK:STDOUT:   %.loc15_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc15_28.7.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 1, !dbg !14
-// CHECK:STDOUT:   store i32 %.loc15_28.6, ptr %.loc15_28.7.array.index, align 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %b.var), !dbg !13
-// CHECK:STDOUT:   store i32 1, ptr %b.var, align 4, !dbg !15
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %c.var), !dbg !13
-// CHECK:STDOUT:   %.loc17_18 = load i32, ptr %b.var, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc17_19.1.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i32 %.loc17_18, !dbg !17
-// CHECK:STDOUT:   %.loc17_19.2 = load i32, ptr %.loc17_19.1.array.index, align 4, !dbg !17
-// CHECK:STDOUT:   store i32 %.loc17_19.2, ptr %c.var, align 4, !dbg !18
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %d.var), !dbg !13
-// CHECK:STDOUT:   %.loc18_18.1.temp = alloca [2 x i32], align 4, !dbg !19
-// CHECK:STDOUT:   call void @_CB.Main(ptr %.loc18_18.1.temp), !dbg !19
-// CHECK:STDOUT:   %.loc18_21.1.array.index = getelementptr inbounds [2 x i32], ptr %.loc18_18.1.temp, i32 0, i32 1, !dbg !19
-// CHECK:STDOUT:   %.loc18_21.2 = load i32, ptr %.loc18_21.1.array.index, align 4, !dbg !19
-// CHECK:STDOUT:   store i32 %.loc18_21.2, ptr %d.var, align 4, !dbg !20
+// CHECK:STDOUT:   %.loc15_28.1.temp = alloca { i32, i32 }, align 8, !dbg !17
+// CHECK:STDOUT:   call void @_CA.Main(ptr %.loc15_28.1.temp), !dbg !17
+// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc15_28.1.temp, i32 0, i32 0, !dbg !17
+// CHECK:STDOUT:   %.loc15_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !17
+// CHECK:STDOUT:   %.loc15_28.4.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 0, !dbg !17
+// CHECK:STDOUT:   store i32 %.loc15_28.3, ptr %.loc15_28.4.array.index, align 4, !dbg !17
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc15_28.1.temp, i32 0, i32 1, !dbg !17
+// CHECK:STDOUT:   %.loc15_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !17
+// CHECK:STDOUT:   %.loc15_28.7.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 1, !dbg !17
+// CHECK:STDOUT:   store i32 %.loc15_28.6, ptr %.loc15_28.7.array.index, align 4, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %b.var), !dbg !14
+// CHECK:STDOUT:   store i32 1, ptr %b.var, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %c.var), !dbg !15
+// CHECK:STDOUT:   %.loc17_18 = load i32, ptr %b.var, align 4, !dbg !18
+// CHECK:STDOUT:   %.loc17_19.1.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i32 %.loc17_18, !dbg !19
+// CHECK:STDOUT:   %.loc17_19.2 = load i32, ptr %.loc17_19.1.array.index, align 4, !dbg !19
+// CHECK:STDOUT:   store i32 %.loc17_19.2, ptr %c.var, align 4, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %d.var), !dbg !16
+// CHECK:STDOUT:   %.loc18_18.1.temp = alloca [2 x i32], align 4, !dbg !20
+// CHECK:STDOUT:   call void @_CB.Main(ptr %.loc18_18.1.temp), !dbg !20
+// CHECK:STDOUT:   %.loc18_21.1.array.index = getelementptr inbounds [2 x i32], ptr %.loc18_18.1.temp, i32 0, i32 1, !dbg !20
+// CHECK:STDOUT:   %.loc18_21.2 = load i32, ptr %.loc18_21.1.array.index, align 4, !dbg !20
+// CHECK:STDOUT:   store i32 %.loc18_21.2, ptr %d.var, align 4, !dbg !16
 // CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -104,11 +104,11 @@ fn Run() {
 // CHECK:STDOUT: !11 = !DILocation(line: 12, column: 27, scope: !9)
 // CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !13 = !DILocation(line: 15, column: 3, scope: !12)
-// CHECK:STDOUT: !14 = !DILocation(line: 15, column: 26, scope: !12)
-// CHECK:STDOUT: !15 = !DILocation(line: 16, column: 3, scope: !12)
-// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 18, scope: !12)
-// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 16, scope: !12)
-// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 3, scope: !12)
-// CHECK:STDOUT: !19 = !DILocation(line: 18, column: 16, scope: !12)
-// CHECK:STDOUT: !20 = !DILocation(line: 18, column: 3, scope: !12)
+// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 3, scope: !12)
+// CHECK:STDOUT: !15 = !DILocation(line: 17, column: 3, scope: !12)
+// CHECK:STDOUT: !16 = !DILocation(line: 18, column: 3, scope: !12)
+// CHECK:STDOUT: !17 = !DILocation(line: 15, column: 26, scope: !12)
+// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 18, scope: !12)
+// CHECK:STDOUT: !19 = !DILocation(line: 17, column: 16, scope: !12)
+// CHECK:STDOUT: !20 = !DILocation(line: 18, column: 16, scope: !12)
 // CHECK:STDOUT: !21 = !DILocation(line: 14, column: 1, scope: !12)

--- a/toolchain/lower/testdata/let/tuple.carbon
+++ b/toolchain/lower/testdata/let/tuple.carbon
@@ -24,16 +24,16 @@ fn F() -> i32 {
 // CHECK:STDOUT: define i32 @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %a.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %tuple.elem1.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   %tuple.elem2.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   %tuple.elem1.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   %tuple.elem2.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !9
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.ee6.loc12_3.2, i64 12, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc13.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %tuple.elem1.loc13.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.0a0.loc13_3.2, i64 8, i1 false), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc13.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.loc13.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.0a0.loc13_3.2, i64 8, i1 false), !dbg !8
 // CHECK:STDOUT:   %tuple.elem0.loc14_43.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc14_43.1 = load i32, ptr %tuple.elem0.loc14_43.tuple.elem, align 4, !dbg !11
 // CHECK:STDOUT:   %tuple.elem1.loc14_43.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !11
@@ -93,9 +93,9 @@ fn F() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 28, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 23, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 12, column: 28, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 23, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 14, column: 43, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 14, column: 46, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 14, column: 42, scope: !4)

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -23,15 +23,15 @@ fn Main() {
 // CHECK:STDOUT: define void @_CMain.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %a.var), !dbg !7
 // CHECK:STDOUT:   store i32 12, ptr %a.var, align 4, !dbg !7
-// CHECK:STDOUT:   store i32 9, ptr %a.var, align 4, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.loc15_5, i64 8, i1 false), !dbg !10
-// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT:   store i32 9, ptr %a.var, align 4, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.loc15_5, i64 8, i1 false), !dbg !11
+// CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -57,7 +57,8 @@ fn Main() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 15, column: 7, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 11, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 15, column: 7, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 11, column: 1, scope: !4)

--- a/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
+++ b/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
@@ -21,15 +21,15 @@ fn F(p: i32**) -> i32 {
 // CHECK:STDOUT: define i32 @_CF.Main(ptr %p) !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca ptr, align 8, !dbg !7
-// CHECK:STDOUT:   %c.var = alloca ptr, align 8, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca ptr, align 8, !dbg !8
+// CHECK:STDOUT:   %c.var = alloca ptr, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %a.var), !dbg !7
 // CHECK:STDOUT:   store ptr %p, ptr %a.var, align 8, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %.loc13_17.2 = load ptr, ptr %p, align 8, !dbg !8
-// CHECK:STDOUT:   store ptr %.loc13_17.2, ptr %b.var, align 8, !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %c.var), !dbg !7
-// CHECK:STDOUT:   store ptr %b.var, ptr %c.var, align 8, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %.loc13_17.2 = load ptr, ptr %p, align 8, !dbg !10
+// CHECK:STDOUT:   store ptr %.loc13_17.2, ptr %b.var, align 8, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %c.var), !dbg !9
+// CHECK:STDOUT:   store ptr %b.var, ptr %c.var, align 8, !dbg !9
 // CHECK:STDOUT:   %.loc15_12 = load ptr, ptr %c.var, align 8, !dbg !11
 // CHECK:STDOUT:   %.loc15_11.2 = load ptr, ptr %.loc15_12, align 8, !dbg !12
 // CHECK:STDOUT:   %.loc15_10.2 = load i32, ptr %.loc15_11.2, align 4, !dbg !13
@@ -55,9 +55,9 @@ fn F(p: i32**) -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 17, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 17, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 15, column: 12, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 15, column: 11, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 15, column: 10, scope: !4)

--- a/toolchain/lower/testdata/struct/empty.carbon
+++ b/toolchain/lower/testdata/struct/empty.carbon
@@ -20,10 +20,10 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca {}, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %x.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   ret i32 0, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -45,4 +45,5 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 3, scope: !4)

--- a/toolchain/lower/testdata/struct/member_access.carbon
+++ b/toolchain/lower/testdata/struct/member_access.carbon
@@ -23,19 +23,19 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { double, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %z.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   %z.var = alloca i32, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 16, ptr %x.var), !dbg !7
-// CHECK:STDOUT:   %.loc12_48.2.a = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %.loc12_48.5.b = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 1, !dbg !8
+// CHECK:STDOUT:   %.loc12_48.2.a = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %.loc12_48.5.b = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %x.var, ptr align 8 @struct.loc12_3.2, i64 16, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   %.loc13_17.1.b = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   %.loc13_17.2 = load i32, ptr %.loc13_17.1.b, align 4, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc13_17.2, ptr %y.var, align 4, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %z.var), !dbg !7
-// CHECK:STDOUT:   %.loc14_16 = load i32, ptr %y.var, align 4, !dbg !11
-// CHECK:STDOUT:   store i32 %.loc14_16, ptr %z.var, align 4, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   %.loc13_17.1.b = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   %.loc13_17.2 = load i32, ptr %.loc13_17.1.b, align 4, !dbg !11
+// CHECK:STDOUT:   store i32 %.loc13_17.2, ptr %y.var, align 4, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %z.var), !dbg !9
+// CHECK:STDOUT:   %.loc14_16 = load i32, ptr %y.var, align 4, !dbg !12
+// CHECK:STDOUT:   store i32 %.loc14_16, ptr %z.var, align 4, !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -63,9 +63,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 31, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 16, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 14, column: 16, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 12, column: 31, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 13, column: 16, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 14, column: 16, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 15, column: 3, scope: !4)

--- a/toolchain/lower/testdata/struct/one_entry.carbon
+++ b/toolchain/lower/testdata/struct/one_entry.carbon
@@ -20,14 +20,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca { i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca { i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %x.var), !dbg !7
 // CHECK:STDOUT:   store { i32 } { i32 4 }, ptr %x.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   %.loc13_22.1.a = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %.loc13_22.2 = load i32, ptr %.loc13_22.1.a, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc13_22.3.struct.init = insertvalue { i32 } poison, i32 %.loc13_22.2, 0, !dbg !8
-// CHECK:STDOUT:   store { i32 } %.loc13_22.3.struct.init, ptr %y.var, align 4, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   %.loc13_22.1.a = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   %.loc13_22.2 = load i32, ptr %.loc13_22.1.a, align 4, !dbg !9
+// CHECK:STDOUT:   %.loc13_22.3.struct.init = insertvalue { i32 } poison, i32 %.loc13_22.2, 0, !dbg !9
+// CHECK:STDOUT:   store { i32 } %.loc13_22.3.struct.init, ptr %y.var, align 4, !dbg !8
 // CHECK:STDOUT:   ret i32 0, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -50,6 +50,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 22, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 22, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 14, column: 3, scope: !4)

--- a/toolchain/lower/testdata/struct/two_entries.carbon
+++ b/toolchain/lower/testdata/struct/two_entries.carbon
@@ -22,21 +22,21 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %x.var), !dbg !7
-// CHECK:STDOUT:   %.loc12_46.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %.loc12_46.6.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !8
+// CHECK:STDOUT:   %.loc12_46.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   %.loc12_46.6.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @struct.loc12_3.2, i64 8, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   %.loc13_31.1.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %.loc13_31.2 = load i32, ptr %.loc13_31.1.a, align 4, !dbg !9
-// CHECK:STDOUT:   %.loc13_31.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc13_31.2, ptr %.loc13_31.3.a, align 4, !dbg !9
-// CHECK:STDOUT:   %.loc13_31.5.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   %.loc13_31.6 = load i32, ptr %.loc13_31.5.b, align 4, !dbg !9
-// CHECK:STDOUT:   %.loc13_31.7.b = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc13_31.6, ptr %.loc13_31.7.b, align 4, !dbg !9
-// CHECK:STDOUT:   ret i32 0, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   %.loc13_31.1.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %.loc13_31.2 = load i32, ptr %.loc13_31.1.a, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc13_31.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc13_31.2, ptr %.loc13_31.3.a, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc13_31.5.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   %.loc13_31.6 = load i32, ptr %.loc13_31.5.b, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc13_31.7.b = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc13_31.6, ptr %.loc13_31.7.b, align 4, !dbg !10
+// CHECK:STDOUT:   ret i32 0, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -63,6 +63,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 31, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 31, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 12, column: 31, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 31, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 14, column: 3, scope: !4)

--- a/toolchain/lower/testdata/tuple/access/element_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/element_access.carbon
@@ -23,21 +23,21 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %c.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   %c.var = alloca i32, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %a.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   %tuple.elem2.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   %tuple.elem2.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.loc12_3.2, i64 12, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc13.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %.loc13_17 = load i32, ptr %tuple.elem0.loc13.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc13_17, ptr %b.var, align 4, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %c.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem2.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !11
-// CHECK:STDOUT:   %.loc14_17 = load i32, ptr %tuple.elem2.loc14.tuple.elem, align 4, !dbg !11
-// CHECK:STDOUT:   store i32 %.loc14_17, ptr %c.var, align 4, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc13.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc13_17 = load i32, ptr %tuple.elem0.loc13.tuple.elem, align 4, !dbg !11
+// CHECK:STDOUT:   store i32 %.loc13_17, ptr %b.var, align 4, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %c.var), !dbg !9
+// CHECK:STDOUT:   %tuple.elem2.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !12
+// CHECK:STDOUT:   %.loc14_17 = load i32, ptr %tuple.elem2.loc14.tuple.elem, align 4, !dbg !12
+// CHECK:STDOUT:   store i32 %.loc14_17, ptr %c.var, align 4, !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -65,9 +65,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 28, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 16, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 14, column: 16, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 12, column: 28, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 13, column: 16, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 14, column: 16, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 15, column: 3, scope: !4)

--- a/toolchain/lower/testdata/tuple/empty.carbon
+++ b/toolchain/lower/testdata/tuple/empty.carbon
@@ -20,10 +20,10 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca {}, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %x.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   ret i32 0, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -45,4 +45,5 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 3, scope: !4)

--- a/toolchain/lower/testdata/tuple/one_entry.carbon
+++ b/toolchain/lower/testdata/tuple/one_entry.carbon
@@ -20,14 +20,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca { i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca { i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %x.var), !dbg !7
 // CHECK:STDOUT:   store { i32 } { i32 1 }, ptr %x.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %.loc13_20.1 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc13_20.2.tuple.init = insertvalue { i32 } poison, i32 %.loc13_20.1, 0, !dbg !8
-// CHECK:STDOUT:   store { i32 } %.loc13_20.2.tuple.init, ptr %y.var, align 4, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   %.loc13_20.1 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !9
+// CHECK:STDOUT:   %.loc13_20.2.tuple.init = insertvalue { i32 } poison, i32 %.loc13_20.1, 0, !dbg !9
+// CHECK:STDOUT:   store { i32 } %.loc13_20.2.tuple.init, ptr %y.var, align 4, !dbg !8
 // CHECK:STDOUT:   ret i32 0, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -51,6 +51,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 20, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 20, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 14, column: 3, scope: !4)

--- a/toolchain/lower/testdata/tuple/two_entries.carbon
+++ b/toolchain/lower/testdata/tuple/two_entries.carbon
@@ -22,21 +22,21 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %x.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %tuple.elem1.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   %tuple.elem1.loc12.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @tuple.loc12_3.2, i64 8, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %y.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc13_23.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %.loc13_23.1 = load i32, ptr %tuple.elem0.loc13_23.1.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.elem0.loc13_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc13_23.1, ptr %tuple.elem0.loc13_23.2.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.elem1.loc13_23.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   %.loc13_23.3 = load i32, ptr %tuple.elem1.loc13_23.1.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.elem1.loc13_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc13_23.3, ptr %tuple.elem1.loc13_23.2.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   ret i32 0, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 8, ptr %y.var), !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc13_23.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %.loc13_23.1 = load i32, ptr %tuple.elem0.loc13_23.1.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem0.loc13_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc13_23.1, ptr %tuple.elem0.loc13_23.2.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.loc13_23.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   %.loc13_23.3 = load i32, ptr %tuple.elem1.loc13_23.1.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.loc13_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc13_23.3, ptr %tuple.elem1.loc13_23.2.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   ret i32 0, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -63,6 +63,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 23, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 23, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 12, column: 23, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 13, column: 23, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 14, column: 3, scope: !4)

--- a/toolchain/lower/testdata/tuple/value_formation.carbon
+++ b/toolchain/lower/testdata/tuple/value_formation.carbon
@@ -24,42 +24,42 @@ fn F() {
 // CHECK:STDOUT: define void @_CF.Main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca { i32, i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca { i32, i32, i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %a.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.loc16_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   %.loc16_6.1 = load i32, ptr %tuple.elem0.loc16_6.tuple.elem, align 4, !dbg !8
-// CHECK:STDOUT:   %tuple.elem1.loc16_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   %.loc16_6.2 = load i32, ptr %tuple.elem1.loc16_6.tuple.elem, align 4, !dbg !8
-// CHECK:STDOUT:   %tuple.elem2.loc16_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !8
-// CHECK:STDOUT:   %.loc16_6.3 = load i32, ptr %tuple.elem2.loc16_6.tuple.elem, align 4, !dbg !8
-// CHECK:STDOUT:   %tuple.loc16_6 = alloca { i32, i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %tuple.loc16_61 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_6, i32 0, i32 0, !dbg !8
-// CHECK:STDOUT:   store i32 %.loc16_6.1, ptr %tuple.loc16_61, align 4, !dbg !8
-// CHECK:STDOUT:   %tuple.loc16_62 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_6, i32 0, i32 1, !dbg !8
-// CHECK:STDOUT:   store i32 %.loc16_6.2, ptr %tuple.loc16_62, align 4, !dbg !8
-// CHECK:STDOUT:   %tuple.loc16_63 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_6, i32 0, i32 2, !dbg !8
-// CHECK:STDOUT:   store i32 %.loc16_6.3, ptr %tuple.loc16_63, align 4, !dbg !8
-// CHECK:STDOUT:   %tuple.elem0.loc16_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   %.loc16_9.1 = load i32, ptr %tuple.elem0.loc16_9.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.elem1.loc16_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   %.loc16_9.2 = load i32, ptr %tuple.elem1.loc16_9.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.elem2.loc16_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 2, !dbg !9
-// CHECK:STDOUT:   %.loc16_9.3 = load i32, ptr %tuple.elem2.loc16_9.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.loc16_9 = alloca { i32, i32, i32 }, align 8, !dbg !9
-// CHECK:STDOUT:   %tuple.loc16_94 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_9, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc16_9.1, ptr %tuple.loc16_94, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.loc16_95 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_9, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc16_9.2, ptr %tuple.loc16_95, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.loc16_96 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_9, i32 0, i32 2, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc16_9.3, ptr %tuple.loc16_96, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.loc16_10 = alloca { ptr, ptr }, align 8, !dbg !10
-// CHECK:STDOUT:   %tuple.loc16_107 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_10, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   store ptr %tuple.loc16_6, ptr %tuple.loc16_107, align 8, !dbg !10
-// CHECK:STDOUT:   %tuple.loc16_108 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_10, i32 0, i32 1, !dbg !10
-// CHECK:STDOUT:   store ptr %tuple.loc16_9, ptr %tuple.loc16_108, align 8, !dbg !10
-// CHECK:STDOUT:   call void @_CG.Main(ptr %tuple.loc16_10), !dbg !11
-// CHECK:STDOUT:   ret void, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 12, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %tuple.elem0.loc16_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   %.loc16_6.1 = load i32, ptr %tuple.elem0.loc16_6.tuple.elem, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.elem1.loc16_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   %.loc16_6.2 = load i32, ptr %tuple.elem1.loc16_6.tuple.elem, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.elem2.loc16_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !9
+// CHECK:STDOUT:   %.loc16_6.3 = load i32, ptr %tuple.elem2.loc16_6.tuple.elem, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.loc16_6 = alloca { i32, i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %tuple.loc16_61 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_6, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   store i32 %.loc16_6.1, ptr %tuple.loc16_61, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.loc16_62 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_6, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   store i32 %.loc16_6.2, ptr %tuple.loc16_62, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.loc16_63 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_6, i32 0, i32 2, !dbg !9
+// CHECK:STDOUT:   store i32 %.loc16_6.3, ptr %tuple.loc16_63, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.elem0.loc16_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %.loc16_9.1 = load i32, ptr %tuple.elem0.loc16_9.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.loc16_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   %.loc16_9.2 = load i32, ptr %tuple.elem1.loc16_9.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem2.loc16_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 2, !dbg !10
+// CHECK:STDOUT:   %.loc16_9.3 = load i32, ptr %tuple.elem2.loc16_9.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_9 = alloca { i32, i32, i32 }, align 8, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_94 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_9, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_9.1, ptr %tuple.loc16_94, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_95 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_9, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_9.2, ptr %tuple.loc16_95, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_96 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_9, i32 0, i32 2, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_9.3, ptr %tuple.loc16_96, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_10 = alloca { ptr, ptr }, align 8, !dbg !11
+// CHECK:STDOUT:   %tuple.loc16_107 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_10, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   store ptr %tuple.loc16_6, ptr %tuple.loc16_107, align 8, !dbg !11
+// CHECK:STDOUT:   %tuple.loc16_108 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_10, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   store ptr %tuple.loc16_9, ptr %tuple.loc16_108, align 8, !dbg !11
+// CHECK:STDOUT:   call void @_CG.Main(ptr %tuple.loc16_10), !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -81,8 +81,9 @@ fn F() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 6, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 9, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 5, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 16, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 6, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 9, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 16, column: 5, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 13, column: 1, scope: !4)

--- a/toolchain/lower/testdata/var/nested.carbon
+++ b/toolchain/lower/testdata/var/nested.carbon
@@ -23,18 +23,18 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %a.var), !dbg !7
 // CHECK:STDOUT:   store i32 1, ptr %a.var, align 4, !dbg !7
-// CHECK:STDOUT:   br label %while.cond, !dbg !8
+// CHECK:STDOUT:   br label %while.cond, !dbg !9
 // CHECK:STDOUT:
 // CHECK:STDOUT: while.cond:                                       ; preds = %while.body, %entry
-// CHECK:STDOUT:   br i1 true, label %while.body, label %while.done, !dbg !8
+// CHECK:STDOUT:   br i1 true, label %while.body, label %while.done, !dbg !9
 // CHECK:STDOUT:
 // CHECK:STDOUT: while.body:                                       ; preds = %while.cond
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %b.var), !dbg !7
-// CHECK:STDOUT:   %.loc14_18 = load i32, ptr %a.var, align 4, !dbg !9
-// CHECK:STDOUT:   store i32 %.loc14_18, ptr %b.var, align 4, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %b.var), !dbg !8
+// CHECK:STDOUT:   %.loc14_18 = load i32, ptr %a.var, align 4, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc14_18, ptr %b.var, align 4, !dbg !8
 // CHECK:STDOUT:   %.loc15 = load i32, ptr %b.var, align 4, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc15, ptr %a.var, align 4, !dbg !12
 // CHECK:STDOUT:   br label %while.cond, !dbg !13
@@ -64,9 +64,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 13, column: 9, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 14, column: 18, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 14, column: 5, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 5, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 13, column: 9, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 14, column: 18, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 15, column: 9, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 15, column: 5, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 13, column: 3, scope: !4)


### PR DESCRIPTION
The version of clangd/clang-tidy on developer machines has slowly diverged from the one on the CI builders, which is causing a slowly increasing amount of pain as clang-tidy runs fail (incorrectly) over things that a newer clangd/clang-tidy was perfectly fine with. This bumps the version used in the ubuntu builders to 18, which is more recent. Ubuntu stable has 19 available as well, but maybe that is too bleeding edge?

We use apt.llvm.org instead of GitHub releases (https://github.com/llvm/llvm-project/releases) as the former more reliably has packages for newer clang versions on x64. The releases binaries have stopped including ubuntu packages that match the GitHub x64 ubuntu workers for some time (for at least the 18 and 19 releases).

By moving to apt.llvm.org packages we only download and install the headers and libraries needed for development, rather than every output of building llvm, which is much faster and saves lots of disk space. We also remove the system installations of other versions of clang/llvm so we should end up using negative disk space. We can no longer easily cache the installation but it wouldn't give us much anyway (unless apt.llvm.org was down, but it is reliable).

We bump the ubuntu image version for the github workers to 24.10, as apt.llvm.org has stopped building images for 22.10 in 2022 at its end of life.
