### PR TITLE
Make the `file_test` binary work without custom environment variables.

### DIFF
--- a/testing/base/file_helpers.cpp
+++ b/testing/base/file_helpers.cpp
@@ -14,6 +14,14 @@
 
 namespace Carbon::Testing {
 
+auto GetTempDirectory() -> std::filesystem::path {
+  if (char* tmpdir_env = getenv("TEST_TMPDIR"); tmpdir_env != nullptr) {
+    return tmpdir_env;
+  } else {
+    return std::filesystem::temp_directory_path();
+  }
+}
+
 auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string> {
   std::ifstream file_stream(path);
   if (file_stream.fail()) {
@@ -29,13 +37,7 @@ auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string> {
 
 auto WriteTestFile(llvm::StringRef name, llvm::StringRef contents)
     -> ErrorOr<std::filesystem::path> {
-  std::filesystem::path test_tmpdir;
-  if (char* tmpdir_env = getenv("TEST_TMPDIR"); tmpdir_env != nullptr) {
-    test_tmpdir = std::string(tmpdir_env);
-  } else {
-    test_tmpdir = std::filesystem::temp_directory_path();
-  }
-
+  std::filesystem::path test_tmpdir = GetTempDirectory();
   const auto* unit_test = ::testing::UnitTest::GetInstance();
   const auto* test_info = unit_test->current_test_info();
   std::filesystem::path test_file =

--- a/testing/base/file_helpers.h
+++ b/testing/base/file_helpers.h
@@ -12,6 +12,10 @@
 
 namespace Carbon::Testing {
 
+// Returns a directory that should be used to hold temporary files created by
+// test execution.
+auto GetTempDirectory() -> std::filesystem::path;
+
 // Reads a file to string.
 auto ReadFile(std::filesystem::path path) -> ErrorOr<std::string>;
 

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "//common:check",
         "//common:ostream",
         "//common:raw_string_ostream",
+        "//testing/base:file_helpers",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:string_view",
         "@llvm-project//llvm:Support",

--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "testing/base/file_helpers.h"
 
 namespace Carbon::Testing {
 
@@ -149,10 +150,9 @@ auto FileTestAutoupdater::BuildCheckLines(llvm::StringRef output,
     file_to_number_map.insert({name, number});
   }
 
-  // %t substitution means we may see TEST_TMPDIR in output.
-  char* tmpdir_env = getenv("TEST_TMPDIR");
-  CARBON_CHECK(tmpdir_env != nullptr);
-  llvm::StringRef tmpdir = tmpdir_env;
+  // %t substitution means we may see the temporary directory's path in output.
+  std::filesystem::path tmpdir_path = GetTempDirectory();
+  llvm::StringRef tmpdir = tmpdir_path.native();
 
   llvm::SmallVector<llvm::StringRef> lines(llvm::split(output, '\n'));
   // It's typical that output ends with a newline, but we don't want to add a
@@ -190,7 +190,7 @@ auto FileTestAutoupdater::BuildCheckLines(llvm::StringRef output,
       check_line.append("{{}}");
     }
 
-    // Ignore TEST_TMPDIR in output.
+    // Ignore mentions of the temporary directory in output.
     if (auto pos = check_line.find(tmpdir); pos != std::string::npos) {
       check_line.replace(pos, tmpdir.size(), "{{.+}}");
     }

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -108,8 +108,6 @@ class FileTestBase {
   virtual auto AllowParallelRun() const -> bool { return true; }
 
   // Returns the name of the test (relative to the repo root).
-  auto test_name() const -> llvm::StringRef { return test_name_; }
-
   // Returns a bazel label that can be used to invoke this test.
   virtual auto GetBazelLabel() -> std::string;
 
@@ -122,6 +120,8 @@ class FileTestBase {
 
   // Returns the requested bazel command string for the given execution mode.
   auto GetBazelCommand(BazelMode mode) -> std::string;
+
+  auto test_name() const -> llvm::StringRef { return test_name_; }
 
  private:
   llvm::StringRef test_name_;

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -121,7 +121,7 @@ class FileTestBase {
   };
 
   // Returns the requested bazel command string for the given execution mode.
-  virtual auto GetBazelCommand(BazelMode mode) -> std::string;
+  auto GetBazelCommand(BazelMode mode) -> std::string;
 
  private:
   llvm::StringRef test_name_;

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -110,6 +110,19 @@ class FileTestBase {
   // Returns the name of the test (relative to the repo root).
   auto test_name() const -> llvm::StringRef { return test_name_; }
 
+  // Returns a bazel label that can be used to invoke this test.
+  virtual auto GetBazelLabel() -> std::string;
+
+  // Modes for GetBazelCommand.
+  enum class BazelMode : uint8_t {
+    Autoupdate,
+    Dump,
+    Test,
+  };
+
+  // Returns the requested bazel command string for the given execution mode.
+  virtual auto GetBazelCommand(BazelMode mode) -> std::string;
+
  private:
   llvm::StringRef test_name_;
 };
@@ -120,8 +133,8 @@ struct FileTestFactory {
   const char* name;
 
   // A factory function for tests.
-  std::function<
-      auto(llvm::StringRef exe_path, llvm::StringRef test_name)->FileTestBase*>
+  std::function<auto(llvm::StringRef exe_path, llvm::StringRef test_name)
+                    ->std::unique_ptr<FileTestBase>>
       factory_fn;
 };
 
@@ -139,7 +152,7 @@ extern auto GetFileTestFactory() -> FileTestFactory;
 #define CARBON_FILE_TEST_FACTORY(Name)                                       \
   auto GetFileTestFactory() -> FileTestFactory {                             \
     return {#Name, [](llvm::StringRef exe_path, llvm::StringRef test_name) { \
-              return new Name(exe_path, test_name);                          \
+              return std::make_unique<Name>(exe_path, test_name);            \
             }};                                                              \
   }
 

--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/PrettyStackTrace.h"
+#include "testing/base/file_helpers.h"
 #include "testing/file_test/file_test_base.h"
 #include "testing/file_test/test_file.h"
 
@@ -62,8 +63,7 @@ static auto DoArgReplacements(llvm::SmallVector<std::string>& test_args,
         break;
       }
       case 't': {
-        char* tmpdir = getenv("TEST_TMPDIR");
-        CARBON_CHECK(tmpdir != nullptr);
+        std::filesystem::path tmpdir = GetTempDirectory();
         it->replace(percent, 2, llvm::formatv("{0}/temp_file", tmpdir));
         break;
       }

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -38,9 +38,7 @@ class DriverTest : public testing::Test {
             InstallPaths::MakeForBazelRunfiles(Testing::GetExePath())),
         driver_(fs_, &installation_, /*input_stream=*/nullptr,
                 &test_output_stream_, &test_error_stream_) {
-    char* tmpdir_env = getenv("TEST_TMPDIR");
-    CARBON_CHECK(tmpdir_env != nullptr);
-    test_tmpdir_ = tmpdir_env;
+    test_tmpdir_ = Testing::GetTempDirectory();
   }
 
   auto MakeTestFile(llvm::StringRef text,

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -62,6 +62,12 @@ class ToolchainFileTest : public FileTestBase {
     return component_ != "language_server";
   }
 
+  // Force a fixed bazel label to avoid spurious test failures due to differing
+  // run commands when running file_test binary outside of bazel.
+  auto GetBazelLabel() -> std::string override {
+    return "//toolchain/testing:file_test";
+  }
+
  private:
   // Controls whether `Run()` includes the prelude.
   auto is_no_prelude() const -> bool {


### PR DESCRIPTION
Instead of crashing when run outside of `bazel`, make the toolchain's `file_test` binary work properly when no test-specific environment variables are set. This makes it a lot easier to run `file_test` under a debugger.

There are two main changes here:

- Don't crash if `$TEST_TMPDIR` is unset. Instead, fall back to LLVM's temporary directory (typically `$TMPDIR`). We already did this in some places in tests. We now do it in more places.
- Don't fall back to a target label of `<target>` in the reproduction commands if `$TEST_TARGET` is unset, because this causes all the tests to fail because their output doesn't match the expected output due to a differing bazel run command. Instead explicitly specify the target from the `FileTestBase`-derived class.

Infrastructure for this has been added generally, but only rolled out to the toolchain `file_test` binary for now.