### PR TITLE
Flatten TypeIterator::Step::Any to not use nested variants

### DIFF
--- a/toolchain/base/kind_switch.h
+++ b/toolchain/base/kind_switch.h
@@ -125,7 +125,9 @@ struct StdVariantTypeMap<std::variant<Ts...>> {
 };
 
 // Generate StdVariantTypeMap specializations for each number of types in the
-// std::variant<...> type list.
+// std::variant<...> type list. The numbers here represent which number is
+// printed in diagnostics stating a type in the variant has no matching case
+// statement. Duplicate numbers would create an error.
 CARBON_INTERNAL_KIND_TYPE_MAP(0);
 CARBON_INTERNAL_KIND_TYPE_MAP(0, 1);
 CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2);

--- a/toolchain/base/kind_switch.h
+++ b/toolchain/base/kind_switch.h
@@ -119,8 +119,8 @@ template <typename... Ts>
 struct StdVariantTypeMap<std::variant<Ts...>> {
   // The number here should match the number of arguments in the largest
   // `CARBON_INTERNAL_KIND_TYPE_MAP` invocation below.
-  static_assert(sizeof...(Ts) <= 12,
-                "CARBON_KIND_SWITCH supports std::variant with up to 12 types. "
+  static_assert(sizeof...(Ts) <= 24,
+                "CARBON_KIND_SWITCH supports std::variant with up to 24 types. "
                 "Add more if needed.");
 };
 
@@ -138,6 +138,27 @@ CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8);
 CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20, 21);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20, 21, 22);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20, 21, 22, 23);
 
 #undef CARBON_INTERNAL_KIND_IDENTIFIER
 #undef CARBON_INTERNAL_KIND_IDENTIFIERS

--- a/toolchain/check/type_structure.cpp
+++ b/toolchain/check/type_structure.cpp
@@ -217,52 +217,39 @@ auto TypeStructureBuilder::Build(SemIR::TypeIterator type_iter)
       case CARBON_KIND(Step::StructFieldName field_name):
         AppendStructuralConcrete(field_name.name_id);
         break;
-      case CARBON_KIND(Step::StartOnly start):
-        CARBON_KIND_SWITCH(start.any) {
-          case CARBON_KIND(Step::ClassStart class_start):
-            AppendStructuralConcrete(class_start.class_id);
-            break;
-          case CARBON_KIND(Step::StructStart _):
-            AppendStructuralConcrete(TypeStructure::ConcreteStructType());
-            break;
-          case CARBON_KIND(Step::TupleStart _):
-            AppendStructuralConcrete(TypeStructure::ConcreteTupleType());
-            break;
-          case CARBON_KIND(Step::InterfaceStart interface_start):
-            AppendStructuralConcrete(interface_start.interface_id);
-            break;
-        }
+      case CARBON_KIND(Step::ClassStartOnly class_start):
+        AppendStructuralConcrete(class_start.class_id);
         break;
-      case CARBON_KIND(Step::StartWithEnd start_with_end): {
-        CARBON_KIND_SWITCH(start_with_end.any) {
-          case CARBON_KIND(Step::ClassStart class_start):
-            AppendStructuralConcreteOpenParen(class_start.class_id);
-            break;
-          case CARBON_KIND(Step::StructStart _):
-            AppendStructuralConcreteOpenParen(
-                TypeStructure::ConcreteStructType());
-            break;
-          case CARBON_KIND(Step::TupleStart _):
-            AppendStructuralConcreteOpenParen(
-                TypeStructure::ConcreteTupleType());
-            break;
-          case CARBON_KIND(Step::InterfaceStart interface_start):
-            AppendStructuralConcreteOpenParen(interface_start.interface_id);
-            break;
-          case CARBON_KIND(Step::IntStart int_start):
-            AppendStructuralConcreteOpenParen(int_start.type_id);
-            break;
-          case CARBON_KIND(Step::ArrayStart _):
-            AppendStructuralConcreteOpenParen(
-                TypeStructure::ConcreteArrayType());
-            break;
-          case CARBON_KIND(Step::PointerStart _):
-            AppendStructuralConcreteOpenParen(
-                TypeStructure::ConcretePointerType());
-            break;
-        }
+      case CARBON_KIND(Step::ClassStart class_start):
+        AppendStructuralConcreteOpenParen(class_start.class_id);
         break;
-      }
+      case CARBON_KIND(Step::StructStartOnly _):
+        AppendStructuralConcrete(TypeStructure::ConcreteStructType());
+        break;
+      case CARBON_KIND(Step::StructStart _):
+        AppendStructuralConcreteOpenParen(TypeStructure::ConcreteStructType());
+        break;
+      case CARBON_KIND(Step::TupleStartOnly _):
+        AppendStructuralConcrete(TypeStructure::ConcreteTupleType());
+        break;
+      case CARBON_KIND(Step::TupleStart _):
+        AppendStructuralConcreteOpenParen(TypeStructure::ConcreteTupleType());
+        break;
+      case CARBON_KIND(Step::InterfaceStartOnly interface_start):
+        AppendStructuralConcrete(interface_start.interface_id);
+        break;
+      case CARBON_KIND(Step::InterfaceStart interface_start):
+        AppendStructuralConcreteOpenParen(interface_start.interface_id);
+        break;
+      case CARBON_KIND(Step::IntStart int_start):
+        AppendStructuralConcreteOpenParen(int_start.type_id);
+        break;
+      case CARBON_KIND(Step::ArrayStart _):
+        AppendStructuralConcreteOpenParen(TypeStructure::ConcreteArrayType());
+        break;
+      case CARBON_KIND(Step::PointerStart _):
+        AppendStructuralConcreteOpenParen(TypeStructure::ConcretePointerType());
+        break;
     }
   }
 }

