### PR TITLE
Add missing standard library header inclusions

### DIFF
--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 namespace Carbon {
 namespace {
 

--- a/common/command_line_test.cpp
+++ b/common/command_line_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "common/error_test_helpers.h"
 #include "common/raw_string_ostream.h"
 #include "llvm/Support/FormatVariadic.h"

--- a/common/struct_reflection_test.cpp
+++ b/common/struct_reflection_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 namespace Carbon::StructReflection {
 namespace {
 

--- a/common/template_string_test.cpp
+++ b/common/template_string_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <type_traits>
+
 namespace Carbon {
 namespace {
 

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/check_unit.h"
 
+#include <iterator>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/generic.h"
 
+#include <utility>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/eval.h"

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/check/thunk.h"
 
+#include <utility>
+
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/call.h"
 #include "toolchain/check/convert.h"

--- a/toolchain/sem_ir/import_ir.cpp
+++ b/toolchain/sem_ir/import_ir.cpp
@@ -4,6 +4,8 @@
 
 #include "toolchain/sem_ir/import_ir.h"
 
+#include <utility>
+
 #include "toolchain/sem_ir/file.h"
 
 namespace Carbon::SemIR {


### PR DESCRIPTION
Discovered by clang-tidy.

See also #5316.