### PR TITLE
Bump clang version to 19

### DIFF
--- a/.github/actions/build-setup-common/action.yml
+++ b/.github/actions/build-setup-common/action.yml
@@ -47,6 +47,9 @@ runs:
         echo '*** clang++'
         which clang++
         clang++ --version
+        echo '*** clang-tidy'
+        which clang-tidy
+        clang-tidy --version
 
     # Add our bazel configuration and print basic info to ease debugging.
     - name: Configure Bazel and print info

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -23,7 +23,7 @@ runs:
           xcrun simctl delete all
         sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
-    # Install and cache LLVM 18 from Homebrew. Some runners may have LLVM 18,
+    # Install and cache LLVM 19 from Homebrew. Some runners may have LLVM 19,
     # but this is reliable (including with libc++), and gives us testing at the
     # minimum supported LLVM version.
     - name: Cache Homebrew
@@ -46,7 +46,7 @@ runs:
           }}
         # Note the key needs to include all the packages we're adding.
         key:
-          Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}-llvm@18
+          Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}-llvm@19
 
     - name: Install LLVM and Clang with Homebrew
       if: steps.cache-homebrew-macos.outputs.cache-hit != 'true'
@@ -60,11 +60,11 @@ runs:
         LEAVES=$(brew leaves | egrep -v '^(bazelisk|gh|git|git-lfs|gnu-tar|go@.*|jq|pipx|node@.*|openssl@.*|wget|yq|zlib)$')
         brew uninstall -f --ignore-dependencies $LEAVES
         echo '*** Installing LLVM deps'
-        brew install --force-bottle --only-dependencies llvm@18
+        brew install --force-bottle --only-dependencies llvm@19
         echo '*** Installing LLVM itself'
-        brew install --force-bottle --force --verbose llvm@18
-        echo '*** brew info llvm@18'
-        brew info llvm@18
+        brew install --force-bottle --force --verbose llvm@19
+        echo '*** brew info llvm@19'
+        brew info llvm@19
         echo '*** brew autoremove'
         brew autoremove
         echo '*** brew info'
@@ -77,7 +77,7 @@ runs:
     - name: Setup LLVM and Clang
       shell: bash
       run: |
-        LLVM_PATH="$(brew --prefix llvm@18)"
+        LLVM_PATH="$(brew --prefix llvm@19)"
         echo "Using ${LLVM_PATH}"
         echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
         echo '*** ls "${LLVM_PATH}"'

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -30,7 +30,7 @@ runs:
       id: cache-homebrew-macos
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       env:
-        cache-name: cache-homebrew
+        cache-name: cache-homebrew-llvm-18
       with:
         # Cover all the critical parts of Homebrew here. Homebrew on Arm macOS
         # uses its own prefix making this easy to cover, but we need a few

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -23,7 +23,7 @@ runs:
           xcrun simctl delete all
         sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
-    # Install and cache LLVM 16 from Homebrew. Some runners may have LLVM 16,
+    # Install and cache LLVM 18 from Homebrew. Some runners may have LLVM 18,
     # but this is reliable (including with libc++), and gives us testing at the
     # minimum supported LLVM version.
     - name: Cache Homebrew
@@ -61,11 +61,11 @@ runs:
         LEAVES=$(brew leaves | egrep -v '^(bazelisk|gh|git|git-lfs|gnu-tar|go@.*|jq|pipx|node@.*|openssl@.*|wget|yq|zlib)$')
         brew uninstall -f --ignore-dependencies $LEAVES
         echo '*** Installing LLVM deps'
-        brew install --force-bottle --only-dependencies llvm@16
+        brew install --force-bottle --only-dependencies llvm@18
         echo '*** Installing LLVM itself'
-        brew install --force-bottle --force --verbose llvm@16
-        echo '*** brew info llvm@16'
-        brew info llvm@16
+        brew install --force-bottle --force --verbose llvm@18
+        echo '*** brew info llvm@18'
+        brew info llvm@18
         echo '*** brew autoremove'
         brew autoremove
         echo '*** brew info'
@@ -78,7 +78,7 @@ runs:
     - name: Setup LLVM and Clang
       shell: bash
       run: |
