### PR TITLE
Require clang 19 in bazel 

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -222,7 +222,7 @@
   "moduleExtensions": {
     "//bazel/cc_toolchains:clang_configuration.bzl%clang_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "YfAlFgFWuxAcofKFZTG3JR3DeQD3yED9F1mzTVz6xoA=",
+        "bzlTransitiveDigest": "0KCe1WImgzaPngWGfJswCYagC+t+fC+G9oQJ7+WYLvA=",
         "usagesDigest": "lTxkeAFhR0iBEa3dg5hWvtd2HFCr5zCJx/fl27A+IKA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -669,23 +669,14 @@ def _impl(ctx):
         )],
     )
 
-    if clang_version and clang_version <= 16:
-        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
-        libcpp_release_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=0"]
-    elif clang_version and clang_version <= 17:
-        # Clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of
-        # HARDENED_MODE and DEBUG_MODE.
-        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-        libcpp_release_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-    else:
-        # Clang 18 changes HARDENED_MODE to use 4 values:
-        # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
-        libcpp_debug_flags = [
-            "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
-        ]
-        libcpp_release_flags = [
-            "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_FAST",
-        ]
+    # Clang HARDENED_MODE to has 4 possible values:
+    # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
+    libcpp_debug_flags = [
+        "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
+    ]
+    libcpp_release_flags = [
+        "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_FAST",
+    ]
 
     linux_flags_feature = feature(
         name = "linux_flags",

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -182,9 +182,9 @@ def _configure_clang_toolchain_impl(repository_ctx):
     (clang, clang_version, clang_version_for_cache) = _detect_system_clang(
         repository_ctx,
     )
-    if clang_version and clang_version < 16:
+    if clang_version and clang_version < 19:
         fail("Found clang {0}. ".format(clang_version) +
-             "Carbon requires clang >=16. See " +
+             "Carbon requires clang >=19. See " +
              "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/contribution_tools.md#old-llvm-versions")
 
     clang_cpp = clang.dirname.get_child("clang++")


### PR DESCRIPTION
Now that we're using Clang 19 in our CI tests (since https://github.com/carbon-language/carbon-lang/pull/5440), require 19+ in the bazel rules.

Drop support for the old hardening flags for libc++ in Clang 16 and 17.