### PR TITLE
Revert to Ubuntu 22 builders

### DIFF
--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -22,22 +22,48 @@ runs:
         # to save time.
         large-packages: false
 
-    - name: Show system LLVM and Clang installation
-      shell: bash
-      run: |
-        dpkg -l '*clang*' '*llvm*'
+    # Cache and install a recent version of LLVM. This uses the GitHub action
+    # cache to avoid directly downloading on each iteration and improve
+    # reliability.
+    - name: Cache LLVM and Clang installation
+      id: cache-llvm-ubuntu
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      with:
+        path: ~/llvm
+        key: LLVM-19.1.7-Cache-ubuntu-${{ runner.arch }}
 
-    # Install a recent version of LLVM. We use LLVM's apt.llvm.org in order to
-    # have access to all released versions, instead of the GitHub releases which
-    # are often missing binaries for ubuntu x64.
     - name: Download LLVM and Clang installation
-      env:
-        clang_version: 19
+      if: steps.cache-llvm-ubuntu.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        echo '*** Installing upstream clang packages'
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh ${clang_version} all
+        cd ~
+        LLVM_RELEASE=19.1.7
+        LLVM_TARBALL_NAME=LLVM-$LLVM_RELEASE-Linux-X64
+        LLVM_PATH=~/llvm
+        echo "*** Downloading $LLVM_RELEASE"
+        wget --show-progress=off "https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_RELEASE/$LLVM_TARBALL_NAME.tar.xz"
+        echo "*** Extracting $LLVM_TARBALL_NAME.tar.xz"
+        mkdir $LLVM_PATH
+        tar -xJf $LLVM_TARBALL_NAME.tar.xz --strip-components=1 -C $LLVM_PATH
+        echo "*** Deleting $LLVM_TARBALL_NAME.tar.xz"
+        rm $LLVM_TARBALL_NAME.tar.xz
+        echo "*** Testing `clang++ --version`"
+        $LLVM_PATH/bin/clang++ --version
+        # The installation contains *huge* parts of LLVM we don't need for the
+        # toolchain. Prune them here to keep our cache small.
+        echo "*** Cleaning the 'llvm' directory"
+        rm $LLVM_PATH/lib/{*.a,*.so,*.so.*}
+        rm $LLVM_PATH/bin/{flang-*,mlir-*,clang-{scan-deps,check,repl},*-test,llvm-{lto*,reduce,bolt*,exegesis,jitlink},bugpoint,opt,llc}
+        echo "*** Size of the 'llvm' directory"
+        du -hs $LLVM_PATH
 
-        echo "/lib/llvm-19/bin" >> "$GITHUB_PATH"
+    - name: Setup LLVM and Clang paths
+      shell: bash
+      run: |
+        LLVM_PATH=~/llvm
+        echo "Using ${LLVM_PATH}"
+        echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
+        echo '*** ls "${LLVM_PATH}"'
+        ls "${LLVM_PATH}"
+        echo '*** ls "${LLVM_PATH}/bin"'
+        ls "${LLVM_PATH}/bin"

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Harden Runner
@@ -51,7 +51,7 @@ jobs:
       - id: test-setup
         uses: ./.github/actions/test-setup
         with:
-          matrix_runner: 'ubuntu-24.04'
+          matrix_runner: 'ubuntu-22.04'
           base_sha:
             ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.base.sha ||

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -68,7 +68,7 @@ jobs:
 
       - uses: ./.github/actions/build-setup-common
         with:
-          matrix_runner: ubuntu-24.04
+          matrix_runner: ubuntu-22.04
           remote_cache_upload: ${{ env.remote_cache_upload }}
 
       - name: Get nightly date

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -15,11 +15,12 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: block
           # When adding endpoints, see README.md.
           # prettier-ignore
@@ -45,7 +46,7 @@ jobs:
       # Ensure LLVM is set up consistently.
       - uses: ./.github/actions/build-setup-common
         with:
-          matrix_runner: ubuntu-24.04
+          matrix_runner: ubuntu-22.04
           remote_cache_upload: '--remote_upload_local_results=false'
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         # Test a recent version of each supported OS.
-        runner: ['ubuntu-24.04', 'macos-14']
+        runner: ['ubuntu-22.04', 'macos-14']
         build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
The Ubuntu 24 builders have a newer GLIBC than is present on the compiler-explorer machines: https://github.com/compiler-explorer/compiler-explorer/issues/7636#issuecomment-2880962252. This results in the following error when running Carbon nightly:
```
/opt/compiler-explorer/carbon-trunk/bin/carbon: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /opt/compiler-explorer/carbon-trunk/bin/carbon)
```

To resolve this, we need to build Carbon in a sysroot with a compatible glibc version, and the most straightforward way to do that is to bump our builders back down to Ubuntu 22.

To do that, we can't use apt.llvm.org again, since Ubuntu 22 is no longer supported there. So we revert back to pulling a Linux X64 tarball from the LLVM GitHub Releases page. Instead of getting an ubuntu-specific tarball (which does not exist), we grab the generic Linux one, which seems to work fine.

Note that the binaries in the LLVM release package appear to depend on glibc version 2.34, as determined by `objdump -T bin/clang|grep GLIBC_|  sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu`, so these binaries should hopefully be okay to package with the Carbon toolchain for the compiler-explorer machines as well.