### PR TITLE
Avoid resolving the decl block for specifics in imported instructions

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -105,6 +105,7 @@ cc_library(
         ":node_stack",
         "//common:array_stack",
         "//common:check",
+        "//common:concepts",
         "//common:find",
         "//common:map",
         "//common:ostream",

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -768,7 +768,7 @@ template <typename... Types>
 struct KindHasGetConstantValueOverload<TypeEnum<Types...>> {
   static constexpr auto Value(TypeEnum<Types...> e) -> bool {
     constexpr auto Values = [] {
-      std::array<bool, SemIR::IdKind::NumValues> values = {false};
+      std::array<bool, SemIR::IdKind::NumTypes> values = {};
       ((values[SemIR::IdKind::template For<Types>.ToIndex()] =
             HasGetConstantValueOverload<Types>),
        ...);

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -762,9 +762,6 @@ static auto ReplaceTypeWithConstantValue(EvalContext& eval_context,
   return IsConstant(*phase);
 }
 
-static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
-                                       const SemIR::Inst& inst) -> void;
-
 // Resolve the specific declaration in the given instruction field. There is an
 // overload for any field type that has a GetConstantValue() overload which
 // canonicalizes a specific as part of forming its constant value.
@@ -791,7 +788,7 @@ static auto ResolveSpecificDeclForField(EvalContext& eval_context,
     return;
   }
 
-  ResolveSpecificDeclaration(eval_context.context(),
+  ResolveSpecificDecl(eval_context.context(),
                              eval_context.fallback_loc_id(), specific_id);
 }
 
@@ -854,6 +851,8 @@ static constexpr auto MakeResolveSpecificHandlerTable(
   return table;
 }
 
+// Resolves the specific declarations for a specific id in any field of the
+// `inst` instruction.
 static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
                                        const SemIR::Inst& inst) -> void {
   static constexpr auto Table =

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -762,105 +762,102 @@ static auto ReplaceTypeWithConstantValue(EvalContext& eval_context,
   return IsConstant(*phase);
 }
 
-// Resolve the specific declaration in the given instruction field. There is an
-// overload for any field type that has a GetConstantValue() overload which
-// canonicalizes a specific as part of forming its constant value.
-static auto ResolveSpecificDeclForField(EvalContext& eval_context,
-                                        SemIR::SpecificId specific_id) -> void {
-  if (!specific_id.has_value()) {
-    return;
-  }
+template <typename... T>
+struct KindHasGetConstantValueOverload;
 
-  const auto& specific = eval_context.specifics().Get(specific_id);
-  const auto& generic = eval_context.generics().Get(specific.generic_id);
-  if (!generic.decl_block_id.has_value()) {
-    // Impl witness table construction happens before its own generic is
-    // finished, in order to make the table's instructions dependent
-    // instructions of the Impl's generic. So we can not resolve the specific
-    // declaration for such instructions at the time they are created, as the
-    // generic's declaration eval block is not yet constructed (with those
-    // dependent instructions in it).
-    //
-    // TODO: Find a way to avoid this early out by making the evaluation of
-    // instructions in the witness table that require a specific happen after
-    // the generic is complete. Or find a way to limit this just to the impl
-    // witness table and ensure the declarations will be resolved.
-    return;
-  }
-
-  ResolveSpecificDecl(eval_context.context(),
-                             eval_context.fallback_loc_id(), specific_id);
-}
-
-static auto ResolveSpecificDeclForField(
-    EvalContext& eval_context, SemIR::SpecificInterfaceId specific_interface_id)
-    -> void {
-  if (!specific_interface_id.has_value()) {
-    return;
-  }
-  ResolveSpecificDeclForField(eval_context, eval_context.specific_interfaces()
-                                                .Get(specific_interface_id)
-                                                .specific_id);
-}
-
-static auto ResolveSpecificDeclForField(EvalContext& eval_context,
-                                        SemIR::FacetTypeId facet_type_id)
-    -> void {
-  const auto& info = eval_context.context().facet_types().Get(facet_type_id);
-  for (const auto& interface : info.extend_constraints) {
-    ResolveSpecificDeclForField(eval_context, interface.specific_id);
-  }
-  for (const auto& interface : info.self_impls_constraints) {
-    ResolveSpecificDeclForField(eval_context, interface.specific_id);
-  }
-}
-
-// An overload for id types that have a GetConstantValue() overload but for
-// which that overload does not canonicalize any SpecificId in the value type.
-template <typename T>
-  requires SameAsOneOf<T, SemIR::DestInstId, SemIR::EntityNameId,
-                       SemIR::InstBlockId, SemIR::InstId, SemIR::MetaInstId,
-                       SemIR::StructTypeFieldsId, SemIR::TypeInstId>
-static auto ResolveSpecificDeclForField(EvalContext& /*eval_context*/,
-                                        T /*id*/) {}
-
-using ResolveSpecificHandlerFnT = auto(EvalContext& context, int32_t arg)
-    -> void;
-
-// Returns a lookup table to get constants by Id::Kind. Requires a null IdKind
-// as a parameter in order to get the type pack.
 template <typename... Types>
-static constexpr auto MakeResolveSpecificHandlerTable(
-    TypeEnum<Types...>* /*id_kind*/)
-    -> std::array<ResolveSpecificHandlerFnT*, SemIR::IdKind::NumValues> {
-  std::array<ResolveSpecificHandlerFnT*, SemIR::IdKind::NumValues> table = {};
-  ((table[SemIR::IdKind::template For<Types>.ToIndex()] =
-        [](EvalContext& eval_context, int32_t arg) {
-          if constexpr (HasGetConstantValueOverload<Types>) {
-            auto id = SemIR::Inst::FromRaw<Types>(arg);
-            ResolveSpecificDeclForField(eval_context, id);
-          }
-        }),
-   ...);
-  table[SemIR::IdKind::Invalid.ToIndex()] = [](EvalContext& /*context*/,
-                                               int32_t /*arg*/) {
-    CARBON_FATAL("Instruction has argument with invalid IdKind");
-  };
-  table[SemIR::IdKind::None.ToIndex()] = [](EvalContext& /*context*/,
-                                            int32_t /*arg*/) {};
-  return table;
-}
+struct KindHasGetConstantValueOverload<TypeEnum<Types...>> {
+  static constexpr auto Value(TypeEnum<Types...> e) -> bool {
+    constexpr auto Values = [] {
+      std::array<bool, SemIR::IdKind::NumValues> values = {false};
+      ((values[SemIR::IdKind::template For<Types>.ToIndex()] =
+            HasGetConstantValueOverload<Types>),
+       ...);
+      return values;
+    }();
+    return Values[e.ToIndex()];
+  }
+};
 
 // Resolves the specific declarations for a specific id in any field of the
-// `inst` instruction.
+// `inst` instruction. This must be done for any field type that has a
+// GetConstantValue() overload which canonicalizes a specific (and thus
+// potentially forming a new specific) as part of forming its constant value.
 static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
                                        const SemIR::Inst& inst) -> void {
-  static constexpr auto Table =
-      MakeResolveSpecificHandlerTable(static_cast<SemIR::IdKind*>(nullptr));
-  Table[inst.arg0_and_kind().kind().ToIndex()](eval_context,
-                                               inst.arg0_and_kind().value());
-  Table[inst.arg1_and_kind().kind().ToIndex()](eval_context,
-                                               inst.arg1_and_kind().value());
+  auto resolve_specific_decl = [&](SemIR::SpecificId specific_id) {
+    if (!specific_id.has_value()) {
+      return;
+    }
+
+    const auto& specific = eval_context.specifics().Get(specific_id);
+    const auto& generic = eval_context.generics().Get(specific.generic_id);
+    if (!generic.decl_block_id.has_value()) {
+      // Impl witness table construction happens before its own generic is
+      // finished, in order to make the table's instructions dependent
+      // instructions of the Impl's generic. So we can not resolve the specific
+      // declaration for such instructions at the time they are created, as the
+      // generic's declaration eval block is not yet constructed (with those
+      // dependent instructions in it).
+      //
+      // TODO: Find a way to avoid this early out by making the evaluation of
+      // instructions in the witness table that require a specific happen after
+      // the generic is complete. Or find a way to limit this just to the impl
+      // witness table and ensure the declarations will be resolved.
+      return;
+    }
+    ResolveSpecificDecl(eval_context.context(), eval_context.fallback_loc_id(),
+                        specific_id);
+  };
+
+  for (auto arg_and_kind : {inst.arg0_and_kind(), inst.arg1_and_kind()}) {
+    CARBON_KIND_SWITCH(arg_and_kind) {
+      case CARBON_KIND(SemIR::SpecificId specific_id): {
+        resolve_specific_decl(specific_id);
+        break;
+      }
+      case CARBON_KIND(SemIR::SpecificInterfaceId specific_interface_id): {
+        resolve_specific_decl(eval_context.specific_interfaces()
+                                  .Get(specific_interface_id)
+                                  .specific_id);
+        break;
+      }
+      case CARBON_KIND(SemIR::FacetTypeId facet_type_id): {
+        const auto& info =
+            eval_context.context().facet_types().Get(facet_type_id);
+        for (const auto& interface : info.extend_constraints) {
+          resolve_specific_decl(interface.specific_id);
+        }
+        for (const auto& interface : info.self_impls_constraints) {
+          resolve_specific_decl(interface.specific_id);
+        }
+        break;
+      }
+
+      case CARBON_KIND(SemIR::DestInstId _):
+        break;
+      case CARBON_KIND(SemIR::EntityNameId _):
+        break;
+      case CARBON_KIND(SemIR::InstBlockId _):
+        break;
+      case CARBON_KIND(SemIR::InstId _):
+        break;
+      case CARBON_KIND(SemIR::MetaInstId _):
+        break;
+      case CARBON_KIND(SemIR::StructTypeFieldsId _):
+        break;
+      case CARBON_KIND(SemIR::TypeInstId _):
+        break;
+
+      default:
+        CARBON_CHECK(
+            !KindHasGetConstantValueOverload<SemIR::IdKind>::Value(
+                arg_and_kind.kind()),
+            "Missing case for {0} which has a GetConstantValue() overload",
+            arg_and_kind.kind());
+        break;
+    }
+  }
 }
 
 auto AddImportedConstant(Context& context, SemIR::Inst inst)

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -768,7 +768,7 @@ template <typename... Types>
 struct KindHasGetConstantValueOverload<TypeEnum<Types...>> {
   static constexpr auto Value(TypeEnum<Types...> e) -> bool {
     constexpr auto Values = [] {
-      std::array<bool, SemIR::IdKind::NumTypes> values = {};
+      std::array<bool, SemIR::IdKind::NumValues> values = {false};
       ((values[SemIR::IdKind::template For<Types>.ToIndex()] =
             HasGetConstantValueOverload<Types>),
        ...);

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -778,72 +778,69 @@ struct KindHasGetConstantValueOverload<TypeEnum<Types...>> {
   }
 };
 
+static auto ResolveSpecificDeclForSpecificId(EvalContext& eval_context,
+                                             SemIR::SpecificId specific_id)
+    -> void {
+  if (!specific_id.has_value()) {
+    return;
+  }
+
+  const auto& specific = eval_context.specifics().Get(specific_id);
+  const auto& generic = eval_context.generics().Get(specific.generic_id);
+  if (specific_id == generic.self_specific_id) {
+    // Impl witness table construction happens before its generic decl is
+    // finish, in order to make the table's instructions dependent
+    // instructions of the Impl's generic. But those instructions can refer to
+    // the generic's self specific. We can not resolve the specific
+    // declaration for the self specific until the generic is finished, but it
+    // is explicitly resolved at that time in `FinishGenericDecl()`.
+    return;
+  }
+  ResolveSpecificDecl(eval_context.context(), eval_context.fallback_loc_id(),
+                      specific_id);
+}
+
 // Resolves the specific declarations for a specific id in any field of the
 // `inst` instruction.
 static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
                                        const SemIR::Inst& inst) -> void {
-  auto resolve_specific_decl = [&](SemIR::SpecificId specific_id) {
-    if (!specific_id.has_value()) {
-      return;
-    }
-
-    const auto& specific = eval_context.specifics().Get(specific_id);
-    const auto& generic = eval_context.generics().Get(specific.generic_id);
-    if (specific_id == generic.self_specific_id) {
-      // Impl witness table construction happens before its generic decl is
-      // finish, in order to make the table's instructions dependent
-      // instructions of the Impl's generic. But those instructions can refer to
-      // the generic's self specific. We can not resolve the specific
-      // declaration for the self specific until the generic is finished, but it
-      // is explicitly resolved at that time in `FinishGenericDecl()`.
-      return;
-    }
-    ResolveSpecificDecl(eval_context.context(), eval_context.fallback_loc_id(),
-                        specific_id);
-  };
-
   for (auto arg_and_kind : {inst.arg0_and_kind(), inst.arg1_and_kind()}) {
     // This switch must handle any field type that has a GetConstantValue()
     // overload which canonicalizes a specific (and thus potentially forms a new
     // specific) as part of forming its constant value.
     CARBON_KIND_SWITCH(arg_and_kind) {
-      case CARBON_KIND(SemIR::SpecificId specific_id): {
-        resolve_specific_decl(specific_id);
-        break;
-      }
-      case CARBON_KIND(SemIR::SpecificInterfaceId specific_interface_id): {
-        resolve_specific_decl(eval_context.specific_interfaces()
-                                  .Get(specific_interface_id)
-                                  .specific_id);
-        break;
-      }
       case CARBON_KIND(SemIR::FacetTypeId facet_type_id): {
         const auto& info =
             eval_context.context().facet_types().Get(facet_type_id);
         for (const auto& interface : info.extend_constraints) {
-          resolve_specific_decl(interface.specific_id);
+          ResolveSpecificDeclForSpecificId(eval_context, interface.specific_id);
         }
         for (const auto& interface : info.self_impls_constraints) {
-          resolve_specific_decl(interface.specific_id);
+          ResolveSpecificDeclForSpecificId(eval_context, interface.specific_id);
         }
+        break;
+      }
+      case CARBON_KIND(SemIR::SpecificId specific_id): {
+        ResolveSpecificDeclForSpecificId(eval_context, specific_id);
+        break;
+      }
+      case CARBON_KIND(SemIR::SpecificInterfaceId specific_interface_id): {
+        ResolveSpecificDeclForSpecificId(eval_context,
+                                         eval_context.specific_interfaces()
+                                             .Get(specific_interface_id)
+                                             .specific_id);
         break;
       }
 
         // These id types have a GetConstantValue() overload but that overload
         // does not canonicalize any SpecificId in the value type.
-      case CARBON_KIND(SemIR::DestInstId _):
-        break;
-      case CARBON_KIND(SemIR::EntityNameId _):
-        break;
-      case CARBON_KIND(SemIR::InstBlockId _):
-        break;
-      case CARBON_KIND(SemIR::InstId _):
-        break;
-      case CARBON_KIND(SemIR::MetaInstId _):
-        break;
-      case CARBON_KIND(SemIR::StructTypeFieldsId _):
-        break;
-      case CARBON_KIND(SemIR::TypeInstId _):
+      case SemIR::IdKind::For<SemIR::DestInstId>:
+      case SemIR::IdKind::For<SemIR::EntityNameId>:
+      case SemIR::IdKind::For<SemIR::InstBlockId>:
+      case SemIR::IdKind::For<SemIR::InstId>:
+      case SemIR::IdKind::For<SemIR::MetaInstId>:
+      case SemIR::IdKind::For<SemIR::StructTypeFieldsId>:
+      case SemIR::IdKind::For<SemIR::TypeInstId>:
         break;
 
       default:

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -779,9 +779,7 @@ struct KindHasGetConstantValueOverload<TypeEnum<Types...>> {
 };
 
 // Resolves the specific declarations for a specific id in any field of the
-// `inst` instruction. This must be done for any field type that has a
-// GetConstantValue() overload which canonicalizes a specific (and thus
-// potentially forms a new specific) as part of forming its constant value.
+// `inst` instruction.
 static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
                                        const SemIR::Inst& inst) -> void {
   auto resolve_specific_decl = [&](SemIR::SpecificId specific_id) {
@@ -791,18 +789,13 @@ static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
 
     const auto& specific = eval_context.specifics().Get(specific_id);
     const auto& generic = eval_context.generics().Get(specific.generic_id);
-    if (!generic.decl_block_id.has_value()) {
-      // Impl witness table construction happens before its own generic is
-      // finished, in order to make the table's instructions dependent
-      // instructions of the Impl's generic. So we can not resolve the specific
-      // declaration for such instructions at the time they are created, as the
-      // generic's declaration eval block is not yet constructed (with those
-      // dependent instructions in it).
-      //
-      // TODO: Find a way to avoid this early out by making the evaluation of
-      // instructions in the witness table that require a specific happen after
-      // the generic is complete. Or find a way to limit this just to the impl
-      // witness table and ensure the declarations will be resolved.
+    if (specific_id == generic.self_specific_id) {
+      // Impl witness table construction happens before its generic decl is
+      // finish, in order to make the table's instructions dependent
+      // instructions of the Impl's generic. But those instructions can refer to
+      // the generic's self specific. We can not resolve the specific
+      // declaration for the self specific until the generic is finished, but it
+      // is explicitly resolved at that time in `FinishGenericDecl()`.
       return;
     }
     ResolveSpecificDecl(eval_context.context(), eval_context.fallback_loc_id(),
@@ -810,6 +803,9 @@ static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
   };
 
   for (auto arg_and_kind : {inst.arg0_and_kind(), inst.arg1_and_kind()}) {
+    // This switch must handle any field type that has a GetConstantValue()
+    // overload which canonicalizes a specific (and thus potentially forms a new
+    // specific) as part of forming its constant value.
     CARBON_KIND_SWITCH(arg_and_kind) {
       case CARBON_KIND(SemIR::SpecificId specific_id): {
         resolve_specific_decl(specific_id);

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "common/concepts.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/action.h"
 #include "toolchain/check/diagnostic_helpers.h"
@@ -180,6 +181,7 @@ class EvalContext {
   auto facet_types() -> CanonicalValueStore<SemIR::FacetTypeId>& {
     return sem_ir().facet_types();
   }
+  auto generics() -> const SemIR::GenericStore& { return sem_ir().generics(); }
   auto specifics() -> const SemIR::SpecificStore& {
     return sem_ir().specifics();
   }
@@ -542,29 +544,21 @@ static auto GetConstantValue(EvalContext& eval_context,
     return SemIR::SpecificId::None;
   }
 
+  // Generally, when making a new specific, it's done through MakeSpecific(),
+  // which will ensure the declaration is resolved.
+  //
+  // However, the SpecificId returned here is intentionally left without its
+  // declaration resolved. Imported instructions with SpecificIds should not
+  // have the specific's declaration resolved, but other instructions which
+  // include a new SpecificId should.
+  //
+  // The resolving of the specific's declaration will be ensured later when
+  // evaluating the instruction containing the SpecificId.
   if (args_id == specific.args_id) {
-    const auto& specific = eval_context.specifics().Get(specific_id);
-    // A constant specific_id should always have a resolved declaration. The
-    // specific_id from the instruction may coincidentally be canonical, and so
-    // constant evaluation gives the same value. In that case, we still need to
-    // ensure its declaration is resolved.
-    //
-    // However, don't resolve the declaration if the generic's eval block hasn't
-    // been set yet. This happens when building the eval block during import.
-    //
-    // TODO: Change importing of generic eval blocks to be less fragile and
-    // remove this `if` so we unconditionally call `ResolveSpecificDeclaration`.
-    if (!specific.decl_block_id.has_value() && eval_context.context()
-                                                   .generics()
-                                                   .Get(specific.generic_id)
-                                                   .decl_block_id.has_value()) {
-      ResolveSpecificDeclaration(eval_context.context(),
-                                 eval_context.fallback_loc_id(), specific_id);
-    }
     return specific_id;
   }
-  return MakeSpecific(eval_context.context(), eval_context.fallback_loc_id(),
-                      specific.generic_id, args_id);
+  return eval_context.context().specifics().GetOrAdd(specific.generic_id,
+                                                     args_id);
 }
 
 static auto GetConstantValue(EvalContext& eval_context,
@@ -768,6 +762,108 @@ static auto ReplaceTypeWithConstantValue(EvalContext& eval_context,
   return IsConstant(*phase);
 }
 
+static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
+                                       const SemIR::Inst& inst) -> void;
+
+// Resolve the specific declaration in the given instruction field. There is an
+// overload for any field type that has a GetConstantValue() overload which
+// canonicalizes a specific as part of forming its constant value.
+static auto ResolveSpecificDeclForField(EvalContext& eval_context,
+                                        SemIR::SpecificId specific_id) -> void {
+  if (!specific_id.has_value()) {
+    return;
+  }
+
+  const auto& specific = eval_context.specifics().Get(specific_id);
+  const auto& generic = eval_context.generics().Get(specific.generic_id);
+  if (!generic.decl_block_id.has_value()) {
+    // Impl witness table construction happens before its own generic is
+    // finished, in order to make the table's instructions dependent
+    // instructions of the Impl's generic. So we can not resolve the specific
+    // declaration for such instructions at the time they are created, as the
+    // generic's declaration eval block is not yet constructed (with those
+    // dependent instructions in it).
+    //
+    // TODO: Find a way to avoid this early out by making the evaluation of
+    // instructions in the witness table that require a specific happen after
+    // the generic is complete. Or find a way to limit this just to the impl
+    // witness table and ensure the declarations will be resolved.
+    return;
+  }
+
+  ResolveSpecificDeclaration(eval_context.context(),
+                             eval_context.fallback_loc_id(), specific_id);
+}
+
+static auto ResolveSpecificDeclForField(
+    EvalContext& eval_context, SemIR::SpecificInterfaceId specific_interface_id)
+    -> void {
+  if (!specific_interface_id.has_value()) {
+    return;
+  }
+  ResolveSpecificDeclForField(eval_context, eval_context.specific_interfaces()
+                                                .Get(specific_interface_id)
+                                                .specific_id);
+}
+
+static auto ResolveSpecificDeclForField(EvalContext& eval_context,
+                                        SemIR::FacetTypeId facet_type_id)
+    -> void {
+  const auto& info = eval_context.context().facet_types().Get(facet_type_id);
+  for (const auto& interface : info.extend_constraints) {
+    ResolveSpecificDeclForField(eval_context, interface.specific_id);
+  }
+  for (const auto& interface : info.self_impls_constraints) {
+    ResolveSpecificDeclForField(eval_context, interface.specific_id);
+  }
+}
+
+// An overload for id types that have a GetConstantValue() overload but for
+// which that overload does not canonicalize any SpecificId in the value type.
+template <typename T>
+  requires SameAsOneOf<T, SemIR::DestInstId, SemIR::EntityNameId,
+                       SemIR::InstBlockId, SemIR::InstId, SemIR::MetaInstId,
+                       SemIR::StructTypeFieldsId, SemIR::TypeInstId>
+static auto ResolveSpecificDeclForField(EvalContext& /*eval_context*/,
+                                        T /*id*/) {}
+
+using ResolveSpecificHandlerFnT = auto(EvalContext& context, int32_t arg)
+    -> void;
+
+// Returns a lookup table to get constants by Id::Kind. Requires a null IdKind
+// as a parameter in order to get the type pack.
+template <typename... Types>
+static constexpr auto MakeResolveSpecificHandlerTable(
+    TypeEnum<Types...>* /*id_kind*/)
+    -> std::array<ResolveSpecificHandlerFnT*, SemIR::IdKind::NumValues> {
+  std::array<ResolveSpecificHandlerFnT*, SemIR::IdKind::NumValues> table = {};
+  ((table[SemIR::IdKind::template For<Types>.ToIndex()] =
+        [](EvalContext& eval_context, int32_t arg) {
+          if constexpr (HasGetConstantValueOverload<Types>) {
+            auto id = SemIR::Inst::FromRaw<Types>(arg);
+            ResolveSpecificDeclForField(eval_context, id);
+          }
+        }),
+   ...);
+  table[SemIR::IdKind::Invalid.ToIndex()] = [](EvalContext& /*context*/,
+                                               int32_t /*arg*/) {
+    CARBON_FATAL("Instruction has argument with invalid IdKind");
+  };
+  table[SemIR::IdKind::None.ToIndex()] = [](EvalContext& /*context*/,
+                                            int32_t /*arg*/) {};
+  return table;
+}
+
+static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
+                                       const SemIR::Inst& inst) -> void {
+  static constexpr auto Table =
+      MakeResolveSpecificHandlerTable(static_cast<SemIR::IdKind*>(nullptr));
+  Table[inst.arg0_and_kind().kind().ToIndex()](eval_context,
+                                               inst.arg0_and_kind().value());
+  Table[inst.arg1_and_kind().kind().ToIndex()](eval_context,
+                                               inst.arg1_and_kind().value());
+}
+
 auto AddImportedConstant(Context& context, SemIR::Inst inst)
     -> SemIR::ConstantId {
   EvalContext eval_context(&context, SemIR::LocId::None);
@@ -775,8 +871,6 @@ auto AddImportedConstant(Context& context, SemIR::Inst inst)
                inst.kind());
   Phase phase = GetPhase(context.constant_values(),
                          context.types().GetConstantId(inst.type_id()));
-  // TODO: Can we avoid doing this replacement? It may do things that are
-  // undesirable during importing, such as resolving specifics.
   if (!ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase)) {
     return SemIR::ConstantId::NotConstant;
   }
@@ -1769,6 +1863,12 @@ static auto TryEvalTypedInst(EvalContext& eval_context, SemIR::InstId inst_id,
       }
       return MakeNonConstantResult(phase);
     }
+
+    // When canonicalizing a SpecificId, we defer resolving the specific's
+    // declaration until here, to avoid resolving declarations from imported
+    // specifics. (Imported instructions are not evaluated.)
+    ResolveSpecificDeclForInst(eval_context, inst);
+
     if constexpr (ConstantKind == SemIR::InstConstantKind::Always ||
                   ConstantKind == SemIR::InstConstantKind::WheneverPossible) {
       return MakeConstantResult(eval_context.context(), inst, phase);

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -781,7 +781,7 @@ struct KindHasGetConstantValueOverload<TypeEnum<Types...>> {
 // Resolves the specific declarations for a specific id in any field of the
 // `inst` instruction. This must be done for any field type that has a
 // GetConstantValue() overload which canonicalizes a specific (and thus
-// potentially forming a new specific) as part of forming its constant value.
+// potentially forms a new specific) as part of forming its constant value.
 static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
                                        const SemIR::Inst& inst) -> void {
   auto resolve_specific_decl = [&](SemIR::SpecificId specific_id) {

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -9,7 +9,6 @@
 #include <optional>
 #include <utility>
 
-#include "common/concepts.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/action.h"
 #include "toolchain/check/diagnostic_helpers.h"
@@ -834,6 +833,8 @@ static auto ResolveSpecificDeclForInst(EvalContext& eval_context,
         break;
       }
 
+        // These id types have a GetConstantValue() overload but that overload
+        // does not canonicalize any SpecificId in the value type.
       case CARBON_KIND(SemIR::DestInstId _):
         break;
       case CARBON_KIND(SemIR::EntityNameId _):

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -475,8 +475,8 @@ auto FinishGenericDecl(Context& context, SemIR::LocId loc_id,
   context.generic_region_stack().Pop();
   context.generics().Get(generic_id).decl_block_id = decl_block_id;
 
-  ResolveSpecificDeclaration(context, loc_id,
-                             context.generics().GetSelfSpecific(generic_id));
+  ResolveSpecificDecl(context, loc_id,
+                      context.generics().GetSelfSpecific(generic_id));
 }
 
 auto BuildGenericDecl(Context& context, SemIR::InstId decl_id)
@@ -643,8 +643,8 @@ auto FinishGenericDefinition(Context& context, SemIR::GenericId generic_id)
   context.generics().Get(generic_id).definition_block_id = definition_block_id;
 }
 
-auto ResolveSpecificDeclaration(Context& context, SemIR::LocId loc_id,
-                                SemIR::SpecificId specific_id) -> void {
+auto ResolveSpecificDecl(Context& context, SemIR::LocId loc_id,
+                         SemIR::SpecificId specific_id) -> void {
   // If this is the first time we've formed this specific, evaluate its decl
   // block to form information about the specific.
   if (!context.specifics().Get(specific_id).decl_block_id.has_value()) {
@@ -666,7 +666,7 @@ auto MakeSpecific(Context& context, SemIR::LocId loc_id,
                   SemIR::GenericId generic_id, SemIR::InstBlockId args_id)
     -> SemIR::SpecificId {
   auto specific_id = context.specifics().GetOrAdd(generic_id, args_id);
-  ResolveSpecificDeclaration(context, loc_id, specific_id);
+  ResolveSpecificDecl(context, loc_id, specific_id);
   return specific_id;
 }
 
@@ -703,7 +703,7 @@ auto MakeSelfSpecific(Context& context, SemIR::LocId loc_id,
   // TODO: This could be made more efficient. We don't need to perform
   // substitution here; we know we want identity mappings for all constants and
   // types. We could also consider not storing the mapping at all in this case.
-  ResolveSpecificDeclaration(context, loc_id, specific_id);
+  ResolveSpecificDecl(context, loc_id, specific_id);
   return specific_id;
 }
 

--- a/toolchain/check/generic.h
+++ b/toolchain/check/generic.h
@@ -102,8 +102,8 @@ auto MakeSelfSpecific(Context& context, SemIR::LocId loc_id,
 // Resolve the declaration of the given specific, by evaluating the eval block
 // of the corresponding generic and storing a corresponding value block in the
 // specific.
-auto ResolveSpecificDeclaration(Context& context, SemIR::LocId loc_id,
-                                SemIR::SpecificId specific_id) -> void;
+auto ResolveSpecificDecl(Context& context, SemIR::LocId loc_id,
+                         SemIR::SpecificId specific_id) -> void;
 
 // Attempts to resolve the definition of the given specific, by evaluating the
 // eval block of the corresponding generic and storing a corresponding value

--- a/toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon
@@ -699,12 +699,6 @@ var n: Int(64) = MakeFromClass(FromLiteral(64) as OtherInt);
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.a71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Op.1(constants.%Add.facet.5a7) {
-// CHECK:STDOUT:   %Self => constants.%Add.facet.5a7
-// CHECK:STDOUT:   %Self.as_type => constants.%MyInt.09f
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.a71
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: specific @Double(constants.%int_64) {
 // CHECK:STDOUT:   %N => constants.%int_64
 // CHECK:STDOUT:   %MyInt => constants.%MyInt.f30


### PR DESCRIPTION
Move the operation of resolving the specific decl block from `GetConstantValue()` to `TryEvalTypedInst()`, with is now happening after replacing the fields of the instruction with new constant values, but before running the evaluation of the instruction. Since imported instructions are not evaluated, this avoids resolving the specific decl block from imported instructions, resolving a TODO in `AddImportedConstant()`. Now `AddImportedConstant()` can replace constant values in its fields without having to worry about that operation resolving any specific decl blocks.

We get to add a new TODO however, to explain why we still need a special case in resolving specific decl blocks for handling `Impl` construction. The witness table contains instructions with specifics referring to the generic self of the impl declaration. But the table must be constructed before the impl's generic is finished, in order to make the instructions dependent for the generic. But then resolving the specific decl block can't be done when the instructions are created and evaluated, as that requires a finished generic.