--- a/toolchain/sem_ir/type_iterator.cpp
+++ b/toolchain/sem_ir/type_iterator.cpp
@@ -30,13 +30,12 @@ auto TypeIterator::Next() -> Step {
     if (const auto* interface = std::get_if<SemIR::SpecificInterface>(&next)) {
       auto args = GetSpecificArgs(interface->specific_id);
       if (args.empty()) {
-        return Step::StartOnly(
-            Step::InterfaceStart{.interface_id = interface->interface_id});
+        return Step::InterfaceStartOnly{
+            {.interface_id = interface->interface_id}};
       } else {
         Push(EndType());
         PushArgs(args);
-        return Step::StartWithEnd(
-            Step::InterfaceStart{.interface_id = interface->interface_id});
+        return Step::InterfaceStart{.interface_id = interface->interface_id};
       }
     }
 
@@ -97,7 +96,7 @@ auto TypeIterator::Next() -> Step {
       case CARBON_KIND(SemIR::IntType int_type): {
         Push(EndType());
         PushArgs({int_type.bit_width_id});
-        return Step::StartWithEnd(Step::IntStart{.type_id = type_id});
+        return Step::IntStart{.type_id = type_id};
       }
 
         // ==== Aggregate types ====
@@ -106,18 +105,18 @@ auto TypeIterator::Next() -> Step {
         Push(EndType());
         PushInstId(array_type.element_type_inst_id);
         PushInstId(array_type.bound_id);
-        return Step::StartWithEnd(Step::ArrayStart{.type_id = type_id});
+        return Step::ArrayStart{.type_id = type_id};
       }
       case CARBON_KIND(SemIR::ClassType class_type): {
         auto args = GetSpecificArgs(class_type.specific_id);
         if (args.empty()) {
-          return Step::StartOnly(Step::ClassStart{
-              .class_id = class_type.class_id, .type_id = type_id});
+          return Step::ClassStartOnly{
+              {.class_id = class_type.class_id, .type_id = type_id}};
         } else {
           Push(EndType());
           PushArgs(args);
-          return Step::StartWithEnd(Step::ClassStart{
-              .class_id = class_type.class_id, .type_id = type_id});
+          return Step::ClassStart{.class_id = class_type.class_id,
+                                  .type_id = type_id};
         }
       }
       case CARBON_KIND(SemIR::ConstType const_type): {
@@ -133,30 +132,30 @@ auto TypeIterator::Next() -> Step {
       case CARBON_KIND(SemIR::PointerType pointer_type): {
         Push(EndType());
         PushInstId(pointer_type.pointee_id);
-        return Step::StartWithEnd(Step::PointerStart());
+        return Step::PointerStart();
       }
       case CARBON_KIND(SemIR::TupleType tuple_type): {
         auto inner_types =
             sem_ir_->inst_blocks().Get(tuple_type.type_elements_id);
         if (inner_types.empty()) {
-          return Step::StartOnly(Step::TupleStart{.type_id = type_id});
+          return Step::TupleStartOnly{{.type_id = type_id}};
         } else {
           Push(EndType());
           PushArgs(sem_ir_->inst_blocks().Get(tuple_type.type_elements_id));
-          return Step::StartWithEnd(Step::TupleStart{.type_id = type_id});
+          return Step::TupleStart{.type_id = type_id};
         }
       }
       case CARBON_KIND(SemIR::StructType struct_type): {
         auto fields = sem_ir_->struct_type_fields().Get(struct_type.fields_id);
         if (fields.empty()) {
-          return Step::StartOnly(Step::StructStart{.type_id = type_id});
+          return Step::StructStartOnly{{.type_id = type_id}};
         } else {
           Push(EndType());
           for (const auto& field : llvm::reverse(fields)) {
             Push(StructFieldName{.name_id = field.name_id});
             PushInstId(field.type_inst_id);
           }
-          return Step::StartWithEnd(Step::StructStart{.type_id = type_id});
+          return Step::StructStart{.type_id = type_id};
         }
       }
       default:


### PR DESCRIPTION
Instead of wrapping `ClassStart` with `StartOnly` or `StartWithEnd`, provide both `ClassStart` and `ClassStartOnly`. Use inheritance to share the fields. Initializing the subclass as an aggregate is still possible, but requires an extra set of curlies.

This flattens the switch in TypeStructureBuilder::Build to a single level.

Since this puts 19 elements in the Any variant, we need to extend the CARBON_KIND_SWITCH support to more than 12 elements, so we bump it up to 24.

This was suggested by @jonmeow here: https://github.com/carbon-language/carbon-lang/pull/5430#discussion_r2078444685