### PR TITLE
Add FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION to fuzzer mode and enable DCHECKs under fuzzing

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -661,12 +661,20 @@ def _impl(ctx):
 
     fuzzer = feature(
         name = "fuzzer",
-        flag_sets = [flag_set(
-            actions = all_compile_actions + all_link_actions,
-            flag_groups = [flag_group(flags = [
-                "-fsanitize=fuzzer-no-link",
-            ])],
-        )],
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions + all_link_actions,
+                flag_groups = [flag_group(flags = [
+                    "-fsanitize=fuzzer-no-link",
+                ])],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION",
+                ])],
+            ),
+        ],
     )
 
     # Clang HARDENED_MODE has 4 possible values:

--- a/common/check.h
+++ b/common/check.h
@@ -24,8 +24,11 @@ namespace Carbon {
   CARBON_INTERNAL_CHECK_CONDITION(condition) \
   ? (void)0 : CARBON_INTERNAL_CHECK(condition __VA_OPT__(, ) __VA_ARGS__)
 
-// DCHECK calls CHECK in debug mode, and does nothing otherwise.
-#ifndef NDEBUG
+// DCHECK calls CHECK in debug or fuzzing mode, and does nothing otherwise.
+//
+// Note FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION is a standard define coming
+// from LibFuzzer: https://llvm.org/docs/LibFuzzer.html
+#if !defined(NDEBUG) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 #define CARBON_DCHECK(condition, ...) \
   CARBON_CHECK(condition __VA_OPT__(, ) __VA_ARGS__)
 #else

--- a/common/raw_hashtable_metadata_group.h
+++ b/common/raw_hashtable_metadata_group.h
@@ -480,11 +480,12 @@ class MetadataGroup : public Printable<MetadataGroup> {
   friend class BenchmarkSimdMetadataGroup;
 
   // All SIMD variants that we have an implementation for should be enabled for
-  // debugging. This lets us maintain a SIMD implementation even if it is not
-  // used due to performance reasons, and easily re-enable it if the performance
-  // changes.
+  // debugging and fuzzing. This lets us maintain a SIMD implementation even if
+  // it is not used due to performance reasons, and easily re-enable it if the
+  // performance changes.
   static constexpr bool DebugSimd =
-#if !defined(NDEBUG) && (CARBON_NEON_SIMD_SUPPORT || CARBON_X86_SIMD_SUPPORT)
+#if (!defined(NDEBUG) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)) && \
+    (CARBON_NEON_SIMD_SUPPORT || CARBON_X86_SIMD_SUPPORT)
       true;
 #else
       false;


### PR DESCRIPTION
The `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` flag is a standard flag proposed by LibFuzzer that is meant to inform compiled code that it is being built for fuzzing, as described here: https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode

We add the flag to our `fuzzing` feature/config, and enable DCHECKs when under fuzzing so that we can catch bugs that currently are caught on the other side of  DCHECK, even if they don't cause ASAN to trap a read/write beyond the capacity of a value store.