### PR TITLE
Have FormatScopeIfUsed consider ranges before printing

### DIFF
--- a/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
@@ -88,9 +88,6 @@ fn F();
 
 // CHECK:STDOUT: --- function.carbon
 // CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   %C.decl: %C.type = fn_decl @C [concrete = constants.%C] {
 // CHECK:STDOUT:     %return.patt: %pattern_type = return_slot_pattern [concrete]
@@ -135,9 +132,6 @@ fn F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- class.carbon
 // CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
@@ -167,9 +161,6 @@ fn F();
 // CHECK:STDOUT: fn @I();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- call_params.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges_only.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges_only.carbon
@@ -26,9 +26,6 @@ fn F();
 
 // CHECK:STDOUT: --- with-range.carbon
 // CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -286,6 +286,12 @@ auto Formatter::IndentLabel() -> void {
 
 auto Formatter::FormatScopeIfUsed(InstNamer::ScopeId scope_id,
                                   llvm::ArrayRef<InstId> block) -> void {
+  if (use_dump_sem_ir_ranges_) {
+    // Don't format the scope if no instructions are in a dump range.
+    block = block.drop_while(
+        [&](InstId inst_id) { return !ShouldFormatInst(inst_id); });
+  }
+
   if (block.empty()) {
     return;
   }


### PR DESCRIPTION
If there will be no in-scope instructions printed, have `FormatScopeIfUsed` skip the relevant scope.

Note, this only affects constants and imports. It's not changing the file scope, which is usually printed when empty.