### PR TITLE
Validate that rewrite constraints match the requirements

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -525,10 +525,10 @@ auto CheckUnit::CheckPoisonedConcreteImplLookupQueries() -> void {
   auto poisoned_queries =
       std::exchange(context_.poisoned_concrete_impl_lookup_queries(), {});
   for (const auto& poison : poisoned_queries) {
-    auto witness_result =
-        EvalLookupSingleImplWitness(context_, poison.loc_id, poison.query,
-                                    poison.non_canonical_query_self_inst_id,
-                                    /*poison_concrete_results=*/false);
+    auto [witness_result, _] = EvalLookupSingleImplWitness(
+        context_, poison.loc_id, poison.non_canonical_query_self_inst_id,
+        poison.query_specific_interface,
+        /*poison_concrete_results=*/false);
     CARBON_CHECK(witness_result.has_concrete_value());
     auto found_witness_id = witness_result.concrete_witness();
     if (found_witness_id != poison.impl_witness) {
@@ -553,11 +553,11 @@ auto CheckUnit::CheckPoisonedConcreteImplLookupQueries() -> void {
           PoisonedImplLookupConcreteResult, Error,
           "found `impl` that would change the result of an earlier "
           "use of `{0} as {1}`",
-          InstIdAsRawType, SpecificInterfaceIdAsRawType);
+          InstIdAsRawType, SpecificInterfaceAsRawType);
       auto builder =
           emitter_.Build(poison.loc_id, PoisonedImplLookupConcreteResult,
-                         poison.query.query_self_inst_id,
-                         poison.query.query_specific_interface_id);
+                         poison.non_canonical_query_self_inst_id,
+                         poison.query_specific_interface);
       CARBON_DIAGNOSTIC(
           PoisonedImplLookupConcreteResultNoteBadImpl, Note,
           "the use would select the `impl` here but it was not found yet");

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -214,8 +214,8 @@ class Context {
     // The location the LookupImplWitness originated from.
     SemIR::LocId loc_id;
     // The query for a witness of an impl for an interface.
-    SemIR::LookupImplWitness query;
     SemIR::InstId non_canonical_query_self_inst_id;
+    SemIR::SpecificInterface query_specific_interface;
     // The resulting ImplWitness.
     SemIR::InstId impl_witness;
   };

--- a/toolchain/check/diagnostic_emitter.cpp
+++ b/toolchain/check/diagnostic_emitter.cpp
@@ -154,10 +154,9 @@ auto DiagnosticEmitter::ConvertArg(llvm::Any arg) const -> llvm::Any {
     return "`" + StringifySpecificInterface(*sem_ir_, specific_interface) + "`";
   }
   if (auto* specific_interface_raw =
-          llvm::any_cast<SpecificInterfaceIdAsRawType>(&arg)) {
-    auto specific_interface = sem_ir_->specific_interfaces().Get(
-        specific_interface_raw->specific_interface_id);
-    return StringifySpecificInterface(*sem_ir_, specific_interface);
+          llvm::any_cast<SpecificInterfaceAsRawType>(&arg)) {
+    return StringifySpecificInterface(
+        *sem_ir_, specific_interface_raw->specific_interface);
   }
   return DiagnosticEmitterBase::ConvertArg(arg);
 }

--- a/toolchain/check/diagnostic_helpers.h
+++ b/toolchain/check/diagnostic_helpers.h
@@ -127,14 +127,14 @@ struct TypedInt {
   llvm::APInt value;
 };
 
-struct SpecificInterfaceIdAsRawType {
+struct SpecificInterfaceAsRawType {
   using DiagnosticType = Diagnostics::TypeInfo<std::string>;
 
   // NOLINTNEXTLINE(google-explicit-constructor)
-  SpecificInterfaceIdAsRawType(SemIR::SpecificInterfaceId specific_interface_id)
-      : specific_interface_id(specific_interface_id) {}
+  SpecificInterfaceAsRawType(SemIR::SpecificInterface specific_interface)
+      : specific_interface(specific_interface) {}
 
-  SemIR::SpecificInterfaceId specific_interface_id;
+  SemIR::SpecificInterface specific_interface;
 };
 
 }  // namespace Carbon::Check

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1989,47 +1989,21 @@ auto TryEvalTypedInst<SemIR::LookupImplWitness>(EvalContext& eval_context,
 
   Phase phase = Phase::Concrete;
 
-  CARBON_CHECK(
-      ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase));
-  CARBON_CHECK(ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase));
+  bool ok = ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase);
+  CARBON_CHECK(ok);
+  ok = ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase);
+  CARBON_CHECK(ok);
 
   if (!eval_context.has_specific()) {
     return ConvertEvalResultToConstantId(
         eval_context.context(), ConstantEvalResult::NewSamePhase(inst), phase);
   } else {
-    auto lookup_inst = inst.As<SemIR::LookupImplWitness>();
-
-    // The self value is canonicalized in order to produce a canonical
-    // LookupImplWitness instruction. We save the non-canonical instruction as
-    // it may be a concrete `FacetValue` that contains a concrete witness.
-    auto non_canonical_query_self_inst_id = lookup_inst.query_self_inst_id;
-    lookup_inst.query_self_inst_id = GetCanonicalizedFacetOrTypeValue(
-        eval_context.context(), lookup_inst.query_self_inst_id);
-
-    auto result = EvalLookupSingleImplWitness(
-        eval_context.context(), SemIR::LocId(inst_id), lookup_inst,
-        non_canonical_query_self_inst_id,
-        /*poison_concrete_results=*/true);
-    // The `LookupImplWitness` instruction is only created and evaluated when we
-    // already know there is a witness.
-    CARBON_CHECK(result.has_value());
-    if (!result.has_concrete_value()) {
-      return ConvertEvalResultToConstantId(
-          eval_context.context(), ConstantEvalResult::NewSamePhase(lookup_inst),
-          phase);
-    }
     return ConvertEvalResultToConstantId(
         eval_context.context(),
-        ConstantEvalResult::Existing(
-            eval_context.constant_values().Get(result.concrete_witness())),
+        EvalConstantInst(eval_context.context(), inst_id,
+                         inst.As<SemIR::LookupImplWitness>()),
         phase);
   }
-
-  return ConvertEvalResultToConstantId(
-      eval_context.context(),
-      EvalConstantInst(eval_context.context(), inst_id,
-                       inst.As<SemIR::LookupImplWitness>()),
-      phase);
 }
 
 // TODO: Convert this to an EvalConstantInst instruction. This will require

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1989,15 +1989,24 @@ auto TryEvalTypedInst<SemIR::LookupImplWitness>(EvalContext& eval_context,
 
   Phase phase = Phase::Concrete;
 
-  bool ok = ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase);
-  CARBON_CHECK(ok);
-  ok = ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase);
-  CARBON_CHECK(ok);
+  bool type_constant_result =
+      ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase);
+  CARBON_CHECK(type_constant_result);
+  bool fields_constant_result =
+      ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase);
+  CARBON_CHECK(fields_constant_result);
 
   if (!eval_context.has_specific()) {
+    // This is a shortcut in the case where `LookupImplWitness()` has already
+    // done the impl lookup and found a non-concrete result. Then it needs to
+    // make a `LookupImplWitness` instruction to be executed later against a
+    // specific, where is how we got here, but we don't need to do another
+    // lookup immediately. We just return the instruction as-is.
     return ConvertEvalResultToConstantId(
         eval_context.context(), ConstantEvalResult::NewSamePhase(inst), phase);
   } else {
+    // The instruction is being re-evaluated against a specific, so we should
+    // execute impl lookup now.
     return ConvertEvalResultToConstantId(
         eval_context.context(),
         EvalConstantInst(eval_context.context(), inst_id,

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -15,6 +15,7 @@
 #include "toolchain/check/eval_inst.h"
 #include "toolchain/check/facet_type.h"
 #include "toolchain/check/generic.h"
+#include "toolchain/check/impl_lookup.h"
 #include "toolchain/check/import_ref.h"
 #include "toolchain/check/type.h"
 #include "toolchain/check/type_completion.h"
@@ -206,6 +207,8 @@ class EvalContext {
   auto sem_ir() -> SemIR::File& { return context().sem_ir(); }
 
   auto emitter() -> DiagnosticEmitterBase& { return context().emitter(); }
+
+  auto has_specific() const -> bool { return specific_id_.has_value(); }
 
  private:
   // The type-checking context in which we're performing evaluation.
@@ -1975,6 +1978,58 @@ static auto IsPeriodSelf(EvalContext& eval_context, SemIR::ConstantId const_id)
     return bind_name.name_id == SemIR::NameId::PeriodSelf;
   }
   return false;
+}
+
+template <>
+auto TryEvalTypedInst<SemIR::LookupImplWitness>(EvalContext& eval_context,
+                                                SemIR::InstId inst_id,
+                                                SemIR::Inst inst)
+    -> SemIR::ConstantId {
+  CARBON_CHECK(inst_id.has_value());
+
+  Phase phase = Phase::Concrete;
+
+  CARBON_CHECK(
+      ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase));
+  CARBON_CHECK(ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase));
+
+  if (!eval_context.has_specific()) {
+    return ConvertEvalResultToConstantId(
+        eval_context.context(), ConstantEvalResult::NewSamePhase(inst), phase);
+  } else {
+    auto lookup_inst = inst.As<SemIR::LookupImplWitness>();
+
+    // The self value is canonicalized in order to produce a canonical
+    // LookupImplWitness instruction. We save the non-canonical instruction as
+    // it may be a concrete `FacetValue` that contains a concrete witness.
+    auto non_canonical_query_self_inst_id = lookup_inst.query_self_inst_id;
+    lookup_inst.query_self_inst_id = GetCanonicalizedFacetOrTypeValue(
+        eval_context.context(), lookup_inst.query_self_inst_id);
+
+    auto result = EvalLookupSingleImplWitness(
+        eval_context.context(), SemIR::LocId(inst_id), lookup_inst,
+        non_canonical_query_self_inst_id,
+        /*poison_concrete_results=*/true);
+    // The `LookupImplWitness` instruction is only created and evaluated when we
+    // already know there is a witness.
+    CARBON_CHECK(result.has_value());
+    if (!result.has_concrete_value()) {
+      return ConvertEvalResultToConstantId(
+          eval_context.context(), ConstantEvalResult::NewSamePhase(lookup_inst),
+          phase);
+    }
+    return ConvertEvalResultToConstantId(
+        eval_context.context(),
+        ConstantEvalResult::Existing(
+            eval_context.constant_values().Get(result.concrete_witness())),
+        phase);
+  }
+
+  return ConvertEvalResultToConstantId(
+      eval_context.context(),
+      EvalConstantInst(eval_context.context(), inst_id,
+                       inst.As<SemIR::LookupImplWitness>()),
+      phase);
 }
 
 // TODO: Convert this to an EvalConstantInst instruction. This will require

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1980,41 +1980,6 @@ static auto IsPeriodSelf(EvalContext& eval_context, SemIR::ConstantId const_id)
   return false;
 }
 
-template <>
-auto TryEvalTypedInst<SemIR::LookupImplWitness>(EvalContext& eval_context,
-                                                SemIR::InstId inst_id,
-                                                SemIR::Inst inst)
-    -> SemIR::ConstantId {
-  CARBON_CHECK(inst_id.has_value());
-
-  Phase phase = Phase::Concrete;
-
-  bool type_constant_result =
-      ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase);
-  CARBON_CHECK(type_constant_result);
-  bool fields_constant_result =
-      ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase);
-  CARBON_CHECK(fields_constant_result);
-
-  if (!eval_context.has_specific()) {
-    // This is a shortcut in the case where `LookupImplWitness()` has already
-    // done the impl lookup and found a non-concrete result. Then it needs to
-    // make a `LookupImplWitness` instruction to be executed later against a
-    // specific, where is how we got here, but we don't need to do another
-    // lookup immediately. We just return the instruction as-is.
-    return ConvertEvalResultToConstantId(
-        eval_context.context(), ConstantEvalResult::NewSamePhase(inst), phase);
-  } else {
-    // The instruction is being re-evaluated against a specific, so we should
-    // execute impl lookup now.
-    return ConvertEvalResultToConstantId(
-        eval_context.context(),
-        EvalConstantInst(eval_context.context(), inst_id,
-                         inst.As<SemIR::LookupImplWitness>()),
-        phase);
-  }
-}
-
 // TODO: Convert this to an EvalConstantInst instruction. This will require
 // providing a `GetConstantValue` overload for a requirement block.
 template <>

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -15,7 +15,6 @@
 #include "toolchain/check/eval_inst.h"
 #include "toolchain/check/facet_type.h"
 #include "toolchain/check/generic.h"
-#include "toolchain/check/impl_lookup.h"
 #include "toolchain/check/import_ref.h"
 #include "toolchain/check/type.h"
 #include "toolchain/check/type_completion.h"
@@ -207,8 +206,6 @@ class EvalContext {
   auto sem_ir() -> SemIR::File& { return context().sem_ir(); }
 
   auto emitter() -> DiagnosticEmitterBase& { return context().emitter(); }
-
-  auto has_specific() const -> bool { return specific_id_.has_value(); }
 
  private:
   // The type-checking context in which we're performing evaluation.

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -199,6 +199,28 @@ auto EvalConstantInst(Context& /*context*/, SemIR::FunctionDecl inst)
 }
 
 auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
