### PR TITLE
Remove `needs_substitution` logic

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -34,7 +34,15 @@ class DeductionWorklist {
     SemIR::InstId param;
     SemIR::InstId arg;
     bool needs_substitution;
+    bool susbituting = false;
   };
+
+  auto AddSubstituting(SemIR::InstId param, SemIR::InstId arg) -> void {
+    deductions_.push_back({.param = param,
+                           .arg = arg,
+                           .needs_substitution = false,
+                           .susbituting = true});
+  }
 
   // Adds a single (param, arg) deduction.
   auto Add(SemIR::InstId param, SemIR::InstId arg, bool needs_substitution)
@@ -184,6 +192,10 @@ class DeductionContext {
     worklist_.Add(param, arg, needs_substitution);
   }
 
+  auto AddSubstituting(SemIR::InstId param, SemIR::InstId arg) -> void {
+    worklist_.AddSubstituting(param, arg);
+  }
+
   // Same as `Add` but for an array or block of operands.
   template <typename ParamT, typename ArgT>
   auto AddAll(ParamT param, ArgT arg, bool needs_substitution) -> void {
@@ -293,18 +305,20 @@ DeductionContext::DeductionContext(Context* context, SemIR::LocId loc_id,
 
 auto DeductionContext::Deduce() -> bool {
   while (!worklist_.Done()) {
-    auto [param_id, arg_id, needs_substitution] = worklist_.PopNext();
+    auto [param_id, arg_id, needs_substitution, substituting] =
+        worklist_.PopNext();
 
     // TODO: Bail out if there's nothing to deduce: if we're not in a pattern
     // and the parameter doesn't have a symbolic constant value.
 
+    auto param_inst = context().insts().Get(param_id);
     auto param_type_id = context().insts().Get(param_id).type_id();
     if (context().types().Is<SemIR::PatternType>(param_type_id)) {
       param_type_id =
           SemIR::ExtractScrutineeType(context().sem_ir(), param_type_id);
     }
     // If the parameter has a symbolic type, deduce against that.
-    if (param_type_id.is_symbolic()) {
+    if (!substituting && param_type_id.is_symbolic()) {
       Add(context().types().GetInstId(param_type_id),
           context().types().GetInstId(context().insts().Get(arg_id).type_id()),
           needs_substitution);
@@ -334,7 +348,6 @@ auto DeductionContext::Deduce() -> bool {
     // Attempt to match `param_inst` against `arg_id`. If the match succeeds,
     // this should `continue` the outer loop. On `break`, we will try to desugar
     // the parameter to continue looking for a match.
-    auto param_inst = context().insts().Get(param_id);
     CARBON_KIND_SWITCH(param_inst) {
       // Deducing a symbolic binding pattern from an argument deduces the
       // binding as having that constant value. For example, deducing
@@ -382,8 +395,14 @@ auto DeductionContext::Deduce() -> bool {
       // constant value deduces the binding as having that value. For example,
       // deducing `[T:! type](x: T)` against `("foo")` deduces `T` as `String`.
       case CARBON_KIND(SemIR::BindSymbolicName bind): {
+        if (substituting) {
+          break;
+        }
         auto& entity_name = context().entity_names().Get(bind.entity_name_id);
         auto index = entity_name.bind_index();
+        CARBON_CHECK(index.index - first_deduced_index_.index <
+                         static_cast<int>(non_deduced_indexes_.size()),
+                     "Deduced value for unexpected index {0}", index);
         if (!index.has_value() || index < first_deduced_index_ ||
             non_deduced_indexes_[index.index - first_deduced_index_.index]) {
           break;
@@ -478,8 +497,9 @@ auto DeductionContext::Deduce() -> bool {
       if (!param_const_id.has_value() || !param_const_id.is_symbolic()) {
         continue;
       }
-      Add(context().constant_values().GetInstId(param_const_id), arg_id,
-          /*needs_substitution=*/false);
+      AddSubstituting(context().constant_values().GetInstId(param_const_id),
+                      arg_id);
+      continue;
     }
   }
 

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -33,34 +33,20 @@ class DeductionWorklist {
   struct PendingDeduction {
     SemIR::InstId param;
     SemIR::InstId arg;
-    bool needs_substitution;
-    bool susbituting = false;
   };
 
-  auto AddSubstituting(SemIR::InstId param, SemIR::InstId arg) -> void {
-    deductions_.push_back({.param = param,
-                           .arg = arg,
-                           .needs_substitution = false,
-                           .susbituting = true});
-  }
-
   // Adds a single (param, arg) deduction.
-  auto Add(SemIR::InstId param, SemIR::InstId arg, bool needs_substitution)
-      -> void {
-    deductions_.push_back(
-        {.param = param, .arg = arg, .needs_substitution = needs_substitution});
+  auto Add(SemIR::InstId param, SemIR::InstId arg) -> void {
+    deductions_.push_back({.param = param, .arg = arg});
   }
 
   // Adds a single (param, arg) type deduction.
-  auto Add(SemIR::TypeId param, SemIR::TypeId arg, bool needs_substitution)
-      -> void {
-    Add(context_->types().GetInstId(param), context_->types().GetInstId(arg),
-        needs_substitution);
+  auto Add(SemIR::TypeId param, SemIR::TypeId arg) -> void {
+    Add(context_->types().GetInstId(param), context_->types().GetInstId(arg));
   }
 
   // Adds a single (param, arg) deduction of a specific.
-  auto Add(SemIR::SpecificId param, SemIR::SpecificId arg,
-           bool needs_substitution) -> void {
+  auto Add(SemIR::SpecificId param, SemIR::SpecificId arg) -> void {
     if (!param.has_value() || !arg.has_value()) {
       return;
     }
@@ -71,31 +57,31 @@ class DeductionWorklist {
       // non-deduced. For now we treat it as non-deduced.
       return;
     }
-    AddAll(param_specific.args_id, arg_specific.args_id, needs_substitution);
+    AddAll(param_specific.args_id, arg_specific.args_id);
   }
 
   // Adds a list of (param, arg) deductions. These are added in reverse order so
   // they are popped in forward order.
   template <typename ElementId>
-  auto AddAll(llvm::ArrayRef<ElementId> params, llvm::ArrayRef<ElementId> args,
-              bool needs_substitution) -> void {
+  auto AddAll(llvm::ArrayRef<ElementId> params, llvm::ArrayRef<ElementId> args)
+      -> void {
     if (params.size() != args.size()) {
       // TODO: Decide whether to error on this or just treat the parameter list
       // as non-deduced. For now we treat it as non-deduced.
       return;
     }
     for (auto [param, arg] : llvm::reverse(llvm::zip_equal(params, args))) {
-      Add(param, arg, needs_substitution);
+      Add(param, arg);
     }
   }
 
-  auto AddAll(SemIR::InstBlockId params, llvm::ArrayRef<SemIR::InstId> args,
-              bool needs_substitution) -> void {
-    AddAll(context_->inst_blocks().Get(params), args, needs_substitution);
+  auto AddAll(SemIR::InstBlockId params, llvm::ArrayRef<SemIR::InstId> args)
+      -> void {
+    AddAll(context_->inst_blocks().Get(params), args);
   }
 
-  auto AddAll(SemIR::StructTypeFieldsId params, SemIR::StructTypeFieldsId args,
-              bool needs_substitution) -> void {
+  auto AddAll(SemIR::StructTypeFieldsId params, SemIR::StructTypeFieldsId args)
+      -> void {
     const auto& param_fields = context_->struct_type_fields().Get(params);
     const auto& arg_fields = context_->struct_type_fields().Get(args);
     if (param_fields.size() != arg_fields.size()) {
@@ -112,19 +98,17 @@ class DeductionWorklist {
     }
     for (auto [param, arg] :
          llvm::reverse(llvm::zip_equal(param_fields, arg_fields))) {
-      Add(param.type_inst_id, arg.type_inst_id, needs_substitution);
+      Add(param.type_inst_id, arg.type_inst_id);
     }
   }
 
-  auto AddAll(SemIR::InstBlockId params, SemIR::InstBlockId args,
-              bool needs_substitution) -> void {
+  auto AddAll(SemIR::InstBlockId params, SemIR::InstBlockId args) -> void {
     AddAll(context_->inst_blocks().Get(params),
-           context_->inst_blocks().Get(args), needs_substitution);
+           context_->inst_blocks().Get(args));
   }
 
   // Adds a (param, arg) pair for an instruction argument, given its kind.
-  auto AddInstArg(SemIR::Inst::ArgAndKind param, int32_t arg,
-                  bool needs_substitution) -> void {
+  auto AddInstArg(SemIR::Inst::ArgAndKind param, int32_t arg) -> void {
     CARBON_KIND_SWITCH(param) {
       case SemIR::IdKind::None:
       case SemIR::IdKind::For<SemIR::ClassId>:
@@ -136,23 +120,23 @@ class DeductionWorklist {
       case SemIR::IdKind::For<SemIR::FacetTypeId>:
         break;
       case CARBON_KIND(SemIR::InstId inst_id): {
-        Add(inst_id, SemIR::InstId(arg), needs_substitution);
+        Add(inst_id, SemIR::InstId(arg));
         break;
       }
       case CARBON_KIND(SemIR::TypeInstId inst_id): {
-        Add(inst_id, SemIR::InstId(arg), needs_substitution);
+        Add(inst_id, SemIR::InstId(arg));
         break;
       }
       case CARBON_KIND(SemIR::StructTypeFieldsId fields_id): {
-        AddAll(fields_id, SemIR::StructTypeFieldsId(arg), needs_substitution);
+        AddAll(fields_id, SemIR::StructTypeFieldsId(arg));
         break;
       }
       case CARBON_KIND(SemIR::InstBlockId inst_block_id): {
-        AddAll(inst_block_id, SemIR::InstBlockId(arg), needs_substitution);
+        AddAll(inst_block_id, SemIR::InstBlockId(arg));
         break;
       }
       case CARBON_KIND(SemIR::SpecificId specific_id): {
-        Add(specific_id, SemIR::SpecificId(arg), needs_substitution);
+        Add(specific_id, SemIR::SpecificId(arg));
         break;
       }
       default:
@@ -188,18 +172,14 @@ class DeductionContext {
   // indicates whether we need to substitute known generic parameters into
   // `param`.
   template <typename ParamT, typename ArgT>
-  auto Add(ParamT param, ArgT arg, bool needs_substitution) -> void {
-    worklist_.Add(param, arg, needs_substitution);
-  }
-
-  auto AddSubstituting(SemIR::InstId param, SemIR::InstId arg) -> void {
-    worklist_.AddSubstituting(param, arg);
+  auto Add(ParamT param, ArgT arg) -> void {
+    worklist_.Add(param, arg);
   }
 
   // Same as `Add` but for an array or block of operands.
   template <typename ParamT, typename ArgT>
-  auto AddAll(ParamT param, ArgT arg, bool needs_substitution) -> void {
-    worklist_.AddAll(param, arg, needs_substitution);
+  auto AddAll(ParamT param, ArgT arg) -> void {
+    worklist_.AddAll(param, arg);
   }
 
   // Performs all deductions in the deduction worklist. Returns whether
@@ -305,23 +285,20 @@ DeductionContext::DeductionContext(Context* context, SemIR::LocId loc_id,
 
 auto DeductionContext::Deduce() -> bool {
   while (!worklist_.Done()) {
-    auto [param_id, arg_id, needs_substitution, substituting] =
-        worklist_.PopNext();
+    auto [param_id, arg_id] = worklist_.PopNext();
 
     // TODO: Bail out if there's nothing to deduce: if we're not in a pattern
     // and the parameter doesn't have a symbolic constant value.
 
-    auto param_inst = context().insts().Get(param_id);
     auto param_type_id = context().insts().Get(param_id).type_id();
     if (context().types().Is<SemIR::PatternType>(param_type_id)) {
       param_type_id =
           SemIR::ExtractScrutineeType(context().sem_ir(), param_type_id);
     }
     // If the parameter has a symbolic type, deduce against that.
-    if (!substituting && param_type_id.is_symbolic()) {
+    if (param_type_id.is_symbolic()) {
       Add(context().types().GetInstId(param_type_id),
-          context().types().GetInstId(context().insts().Get(arg_id).type_id()),
-          needs_substitution);
+          context().types().GetInstId(context().insts().Get(arg_id).type_id()));
     } else {
       // The argument (e.g. a TupleLiteral of types) may be convertible to a
       // compile-time value (e.g. TupleType) that we can decompose further.
@@ -348,6 +325,7 @@ auto DeductionContext::Deduce() -> bool {
     // Attempt to match `param_inst` against `arg_id`. If the match succeeds,
     // this should `continue` the outer loop. On `break`, we will try to desugar
     // the parameter to continue looking for a match.
+    auto param_inst = context().insts().Get(param_id);
     CARBON_KIND_SWITCH(param_inst) {
       // Deducing a symbolic binding pattern from an argument deduces the
       // binding as having that constant value. For example, deducing
@@ -395,14 +373,8 @@ auto DeductionContext::Deduce() -> bool {
       // constant value deduces the binding as having that value. For example,
       // deducing `[T:! type](x: T)` against `("foo")` deduces `T` as `String`.
       case CARBON_KIND(SemIR::BindSymbolicName bind): {
-        if (substituting) {
-          break;
-        }
         auto& entity_name = context().entity_names().Get(bind.entity_name_id);
         auto index = entity_name.bind_index();
-        CARBON_CHECK(index.index - first_deduced_index_.index <
-                         static_cast<int>(non_deduced_indexes_.size()),
-                     "Deduced value for unexpected index {0}", index);
         if (!index.has_value() || index < first_deduced_index_ ||
             non_deduced_indexes_[index.index - first_deduced_index_.index]) {
           break;
@@ -436,7 +408,7 @@ auto DeductionContext::Deduce() -> bool {
       }
 
       case CARBON_KIND(SemIR::ValueParamPattern pattern): {
-        Add(pattern.subpattern_id, arg_id, needs_substitution);
+        Add(pattern.subpattern_id, arg_id);
         continue;
       }
 
@@ -454,7 +426,7 @@ auto DeductionContext::Deduce() -> bool {
         // argument would be a facet value, whose type is the same facet type of
         // `G`. So here we "undo" the `as type` operation that's built into the
         // `g` parameter's type.
-        Add(access.facet_value_inst_id, arg_id, needs_substitution);
+        Add(access.facet_value_inst_id, arg_id);
         continue;
       }
 
@@ -468,10 +440,8 @@ auto DeductionContext::Deduce() -> bool {
           if (arg_inst.kind() != param_inst.kind()) {
             break;
           }
-          worklist_.AddInstArg(param_inst.arg0_and_kind(), arg_inst.arg0(),
-                               needs_substitution);
-          worklist_.AddInstArg(param_inst.arg1_and_kind(), arg_inst.arg1(),
-                               needs_substitution);
+          worklist_.AddInstArg(param_inst.arg0_and_kind(), arg_inst.arg0());
+          worklist_.AddInstArg(param_inst.arg1_and_kind(), arg_inst.arg1());
           continue;
         }
         break;
@@ -487,18 +457,7 @@ auto DeductionContext::Deduce() -> bool {
     auto param_const_inst_id =
         context().constant_values().GetInstId(param_const_id);
     if (param_const_inst_id != param_id) {
-      Add(param_const_inst_id, arg_id, needs_substitution);
-      continue;
-    }
-
-    // If we've not yet substituted into the parameter, do so now and try again.
-    if (needs_substitution) {
-      param_const_id = SubstConstant(context(), param_const_id, substitutions_);
-      if (!param_const_id.has_value() || !param_const_id.is_symbolic()) {
-        continue;
-      }
-      AddSubstituting(context().constant_values().GetInstId(param_const_id),
-                      arg_id);
+      Add(param_const_inst_id, arg_id);
       continue;
     }
   }
@@ -634,7 +593,7 @@ auto DeduceGenericCallArguments(
   // Prepare to perform deduction of the explicit parameters against their
   // arguments.
   // TODO: Also perform deduction for type of self.
-  deduction.AddAll(param_patterns_id, arg_ids, /*needs_substitution=*/true);
+  deduction.AddAll(param_patterns_id, arg_ids);
 
   if (!deduction.Deduce() || !deduction.CheckDeductionIsComplete()) {
     return SemIR::SpecificId::None;
@@ -653,10 +612,8 @@ auto DeduceImplArguments(Context& context, SemIR::LocId loc_id, DeduceImpl impl,
                              /*diagnose=*/false);
 
   // Prepare to perform deduction of the type and interface.
-  deduction.Add(impl.self_id, context.constant_values().GetInstId(self_id),
-                /*needs_substitution=*/false);
-  deduction.Add(impl.specific_id, constraint_specific_id,
-                /*needs_substitution=*/false);
+  deduction.Add(impl.self_id, context.constant_values().GetInstId(self_id));
+  deduction.Add(impl.specific_id, constraint_specific_id);
 
   if (!deduction.Deduce() || !deduction.CheckDeductionIsComplete()) {
     return SemIR::SpecificId::None;

--- a/toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
+++ b/toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
@@ -1,0 +1,456 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
+// EXTRA-ARGS: --custom-core
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
+
+// --- fail_todo_deduce_through_binding_pattern.carbon
+
+class Node(T:! type) {
+  fn Create(value: T) {}
+}
+
+fn PushBack(U:! type, V:! type) {
+  // CHECK:STDERR: fail_todo_deduce_through_binding_pattern.carbon:[[@LINE+10]]:18: error: cannot implicitly convert expression of type `()` to `V` [ConversionFailure]
+  // CHECK:STDERR:   Node(V).Create(());
+  // CHECK:STDERR:                  ^~
+  // CHECK:STDERR: fail_todo_deduce_through_binding_pattern.carbon:[[@LINE+7]]:18: note: type `()` does not implement interface `Core.ImplicitAs(V)` [MissingImplInMemberAccessNote]
+  // CHECK:STDERR:   Node(V).Create(());
+  // CHECK:STDERR:                  ^~
+  // CHECK:STDERR: fail_todo_deduce_through_binding_pattern.carbon:[[@LINE-10]]:13: note: initializing function parameter [InCallToFunctionParam]
+  // CHECK:STDERR:   fn Create(value: T) {}
+  // CHECK:STDERR:             ^~~~~~~~
+  // CHECK:STDERR:
+  Node(V).Create(());
+}
+
+// CHECK:STDOUT: --- fail_todo_deduce_through_binding_pattern.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %Node.type: type = generic_class_type @Node [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %Node.generic: %Node.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Node.cc0: type = class_type @Node, @Node(%T) [symbolic]
+// CHECK:STDOUT:   %pattern_type.7dcd0a.1: type = pattern_type %T [symbolic]
+// CHECK:STDOUT:   %Create.type.4ea: type = fn_type @Create, @Node(%T) [symbolic]
+// CHECK:STDOUT:   %Create.3ce: %Create.type.4ea = struct_value () [symbolic]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %T [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U, 0 [symbolic]
+// CHECK:STDOUT:   %V: type = bind_symbolic_name V, 1 [symbolic]
+// CHECK:STDOUT:   %PushBack.type: type = fn_type @PushBack [concrete]
+// CHECK:STDOUT:   %PushBack: %PushBack.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Node.e3b: type = class_type @Node, @Node(%V) [symbolic]
+// CHECK:STDOUT:   %Create.type.0d8: type = fn_type @Create, @Node(%V) [symbolic]
+// CHECK:STDOUT:   %Create.b52: %Create.type.0d8 = struct_value () [symbolic]
+// CHECK:STDOUT:   %require_complete.262: <witness> = require_complete_type %Node.e3b [symbolic]
+// CHECK:STDOUT:   %pattern_type.a32: type = pattern_type %V [symbolic]
+// CHECK:STDOUT:   %Create.specific_fn: <specific function> = specific_function %Create.b52, @Create(%V) [symbolic]
+// CHECK:STDOUT:   %require_complete.b54: <witness> = require_complete_type %V [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.cc7 = struct_value () [concrete]
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.d62: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic]
+// CHECK:STDOUT:   %Self.519: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Convert.type.275: type = fn_type @Convert, @ImplicitAs(%Dest) [symbolic]
+// CHECK:STDOUT:   %Convert.42e: %Convert.type.275 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self.519 [symbolic]
+// CHECK:STDOUT:   %pattern_type.f3e: type = pattern_type %Self.as_type [symbolic]
+// CHECK:STDOUT:   %pattern_type.7dcd0a.2: type = pattern_type %Dest [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.ca0: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest) [symbolic]
+// CHECK:STDOUT:   %assoc0.9f5: %ImplicitAs.assoc_type.ca0 = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.d88: type = facet_type <@ImplicitAs, @ImplicitAs(%V)> [symbolic]
+// CHECK:STDOUT:   %Self.533: %ImplicitAs.type.d88 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Convert.type.5a5: type = fn_type @Convert, @ImplicitAs(%V) [symbolic]
+// CHECK:STDOUT:   %Convert.f21: %Convert.type.5a5 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.5fe: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V) [symbolic]
+// CHECK:STDOUT:   %assoc0.a0b: %ImplicitAs.assoc_type.5fe = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic]
+// CHECK:STDOUT:   %require_complete.6c8: <witness> = require_complete_type %ImplicitAs.type.d88 [symbolic]
+// CHECK:STDOUT:   %assoc0.dc0: %ImplicitAs.assoc_type.ca0 = assoc_entity element0, imports.%Core.import_ref.207 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [concrete] {
+// CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.cc7 = import_ref Core//prelude, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
+// CHECK:STDOUT:   %Core.import_ref.5ab3ec.1: type = import_ref Core//prelude, loc12_22, loaded [symbolic = @ImplicitAs.%Dest (constants.%Dest)]
+// CHECK:STDOUT:   %Core.import_ref.ff5 = import_ref Core//prelude, inst69 [no loc], unloaded
+// CHECK:STDOUT:   %Core.import_ref.492: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.ca0) = import_ref Core//prelude, loc14_35, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.dc0)]
+// CHECK:STDOUT:   %Core.Convert = import_ref Core//prelude, Convert, unloaded
+// CHECK:STDOUT:   %Core.import_ref.5ab3ec.2: type = import_ref Core//prelude, loc12_22, loaded [symbolic = @ImplicitAs.%Dest (constants.%Dest)]
+// CHECK:STDOUT:   %Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) = import_ref Core//prelude, inst69 [no loc], loaded [symbolic = @ImplicitAs.%Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Core.import_ref.1c7: @ImplicitAs.%Convert.type (%Convert.type.275) = import_ref Core//prelude, loc14_35, loaded [symbolic = @ImplicitAs.%Convert (constants.%Convert.42e)]
+// CHECK:STDOUT:   %Core.import_ref.207 = import_ref Core//prelude, loc14_35, unloaded
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .Node = %Node.decl
+// CHECK:STDOUT:     .PushBack = %PushBack.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %Node.decl: %Node.type = class_decl @Node [concrete = constants.%Node.generic] {
+// CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.loc2_12.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc2_12.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %PushBack.decl: %PushBack.type = fn_decl @PushBack [concrete = constants.%PushBack] {
+// CHECK:STDOUT:     %U.patt: %pattern_type.98f = symbolic_binding_pattern U, 0 [concrete]
+// CHECK:STDOUT:     %V.patt: %pattern_type.98f = symbolic_binding_pattern V, 1 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %U.loc6_13.1: type = bind_symbolic_name U, 0 [symbolic = %U.loc6_13.2 (constants.%U)]
+// CHECK:STDOUT:     %V.loc6_23.1: type = bind_symbolic_name V, 1 [symbolic = %V.loc6_23.2 (constants.%V)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(imports.%Core.import_ref.5ab3ec.1: type) [from "include_files/convert.carbon"] {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%Dest) [symbolic = %Convert.type (constants.%Convert.type.275)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type.275) = struct_value () [symbolic = %Convert (constants.%Convert.42e)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.ca0)]
+// CHECK:STDOUT:   %assoc0: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.ca0) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.9f5)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Core.import_ref.ff5
+// CHECK:STDOUT:     .Convert = imports.%Core.import_ref.492
+// CHECK:STDOUT:     witness = (imports.%Core.Convert)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic class @Node(%T.loc2_12.1: type) {
+// CHECK:STDOUT:   %T.loc2_12.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc2_12.2 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @Node(%T.loc2_12.2) [symbolic = %Create.type (constants.%Create.type.4ea)]
+// CHECK:STDOUT:   %Create: @Node.%Create.type (%Create.type.4ea) = struct_value () [symbolic = %Create (constants.%Create.3ce)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   class {
+// CHECK:STDOUT:     %Create.decl: @Node.%Create.type (%Create.type.4ea) = fn_decl @Create [symbolic = @Node.%Create (constants.%Create.3ce)] {
+// CHECK:STDOUT:       %value.patt: @Create.%pattern_type (%pattern_type.7dcd0a.1) = binding_pattern value [concrete]
+// CHECK:STDOUT:       %value.param_patt: @Create.%pattern_type (%pattern_type.7dcd0a.1) = value_param_pattern %value.patt, call_param0 [concrete]
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %value.param: @Create.%T (%T) = value_param call_param0
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Node.%T.loc2_12.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %value: @Create.%T (%T) = bind_name value, %value.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
+// CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:     complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = constants.%Node.cc0
+// CHECK:STDOUT:     .T = <poisoned>
+// CHECK:STDOUT:     .Create = %Create.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Create(@Node.%T.loc2_12.1: type) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%value.param: @Create.%T (%T)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @PushBack(%U.loc6_13.1: type, %V.loc6_23.1: type) {
+// CHECK:STDOUT:   %U.loc6_13.2: type = bind_symbolic_name U, 0 [symbolic = %U.loc6_13.2 (constants.%U)]
+// CHECK:STDOUT:   %V.loc6_23.2: type = bind_symbolic_name V, 1 [symbolic = %V.loc6_23.2 (constants.%V)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Node.loc17_9.2: type = class_type @Node, @Node(%V.loc6_23.2) [symbolic = %Node.loc17_9.2 (constants.%Node.e3b)]
+// CHECK:STDOUT:   %require_complete.loc17_10: <witness> = require_complete_type %Node.loc17_9.2 [symbolic = %require_complete.loc17_10 (constants.%require_complete.262)]
+// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @Node(%V.loc6_23.2) [symbolic = %Create.type (constants.%Create.type.0d8)]
+// CHECK:STDOUT:   %Create: @PushBack.%Create.type (%Create.type.0d8) = struct_value () [symbolic = %Create (constants.%Create.b52)]
+// CHECK:STDOUT:   %Create.specific_fn.loc17_10.2: <specific function> = specific_function %Create, @Create(%V.loc6_23.2) [symbolic = %Create.specific_fn.loc17_10.2 (constants.%Create.specific_fn)]
+// CHECK:STDOUT:   %require_complete.loc17_19.1: <witness> = require_complete_type %V.loc6_23.2 [symbolic = %require_complete.loc17_19.1 (constants.%require_complete.b54)]
+// CHECK:STDOUT:   %ImplicitAs.type.loc17_19.2: type = facet_type <@ImplicitAs, @ImplicitAs(%V.loc6_23.2)> [symbolic = %ImplicitAs.type.loc17_19.2 (constants.%ImplicitAs.type.d88)]
+// CHECK:STDOUT:   %require_complete.loc17_19.2: <witness> = require_complete_type %ImplicitAs.type.loc17_19.2 [symbolic = %require_complete.loc17_19.2 (constants.%require_complete.6c8)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.loc6_23.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.5fe)]
+// CHECK:STDOUT:   %assoc0: @PushBack.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.a0b)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %Node.ref: %Node.type = name_ref Node, file.%Node.decl [concrete = constants.%Node.generic]
+// CHECK:STDOUT:     %V.ref: type = name_ref V, %V.loc6_23.1 [symbolic = %V.loc6_23.2 (constants.%V)]
+// CHECK:STDOUT:     %Node.loc17_9.1: type = class_type @Node, @Node(constants.%V) [symbolic = %Node.loc17_9.2 (constants.%Node.e3b)]
+// CHECK:STDOUT:     %.loc17_10: @PushBack.%Create.type (%Create.type.0d8) = specific_constant @Node.%Create.decl, @Node(constants.%V) [symbolic = %Create (constants.%Create.b52)]
+// CHECK:STDOUT:     %Create.ref: @PushBack.%Create.type (%Create.type.0d8) = name_ref Create, %.loc17_10 [symbolic = %Create (constants.%Create.b52)]
+// CHECK:STDOUT:     %.loc17_19.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:     %Create.specific_fn.loc17_10.1: <specific function> = specific_function %Create.ref, @Create(constants.%V) [symbolic = %Create.specific_fn.loc17_10.2 (constants.%Create.specific_fn)]
+// CHECK:STDOUT:     %ImplicitAs.type.loc17_19.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%V)> [symbolic = %ImplicitAs.type.loc17_19.2 (constants.%ImplicitAs.type.d88)]
+// CHECK:STDOUT:     %.loc17_19.2: @PushBack.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%V) [symbolic = %assoc0 (constants.%assoc0.a0b)]
+// CHECK:STDOUT:     %Convert.ref: @PushBack.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = name_ref Convert, %.loc17_19.2 [symbolic = %assoc0 (constants.%assoc0.a0b)]
+// CHECK:STDOUT:     %.loc17_19.3: @PushBack.%V.loc6_23.2 (%V) = converted %.loc17_19.1, <error> [concrete = <error>]
+// CHECK:STDOUT:     %Create.call: init %empty_tuple.type = call %Create.specific_fn.loc17_10.1(<error>)
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(imports.%Core.import_ref.5ab3ec.2: type, imports.%Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62)) [from "include_files/convert.carbon"] {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: @Convert.%ImplicitAs.type (%ImplicitAs.type.d62) = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic = %Self.as_type (constants.%Self.as_type)]
+// CHECK:STDOUT:   %pattern_type.1: type = pattern_type %Self.as_type [symbolic = %pattern_type.1 (constants.%pattern_type.f3e)]
+// CHECK:STDOUT:   %pattern_type.2: type = pattern_type %Dest [symbolic = %pattern_type.2 (constants.%pattern_type.7dcd0a.2)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Node(constants.%T) {
+// CHECK:STDOUT:   %T.loc2_12.2 => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Create.type => constants.%Create.type.4ea
+// CHECK:STDOUT:   %Create => constants.%Create.3ce
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Create(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @PushBack(constants.%U, constants.%V) {
+// CHECK:STDOUT:   %U.loc6_13.2 => constants.%U
+// CHECK:STDOUT:   %V.loc6_23.2 => constants.%V
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Node(constants.%V) {
+// CHECK:STDOUT:   %T.loc2_12.2 => constants.%V
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Create.type => constants.%Create.type.0d8
+// CHECK:STDOUT:   %Create => constants.%Create.b52
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Create(constants.%V) {
+// CHECK:STDOUT:   %T => constants.%V
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.a32
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.b54
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%Dest) {
+// CHECK:STDOUT:   %Dest => constants.%Dest
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%Dest, constants.%Self.519) {
+// CHECK:STDOUT:   %Dest => constants.%Dest
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.d62
+// CHECK:STDOUT:   %Self => constants.%Self.519
+// CHECK:STDOUT:   %Self.as_type => constants.%Self.as_type
+// CHECK:STDOUT:   %pattern_type.1 => constants.%pattern_type.f3e
+// CHECK:STDOUT:   %pattern_type.2 => constants.%pattern_type.7dcd0a.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%V) {
+// CHECK:STDOUT:   %Dest => constants.%V
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.d88
+// CHECK:STDOUT:   %Self => constants.%Self.533
+// CHECK:STDOUT:   %Convert.type => constants.%Convert.type.5a5
+// CHECK:STDOUT:   %Convert => constants.%Convert.f21
+// CHECK:STDOUT:   %ImplicitAs.assoc_type => constants.%ImplicitAs.assoc_type.5fe
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0.a0b
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- include_files/convert.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic]
+// CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %As.type.b51: type = generic_interface_type @As [concrete]
+// CHECK:STDOUT:   %As.generic: %As.type.b51 = struct_value () [concrete]
+// CHECK:STDOUT:   %As.type.8ba: type = facet_type <@As, @As(%Dest)> [symbolic]
+// CHECK:STDOUT:   %Self.b4e: %As.type.8ba = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type.7f0: type = facet_access_type %Self.b4e [symbolic]
+// CHECK:STDOUT:   %pattern_type.947: type = pattern_type %Self.as_type.7f0 [symbolic]
+// CHECK:STDOUT:   %pattern_type.7dc: type = pattern_type %Dest [symbolic]
+// CHECK:STDOUT:   %Convert.type.ad1: type = fn_type @Convert.1, @As(%Dest) [symbolic]
+// CHECK:STDOUT:   %Convert.0ed: %Convert.type.ad1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %As.assoc_type: type = assoc_entity_type @As, @As(%Dest) [symbolic]
+// CHECK:STDOUT:   %assoc0.1d5: %As.assoc_type = assoc_entity element0, @As.%Convert.decl [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.96f: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.96f = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.07f: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic]
+// CHECK:STDOUT:   %Self.0f3: %ImplicitAs.type.07f = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.as_type.419: type = facet_access_type %Self.0f3 [symbolic]
+// CHECK:STDOUT:   %pattern_type.a93: type = pattern_type %Self.as_type.419 [symbolic]
+// CHECK:STDOUT:   %Convert.type.4cf: type = fn_type @Convert.2, @ImplicitAs(%Dest) [symbolic]
+// CHECK:STDOUT:   %Convert.147: %Convert.type.4cf = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest) [symbolic]
+// CHECK:STDOUT:   %assoc0.8f8: %ImplicitAs.assoc_type = assoc_entity element0, @ImplicitAs.%Convert.decl [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .As = %As.decl
+// CHECK:STDOUT:     .ImplicitAs = %ImplicitAs.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %As.decl: %As.type.b51 = interface_decl @As [concrete = constants.%As.generic] {
+// CHECK:STDOUT:     %Dest.patt: %pattern_type.98f = symbolic_binding_pattern Dest, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Dest.loc8_14.1: type = bind_symbolic_name Dest, 0 [symbolic = %Dest.loc8_14.2 (constants.%Dest)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ImplicitAs.decl: %ImplicitAs.type.96f = interface_decl @ImplicitAs [concrete = constants.%ImplicitAs.generic] {
+// CHECK:STDOUT:     %Dest.patt: %pattern_type.98f = symbolic_binding_pattern Dest, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Dest.loc12_22.1: type = bind_symbolic_name Dest, 0 [symbolic = %Dest.loc12_22.2 (constants.%Dest)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @As(%Dest.loc8_14.1: type) {
+// CHECK:STDOUT:   %Dest.loc8_14.2: type = bind_symbolic_name Dest, 0 [symbolic = %Dest.loc8_14.2 (constants.%Dest)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %As.type: type = facet_type <@As, @As(%Dest.loc8_14.2)> [symbolic = %As.type (constants.%As.type.8ba)]
+// CHECK:STDOUT:   %Self.2: @As.%As.type (%As.type.8ba) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.b4e)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert.1, @As(%Dest.loc8_14.2) [symbolic = %Convert.type (constants.%Convert.type.ad1)]
+// CHECK:STDOUT:   %Convert: @As.%Convert.type (%Convert.type.ad1) = struct_value () [symbolic = %Convert (constants.%Convert.0ed)]
+// CHECK:STDOUT:   %As.assoc_type: type = assoc_entity_type @As, @As(%Dest.loc8_14.2) [symbolic = %As.assoc_type (constants.%As.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc9_35.2: @As.%As.assoc_type (%As.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc9_35.2 (constants.%assoc0.1d5)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @As.%As.type (%As.type.8ba) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.b4e)]
+// CHECK:STDOUT:     %Convert.decl: @As.%Convert.type (%Convert.type.ad1) = fn_decl @Convert.1 [symbolic = @As.%Convert (constants.%Convert.0ed)] {
+// CHECK:STDOUT:       %self.patt: @Convert.1.%pattern_type.loc9_14 (%pattern_type.947) = binding_pattern self [concrete]
+// CHECK:STDOUT:       %self.param_patt: @Convert.1.%pattern_type.loc9_14 (%pattern_type.947) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %return.patt: @Convert.1.%pattern_type.loc9_28 (%pattern_type.7dc) = return_slot_pattern [concrete]
+// CHECK:STDOUT:       %return.param_patt: @Convert.1.%pattern_type.loc9_28 (%pattern_type.7dc) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %Dest.ref: type = name_ref Dest, @As.%Dest.loc8_14.1 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:       %self.param: @Convert.1.%Self.as_type.loc9_20.1 (%Self.as_type.7f0) = value_param call_param0
+// CHECK:STDOUT:       %.loc9_20.1: type = splice_block %.loc9_20.3 [symbolic = %Self.as_type.loc9_20.1 (constants.%Self.as_type.7f0)] {
+// CHECK:STDOUT:         %.loc9_20.2: @Convert.1.%As.type (%As.type.8ba) = specific_constant @As.%Self.1, @As(constants.%Dest) [symbolic = %Self (constants.%Self.b4e)]
+// CHECK:STDOUT:         %Self.ref: @Convert.1.%As.type (%As.type.8ba) = name_ref Self, %.loc9_20.2 [symbolic = %Self (constants.%Self.b4e)]
+// CHECK:STDOUT:         %Self.as_type.loc9_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc9_20.1 (constants.%Self.as_type.7f0)]
+// CHECK:STDOUT:         %.loc9_20.3: type = converted %Self.ref, %Self.as_type.loc9_20.2 [symbolic = %Self.as_type.loc9_20.1 (constants.%Self.as_type.7f0)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.1.%Self.as_type.loc9_20.1 (%Self.as_type.7f0) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.1.%Dest (%Dest) = out_param call_param1
+// CHECK:STDOUT:       %return: ref @Convert.1.%Dest (%Dest) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc9_35.1: @As.%As.assoc_type (%As.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc9_35.2 (constants.%assoc0.1d5)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Dest = <poisoned>
+// CHECK:STDOUT:     .Convert = %assoc0.loc9_35.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(%Dest.loc12_22.1: type) {
+// CHECK:STDOUT:   %Dest.loc12_22.2: type = bind_symbolic_name Dest, 0 [symbolic = %Dest.loc12_22.2 (constants.%Dest)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest.loc12_22.2)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self.2: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.0f3)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert.2, @ImplicitAs(%Dest.loc12_22.2) [symbolic = %Convert.type (constants.%Convert.type.4cf)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type.4cf) = struct_value () [symbolic = %Convert (constants.%Convert.147)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest.loc12_22.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc14_35.2: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc14_35.2 (constants.%assoc0.8f8)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.0f3)]
+// CHECK:STDOUT:     %Convert.decl: @ImplicitAs.%Convert.type (%Convert.type.4cf) = fn_decl @Convert.2 [symbolic = @ImplicitAs.%Convert (constants.%Convert.147)] {
+// CHECK:STDOUT:       %self.patt: @Convert.2.%pattern_type.loc14_14 (%pattern_type.a93) = binding_pattern self [concrete]
+// CHECK:STDOUT:       %self.param_patt: @Convert.2.%pattern_type.loc14_14 (%pattern_type.a93) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %return.patt: @Convert.2.%pattern_type.loc14_28 (%pattern_type.7dc) = return_slot_pattern [concrete]
+// CHECK:STDOUT:       %return.param_patt: @Convert.2.%pattern_type.loc14_28 (%pattern_type.7dc) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %Dest.ref: type = name_ref Dest, @ImplicitAs.%Dest.loc12_22.1 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:       %self.param: @Convert.2.%Self.as_type.loc14_20.1 (%Self.as_type.419) = value_param call_param0
+// CHECK:STDOUT:       %.loc14_20.1: type = splice_block %.loc14_20.3 [symbolic = %Self.as_type.loc14_20.1 (constants.%Self.as_type.419)] {
+// CHECK:STDOUT:         %.loc14_20.2: @Convert.2.%ImplicitAs.type (%ImplicitAs.type.07f) = specific_constant @ImplicitAs.%Self.1, @ImplicitAs(constants.%Dest) [symbolic = %Self (constants.%Self.0f3)]
+// CHECK:STDOUT:         %Self.ref: @Convert.2.%ImplicitAs.type (%ImplicitAs.type.07f) = name_ref Self, %.loc14_20.2 [symbolic = %Self (constants.%Self.0f3)]
+// CHECK:STDOUT:         %Self.as_type.loc14_20.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc14_20.1 (constants.%Self.as_type.419)]
+// CHECK:STDOUT:         %.loc14_20.3: type = converted %Self.ref, %Self.as_type.loc14_20.2 [symbolic = %Self.as_type.loc14_20.1 (constants.%Self.as_type.419)]
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:       %self: @Convert.2.%Self.as_type.loc14_20.1 (%Self.as_type.419) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @Convert.2.%Dest (%Dest) = out_param call_param1
+// CHECK:STDOUT:       %return: ref @Convert.2.%Dest (%Dest) = return_slot %return.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc14_35.1: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type) = assoc_entity element0, %Convert.decl [symbolic = %assoc0.loc14_35.2 (constants.%assoc0.8f8)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.1
+// CHECK:STDOUT:     .Dest = <poisoned>
+// CHECK:STDOUT:     .Convert = %assoc0.loc14_35.1
+// CHECK:STDOUT:     witness = (%Convert.decl)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert.1(@As.%Dest.loc8_14.1: type, @As.%Self.1: @As.%As.type (%As.type.8ba)) {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:   %As.type: type = facet_type <@As, @As(%Dest)> [symbolic = %As.type (constants.%As.type.8ba)]
+// CHECK:STDOUT:   %Self: @Convert.1.%As.type (%As.type.8ba) = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.b4e)]
+// CHECK:STDOUT:   %Self.as_type.loc9_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc9_20.1 (constants.%Self.as_type.7f0)]
+// CHECK:STDOUT:   %pattern_type.loc9_14: type = pattern_type %Self.as_type.loc9_20.1 [symbolic = %pattern_type.loc9_14 (constants.%pattern_type.947)]
+// CHECK:STDOUT:   %pattern_type.loc9_28: type = pattern_type %Dest [symbolic = %pattern_type.loc9_28 (constants.%pattern_type.7dc)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%self.param: @Convert.1.%Self.as_type.loc9_20.1 (%Self.as_type.7f0)) -> @Convert.1.%Dest (%Dest);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert.2(@ImplicitAs.%Dest.loc12_22.1: type, @ImplicitAs.%Self.1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.07f)) {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.07f)]
+// CHECK:STDOUT:   %Self: @Convert.2.%ImplicitAs.type (%ImplicitAs.type.07f) = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.0f3)]
+// CHECK:STDOUT:   %Self.as_type.loc14_20.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc14_20.1 (constants.%Self.as_type.419)]
+// CHECK:STDOUT:   %pattern_type.loc14_14: type = pattern_type %Self.as_type.loc14_20.1 [symbolic = %pattern_type.loc14_14 (constants.%pattern_type.a93)]
+// CHECK:STDOUT:   %pattern_type.loc14_28: type = pattern_type %Dest [symbolic = %pattern_type.loc14_28 (constants.%pattern_type.7dc)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%self.param: @Convert.2.%Self.as_type.loc14_20.1 (%Self.as_type.419)) -> @Convert.2.%Dest (%Dest);
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @As(constants.%Dest) {
+// CHECK:STDOUT:   %Dest.loc8_14.2 => constants.%Dest
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert.1(constants.%Dest, constants.%Self.b4e) {
+// CHECK:STDOUT:   %Dest => constants.%Dest
+// CHECK:STDOUT:   %As.type => constants.%As.type.8ba
+// CHECK:STDOUT:   %Self => constants.%Self.b4e
+// CHECK:STDOUT:   %Self.as_type.loc9_20.1 => constants.%Self.as_type.7f0
+// CHECK:STDOUT:   %pattern_type.loc9_14 => constants.%pattern_type.947
+// CHECK:STDOUT:   %pattern_type.loc9_28 => constants.%pattern_type.7dc
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%Dest) {
+// CHECK:STDOUT:   %Dest.loc12_22.2 => constants.%Dest
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert.2(constants.%Dest, constants.%Self.0f3) {
+// CHECK:STDOUT:   %Dest => constants.%Dest
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.07f
+// CHECK:STDOUT:   %Self => constants.%Self.0f3
+// CHECK:STDOUT:   %Self.as_type.loc14_20.1 => constants.%Self.as_type.419
+// CHECK:STDOUT:   %pattern_type.loc14_14 => constants.%pattern_type.a93
+// CHECK:STDOUT:   %pattern_type.loc14_28 => constants.%pattern_type.7dc
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
+++ b/toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
@@ -11,51 +11,76 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/deduce/min_prelude/binding_pattern.carbon
 
-// --- fail_todo_deduce_through_binding_pattern.carbon
+// --- fail_incompatible_deduce.carbon
 
-class Node(T:! type) {
+library "[[@TEST_NAME]]";
+
+class C(T:! type) {
   fn Create(value: T) {}
 }
 
-fn PushBack(U:! type, V:! type) {
-  // CHECK:STDERR: fail_todo_deduce_through_binding_pattern.carbon:[[@LINE+10]]:18: error: cannot implicitly convert expression of type `()` to `V` [ConversionFailure]
-  // CHECK:STDERR:   Node(V).Create(());
-  // CHECK:STDERR:                  ^~
-  // CHECK:STDERR: fail_todo_deduce_through_binding_pattern.carbon:[[@LINE+7]]:18: note: type `()` does not implement interface `Core.ImplicitAs(V)` [MissingImplInMemberAccessNote]
-  // CHECK:STDERR:   Node(V).Create(());
-  // CHECK:STDERR:                  ^~
-  // CHECK:STDERR: fail_todo_deduce_through_binding_pattern.carbon:[[@LINE-10]]:13: note: initializing function parameter [InCallToFunctionParam]
+fn F(U:! type, V:! type) {
+  // CHECK:STDERR: fail_incompatible_deduce.carbon:[[@LINE+10]]:15: error: cannot implicitly convert expression of type `{}` to `V` [ConversionFailure]
+  // CHECK:STDERR:   C(V).Create({});
+  // CHECK:STDERR:               ^~
+  // CHECK:STDERR: fail_incompatible_deduce.carbon:[[@LINE+7]]:15: note: type `{}` does not implement interface `Core.ImplicitAs(V)` [MissingImplInMemberAccessNote]
+  // CHECK:STDERR:   C(V).Create({});
+  // CHECK:STDERR:               ^~
+  // CHECK:STDERR: fail_incompatible_deduce.carbon:[[@LINE-10]]:13: note: initializing function parameter [InCallToFunctionParam]
   // CHECK:STDERR:   fn Create(value: T) {}
   // CHECK:STDERR:             ^~~~~~~~
   // CHECK:STDERR:
-  Node(V).Create(());
+  C(V).Create({});
 }
 
-// CHECK:STDOUT: --- fail_todo_deduce_through_binding_pattern.carbon
+// --- fail_todo_compatible_deduce.carbon
+
+library "[[@TEST_NAME]]";
+
+class C(T:! type) {
+  fn Create(value: T) {}
+}
+
+// TODO: This `where` should be sufficient to say that `{} as V` works.
+fn F(U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
+  // CHECK:STDERR: fail_todo_compatible_deduce.carbon:[[@LINE+10]]:15: error: cannot implicitly convert expression of type `{}` to `V` [ConversionFailure]
+  // CHECK:STDERR:   C(V).Create({});
+  // CHECK:STDERR:               ^~
+  // CHECK:STDERR: fail_todo_compatible_deduce.carbon:[[@LINE+7]]:15: note: type `{}` does not implement interface `Core.ImplicitAs(V)` [MissingImplInMemberAccessNote]
+  // CHECK:STDERR:   C(V).Create({});
+  // CHECK:STDERR:               ^~
+  // CHECK:STDERR: fail_todo_compatible_deduce.carbon:[[@LINE-11]]:13: note: initializing function parameter [InCallToFunctionParam]
+  // CHECK:STDERR:   fn Create(value: T) {}
+  // CHECK:STDERR:             ^~~~~~~~
+  // CHECK:STDERR:
+  C(V).Create({});
+}
+
+// CHECK:STDOUT: --- fail_incompatible_deduce.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
-// CHECK:STDOUT:   %Node.type: type = generic_class_type @Node [concrete]
+// CHECK:STDOUT:   %C.type: type = generic_class_type @C [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %Node.generic: %Node.type = struct_value () [concrete]
-// CHECK:STDOUT:   %Node.cc0: type = class_type @Node, @Node(%T) [symbolic]
+// CHECK:STDOUT:   %C.generic: %C.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.f2e: type = class_type @C, @C(%T) [symbolic]
 // CHECK:STDOUT:   %pattern_type.7dcd0a.1: type = pattern_type %T [symbolic]
-// CHECK:STDOUT:   %Create.type.4ea: type = fn_type @Create, @Node(%T) [symbolic]
-// CHECK:STDOUT:   %Create.3ce: %Create.type.4ea = struct_value () [symbolic]
+// CHECK:STDOUT:   %Create.type.f31: type = fn_type @Create, @C(%T) [symbolic]
+// CHECK:STDOUT:   %Create.cc8: %Create.type.f31 = struct_value () [symbolic]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
 // CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %T [symbolic]
 // CHECK:STDOUT:   %U: type = bind_symbolic_name U, 0 [symbolic]
 // CHECK:STDOUT:   %V: type = bind_symbolic_name V, 1 [symbolic]
-// CHECK:STDOUT:   %PushBack.type: type = fn_type @PushBack [concrete]
-// CHECK:STDOUT:   %PushBack: %PushBack.type = struct_value () [concrete]
-// CHECK:STDOUT:   %Node.e3b: type = class_type @Node, @Node(%V) [symbolic]
-// CHECK:STDOUT:   %Create.type.0d8: type = fn_type @Create, @Node(%V) [symbolic]
-// CHECK:STDOUT:   %Create.b52: %Create.type.0d8 = struct_value () [symbolic]
-// CHECK:STDOUT:   %require_complete.262: <witness> = require_complete_type %Node.e3b [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.5e5: type = class_type @C, @C(%V) [symbolic]
+// CHECK:STDOUT:   %Create.type.beb: type = fn_type @Create, @C(%V) [symbolic]
+// CHECK:STDOUT:   %Create.dca: %Create.type.beb = struct_value () [symbolic]
+// CHECK:STDOUT:   %require_complete.d93: <witness> = require_complete_type %C.5e5 [symbolic]
 // CHECK:STDOUT:   %pattern_type.a32: type = pattern_type %V [symbolic]
-// CHECK:STDOUT:   %Create.specific_fn: <specific function> = specific_function %Create.b52, @Create(%V) [symbolic]
+// CHECK:STDOUT:   %Create.specific_fn: <specific function> = specific_function %Create.dca, @Create(%V) [symbolic]
 // CHECK:STDOUT:   %require_complete.b54: <witness> = require_complete_type %V [symbolic]
 // CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
 // CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.cc7 = struct_value () [concrete]
@@ -98,21 +123,21 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .Node = %Node.decl
-// CHECK:STDOUT:     .PushBack = %PushBack.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %Node.decl: %Node.type = class_decl @Node [concrete = constants.%Node.generic] {
+// CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [concrete = constants.%C.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc2_12.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc2_12.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %PushBack.decl: %PushBack.type = fn_decl @PushBack [concrete = constants.%PushBack] {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %U.patt: %pattern_type.98f = symbolic_binding_pattern U, 0 [concrete]
 // CHECK:STDOUT:     %V.patt: %pattern_type.98f = symbolic_binding_pattern V, 1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.loc6_13.1: type = bind_symbolic_name U, 0 [symbolic = %U.loc6_13.2 (constants.%U)]
-// CHECK:STDOUT:     %V.loc6_23.1: type = bind_symbolic_name V, 1 [symbolic = %V.loc6_23.2 (constants.%V)]
+// CHECK:STDOUT:     %U.loc8_6.1: type = bind_symbolic_name U, 0 [symbolic = %U.loc8_6.2 (constants.%U)]
+// CHECK:STDOUT:     %V.loc8_16.1: type = bind_symbolic_name V, 1 [symbolic = %V.loc8_16.2 (constants.%V)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -135,20 +160,20 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Node(%T.loc2_12.1: type) {
-// CHECK:STDOUT:   %T.loc2_12.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc2_12.2 (constants.%T)]
+// CHECK:STDOUT: generic class @C(%T.loc4_9.1: type) {
+// CHECK:STDOUT:   %T.loc4_9.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_9.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @Node(%T.loc2_12.2) [symbolic = %Create.type (constants.%Create.type.4ea)]
-// CHECK:STDOUT:   %Create: @Node.%Create.type (%Create.type.4ea) = struct_value () [symbolic = %Create (constants.%Create.3ce)]
+// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @C(%T.loc4_9.2) [symbolic = %Create.type (constants.%Create.type.f31)]
+// CHECK:STDOUT:   %Create: @C.%Create.type (%Create.type.f31) = struct_value () [symbolic = %Create (constants.%Create.cc8)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %Create.decl: @Node.%Create.type (%Create.type.4ea) = fn_decl @Create [symbolic = @Node.%Create (constants.%Create.3ce)] {
+// CHECK:STDOUT:     %Create.decl: @C.%Create.type (%Create.type.f31) = fn_decl @Create [symbolic = @C.%Create (constants.%Create.cc8)] {
 // CHECK:STDOUT:       %value.patt: @Create.%pattern_type (%pattern_type.7dcd0a.1) = binding_pattern value [concrete]
 // CHECK:STDOUT:       %value.param_patt: @Create.%pattern_type (%pattern_type.7dcd0a.1) = value_param_pattern %value.patt, call_param0 [concrete]
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %value.param: @Create.%T (%T) = value_param call_param0
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Node.%T.loc2_12.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @C.%T.loc4_9.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %value: @Create.%T (%T) = bind_name value, %value.param
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
@@ -156,13 +181,13 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT:     complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
-// CHECK:STDOUT:     .Self = constants.%Node.cc0
+// CHECK:STDOUT:     .Self = constants.%C.f2e
 // CHECK:STDOUT:     .T = <poisoned>
 // CHECK:STDOUT:     .Create = %Create.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Create(@Node.%T.loc2_12.1: type) {
+// CHECK:STDOUT: generic fn @Create(@C.%T.loc4_9.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %T [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
 // CHECK:STDOUT:
@@ -175,36 +200,36 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @PushBack(%U.loc6_13.1: type, %V.loc6_23.1: type) {
-// CHECK:STDOUT:   %U.loc6_13.2: type = bind_symbolic_name U, 0 [symbolic = %U.loc6_13.2 (constants.%U)]
-// CHECK:STDOUT:   %V.loc6_23.2: type = bind_symbolic_name V, 1 [symbolic = %V.loc6_23.2 (constants.%V)]
+// CHECK:STDOUT: generic fn @F(%U.loc8_6.1: type, %V.loc8_16.1: type) {
+// CHECK:STDOUT:   %U.loc8_6.2: type = bind_symbolic_name U, 0 [symbolic = %U.loc8_6.2 (constants.%U)]
+// CHECK:STDOUT:   %V.loc8_16.2: type = bind_symbolic_name V, 1 [symbolic = %V.loc8_16.2 (constants.%V)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Node.loc17_9.2: type = class_type @Node, @Node(%V.loc6_23.2) [symbolic = %Node.loc17_9.2 (constants.%Node.e3b)]
-// CHECK:STDOUT:   %require_complete.loc17_10: <witness> = require_complete_type %Node.loc17_9.2 [symbolic = %require_complete.loc17_10 (constants.%require_complete.262)]
-// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @Node(%V.loc6_23.2) [symbolic = %Create.type (constants.%Create.type.0d8)]
-// CHECK:STDOUT:   %Create: @PushBack.%Create.type (%Create.type.0d8) = struct_value () [symbolic = %Create (constants.%Create.b52)]
-// CHECK:STDOUT:   %Create.specific_fn.loc17_10.2: <specific function> = specific_function %Create, @Create(%V.loc6_23.2) [symbolic = %Create.specific_fn.loc17_10.2 (constants.%Create.specific_fn)]
-// CHECK:STDOUT:   %require_complete.loc17_19.1: <witness> = require_complete_type %V.loc6_23.2 [symbolic = %require_complete.loc17_19.1 (constants.%require_complete.b54)]
-// CHECK:STDOUT:   %ImplicitAs.type.loc17_19.2: type = facet_type <@ImplicitAs, @ImplicitAs(%V.loc6_23.2)> [symbolic = %ImplicitAs.type.loc17_19.2 (constants.%ImplicitAs.type.d88)]
-// CHECK:STDOUT:   %require_complete.loc17_19.2: <witness> = require_complete_type %ImplicitAs.type.loc17_19.2 [symbolic = %require_complete.loc17_19.2 (constants.%require_complete.6c8)]
-// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.loc6_23.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.5fe)]
-// CHECK:STDOUT:   %assoc0: @PushBack.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.a0b)]
+// CHECK:STDOUT:   %C.loc19_6.2: type = class_type @C, @C(%V.loc8_16.2) [symbolic = %C.loc19_6.2 (constants.%C.5e5)]
+// CHECK:STDOUT:   %require_complete.loc19_7: <witness> = require_complete_type %C.loc19_6.2 [symbolic = %require_complete.loc19_7 (constants.%require_complete.d93)]
+// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @C(%V.loc8_16.2) [symbolic = %Create.type (constants.%Create.type.beb)]
+// CHECK:STDOUT:   %Create: @F.%Create.type (%Create.type.beb) = struct_value () [symbolic = %Create (constants.%Create.dca)]
+// CHECK:STDOUT:   %Create.specific_fn.loc19_7.2: <specific function> = specific_function %Create, @Create(%V.loc8_16.2) [symbolic = %Create.specific_fn.loc19_7.2 (constants.%Create.specific_fn)]
+// CHECK:STDOUT:   %require_complete.loc19_16.1: <witness> = require_complete_type %V.loc8_16.2 [symbolic = %require_complete.loc19_16.1 (constants.%require_complete.b54)]
+// CHECK:STDOUT:   %ImplicitAs.type.loc19_16.2: type = facet_type <@ImplicitAs, @ImplicitAs(%V.loc8_16.2)> [symbolic = %ImplicitAs.type.loc19_16.2 (constants.%ImplicitAs.type.d88)]
+// CHECK:STDOUT:   %require_complete.loc19_16.2: <witness> = require_complete_type %ImplicitAs.type.loc19_16.2 [symbolic = %require_complete.loc19_16.2 (constants.%require_complete.6c8)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.loc8_16.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.5fe)]
+// CHECK:STDOUT:   %assoc0: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.a0b)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %Node.ref: %Node.type = name_ref Node, file.%Node.decl [concrete = constants.%Node.generic]
-// CHECK:STDOUT:     %V.ref: type = name_ref V, %V.loc6_23.1 [symbolic = %V.loc6_23.2 (constants.%V)]
-// CHECK:STDOUT:     %Node.loc17_9.1: type = class_type @Node, @Node(constants.%V) [symbolic = %Node.loc17_9.2 (constants.%Node.e3b)]
-// CHECK:STDOUT:     %.loc17_10: @PushBack.%Create.type (%Create.type.0d8) = specific_constant @Node.%Create.decl, @Node(constants.%V) [symbolic = %Create (constants.%Create.b52)]
-// CHECK:STDOUT:     %Create.ref: @PushBack.%Create.type (%Create.type.0d8) = name_ref Create, %.loc17_10 [symbolic = %Create (constants.%Create.b52)]
-// CHECK:STDOUT:     %.loc17_19.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %Create.specific_fn.loc17_10.1: <specific function> = specific_function %Create.ref, @Create(constants.%V) [symbolic = %Create.specific_fn.loc17_10.2 (constants.%Create.specific_fn)]
-// CHECK:STDOUT:     %ImplicitAs.type.loc17_19.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%V)> [symbolic = %ImplicitAs.type.loc17_19.2 (constants.%ImplicitAs.type.d88)]
-// CHECK:STDOUT:     %.loc17_19.2: @PushBack.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%V) [symbolic = %assoc0 (constants.%assoc0.a0b)]
-// CHECK:STDOUT:     %Convert.ref: @PushBack.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = name_ref Convert, %.loc17_19.2 [symbolic = %assoc0 (constants.%assoc0.a0b)]
-// CHECK:STDOUT:     %.loc17_19.3: @PushBack.%V.loc6_23.2 (%V) = converted %.loc17_19.1, <error> [concrete = <error>]
-// CHECK:STDOUT:     %Create.call: init %empty_tuple.type = call %Create.specific_fn.loc17_10.1(<error>)
+// CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
+// CHECK:STDOUT:     %V.ref: type = name_ref V, %V.loc8_16.1 [symbolic = %V.loc8_16.2 (constants.%V)]
+// CHECK:STDOUT:     %C.loc19_6.1: type = class_type @C, @C(constants.%V) [symbolic = %C.loc19_6.2 (constants.%C.5e5)]
+// CHECK:STDOUT:     %.loc19_7: @F.%Create.type (%Create.type.beb) = specific_constant @C.%Create.decl, @C(constants.%V) [symbolic = %Create (constants.%Create.dca)]
+// CHECK:STDOUT:     %Create.ref: @F.%Create.type (%Create.type.beb) = name_ref Create, %.loc19_7 [symbolic = %Create (constants.%Create.dca)]
+// CHECK:STDOUT:     %.loc19_16.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:     %Create.specific_fn.loc19_7.1: <specific function> = specific_function %Create.ref, @Create(constants.%V) [symbolic = %Create.specific_fn.loc19_7.2 (constants.%Create.specific_fn)]
+// CHECK:STDOUT:     %ImplicitAs.type.loc19_16.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%V)> [symbolic = %ImplicitAs.type.loc19_16.2 (constants.%ImplicitAs.type.d88)]
+// CHECK:STDOUT:     %.loc19_16.2: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%V) [symbolic = %assoc0 (constants.%assoc0.a0b)]
+// CHECK:STDOUT:     %Convert.ref: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.5fe) = name_ref Convert, %.loc19_16.2 [symbolic = %assoc0 (constants.%assoc0.a0b)]
+// CHECK:STDOUT:     %.loc19_16.3: @F.%V.loc8_16.2 (%V) = converted %.loc19_16.1, <error> [concrete = <error>]
+// CHECK:STDOUT:     %Create.call: init %empty_tuple.type = call %Create.specific_fn.loc19_7.1(<error>)
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -220,12 +245,12 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT:   fn;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Node(constants.%T) {
-// CHECK:STDOUT:   %T.loc2_12.2 => constants.%T
+// CHECK:STDOUT: specific @C(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Create.type => constants.%Create.type.4ea
-// CHECK:STDOUT:   %Create => constants.%Create.3ce
+// CHECK:STDOUT:   %Create.type => constants.%Create.type.f31
+// CHECK:STDOUT:   %Create => constants.%Create.cc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Create(constants.%T) {
@@ -233,17 +258,17 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @PushBack(constants.%U, constants.%V) {
-// CHECK:STDOUT:   %U.loc6_13.2 => constants.%U
-// CHECK:STDOUT:   %V.loc6_23.2 => constants.%V
+// CHECK:STDOUT: specific @F(constants.%U, constants.%V) {
+// CHECK:STDOUT:   %U.loc8_6.2 => constants.%U
+// CHECK:STDOUT:   %V.loc8_16.2 => constants.%V
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Node(constants.%V) {
-// CHECK:STDOUT:   %T.loc2_12.2 => constants.%V
+// CHECK:STDOUT: specific @C(constants.%V) {
+// CHECK:STDOUT:   %T.loc4_9.2 => constants.%V
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Create.type => constants.%Create.type.0d8
-// CHECK:STDOUT:   %Create => constants.%Create.b52
+// CHECK:STDOUT:   %Create.type => constants.%Create.type.beb
+// CHECK:STDOUT:   %Create => constants.%Create.dca
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Create(constants.%V) {
@@ -277,6 +302,278 @@ fn PushBack(U:! type, V:! type) {
 // CHECK:STDOUT:   %Convert => constants.%Convert.f21
 // CHECK:STDOUT:   %ImplicitAs.assoc_type => constants.%ImplicitAs.assoc_type.5fe
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.a0b
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_todo_compatible_deduce.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic]
+// CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %C.type: type = generic_class_type @C [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %C.generic: %C.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.f2e: type = class_type @C, @C(%T) [symbolic]
+// CHECK:STDOUT:   %pattern_type.7dcd0a.1: type = pattern_type %T [symbolic]
+// CHECK:STDOUT:   %Create.type.f31: type = fn_type @Create, @C(%T) [symbolic]
+// CHECK:STDOUT:   %Create.cc8: %Create.type.f31 = struct_value () [symbolic]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %require_complete.4ae: <witness> = require_complete_type %T [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U, 0 [symbolic]
+// CHECK:STDOUT:   %.Self: type = bind_symbolic_name .Self [symbolic_self]
+// CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.cc7 = struct_value () [concrete]
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.d62: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic]
+// CHECK:STDOUT:   %Self.519: %ImplicitAs.type.d62 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Convert.type.275: type = fn_type @Convert, @ImplicitAs(%Dest) [symbolic]
+// CHECK:STDOUT:   %Convert.42e: %Convert.type.275 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self.519 [symbolic]
+// CHECK:STDOUT:   %pattern_type.f3e: type = pattern_type %Self.as_type [symbolic]
+// CHECK:STDOUT:   %pattern_type.7dcd0a.2: type = pattern_type %Dest [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.ca0: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest) [symbolic]
+// CHECK:STDOUT:   %assoc0.9f5: %ImplicitAs.assoc_type.ca0 = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.aba: type = facet_type <@ImplicitAs, @ImplicitAs(%.Self)> [symbolic_self]
+// CHECK:STDOUT:   %type_where: type = facet_type <type where TODO> [concrete]
+// CHECK:STDOUT:   %V: %type_where = bind_symbolic_name V, 1 [symbolic]
+// CHECK:STDOUT:   %pattern_type.344: type = pattern_type %type_where [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %V.as_type: type = facet_access_type %V [symbolic]
+// CHECK:STDOUT:   %C.cd6: type = class_type @C, @C(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %Create.type.ff1: type = fn_type @Create, @C(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %Create.96b: %Create.type.ff1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %require_complete.558: <witness> = require_complete_type %C.cd6 [symbolic]
+// CHECK:STDOUT:   %pattern_type.6e0: type = pattern_type %V.as_type [symbolic]
+// CHECK:STDOUT:   %Create.specific_fn: <specific function> = specific_function %Create.96b, @Create(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %require_complete.0b5: <witness> = require_complete_type %V.as_type [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.113: type = facet_type <@ImplicitAs, @ImplicitAs(%V.as_type)> [symbolic]
+// CHECK:STDOUT:   %Self.8ea: %ImplicitAs.type.113 = bind_symbolic_name Self, 1 [symbolic]
+// CHECK:STDOUT:   %Convert.type.ec0: type = fn_type @Convert, @ImplicitAs(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %Convert.b52: %Convert.type.ec0 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.83a: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %assoc0.5dc: %ImplicitAs.assoc_type.83a = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic]
+// CHECK:STDOUT:   %require_complete.9fe: <witness> = require_complete_type %ImplicitAs.type.113 [symbolic]
+// CHECK:STDOUT:   %assoc0.dc0: %ImplicitAs.assoc_type.ca0 = assoc_entity element0, imports.%Core.import_ref.207 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [concrete] {
+// CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
+// CHECK:STDOUT:     import Core//prelude
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.cc7 = import_ref Core//prelude, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
+// CHECK:STDOUT:   %Core.import_ref.5ab3ec.1: type = import_ref Core//prelude, loc12_22, loaded [symbolic = @ImplicitAs.%Dest (constants.%Dest)]
+// CHECK:STDOUT:   %Core.import_ref.ff5 = import_ref Core//prelude, inst69 [no loc], unloaded
+// CHECK:STDOUT:   %Core.import_ref.492: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.ca0) = import_ref Core//prelude, loc14_35, loaded [symbolic = @ImplicitAs.%assoc0 (constants.%assoc0.dc0)]
+// CHECK:STDOUT:   %Core.Convert = import_ref Core//prelude, Convert, unloaded
+// CHECK:STDOUT:   %Core.import_ref.5ab3ec.2: type = import_ref Core//prelude, loc12_22, loaded [symbolic = @ImplicitAs.%Dest (constants.%Dest)]
+// CHECK:STDOUT:   %Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) = import_ref Core//prelude, inst69 [no loc], loaded [symbolic = @ImplicitAs.%Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Core.import_ref.1c7: @ImplicitAs.%Convert.type (%Convert.type.275) = import_ref Core//prelude, loc14_35, loaded [symbolic = @ImplicitAs.%Convert (constants.%Convert.42e)]
+// CHECK:STDOUT:   %Core.import_ref.207 = import_ref Core//prelude, loc14_35, unloaded
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %C.decl: %C.type = class_decl @C [concrete = constants.%C.generic] {
+// CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %T.loc4_9.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_9.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %U.patt: %pattern_type.98f = symbolic_binding_pattern U, 0 [concrete]
+// CHECK:STDOUT:     %V.patt: %pattern_type.344 = symbolic_binding_pattern V, 1 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %U.loc9_6.1: type = bind_symbolic_name U, 0 [symbolic = %U.loc9_6.2 (constants.%U)]
+// CHECK:STDOUT:     %.loc9_25.1: type = splice_block %.loc9_25.2 [concrete = constants.%type_where] {
+// CHECK:STDOUT:       %.Self: type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:       %.loc9_32.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:       %Core.ref: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
+// CHECK:STDOUT:       %ImplicitAs.ref: %ImplicitAs.type.cc7 = name_ref ImplicitAs, imports.%Core.ImplicitAs [concrete = constants.%ImplicitAs.generic]
+// CHECK:STDOUT:       %.Self.ref: type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:       %ImplicitAs.type.loc9: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%.Self)> [symbolic_self = constants.%ImplicitAs.type.aba]
+// CHECK:STDOUT:       %.loc9_32.2: type = converted %.loc9_32.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
+// CHECK:STDOUT:       %.loc9_25.2: type = where_expr %.Self [concrete = constants.%type_where] {
+// CHECK:STDOUT:         requirement_impls %.loc9_32.2, %ImplicitAs.type.loc9
+// CHECK:STDOUT:       }
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %V.loc9_16.1: %type_where = bind_symbolic_name V, 1 [symbolic = %V.loc9_16.2 (constants.%V)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @ImplicitAs(imports.%Core.import_ref.5ab3ec.1: type) [from "include_files/convert.carbon"] {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62) = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Convert.type: type = fn_type @Convert, @ImplicitAs(%Dest) [symbolic = %Convert.type (constants.%Convert.type.275)]
+// CHECK:STDOUT:   %Convert: @ImplicitAs.%Convert.type (%Convert.type.275) = struct_value () [symbolic = %Convert (constants.%Convert.42e)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.ca0)]
+// CHECK:STDOUT:   %assoc0: @ImplicitAs.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.ca0) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.9f5)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Core.import_ref.ff5
+// CHECK:STDOUT:     .Convert = imports.%Core.import_ref.492
+// CHECK:STDOUT:     witness = (imports.%Core.Convert)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic class @C(%T.loc4_9.1: type) {
+// CHECK:STDOUT:   %T.loc4_9.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc4_9.2 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @C(%T.loc4_9.2) [symbolic = %Create.type (constants.%Create.type.f31)]
+// CHECK:STDOUT:   %Create: @C.%Create.type (%Create.type.f31) = struct_value () [symbolic = %Create (constants.%Create.cc8)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   class {
+// CHECK:STDOUT:     %Create.decl: @C.%Create.type (%Create.type.f31) = fn_decl @Create [symbolic = @C.%Create (constants.%Create.cc8)] {
+// CHECK:STDOUT:       %value.patt: @Create.%pattern_type (%pattern_type.7dcd0a.1) = binding_pattern value [concrete]
+// CHECK:STDOUT:       %value.param_patt: @Create.%pattern_type (%pattern_type.7dcd0a.1) = value_param_pattern %value.patt, call_param0 [concrete]
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %value.param: @Create.%T (%T) = value_param call_param0
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @C.%T.loc4_9.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %value: @Create.%T (%T) = bind_name value, %value.param
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
+// CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:     complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = constants.%C.f2e
+// CHECK:STDOUT:     .T = <poisoned>
+// CHECK:STDOUT:     .Create = %Create.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Create(@C.%T.loc4_9.1: type) {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%value.param: @Create.%T (%T)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @Convert(imports.%Core.import_ref.5ab3ec.2: type, imports.%Core.import_ref.ce1: @ImplicitAs.%ImplicitAs.type (%ImplicitAs.type.d62)) [from "include_files/convert.carbon"] {
+// CHECK:STDOUT:   %Dest: type = bind_symbolic_name Dest, 0 [symbolic = %Dest (constants.%Dest)]
+// CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(%Dest)> [symbolic = %ImplicitAs.type (constants.%ImplicitAs.type.d62)]
+// CHECK:STDOUT:   %Self: @Convert.%ImplicitAs.type (%ImplicitAs.type.d62) = bind_symbolic_name Self, 1 [symbolic = %Self (constants.%Self.519)]
+// CHECK:STDOUT:   %Self.as_type: type = facet_access_type %Self [symbolic = %Self.as_type (constants.%Self.as_type)]
+// CHECK:STDOUT:   %pattern_type.1: type = pattern_type %Self.as_type [symbolic = %pattern_type.1 (constants.%pattern_type.f3e)]
+// CHECK:STDOUT:   %pattern_type.2: type = pattern_type %Dest [symbolic = %pattern_type.2 (constants.%pattern_type.7dcd0a.2)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(%U.loc9_6.1: type, %V.loc9_16.1: %type_where) {
+// CHECK:STDOUT:   %U.loc9_6.2: type = bind_symbolic_name U, 0 [symbolic = %U.loc9_6.2 (constants.%U)]
+// CHECK:STDOUT:   %V.loc9_16.2: %type_where = bind_symbolic_name V, 1 [symbolic = %V.loc9_16.2 (constants.%V)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %V.as_type.loc20_6.2: type = facet_access_type %V.loc9_16.2 [symbolic = %V.as_type.loc20_6.2 (constants.%V.as_type)]
+// CHECK:STDOUT:   %C.loc20_6.2: type = class_type @C, @C(%V.as_type.loc20_6.2) [symbolic = %C.loc20_6.2 (constants.%C.cd6)]
+// CHECK:STDOUT:   %require_complete.loc20_7: <witness> = require_complete_type %C.loc20_6.2 [symbolic = %require_complete.loc20_7 (constants.%require_complete.558)]
+// CHECK:STDOUT:   %Create.type: type = fn_type @Create, @C(%V.as_type.loc20_6.2) [symbolic = %Create.type (constants.%Create.type.ff1)]
+// CHECK:STDOUT:   %Create: @F.%Create.type (%Create.type.ff1) = struct_value () [symbolic = %Create (constants.%Create.96b)]
+// CHECK:STDOUT:   %Create.specific_fn.loc20_7.2: <specific function> = specific_function %Create, @Create(%V.as_type.loc20_6.2) [symbolic = %Create.specific_fn.loc20_7.2 (constants.%Create.specific_fn)]
+// CHECK:STDOUT:   %require_complete.loc20_16.1: <witness> = require_complete_type %V.as_type.loc20_6.2 [symbolic = %require_complete.loc20_16.1 (constants.%require_complete.0b5)]
+// CHECK:STDOUT:   %ImplicitAs.type.loc20_16.2: type = facet_type <@ImplicitAs, @ImplicitAs(%V.as_type.loc20_6.2)> [symbolic = %ImplicitAs.type.loc20_16.2 (constants.%ImplicitAs.type.113)]
+// CHECK:STDOUT:   %require_complete.loc20_16.2: <witness> = require_complete_type %ImplicitAs.type.loc20_16.2 [symbolic = %require_complete.loc20_16.2 (constants.%require_complete.9fe)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.as_type.loc20_6.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.83a)]
+// CHECK:STDOUT:   %assoc0: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.83a) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.5dc)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
+// CHECK:STDOUT:     %V.ref: %type_where = name_ref V, %V.loc9_16.1 [symbolic = %V.loc9_16.2 (constants.%V)]
+// CHECK:STDOUT:     %V.as_type.loc20_6.1: type = facet_access_type %V.ref [symbolic = %V.as_type.loc20_6.2 (constants.%V.as_type)]
+// CHECK:STDOUT:     %.loc20_6: type = converted %V.ref, %V.as_type.loc20_6.1 [symbolic = %V.as_type.loc20_6.2 (constants.%V.as_type)]
+// CHECK:STDOUT:     %C.loc20_6.1: type = class_type @C, @C(constants.%V.as_type) [symbolic = %C.loc20_6.2 (constants.%C.cd6)]
+// CHECK:STDOUT:     %.loc20_7: @F.%Create.type (%Create.type.ff1) = specific_constant @C.%Create.decl, @C(constants.%V.as_type) [symbolic = %Create (constants.%Create.96b)]
+// CHECK:STDOUT:     %Create.ref: @F.%Create.type (%Create.type.ff1) = name_ref Create, %.loc20_7 [symbolic = %Create (constants.%Create.96b)]
+// CHECK:STDOUT:     %.loc20_16.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:     %Create.specific_fn.loc20_7.1: <specific function> = specific_function %Create.ref, @Create(constants.%V.as_type) [symbolic = %Create.specific_fn.loc20_7.2 (constants.%Create.specific_fn)]
+// CHECK:STDOUT:     %ImplicitAs.type.loc20_16.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%V.as_type)> [symbolic = %ImplicitAs.type.loc20_16.2 (constants.%ImplicitAs.type.113)]
+// CHECK:STDOUT:     %.loc20_16.2: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.83a) = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%V.as_type) [symbolic = %assoc0 (constants.%assoc0.5dc)]
+// CHECK:STDOUT:     %Convert.ref: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.83a) = name_ref Convert, %.loc20_16.2 [symbolic = %assoc0 (constants.%assoc0.5dc)]
+// CHECK:STDOUT:     %.loc20_16.3: @F.%V.as_type.loc20_6.2 (%V.as_type) = converted %.loc20_16.1, <error> [concrete = <error>]
+// CHECK:STDOUT:     %Create.call: init %empty_tuple.type = call %Create.specific_fn.loc20_7.1(<error>)
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_9.2 => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Create.type => constants.%Create.type.f31
+// CHECK:STDOUT:   %Create => constants.%Create.cc8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Create(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%Dest) {
+// CHECK:STDOUT:   %Dest => constants.%Dest
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Convert(constants.%Dest, constants.%Self.519) {
+// CHECK:STDOUT:   %Dest => constants.%Dest
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.d62
+// CHECK:STDOUT:   %Self => constants.%Self.519
+// CHECK:STDOUT:   %Self.as_type => constants.%Self.as_type
+// CHECK:STDOUT:   %pattern_type.1 => constants.%pattern_type.f3e
+// CHECK:STDOUT:   %pattern_type.2 => constants.%pattern_type.7dcd0a.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%.Self) {
+// CHECK:STDOUT:   %Dest => constants.%.Self
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%U, constants.%V) {
+// CHECK:STDOUT:   %U.loc9_6.2 => constants.%U
+// CHECK:STDOUT:   %V.loc9_16.2 => constants.%V
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C(constants.%V.as_type) {
+// CHECK:STDOUT:   %T.loc4_9.2 => constants.%V.as_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %Create.type => constants.%Create.type.ff1
+// CHECK:STDOUT:   %Create => constants.%Create.96b
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Create(constants.%V.as_type) {
+// CHECK:STDOUT:   %T => constants.%V.as_type
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.6e0
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.0b5
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @ImplicitAs(constants.%V.as_type) {
+// CHECK:STDOUT:   %Dest => constants.%V.as_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %ImplicitAs.type => constants.%ImplicitAs.type.113
+// CHECK:STDOUT:   %Self => constants.%Self.8ea
+// CHECK:STDOUT:   %Convert.type => constants.%Convert.type.ec0
+// CHECK:STDOUT:   %Convert => constants.%Convert.b52
+// CHECK:STDOUT:   %ImplicitAs.assoc_type => constants.%ImplicitAs.assoc_type.83a
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0.5dc
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- include_files/convert.carbon

--- a/toolchain/check/testdata/impl/use_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/use_assoc_const.carbon
@@ -2181,12 +2181,12 @@ fn F() {
 // CHECK:STDOUT:   %J.facet: %J.type = facet_value %T.as_type.loc8_45.2, (%J.lookup_impl_witness) [symbolic = %J.facet (constants.%J.facet.487)]
 // CHECK:STDOUT:   %.loc26_11.2: type = fn_type_with_self_type constants.%F.type, %J.facet [symbolic = %.loc26_11.2 (constants.%.9b0)]
 // CHECK:STDOUT:   %impl.elem1.loc26_11.2: @GenericCallFI32.%.loc26_11.2 (%.9b0) = impl_witness_access %J.lookup_impl_witness, element1 [symbolic = %impl.elem1.loc26_11.2 (constants.%impl.elem1)]
-// CHECK:STDOUT:   %impl.elem0.1: type = impl_witness_access %J.lookup_impl_witness, element0 [symbolic = %impl.elem0.1 (constants.%impl.elem0.db9)]
 // CHECK:STDOUT:   %specific_impl_fn.loc26_11.2: <specific function> = specific_impl_function %impl.elem1.loc26_11.2, @F(%J.facet) [symbolic = %specific_impl_fn.loc26_11.2 (constants.%specific_impl_fn)]
-// CHECK:STDOUT:   %require_complete.loc26_15: <witness> = require_complete_type %impl.elem0.1 [symbolic = %require_complete.loc26_15 (constants.%require_complete.cfd)]
-// CHECK:STDOUT:   %ImplicitAs.type.loc26_14.2: type = facet_type <@ImplicitAs, @ImplicitAs(%impl.elem0.1)> [symbolic = %ImplicitAs.type.loc26_14.2 (constants.%ImplicitAs.type.7df)]
+// CHECK:STDOUT:   %impl.elem0.loc26: type = impl_witness_access %J.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc26 (constants.%impl.elem0.db9)]
+// CHECK:STDOUT:   %require_complete.loc26_15: <witness> = require_complete_type %impl.elem0.loc26 [symbolic = %require_complete.loc26_15 (constants.%require_complete.cfd)]
+// CHECK:STDOUT:   %ImplicitAs.type.loc26_14.2: type = facet_type <@ImplicitAs, @ImplicitAs(%impl.elem0.loc26)> [symbolic = %ImplicitAs.type.loc26_14.2 (constants.%ImplicitAs.type.7df)]
 // CHECK:STDOUT:   %require_complete.loc26_14: <witness> = require_complete_type %ImplicitAs.type.loc26_14.2 [symbolic = %require_complete.loc26_14 (constants.%require_complete.402)]
-// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%impl.elem0.1) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.c64)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%impl.elem0.loc26) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.c64)]
 // CHECK:STDOUT:   %assoc0: @GenericCallFI32.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.c64) = assoc_entity element0, imports.%Core.import_ref.1c7 [symbolic = %assoc0 (constants.%assoc0.965)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%t.param: @GenericCallFI32.%T.as_type.loc8_45.2 (%T.as_type)) -> %i32 {
@@ -2201,8 +2201,8 @@ fn F() {
 // CHECK:STDOUT:     %ImplicitAs.type.loc26_14.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%impl.elem0.db9)> [symbolic = %ImplicitAs.type.loc26_14.2 (constants.%ImplicitAs.type.7df)]
 // CHECK:STDOUT:     %.loc26_14.1: @GenericCallFI32.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.c64) = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%impl.elem0.db9) [symbolic = %assoc0 (constants.%assoc0.965)]
 // CHECK:STDOUT:     %Convert.ref: @GenericCallFI32.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.c64) = name_ref Convert, %.loc26_14.1 [symbolic = %assoc0 (constants.%assoc0.965)]
-// CHECK:STDOUT:     %.loc26_14.2: @GenericCallFI32.%impl.elem0.1 (%impl.elem0.db9) = converted %int_2, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.loc26_15: init @GenericCallFI32.%impl.elem0.1 (%impl.elem0.db9) = call %specific_impl_fn.loc26_11.1(<error>) [concrete = <error>]
+// CHECK:STDOUT:     %.loc26_14.2: @GenericCallFI32.%impl.elem0.loc26 (%impl.elem0.db9) = converted %int_2, <error> [concrete = <error>]
+// CHECK:STDOUT:     %.loc26_15: init @GenericCallFI32.%impl.elem0.loc26 (%impl.elem0.db9) = call %specific_impl_fn.loc26_11.1(<error>) [concrete = <error>]
 // CHECK:STDOUT:     %.loc26_16: %i32 = converted %.loc26_15, <error> [concrete = <error>]
 // CHECK:STDOUT:     return <error>
 // CHECK:STDOUT:   }


### PR DESCRIPTION
This is fixing a deduce crash, with regression tests added in binding_pattern.carbon. In `needs_substitution`, it adds the `BindSymbolicName` with the compile time bind index corresponding to the wrong generic scope, which causes a bad result. It appears `needs_substitution` logic is no longer needed (per zygoloid, `CheckDeductionIsComplete` handles related issues) so can be removed.

This changes the order of IR in use_assoc_const.carbon but the result appears equivalent to me.

This was a fuzzer-found crash.