-        LLVM_PATH="$(brew --prefix llvm@16)"
+        LLVM_PATH="$(brew --prefix llvm@18)"
         echo "Using ${LLVM_PATH}"
         echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
         echo '*** ls "${LLVM_PATH}"'

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -27,10 +27,8 @@ runs:
     # but this is reliable (including with libc++), and gives us testing at the
     # minimum supported LLVM version.
     - name: Cache Homebrew
-      id: cache-homebrew-macos-llvm-18
+      id: cache-homebrew-macos
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      env:
-        cache-name: cache-homebrew
       with:
         # Cover all the critical parts of Homebrew here. Homebrew on Arm macOS
         # uses its own prefix making this easy to cover, but we need a few
@@ -47,10 +45,11 @@ runs:
             '
           }}
         # Note the key needs to include all the packages we're adding.
-        key: Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}
+        key:
+          Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}-llvm@18
 
     - name: Install LLVM and Clang with Homebrew
-      if: steps.cache-homebrew-macos-llvm-18.outputs.cache-hit != 'true'
+      if: steps.cache-homebrew-macos.outputs.cache-hit != 'true'
       shell: bash
       run: |
         echo '*** Prune brew leaves'

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -27,10 +27,10 @@ runs:
     # but this is reliable (including with libc++), and gives us testing at the
     # minimum supported LLVM version.
     - name: Cache Homebrew
-      id: cache-homebrew-macos
+      id: cache-homebrew-macos-llvm-18
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       env:
-        cache-name: cache-homebrew-llvm-18
+        cache-name: cache-homebrew
       with:
         # Cover all the critical parts of Homebrew here. Homebrew on Arm macOS
         # uses its own prefix making this easy to cover, but we need a few
@@ -50,7 +50,7 @@ runs:
         key: Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}
 
     - name: Install LLVM and Clang with Homebrew
