### PR TITLE
Remove old clang-format workaround for attr on enum

### DIFF
--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -24,15 +24,11 @@ class TypeEnum : public Printable<TypeEnum<Types...>> {
 
   static_assert(NumValues <= 256, "Too many types for raw enum.");
 
-// TODO: Works around a clang-format bug:
-// https://github.com/llvm/llvm-project/issues/85476
-#define CARBON_OPEN_ENUM [[clang::enum_extensibility(open)]]
-
   // The underlying raw enumeration type.
   //
   // The enum_extensibility attribute indicates that this enum is intended to
   // take values that do not correspond to its declared enumerators.
-  enum class CARBON_OPEN_ENUM RawEnumType : uint8_t {
+  enum class [[clang::enum_extensibility(open)]] RawEnumType : uint8_t {
     // The first sizeof...(Types) values correspond to the types.
 
     // An explicitly invalid value.

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -40,8 +40,6 @@ class TypeEnum : public Printable<TypeEnum<Types...>> {
     None,
   };
 
-#undef CARBON_OPEN_ENUM
-
   // Accesses the type given an enum value.
   template <RawEnumType K>
     requires(K != RawEnumType::Invalid)


### PR DESCRIPTION
The underlying https://github.com/llvm/llvm-project/issues/85476 is fixed, and appears to format as desired with the current clang-format version.