### PR TITLE
Give different inst id types different labels in CARBON_CHECK output

### DIFF
--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -69,6 +69,7 @@ constexpr InstId InstId::InitTombstone = InstId(NoneIndex - 1);
 // construction, and this allows that check to be represented in the type
 // system.
 struct TypeInstId : public InstId {
+  static constexpr llvm::StringLiteral Label = "type_inst";
   static const TypeInstId None;
 
   using InstId::InstId;
@@ -96,6 +97,8 @@ constexpr TypeInstId TypeInstId::None = TypeInstId::UnsafeMake(InstId::None);
 // than substituting into it.
 class AbsoluteInstId : public InstId {
  public:
+  static constexpr llvm::StringLiteral Label = "absolute_inst";
+
   // Support implicit conversion from InstId so that InstId and AbsoluteInstId
   // have the same interface.
   // NOLINTNEXTLINE(google-explicit-constructor)
@@ -118,6 +121,8 @@ class AbsoluteInstId : public InstId {
 // an instruction.
 class DestInstId : public InstId {
  public:
+  static constexpr llvm::StringLiteral Label = "dest_inst";
+
   // Support implicit conversion from InstId so that InstId and DestInstId
   // have the same interface.
   // NOLINTNEXTLINE(google-explicit-constructor)
@@ -141,6 +146,8 @@ class DestInstId : public InstId {
 // has a non-constant value, the field is left unchanged by evaluation.
 class MetaInstId : public InstId {
  public:
+  static constexpr llvm::StringLiteral Label = "meta_inst";
+
   // Support implicit conversion from InstId so that InstId and MetaInstId
   // have the same interface.
   // NOLINTNEXTLINE(google-explicit-constructor)


### PR DESCRIPTION
For an `IdKind value`, `CARBON_CHECK(false, "{0}", value)` prints the `Label` of the id type in place of the `{0}`. For different inst types, we would like to display `TypeEnum(...)` with the actual inst type rather than always `TypeEnum(inst)`. The latter is misleading, suggesting the `IdKind` value is `InstId` when it may be `TypeInstId`, or `MetaInstId`, etc.