-      if: steps.cache-homebrew-macos.outputs.cache-hit != 'true'
+      if: steps.cache-homebrew-macos-llvm-18.outputs.cache-hit != 'true'
       shell: bash
       run: |
         echo '*** Prune brew leaves'

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -42,8 +42,22 @@ runs:
       run: |
         echo '*** Removing system clang packages'
         for version in ${remove_clang_versions//,/ }; do
-          sudo apt-get remove \
-            '^(clang(d)?|libc\+\+(abi)?|lib(clang|omp|unwind)|lld|lldb|llvm)-'
+          sudo apt-get remove clang-${version} \
+            clang-format-${version} \
+            clang-tidy-${version} \
+            clang-tools-${version} \
+            clangd-${version} \
+            lld-${version} \
+            lldb-${version} \
+            llvm-${version}-dev \
+            llvm-${version}-tools \
+            libc++-${version}-dev \
+            libc++abi-${version}-dev \
+            libclang-${version}-dev \
+            libclang-common-${version}-dev \
+            libclang-cpp${version}-dev \
+            libomp-${version}-dev \
+            libunwind-${version}-dev
           done
 
         echo '*** Installing upstream clang packages'

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Show system LLVM and Clang installation
       shell: bash
       run: |
-        dpkg -l|grep -E 'clang|llvm'
+        dpkg -l '*clang*' '*llvm*'
 
     # Install a recent version of LLVM. We use LLVM's apt.llvm.org in order to
     # have access to all released versions, instead of the GitHub releases which

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -32,35 +32,17 @@ runs:
     # are often missing binaries for ubuntu x64.
     - name: Download LLVM and Clang installation
       env:
-        # We will use this clang version.
-        clang_version: 18
-        # The ubuntu 24.04 image has 16, 17, and 18 installed.
-        # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
-        # We r
-        remove_clang_versions: '16,17'
+        clang_version: 19
       shell: bash
       run: |
-        echo '*** Removing system clang packages'
-        for version in ${remove_clang_versions//,/ }; do
-          sudo apt-get remove clang-${version} \
-            clang-format-${version} \
-            clang-tidy-${version} \
-            clang-tools-${version} \
-            clangd-${version} \
-            lld-${version} \
-            lldb-${version} \
-            llvm-${version}-dev \
-            llvm-${version}-tools \
-            libc++-${version}-dev \
-            libc++abi-${version}-dev \
-            libclang-${version}-dev \
-            libclang-common-${version}-dev \
-            libclang-cpp${version}-dev \
-            libomp-${version}-dev \
-            libunwind-${version}-dev
-          done
-
         echo '*** Installing upstream clang packages'
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh ${clang_version} all
+
+        sudo ln -sf /lib/llvm-19/bin/clang /bin/
+        sudo ln -sf /lib/llvm-19/bin/clang++ /bin/
+        sudo ln -sf /lib/llvm-19/bin/clang-format /bin/
+        sudo ln -sf /lib/llvm-19/bin/clang-tidy /bin/
+        sudo ln -sf /lib/llvm-19/bin/lld /bin/
+        sudo ln -sf /lib/llvm-19/bin/llvm-symbolizer /bin/

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -34,32 +34,16 @@ runs:
       env:
         # We will use this clang version.
         clang_version: 18
-        # The ubuntu 24.04 image has these versions installed:
+        # The ubuntu 24.04 image has 16, 17, and 18 installed.
         # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
-        installed_clang_version: '16,17,18'
-      if: env.clang_version != env.installed_clang_version
+        # We r
+        remove_clang_versions: '16,17'
       shell: bash
       run: |
         echo '*** Removing system clang packages'
-        for version in ${installed_clang_version//,/ }; do
-          sudo apt-get remove clang-${version} \
-            lldb-${version} \
-            lld-${version} \
-            clangd-${version} \
-            clang-tidy-${version} \
-            clang-format-${version} \
-            clang-tools-${version} \
-            llvm-${version}-dev \
-            lld-${version} \
-            lldb-${version} \
-            llvm-${version}-tools \
-            libomp-${version}-dev \
-            libc++-${version}-dev \
-            libc++abi-${version}-dev \
-            libclang-common-${version}-dev \
-            libclang-${version}-dev \
-            libclang-cpp${version}-dev \
-            libunwind-${version}-dev
+        for version in ${remove_clang_versions//,/ }; do
+          sudo apt-get remove \
+            '^(clang(d)?|libc\+\+(abi)?|lib(clang|omp|unwind)|lld|lldb|llvm)-'
           done
 
         echo '*** Installing upstream clang packages'

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -40,9 +40,4 @@ runs:
         chmod +x llvm.sh
         sudo ./llvm.sh ${clang_version} all
 
-        sudo ln -sf /lib/llvm-19/bin/clang /bin/
-        sudo ln -sf /lib/llvm-19/bin/clang++ /bin/
-        sudo ln -sf /lib/llvm-19/bin/clang-format /bin/
-        sudo ln -sf /lib/llvm-19/bin/clang-tidy /bin/
-        sudo ln -sf /lib/llvm-19/bin/lld /bin/
-        sudo ln -sf /lib/llvm-19/bin/llvm-symbolizer /bin/
+        echo "/lib/llvm-19/bin" >> "$GITHUB_PATH"

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -22,48 +22,47 @@ runs:
         # to save time.
         large-packages: false
 
-    # Cache and install a recent version of LLVM. This uses the GitHub action
-    # cache to avoid directly downloading on each iteration and improve
-    # reliability.
-    - name: Cache LLVM and Clang installation
-      id: cache-llvm-ubuntu
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      env:
-        cache-name: cache-llvm
-      with:
-        path: ~/llvm
-        key: LLVM-16-Cache-ubuntu-${{ runner.arch }}
+    - name: Show system LLVM and Clang installation
+      shell: bash
+      run: |
+        dpkg -l|grep -E 'clang|llvm'
 
+    # Install a recent version of LLVM. We use LLVM's apt.llvm.org in order to
+    # have access to all released versions, instead of the GitHub releases which
+    # are often missing binaries for ubuntu x64.
     - name: Download LLVM and Clang installation
-      if: steps.cache-llvm-ubuntu.outputs.cache-hit != 'true'
+      env:
+        # We will use this clang version.
+        clang_version: 18
+        # The ubuntu 24.04 image has these versions installed:
+        # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+        installed_clang_version: '16,17,18'
+      if: env.clang_version != env.installed_clang_version
       shell: bash
       run: |
-        cd ~
-        LLVM_RELEASE=clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04
-        echo "*** Downloading $LLVM_RELEASE"
-        wget --show-progress=off "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.4/$LLVM_RELEASE.tar.xz"
-        echo "*** Extracting $LLVM_RELEASE"
-        tar -xJf "$LLVM_RELEASE.tar.xz"
-        echo "*** Moving to 'llvm'"
-        mv "$LLVM_RELEASE" llvm
-        echo "*** Testing `clang++ --version`"
-        ~/llvm/bin/clang++ --version
+        echo '*** Removing system clang packages'
+        for version in ${installed_clang_version//,/ }; do
+          sudo apt-get remove clang-${version} \
+            lldb-${version} \
+            lld-${version} \
+            clangd-${version} \
+            clang-tidy-${version} \
+            clang-format-${version} \
+            clang-tools-${version} \
+            llvm-${version}-dev \
+            lld-${version} \
+            lldb-${version} \
+            llvm-${version}-tools \
+            libomp-${version}-dev \
+            libc++-${version}-dev \
+            libc++abi-${version}-dev \
+            libclang-common-${version}-dev \
+            libclang-${version}-dev \
+            libclang-cpp${version}-dev \
+            libunwind-${version}-dev
+          done
 
-        # The installation contains *huge* parts of LLVM we don't need for the
-        # toolchain. Prune them here to keep our cache small.
-        echo "*** Cleaning the 'llvm' directory"
-        rm llvm/lib/{*.a,*.so,*.so.*,*.bc}
-        rm llvm/bin/{flang-*,mlir-*,clang-{scan-deps,check,repl},*-test,llvm-{lto*,reduce,bolt*,exegesis,jitlink},bugpoint,opt,llc}
-        echo "*** Size of the 'llvm' directory"
-        du -hs llvm
-
-    - name: Setup LLVM and Clang paths
-      shell: bash
-      run: |
-        LLVM_PATH=~/llvm
-        echo "Using ${LLVM_PATH}"
-        echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
-        echo '*** ls "${LLVM_PATH}"'
-        ls "${LLVM_PATH}"
-        echo '*** ls "${LLVM_PATH}/bin"'
-        ls "${LLVM_PATH}/bin"
+        echo '*** Installing upstream clang packages'
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh ${clang_version} all

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Harden Runner
@@ -51,7 +51,7 @@ jobs:
       - id: test-setup
         uses: ./.github/actions/test-setup
         with:
-          matrix_runner: 'ubuntu-22.04'
+          matrix_runner: 'ubuntu-24.04'
           base_sha:
             ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.base.sha ||

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -68,7 +68,7 @@ jobs:
 
       - uses: ./.github/actions/build-setup-common
         with:
-          matrix_runner: ubuntu-22.04
+          matrix_runner: ubuntu-24.04
           remote_cache_upload: ${{ env.remote_cache_upload }}
 
       - name: Get nightly date

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -15,12 +15,11 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          disable-sudo: true
           egress-policy: block
           # When adding endpoints, see README.md.
           # prettier-ignore
@@ -46,7 +45,7 @@ jobs:
       # Ensure LLVM is set up consistently.
       - uses: ./.github/actions/build-setup-common
         with:
-          matrix_runner: ubuntu-latest
+          matrix_runner: ubuntu-24.04
           remote_cache_upload: '--remote_upload_local_results=false'
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         # Test a recent version of each supported OS.
-        runner: ['ubuntu-22.04', 'macos-14']
+        runner: ['ubuntu-24.04', 'macos-14']
         build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.runner }}
 

--- a/common/ostream.h
+++ b/common/ostream.h
@@ -20,6 +20,7 @@ namespace Carbon {
 // CRTP base class for printable types. Children (DerivedT) must implement:
 // - auto Print(llvm::raw_ostream& out) const -> void
 template <typename DerivedT>
+// NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
 class Printable {
   // Provides simple printing for debuggers.
   LLVM_DUMP_METHOD auto Dump() const -> std::string {

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -50,8 +50,8 @@ These commands should help set up a development environment on your machine.
 # Update apt.
 sudo apt update
 
-# Check that the `clang` version is at least 18, our minimum version. That needs
-# the number of the `:` in the output to be over 18. For example, `1:18.0-1`.
+# Check that the `clang` version is at least 19, our minimum version. That needs
+# the number of the `:` in the output to be over 19. For example, `1:19.0-1`.
 apt-cache show clang | grep 'Version:'
 
 # Install tools.
@@ -88,28 +88,28 @@ it to your `$PATH`, and aliasing `bazel` to it.
 
 #### Old `clang` versions
 
-If the version of `clang` is earlier than 18, you may still have version 18
+If the version of `clang` is earlier than 19, you may still have version 19
 available. You can use the following install instead:
 
 ```shell
 # Install explicitly versioned Clang tools.
 sudo apt install \
-  clang-18 \
-  libc++-18-dev \
-  libc++abi-18-dev \
-  lld-18 \
-  lldb-18
+  clang-19 \
+  libc++-19-dev \
+  libc++abi-19-dev \
+  lld-19 \
+  lldb-19
 
 # In your Carbon checkout, tell Bazel where to find `clang`. You can also
 # export this path as the `CC` environment variable, or add it directly to
 # your `PATH`.
-echo "build --repo_env=CC=$(readlink -f $(which clang-18))" >> user.bazelrc
+echo "build --repo_env=CC=$(readlink -f $(which clang-19))" >> user.bazelrc
 ```
 
-Alternatively, you can install Clang tools on Debian-based distros from
-[https://apt.llvm.org](https://apt.llvm.org).
+And if it's not available directly from the distribution, you can install Clang
+tools on Debian/Ubuntu from <https://apt.llvm.org>.
 
-> NOTE: Most LLVM 18+ installs should build Carbon. If you're having issues, see
+> NOTE: Most LLVM 19+ installs should build Carbon. If you're having issues, see
 > [troubleshooting build issues](#troubleshooting-build-issues).
 
 ### macOS
@@ -248,13 +248,11 @@ considering if they fit your workflow.
 
 The required setup for LLDB is:
 
-1.  Install a minimum of LLVM 19 instead of LLVM 18.
-    -   The `lldb-dap` tool was added as part of LLVM 19.
-2.  In the `.vscode` subdirectory, symlink `lldb_launch.json` to `launch.json`.
+1.  In the `.vscode` subdirectory, symlink `lldb_launch.json` to `launch.json`.
     For example: `ln -s lldb_launch.json .vscode/launch.json`
-3.  Install the
+2.  Install the
     [`llvm-vs-code-extensions.lldb-dap` extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap).
-4.  In VS Code settings, it may be necessary to set `lldb-dap.executable-path`
+3.  In VS Code settings, it may be necessary to set `lldb-dap.executable-path`
     to the path of `lldb-dap`.
 
 A typical debug session looks like:
@@ -308,8 +306,8 @@ includes things such as changing LLVM versions, or installing libc++. Running
 
 Many build issues result from the particular options `clang` and `llvm` have
 been built with, particularly when it comes to system-installed versions. If you
-run `clang --version`, you should see at least version 18. If you see an older
-version, please update, or use the special `clang-18` instructions above.
+run `clang --version`, you should see at least version 19. If you see an older
+version, please update, or use the special `clang-19` instructions above.
 
 System installs of macOS typically won't work, for example being an old LLVM
 version or missing llvm-ar; [setup commands](#setup-commands) includes LLVM from
@@ -326,7 +324,7 @@ providing the output of the following diagnostic commands:
 ```shell
 echo $CC
 which clang
-which clang-18
+which clang-19
 clang --version
 grep llvm_bindir $(bazel info workspace)/bazel-execroot/external/+clang_toolchain_extension+bazel_cc_toolchain/clang_detected_variables.bzl
 

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -50,8 +50,8 @@ These commands should help set up a development environment on your machine.
 # Update apt.
 sudo apt update
 
-# Check that the `clang` version is at least 16, our minimum version. That needs
-# the number of the `:` in the output to be over 16. For example, `1:16.0-57`.
+# Check that the `clang` version is at least 18, our minimum version. That needs
+# the number of the `:` in the output to be over 18. For example, `1:18.0-1`.
 apt-cache show clang | grep 'Version:'
 
 # Install tools.
@@ -88,25 +88,28 @@ it to your `$PATH`, and aliasing `bazel` to it.
 
 #### Old `clang` versions
 
-If the version of `clang` is earlier than 16, you may still have version 16
+If the version of `clang` is earlier than 18, you may still have version 18
 available. You can use the following install instead:
 
 ```shell
 # Install explicitly versioned Clang tools.
 sudo apt install \
-  clang-16 \
-  libc++-16-dev \
-  libc++abi-16-dev \
-  lld-16 \
-  lldb-16
+  clang-18 \
+  libc++-18-dev \
+  libc++abi-18-dev \
+  lld-18 \
+  lldb-18
 
 # In your Carbon checkout, tell Bazel where to find `clang`. You can also
 # export this path as the `CC` environment variable, or add it directly to
 # your `PATH`.
-echo "build --repo_env=CC=$(readlink -f $(which clang-16))" >> user.bazelrc
+echo "build --repo_env=CC=$(readlink -f $(which clang-18))" >> user.bazelrc
 ```
 
-> NOTE: Most LLVM 16+ installs should build Carbon. If you're having issues, see
+Alternatively, you can install Clang tools on Debian-based distros from
+[https://apt.llvm.org](https://apt.llvm.org).
+
+> NOTE: Most LLVM 18+ installs should build Carbon. If you're having issues, see
 > [troubleshooting build issues](#troubleshooting-build-issues).
 
 ### macOS
@@ -245,7 +248,7 @@ considering if they fit your workflow.
 
 The required setup for LLDB is:
 
-1.  Install a minimum of LLVM 19 instead of LLVM 16.
+1.  Install a minimum of LLVM 19 instead of LLVM 18.
     -   The `lldb-dap` tool was added as part of LLVM 19.
 2.  In the `.vscode` subdirectory, symlink `lldb_launch.json` to `launch.json`.
     For example: `ln -s lldb_launch.json .vscode/launch.json`
@@ -305,8 +308,8 @@ includes things such as changing LLVM versions, or installing libc++. Running
 
 Many build issues result from the particular options `clang` and `llvm` have
 been built with, particularly when it comes to system-installed versions. If you
-run `clang --version`, you should see at least version 16. If you see an older
-version, please update, or use the special `clang-16` instructions above.
+run `clang --version`, you should see at least version 18. If you see an older
+version, please update, or use the special `clang-18` instructions above.
 
 System installs of macOS typically won't work, for example being an old LLVM
 version or missing llvm-ar; [setup commands](#setup-commands) includes LLVM from
@@ -323,7 +326,7 @@ providing the output of the following diagnostic commands:
 ```shell
 echo $CC
 which clang
-which clang-16
+which clang-18
 clang --version
 grep llvm_bindir $(bazel info workspace)/bazel-execroot/external/+clang_toolchain_extension+bazel_cc_toolchain/clang_detected_variables.bzl
 


### PR DESCRIPTION
The version of clangd/clang-tidy on developer machines has slowly diverged from the one on the CI builders, which is causing a slowly increasing amount of pain as clang-tidy CI runs fail (incorrectly) over things that a newer clangd/clang-tidy was perfectly fine with locally. This bumps the Clang version used in the ubuntu builders to 19, which is the most recent in Debian stable.

We use https://apt.llvm.org instead of LLVM's GitHub releases (https://github.com/llvm/llvm-project/releases) as the former more reliably has packages for newer Clang/LLVM versions on x64. The community-build releases binaries on LLVM's GitHub have stopped including Ubuntu packages that match the GitHub x64 Ubuntu workers for some time (for at least the 18 and 19 releases).

By moving to apt.llvm.org packages we only download and install the headers and libraries needed for development, rather than every output of building llvm, which is much faster and saves lots of disk space. We also remove the system installations of other versions of clang/llvm so we should end up using negative disk space. We can no longer easily cache the installation but apt.llvm.org is a reliable end point.

We bump the ubuntu image version for the github workers to 24.04, as apt.llvm.org has stopped building images for 22.10 in 2022 at its end of life.

The `pre_commit` workflow disabled sudo unlike the other workflows that install Clang/LLVM, including the `clang-tidy` workflow (which is also run on `pull_request`). We bring it into alignment with the other workflows so that we can install the llvm packages. And we lock its ubuntu image to 24.04 so that it can be moved in lockstep with the other workflows that depend on Clang/LLVM.