### PR TITLE
Pin the version of prettier used by pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         language: node
         additional_dependencies: ['prettier@3.3.3']
         types_or: [html, javascript, json, markdown, yaml]
-        entry: npx prettier --write --log-level=warn
+        entry: npx prettier@3.3.3 --write --log-level=warn
   - repo: local
     hooks:
       - id: buildifier


### PR DESCRIPTION
Without this, `npx prettier` can end up running some other version.
