### PR TITLE
Preserve the `is_final` bit when importing an `impl` declaration

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2126,7 +2126,8 @@ static auto MakeImplDeclaration(ImportContext& context,
        {.self_id = SemIR::TypeInstId::None,
         .constraint_id = SemIR::TypeInstId::None,
         .interface = SemIR::SpecificInterface::None,
-        .witness_id = witness_id}});
+        .witness_id = witness_id,
+        .is_final = import_impl.is_final}});
 
   // Write the impl ID into the ImplDecl.
   auto impl_const_id =

--- a/toolchain/check/testdata/impl/lookup/min_prelude/final_placement.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/final_placement.carbon
@@ -67,4 +67,4 @@ import library "type_d";
 import library "interface_z";
 
 // TODO: Can not write a final impl on `D` outside the file where `D` is defined.
-final impl D as Z(()) where .X = () {}
+final impl D as Z({}) where .X = () {}

--- a/toolchain/check/testdata/impl/lookup/min_prelude/import_final.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/import_final.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
+// EXTRA-ARGS: --no-dump-sem-ir --custom-core
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/min_prelude/import_final.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/lookup/min_prelude/import_final.carbon
+
+// --- interface_z.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let X:! type;
+}
+
+class C {}
+final impl forall [T:! type] T as Z where .X = C {}
+
+// --- import_final.carbon
+library "[[@TEST_NAME]]";
+
+import library "interface_z";
+
+fn F[U:! type](T:! Z) {
+  // The value of `.X` can be known to be `C` here when the impl `T as Z(C)` is
+  // final.
+  let a: T.X = {} as C;
+}


### PR DESCRIPTION
We were importing all impls as non-final, since we forgot to set the new field when constructing the imported Impl. Adds a test that fails before this PR, since the imported Impl is treated as non-final.