### PR TITLE
Switch BuildData to char arrays

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -38,7 +38,10 @@ cc_library(
 
 cc_library(
     name = "build_data",
-    srcs = ["build_data_linkstamp.h"],
+    srcs = [
+        "build_data.cpp",
+        "build_data_linkstamp.h",
+    ],
     hdrs = ["build_data.h"],
     linkstamp = "build_data_linkstamp.cpp",
     deps = ["@llvm-project//llvm:Support"],

--- a/common/build_data.cpp
+++ b/common/build_data.cpp
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/build_data.h"
+
+namespace Carbon::BuildData {
+
+const llvm::StringRef Platform = Internal::platform;
+
+// Whether coverage is enabled.
+const bool BuildCoverageEnabled = Internal::build_coverage_enabled;
+
+// The binary target, such as `//common:build_data_test`.
+const llvm::StringRef TargetName = Internal::target_name;
+
+// The path to the build target, such as
+// `bazel-out/k8-fastbuild/bin/common/build_data_test`.
+const llvm::StringRef BuildTarget = Internal::build_target;
+
+}  // namespace Carbon::BuildData

--- a/common/build_data.cpp
+++ b/common/build_data.cpp
@@ -7,15 +7,8 @@
 namespace Carbon::BuildData {
 
 const llvm::StringRef Platform = Internal::platform;
-
-// Whether coverage is enabled.
 const bool BuildCoverageEnabled = Internal::build_coverage_enabled;
-
-// The binary target, such as `//common:build_data_test`.
 const llvm::StringRef TargetName = Internal::target_name;
-
-// The path to the build target, such as
-// `bazel-out/k8-fastbuild/bin/common/build_data_test`.
 const llvm::StringRef BuildTarget = Internal::build_target;
 
 }  // namespace Carbon::BuildData

--- a/common/build_data.h
+++ b/common/build_data.h
@@ -17,17 +17,17 @@ namespace Carbon::BuildData {
 // names for the public variables, but cannot use constexpr.
 
 // The platform, per https://bazel.build/extending/platforms.
-inline const llvm::StringRef Platform = Internal::platform;
+extern const llvm::StringRef Platform;
 
 // Whether coverage is enabled.
-inline const bool BuildCoverageEnabled = Internal::build_coverage_enabled;
+extern const bool BuildCoverageEnabled;
 
 // The binary target, such as `//common:build_data_test`.
-inline const llvm::StringRef TargetName = Internal::target_name;
+extern const llvm::StringRef TargetName;
 
 // The path to the build target, such as
 // `bazel-out/k8-fastbuild/bin/common/build_data_test`.
-inline const llvm::StringRef BuildTarget = Internal::build_target;
+extern const llvm::StringRef BuildTarget;
 
 // NOLINTEND(readability-identifier-naming)
 

--- a/common/build_data_linkstamp.cpp
+++ b/common/build_data_linkstamp.cpp
@@ -6,9 +6,9 @@
 
 namespace Carbon::BuildData::Internal {
 
-const std::string_view platform = GPLATFORM;
+const char platform[] = GPLATFORM;
 const bool build_coverage_enabled = BUILD_COVERAGE_ENABLED;
-const std::string_view target_name = G3_TARGET_NAME;
-const std::string_view build_target = G3_BUILD_TARGET;
+const char target_name[] = G3_TARGET_NAME;
+const char build_target[] = G3_BUILD_TARGET;
 
 }  // namespace Carbon::BuildData::Internal

--- a/common/build_data_linkstamp.h
+++ b/common/build_data_linkstamp.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_COMMON_BUILD_DATA_LINKSTAMP_H_
 #define CARBON_COMMON_BUILD_DATA_LINKSTAMP_H_
 
-#include <string_view>
-
 namespace Carbon::BuildData::Internal {
 
 // See build_data.h; the list of names here should match.
@@ -19,12 +17,13 @@ namespace Carbon::BuildData::Internal {
 // use).
 //
 // Also, when build_data_linkstamp.cpp is compiled, this doesn't receive deps,
-// so we can't use things like `llvm::StringRef` here. As a result, we use
+// so we can't use things like `llvm::StringRef` here. It should ideally be
+// purely hermetic -- not even using STL for `string_view`. As a result, we use
 // `build_data.h` as an intermediary to do a `StringRef` wrap.
-extern const std::string_view platform;
+extern const char platform[];
 extern const bool build_coverage_enabled;
-extern const std::string_view target_name;
-extern const std::string_view build_target;
+extern const char target_name[];
+extern const char build_target[];
 
 }  // namespace Carbon::BuildData::Internal
 


### PR DESCRIPTION
string_view was suggested at https://github.com/carbon-language/carbon-lang/pull/5451#discussion_r2080640267, but it turns out it's helpful to be even more hermetic for build configuration.