+                      SemIR::LookupImplWitness inst) -> ConstantEvalResult {
+  // The self value is canonicalized in order to produce a canonical
+  // LookupImplWitness instruction. We save the non-canonical instruction as it
+  // may be a concrete `FacetValue` that contains a concrete witness.
+  auto non_canonical_query_self_inst_id = inst.query_self_inst_id;
+  inst.query_self_inst_id =
+      GetCanonicalizedFacetOrTypeValue(context, inst.query_self_inst_id);
+
+  auto result = EvalLookupSingleImplWitness(
+      context, SemIR::LocId(inst_id), inst, non_canonical_query_self_inst_id,
+      /*poison_concrete_results=*/true);
+  // The `LookupImplWitness` instruction is only created and evaluated when we
+  // already know there is a witness.
+  CARBON_CHECK(result.has_value());
+  if (!result.has_concrete_value()) {
+    return ConstantEvalResult::NewSamePhase(inst);
+  }
+  return ConstantEvalResult::Existing(
+      context.constant_values().Get(result.concrete_witness()));
+}
+
+auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                       SemIR::ImplWitnessAccess inst) -> ConstantEvalResult {
   // This is PerformAggregateAccess followed by GetConstantValueInSpecific.
   if (auto witness =

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -199,32 +199,6 @@ auto EvalConstantInst(Context& /*context*/, SemIR::FunctionDecl inst)
 }
 
 auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::LookupImplWitness inst) -> ConstantEvalResult {
-  // The self value is canonicalized in order to produce a canonical
-  // LookupImplWitness instruction. We save the non-canonical instruction as it
-  // may be a concrete `FacetValue` that contains a concrete witness.
-  auto non_canonical_query_self_inst_id = inst.query_self_inst_id;
-  inst.query_self_inst_id =
-      GetCanonicalizedFacetOrTypeValue(context, inst.query_self_inst_id);
-
-  auto result = EvalLookupSingleImplWitness(
-      context, SemIR::LocId(inst_id), inst, non_canonical_query_self_inst_id,
-      /*poison_concrete_results=*/true);
-  if (!result.has_value()) {
-    // We use NotConstant to communicate back to impl lookup that the lookup
-    // failed. This can not happen for a deferred symbolic lookup in a generic
-    // eval block, since we only add the deferred lookup instruction (being
-    // evaluated here) to the SemIR if the lookup succeeds.
-    return ConstantEvalResult::NotConstant;
-  }
-  if (!result.has_concrete_value()) {
-    return ConstantEvalResult::NewSamePhase(inst);
-  }
-  return ConstantEvalResult::Existing(
-      context.constant_values().Get(result.concrete_witness()));
-}
-
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                       SemIR::ImplWitnessAccess inst) -> ConstantEvalResult {
   // This is PerformAggregateAccess followed by GetConstantValueInSpecific.
   if (auto witness =

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -200,22 +200,37 @@ auto EvalConstantInst(Context& /*context*/, SemIR::FunctionDecl inst)
 
 auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                       SemIR::LookupImplWitness inst) -> ConstantEvalResult {
-  // The self value is canonicalized in order to produce a canonical
-  // LookupImplWitness instruction. We save the non-canonical instruction as it
-  // may be a concrete `FacetValue` that contains a concrete witness.
-  auto non_canonical_query_self_inst_id = inst.query_self_inst_id;
-  inst.query_self_inst_id =
-      GetCanonicalizedFacetOrTypeValue(context, inst.query_self_inst_id);
+  // NOTE: Do not retain a reference to the SpecificInterface obtained from a
+  // value store by SpecificInterfaceId. Doing impl lookup does deduce which can
+  // do more impl lookups, and impl lookup can add a new SpecificInterface to
+  // the store which can reallocate and invalidate any references held here into
+  // the store.
+  auto query_specific_interface =
+      context.specific_interfaces().Get(inst.query_specific_interface_id);
 
-  auto result = EvalLookupSingleImplWitness(
-      context, SemIR::LocId(inst_id), inst, non_canonical_query_self_inst_id,
+  // We use the potentially non-canonical instruction substituted into the
+  // LookupImplWitness as it may be a concrete `FacetValue` that contains a
+  // concrete witness.
+  auto [result, canonical_self_inst_id] = EvalLookupSingleImplWitness(
+      context, SemIR::LocId(inst_id), inst.query_self_inst_id,
+      query_specific_interface,
       /*poison_concrete_results=*/true);
   // The `LookupImplWitness` instruction is only created and evaluated when we
   // already know there is a witness.
   CARBON_CHECK(result.has_value());
+
+  // Store the canonicalized self instruction to make the `LookupImplWitness`
+  // instruction canonical as well.
+  inst.query_self_inst_id = canonical_self_inst_id;
+
   if (!result.has_concrete_value()) {
+    // If a non-concrete witness was found, return the current
+    // `LookupImplWitness` instruction so that it can be evaluated again in the
+    // future against another specific to look for a concrete witness.
     return ConstantEvalResult::NewSamePhase(inst);
   }
+  // Return the found concrete witness, an `ImplWitness` instruction. This ends
+  // the use of this `LookupImplWitness` instruction.
   return ConstantEvalResult::Existing(
       context.constant_values().Get(result.concrete_witness()));
 }

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -392,8 +392,8 @@ class AppliedRewriteRules {
     return values_.back();
   }
 
-  // Maps to an index in both of vectors below. Constants with the same index
-  // value are considered equivalent.
+  // Maps to an index in the vector below. Constants with the same index value
+  // are considered equivalent.
   Map<RewriteRule::AssociatedConstant, int> indexes_;
   llvm::SmallVector<Value> values_;
 };

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -4,12 +4,14 @@
 
 #include "toolchain/check/facet_type.h"
 
+#include "toolchain/base/kind_switch.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/check/import_ref.h"
 #include "toolchain/check/inst.h"
 #include "toolchain/check/interface.h"
 #include "toolchain/check/type.h"
 #include "toolchain/check/type_completion.h"
+#include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -261,6 +263,417 @@ auto AllocateFacetTypeImplWitness(Context& context,
   llvm::SmallVector<SemIR::InstId> empty_table(
       assoc_entities.size(), SemIR::ImplWitnessTablePlaceholder::TypeInstId);
   context.inst_blocks().ReplacePlaceholder(witness_id, empty_table);
+}
+
+// A rewrite that associates either a value or an associated constant on the
+// RHS with the associated constant on the LHS.
+//
+// Rewrite rules can come from concrete impl witnesses or from facet types,
+// and this generalizes them into a common structure that structurally tracks
+// if the associated value on the right names a constant.
+//
+// All ConstantIds must be mapped into the specific of the witness or facet
+// that they come from in order to make them comparable in a given context.
+struct RewriteRule {
+  struct AssociatedConstant {
+    // The value of an AssociatedConstantDecl instruction.
+    SemIR::ConstantId const_id;
+    auto operator==(const AssociatedConstant& rhs) const -> bool = default;
+  };
+  struct AssignedValue {
+    // The final value assigned to an associated constant. May be anything
+    // other than an AssociatedConstantDecl.
+    SemIR::ConstantId const_id;
+    auto operator==(const AssignedValue& rhs) const -> bool = default;
+  };
+
+  using Assignment = std::variant<AssociatedConstant, AssignedValue>;
+
+  AssociatedConstant lhs;
+  Assignment rhs;
+};
+
+// Tracks rewrite rules via their equivalency sets of `AssociatedConstant`s and
+// the constant values assigned to each equivalency set.
+class AppliedRewriteRules {
+ public:
+  struct Value {
+    auto const_value_id() -> SemIR::ConstantId { return const_value_id_; }
+
+   private:
+    friend AppliedRewriteRules;
+
+    Value() = default;
+
+    SemIR::ConstantId const_value_id_ = SemIR::ConstantId::None;
+    int index = -1;
+  };
+
+  auto Apply(RewriteRule rewrite_rule) -> void {
+    auto lhs = rewrite_rule.lhs;
+    CARBON_KIND_SWITCH(rewrite_rule.rhs) {
+      case CARBON_KIND(RewriteRule::AssociatedConstant rhs): {
+        auto* lhs_value = FindValue(lhs);
+        auto* rhs_value = FindValue(rhs);
+        if (lhs_value && rhs_value) {
+          if (lhs_value != rhs_value) {
+            Merge(*lhs_value, *rhs_value);
+          }
+        } else if (lhs_value) {
+          // Add the rhs to the lhs equivalency set.
+          AddEquivalent(*lhs_value, rhs);
+        } else if (rhs_value) {
+          // Add the lhs to the rhs equivalency set.
+          AddEquivalent(*rhs_value, lhs);
+        } else {
+          // Create a new equivalency set.
+          auto& new_value = AddIndependent(lhs);
+          if (lhs != rhs) {
+            AddEquivalent(new_value, rhs);
+          }
+        }
+        break;
+      }
+      case CARBON_KIND(RewriteRule::AssignedValue rhs): {
+        auto* lhs_value = FindValue(lhs);
+        if (lhs_value) {
+          // Assign the constant value to the equivalency group.
+          SetConstant(*lhs_value, rhs.const_id);
+        } else {
+          // Create a new equivalency set, with the assigned constant value.
+          auto& new_value = AddIndependent(lhs);
+          SetConstant(new_value, rhs.const_id);
+        }
+        break;
+      }
+    }
+  }
+
+  auto FindValue(RewriteRule::AssociatedConstant ac) -> Value* {
+    if (auto e = indexes_.Lookup(ac)) {
+      int index = e.value();
+      return &values_[index];
+    } else {
+      return nullptr;
+    }
+  }
+
+ private:
+  auto SetConstant(Value& into, SemIR::ConstantId const_value_id) -> void {
+    into.const_value_id_ = const_value_id;
+  }
+
+  auto Merge(Value& into, Value& from) -> void {
+    if (from.const_value_id_.has_value()) {
+      if (into.const_value_id_.has_value()) {
+        CARBON_CHECK(from.const_value_id_ == into.const_value_id_);
+      }
+      into.const_value_id_ = from.const_value_id_;
+    }
+    indexes_.ForEach([=](RewriteRule::AssociatedConstant& /*key*/, int& index) {
+      if (index == from.index) {
+        index = into.index;
+      }
+    });
+  }
+
+  auto AddEquivalent(Value& into, RewriteRule::AssociatedConstant ac) -> void {
+    auto result = indexes_.Insert(ac, into.index);
+    CARBON_CHECK(result.is_inserted());
+  }
+
+  auto AddIndependent(RewriteRule::AssociatedConstant ac) -> Value& {
+    CARBON_CHECK(values_.size() < std::numeric_limits<int>::max());
+    auto new_index = static_cast<int>(values_.size());
+    values_.push_back(Value());
+    values_.back().index = new_index;
+    auto result = indexes_.Insert(ac, new_index);
+    CARBON_CHECK(result.is_inserted());
+    return values_.back();
+  }
+
+  // Maps to an index in both of vectors below. Constants with the same index
+  // value are considered equivalent.
+  Map<RewriteRule::AssociatedConstant, int> indexes_;
+  llvm::SmallVector<Value> values_;
+};
+
+// Returns the value of the `AssociatedConstantDecl` accessed by an
+// `ImplWitnessAccess`, or nullopt if the access is not to an associated
+// constant (such as for an access to an associated function, or an error).
+//
+// The AssociatedConstantDecl is mapped into the specific of the witness.
+static auto TryGetAssociatedConstantFromImplWitnessAccess(
+    Context& context, const SemIR::ImplWitnessAccess& witness_access)
+    -> std::optional<SemIR::ConstantId> {
+  auto witness = context.insts().GetAs<SemIR::LookupImplWitness>(
+      witness_access.witness_id);
+  auto specific_interface =
+      context.specific_interfaces().Get(witness.query_specific_interface_id);
+  const auto& interface =
+      context.interfaces().Get(specific_interface.interface_id);
+  auto assoc_entities =
+      context.inst_blocks().Get(interface.associated_entities_id);
+  auto decl_id = assoc_entities[witness_access.index.index];
+  if (decl_id == SemIR::ErrorInst::InstId) {
+    return std::nullopt;
+  }
+  if (!context.insts().Is<SemIR::AssociatedConstantDecl>(decl_id)) {
+    // Something in the interface other than an associated constant.
+    return std::nullopt;
+  }
+  auto decl_const_id = SemIR::GetConstantValueInSpecific(
+      context.sem_ir(), specific_interface.specific_id, decl_id);
+  return decl_const_id;
+}
+
+// Generates the rewrite rules retrieved from the witness tables found in a
+// FacetType.
+class RewriteRulesFromFacetType {
+ public:
+  explicit RewriteRulesFromFacetType(Context& context,
+                                     SemIR::FacetTypeId facet_type_id)
+      : context_(context) {
+    if (facet_type_id.has_value()) {
+      const auto& facet_type_info = context.facet_types().Get(facet_type_id);
+      it_ = facet_type_info.rewrite_constraints.begin();
+      end_ = facet_type_info.rewrite_constraints.end();
+    } else {
+      it_ = end_ = nullptr;
+    }
+  }
+
+  // Returns each RewriteRule found in the FacetType, then returns nullopt.
+  auto Next() -> std::optional<RewriteRule> {
+    while (it_ != end_) {
+      auto lhs_id = it_->lhs_id;
+      auto rhs_id = it_->rhs_id;
+      ++it_;
+
+      while (lhs_id == SemIR::ErrorInst::InstId ||
+             rhs_id == SemIR::ErrorInst::InstId) {
+        lhs_id = it_->lhs_id;
+        rhs_id = it_->rhs_id;
+        ++it_;
+        if (it_ == end_) {
+          return std::nullopt;
+        }
+      }
+
+      auto lhs_witness_access =
+          context_.insts().GetAs<SemIR::ImplWitnessAccess>(lhs_id);
+      auto lhs = TryGetAssociatedConstantFromImplWitnessAccess(
+          context_, lhs_witness_access);
+      if (!lhs) {
+        // We found an associated value that is not a constant (like a
+        // function), so continue to the next element in the table.
+        continue;
+      }
+
+      if (auto rhs_witness_access =
+              context_.insts().TryGetAs<SemIR::ImplWitnessAccess>(rhs_id)) {
+        auto rhs = TryGetAssociatedConstantFromImplWitnessAccess(
+            context_, *rhs_witness_access);
+        if (!rhs) {
+          // The RHS is comes from a witness table but is not an associated
+          // constant, such as if we find an error. Continue to the next element
+          // in this table.
+          continue;
+        }
+        return {{.lhs = RewriteRule::AssociatedConstant{.const_id = *lhs},
+                 .rhs = RewriteRule::AssociatedConstant{.const_id = *rhs}}};
+      } else {
+        auto rhs = context_.constant_values().Get(rhs_id);
+        return {{.lhs = RewriteRule::AssociatedConstant{.const_id = *lhs},
+                 .rhs = RewriteRule::AssignedValue{.const_id = rhs}}};
+      }
+    }
+
+    return std::nullopt;
+  }
+
+ private:
+  Context& context_;
+  const Carbon::SemIR::FacetTypeInfo::RewriteConstraint* it_;
+  const Carbon::SemIR::FacetTypeInfo::RewriteConstraint* end_;
+};
+
+class RewriteRulesFromImplWitness {
+ public:
+  RewriteRulesFromImplWitness(Context& context, SemIR::InstId witness_id)
+      : context_(context) {
+    const auto& witness = context.insts().GetAs<SemIR::ImplWitness>(witness_id);
+    auto table = context.insts().GetAs<SemIR::ImplWitnessTable>(
+        witness.witness_table_id);
+
+    const auto& impl = context.impls().Get(table.impl_id);
+    const auto& interface =
+        context.interfaces().Get(impl.interface.interface_id);
+
+    if (!interface.associated_entities_id.has_value()) {
+      return;
+    }
+
+    impl_interface_specific_id_ = impl.interface.specific_id;
+    witness_specific_id_ = witness.specific_id;
+
+    lhs_inst_ids_ =
+        context_.inst_blocks().Get(interface.associated_entities_id);
+    lhs_inst_ids_it_ = lhs_inst_ids_.begin();
+    rhs_inst_ids_ = context.inst_blocks().Get(table.elements_id);
+    rhs_inst_ids_it_ = rhs_inst_ids_.begin();
+  }
+
+  auto Next() -> std::optional<RewriteRule> {
+    while (true) {
+      // The witness table may have fewer entries in it (or even zero if there's
+      // no impl definition) than the interface has, but they are in the same
+      // order for whatever is present.
+      if (lhs_inst_ids_it_ == lhs_inst_ids_.end()) {
+        return std::nullopt;
+      }
+      if (rhs_inst_ids_it_ == rhs_inst_ids_.end()) {
+        return std::nullopt;
+      }
+
+      auto lhs_inst_id = *lhs_inst_ids_it_;
+      ++lhs_inst_ids_it_;
+      auto rhs_inst_id = *rhs_inst_ids_it_;
+      ++rhs_inst_ids_it_;
+
+      auto lhs_assoc_const_decl_id = SemIR::ConstantId::None;
+      if (context_.insts().Is<SemIR::AssociatedConstantDecl>(lhs_inst_id)) {
+        lhs_assoc_const_decl_id = SemIR::GetConstantValueInSpecific(
+            context_.sem_ir(), impl_interface_specific_id_, lhs_inst_id);
+      }
+      if (!lhs_assoc_const_decl_id.has_value()) {
+        // This entry in the witness table is not for an associated constant.
+        continue;
+      }
+
+      if (rhs_inst_id == SemIR::ErrorInst::InstId) {
+        continue;
+      }
+
+      auto lhs =
+          RewriteRule::AssociatedConstant{.const_id = lhs_assoc_const_decl_id};
+
+      if (context_.insts().Is<SemIR::ImplWitnessTablePlaceholder>(
+              rhs_inst_id)) {
+        // This witness doesn't specify a value for the LHS associated
+        // constant.
+        continue;
+      }
+
+      auto witness_constant =
+          context_.insts().GetAs<SemIR::ImplWitnessAssociatedConstant>(
+              rhs_inst_id);
+      rhs_inst_id = witness_constant.inst_id;
+
+      if (auto rhs_witness_access =
+              context_.insts().TryGetAs<SemIR::ImplWitnessAccess>(
+                  rhs_inst_id)) {
+        auto rhs = TryGetAssociatedConstantFromImplWitnessAccess(
+            context_, *rhs_witness_access);
+        if (!rhs) {
+          // The RHS is comes from a witness table but is not an associated
+          // constant, such as if we find an error. Continue to the next element
+          // in this table.
+          continue;
+        }
+        return {{.lhs = lhs,
+                 .rhs = RewriteRule::AssociatedConstant{.const_id = *rhs}}};
+      } else {
+        auto rhs_const_id = SemIR::GetConstantValueInSpecific(
+            context_.sem_ir(), witness_specific_id_, rhs_inst_id);
+        return {{.lhs = lhs,
+                 .rhs = RewriteRule::AssignedValue{.const_id = rhs_const_id}}};
+      }
+    }
+  }
+
+ private:
+  Context& context_;
+  SemIR::SpecificId impl_interface_specific_id_ = SemIR::SpecificId::None;
+  SemIR::SpecificId witness_specific_id_ = SemIR::SpecificId::None;
+  llvm::ArrayRef<SemIR::InstId> lhs_inst_ids_;
+  const SemIR::InstId* lhs_inst_ids_it_ = lhs_inst_ids_.end();
+  llvm::ArrayRef<SemIR::InstId> rhs_inst_ids_;
+  const SemIR::InstId* rhs_inst_ids_it_ = rhs_inst_ids_.end();
+};
+
+auto CheckRewriteConstraintsMatchRequirements(
+    Context& context, SemIR::FacetTypeId requirements_facet_type_id,
+    llvm::ArrayRef<RewriteSource> rewrite_sources) -> bool {
+  AppliedRewriteRules provided_rewrite_values;
+
+  for (auto rewrite_source : rewrite_sources) {
+    CARBON_KIND_SWITCH(rewrite_source) {
+      case CARBON_KIND(SemIR::InstId witness_id):
+        for (auto rules = RewriteRulesFromImplWitness(context, witness_id);
+             auto rule = rules.Next();) {
+          provided_rewrite_values.Apply(*rule);
+        }
+        break;
+      case CARBON_KIND(SemIR::FacetTypeId facet_type_id):
+        for (auto rules = RewriteRulesFromFacetType(context, facet_type_id);
+             auto rule = rules.Next();) {
+          provided_rewrite_values.Apply(*rule);
+        }
+        break;
+    }
+  }
+
+  for (auto required_rules =
+           RewriteRulesFromFacetType(context, requirements_facet_type_id);
+       auto required_rule = required_rules.Next();) {
+    CARBON_KIND_SWITCH(required_rule->rhs) {
+      case CARBON_KIND(RewriteRule::AssociatedConstant rhs): {
+        // The lhs and rhs must be in the same equivalency group.
+        auto* lhs_value = provided_rewrite_values.FindValue(required_rule->lhs);
+        auto* rhs_value = provided_rewrite_values.FindValue(rhs);
+        if (!lhs_value) {
+          // LHS of a rewrite rule has no value provided by a witness.
+          return false;
+        }
+        if (!rhs_value) {
+          // RHS of a rewrite rule has no value provided by a witness.
+          return false;
+        }
+        if (lhs_value != rhs_value) {
+          if (lhs_value->const_value_id().has_value() ||
+              rhs_value->const_value_id().has_value()) {
+            if (lhs_value->const_value_id() != rhs_value->const_value_id()) {
+              // LHS and RHS of the rewrite constraint were given different
+              // concrete values by a witness.
+              return false;
+            }
+          }
+        }
+        break;
+      }
+      case CARBON_KIND(RewriteRule::AssignedValue rhs): {
+        auto* lhs_value = provided_rewrite_values.FindValue(required_rule->lhs);
+        if (!lhs_value) {
+          // LHS of rewrite rule has no value provided by a witness.
+          return false;
+        }
+        if (!lhs_value->const_value_id().has_value()) {
+          // LHS of rewrite rule requires a concrete value provided by a witness
+          // but not was given one.
+          return false;
+        }
+        if (lhs_value->const_value_id() != rhs.const_id) {
+          // LHS of rewrite rule has a different concrete value than the one
+          // provided by a witness.
+          return false;
+        }
+        break;
+      }
+    }
+  }
+
+  return true;
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -514,9 +514,7 @@ class RewriteRulesFromImplWitness {
 
     lhs_inst_ids_ =
         context_.inst_blocks().Get(interface.associated_entities_id);
-    lhs_inst_ids_it_ = lhs_inst_ids_.begin();
     rhs_inst_ids_ = context.inst_blocks().Get(table.elements_id);
-    rhs_inst_ids_it_ = rhs_inst_ids_.begin();
   }
 
   auto Next() -> std::optional<RewriteRule> {
@@ -524,17 +522,17 @@ class RewriteRulesFromImplWitness {
       // The witness table (the RHS) may have fewer entries in it (or even zero
       // if there's no impl definition) than the interface (the LHS) has, but
       // they are in the same order for whatever is present.
-      if (lhs_inst_ids_it_ == lhs_inst_ids_.end()) {
+      if (lhs_inst_ids_.empty()) {
         return std::nullopt;
       }
-      if (rhs_inst_ids_it_ == rhs_inst_ids_.end()) {
+      if (rhs_inst_ids_.empty()) {
         return std::nullopt;
       }
 
-      auto lhs_inst_id = *lhs_inst_ids_it_;
-      ++lhs_inst_ids_it_;
-      auto rhs_inst_id = *rhs_inst_ids_it_;
-      ++rhs_inst_ids_it_;
+      auto lhs_inst_id = lhs_inst_ids_.front();
+      lhs_inst_ids_ = lhs_inst_ids_.drop_front();
+      auto rhs_inst_id = rhs_inst_ids_.front();
+      rhs_inst_ids_ = rhs_inst_ids_.drop_front();
 
       auto lhs_assoc_const_decl_id = SemIR::ConstantId::None;
       if (context_.insts().Is<SemIR::AssociatedConstantDecl>(lhs_inst_id)) {
@@ -592,9 +590,7 @@ class RewriteRulesFromImplWitness {
   SemIR::SpecificId impl_interface_specific_id_ = SemIR::SpecificId::None;
   SemIR::SpecificId witness_specific_id_ = SemIR::SpecificId::None;
   llvm::ArrayRef<SemIR::InstId> lhs_inst_ids_;
-  const SemIR::InstId* lhs_inst_ids_it_ = lhs_inst_ids_.end();
   llvm::ArrayRef<SemIR::InstId> rhs_inst_ids_;
-  const SemIR::InstId* rhs_inst_ids_it_ = rhs_inst_ids_.end();
 };
 
 auto CheckRewriteConstraintsMatchRequirements(

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -526,9 +526,9 @@ class RewriteRulesFromImplWitness {
 
   auto Next() -> std::optional<RewriteRule> {
     while (true) {
-      // The witness table may have fewer entries in it (or even zero if there's
-      // no impl definition) than the interface has, but they are in the same
-      // order for whatever is present.
+      // The witness table (the RHS) may have fewer entries in it (or even zero
+      // if there's no impl definition) than the interface (the LHS) has, but
+      // they are in the same order for whatever is present.
       if (lhs_inst_ids_it_ == lhs_inst_ids_.end()) {
         return std::nullopt;
       }

--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -450,14 +450,9 @@ class RewriteRulesFromFacetType {
       auto rhs_id = it_->rhs_id;
       ++it_;
 
-      while (lhs_id == SemIR::ErrorInst::InstId ||
-             rhs_id == SemIR::ErrorInst::InstId) {
-        lhs_id = it_->lhs_id;
-        rhs_id = it_->rhs_id;
-        ++it_;
-        if (it_ == end_) {
-          return std::nullopt;
-        }
+      if (lhs_id == SemIR::ErrorInst::InstId ||
+          rhs_id == SemIR::ErrorInst::InstId) {
+        continue;
       }
 
       auto lhs_witness_access =

--- a/toolchain/check/facet_type.h
+++ b/toolchain/check/facet_type.h
@@ -58,6 +58,20 @@ auto AllocateFacetTypeImplWitness(Context& context,
                                   SemIR::InterfaceId interface_id,
                                   SemIR::InstBlockId witness_id) -> void;
 
+// Rewrite constraints that assign values to associated constants can come from
+// a concrete `ImplWitness` or from a `FacetType`.
+//
+// If the RewriteSource is holding an `InstId`, it must always be for an
+// `ImplWitness`. Neither value may contain `None`.
+using RewriteSource = std::variant<SemIR::InstId, SemIR::FacetTypeId>;
+
+// Verify that the rewrite constraints provided by `rewrite_sources` satisfy all
+// of the requirements, and do not contradict with any requirements, from the
+// facet type referred to by `requirements_facet_type_id`.
+auto CheckRewriteConstraintsMatchRequirements(
+    Context& context, SemIR::FacetTypeId requirements_facet_type_id,
+    llvm::ArrayRef<RewriteSource> rewrite_sources) -> bool;
+
 }  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_CHECK_FACET_TYPE_H_

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -408,7 +408,7 @@ static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
   // we want eval to not actually do another lookup here, but we must create the
   // instruction through eval. It takes care to bypass running lookup again for
   // this caller.
-  auto witness_const_id = EvalOrAddInst<SemIR::LookupImplWitness>(
+  auto witness_const_id = AddInstWithoutEval<SemIR::LookupImplWitness>(
       context, context.insts().GetCanonicalLocId(loc_id).ToImplicit(),
       {
           .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -368,10 +368,10 @@ static auto LookupImplWitnessInSelfFacetValue(
 
 struct WitnessResult {
   // Either a concrete `ImplWitness` or a symbolic `LookupImplWitness`.
-  SemIR::InstId witness_id;
+  SemIR::InstId witness_id = SemIR::InstId::None;
   // If the witness is not concrete, and was found through a facet value, this
   // is the `FacetType` info from the type of that facet value.
-  SemIR::FacetTypeId facet_type_id;
+  SemIR::FacetTypeId facet_type_id = SemIR::FacetTypeId::None;
 };
 
 // Begin a search for an impl declaration matching the query. We do this by
@@ -382,47 +382,42 @@ struct WitnessResult {
 // context the query came from.
 static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
                                       SemIR::ConstantId query_self_const_id,
-                                      SemIR::SpecificInterface interface)
+                                      SemIR::SpecificInterface query_interface)
     -> WitnessResult {
-  auto result = WitnessResult{
-      .witness_id = SemIR::InstId::None,
-      .facet_type_id = SemIR::FacetTypeId::None,
-  };
-
-  // TODO: This is repeating the implementation of EvalConstantInst. Can we
-  // share even more code?
-
-  auto lookup_inst = SemIR::LookupImplWitness{
-      .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
-      .query_self_inst_id =
-          context.constant_values().GetInstId(query_self_const_id),
-      .query_specific_interface_id =
-          context.specific_interfaces().Add(interface),
-  };
-  auto non_canon = lookup_inst.query_self_inst_id;
-  lookup_inst.query_self_inst_id =
-      GetCanonicalizedFacetOrTypeValue(context, lookup_inst.query_self_inst_id);
-
-  auto lookup_result =
-      EvalLookupSingleImplWitness(context, loc_id, lookup_inst, non_canon,
-                                  /*poison_concrete_results=*/true);
+  auto query_self_inst_id =
+      context.constant_values().GetInstId(query_self_const_id);
+  auto [lookup_result, canonical_self_inst_id] = EvalLookupSingleImplWitness(
+      context, loc_id, query_self_inst_id, query_interface,
+      /*poison_concrete_results=*/true);
   if (!lookup_result.has_value()) {
-    return result;
-  }
-  if (lookup_result.has_concrete_value()) {
-    result.witness_id = lookup_result.concrete_witness();
-    return result;
-  }
-  if (lookup_result.has_facet_type_value()) {
-    result.facet_type_id = lookup_result.facet_value_type();
+    return {};
   }
 
-  auto witness_const_id = EvalOrAddInst(
+  // If a concrete witness was found, the result is that concrete witness (an
+  // `ImplWitness` instruction. So we do not need to create a
+  // `LookupImplWitness` instruction to return.
+  if (lookup_result.has_concrete_value()) {
+    return {.witness_id = lookup_result.concrete_witness()};
+  }
+
+  // A symbolic witness was found, so the result is a `LookupImplWitness`
+  // instruction which will re-execute the query in the future once the it can
+  // be made more specific (when applying a `SpecificId`).
+  //
+  // Since we already ran this query above (via `EvalLookupSingleImplWitness`)
+  // we want eval to not actually do another lookup here, but we must create the
+  // instruction through eval. It takes care to bypass running lookup again for
+  // this caller.
+  auto witness_const_id = EvalOrAddInst<SemIR::LookupImplWitness>(
       context, context.insts().GetCanonicalLocId(loc_id).ToImplicit(),
-      lookup_inst);
-  CARBON_CHECK(witness_const_id.is_constant());
-  result.witness_id = context.constant_values().GetInstId(witness_const_id);
-  return result;
+      {
+          .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
+          .query_self_inst_id = canonical_self_inst_id,
+          .query_specific_interface_id =
+              context.specific_interfaces().Add(query_interface),
+      });
+  return {.witness_id = context.constant_values().GetInstId(witness_const_id),
+          .facet_type_id = lookup_result.facet_value_type()};
 }
 
 auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
@@ -630,23 +625,21 @@ static auto CollectCandidateImplsForQuery(
   return candidate_impls;
 }
 
-auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
-                                 SemIR::LookupImplWitness eval_query,
-                                 SemIR::InstId non_canonical_query_self_inst_id,
-                                 bool poison_concrete_results)
-    -> EvalImplLookupResult {
-  // NOTE: Do not retain this reference to the SpecificInterface obtained from a
-  // value store by SpecificInterfaceId. Doing impl lookup does deduce which can
-  // do more impl lookups, and impl lookup can add a new SpecificInterface to
-  // the store which can reallocate and invalidate any references held here into
-  // the store.
-  auto query_specific_interface =
-      context.specific_interfaces().Get(eval_query.query_specific_interface_id);
+auto EvalLookupSingleImplWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::InstId non_canonical_query_self_inst_id,
+    SemIR::SpecificInterface query_specific_interface,
+    bool poison_concrete_results)
+    -> std::pair<EvalImplLookupResult, SemIR::InstId> {
+  auto query_self_inst_id = GetCanonicalizedFacetOrTypeValue(
+      context, non_canonical_query_self_inst_id);
 
+  // The non-canonical self type may be a `FacetValue` which can provide a
+  // witness, so we use that instruction here.
   auto facet_lookup_result = LookupImplWitnessInSelfFacetValue(
       context, non_canonical_query_self_inst_id, query_specific_interface);
   if (facet_lookup_result.has_concrete_value()) {
-    return facet_lookup_result;
+    return {facet_lookup_result, query_self_inst_id};
   }
 
   // If the self type is a facet that provides a witness, then we are in an
@@ -664,17 +657,17 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
   bool self_facet_provides_witness = facet_lookup_result.has_value();
   if (self_facet_provides_witness) {
     if (auto bind = context.insts().TryGetAs<SemIR::BindSymbolicName>(
-            eval_query.query_self_inst_id)) {
+            query_self_inst_id)) {
       const auto& entity = context.entity_names().Get(bind->entity_name_id);
       if (entity.name_id == SemIR::NameId::PeriodSelf ||
           entity.name_id == SemIR::NameId::SelfType) {
-        return facet_lookup_result;
+        return {facet_lookup_result, query_self_inst_id};
       }
     }
   }
 
   SemIR::ConstantId query_self_const_id =
-      context.constant_values().Get(eval_query.query_self_inst_id);
+      context.constant_values().Get(query_self_inst_id);
 
   auto query_type_structure = BuildTypeStructure(
       context, context.constant_values().GetInstId(query_self_const_id),
@@ -725,12 +718,12 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
                                   context.impls().Get(candidate.impl_id))) {
         context.poisoned_concrete_impl_lookup_queries().push_back(
             {.loc_id = loc_id,
-             .query = eval_query,
              .non_canonical_query_self_inst_id =
                  non_canonical_query_self_inst_id,
+             .query_specific_interface = query_specific_interface,
              .impl_witness = result.concrete_witness()});
       }
-      return result;
+      return {result, query_self_inst_id};
     }
   }
 
@@ -738,10 +731,10 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
     // If we did not find a final impl, but the self value is a facet that
     // provides a symbolic witness, when we record that an impl will exist for
     // the specific, but is yet unknown.
-    return facet_lookup_result;
+    return {facet_lookup_result, query_self_inst_id};
   }
 
-  return EvalImplLookupResult::MakeNone();
+  return {EvalImplLookupResult::MakeNone(), query_self_inst_id};
 }
 
 auto LookupMatchesImpl(Context& context, SemIR::LocId loc_id,

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -483,26 +483,26 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
       .query_facet_type_const_id = query_facet_type_const_id,
   });
   // We need to find a witness for each interface in `interfaces`. Every
-  // consumer of a facet type needs to agree on the order of interfaces used
-  // for its witnesses.
+  // consumer of a facet type needs to agree on the order of interfaces used for
+  // its witnesses.
   llvm::SmallVector<WitnessResult> result_witnesses;
   for (const auto& interface : interfaces) {
-    // TODO: Since both `interfaces` and `query_self_const_id` are sorted
-    // lists, do an O(N+M) merge instead of O(N*M) nested loops.
+    // TODO: Since both `interfaces` and `query_self_const_id` are sorted lists,
+    // do an O(N+M) merge instead of O(N*M) nested loops.
     auto result = GetOrAddLookupImplWitness(context, loc_id,
                                             query_self_const_id, interface);
     if (result.witness_id.has_value()) {
       result_witnesses.push_back(result);
     } else {
-      // At least one queried interface in the facet type has no witness for
-      // the given type, we can stop looking for more.
+      // At least one queried interface in the facet type has no witness for the
+      // given type, we can stop looking for more.
       break;
     }
   }
   stack.pop_back();
 
-  // All interfaces in the query facet type must have been found to be
-  // available through some impl, or directly on the value's facet type if
+  // All interfaces in the query facet type must have been found to be available
+  // through some impl, or directly on the value's facet type if
   // `query_self_const_id` is a facet value.
   if (result_witnesses.size() != interfaces.size()) {
     return SemIR::InstBlockId::None;
@@ -584,8 +584,8 @@ static auto CollectCandidateImplsForQuery(
     // parameters of the impl.
     //
     // As a shortcut, if the impl's constraint is not symbolic (does not
-    // depend on any generic parameters), then we can determine whether we
-    // match by looking if the specific ids match exactly.
+    // depend on any generic parameters), then we can determine whether we match
+    // by looking if the specific ids match exactly.
     auto impl_interface_const_id =
         context.constant_values().Get(impl.constraint_id);
     if (!impl_interface_const_id.is_symbolic() &&
@@ -635,11 +635,11 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
                                  SemIR::InstId non_canonical_query_self_inst_id,
                                  bool poison_concrete_results)
     -> EvalImplLookupResult {
-  // NOTE: Do not retain this reference to the SpecificInterface obtained from
-  // a value store by SpecificInterfaceId. Doing impl lookup does deduce which
-  // can do more impl lookups, and impl lookup can add a new SpecificInterface
-  // to the store which can reallocate and invalidate any references held here
-  // into the store.
+  // NOTE: Do not retain this reference to the SpecificInterface obtained from a
+  // value store by SpecificInterfaceId. Doing impl lookup does deduce which can
+  // do more impl lookups, and impl lookup can add a new SpecificInterface to
+  // the store which can reallocate and invalidate any references held here into
+  // the store.
   auto query_specific_interface =
       context.specific_interfaces().Get(eval_query.query_specific_interface_id);
 
@@ -652,15 +652,15 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
   // If the self type is a facet that provides a witness, then we are in an
   // `interface` or an `impl`. In both cases, we don't want to do any impl
   // lookups. The query will eventually resolve to a concrete witness when it
-  // can get it from the self facet value, when it has a specific applied in
-  // the future.
+  // can get it from the self facet value, when it has a specific applied in the
+  // future.
   //
   // In particular, this avoids a LookupImplWitness instruction in the eval
   // block of an impl declaration from doing impl lookup. Specifically the
-  // lookup of the implicit .Self in `impl ... where .X`. If it does impl
-  // lookup when the eval block is run, it finds the same `impl`, tries to
-  // build a specific from it, which runs the eval block, creating a recursive
-  // loop that crashes.
+  // lookup of the implicit .Self in `impl ... where .X`. If it does impl lookup
+  // when the eval block is run, it finds the same `impl`, tries to build a
+  // specific from it, which runs the eval block, creating a recursive loop that
+  // crashes.
   bool self_facet_provides_witness = facet_lookup_result.has_value();
   if (self_facet_provides_witness) {
     if (auto bind = context.insts().TryGetAs<SemIR::BindSymbolicName>(
@@ -682,16 +682,16 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
   bool query_is_concrete =
       QueryIsConcrete(context, query_self_const_id, query_specific_interface);
 
-  // If we have a symbolic witness in the self query, then the query can not
-  // be concrete: the query includes a symbolic self value.
+  // If we have a symbolic witness in the self query, then the query can not be
+  // concrete: the query includes a symbolic self value.
   CARBON_CHECK(!self_facet_provides_witness || !query_is_concrete);
 
-  // If the self value is a (symbolic) facet value that has a symbolic
-  // witness, then we don't need to do impl lookup, except that we want to
-  // find any final impls to return a concrete witness if possible. So we
-  // limit the query to final impls only in that case. Note as in the CHECK
-  // above, the query can not be concrete in this case, so only final impls
-  // can produce a concrete witness for this query.
+  // If the self value is a (symbolic) facet value that has a symbolic witness,
+  // then we don't need to do impl lookup, except that we want to find any final
+  // impls to return a concrete witness if possible. So we limit the query to
+  // final impls only in that case. Note as in the CHECK above, the query can
+  // not be concrete in this case, so only final impls can produce a concrete
+  // witness for this query.
   auto candidate_impls = CollectCandidateImplsForQuery(
       context, self_facet_provides_witness, query_type_structure,
       query_specific_interface);
@@ -717,9 +717,9 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
       // Record the query which found a concrete impl witness. It's illegal to
       // write a final impl afterward that would match the same query.
       //
-      // If the impl was effectively final, then we don't need to poison here.
-      // A change of query result will already be diagnosed at the point where
-      // the new impl decl was written that changes the result.
+      // If the impl was effectively final, then we don't need to poison here. A
+      // change of query result will already be diagnosed at the point where the
+      // new impl decl was written that changes the result.
       if (poison_concrete_results && result.has_concrete_value() &&
           !IsImplEffectivelyFinal(context,
                                   context.impls().Get(candidate.impl_id))) {

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -389,6 +389,9 @@ static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
       .facet_type_id = SemIR::FacetTypeId::None,
   };
 
+  // TODO: This is repeating the implementation of EvalConstantInst. Can we
+  // share even more code?
+
   auto lookup_inst = SemIR::LookupImplWitness{
       .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
       .query_self_inst_id =

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -405,17 +405,20 @@ static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
   // be made more specific (when applying a `SpecificId`).
   //
   // Since we already ran this query above (via `EvalLookupSingleImplWitness`)
-  // we want eval to not actually do another lookup here, but we must create the
-  // instruction through eval. It takes care to bypass running lookup again for
-  // this caller.
-  auto witness_const_id = AddInstWithoutEval<SemIR::LookupImplWitness>(
-      context, context.insts().GetCanonicalLocId(loc_id).ToImplicit(),
-      {
-          .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
-          .query_self_inst_id = canonical_self_inst_id,
-          .query_specific_interface_id =
-              context.specific_interfaces().Add(query_interface),
-      });
+  // we want eval to not actually do another lookup here. As we know the
+  // instruction would evaluate to itself in this case, it is a reduced constant
+  // instruction and we use `AddReducedConstantWithoutEval` to keep eval from
+  // performing a redundant impl lookup.
+  auto witness_const_id =
+      AddReducedConstantWithoutEval<SemIR::LookupImplWitness>(
+          context, context.insts().GetCanonicalLocId(loc_id).ToImplicit(),
+          {
+              .type_id =
+                  GetSingletonType(context, SemIR::WitnessType::TypeInstId),
+              .query_self_inst_id = canonical_self_inst_id,
+              .query_specific_interface_id =
+                  context.specific_interfaces().Add(query_interface),
+          });
   return {.witness_id = context.constant_values().GetInstId(witness_const_id),
           .facet_type_id = lookup_result.facet_value_type()};
 }

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -13,6 +13,7 @@
 #include "toolchain/check/deduce.h"
 #include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/eval.h"
+#include "toolchain/check/facet_type.h"
 #include "toolchain/check/generic.h"
 #include "toolchain/check/impl.h"
 #include "toolchain/check/import_ref.h"
@@ -302,7 +303,7 @@ static auto GetWitnessIdForImpl(Context& context, SemIR::LocId loc_id,
         context.constant_values().GetInstId(SemIR::GetConstantValueInSpecific(
             context.sem_ir(), specific_id, witness_id)));
   } else {
-    return EvalImplLookupResult::MakeNonFinal();
+    return EvalImplLookupResult::MakeNonFinalImpl();
   }
 }
 
@@ -361,8 +362,17 @@ static auto LookupImplWitnessInSelfFacetValue(
       return EvalImplLookupResult::MakeFinal(witness_id);
     }
   }
-  return EvalImplLookupResult::MakeNonFinal();
+  return EvalImplLookupResult::MakeNonFinalFacetValue(
+      facet_type->facet_type_id);
 }
+
+struct WitnessResult {
+  // Either a concrete `ImplWitness` or a symbolic `LookupImplWitness`.
+  SemIR::InstId witness_id;
+  // If the witness is not concrete, and was found through a facet value, this
+  // is the `FacetType` info from the type of that facet value.
+  SemIR::FacetTypeId facet_type_id;
+};
 
 // Begin a search for an impl declaration matching the query. We do this by
 // creating an LookupImplWitness instruction and evaluating. If it's able to
@@ -373,22 +383,43 @@ static auto LookupImplWitnessInSelfFacetValue(
 static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
                                       SemIR::ConstantId query_self_const_id,
                                       SemIR::SpecificInterface interface)
-    -> SemIR::InstId {
+    -> WitnessResult {
+  auto result = WitnessResult{
+      .witness_id = SemIR::InstId::None,
+      .facet_type_id = SemIR::FacetTypeId::None,
+  };
+
+  auto lookup_inst = SemIR::LookupImplWitness{
+      .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
+      .query_self_inst_id =
+          context.constant_values().GetInstId(query_self_const_id),
+      .query_specific_interface_id =
+          context.specific_interfaces().Add(interface),
+  };
+  auto non_canon = lookup_inst.query_self_inst_id;
+  lookup_inst.query_self_inst_id =
+      GetCanonicalizedFacetOrTypeValue(context, lookup_inst.query_self_inst_id);
+
+  auto lookup_result =
+      EvalLookupSingleImplWitness(context, loc_id, lookup_inst, non_canon,
+                                  /*poison_concrete_results=*/true);
+  if (!lookup_result.has_value()) {
+    return result;
+  }
+  if (lookup_result.has_concrete_value()) {
+    result.witness_id = lookup_result.concrete_witness();
+    return result;
+  }
+  if (lookup_result.has_facet_type_value()) {
+    result.facet_type_id = lookup_result.facet_value_type();
+  }
+
   auto witness_const_id = EvalOrAddInst(
       context, context.insts().GetCanonicalLocId(loc_id).ToImplicit(),
-      SemIR::LookupImplWitness{
-          .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
-          .query_self_inst_id =
-              context.constant_values().GetInstId(query_self_const_id),
-          .query_specific_interface_id =
-              context.specific_interfaces().Add(interface),
-      });
-  // We use a NotConstant result from eval to communicate back an impl
-  // lookup failure. See `EvalConstantInst()` for `LookupImplWitness`.
-  if (!witness_const_id.is_constant()) {
-    return SemIR::InstId::None;
-  }
-  return context.constant_values().GetInstId(witness_const_id);
+      lookup_inst);
+  CARBON_CHECK(witness_const_id.is_constant());
+  result.witness_id = context.constant_values().GetInstId(witness_const_id);
+  return result;
 }
 
 auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
@@ -449,34 +480,52 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
       .query_facet_type_const_id = query_facet_type_const_id,
   });
   // We need to find a witness for each interface in `interfaces`. Every
-  // consumer of a facet type needs to agree on the order of interfaces used for
-  // its witnesses.
-  llvm::SmallVector<SemIR::InstId> result_witness_ids;
+  // consumer of a facet type needs to agree on the order of interfaces used
+  // for its witnesses.
+  llvm::SmallVector<WitnessResult> result_witnesses;
   for (const auto& interface : interfaces) {
-    // TODO: Since both `interfaces` and `query_self_const_id` are sorted lists,
-    // do an O(N+M) merge instead of O(N*M) nested loops.
-    auto result_witness_id = GetOrAddLookupImplWitness(
-        context, loc_id, query_self_const_id, interface);
-    if (result_witness_id.has_value()) {
-      result_witness_ids.push_back(result_witness_id);
+    // TODO: Since both `interfaces` and `query_self_const_id` are sorted
+    // lists, do an O(N+M) merge instead of O(N*M) nested loops.
+    auto result = GetOrAddLookupImplWitness(context, loc_id,
+                                            query_self_const_id, interface);
+    if (result.witness_id.has_value()) {
+      result_witnesses.push_back(result);
     } else {
-      // At least one queried interface in the facet type has no witness for the
-      // given type, we can stop looking for more.
+      // At least one queried interface in the facet type has no witness for
+      // the given type, we can stop looking for more.
       break;
     }
   }
   stack.pop_back();
 
-  // All interfaces in the query facet type must have been found to be available
-  // through some impl, or directly on the value's facet type if
+  // All interfaces in the query facet type must have been found to be
+  // available through some impl, or directly on the value's facet type if
   // `query_self_const_id` is a facet value.
-  if (result_witness_ids.size() != interfaces.size()) {
+  if (result_witnesses.size() != interfaces.size()) {
+    return SemIR::InstBlockId::None;
+  }
+
+  auto requirement_facet_type = context.insts().GetAs<SemIR::FacetType>(
+      context.constant_values().GetInstId(query_facet_type_const_id));
+  llvm::SmallVector<RewriteSource> rewrites;
+  rewrites.reserve(result_witnesses.size());
+  for (auto& result : result_witnesses) {
+    if (context.insts().Is<SemIR::ImplWitness>(result.witness_id)) {
+      rewrites.push_back(result.witness_id);
+    } else if (result.facet_type_id.has_value()) {
+      rewrites.push_back(result.facet_type_id);
+    }
+  };
+  if (!CheckRewriteConstraintsMatchRequirements(
+          context, requirement_facet_type.facet_type_id, rewrites)) {
     return SemIR::InstBlockId::None;
   }
 
   // TODO: Validate that the witness satisfies the other requirements in
   // `interface_const_id`.
 
+  llvm::SmallVector<SemIR::InstId> result_witness_ids(llvm::map_range(
+      result_witnesses, [](auto& result) { return result.witness_id; }));
   return context.inst_blocks().AddCanonical(result_witness_ids);
 }
 
@@ -532,8 +581,8 @@ static auto CollectCandidateImplsForQuery(
     // parameters of the impl.
     //
     // As a shortcut, if the impl's constraint is not symbolic (does not
-    // depend on any generic parameters), then we can determine whether we match
-    // by looking if the specific ids match exactly.
+    // depend on any generic parameters), then we can determine whether we
+    // match by looking if the specific ids match exactly.
     auto impl_interface_const_id =
         context.constant_values().Get(impl.constraint_id);
     if (!impl_interface_const_id.is_symbolic() &&
@@ -583,11 +632,11 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
                                  SemIR::InstId non_canonical_query_self_inst_id,
                                  bool poison_concrete_results)
     -> EvalImplLookupResult {
-  // NOTE: Do not retain this reference to the SpecificInterface obtained from a
-  // value store by SpecificInterfaceId. Doing impl lookup does deduce which can
-  // do more impl lookups, and impl lookup can add a new SpecificInterface to
-  // the store which can reallocate and invalidate any references held here into
-  // the store.
+  // NOTE: Do not retain this reference to the SpecificInterface obtained from
+  // a value store by SpecificInterfaceId. Doing impl lookup does deduce which
+  // can do more impl lookups, and impl lookup can add a new SpecificInterface
+  // to the store which can reallocate and invalidate any references held here
+  // into the store.
   auto query_specific_interface =
       context.specific_interfaces().Get(eval_query.query_specific_interface_id);
 
@@ -600,15 +649,15 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
   // If the self type is a facet that provides a witness, then we are in an
   // `interface` or an `impl`. In both cases, we don't want to do any impl
   // lookups. The query will eventually resolve to a concrete witness when it
-  // can get it from the self facet value, when it has a specific applied in the
-  // future.
+  // can get it from the self facet value, when it has a specific applied in
+  // the future.
   //
   // In particular, this avoids a LookupImplWitness instruction in the eval
   // block of an impl declaration from doing impl lookup. Specifically the
-  // lookup of the implicit .Self in `impl ... where .X`. If it does impl lookup
-  // when the eval block is run, it finds the same `impl`, tries to build a
-  // specific from it, which runs the eval block, creating a recursive loop that
-  // crashes.
+  // lookup of the implicit .Self in `impl ... where .X`. If it does impl
+  // lookup when the eval block is run, it finds the same `impl`, tries to
+  // build a specific from it, which runs the eval block, creating a recursive
+  // loop that crashes.
   bool self_facet_provides_witness = facet_lookup_result.has_value();
   if (self_facet_provides_witness) {
     if (auto bind = context.insts().TryGetAs<SemIR::BindSymbolicName>(
@@ -616,7 +665,7 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
       const auto& entity = context.entity_names().Get(bind->entity_name_id);
       if (entity.name_id == SemIR::NameId::PeriodSelf ||
           entity.name_id == SemIR::NameId::SelfType) {
-        return EvalImplLookupResult::MakeNonFinal();
+        return facet_lookup_result;
       }
     }
   }
@@ -630,16 +679,16 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
   bool query_is_concrete =
       QueryIsConcrete(context, query_self_const_id, query_specific_interface);
 
-  // If we have a symbolic witness in the self query, then the query can not be
-  // concrete: the query includes a symbolic self value.
+  // If we have a symbolic witness in the self query, then the query can not
+  // be concrete: the query includes a symbolic self value.
   CARBON_CHECK(!self_facet_provides_witness || !query_is_concrete);
 
-  // If the self value is a (symbolic) facet value that has a symbolic witness,
-  // then we don't need to do impl lookup, except that we want to find any final
-  // impls to return a concrete witness if possible. So we limit the query to
-  // final impls only in that case. Note as in the CHECK above, the query can
-  // not be concrete in this case, so only final impls can produce a concrete
-  // witness for this query.
+  // If the self value is a (symbolic) facet value that has a symbolic
+  // witness, then we don't need to do impl lookup, except that we want to
+  // find any final impls to return a concrete witness if possible. So we
+  // limit the query to final impls only in that case. Note as in the CHECK
+  // above, the query can not be concrete in this case, so only final impls
+  // can produce a concrete witness for this query.
   auto candidate_impls = CollectCandidateImplsForQuery(
       context, self_facet_provides_witness, query_type_structure,
       query_specific_interface);
@@ -665,9 +714,9 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
       // Record the query which found a concrete impl witness. It's illegal to
       // write a final impl afterward that would match the same query.
       //
-      // If the impl was effectively final, then we don't need to poison here. A
-      // change of query result will already be diagnosed at the point where the
-      // new impl decl was written that changes the result.
+      // If the impl was effectively final, then we don't need to poison here.
+      // A change of query result will already be diagnosed at the point where
+      // the new impl decl was written that changes the result.
       if (poison_concrete_results && result.has_concrete_value() &&
           !IsImplEffectivelyFinal(context,
                                   context.impls().Get(candidate.impl_id))) {
@@ -686,7 +735,7 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
     // If we did not find a final impl, but the self value is a facet that
     // provides a symbolic witness, when we record that an impl will exist for
     // the specific, but is yet unknown.
-    return EvalImplLookupResult::MakeNonFinal();
+    return facet_lookup_result;
   }
 
   return EvalImplLookupResult::MakeNone();

--- a/toolchain/check/impl_lookup.h
+++ b/toolchain/check/impl_lookup.h
@@ -62,8 +62,13 @@ class [[nodiscard]] EvalImplLookupResult {
   static auto MakeFinal(SemIR::InstId inst_id) -> EvalImplLookupResult {
     return EvalImplLookupResult(inst_id);
   }
-  static auto MakeNonFinal() -> EvalImplLookupResult {
+  static auto MakeNonFinalImpl() -> EvalImplLookupResult {
     return EvalImplLookupResult(FoundNonFinalImpl());
+  }
+  static auto MakeNonFinalFacetValue(SemIR::FacetTypeId facet_type_id)
+      -> EvalImplLookupResult {
+    CARBON_CHECK(facet_type_id.has_value());
+    return EvalImplLookupResult(facet_type_id);
   }
 
   // True if a concrete impl witness was found or a non-final impl. In the
@@ -71,6 +76,7 @@ class [[nodiscard]] EvalImplLookupResult {
   // that it exists.
   auto has_value() const -> bool {
     return std::holds_alternative<FoundNonFinalImpl>(result_) ||
+           std::holds_alternative<SemIR::FacetTypeId>(result_) ||
            std::get<SemIR::InstId>(result_).has_value();
   }
 
@@ -88,13 +94,27 @@ class [[nodiscard]] EvalImplLookupResult {
     return std::get<SemIR::InstId>(result_);
   }
 
+  // True if there is a non-concrete witness in the result which was derived
+  // from a facet value. A non-final impl was found and a further more specific
+  // query will need to be done, but the `FacetType` can be observed to
+  // determine constraints written on it.
+  auto has_facet_type_value() const -> bool {
+    return std::holds_alternative<SemIR::FacetTypeId>(result_);
+  }
+
+  auto facet_value_type() const -> SemIR::FacetTypeId {
+    return std::get<SemIR::FacetTypeId>(result_);
+  }
+
  private:
   struct FoundNonFinalImpl {};
 
   explicit EvalImplLookupResult(SemIR::InstId inst_id) : result_(inst_id) {}
+  explicit EvalImplLookupResult(SemIR::FacetTypeId facet_type_id)
+      : result_(facet_type_id) {}
   explicit EvalImplLookupResult(FoundNonFinalImpl f) : result_(f) {}
 
-  std::variant<SemIR::InstId, FoundNonFinalImpl> result_;
+  std::variant<SemIR::InstId, FoundNonFinalImpl, SemIR::FacetTypeId> result_;
 };
 
 // Looks for a witness instruction of an impl declaration for a query consisting

--- a/toolchain/check/impl_lookup.h
+++ b/toolchain/check/impl_lookup.h
@@ -63,7 +63,7 @@ class [[nodiscard]] EvalImplLookupResult {
     return EvalImplLookupResult(inst_id);
   }
   static auto MakeNonFinalImpl() -> EvalImplLookupResult {
-    return EvalImplLookupResult(FoundNonFinalImpl());
+    return EvalImplLookupResult(SemIR::FacetTypeId::None);
   }
   static auto MakeNonFinalFacetValue(SemIR::FacetTypeId facet_type_id)
       -> EvalImplLookupResult {
@@ -73,10 +73,10 @@ class [[nodiscard]] EvalImplLookupResult {
 
   // True if a concrete impl witness was found or a non-final impl. In the
   // latter case the InstId of the impl's witness is not returned, only the fact
-  // that it exists.
+  // that it exists, and possibly a `FacetTypeId` if the witness was obtained
+  // from a facet value.
   auto has_value() const -> bool {
-    return std::holds_alternative<FoundNonFinalImpl>(result_) ||
-           std::holds_alternative<SemIR::FacetTypeId>(result_) ||
+    return std::holds_alternative<SemIR::FacetTypeId>(result_) ||
            std::get<SemIR::InstId>(result_).has_value();
   }
 
@@ -94,27 +94,21 @@ class [[nodiscard]] EvalImplLookupResult {
     return std::get<SemIR::InstId>(result_);
   }
 
-  // True if there is a non-concrete witness in the result which was derived
-  // from a facet value. A non-final impl was found and a further more specific
-  // query will need to be done, but the `FacetType` can be observed to
-  // determine constraints written on it.
-  auto has_facet_type_value() const -> bool {
-    return std::holds_alternative<SemIR::FacetTypeId>(result_);
-  }
-
+  // Only valid if `has_concrete_value()` is false. Returns the FacetTypeId for
+  // the facet from which a non-concrete witness was found, if any.
   auto facet_value_type() const -> SemIR::FacetTypeId {
     return std::get<SemIR::FacetTypeId>(result_);
   }
 
  private:
-  struct FoundNonFinalImpl {};
-
   explicit EvalImplLookupResult(SemIR::InstId inst_id) : result_(inst_id) {}
   explicit EvalImplLookupResult(SemIR::FacetTypeId facet_type_id)
       : result_(facet_type_id) {}
-  explicit EvalImplLookupResult(FoundNonFinalImpl f) : result_(f) {}
 
-  std::variant<SemIR::InstId, FoundNonFinalImpl, SemIR::FacetTypeId> result_;
+  // - If FacetTypeId is active, it means a non-concrete witness was found.
+  // - If InstId is active but None, is means no witness was found.
+  // - If InstId is active and not None, it means a concrete witness was found.
+  std::variant<SemIR::InstId, SemIR::FacetTypeId> result_;
 };
 
 // Looks for a witness instruction of an impl declaration for a query consisting
@@ -122,11 +116,16 @@ class [[nodiscard]] EvalImplLookupResult {
 // execute lookup via the LookupImplWitness instruction. It does not consider
 // the self facet value for finding a witness, since LookupImplWitness() would
 // have found that and not caused us to defer lookup to here.
-auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
-                                 SemIR::LookupImplWitness eval_query,
-                                 SemIR::InstId non_canonical_query_self_inst_id,
-                                 bool poison_concrete_results)
-    -> EvalImplLookupResult;
+//
+// Returns with the lookup result the canonicalized query self instruction,
+// which is to be stored in the `LookupImplWitness` instruction to make it
+// canonical.
+auto EvalLookupSingleImplWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::InstId non_canonical_query_self_inst_id,
+    SemIR::SpecificInterface query_specific_interface,
+    bool poison_concrete_results)
+    -> std::pair<EvalImplLookupResult, SemIR::InstId>;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/inst.cpp
+++ b/toolchain/check/inst.cpp
@@ -222,7 +222,8 @@ auto EvalOrAddInst(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
   }
 }
 
-auto AddInstWithoutEval(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
+auto AddReducedConstantWithoutEval(Context& context,
+                                   SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::ConstantId {
   CARBON_CHECK(!loc_id_and_inst.inst.kind().has_cleanup());
   switch (loc_id_and_inst.inst.kind().constant_needs_inst_id()) {

--- a/toolchain/check/inst.cpp
+++ b/toolchain/check/inst.cpp
@@ -14,10 +14,18 @@
 
 namespace Carbon::Check {
 
+namespace {
+enum WithOrWithoutEval {
+  WithEval,
+  WithoutEval,
+};
+}
+
 // Finish producing an instruction. Set its constant value, and register it in
 // any applicable instruction lists.
 static auto FinishInst(Context& context, SemIR::InstId inst_id,
-                       SemIR::Inst inst) -> void {
+                       SemIR::Inst inst, WithOrWithoutEval eval = WithEval)
+    -> void {
   DependentInst::Kind dep_kind = DependentInst::None;
 
   // If the instruction has a symbolic constant type, track that we need to
@@ -28,7 +36,15 @@ static auto FinishInst(Context& context, SemIR::InstId inst_id,
   }
 
   // If the instruction has a constant value, compute it.
-  auto const_id = TryEvalInstUnsafe(context, inst_id, inst);
+  auto const_id = SemIR::ConstantId::None;
+  switch (eval) {
+    case WithEval:
+      const_id = TryEvalInstUnsafe(context, inst_id, inst);
+      break;
+    case WithoutEval:
+      const_id = AddImportedConstant(context, inst);
+      break;
+  }
   context.constant_values().Set(inst_id, const_id);
   if (const_id.is_constant()) {
     CARBON_VLOG_TO(context.vlog_stream(), "Constant: {0} -> {1}\n", inst,
@@ -54,19 +70,32 @@ static auto FinishInst(Context& context, SemIR::InstId inst_id,
   }
 }
 
-auto AddInst(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
-    -> SemIR::InstId {
-  auto inst_id = AddInstInNoBlock(context, loc_id_and_inst);
+static auto AddInstInNoBlockWithOptionalEval(
+    Context& context, SemIR::LocIdAndInst loc_id_and_inst,
+    WithOrWithoutEval eval) -> SemIR::InstId {
+  auto inst_id = context.sem_ir().insts().AddInNoBlock(loc_id_and_inst);
+  CARBON_VLOG_TO(context.vlog_stream(), "AddInst: {0}\n", loc_id_and_inst.inst);
+  FinishInst(context, inst_id, loc_id_and_inst.inst, eval);
+  return inst_id;
+}
+
+static auto AddInstWithOptionalEval(Context& context,
+                                    SemIR::LocIdAndInst loc_id_and_inst,
+                                    WithOrWithoutEval eval) -> SemIR::InstId {
+  auto inst_id =
+      AddInstInNoBlockWithOptionalEval(context, loc_id_and_inst, eval);
   context.inst_block_stack().AddInstId(inst_id);
   return inst_id;
 }
 
+auto AddInst(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
+    -> SemIR::InstId {
+  return AddInstWithOptionalEval(context, loc_id_and_inst, WithEval);
+}
+
 auto AddInstInNoBlock(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::InstId {
-  auto inst_id = context.sem_ir().insts().AddInNoBlock(loc_id_and_inst);
-  CARBON_VLOG_TO(context.vlog_stream(), "AddInst: {0}\n", loc_id_and_inst.inst);
-  FinishInst(context, inst_id, loc_id_and_inst.inst);
-  return inst_id;
+  return AddInstInNoBlockWithOptionalEval(context, loc_id_and_inst, WithEval);
 }
 
 auto AddDependentActionInst(Context& context,
@@ -188,6 +217,32 @@ auto EvalOrAddInst(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
     case SemIR::InstConstantNeedsInstIdKind::Permanent: {
       // Evaluation needs a permanent InstId. Add the instruction.
       auto inst_id = AddInst(context, loc_id_and_inst);
+      return context.constant_values().Get(inst_id);
+    }
+  }
+}
+
+auto AddInstWithoutEval(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
+    -> SemIR::ConstantId {
+  CARBON_CHECK(!loc_id_and_inst.inst.kind().has_cleanup());
+  switch (loc_id_and_inst.inst.kind().constant_needs_inst_id()) {
+    case SemIR::InstConstantNeedsInstIdKind::No: {
+      return AddImportedConstant(context, loc_id_and_inst.inst);
+    }
+
+    case SemIR::InstConstantNeedsInstIdKind::DuringEvaluation: {
+      // Evaluation temporarily needs an InstId. Add one for now.
+      auto inst_id = AddInstInNoBlockWithOptionalEval(context, loc_id_and_inst,
+                                                      WithoutEval);
+      // TODO: Consider removing `inst_id` from `insts` if it's still the most
+      // recently added instruction.
+      return context.constant_values().Get(inst_id);
+    }
+
+    case SemIR::InstConstantNeedsInstIdKind::Permanent: {
+      // Evaluation needs a permanent InstId. Add the instruction.
+      auto inst_id =
+          AddInstWithOptionalEval(context, loc_id_and_inst, WithoutEval);
       return context.constant_values().Get(inst_id);
     }
   }

--- a/toolchain/check/inst.h
+++ b/toolchain/check/inst.h
@@ -100,18 +100,23 @@ auto EvalOrAddInst(Context& context, LocT loc, InstT inst)
 // Add an instruction and return its constant value by canonicalizing it but
 // without evaluating the instruction. The instruction will need to be evaluated
 // later to have any effect.
-auto AddInstWithoutEval(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
+//
+// The caller must provide a "reduced" instruction, that is an instruction which
+// will have its operands canonicalized but that it knows will otherwise be a
+// no-op during eval, producing the same instruction as the result.
+auto AddReducedConstantWithoutEval(Context& context,
+                                   SemIR::LocIdAndInst loc_id_and_inst)
     -> SemIR::ConstantId;
 
-// Convenience for AddInstWithoutEval with typed nodes.
+// Convenience for AddReducedConstantWithoutEval with typed nodes.
 //
 // As a safety check, prevent use with storage insts (see `AddInstWithCleanup`).
 template <typename InstT, typename LocT>
   requires(!InstT::Kind.has_cleanup() &&
            std::convertible_to<LocT, SemIR::LocId>)
-auto AddInstWithoutEval(Context& context, LocT loc, InstT inst)
+auto AddReducedConstantWithoutEval(Context& context, LocT loc, InstT inst)
     -> SemIR::ConstantId {
-  return AddInstWithoutEval(context, SemIR::LocIdAndInst(loc, inst));
+  return AddReducedConstantWithoutEval(context, SemIR::LocIdAndInst(loc, inst));
 }
 
 // Adds an instruction and enqueues it to be added to the eval block of the

--- a/toolchain/check/inst.h
+++ b/toolchain/check/inst.h
@@ -97,6 +97,23 @@ auto EvalOrAddInst(Context& context, LocT loc, InstT inst)
   return EvalOrAddInst(context, SemIR::LocIdAndInst(loc, inst));
 }
 
+// Add an instruction and return its constant value by canonicalizing it but
+// without evaluating the instruction. The instruction will need to be evaluated
+// later to have any effect.
+auto AddInstWithoutEval(Context& context, SemIR::LocIdAndInst loc_id_and_inst)
+    -> SemIR::ConstantId;
+
+// Convenience for AddInstWithoutEval with typed nodes.
+//
+// As a safety check, prevent use with storage insts (see `AddInstWithCleanup`).
+template <typename InstT, typename LocT>
+  requires(!InstT::Kind.has_cleanup() &&
+           std::convertible_to<LocT, SemIR::LocId>)
+auto AddInstWithoutEval(Context& context, LocT loc, InstT inst)
+    -> SemIR::ConstantId {
+  return AddInstWithoutEval(context, SemIR::LocIdAndInst(loc, inst));
+}
+
 // Adds an instruction and enqueues it to be added to the eval block of the
 // enclosing generic, returning the produced ID. The instruction is expected to
 // be a dependent template instantiation action.

--- a/toolchain/check/testdata/facet/min_prelude/facet_assoc_const.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/facet_assoc_const.carbon
@@ -1,0 +1,176 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/min_prelude/facet_assoc_const.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/min_prelude/facet_assoc_const.carbon
+
+// --- success.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let T:! type; }
+
+fn F(T:! I where .T = {}) {}
+
+// --- success_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let T:! type; let U:! type; }
+
+fn F(T:! I where .T = .U) {}
+
+// --- todo_fail_two_different.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+fn F(T:! L where .W = {} and .W = ()) {}
+
+// --- todo_fail_two_different_first_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; let X:! type; }
+
+fn F(T:! L where .W = .X and .W = ()) {}
+
+// --- todo_fail_two_different_second_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; let X:! type; }
+
+fn F(T:! L where .W = () and .W = .X) {}
+
+// --- fail_two_different_first_bad.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+// CHECK:STDERR: fail_two_different_first_bad.carbon:[[@LINE+4]]:23: error: name `BAD5` not found [NameNotFound]
+// CHECK:STDERR: fn F(T:! L where .W = BAD5 and .W = ()) {}
+// CHECK:STDERR:                       ^~~~
+// CHECK:STDERR:
+fn F(T:! L where .W = BAD5 and .W = ()) {}
+
+// --- fail_two_different_second_bad.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+// CHECK:STDERR: fail_two_different_second_bad.carbon:[[@LINE+4]]:35: error: name `BAD6` not found [NameNotFound]
+// CHECK:STDERR: fn F(T:! L where .W = {} and .W = BAD6) {}
+// CHECK:STDERR:                                   ^~~~
+// CHECK:STDERR:
+fn F(T:! L where .W = {} and .W = BAD6) {}
+
+// --- fail_two_different_both_bad.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+// CHECK:STDERR: fail_two_different_both_bad.carbon:[[@LINE+8]]:23: error: name `BAD7` not found [NameNotFound]
+// CHECK:STDERR: fn F(T:! L where .W = BAD7 and .W = BAD8) {}
+// CHECK:STDERR:                       ^~~~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_two_different_both_bad.carbon:[[@LINE+4]]:37: error: name `BAD8` not found [NameNotFound]
+// CHECK:STDERR: fn F(T:! L where .W = BAD7 and .W = BAD8) {}
+// CHECK:STDERR:                                     ^~~~
+// CHECK:STDERR:
+fn F(T:! L where .W = BAD7 and .W = BAD8) {}
+
+// --- todo_fail_two_different_combined_from_bitand.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+fn F(T:! (L where .W = {}) & (L where .W = ())) {}
+
+// --- two_different_combined_from_impl_and_facet.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+impl forall [T:! M] T as L where .W = () {}
+
+fn F(T:! M & (L where .W = {})) {}
+
+class C;
+impl C as L where .W = {} {}
+impl C as M {}
+
+fn G() {
+  F(C);
+}
+
+// --- todo_fail_two_different_combined_from_final_impl_and_facet.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+fn F(T:! M & (L where .W = {})) {}
+
+// --- repeated.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; }
+
+fn F(T:! M where .X = {} and .X = {}) {}
+
+fn G(T:! M where .X = {}) {
+  F(T);
+}
+
+// --- repeated_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; let Y:! type; }
+
+fn F(T:! M where .X = .Y and .X = .Y) {}
+
+fn G(T:! M where .X = () and .Y = ()) {
+  F(T);
+}
+
+// --- todo_fail_cycle.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; let Y:! type; }
+
+// TODO: This should fail, since there's no canonical form for .X or .Y.
+fn F(T:! M where .X = .Y and .Y = .X) {}
+
+// --- non-type.carbon
+library "[[@TEST_NAME]]";
+
+interface N {
+  let Y:! {.a: {}};
+}
+
+fn F(T:! N where .Y = {.a = {}}) { }
+
+// --- non-type_repeated.carbon
+library "[[@TEST_NAME]]";
+
+interface N {
+  let Y:! {.a: {}};
+}
+
+fn F(T:! N where .Y = {.a = {}} and .Y = {.a = {}}) { }
+
+// --- todo_fail_non-type_different.carbon
+library "[[@TEST_NAME]]";
+
+interface N {
+  let Y:! {.a: type};
+}
+
+fn F(T:! N where .Y = {.a = {}} and .Y = {.a = ()}) {}

--- a/toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
@@ -1,0 +1,405 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
+
+// --- facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+fn F(T:! I where .X = ()) {}
+
+fn G(T:! I where .X = ()) {
+  F(T);
+}
+
+// --- generic_interface_facet_value.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! type) { let X:! type; }
+
+class C;
+final impl forall [T:! type] T as I(()) where .X = () {}
+final impl forall [T:! type] T as I({}) where .X = {} {}
+
+fn F(U:! type, T:! I(U) where .X = ()) {}
+fn G() {
+  F((), C);
+}
+
+// --- fail_generic_interface_facet_value_wrong_specific_impl.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! type) { let X:! type; }
+
+class C;
+final impl forall [T:! type] T as I(()) where .X = () {}
+final impl forall [T:! type] T as I({}) where .X = {} {}
+
+fn F(U:! type, T:! I(U) where .X = ()) {}
+fn G() {
+  // This finds the impl where `.X = {}`, but F requires that `.X = ()`.
+  //
+  // CHECK:STDERR: fail_generic_interface_facet_value_wrong_specific_impl.carbon:[[@LINE+7]]:3: error: cannot convert type `C` into type implementing `I({}) where .(I({}).X) = ()` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   F({}, C);
+  // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR: fail_generic_interface_facet_value_wrong_specific_impl.carbon:[[@LINE-7]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+  // CHECK:STDERR: fn F(U:! type, T:! I(U) where .X = ()) {}
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  F({}, C);
+}
+
+// --- dependent_rules.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+interface J { let Y:! type; }
+
+fn F(T:! I & J where .X = .Y) {
+  // Allowed since `T impls I`, `T impls J`, and has constraint providing
+  // T.(I.X) = T.(J.Y)`.
+  F(T);
+}
+
+// --- fail_todo_dependent_rules_compound.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+interface J { let Y:! type; }
+
+// CHECK:STDERR: fail_todo_dependent_rules_compound.carbon:[[@LINE+8]]:23: error: expected identifier or `Self` after `.` [ExpectedIdentifierOrSelfAfterPeriod]
+// CHECK:STDERR: fn F(T:! I & J where .(I.X) = .(J.Y)) {
+// CHECK:STDERR:                       ^
+// CHECK:STDERR:
+// CHECK:STDERR: fail_todo_dependent_rules_compound.carbon:[[@LINE+4]]:23: error: semantics TODO: `handle invalid parse trees in `check`` [SemanticsTodo]
+// CHECK:STDERR: fn F(T:! I & J where .(I.X) = .(J.Y)) {
+// CHECK:STDERR:                       ^
+// CHECK:STDERR:
+fn F(T:! I & J where .(I.X) = .(J.Y)) {
+  // Allowed since `T impls I`, `T impls J`, and has constraint providing
+  // T.(I.X) = T.(J.Y)`.
+  F(T);
+}
+
+// --- parameterized_interface.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! type) { let X:! type; }
+
+final impl forall [J:! I(())] J as I({}) where .X = {} {}
+
+fn F(T:! I({}) where .X = {}) {}
+
+fn G(T:! I(()) where .X = ()) {
+  F(T);
+}
+
+// --- fail_todo_parameterized_interface_compound.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! type) { let X:! type; }
+
+final impl forall [J:! I(())] J as I({}) where .X = {} {}
+
+// CHECK:STDERR: fail_todo_parameterized_interface_compound.carbon:[[@LINE+8]]:31: error: expected identifier or `Self` after `.` [ExpectedIdentifierOrSelfAfterPeriod]
+// CHECK:STDERR: fn F(T:! I(()) & I({}) where .(I(()).X) = () and .(I({}).X) = {}) {}
+// CHECK:STDERR:                               ^
+// CHECK:STDERR:
+// CHECK:STDERR: fail_todo_parameterized_interface_compound.carbon:[[@LINE+4]]:31: error: semantics TODO: `handle invalid parse trees in `check`` [SemanticsTodo]
+// CHECK:STDERR: fn F(T:! I(()) & I({}) where .(I(()).X) = () and .(I({}).X) = {}) {}
+// CHECK:STDERR:                               ^
+// CHECK:STDERR:
+fn F(T:! I(()) & I({}) where .(I(()).X) = () and .(I({}).X) = {}) {}
+
+fn G(T:! I(()) where .X = ()) {
+  F(T);
+}
+
+// --- dependent_rules_chains_from_facet_type.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X1:! type;
+  let X2:! type;
+  let X3:! type;
+  // Only used in source facet, to ensure the facet type differs from the
+  // conversion target.
+  let Y:! type;
+}
+
+fn F1(T:! I where .X1 = .X2 and .X2 = .X3 and .X2 = ()) {}
+fn F2(T:! I where .X1 = .X3 and .X2 = .X3 and .X2 = ()) {}
+
+fn G1(T:! I where .X1 = () and .X2 = () and .X3 = () and .Y = ()) {
+  F1(T);
+  F2(T);
+}
+
+fn G2(T:! I where .X1 = () and .X2 = () and .X3 = .X2 and .Y = ()) {
+  F1(T);
+  F2(T);
+}
+
+fn G3(T:! I where .X1 = .X3 and .X2 = () and .X3 = .X2 and .Y = ()) {
+  F1(T);
+  F2(T);
+}
+
+fn G4(T:! I where .X1 = () and .X2 = .X3 and .X3 = .X1 and .Y = ()) {
+  F1(T);
+  F2(T);
+}
+
+// .X2 and .X3 are equal but have no known value.
+fn F3(T:! I where .X1 = () and .X2 = .X3 and .X3 = .X2) {}
+
+fn G5(T:! I where .X3 = .X2 and .X2 = .X3 and .X1 = () and .Y = ()) {
+  F3(T);
+}
+
+fn G6(T:! I where .X3 = .X3 and .X2 = .X3 and .X1 = () and .Y = ()) {
+  F3(T);
+}
+
+// .X2 is assigned itself, which precludes it from having a known value.
+fn F4(T:! I where .X1 = () and .X2 = .X2 and .X3 = .X2) {}
+
+fn G7(T:! I where .X3 = .X2 and .X2 = .X3 and .X1 = () and .Y = ()) {
+  F4(T);
+}
+
+fn G8(T:! I where .X3 = .X3 and .X2 = .X3 and .X1 = () and .Y = ()) {
+  F4(T);
+}
+
+// --- dependent_rules_chains_from_impl.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X1:! type;
+  let X2:! type;
+  let X3:! type;
+  // Only used in source facet, to ensure the facet type differs from the
+  // conversion target.
+  let Y:! type;
+}
+
+fn F1(T:! I where .X1 = .X2 and .X2 = .X3 and .X2 = ()) {}
+fn F2(T:! I where .X1 = .X3 and .X2 = .X3 and .X2 = ()) {}
+
+class C1;
+impl C1 as I where .X1 = () and .X2 = () and .X3 = () and .Y = () {}
+
+fn G1() {
+  F1(C1);
+  F2(C1);
+}
+
+class C2;
+impl C2 as I where .X1 = () and .X2 = () and .X3 = .X2 and .Y = () {}
+
+fn G2() {
+  F1(C2);
+  F2(C2);
+}
+
+class C3;
+impl C3 as I where .X1 = .X3 and .X2 = () and .X3 = .X2 and .Y = () {}
+
+fn G3() {
+  F1(C3);
+  F2(C3);
+}
+
+class C4;
+impl C4 as I where .X1 = () and .X2 = .X3 and .X3 = .X1 and .Y = () {}
+
+fn G4() {
+  F1(C4);
+  F2(C4);
+}
+
+// .X2 and .X3 are equal but have no known value.
+fn F3(T:! I where .X1 = () and .X2 = .X3 and .X3 = .X2) {}
+
+class C5;
+impl C5 as I where .X3 = .X2 and .X2 = .X3 and .X1 = () and .Y = () {}
+
+fn G5() {
+  F3(C5);
+}
+
+class C6;
+impl C6 as I where .X3 = .X3 and .X2 = .X3 and .X1 = () and .Y = () {}
+
+fn G6() {
+  F3(C6);
+}
+
+// .X2 is assigned itself, which precludes it from having a known value.
+fn F4(T:! I where .X1 = () and .X2 = .X2 and .X3 = .X2) {}
+
+class C7;
+impl C7 as I where .X3 = .X2 and .X2 = .X3 and .X1 = () and .Y = () {}
+
+fn G7() {
+  F4(C7);
+}
+
+class C8;
+impl C8 as I where .X3 = .X3 and .X2 = .X3 and .X1 = () and .Y = () {}
+
+fn G8() {
+  F4(C8);
+}
+
+// --- impl_provides_rewrite_requirements.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+interface J { let Y:! type; }
+
+class C;
+
+final impl forall [T:! I] T as J where .Y = C {}
+
+fn F(T:! I & J where .Y = C) {}
+fn G(T:! I) {
+  F(T);
+}
+
+// --- facet_provides_rewrite_requirements.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+interface J { let Y:! type; }
+
+class C;
+
+final impl forall [T:! J] T as I {}
+
+fn F(T:! I & J where .Y = C) {}
+fn G(T:! J where .Y = C) {
+  F(T);
+}
+
+// --- fail_non_final_impl_deduce.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C(T:! type);
+impl forall [T:! type] T as I where .X = () {}
+
+fn F(T:! I where .X = ()) {}
+fn G(T:! type) {
+  // CHECK:STDERR: fail_non_final_impl_deduce.carbon:[[@LINE+7]]:3: error: cannot convert type `C(T)` into type implementing `I where .(I.X) = ()` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   F(C(T));
+  // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR: fail_non_final_impl_deduce.carbon:[[@LINE-5]]:6: note: initializing generic parameter `T` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn F(T:! I where .X = ()) {}
+  // CHECK:STDERR:      ^
+  // CHECK:STDERR:
+  F(C(T));
+}
+
+// --- fail_non_final_impl_explicit.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C(T:! type);
+impl forall [T:! type] T as I where .X = () {}
+
+fn F(T:! type) {
+  // CHECK:STDERR: fail_non_final_impl_explicit.carbon:[[@LINE+4]]:3: error: cannot convert type `C(T)` into type implementing `I where .(I.X) = ()` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   C(T) as (I where .X = ());
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  C(T) as (I where .X = ());
+}
+
+// --- concrete_query_non_final_impl_deduce.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C;
+impl forall [T:! type] T as I where .X = () {}
+
+fn F(T:! I where .X = ()) {}
+fn G() {
+  F(C);
+}
+
+// --- concrete_query_non_final_impl_explicit.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C;
+impl forall [T:! type] T as I where .X = () {}
+
+fn F() {
+  C as (I where .X = ());
+}
+
+// --- final_impl_deduce.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C;
+final impl forall [T:! type] T as I where .X = () {}
+
+fn F(T:! I where .X = ()) {}
+fn G() {
+  F(C);
+}
+
+// --- final_impl_explicit.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C;
+final impl forall [T:! type] T as I where .X = () {}
+
+fn F() {
+  C as (I where .X = ());
+}
+
+// --- concrete_specialization_impl_deduce.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C;
+impl C as I where .X = () {}
+
+fn F(T:! I where .X = ()) {}
+fn G() {
+  F(C);
+}
+
+// --- concrete_specialization_impl_explicit.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let X:! type; }
+
+class C;
+impl C as I where .X = () {}
+
+fn F() {
+  C as (I where .X = ());
+}

--- a/toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
@@ -403,3 +403,49 @@ impl C as I where .X = () {}
 fn F() {
   C as (I where .X = ());
 }
+
+// --- todo_rewrite_value_in_class_param.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X:! type;
+  let Y:! type;
+}
+
+class C(T:! type);
+
+fn F(T:! I where .X = C(.Y)) {}
+
+fn G(T:! I where .X = C(()) and .Y = ()) {
+  // CHECK:STDERR: todo_rewrite_value_in_class_param.carbon:[[@LINE+7]]:3: error: cannot convert type `T` that implements `I where .(I.X) = C(()) and .(I.Y) = ()` into type implementing `I where .(I.X) = C(.(I.Y))` [ConversionFailureFacetToFacet]
+  // CHECK:STDERR:   F(T);
+  // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR: todo_rewrite_value_in_class_param.carbon:[[@LINE-6]]:6: note: initializing generic parameter `T` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn F(T:! I where .X = C(.Y)) {}
+  // CHECK:STDERR:      ^
+  // CHECK:STDERR:
+  F(T);
+}
+
+// --- fail_wrong_rewrite_value_in_class_param.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X:! type;
+  let Y:! type;
+}
+
+class C(T:! type);
+
+fn F(T:! I where .X = C(.Y)) {}
+
+fn G(T:! I where .X = C(()) and .Y = {}) {
+  // CHECK:STDERR: fail_wrong_rewrite_value_in_class_param.carbon:[[@LINE+7]]:3: error: cannot convert type `T` that implements `I where .(I.X) = C(()) and .(I.Y) = {}` into type implementing `I where .(I.X) = C(.(I.Y))` [ConversionFailureFacetToFacet]
+  // CHECK:STDERR:   F(T);
+  // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR: fail_wrong_rewrite_value_in_class_param.carbon:[[@LINE-6]]:6: note: initializing generic parameter `T` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn F(T:! I where .X = C(.Y)) {}
+  // CHECK:STDERR:      ^
+  // CHECK:STDERR:
+  F(T);
+}

--- a/toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/validate_rewrite_constraints.carbon
@@ -449,3 +449,51 @@ fn G(T:! I where .X = C(()) and .Y = {}) {
   // CHECK:STDERR:
   F(T);
 }
+
+// --- function_in_interface_ignored.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X:! type;
+  fn F();
+}
+
+fn F(T:! I where .X = ()) {}
+
+fn G(T:! I where .X = ()) {
+  F(T);
+}
+
+// --- function_as_rewrite_value.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X:! type;
+  let Y:! X;
+  fn A();
+}
+
+fn F(T:! I where .Y = .A) {}
+
+fn G(T:! I where .Y = .A) {
+  F(T);
+}
+
+// --- todo_fail_wrong_function_as_rewrite_value.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let X:! type;
+  let Y:! X;
+  fn A();
+  fn B();
+}
+
+fn F(T:! I where .Y = .A) {}
+
+fn G(T:! I where .Y = .B) {
+  // TODO: This should be diagnosed as the wrong value being assigned to .Y for
+  // what F is expecting.
+  //
+  F(T);
+}

--- a/toolchain/check/testdata/impl/lookup/min_prelude/specialization_with_symbolic_rewrite.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/specialization_with_symbolic_rewrite.carbon
@@ -315,7 +315,6 @@ fn F[T:! Ptr](var t: T) -> T.(Ptr.Type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc13_19.2 [symbolic = %require_complete (constants.%require_complete.2b1)]
-// CHECK:STDOUT:   %Z.impl_witness: <witness> = impl_witness file.%Z.impl_witness_table.loc11, @impl.62c(%T.as_type.loc13_19.2) [symbolic = %Z.impl_witness (constants.%Z.impl_witness.7c2)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%t.param: @F.%T.as_type.loc13_19.2 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:
@@ -1060,7 +1059,6 @@ fn F[T:! Ptr](var t: T) -> T.(Ptr.Type) {
 // CHECK:STDOUT:   %T.loc9_6.2: %Ptr.type = bind_symbolic_name T, 0 [symbolic = %T.loc9_6.2 (constants.%T)]
 // CHECK:STDOUT:   %T.as_type.loc9_22.2: type = facet_access_type %T.loc9_6.2 [symbolic = %T.as_type.loc9_22.2 (constants.%T.as_type)]
 // CHECK:STDOUT:   %pattern_type.loc9_19: type = pattern_type %T.as_type.loc9_22.2 [symbolic = %pattern_type.loc9_19 (constants.%pattern_type.87e)]
-// CHECK:STDOUT:   %Ptr.impl_witness: <witness> = impl_witness file.%Ptr.impl_witness_table, @impl(%T.as_type.loc9_22.2) [symbolic = %Ptr.impl_witness (constants.%Ptr.impl_witness.5aa)]
 // CHECK:STDOUT:   %ptr: type = ptr_type %T.as_type.loc9_22.2 [symbolic = %ptr (constants.%ptr.900)]
 // CHECK:STDOUT:   %pattern_type.loc9_25: type = pattern_type %ptr [symbolic = %pattern_type.loc9_25 (constants.%pattern_type.a95)]
 // CHECK:STDOUT:
@@ -1104,7 +1102,6 @@ fn F[T:! Ptr](var t: T) -> T.(Ptr.Type) {
 // CHECK:STDOUT:   %T.loc9_6.2 => constants.%T
 // CHECK:STDOUT:   %T.as_type.loc9_22.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type.loc9_19 => constants.%pattern_type.87e
-// CHECK:STDOUT:   %Ptr.impl_witness => constants.%Ptr.impl_witness.5aa
 // CHECK:STDOUT:   %ptr => constants.%ptr.900
 // CHECK:STDOUT:   %pattern_type.loc9_25 => constants.%pattern_type.a95
 // CHECK:STDOUT: }
@@ -1241,7 +1238,6 @@ fn F[T:! Ptr](var t: T) -> T.(Ptr.Type) {
 // CHECK:STDOUT:   %T.loc9_6.2: %Ptr.type = bind_symbolic_name T, 0 [symbolic = %T.loc9_6.2 (constants.%T)]
 // CHECK:STDOUT:   %T.as_type.loc9_22.2: type = facet_access_type %T.loc9_6.2 [symbolic = %T.as_type.loc9_22.2 (constants.%T.as_type)]
 // CHECK:STDOUT:   %pattern_type.loc9_19: type = pattern_type %T.as_type.loc9_22.2 [symbolic = %pattern_type.loc9_19 (constants.%pattern_type.87e)]
-// CHECK:STDOUT:   %Ptr.impl_witness: <witness> = impl_witness file.%Ptr.impl_witness_table, @impl(%T.as_type.loc9_22.2) [symbolic = %Ptr.impl_witness (constants.%Ptr.impl_witness.5aa)]
 // CHECK:STDOUT:   %ptr: type = ptr_type %T.as_type.loc9_22.2 [symbolic = %ptr (constants.%ptr.900)]
 // CHECK:STDOUT:   %pattern_type.loc9_25: type = pattern_type %ptr [symbolic = %pattern_type.loc9_25 (constants.%pattern_type.a95)]
 // CHECK:STDOUT:
@@ -1285,7 +1281,6 @@ fn F[T:! Ptr](var t: T) -> T.(Ptr.Type) {
 // CHECK:STDOUT:   %T.loc9_6.2 => constants.%T
 // CHECK:STDOUT:   %T.as_type.loc9_22.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type.loc9_19 => constants.%pattern_type.87e
-// CHECK:STDOUT:   %Ptr.impl_witness => constants.%Ptr.impl_witness.5aa
 // CHECK:STDOUT:   %ptr => constants.%ptr.900
 // CHECK:STDOUT:   %pattern_type.loc9_25 => constants.%pattern_type.a95
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
@@ -14,6 +16,13 @@ library "[[@TEST_NAME]]";
 interface I { let T:! type; }
 
 impl () as I where .T = {} {}
+
+// --- success_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let T:! type; let U:! type; }
+
+impl () as I where .T = .U and .U = {} {}
 
 // --- redecl.carbon
 library "[[@TEST_NAME]]";
@@ -106,6 +115,42 @@ interface L { let W:! type; }
 // CHECK:STDERR:
 impl () as L where .W = {} and .W = () {}
 
+// --- fail_two_different_first_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface L2 { let W2:! type; let X2:! type; }
+
+// CHECK:STDERR: fail_two_different_first_associated.carbon:[[@LINE+11]]:12: error: associated constant W2 given two different values `()` and `.(L2.X2)` [AssociatedConstantWithDifferentValues]
+// CHECK:STDERR: impl () as L2 where .W2 = .X2 and .W2 = () {}
+// CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_two_different_first_associated.carbon:[[@LINE+7]]:1: error: associated constant X2 not given a value in impl of interface L2 [ImplAssociatedConstantNeedsValue]
+// CHECK:STDERR: impl () as L2 where .W2 = .X2 and .W2 = () {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_two_different_first_associated.carbon:[[@LINE-9]]:35: note: associated constant declared here [AssociatedConstantHere]
+// CHECK:STDERR: interface L2 { let W2:! type; let X2:! type; }
+// CHECK:STDERR:                                   ^~~~~~~~~
+// CHECK:STDERR:
+impl () as L2 where .W2 = .X2 and .W2 = () {}
+
+// --- fail_two_different_second_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface L2 { let W2:! type; let X2:! type; }
+
+// CHECK:STDERR: fail_two_different_second_associated.carbon:[[@LINE+11]]:12: error: associated constant W2 given two different values `()` and `.(L2.X2)` [AssociatedConstantWithDifferentValues]
+// CHECK:STDERR: impl () as L2 where .W2 = () and .W2 = .X2 {}
+// CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_two_different_second_associated.carbon:[[@LINE+7]]:1: error: associated constant X2 not given a value in impl of interface L2 [ImplAssociatedConstantNeedsValue]
+// CHECK:STDERR: impl () as L2 where .W2 = () and .W2 = .X2 {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_two_different_second_associated.carbon:[[@LINE-9]]:35: note: associated constant declared here [AssociatedConstantHere]
+// CHECK:STDERR: interface L2 { let W2:! type; let X2:! type; }
+// CHECK:STDERR:                                   ^~~~~~~~~
+// CHECK:STDERR:
+impl () as L2 where .W2 = () and .W2 = .X2 {}
+
 // --- fail_two_different_first_bad.carbon
 library "[[@TEST_NAME]]";
 
@@ -150,6 +195,28 @@ interface M { let X:! type; }
 
 impl () as M where .X = {} and .X = {} {}
 
+// --- repeated_associated.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; let Y:! type; }
+
+// CHECK:STDERR: repeated_associated.carbon:[[@LINE+7]]:1: error: associated constant Y not given a value in impl of interface M [ImplAssociatedConstantNeedsValue]
+// CHECK:STDERR: impl () as M where .X = .Y and .X = .Y {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: repeated_associated.carbon:[[@LINE-5]]:33: note: associated constant declared here [AssociatedConstantHere]
+// CHECK:STDERR: interface M { let X:! type; let Y:! type; }
+// CHECK:STDERR:                                 ^~~~~~~~
+// CHECK:STDERR:
+impl () as M where .X = .Y and .X = .Y {}
+
+// --- todo_fail_cycle.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; let Y:! type; }
+
+// TODO: This should fail, since there's no canonical form for .X or .Y.
+impl () as M where .X = .Y and .Y = .X {}
+
 // --- non-type.carbon
 library "[[@TEST_NAME]]";
 
@@ -158,6 +225,28 @@ interface N {
 }
 
 impl () as N where .Y = {.a = {}} { }
+
+// --- non-type_repeated.carbon
+library "[[@TEST_NAME]]";
+
+interface N {
+  let Y:! {.a: {}};
+}
+
+impl () as N where .Y = {.a = {}} and .Y = {.a = {}} { }
+
+// --- fail_non-type_different.carbon
+library "[[@TEST_NAME]]";
+
+interface N {
+  let Y:! {.a: type};
+}
+
+// CHECK:STDERR: fail_non-type_different.carbon:[[@LINE+4]]:12: error: associated constant Y given two different values `{.a = {}}` and `{.a = ()}` [AssociatedConstantWithDifferentValues]
+// CHECK:STDERR: impl () as N where .Y = {.a = {}} and .Y = {.a = ()} {}
+// CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl () as N where .Y = {.a = {}} and .Y = {.a = ()} {}
 
 // --- fail_where_rewrite_function.carbon
 library "[[@TEST_NAME]]";
@@ -173,1090 +262,3 @@ class CD { }
 impl CD as IF where .F = 0 {
   fn F() {}
 }
-
-// CHECK:STDOUT: --- success.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
-// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %I.assoc_type: type = assoc_entity_type @I [concrete]
-// CHECK:STDOUT:   %assoc0: %I.assoc_type = assoc_entity element0, @I.%T [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %I.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %I.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @I [symbolic_self]
-// CHECK:STDOUT:   %I.facet: %I.type = facet_value %.Self.as_type, (%I.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %I.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %I_where.type: type = facet_type <@I where %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I = %I.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc5_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc5_7.2: type = converted %.loc5_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:     %.Self: %I.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %I.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T.ref: %I.assoc_type = name_ref T, @T.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc5_20: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%I.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc5_26.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc5_26.2: type = converted %.loc5_26.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc5_14: type = where_expr %.Self [concrete = constants.%I_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc5_26.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (%impl_witness_assoc_constant), @impl [concrete]
-// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: type = impl_witness_assoc_constant constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %T: type = assoc_const_decl @T [concrete] {
-// CHECK:STDOUT:     %assoc0: %I.assoc_type = assoc_entity element0, @I.%T [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .T = @T.%assoc0
-// CHECK:STDOUT:   witness = (%T)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @T(@I.%Self: %I.type) {
-// CHECK:STDOUT:   assoc_const T:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc5_7.2 as %.loc5_14 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%I.impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T(constants.%I.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- redecl.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I2.type: type = facet_type <@I2> [concrete]
-// CHECK:STDOUT:   %Self: %I2.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %I2.assoc_type: type = assoc_entity_type @I2 [concrete]
-// CHECK:STDOUT:   %assoc0: %I2.assoc_type = assoc_entity element0, @I2.%T2 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %I2.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %I2.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @I2 [symbolic_self]
-// CHECK:STDOUT:   %I2.facet: %I2.type = facet_value %.Self.as_type, (%I2.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %I2.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %I2_where.type: type = facet_type <@I2 where %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %I2.impl_witness: <witness> = impl_witness file.%I2.impl_witness_table [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I2 = %I2.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I2.decl: type = interface_decl @I2 [concrete = constants.%I2.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc5_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc5_7.2: type = converted %.loc5_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I2.ref.loc5: type = name_ref I2, file.%I2.decl [concrete = constants.%I2.type]
-// CHECK:STDOUT:     %.Self.1: %I2.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc5: %I2.type = name_ref .Self, %.Self.1 [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T2.ref.loc5: %I2.assoc_type = name_ref T2, @T2.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc5: type = facet_access_type %.Self.ref.loc5 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc5_21: type = converted %.Self.ref.loc5, %.Self.as_type.loc5 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc5: type = impl_witness_access constants.%I2.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc5_28.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %.loc5_28.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc5_15: type = where_expr %.Self.1 [concrete = constants.%I2_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc5, %.loc5_28.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I2.impl_witness_table = impl_witness_table (%impl_witness_assoc_constant), @impl [concrete]
-// CHECK:STDOUT:   %I2.impl_witness: <witness> = impl_witness %I2.impl_witness_table [concrete = constants.%I2.impl_witness]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: type = impl_witness_assoc_constant constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc6_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc6_7.2: type = converted %.loc6_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I2.ref.loc6: type = name_ref I2, file.%I2.decl [concrete = constants.%I2.type]
-// CHECK:STDOUT:     %.Self.2: %I2.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc6: %I2.type = name_ref .Self, %.Self.2 [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T2.ref.loc6: %I2.assoc_type = name_ref T2, @T2.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc6: type = facet_access_type %.Self.ref.loc6 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc6_21: type = converted %.Self.ref.loc6, %.Self.as_type.loc6 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc6: type = impl_witness_access constants.%I2.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc6_28.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc6_28.2: type = converted %.loc6_28.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc6_15: type = where_expr %.Self.2 [concrete = constants.%I2_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc6, %.loc6_28.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I2 {
-// CHECK:STDOUT:   %Self: %I2.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %T2: type = assoc_const_decl @T2 [concrete] {
-// CHECK:STDOUT:     %assoc0: %I2.assoc_type = assoc_entity element0, @I2.%T2 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .T2 = @T2.%assoc0
-// CHECK:STDOUT:   witness = (%T2)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @T2(@I2.%Self: %I2.type) {
-// CHECK:STDOUT:   assoc_const T2:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc5_7.2 as %.loc5_15 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%I2.impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T2(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T2(constants.%I2.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_redecl_adds_rewrites.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I3.type: type = facet_type <@I3> [concrete]
-// CHECK:STDOUT:   %Self: %I3.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %I3.assoc_type: type = assoc_entity_type @I3 [concrete]
-// CHECK:STDOUT:   %assoc0: %I3.assoc_type = assoc_entity element0, @I3.%T3 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %I3.impl_witness.c9d: <witness> = impl_witness file.%I3.impl_witness_table.loc9 [concrete]
-// CHECK:STDOUT:   %.Self: %I3.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %I3.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @I3 [symbolic_self]
-// CHECK:STDOUT:   %I3.facet: %I3.type = facet_value %.Self.as_type, (%I3.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %I3.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %I3_where.type: type = facet_type <@I3 where %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %I3.impl_witness.ea7: <witness> = impl_witness file.%I3.impl_witness_table.loc10 [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I3 = %I3.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I3.decl: type = interface_decl @I3 [concrete = constants.%I3.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl.b46 [concrete] {} {
-// CHECK:STDOUT:     %.loc9_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_7.2: type = converted %.loc9_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I3.ref: type = name_ref I3, file.%I3.decl [concrete = constants.%I3.type]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I3.impl_witness_table.loc9 = impl_witness_table (), @impl.b46 [concrete]
-// CHECK:STDOUT:   %I3.impl_witness.loc9: <witness> = impl_witness %I3.impl_witness_table.loc9 [concrete = constants.%I3.impl_witness.c9d]
-// CHECK:STDOUT:   impl_decl @impl.4b6 [concrete] {} {
-// CHECK:STDOUT:     %.loc10_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc10_7.2: type = converted %.loc10_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I3.ref: type = name_ref I3, file.%I3.decl [concrete = constants.%I3.type]
-// CHECK:STDOUT:     %.Self: %I3.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %I3.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T3.ref: %I3.assoc_type = name_ref T3, @T3.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc10_21: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%I3.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc10_28.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc10_28.2: type = converted %.loc10_28.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc10_15: type = where_expr %.Self [concrete = constants.%I3_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc10_28.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I3.impl_witness_table.loc10 = impl_witness_table (%impl_witness_assoc_constant), @impl.4b6 [concrete]
-// CHECK:STDOUT:   %I3.impl_witness.loc10: <witness> = impl_witness %I3.impl_witness_table.loc10 [concrete = constants.%I3.impl_witness.ea7]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: type = impl_witness_assoc_constant constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I3 {
-// CHECK:STDOUT:   %Self: %I3.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %T3: type = assoc_const_decl @T3 [concrete] {
-// CHECK:STDOUT:     %assoc0: %I3.assoc_type = assoc_entity element0, @I3.%T3 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .T3 = @T3.%assoc0
-// CHECK:STDOUT:   witness = (%T3)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @T3(@I3.%Self: %I3.type) {
-// CHECK:STDOUT:   assoc_const T3:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.b46: %.loc9_7.2 as %I3.ref;
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.4b6: %.loc10_7.2 as %.loc10_15 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%I3.impl_witness.loc10
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T3(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T3(constants.%I3.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_mismatch.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %J.type: type = facet_type <@J> [concrete]
-// CHECK:STDOUT:   %Self: %J.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %J.assoc_type: type = assoc_entity_type @J [concrete]
-// CHECK:STDOUT:   %assoc0: %J.assoc_type = assoc_entity element0, @J.%U [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %J.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %J.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @J [symbolic_self]
-// CHECK:STDOUT:   %J.facet: %J.type = facet_value %.Self.as_type, (%J.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %J.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %J_where.type.49a: type = facet_type <@J where %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %J.impl_witness.2a1: <witness> = impl_witness file.%J.impl_witness_table.loc9 [concrete]
-// CHECK:STDOUT:   %J_where.type.344: type = facet_type <@J where %impl.elem0 = %empty_tuple.type> [concrete]
-// CHECK:STDOUT:   %J.impl_witness.006: <witness> = impl_witness file.%J.impl_witness_table.loc10 [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .J = %J.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.decl: type = interface_decl @J [concrete = constants.%J.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl.3df [concrete] {} {
-// CHECK:STDOUT:     %.loc9_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_7.2: type = converted %.loc9_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:     %.Self: %J.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %J.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %U.ref: %J.assoc_type = name_ref U, @U.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_20: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%J.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc9_26.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc9_26.2: type = converted %.loc9_26.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc9_14: type = where_expr %.Self [concrete = constants.%J_where.type.49a] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc9_26.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table.loc9 = impl_witness_table (%impl_witness_assoc_constant.loc9), @impl.3df [concrete]
-// CHECK:STDOUT:   %J.impl_witness.loc9: <witness> = impl_witness %J.impl_witness_table.loc9 [concrete = constants.%J.impl_witness.2a1]
-// CHECK:STDOUT:   %impl_witness_assoc_constant.loc9: type = impl_witness_assoc_constant constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:   impl_decl @impl.153 [concrete] {} {
-// CHECK:STDOUT:     %.loc10_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc10_7.2: type = converted %.loc10_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:     %.Self: %J.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %J.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %U.ref: %J.assoc_type = name_ref U, @U.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc10_20: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%J.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc10_26.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc10_26.2: type = converted %.loc10_26.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %.loc10_14: type = where_expr %.Self [concrete = constants.%J_where.type.344] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc10_26.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table.loc10 = impl_witness_table (%impl_witness_assoc_constant.loc10), @impl.153 [concrete]
-// CHECK:STDOUT:   %J.impl_witness.loc10: <witness> = impl_witness %J.impl_witness_table.loc10 [concrete = constants.%J.impl_witness.006]
-// CHECK:STDOUT:   %impl_witness_assoc_constant.loc10: type = impl_witness_assoc_constant constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @J {
-// CHECK:STDOUT:   %Self: %J.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %U: type = assoc_const_decl @U [concrete] {
-// CHECK:STDOUT:     %assoc0: %J.assoc_type = assoc_entity element0, @J.%U [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .U = @U.%assoc0
-// CHECK:STDOUT:   witness = (%U)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @U(@J.%Self: %J.type) {
-// CHECK:STDOUT:   assoc_const U:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.3df: %.loc9_7.2 as %.loc9_14;
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.153: %.loc10_7.2 as %.loc10_14 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%J.impl_witness.loc10
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @U(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @U(constants.%J.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_mismatch_bad_value.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I4.type: type = facet_type <@I4> [concrete]
-// CHECK:STDOUT:   %Self: %I4.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %I4.assoc_type: type = assoc_entity_type @I4 [concrete]
-// CHECK:STDOUT:   %assoc0: %I4.assoc_type = assoc_entity element0, @I4.%T4 [concrete]
-// CHECK:STDOUT:   %assoc1: %I4.assoc_type = assoc_entity element1, @I4.%T5 [concrete]
-// CHECK:STDOUT:   %assoc2: %I4.assoc_type = assoc_entity element2, @I4.%T6 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %I4.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %I4.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @I4 [symbolic_self]
-// CHECK:STDOUT:   %I4.facet: %I4.type = facet_value %.Self.as_type, (%I4.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %I4.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %impl.elem1: type = impl_witness_access %I4.lookup_impl_witness, element1 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %empty_struct_type} [concrete]
-// CHECK:STDOUT:   %impl.elem2: type = impl_witness_access %I4.lookup_impl_witness, element2 [symbolic_self]
-// CHECK:STDOUT:   %struct_type.b: type = struct_type {.b: %empty_struct_type} [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I4 = %I4.decl
-// CHECK:STDOUT:     .BAD1 = <poisoned>
-// CHECK:STDOUT:     .BAD2 = <poisoned>
-// CHECK:STDOUT:     .BAD3 = <poisoned>
-// CHECK:STDOUT:     .BAD4 = <poisoned>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I4.decl: type = interface_decl @I4 [concrete = constants.%I4.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl.de506c.1 [concrete] {} {
-// CHECK:STDOUT:     %.loc17_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc17_7.2: type = converted %.loc17_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I4.ref: type = name_ref I4, file.%I4.decl [concrete = constants.%I4.type]
-// CHECK:STDOUT:     %.Self: %I4.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc17_21: %I4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T4.ref: %I4.assoc_type = name_ref T4, @T4.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc17_21: type = facet_access_type %.Self.ref.loc17_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc17_21: type = converted %.Self.ref.loc17_21, %.Self.as_type.loc17_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%I4.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %BAD1.ref: <error> = name_ref BAD1, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.Self.ref.loc17_36: %I4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T5.ref: %I4.assoc_type = name_ref T5, @T5.%assoc1 [concrete = constants.%assoc1]
-// CHECK:STDOUT:     %.Self.as_type.loc17_36: type = facet_access_type %.Self.ref.loc17_36 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc17_36: type = converted %.Self.ref.loc17_36, %.Self.as_type.loc17_36 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem1: type = impl_witness_access constants.%I4.lookup_impl_witness, element1 [symbolic_self = constants.%impl.elem1]
-// CHECK:STDOUT:     %.loc17_48.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc17_48.2: type = converted %.loc17_48.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %struct_type.a: type = struct_type {.a: %empty_struct_type} [concrete = constants.%struct_type.a]
-// CHECK:STDOUT:     %.Self.ref.loc17_55: %I4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T6.ref: %I4.assoc_type = name_ref T6, @T6.%assoc2 [concrete = constants.%assoc2]
-// CHECK:STDOUT:     %.Self.as_type.loc17_55: type = facet_access_type %.Self.ref.loc17_55 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc17_55: type = converted %.Self.ref.loc17_55, %.Self.as_type.loc17_55 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem2: type = impl_witness_access constants.%I4.lookup_impl_witness, element2 [symbolic_self = constants.%impl.elem2]
-// CHECK:STDOUT:     %BAD2.ref: <error> = name_ref BAD2, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.loc17_15: type = where_expr %.Self [concrete = <error>] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, <error>
-// CHECK:STDOUT:       requirement_rewrite %impl.elem1, %struct_type.a
-// CHECK:STDOUT:       requirement_rewrite %impl.elem2, <error>
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   impl_decl @impl.de506c.2 [concrete] {} {
-// CHECK:STDOUT:     %.loc27_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc27_7.2: type = converted %.loc27_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %I4.ref: type = name_ref I4, file.%I4.decl [concrete = constants.%I4.type]
-// CHECK:STDOUT:     %.Self: %I4.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc27_21: %I4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T4.ref: %I4.assoc_type = name_ref T4, @T4.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc27_21: type = facet_access_type %.Self.ref.loc27_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc27_21: type = converted %.Self.ref.loc27_21, %.Self.as_type.loc27_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%I4.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc27_33.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc27_33.2: type = converted %.loc27_33.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %struct_type.b: type = struct_type {.b: %empty_struct_type} [concrete = constants.%struct_type.b]
-// CHECK:STDOUT:     %.Self.ref.loc27_40: %I4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T5.ref: %I4.assoc_type = name_ref T5, @T5.%assoc1 [concrete = constants.%assoc1]
-// CHECK:STDOUT:     %.Self.as_type.loc27_40: type = facet_access_type %.Self.ref.loc27_40 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc27_40: type = converted %.Self.ref.loc27_40, %.Self.as_type.loc27_40 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem1: type = impl_witness_access constants.%I4.lookup_impl_witness, element1 [symbolic_self = constants.%impl.elem1]
-// CHECK:STDOUT:     %BAD3.ref: <error> = name_ref BAD3, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.Self.ref.loc27_55: %I4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T6.ref: %I4.assoc_type = name_ref T6, @T6.%assoc2 [concrete = constants.%assoc2]
-// CHECK:STDOUT:     %.Self.as_type.loc27_55: type = facet_access_type %.Self.ref.loc27_55 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc27_55: type = converted %.Self.ref.loc27_55, %.Self.as_type.loc27_55 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem2: type = impl_witness_access constants.%I4.lookup_impl_witness, element2 [symbolic_self = constants.%impl.elem2]
-// CHECK:STDOUT:     %BAD4.ref: <error> = name_ref BAD4, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.loc27_15: type = where_expr %.Self [concrete = <error>] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %struct_type.b
-// CHECK:STDOUT:       requirement_rewrite %impl.elem1, <error>
-// CHECK:STDOUT:       requirement_rewrite %impl.elem2, <error>
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I4 {
-// CHECK:STDOUT:   %Self: %I4.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %T4: type = assoc_const_decl @T4 [concrete] {
-// CHECK:STDOUT:     %assoc0: %I4.assoc_type = assoc_entity element0, @I4.%T4 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %T5: type = assoc_const_decl @T5 [concrete] {
-// CHECK:STDOUT:     %assoc1: %I4.assoc_type = assoc_entity element1, @I4.%T5 [concrete = constants.%assoc1]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %T6: type = assoc_const_decl @T6 [concrete] {
-// CHECK:STDOUT:     %assoc2: %I4.assoc_type = assoc_entity element2, @I4.%T6 [concrete = constants.%assoc2]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .T4 = @T4.%assoc0
-// CHECK:STDOUT:   .T5 = @T5.%assoc1
-// CHECK:STDOUT:   .T6 = @T6.%assoc2
-// CHECK:STDOUT:   witness = (%T4, %T5, %T6)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @T4(@I4.%Self: %I4.type) {
-// CHECK:STDOUT:   assoc_const T4:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @T5(@I4.%Self: %I4.type) {
-// CHECK:STDOUT:   assoc_const T5:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @T6(@I4.%Self: %I4.type) {
-// CHECK:STDOUT:   assoc_const T6:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.de506c.1: %.loc17_7.2 as %.loc17_15;
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.de506c.2: %.loc27_7.2 as %.loc27_15 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T4(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T5(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T6(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T4(constants.%I4.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T5(constants.%I4.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @T6(constants.%I4.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_missing_on_definition.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %K.type: type = facet_type <@K> [concrete]
-// CHECK:STDOUT:   %Self: %K.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %K.assoc_type: type = assoc_entity_type @K [concrete]
-// CHECK:STDOUT:   %assoc0: %K.assoc_type = assoc_entity element0, @K.%V [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %K.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %K.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @K [symbolic_self]
-// CHECK:STDOUT:   %K.facet: %K.type = facet_value %.Self.as_type, (%K.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %K.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %K_where.type: type = facet_type <@K where %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %K.impl_witness.3ea: <witness> = impl_witness file.%K.impl_witness_table.loc5 [concrete]
-// CHECK:STDOUT:   %K.impl_witness.3f0: <witness> = impl_witness file.%K.impl_witness_table.loc17 [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .K = %K.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %K.decl: type = interface_decl @K [concrete = constants.%K.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl.16d [concrete] {} {
-// CHECK:STDOUT:     %.loc5_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc5_7.2: type = converted %.loc5_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %K.ref: type = name_ref K, file.%K.decl [concrete = constants.%K.type]
-// CHECK:STDOUT:     %.Self: %K.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %K.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %V.ref: %K.assoc_type = name_ref V, @V.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc5_20: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%K.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc5_26.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc5_26.2: type = converted %.loc5_26.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc5_14: type = where_expr %.Self [concrete = constants.%K_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc5_26.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %K.impl_witness_table.loc5 = impl_witness_table (%impl_witness_assoc_constant), @impl.16d [concrete]
-// CHECK:STDOUT:   %K.impl_witness.loc5: <witness> = impl_witness %K.impl_witness_table.loc5 [concrete = constants.%K.impl_witness.3ea]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: type = impl_witness_assoc_constant constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:   impl_decl @impl.4b0 [concrete] {} {
-// CHECK:STDOUT:     %.loc17_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc17_7.2: type = converted %.loc17_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %K.ref: type = name_ref K, file.%K.decl [concrete = constants.%K.type]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %K.impl_witness_table.loc17 = impl_witness_table (<error>), @impl.4b0 [concrete]
-// CHECK:STDOUT:   %K.impl_witness.loc17: <witness> = impl_witness %K.impl_witness_table.loc17 [concrete = constants.%K.impl_witness.3f0]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @K {
-// CHECK:STDOUT:   %Self: %K.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %V: type = assoc_const_decl @V [concrete] {
-// CHECK:STDOUT:     %assoc0: %K.assoc_type = assoc_entity element0, @K.%V [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .V = @V.%assoc0
-// CHECK:STDOUT:   witness = (%V)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @V(@K.%Self: %K.type) {
-// CHECK:STDOUT:   assoc_const V:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.16d: %.loc5_7.2 as %.loc5_14;
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.4b0: %.loc17_7.2 as %K.ref {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%K.impl_witness.loc17
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @V(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @V(constants.%K.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_two_different.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %L.type: type = facet_type <@L> [concrete]
-// CHECK:STDOUT:   %Self: %L.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %L.assoc_type: type = assoc_entity_type @L [concrete]
-// CHECK:STDOUT:   %assoc0: %L.assoc_type = assoc_entity element0, @L.%W [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %L.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %L.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @L [symbolic_self]
-// CHECK:STDOUT:   %L.facet: %L.type = facet_value %.Self.as_type, (%L.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %L.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %L_where.type: type = facet_type <@L where %impl.elem0 = %empty_tuple.type and %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %L.impl_witness: <witness> = impl_witness file.%L.impl_witness_table [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .L = %L.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %L.decl: type = interface_decl @L [concrete = constants.%L.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc9_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_7.2: type = converted %.loc9_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %L.ref: type = name_ref L, file.%L.decl [concrete = constants.%L.type]
-// CHECK:STDOUT:     %.Self: %L.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc9_20: %L.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W.ref.loc9_20: %L.assoc_type = name_ref W, @W.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc9_20: type = facet_access_type %.Self.ref.loc9_20 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_20: type = converted %.Self.ref.loc9_20, %.Self.as_type.loc9_20 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc9_20: type = impl_witness_access constants.%L.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc9_26.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc9_26.2: type = converted %.loc9_26.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.Self.ref.loc9_32: %L.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W.ref.loc9_32: %L.assoc_type = name_ref W, @W.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc9_32: type = facet_access_type %.Self.ref.loc9_32 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_32: type = converted %.Self.ref.loc9_32, %.Self.as_type.loc9_32 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc9_32: type = impl_witness_access constants.%L.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc9_38.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_38.2: type = converted %.loc9_38.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %.loc9_14: type = where_expr %.Self [concrete = constants.%L_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc9_20, %.loc9_26.2
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc9_32, %.loc9_38.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %L.impl_witness_table = impl_witness_table (<error>), @impl [concrete]
-// CHECK:STDOUT:   %L.impl_witness: <witness> = impl_witness %L.impl_witness_table [concrete = constants.%L.impl_witness]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: type = impl_witness_assoc_constant constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @L {
-// CHECK:STDOUT:   %Self: %L.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %W: type = assoc_const_decl @W [concrete] {
-// CHECK:STDOUT:     %assoc0: %L.assoc_type = assoc_entity element0, @L.%W [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .W = @W.%assoc0
-// CHECK:STDOUT:   witness = (%W)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @W(@L.%Self: %L.type) {
-// CHECK:STDOUT:   assoc_const W:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc9_7.2 as %.loc9_14 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%L.impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W(constants.%L.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_two_different_first_bad.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %L2.type: type = facet_type <@L2> [concrete]
-// CHECK:STDOUT:   %Self: %L2.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %L2.assoc_type: type = assoc_entity_type @L2 [concrete]
-// CHECK:STDOUT:   %assoc0: %L2.assoc_type = assoc_entity element0, @L2.%W2 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %L2.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %L2.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @L2 [symbolic_self]
-// CHECK:STDOUT:   %L2.facet: %L2.type = facet_value %.Self.as_type, (%L2.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %L2.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .L2 = %L2.decl
-// CHECK:STDOUT:     .BAD5 = <poisoned>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %L2.decl: type = interface_decl @L2 [concrete = constants.%L2.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc9_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_7.2: type = converted %.loc9_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %L2.ref: type = name_ref L2, file.%L2.decl [concrete = constants.%L2.type]
-// CHECK:STDOUT:     %.Self: %L2.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc9_21: %L2.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W2.ref.loc9_21: %L2.assoc_type = name_ref W2, @W2.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc9_21: type = facet_access_type %.Self.ref.loc9_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_21: type = converted %.Self.ref.loc9_21, %.Self.as_type.loc9_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc9_21: type = impl_witness_access constants.%L2.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %BAD5.ref: <error> = name_ref BAD5, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.Self.ref.loc9_36: %L2.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W2.ref.loc9_36: %L2.assoc_type = name_ref W2, @W2.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc9_36: type = facet_access_type %.Self.ref.loc9_36 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_36: type = converted %.Self.ref.loc9_36, %.Self.as_type.loc9_36 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc9_36: type = impl_witness_access constants.%L2.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc9_43.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_43.2: type = converted %.loc9_43.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %.loc9_15: type = where_expr %.Self [concrete = <error>] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc9_21, <error>
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc9_36, %.loc9_43.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @L2 {
-// CHECK:STDOUT:   %Self: %L2.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %W2: type = assoc_const_decl @W2 [concrete] {
-// CHECK:STDOUT:     %assoc0: %L2.assoc_type = assoc_entity element0, @L2.%W2 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .W2 = @W2.%assoc0
-// CHECK:STDOUT:   witness = (%W2)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @W2(@L2.%Self: %L2.type) {
-// CHECK:STDOUT:   assoc_const W2:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc9_7.2 as %.loc9_15 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W2(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W2(constants.%L2.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_two_different_second_bad.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %L3.type: type = facet_type <@L3> [concrete]
-// CHECK:STDOUT:   %Self: %L3.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %L3.assoc_type: type = assoc_entity_type @L3 [concrete]
-// CHECK:STDOUT:   %assoc0: %L3.assoc_type = assoc_entity element0, @L3.%W3 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %L3.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %L3.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @L3 [symbolic_self]
-// CHECK:STDOUT:   %L3.facet: %L3.type = facet_value %.Self.as_type, (%L3.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %L3.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .L3 = %L3.decl
-// CHECK:STDOUT:     .BAD6 = <poisoned>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %L3.decl: type = interface_decl @L3 [concrete = constants.%L3.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc9_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc9_7.2: type = converted %.loc9_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %L3.ref: type = name_ref L3, file.%L3.decl [concrete = constants.%L3.type]
-// CHECK:STDOUT:     %.Self: %L3.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc9_21: %L3.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W3.ref.loc9_21: %L3.assoc_type = name_ref W3, @W3.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc9_21: type = facet_access_type %.Self.ref.loc9_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_21: type = converted %.Self.ref.loc9_21, %.Self.as_type.loc9_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc9_21: type = impl_witness_access constants.%L3.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc9_28.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc9_28.2: type = converted %.loc9_28.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.Self.ref.loc9_34: %L3.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W3.ref.loc9_34: %L3.assoc_type = name_ref W3, @W3.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc9_34: type = facet_access_type %.Self.ref.loc9_34 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc9_34: type = converted %.Self.ref.loc9_34, %.Self.as_type.loc9_34 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc9_34: type = impl_witness_access constants.%L3.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %BAD6.ref: <error> = name_ref BAD6, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.loc9_15: type = where_expr %.Self [concrete = <error>] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc9_21, %.loc9_28.2
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc9_34, <error>
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @L3 {
-// CHECK:STDOUT:   %Self: %L3.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %W3: type = assoc_const_decl @W3 [concrete] {
-// CHECK:STDOUT:     %assoc0: %L3.assoc_type = assoc_entity element0, @L3.%W3 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .W3 = @W3.%assoc0
-// CHECK:STDOUT:   witness = (%W3)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @W3(@L3.%Self: %L3.type) {
-// CHECK:STDOUT:   assoc_const W3:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc9_7.2 as %.loc9_15 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W3(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W3(constants.%L3.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_two_different_both_bad.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %L4.type: type = facet_type <@L4> [concrete]
-// CHECK:STDOUT:   %Self: %L4.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %L4.assoc_type: type = assoc_entity_type @L4 [concrete]
-// CHECK:STDOUT:   %assoc0: %L4.assoc_type = assoc_entity element0, @L4.%W4 [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %L4.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %L4.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @L4 [symbolic_self]
-// CHECK:STDOUT:   %L4.facet: %L4.type = facet_value %.Self.as_type, (%L4.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %L4.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .L4 = %L4.decl
-// CHECK:STDOUT:     .BAD7 = <poisoned>
-// CHECK:STDOUT:     .BAD8 = <poisoned>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %L4.decl: type = interface_decl @L4 [concrete = constants.%L4.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc13_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc13_7.2: type = converted %.loc13_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %L4.ref: type = name_ref L4, file.%L4.decl [concrete = constants.%L4.type]
-// CHECK:STDOUT:     %.Self: %L4.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc13_21: %L4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W4.ref.loc13_21: %L4.assoc_type = name_ref W4, @W4.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc13_21: type = facet_access_type %.Self.ref.loc13_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc13_21: type = converted %.Self.ref.loc13_21, %.Self.as_type.loc13_21 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc13_21: type = impl_witness_access constants.%L4.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %BAD7.ref: <error> = name_ref BAD7, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.Self.ref.loc13_36: %L4.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %W4.ref.loc13_36: %L4.assoc_type = name_ref W4, @W4.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc13_36: type = facet_access_type %.Self.ref.loc13_36 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc13_36: type = converted %.Self.ref.loc13_36, %.Self.as_type.loc13_36 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc13_36: type = impl_witness_access constants.%L4.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %BAD8.ref: <error> = name_ref BAD8, <error> [concrete = <error>]
-// CHECK:STDOUT:     %.loc13_15: type = where_expr %.Self [concrete = <error>] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc13_21, <error>
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc13_36, <error>
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @L4 {
-// CHECK:STDOUT:   %Self: %L4.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %W4: type = assoc_const_decl @W4 [concrete] {
-// CHECK:STDOUT:     %assoc0: %L4.assoc_type = assoc_entity element0, @L4.%W4 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .W4 = @W4.%assoc0
-// CHECK:STDOUT:   witness = (%W4)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @W4(@L4.%Self: %L4.type) {
-// CHECK:STDOUT:   assoc_const W4:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc13_7.2 as %.loc13_15 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W4(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @W4(constants.%L4.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- repeated.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %M.type: type = facet_type <@M> [concrete]
-// CHECK:STDOUT:   %Self: %M.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %M.assoc_type: type = assoc_entity_type @M [concrete]
-// CHECK:STDOUT:   %assoc0: %M.assoc_type = assoc_entity element0, @M.%X [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %.Self: %M.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %M.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @M [symbolic_self]
-// CHECK:STDOUT:   %M.facet: %M.type = facet_value %.Self.as_type, (%M.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %M.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %M_where.type: type = facet_type <@M where %impl.elem0 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %M.impl_witness: <witness> = impl_witness file.%M.impl_witness_table [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .M = %M.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %M.decl: type = interface_decl @M [concrete = constants.%M.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc5_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc5_7.2: type = converted %.loc5_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %M.ref: type = name_ref M, file.%M.decl [concrete = constants.%M.type]
-// CHECK:STDOUT:     %.Self: %M.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref.loc5_20: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %X.ref.loc5_20: %M.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc5_20: type = facet_access_type %.Self.ref.loc5_20 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc5_20: type = converted %.Self.ref.loc5_20, %.Self.as_type.loc5_20 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc5_20: type = impl_witness_access constants.%M.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc5_26.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc5_26.2: type = converted %.loc5_26.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.Self.ref.loc5_32: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %X.ref.loc5_32: %M.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type.loc5_32: type = facet_access_type %.Self.ref.loc5_32 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc5_32: type = converted %.Self.ref.loc5_32, %.Self.as_type.loc5_32 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0.loc5_32: type = impl_witness_access constants.%M.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc5_38.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc5_38.2: type = converted %.loc5_38.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc5_14: type = where_expr %.Self [concrete = constants.%M_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc5_20, %.loc5_26.2
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0.loc5_32, %.loc5_38.2
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %M.impl_witness_table = impl_witness_table (%impl_witness_assoc_constant), @impl [concrete]
-// CHECK:STDOUT:   %M.impl_witness: <witness> = impl_witness %M.impl_witness_table [concrete = constants.%M.impl_witness]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: type = impl_witness_assoc_constant constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @M {
-// CHECK:STDOUT:   %Self: %M.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %X: type = assoc_const_decl @X [concrete] {
-// CHECK:STDOUT:     %assoc0: %M.assoc_type = assoc_entity element0, @M.%X [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .X = @X.%assoc0
-// CHECK:STDOUT:   witness = (%X)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @X(@M.%Self: %M.type) {
-// CHECK:STDOUT:   assoc_const X:! type;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc5_7.2 as %.loc5_14 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%M.impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @X(constants.%M.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- non-type.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %N.type: type = facet_type <@N> [concrete]
-// CHECK:STDOUT:   %Self: %N.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %struct_type.a.225: type = struct_type {.a: %empty_struct_type} [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %N.assoc_type: type = assoc_entity_type @N [concrete]
-// CHECK:STDOUT:   %assoc0: %N.assoc_type = assoc_entity element0, @N.%Y [concrete]
-// CHECK:STDOUT:   %.Self: %N.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %N.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @N [symbolic_self]
-// CHECK:STDOUT:   %N.facet: %N.type = facet_value %.Self.as_type, (%N.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: %struct_type.a.225 = impl_witness_access %N.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
-// CHECK:STDOUT:   %struct: %struct_type.a.225 = struct_value (%empty_struct) [concrete]
-// CHECK:STDOUT:   %N_where.type: type = facet_type <@N where %impl.elem0 = %struct> [concrete]
-// CHECK:STDOUT:   %N.impl_witness: <witness> = impl_witness file.%N.impl_witness_table [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .N = %N.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %N.decl: type = interface_decl @N [concrete = constants.%N.type] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc7_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc7_7.2: type = converted %.loc7_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %N.ref: type = name_ref N, file.%N.decl [concrete = constants.%N.type]
-// CHECK:STDOUT:     %.Self: %N.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %N.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %Y.ref: %N.assoc_type = name_ref Y, @Y.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc7_20: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: %struct_type.a.225 = impl_witness_access constants.%N.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %.loc7_32: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc7_33.1: %struct_type.a.225 = struct_literal (%.loc7_32)
-// CHECK:STDOUT:     %empty_struct: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:     %.loc7_33.2: %empty_struct_type = converted %.loc7_32, %empty_struct [concrete = constants.%empty_struct]
-// CHECK:STDOUT:     %struct: %struct_type.a.225 = struct_value (%.loc7_33.2) [concrete = constants.%struct]
-// CHECK:STDOUT:     %.loc7_33.3: %struct_type.a.225 = converted %.loc7_33.1, %struct [concrete = constants.%struct]
-// CHECK:STDOUT:     %.loc7_14: type = where_expr %.Self [concrete = constants.%N_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc7_33.3
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %N.impl_witness_table = impl_witness_table (%impl_witness_assoc_constant), @impl [concrete]
-// CHECK:STDOUT:   %N.impl_witness: <witness> = impl_witness %N.impl_witness_table [concrete = constants.%N.impl_witness]
-// CHECK:STDOUT:   %impl_witness_assoc_constant: %struct_type.a.225 = impl_witness_assoc_constant constants.%struct [concrete = constants.%struct]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @N {
-// CHECK:STDOUT:   %Self: %N.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %Y: %struct_type.a.225 = assoc_const_decl @Y [concrete] {
-// CHECK:STDOUT:     %assoc0: %N.assoc_type = assoc_entity element0, @N.%Y [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .Y = @Y.%assoc0
-// CHECK:STDOUT:   witness = (%Y)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @Y(@N.%Self: %N.type) {
-// CHECK:STDOUT:   assoc_const Y:! %struct_type.a.225;
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc7_7.2 as %.loc7_14 {
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = file.%N.impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @Y(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @Y(constants.%N.facet) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_where_rewrite_function.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %IF.type: type = facet_type <@IF> [concrete]
-// CHECK:STDOUT:   %Self: %IF.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT:   %F.type.496: type = fn_type @F.1 [concrete]
-// CHECK:STDOUT:   %F.1de: %F.type.496 = struct_value () [concrete]
-// CHECK:STDOUT:   %IF.assoc_type: type = assoc_entity_type @IF [concrete]
-// CHECK:STDOUT:   %assoc0: %IF.assoc_type = assoc_entity element0, @IF.%F.decl [concrete]
-// CHECK:STDOUT:   %CD: type = class_type @CD [concrete]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
-// CHECK:STDOUT:   %.Self: %IF.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %IF.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @IF [symbolic_self]
-// CHECK:STDOUT:   %IF.facet.01b: %IF.type = facet_value %.Self.as_type, (%IF.lookup_impl_witness) [symbolic_self]
-// CHECK:STDOUT:   %.c5b: type = fn_type_with_self_type %F.type.496, %IF.facet.01b [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: %.c5b = impl_witness_access %IF.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete]
-// CHECK:STDOUT:   %IF_where.type: type = facet_type <@IF where %impl.elem0 = %int_0> [concrete]
-// CHECK:STDOUT:   %IF.impl_witness: <witness> = impl_witness file.%IF.impl_witness_table [concrete]
-// CHECK:STDOUT:   %F.type.f56: type = fn_type @F.2 [concrete]
-// CHECK:STDOUT:   %F.fae: %F.type.f56 = struct_value () [concrete]
-// CHECK:STDOUT:   %IF.facet.60c: %IF.type = facet_value %CD, (%IF.impl_witness) [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .IF = %IF.decl
-// CHECK:STDOUT:     .CD = %CD.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %IF.decl: type = interface_decl @IF [concrete = constants.%IF.type] {} {}
-// CHECK:STDOUT:   %CD.decl: type = class_decl @CD [concrete = constants.%CD] {} {}
-// CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %CD.ref: type = name_ref CD, file.%CD.decl [concrete = constants.%CD]
-// CHECK:STDOUT:     %IF.ref: type = name_ref IF, file.%IF.decl [concrete = constants.%IF.type]
-// CHECK:STDOUT:     %.Self: %IF.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %.Self.ref: %IF.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %F.ref: %IF.assoc_type = name_ref F, @IF.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %.loc11_21: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:     %impl.elem0: %.c5b = impl_witness_access constants.%IF.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:     %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
-// CHECK:STDOUT:     %.loc11_15: type = where_expr %.Self [concrete = constants.%IF_where.type] {
-// CHECK:STDOUT:       requirement_rewrite %impl.elem0, %int_0
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %IF.impl_witness_table = impl_witness_table (@impl.%F.decl), @impl [concrete]
-// CHECK:STDOUT:   %IF.impl_witness: <witness> = impl_witness %IF.impl_witness_table [concrete = constants.%IF.impl_witness]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @IF {
-// CHECK:STDOUT:   %Self: %IF.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %F.decl: %F.type.496 = fn_decl @F.1 [concrete = constants.%F.1de] {} {}
-// CHECK:STDOUT:   %assoc0: %IF.assoc_type = assoc_entity element0, %F.decl [concrete = constants.%assoc0]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %assoc0
-// CHECK:STDOUT:   witness = (%F.decl)
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %CD.ref as %.loc11_15 {
-// CHECK:STDOUT:   %F.decl: %F.type.f56 = fn_decl @F.2 [concrete = constants.%F.fae] {} {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   witness = file.%IF.impl_witness
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @CD {
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%CD
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.1(@IF.%Self: %IF.type) {
-// CHECK:STDOUT:   fn();
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2() {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F.1(constants.%Self) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F.1(constants.%IF.facet.60c) {}
-// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
@@ -200,14 +200,7 @@ library "[[@TEST_NAME]]";
 
 interface M { let X:! type; let Y:! type; }
 
-// CHECK:STDERR: repeated_associated.carbon:[[@LINE+7]]:1: error: associated constant Y not given a value in impl of interface M [ImplAssociatedConstantNeedsValue]
-// CHECK:STDERR: impl () as M where .X = .Y and .X = .Y {}
-// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: repeated_associated.carbon:[[@LINE-5]]:33: note: associated constant declared here [AssociatedConstantHere]
-// CHECK:STDERR: interface M { let X:! type; let Y:! type; }
-// CHECK:STDERR:                                 ^~~~~~~~
-// CHECK:STDERR:
-impl () as M where .X = .Y and .X = .Y {}
+impl () as M where .X = .Y and .X = .Y and .Y = () {}
 
 // --- todo_fail_cycle.carbon
 library "[[@TEST_NAME]]";

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -360,7 +360,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %Core.Int: %Int.type = import_ref Core//prelude/types/int, Int, loaded [concrete = constants.%Int.generic]
 // CHECK:STDOUT:   %Implicit.import_ref.c81: %struct_type.a.b.5ca = import_ref Implicit//default, loc8_9, loaded [symbolic = @C.%S (constants.%S)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc8_34, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1424 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1420 [no loc], unloaded
 // CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.595 = import_ref Core//prelude/operators/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -534,7 +534,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.c81: %struct_type.a.b = import_ref Implicit//default, loc8_9, loaded [symbolic = @C.%S (constants.%S)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc8_34, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1424 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1420 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -655,7 +655,7 @@ var c_bad: C({.a = 3, .b = 4}) = F();
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.1ad = impl_witness_table (%Implicit.import_ref.773), @impl.a8d [concrete]
 // CHECK:STDOUT:   %Implicit.import_ref.c81: %struct_type.a.b.5ca = import_ref Implicit//default, loc8_9, loaded [symbolic = @C.%S (constants.%S)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc8_34, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1424 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.b8b = import_ref Implicit//default, inst1420 [no loc], unloaded
 // CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.595 = import_ref Core//prelude/operators/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuple/import.carbon
+++ b/toolchain/check/testdata/tuple/import.carbon
@@ -394,7 +394,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %Core.Int: %Int.type = import_ref Core//prelude/types/int, Int, loaded [concrete = constants.%Int.generic]
 // CHECK:STDOUT:   %Implicit.import_ref.48d: %tuple.type.c2c = import_ref Implicit//default, loc7_9, loaded [symbolic = @C.%X (constants.%X)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc7_26, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1463 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1458 [no loc], unloaded
 // CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.595 = import_ref Core//prelude/operators/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -584,7 +584,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Implicit.import_ref.48d: %tuple.type.c2c = import_ref Implicit//default, loc7_9, loaded [symbolic = @C.%X (constants.%X)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc7_26, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1463 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1458 [no loc], unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -706,7 +706,7 @@ var c_bad: C((3, 4)) = F();
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.1ad = impl_witness_table (%Implicit.import_ref.773), @impl.a8d [concrete]
 // CHECK:STDOUT:   %Implicit.import_ref.48d: %tuple.type.c2c = import_ref Implicit//default, loc7_9, loaded [symbolic = @C.%X (constants.%X)]
 // CHECK:STDOUT:   %Implicit.import_ref.8f2: <witness> = import_ref Implicit//default, loc7_26, loaded [concrete = constants.%complete_type.357]
-// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1463 [no loc], unloaded
+// CHECK:STDOUT:   %Implicit.import_ref.964 = import_ref Implicit//default, inst1458 [no loc], unloaded
 // CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.595 = import_ref Core//prelude/operators/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/where_expr/equal_rewrite.carbon
+++ b/toolchain/check/testdata/where_expr/equal_rewrite.carbon
@@ -62,7 +62,7 @@ fn Reversed(N:! J where .L = bool and .K = ()) {
   Alphabetical(N);
 }
 
-// --- todo_fail_rewrites_mismatch_right.carbon
+// --- fail_rewrites_mismatch_right.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -73,11 +73,17 @@ interface O {
 fn WithInteger(Q:! O where .P = i32) {}
 
 fn WithBool(R:! O where .P = bool) {
-  // TODO: This should fail.
+  // CHECK:STDERR: fail_rewrites_mismatch_right.carbon:[[@LINE+7]]:3: error: cannot convert type `R` that implements `O where .(O.P) = bool` into type implementing `O where .(O.P) = i32` [ConversionFailureFacetToFacet]
+  // CHECK:STDERR:   WithInteger(R);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_rewrites_mismatch_right.carbon:[[@LINE-6]]:16: note: initializing generic parameter `Q` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn WithInteger(Q:! O where .P = i32) {}
+  // CHECK:STDERR:                ^
+  // CHECK:STDERR:
   WithInteger(R);
 }
 
-// --- todo_fail_rewrites_mismatch_left.carbon
+// --- fail_rewrites_mismatch_left.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -89,7 +95,13 @@ interface S {
 fn WithT(V:! S where .T = ()) {}
 
 fn WithU(W:! S where .U = ()) {
-  // TODO: This should fail.
+  // CHECK:STDERR: fail_rewrites_mismatch_left.carbon:[[@LINE+7]]:3: error: cannot convert type `W` that implements `S where .(S.U) = ()` into type implementing `S where .(S.T) = ()` [ConversionFailureFacetToFacet]
+  // CHECK:STDERR:   WithT(W);
+  // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR: fail_rewrites_mismatch_left.carbon:[[@LINE-6]]:10: note: initializing generic parameter `V` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn WithT(V:! S where .T = ()) {}
+  // CHECK:STDERR:          ^
+  // CHECK:STDERR:
   WithT(W);
 }
 
@@ -794,7 +806,7 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- todo_fail_rewrites_mismatch_right.carbon
+// CHECK:STDOUT: --- fail_rewrites_mismatch_right.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %O.type: type = facet_type <@O> [concrete]
@@ -808,7 +820,6 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %O.lookup_impl_witness.c7a, element0 [symbolic_self]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %Int.generic: %Int.type = struct_value () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %O_where.type.e27: type = facet_type <@O where %impl.elem0 = %i32> [concrete]
@@ -824,9 +835,6 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %WithBool.type: type = fn_type @WithBool [concrete]
 // CHECK:STDOUT:   %WithBool: %WithBool.type = struct_value () [concrete]
 // CHECK:STDOUT:   %O.lookup_impl_witness.c41: <witness> = lookup_impl_witness %R, @O [symbolic]
-// CHECK:STDOUT:   %R.as_type: type = facet_access_type %R [symbolic]
-// CHECK:STDOUT:   %facet_value: %O_where.type.e27 = facet_value %R.as_type, (%O.lookup_impl_witness.c41) [symbolic]
-// CHECK:STDOUT:   %WithInteger.specific_fn: <specific function> = specific_function %WithInteger, @WithInteger(%facet_value) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -922,19 +930,11 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %O.lookup_impl_witness: <witness> = lookup_impl_witness %R.loc10_13.2, @O [symbolic = %O.lookup_impl_witness (constants.%O.lookup_impl_witness.c41)]
-// CHECK:STDOUT:   %R.as_type.loc12_16.2: type = facet_access_type %R.loc10_13.2 [symbolic = %R.as_type.loc12_16.2 (constants.%R.as_type)]
-// CHECK:STDOUT:   %facet_value.loc12_16.2: %O_where.type.e27 = facet_value %R.as_type.loc12_16.2, (%O.lookup_impl_witness) [symbolic = %facet_value.loc12_16.2 (constants.%facet_value)]
-// CHECK:STDOUT:   %WithInteger.specific_fn.loc12_3.2: <specific function> = specific_function constants.%WithInteger, @WithInteger(%facet_value.loc12_16.2) [symbolic = %WithInteger.specific_fn.loc12_3.2 (constants.%WithInteger.specific_fn)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %WithInteger.ref: %WithInteger.type = name_ref WithInteger, file.%WithInteger.decl [concrete = constants.%WithInteger]
 // CHECK:STDOUT:     %R.ref: %O_where.type.e45 = name_ref R, %R.loc10_13.1 [symbolic = %R.loc10_13.2 (constants.%R)]
-// CHECK:STDOUT:     %R.as_type.loc12_16.1: type = facet_access_type constants.%R [symbolic = %R.as_type.loc12_16.2 (constants.%R.as_type)]
-// CHECK:STDOUT:     %facet_value.loc12_16.1: %O_where.type.e27 = facet_value %R.as_type.loc12_16.1, (constants.%O.lookup_impl_witness.c41) [symbolic = %facet_value.loc12_16.2 (constants.%facet_value)]
-// CHECK:STDOUT:     %.loc12: %O_where.type.e27 = converted %R.ref, %facet_value.loc12_16.1 [symbolic = %facet_value.loc12_16.2 (constants.%facet_value)]
-// CHECK:STDOUT:     %WithInteger.specific_fn.loc12_3.1: <specific function> = specific_function %WithInteger.ref, @WithInteger(constants.%facet_value) [symbolic = %WithInteger.specific_fn.loc12_3.2 (constants.%WithInteger.specific_fn)]
-// CHECK:STDOUT:     %WithInteger.call: init %empty_tuple.type = call %WithInteger.specific_fn.loc12_3.1()
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -951,13 +951,7 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %R.loc10_13.2 => constants.%R
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @WithInteger(constants.%facet_value) {
-// CHECK:STDOUT:   %Q.loc8_16.2 => constants.%facet_value
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- todo_fail_rewrites_mismatch_left.carbon
+// CHECK:STDOUT: --- fail_rewrites_mismatch_left.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %S.type: type = facet_type <@S> [concrete]
@@ -983,9 +977,6 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:   %WithU.type: type = fn_type @WithU [concrete]
 // CHECK:STDOUT:   %WithU: %WithU.type = struct_value () [concrete]
 // CHECK:STDOUT:   %S.lookup_impl_witness.6f2: <witness> = lookup_impl_witness %W, @S [symbolic]
-// CHECK:STDOUT:   %W.as_type: type = facet_access_type %W [symbolic]
-// CHECK:STDOUT:   %facet_value: %S_where.type.4c2 = facet_value %W.as_type, (%S.lookup_impl_witness.6f2) [symbolic]
-// CHECK:STDOUT:   %WithT.specific_fn: <specific function> = specific_function %WithT, @WithT(%facet_value) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -1084,19 +1075,11 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %S.lookup_impl_witness: <witness> = lookup_impl_witness %W.loc11_10.2, @S [symbolic = %S.lookup_impl_witness (constants.%S.lookup_impl_witness.6f2)]
-// CHECK:STDOUT:   %W.as_type.loc13_10.2: type = facet_access_type %W.loc11_10.2 [symbolic = %W.as_type.loc13_10.2 (constants.%W.as_type)]
-// CHECK:STDOUT:   %facet_value.loc13_10.2: %S_where.type.4c2 = facet_value %W.as_type.loc13_10.2, (%S.lookup_impl_witness) [symbolic = %facet_value.loc13_10.2 (constants.%facet_value)]
-// CHECK:STDOUT:   %WithT.specific_fn.loc13_3.2: <specific function> = specific_function constants.%WithT, @WithT(%facet_value.loc13_10.2) [symbolic = %WithT.specific_fn.loc13_3.2 (constants.%WithT.specific_fn)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %WithT.ref: %WithT.type = name_ref WithT, file.%WithT.decl [concrete = constants.%WithT]
 // CHECK:STDOUT:     %W.ref: %S_where.type.592 = name_ref W, %W.loc11_10.1 [symbolic = %W.loc11_10.2 (constants.%W)]
-// CHECK:STDOUT:     %W.as_type.loc13_10.1: type = facet_access_type constants.%W [symbolic = %W.as_type.loc13_10.2 (constants.%W.as_type)]
-// CHECK:STDOUT:     %facet_value.loc13_10.1: %S_where.type.4c2 = facet_value %W.as_type.loc13_10.1, (constants.%S.lookup_impl_witness.6f2) [symbolic = %facet_value.loc13_10.2 (constants.%facet_value)]
-// CHECK:STDOUT:     %.loc13: %S_where.type.4c2 = converted %W.ref, %facet_value.loc13_10.1 [symbolic = %facet_value.loc13_10.2 (constants.%facet_value)]
-// CHECK:STDOUT:     %WithT.specific_fn.loc13_3.1: <specific function> = specific_function %WithT.ref, @WithT(constants.%facet_value) [symbolic = %WithT.specific_fn.loc13_3.2 (constants.%WithT.specific_fn)]
-// CHECK:STDOUT:     %WithT.call: init %empty_tuple.type = call %WithT.specific_fn.loc13_3.1()
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -1115,12 +1098,6 @@ let K: (E where .F = .Self.G) = bool;
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WithU(constants.%W) {
 // CHECK:STDOUT:   %W.loc11_10.2 => constants.%W
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @WithT(constants.%facet_value) {
-// CHECK:STDOUT:   %V.loc9_10.2 => constants.%facet_value
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_rewrites.carbon


### PR DESCRIPTION
When doing impl lookup from a concrete value, or converting between facet values (which is implemented as impl lookup), ensure that the rewrite constraints known about the source value cover all of the requirements from the target facet type, and do not contradict any requirements.

To do this, we need additional information returned from the second stage of `LookupImplWitness()` (the stage on the other side of eval), to know the FacetType from which a symbolic `LookupImplWitness` finds its answer. The instruction itself erases that information, since it will continuing looking for a concrete answer on further (more specific) evaluations, but LookupImplWitness() needs the facet type to combine the rewrite constraints across all found witnesses and verify that they satisfy the query's constraints.