### PR TITLE
Try out a different IdKind table approach

### DIFF
--- a/common/type_enum.h
+++ b/common/type_enum.h
@@ -65,21 +65,6 @@ class TypeEnum : public Printable<TypeEnum<Types...>> {
   template <typename Type>
   static constexpr bool Contains = For<Type, true>.is_valid();
 
-  // Takes the arguments and returns a full table for all values. Often used to
-  // produce dispatch tables.
-  template <typename ElementT>
-  static constexpr auto MakeTable(std::array<ElementT, NumTypes> types,
-                                  ElementT invalid, ElementT none)
-      -> std::array<ElementT, NumValues> {
-    std::array<ElementT, NumValues> table;
-    for (size_t i = 0; i < NumTypes; ++i) {
-      table[i] = types[i];
-    }
-    table[Invalid.ToIndex()] = invalid;
-    table[None.ToIndex()] = none;
-    return table;
-  }
-
   // Explicitly convert from the raw enum type.
   explicit constexpr TypeEnum(RawEnumType value) : value_(value) {}
 

--- a/common/type_enum.h
+++ b/common/type_enum.h
@@ -65,6 +65,21 @@ class TypeEnum : public Printable<TypeEnum<Types...>> {
   template <typename Type>
   static constexpr bool Contains = For<Type, true>.is_valid();
 
+  // Takes the arguments and returns a full table for all values. Often used to
+  // produce dispatch tables.
+  template <typename ElementT>
+  static constexpr auto MakeTable(std::array<ElementT, NumTypes> types,
+                                  ElementT invalid, ElementT none)
+      -> std::array<ElementT, NumValues> {
+    std::array<ElementT, NumValues> table;
+    for (size_t i = 0; i < NumTypes; ++i) {
+      table[i] = types[i];
+    }
+    table[Invalid.ToIndex()] = invalid;
+    table[None.ToIndex()] = none;
+    return table;
+  }
+
   // Explicitly convert from the raw enum type.
   explicit constexpr TypeEnum(RawEnumType value) : value_(value) {}
 

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -669,34 +669,30 @@ static constexpr bool HasGetConstantValueOverload = requires {
 using ArgHandlerFnT = auto(EvalContext& context, int32_t arg, Phase* phase)
     -> int32_t;
 
-// Returns a lookup table to get constants by Id::Kind. Requires a null IdKind
-// as a parameter in order to get the type pack.
+// Returns the arg handler for an `IdKind`.
 template <typename... Types>
-static constexpr auto MakeArgHandlerTable(TypeEnum<Types...>* /*id_kind*/)
-    -> std::array<ArgHandlerFnT*, SemIR::IdKind::NumValues> {
-  std::array<ArgHandlerFnT*, SemIR::IdKind::NumValues> table = {};
-  ((table[SemIR::IdKind::template For<Types>.ToIndex()] =
-        [](EvalContext& eval_context, int32_t arg, Phase* phase) -> int32_t {
-     auto id = SemIR::Inst::FromRaw<Types>(arg);
-     if constexpr (HasGetConstantValueOverload<Types>) {
-       // If we have a custom `GetConstantValue` overload, call it.
-       return SemIR::Inst::ToRaw(GetConstantValue(eval_context, id, phase));
-     } else {
-       // Otherwise, we assume the value is already constant.
-       return arg;
-     }
-   }),
-   ...);
-  table[SemIR::IdKind::Invalid.ToIndex()] = [](EvalContext& /*context*/,
-                                               int32_t /*arg*/,
-                                               Phase* /*phase*/) -> int32_t {
-    CARBON_FATAL("Instruction has argument with invalid IdKind");
-  };
-  table[SemIR::IdKind::None.ToIndex()] =
+static auto GetArgHandlerFn(TypeEnum<Types...> id_kind) -> ArgHandlerFnT* {
+  static constexpr auto Table = SemIR::IdKind::MakeTable<ArgHandlerFnT*>(
+      {[](EvalContext& eval_context, int32_t arg, Phase* phase) -> int32_t {
+        auto id = SemIR::Inst::FromRaw<Types>(arg);
+        if constexpr (HasGetConstantValueOverload<Types>) {
+          // If we have a custom `GetConstantValue` overload, call it.
+          return SemIR::Inst::ToRaw(GetConstantValue(eval_context, id, phase));
+        } else {
+          // Otherwise, we assume the value is already constant.
+          return arg;
+        }
+      }...},
+      /*invalid=*/
+      [](EvalContext& /*context*/, int32_t /*arg*/,
+         Phase* /*phase*/) -> int32_t {
+        CARBON_FATAL("Instruction has argument with invalid IdKind");
+      },
+      /*none=*/
       [](EvalContext& /*context*/, int32_t arg, Phase* /*phase*/) -> int32_t {
-    return arg;
-  };
-  return table;
+        return arg;
+      });
+  return Table[id_kind.ToIndex()];
 }
 
 // Given the stored value `arg` of an instruction field and its corresponding
@@ -707,9 +703,7 @@ static constexpr auto MakeArgHandlerTable(TypeEnum<Types...>* /*id_kind*/)
 static auto GetConstantValueForArg(EvalContext& eval_context,
                                    SemIR::Inst::ArgAndKind arg_and_kind,
                                    Phase* phase) -> int32_t {
-  static constexpr auto Table =
-      MakeArgHandlerTable(static_cast<SemIR::IdKind*>(nullptr));
-  return Table[arg_and_kind.kind().ToIndex()](eval_context,
+  return GetArgHandlerFn(arg_and_kind.kind())(eval_context,
                                               arg_and_kind.value(), phase);
 }
 

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -672,26 +672,24 @@ using ArgHandlerFnT = auto(EvalContext& context, int32_t arg, Phase* phase)
 // Returns the arg handler for an `IdKind`.
 template <typename... Types>
 static auto GetArgHandlerFn(TypeEnum<Types...> id_kind) -> ArgHandlerFnT* {
-  static constexpr auto Table = SemIR::IdKind::MakeTable<ArgHandlerFnT*>(
-      {[](EvalContext& eval_context, int32_t arg, Phase* phase) -> int32_t {
-        auto id = SemIR::Inst::FromRaw<Types>(arg);
-        if constexpr (HasGetConstantValueOverload<Types>) {
-          // If we have a custom `GetConstantValue` overload, call it.
-          return SemIR::Inst::ToRaw(GetConstantValue(eval_context, id, phase));
-        } else {
-          // Otherwise, we assume the value is already constant.
-          return arg;
-        }
-      }...},
-      /*invalid=*/
-      [](EvalContext& /*context*/, int32_t /*arg*/,
-         Phase* /*phase*/) -> int32_t {
-        CARBON_FATAL("Instruction has argument with invalid IdKind");
-      },
-      /*none=*/
-      [](EvalContext& /*context*/, int32_t arg, Phase* /*phase*/) -> int32_t {
-        return arg;
-      });
+  static constexpr std::array<ArgHandlerFnT*, SemIR::IdKind::NumValues> Table =
+      {
+          [](EvalContext& eval_context, int32_t arg, Phase* phase) -> int32_t {
+            auto id = SemIR::Inst::FromRaw<Types>(arg);
+            if constexpr (HasGetConstantValueOverload<Types>) {
+              // If we have a custom `GetConstantValue` overload, call it.
+              return SemIR::Inst::ToRaw(
+                  GetConstantValue(eval_context, id, phase));
+            } else {
+              // Otherwise, we assume the value is already constant.
+              return arg;
+            }
+          }...,
+          // Invalid and None handling (ordering-sensitive).
+          [](auto...) -> int32_t { CARBON_FATAL("Unexpected invalid IdKind"); },
+          [](EvalContext& /*context*/, int32_t arg,
+             Phase* /*phase*/) -> int32_t { return arg; },
+      };
   return Table[id_kind.ToIndex()];
 }
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -897,9 +897,7 @@ auto Formatter::FormatInstLhs(InstId inst_id, Inst inst) -> void {
 }
 
 auto Formatter::FormatInstArgAndKind(Inst::ArgAndKind arg_and_kind) -> void {
-  static constexpr auto Table =
-      MakeFormatArgFnTable(static_cast<SemIR::IdKind*>(nullptr));
-  Table[arg_and_kind.kind().ToIndex()](*this, arg_and_kind.value());
+  GetFormatArgFn(arg_and_kind.kind())(*this, arg_and_kind.value());
 }
 
 auto Formatter::FormatInstRhs(Inst inst) -> void {

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -287,15 +287,12 @@ class Formatter {
   auto FormatArg(RealId id) -> void;
   auto FormatArg(StringLiteralValueId id) -> void;
 
-  // For MakeFormatArgFnTable.
+  // A `FormatArg` wrapper for `FormatInstArgAndKind`.
   using FormatArgFnT = auto(Formatter& formatter, int32_t arg) -> void;
 
-  // Returns a lookup table to format arguments by their `IdKind`, for
-  // `FormatInstArgAndKind`. Requires a null IdKind as a parameter in order to
-  // get the type pack.
+  // Returns the `FormatArgFnT` for the given `IdKind`.
   template <typename... Types>
-  static constexpr auto MakeFormatArgFnTable(TypeEnum<Types...>* /*id_kind*/)
-      -> std::array<FormatArgFnT*, SemIR::IdKind::NumValues>;
+  static auto GetFormatArgFn(TypeEnum<Types...> id_kind) -> FormatArgFnT*;
 
   // Calls `FormatArg` from an `ArgAndKind`.
   auto FormatInstArgAndKind(Inst::ArgAndKind arg_and_kind) -> void;
@@ -431,26 +428,22 @@ auto Formatter::FormatEntityStart(llvm::StringRef entity_kind,
 }
 
 template <typename... Types>
-constexpr auto Formatter::MakeFormatArgFnTable(TypeEnum<Types...>* /*id_kind*/)
-    -> std::array<FormatArgFnT*, SemIR::IdKind::NumValues> {
-  std::array<FormatArgFnT*, SemIR::IdKind::NumValues> table = {};
-  ((table[SemIR::IdKind::template For<Types>.ToIndex()] =
-        [](Formatter& formatter, int32_t arg) -> void {
-     auto typed_arg = SemIR::Inst::FromRaw<Types>(arg);
-     if constexpr (requires { formatter.FormatArg(typed_arg); }) {
-       formatter.FormatArg(typed_arg);
-     } else {
-       CARBON_FATAL("Missing FormatArg for {0}", typeid(Types).name());
-     }
-   }),
-   ...);
-  table[SemIR::IdKind::Invalid.ToIndex()] = [](Formatter& /*formatter*/,
-                                               int32_t /*arg*/) -> void {
-    CARBON_FATAL("Instruction has argument with invalid IdKind");
-  };
-  table[SemIR::IdKind::None.ToIndex()] = [](Formatter& /*formatter*/,
-                                            int32_t /*arg*/) -> void {};
-  return table;
+auto Formatter::GetFormatArgFn(TypeEnum<Types...> id_kind) -> FormatArgFnT* {
+  static constexpr auto Table = IdKind::MakeTable<FormatArgFnT*>(
+      {[](Formatter& formatter, int32_t arg) -> void {
+        auto typed_arg = SemIR::Inst::FromRaw<Types>(arg);
+        if constexpr (requires { formatter.FormatArg(typed_arg); }) {
+          formatter.FormatArg(typed_arg);
+        } else {
+          CARBON_FATAL("Missing FormatArg for {0}", typeid(Types).name());
+        }
+      }...},
+      /*invalid=*/
+      [](Formatter& /*formatter*/, int32_t /*arg*/) -> void {
+        CARBON_FATAL("Instruction has argument with invalid IdKind");
+      },
+      /*none=*/[](Formatter& /*formatter*/, int32_t /*arg*/) -> void {});
+  return Table[id_kind.ToIndex()];
 }
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -429,20 +429,19 @@ auto Formatter::FormatEntityStart(llvm::StringRef entity_kind,
 
 template <typename... Types>
 auto Formatter::GetFormatArgFn(TypeEnum<Types...> id_kind) -> FormatArgFnT* {
-  static constexpr auto Table = IdKind::MakeTable<FormatArgFnT*>(
-      {[](Formatter& formatter, int32_t arg) -> void {
-        auto typed_arg = SemIR::Inst::FromRaw<Types>(arg);
+  static constexpr std::array<FormatArgFnT*, IdKind::NumValues> Table = {
+      [](Formatter& formatter, int32_t arg) -> void {
+        auto typed_arg = Inst::FromRaw<Types>(arg);
         if constexpr (requires { formatter.FormatArg(typed_arg); }) {
           formatter.FormatArg(typed_arg);
         } else {
           CARBON_FATAL("Missing FormatArg for {0}", typeid(Types).name());
         }
-      }...},
-      /*invalid=*/
-      [](Formatter& /*formatter*/, int32_t /*arg*/) -> void {
-        CARBON_FATAL("Instruction has argument with invalid IdKind");
-      },
-      /*none=*/[](Formatter& /*formatter*/, int32_t /*arg*/) -> void {});
+      }...,
+      // Invalid and None handling (ordering-sensitive).
+      [](auto...) -> void { CARBON_FATAL("Unexpected invalid IdKind"); },
+      [](auto...) -> void {},
+  };
   return Table[id_kind.ToIndex()];
 }
 

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -317,15 +317,14 @@ struct Worklist {
   // Returns the arg handler for an `IdKind`.
   template <typename... Types>
   static auto GetAddFn(TypeEnum<Types...> id_kind) -> AddFnT* {
-    static constexpr auto Table = SemIR::IdKind::MakeTable<AddFnT*>(
-        {[](Worklist& worklist, int32_t arg) {
+    static constexpr std::array<AddFnT*, IdKind::NumValues> Table = {
+        [](Worklist& worklist, int32_t arg) {
           worklist.Add(Inst::FromRaw<Types>(arg));
-        }...},
-        /*invalid=*/
-        [](Worklist& /*worklist*/, int32_t /*arg*/) {
-          CARBON_FATAL("Unexpected invalid argument kind");
-        },
-        /*none=*/[](Worklist& /*worklist*/, int32_t /*arg*/) {});
+        }...,
+        // Invalid and None handling (ordering-sensitive).
+        [](auto...) { CARBON_FATAL("Unexpected invalid IdKind"); },
+        [](auto...) {},
+    };
     return Table[id_kind.ToIndex()];
   }
 

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -314,31 +314,24 @@ struct Worklist {
 
   using AddFnT = auto(Worklist& worklist, int32_t arg) -> void;
 
-  // Returns a lookup table to add an argument of the given kind. Requires a
-  // null IdKind as a parameter in order to get the type pack.
+  // Returns the arg handler for an `IdKind`.
   template <typename... Types>
-  static constexpr auto MakeAddTable(TypeEnum<Types...>* /*id_kind*/)
-      -> std::array<AddFnT*, IdKind::NumValues> {
-    std::array<AddFnT*, IdKind::NumValues> table = {};
-    ((table[IdKind::template For<Types>.ToIndex()] =
-          [](Worklist& worklist, int32_t arg) {
-            worklist.Add(Inst::FromRaw<Types>(arg));
-          }),
-     ...);
-    table[IdKind::Invalid.ToIndex()] = [](Worklist& /*worklist*/,
-                                          int32_t /*arg*/) {
-      CARBON_FATAL("Unexpected invalid argument kind");
-    };
-    table[IdKind::None.ToIndex()] = [](Worklist& /*worklist*/,
-                                       int32_t /*arg*/) {};
-    return table;
+  static auto GetAddFn(TypeEnum<Types...> id_kind) -> AddFnT* {
+    static constexpr auto Table = SemIR::IdKind::MakeTable<AddFnT*>(
+        {[](Worklist& worklist, int32_t arg) {
+          worklist.Add(Inst::FromRaw<Types>(arg));
+        }...},
+        /*invalid=*/
+        [](Worklist& /*worklist*/, int32_t /*arg*/) {
+          CARBON_FATAL("Unexpected invalid argument kind");
+        },
+        /*none=*/[](Worklist& /*worklist*/, int32_t /*arg*/) {});
+    return Table[id_kind.ToIndex()];
   }
 
   // Add an instruction argument to the contents of the current instruction.
   auto AddWithKind(Inst::ArgAndKind arg) -> void {
-    static constexpr auto Table = MakeAddTable(static_cast<IdKind*>(nullptr));
-
-    Table[arg.kind().ToIndex()](*this, arg.value());
+    GetAddFn(arg.kind())(*this, arg.value());
   }
 
   // Ensure all the instructions on the todo list have fingerprints. To avoid a


### PR DESCRIPTION
I was thinking about these after #5526, was wondering how others will feel about this kind of approach:

- Adding a helper to `TypeEnum` to get the table construction.
- In what were previously `Make` functions, return the element instead of returning the table.
- By returning the element, no more need to pass in a nullptr (now have a concrete instance).

I think this is a mild simplification, but maybe worth it.

Note, would appreciate it if there are thoughts on how to provide a boilerplate `Invalid` implementation (maybe it'd be fine to just return `nullptr` and cause a crash that way, but I was hesitant to do that).