### PR TITLE
Fix ASAN poison bugs, add debugging infrastructure for finding them, and enable poisoning with ASAN by default

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -643,22 +643,6 @@ def _impl(ctx):
         ],
     )
 
-    # A feature that enables poisoning of value stores to detect use after
-    # potential reallocation bugs.
-    #
-    # TODO: Remove this and leave poisoning always on once these bugs are
-    # fixed.
-    poison_value_stores = feature(
-        name = "poison_value_stores",
-        requires = [feature_set(["asan"])],
-        flag_sets = [flag_set(
-            actions = all_compile_actions,
-            flag_groups = [flag_group(flags = [
-                "-DCARBON_POISON_VALUE_STORES=1",
-            ])],
-        )],
-    )
-
     fuzzer = feature(
         name = "fuzzer",
         flag_sets = [
@@ -1161,7 +1145,6 @@ def _impl(ctx):
         asan,
         asan_min_size,
         enable_in_fastbuild,
-        poison_value_stores,
         fuzzer,
         layering_check,
         module_maps,

--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -81,9 +81,9 @@ for dep in deps:
     # exist. Specially diagnose them to try to provide a more helpful
     # message.
     if repo in (
-        "@google_benchmark",
-        "@abseil-cpp",
-        "@googletest",
+        "@@google_benchmark+",
+        "@@abseil-cpp+",
+        "@@googletest+",
     ):
         sys.exit("ERROR: dependency only allowed in test code: %s" % dep)
 

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -73,7 +73,7 @@ ABSL_FLAG(int, print_slowest_tests, 5,
 
 // Flags known by a driver that are passed through to it.
 ABSL_FLAG(bool, poison_verbose, false, "Passed through to the driver.");
-ABSL_FLAG(std::string, poison_stop, "", "Passed through to the driver.");
+ABSL_FLAG(std::string, poison_abort, "", "Passed through to the driver.");
 
 static const std::vector<std::string>* g_pass_through_args = nullptr;
 
@@ -559,8 +559,8 @@ static auto Main(int argc, char** argv) -> ErrorOr<int> {
   if (absl::GetFlag(FLAGS_poison_verbose)) {
     pass_through_args.push_back("--poison_verbose");
   }
-  if (auto value = absl::GetFlag(FLAGS_poison_stop); !value.empty()) {
-    std::string stop = "--poison_stop=";
+  if (auto value = absl::GetFlag(FLAGS_poison_abort); !value.empty()) {
+    std::string stop = "--poison_abort=";
     stop += value;
     pass_through_args.push_back(std::move(stop));
   }

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -71,12 +71,6 @@ ABSL_FLAG(int, print_slowest_tests, 5,
           "The number of tests to print when showing slowest tests. Set to 0 "
           "to disabling printing. Set to -1 to print all tests.");
 
-// Flags known by a driver that are passed through to it.
-ABSL_FLAG(bool, poison_verbose, false, "Passed through to the driver.");
-ABSL_FLAG(std::string, poison_abort, "", "Passed through to the driver.");
-
-static const std::vector<std::string>* g_pass_through_args = nullptr;
-
 namespace Carbon::Testing {
 
 // Information for a test case.
@@ -375,7 +369,7 @@ static auto RunSingleTestHelper(FileTestInfo& test, FileTestBase& test_instance)
   llvm::PrettyStackTraceString stack_trace_entry(test_command.c_str());
 
   if (auto err = RunTestFile(test_instance, absl::GetFlag(FLAGS_dump_output),
-                             *g_pass_through_args, **test.test_result);
+                             **test.test_result);
       !err.ok()) {
     test.test_result = std::move(err).error();
   }
@@ -554,17 +548,6 @@ static auto Main(int argc, char** argv) -> ErrorOr<int> {
   Carbon::InitLLVM init_llvm(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   auto positional_args = absl::ParseCommandLine(argc, argv);
-
-  std::vector<std::string> pass_through_args;
-  if (absl::GetFlag(FLAGS_poison_verbose)) {
-    pass_through_args.push_back("--poison_verbose");
-  }
-  if (auto value = absl::GetFlag(FLAGS_poison_abort); !value.empty()) {
-    std::string stop = "--poison_abort=";
-    stop += value;
-    pass_through_args.push_back(std::move(stop));
-  }
-  g_pass_through_args = &pass_through_args;
 
   if (positional_args.size() > 1) {
     ErrorBuilder b;

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -386,6 +386,9 @@ static auto RunSingleTest(FileTestInfo& test, bool single_threaded,
   if (absl::GetFlag(FLAGS_dump_output)) {
     std::unique_lock<std::mutex> lock(output_mutex);
     llvm::errs() << "\n--- Dumping: " << test.test_name << "\n\n";
+  } else if (absl::GetFlag(FLAGS_threads) == 1) {
+    std::unique_lock<std::mutex> lock(output_mutex);
+    llvm::errs() << "\nTEST " << test.test_name << " ";
   }
 
   // Load expected output.

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -71,6 +71,12 @@ ABSL_FLAG(int, print_slowest_tests, 5,
           "The number of tests to print when showing slowest tests. Set to 0 "
           "to disabling printing. Set to -1 to print all tests.");
 
+// Flags known by a driver that are passed through to it.
+ABSL_FLAG(bool, poison_verbose, false, "Passed through to the driver.");
+ABSL_FLAG(std::string, poison_stop, "", "Passed through to the driver.");
+
+static const std::vector<std::string>* g_pass_through_args = nullptr;
+
 namespace Carbon::Testing {
 
 // Information for a test case.
@@ -369,7 +375,7 @@ static auto RunSingleTestHelper(FileTestInfo& test, FileTestBase& test_instance)
   llvm::PrettyStackTraceString stack_trace_entry(test_command.c_str());
 
   if (auto err = RunTestFile(test_instance, absl::GetFlag(FLAGS_dump_output),
-                             **test.test_result);
+                             *g_pass_through_args, **test.test_result);
       !err.ok()) {
     test.test_result = std::move(err).error();
   }
@@ -547,12 +553,23 @@ static auto Main(int argc, char** argv) -> ErrorOr<int> {
 
   Carbon::InitLLVM init_llvm(argc, argv);
   testing::InitGoogleTest(&argc, argv);
-  auto args = absl::ParseCommandLine(argc, argv);
+  auto positional_args = absl::ParseCommandLine(argc, argv);
 
-  if (args.size() > 1) {
+  std::vector<std::string> pass_through_args;
+  if (absl::GetFlag(FLAGS_poison_verbose)) {
+    pass_through_args.push_back("--poison_verbose");
+  }
+  if (auto value = absl::GetFlag(FLAGS_poison_stop); !value.empty()) {
+    std::string stop = "--poison_stop=";
+    stop += value;
+    pass_through_args.push_back(std::move(stop));
+  }
+  g_pass_through_args = &pass_through_args;
+
+  if (positional_args.size() > 1) {
     ErrorBuilder b;
     b << "Unexpected arguments:";
-    for (char* arg : llvm::ArrayRef(args).drop_front()) {
+    for (char* arg : llvm::ArrayRef(positional_args).drop_front()) {
       b << " " << FormatEscaped(arg);
     }
     return b;

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -83,6 +83,11 @@ class FileTestBase {
     return {};
   }
 
+  // Returns additional arguments to add to the Run call, if any.
+  virtual auto GetAdditionalArgs() const -> llvm::SmallVector<std::string> {
+    return {};
+  }
+
   // Returns a regex to match the default file when a line may not be present.
   // May return nullptr if unused. If GetLineNumberReplacements returns an entry
   // with has_file=false, this is required.

--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -90,7 +90,6 @@ static auto DoArgReplacements(llvm::SmallVector<std::string>& test_args,
 }
 
 auto RunTestFile(const FileTestBase& test_base, bool dump_output,
-                 llvm::ArrayRef<std::string> pass_through_args,
                  TestFile& test_file) -> ErrorOr<Success> {
   llvm::SmallVector<TestFile::Split*> all_splits;
   for (auto& split : test_file.file_splits) {
@@ -135,18 +134,21 @@ auto RunTestFile(const FileTestBase& test_base, bool dump_output,
     }
   }
 
+  // The subclass can inject additional arguments unconditionally.
+  auto additional_args = test_base.GetAdditionalArgs();
+
   // Convert the arguments to StringRef and const char* to match the
   // expectations of PrettyStackTraceProgram and Run.
   llvm::SmallVector<llvm::StringRef> test_args_ref;
   llvm::SmallVector<const char*> test_argv_for_stack_trace;
-  test_args_ref.reserve(test_file.test_args.size() + pass_through_args.size());
+  test_args_ref.reserve(test_file.test_args.size() + additional_args.size());
   test_argv_for_stack_trace.reserve(test_file.test_args.size() +
-                                    pass_through_args.size() + 1);
+                                    additional_args.size() + 1);
   for (const auto& arg : test_file.test_args) {
     test_args_ref.push_back(arg);
     test_argv_for_stack_trace.push_back(arg.c_str());
   }
-  for (const auto& arg : pass_through_args) {
+  for (const auto& arg : additional_args) {
     test_args_ref.push_back(arg);
     test_argv_for_stack_trace.push_back(arg.c_str());
   }

--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -90,6 +90,7 @@ static auto DoArgReplacements(llvm::SmallVector<std::string>& test_args,
 }
 
 auto RunTestFile(const FileTestBase& test_base, bool dump_output,
+                 llvm::ArrayRef<std::string> pass_through_args,
                  TestFile& test_file) -> ErrorOr<Success> {
   llvm::SmallVector<TestFile::Split*> all_splits;
   for (auto& split : test_file.file_splits) {
@@ -138,9 +139,14 @@ auto RunTestFile(const FileTestBase& test_base, bool dump_output,
   // expectations of PrettyStackTraceProgram and Run.
   llvm::SmallVector<llvm::StringRef> test_args_ref;
   llvm::SmallVector<const char*> test_argv_for_stack_trace;
-  test_args_ref.reserve(test_file.test_args.size());
-  test_argv_for_stack_trace.reserve(test_file.test_args.size() + 1);
+  test_args_ref.reserve(test_file.test_args.size() + pass_through_args.size());
+  test_argv_for_stack_trace.reserve(test_file.test_args.size() +
+                                    pass_through_args.size() + 1);
   for (const auto& arg : test_file.test_args) {
+    test_args_ref.push_back(arg);
+    test_argv_for_stack_trace.push_back(arg.c_str());
+  }
+  for (const auto& arg : pass_through_args) {
     test_args_ref.push_back(arg);
     test_argv_for_stack_trace.push_back(arg.c_str());
   }

--- a/testing/file_test/run_test.h
+++ b/testing/file_test/run_test.h
@@ -13,6 +13,7 @@ namespace Carbon::Testing {
 
 // Runs the test, updating `test_file`.
 auto RunTestFile(const FileTestBase& test_base, bool dump_output,
+                 llvm::ArrayRef<std::string> pass_through_args,
                  TestFile& test_file) -> ErrorOr<Success>;
 
 }  // namespace Carbon::Testing

--- a/testing/file_test/run_test.h
+++ b/testing/file_test/run_test.h
@@ -13,7 +13,6 @@ namespace Carbon::Testing {
 
 // Runs the test, updating `test_file`.
 auto RunTestFile(const FileTestBase& test_base, bool dump_output,
-                 llvm::ArrayRef<std::string> pass_through_args,
                  TestFile& test_file) -> ErrorOr<Success>;
 
 }  // namespace Carbon::Testing

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -95,7 +95,6 @@ cc_library(
         "//common:hashtable_key_context",
         "//common:ostream",
         "//common:set",
-        "@abseil-cpp//absl/flags:flag",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -86,6 +86,7 @@ cc_library(
 
 cc_library(
     name = "value_store",
+    srcs = ["value_store.cpp"],
     hdrs = ["value_store.h"],
     deps = [
         ":mem_usage",
@@ -94,6 +95,7 @@ cc_library(
         "//common:hashtable_key_context",
         "//common:ostream",
         "//common:set",
+        "@abseil-cpp//absl/flags:flag",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -10,27 +10,30 @@
 
 namespace Carbon {
 
-static bool g_poison_verbose = false;
-static llvm::StringRef g_poison_stop_condition;
-
-auto SetPoisonVerbose(bool v) -> void { g_poison_verbose = v; }
-auto SetPoisonStop(llvm::StringRef s) -> void { g_poison_stop_condition = s; }
-
 namespace Internal {
 
-static auto ShouldPrint() -> bool { return g_poison_verbose; }
+// Gets the global (thread-safe) decision to print poison logs.
+//
+// Initially this is called on each thread (with the same `val`) when deciding
+// to print logs or not, and the first such thread to win which sets the static
+// global bool. Further calls (which do not need to pass a value) just query and
+// get back that `Condition`.
+static auto GetShouldPrint(std::optional<bool> val = std::nullopt) -> bool {
+  static auto should_print = *val;
+  return should_print;
+}
 
 struct Condition {
-  std::string_view label;
+  std::string label;
   uint64_t counter;
 };
 
-static auto ParseStopCondition() -> Condition {
-  if (g_poison_stop_condition.empty()) {
-    return {.label = std::string_view(), .counter = static_cast<uint64_t>(-1)};
+static auto ParseStopCondition(llvm::StringRef condition) -> Condition {
+  if (condition.empty()) {
+    return {.counter = static_cast<uint64_t>(-1)};
   }
 
-  auto [label, counter_str] = g_poison_stop_condition.split(':');
+  auto [label, counter_str] = condition.split(':');
   if (counter_str.empty()) {
     llvm::errs()
         << "ERROR: --poison_stop condition should be 'label:counter'\n";
@@ -46,16 +49,22 @@ static auto ParseStopCondition() -> Condition {
                  << counter_str << "'\n";
     std::exit(1);
   }
-  return {.label = static_cast<std::string_view>(label), .counter = counter};
+  return {.label = std::string(label), .counter = counter};
 }
 
-static auto ShouldStop(std::string_view label, uint64_t counter) -> bool {
-  static auto condition = ParseStopCondition();
-  return counter >= condition.counter && label == condition.label;
+// Gets the global (thread-safe) stop Condition.
+//
+// Initially this is called on each thread (with the same `condition_str`) when
+// setting the stop condition, and the first such thread to win which sets the
+// static global `Condition`. Further calls without a string input just query
+// and get back that `Condition`.
+static auto GetStopCondition(llvm::StringRef condition_str = "") -> Condition {
+  static Condition condition = ParseStopCondition(condition_str);
+  return condition;
 }
 
 auto LogPoison(llvm::StringRef label, int element) -> void {
-  if (!ShouldPrint()) {
+  if (!GetShouldPrint()) {
     return;
   }
   static uint64_t counter = 0;
@@ -66,7 +75,8 @@ auto LogPoison(llvm::StringRef label, int element) -> void {
     llvm::errs() << "++ " << label << " PoisonElement " << element << " ("
                  << label << ":" << counter << ")\n";
   }
-  if (ShouldStop(label, counter)) {
+  auto condition = GetStopCondition();
+  if (counter >= condition.counter && label == condition.label) {
     llvm::errs() << "*** Stopping on poison event. Stack trace below.\n";
     std::abort();
   }
@@ -74,7 +84,7 @@ auto LogPoison(llvm::StringRef label, int element) -> void {
 }
 
 auto LogUnpoison(llvm::StringRef label, int element) -> void {
-  if (!ShouldPrint()) {
+  if (!GetShouldPrint()) {
     return;
   }
   if (element < 0) {
@@ -85,6 +95,10 @@ auto LogUnpoison(llvm::StringRef label, int element) -> void {
 }
 
 }  // namespace Internal
+
+auto SetPoisonVerbose(bool v) -> void { Internal::GetShouldPrint(v); }
+auto SetPoisonStop(llvm::StringRef s) -> void { Internal::GetStopCondition(s); }
+
 }  // namespace Carbon
 
 #endif

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -1,0 +1,99 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/base/value_store.h"
+
+#include "absl/flags/flag.h"
+#include "common/ostream.h"
+
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+
+ABSL_FLAG(bool, poison_verbose, false,
+          "Print out ASAN poison events in the ValueStore.");
+ABSL_FLAG(
+    std::string, poison_stop, "",
+    "Set a condition after which we should stop on the next poison. The "
+    "format is <label>:<counter>. Once the label is poisoned with a "
+    "counter value >= <counter>, the program will abort and print the "
+    "stack trace of the poisoning. Note that the poison counter can vary "
+    "slightly from run to run, so you can use a smaller number to catch the "
+    "poison event that you want. The counter values are printed when "
+    "--poison_verbose is used.");
+
+namespace Carbon::Internal {
+
+static auto ShouldPrint() -> bool {
+  static bool print = absl::GetFlag(FLAGS_poison_verbose);
+  return print;
+}
+
+struct Condition {
+  std::string_view label;
+  uint64_t counter;
+};
+
+static auto ParseStopCondition() -> Condition {
+  static std::string condition_string = absl::GetFlag(FLAGS_poison_stop);
+  llvm::StringRef condition = condition_string;
+  if (condition.empty()) {
+    return {.label = std::string_view(), .counter = static_cast<uint64_t>(-1)};
+  }
+
+  auto [label, counter_str] = condition.split(':');
+  if (counter_str.empty()) {
+    llvm::errs()
+        << "ERROR: --poison_stop condition should be 'label:counter'\n";
+    std::exit(1);
+  }
+  uint64_t counter;
+  // Note: getAsInteger returns false on success @_@.
+  if (counter_str.getAsInteger(0, counter)) {
+    llvm::errs() << "ERROR: counter could not be parsed as an integer\n";
+    llvm::errs()
+        << "ERROR: --poison_stop condition should be 'label:counter'\n";
+    llvm::errs() << " NOTE: found label:'" << label << "' counter:'"
+                 << counter_str << "'\n";
+    std::exit(1);
+  }
+  return {.label = static_cast<std::string_view>(label), .counter = counter};
+}
+
+static auto ShouldStop(std::string_view label, uint64_t counter) -> bool {
+  static auto condition = ParseStopCondition();
+  return counter >= condition.counter && label == condition.label;
+}
+
+auto LogPoison(std::string_view label, int element) -> void {
+  if (!ShouldPrint()) {
+    return;
+  }
+  static uint64_t counter = 0;
+  if (element < 0) {
+    llvm::errs() << "++ " << label << " PoisonAll (" << label << ":" << counter
+                 << ")\n";
+  } else {
+    llvm::errs() << "++ " << label << " PoisonElement " << element << " ("
+                 << label << ":" << counter << ")\n";
+  }
+  if (ShouldStop(label, counter)) {
+    llvm::errs() << "*** Stopping on poison event. Stack trace below.\n";
+    std::abort();
+  }
+  ++counter;
+}
+
+auto LogUnpoison(std::string_view label, int element) -> void {
+  if (!ShouldPrint()) {
+    return;
+  }
+  if (element < 0) {
+    llvm::errs() << "-- " << label << " UnpoisonAll\n";
+  } else {
+  }
+  llvm::errs() << "-- " << label << " UnpoisonElement " << element << '\n';
+}
+
+}  // namespace Carbon::Internal
+
+#endif

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -97,7 +97,9 @@ auto LogUnpoison(llvm::StringRef label, int element) -> void {
 }  // namespace Internal
 
 auto SetPoisonVerbose(bool v) -> void { Internal::GetShouldPrint(v); }
-auto SetPoisonAbortCondition(llvm::StringRef s) -> void { Internal::GetAbortCondition(s); }
+auto SetPoisonAbortCondition(llvm::StringRef s) -> void {
+  Internal::GetAbortCondition(s);
+}
 
 }  // namespace Carbon
 

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -28,7 +28,7 @@ struct Condition {
   uint64_t counter;
 };
 
-static auto ParseStopCondition(llvm::StringRef condition) -> Condition {
+static auto ParseAbortCondition(llvm::StringRef condition) -> Condition {
   if (condition.empty()) {
     return {.counter = static_cast<uint64_t>(-1)};
   }
@@ -36,7 +36,7 @@ static auto ParseStopCondition(llvm::StringRef condition) -> Condition {
   auto [label, counter_str] = condition.split(':');
   if (counter_str.empty()) {
     llvm::errs()
-        << "ERROR: --poison_stop condition should be 'label:counter'\n";
+        << "ERROR: --poison_abort condition should be 'label:counter'\n";
     std::exit(1);
   }
   uint64_t counter;
@@ -44,7 +44,7 @@ static auto ParseStopCondition(llvm::StringRef condition) -> Condition {
   if (counter_str.getAsInteger(0, counter)) {
     llvm::errs() << "ERROR: counter could not be parsed as an integer\n";
     llvm::errs()
-        << "ERROR: --poison_stop condition should be 'label:counter'\n";
+        << "ERROR: --poison_abort condition should be 'label:counter'\n";
     llvm::errs() << " NOTE: found label:'" << label << "' counter:'"
                  << counter_str << "'\n";
     std::exit(1);
@@ -52,14 +52,14 @@ static auto ParseStopCondition(llvm::StringRef condition) -> Condition {
   return {.label = std::string(label), .counter = counter};
 }
 
-// Gets the global (thread-safe) stop Condition.
+// Gets the global (thread-safe) abort Condition.
 //
 // Initially this is called on each thread (with the same `condition_str`) when
-// setting the stop condition, and the first such thread to win which sets the
+// setting the abort condition, and the first such thread to win which sets the
 // static global `Condition`. Further calls without a string input just query
 // and get back that `Condition`.
-static auto GetStopCondition(llvm::StringRef condition_str = "") -> Condition {
-  static Condition condition = ParseStopCondition(condition_str);
+static auto GetAbortCondition(llvm::StringRef condition_str = "") -> Condition {
+  static Condition condition = ParseAbortCondition(condition_str);
   return condition;
 }
 
@@ -75,9 +75,9 @@ auto LogPoison(llvm::StringRef label, int element) -> void {
     llvm::errs() << "++ " << label << " PoisonElement " << element << " ("
                  << label << ":" << counter << ")\n";
   }
-  auto condition = GetStopCondition();
+  auto condition = GetAbortCondition();
   if (counter >= condition.counter && label == condition.label) {
-    llvm::errs() << "*** Stopping on poison event. Stack trace below.\n";
+    llvm::errs() << "*** Aborting on poison event. Stack trace below.\n";
     std::abort();
   }
   ++counter;
@@ -97,7 +97,7 @@ auto LogUnpoison(llvm::StringRef label, int element) -> void {
 }  // namespace Internal
 
 auto SetPoisonVerbose(bool v) -> void { Internal::GetShouldPrint(v); }
-auto SetPoisonStop(llvm::StringRef s) -> void { Internal::GetStopCondition(s); }
+auto SetPoisonAbortCondition(llvm::StringRef s) -> void { Internal::GetAbortCondition(s); }
 
 }  // namespace Carbon
 

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -4,29 +4,21 @@
 
 #include "toolchain/base/value_store.h"
 
-#include "absl/flags/flag.h"
 #include "common/ostream.h"
 
 #ifdef LLVM_ADDRESS_SANITIZER_BUILD
 
-ABSL_FLAG(bool, poison_verbose, false,
-          "Print out ASAN poison events in the ValueStore.");
-ABSL_FLAG(
-    std::string, poison_stop, "",
-    "Set a condition after which we should stop on the next poison. The "
-    "format is <label>:<counter>. Once the label is poisoned with a "
-    "counter value >= <counter>, the program will abort and print the "
-    "stack trace of the poisoning. Note that the poison counter can vary "
-    "slightly from run to run, so you can use a smaller number to catch the "
-    "poison event that you want. The counter values are printed when "
-    "--poison_verbose is used.");
+namespace Carbon {
 
-namespace Carbon::Internal {
+static bool g_poison_verbose = false;
+static llvm::StringRef g_poison_stop_condition;
 
-static auto ShouldPrint() -> bool {
-  static bool print = absl::GetFlag(FLAGS_poison_verbose);
-  return print;
-}
+auto SetPoisonVerbose(bool v) -> void { g_poison_verbose = v; }
+auto SetPoisonStop(llvm::StringRef s) -> void { g_poison_stop_condition = s; }
+
+namespace Internal {
+
+static auto ShouldPrint() -> bool { return g_poison_verbose; }
 
 struct Condition {
   std::string_view label;
@@ -34,13 +26,11 @@ struct Condition {
 };
 
 static auto ParseStopCondition() -> Condition {
-  static std::string condition_string = absl::GetFlag(FLAGS_poison_stop);
-  llvm::StringRef condition = condition_string;
-  if (condition.empty()) {
+  if (g_poison_stop_condition.empty()) {
     return {.label = std::string_view(), .counter = static_cast<uint64_t>(-1)};
   }
 
-  auto [label, counter_str] = condition.split(':');
+  auto [label, counter_str] = g_poison_stop_condition.split(':');
   if (counter_str.empty()) {
     llvm::errs()
         << "ERROR: --poison_stop condition should be 'label:counter'\n";
@@ -94,6 +84,7 @@ auto LogUnpoison(std::string_view label, int element) -> void {
   llvm::errs() << "-- " << label << " UnpoisonElement " << element << '\n';
 }
 
-}  // namespace Carbon::Internal
+}  // namespace Internal
+}  // namespace Carbon
 
 #endif

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -90,8 +90,8 @@ auto LogUnpoison(llvm::StringRef label, int element) -> void {
   if (element < 0) {
     llvm::errs() << "-- " << label << " UnpoisonAll\n";
   } else {
+    llvm::errs() << "-- " << label << " UnpoisonElement " << element << '\n';
   }
-  llvm::errs() << "-- " << label << " UnpoisonElement " << element << '\n';
 }
 
 }  // namespace Internal

--- a/toolchain/base/value_store.cpp
+++ b/toolchain/base/value_store.cpp
@@ -54,7 +54,7 @@ static auto ShouldStop(std::string_view label, uint64_t counter) -> bool {
   return counter >= condition.counter && label == condition.label;
 }
 
-auto LogPoison(std::string_view label, int element) -> void {
+auto LogPoison(llvm::StringRef label, int element) -> void {
   if (!ShouldPrint()) {
     return;
   }
@@ -73,7 +73,7 @@ auto LogPoison(std::string_view label, int element) -> void {
   ++counter;
 }
 
-auto LogUnpoison(std::string_view label, int element) -> void {
+auto LogUnpoison(llvm::StringRef label, int element) -> void {
   if (!ShouldPrint()) {
     return;
   }

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -30,8 +30,12 @@ class ValueStoreNotPrintable {};
 
 #ifdef LLVM_ADDRESS_SANITIZER_BUILD
 namespace Internal {
-auto LogPoison(std::string_view label, int element) -> void;
-auto LogUnpoison(std::string_view label, int element) -> void;
+// Logs the poison event to stderr if `SetPoisonVerbose()` was set to true. A
+// negative `element` indicates the entire store was poisoned.
+auto LogPoison(llvm::StringRef label, int element) -> void;
+// Logs the unpoison event to stderr if `SetPoisonVerbose()` was set to true. A
+// negative `element` indicates the entire store was unpoisoned.
+auto LogUnpoison(llvm::StringRef label, int element) -> void;
 }  // namespace Internal
 
 // Control whether to print verbose ASAN poisoning logs showing each poison

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -42,8 +42,8 @@ auto LogUnpoison(llvm::StringRef label, int element) -> void;
 // event in the value stores. See --poison_verbose.
 auto SetPoisonVerbose(bool v) -> void;
 // Set the condition on which an ASAN poison event will abort the process and
-// dump a stack trace. See --poison_stop.
-auto SetPoisonStop(llvm::StringRef s) -> void;
+// dump a stack trace. See --poison_abort.
+auto SetPoisonAbortCondition(llvm::StringRef s) -> void;
 #endif
 
 // A simple wrapper for accumulating values, providing IDs to later retrieve the

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -23,7 +23,6 @@
 namespace Carbon {
 
 namespace Internal {
-
 // Used as a parent class for non-printable types. This is just for
 // std::conditional, not as an API.
 class ValueStoreNotPrintable {};
@@ -34,6 +33,13 @@ namespace Internal {
 auto LogPoison(std::string_view label, int element) -> void;
 auto LogUnpoison(std::string_view label, int element) -> void;
 }  // namespace Internal
+
+// Control whether to print verbose ASAN poisoning logs showing each poison
+// event in the value stores. See --poison_verbose.
+auto SetPoisonVerbose(bool v) -> void;
+// Set the condition on which an ASAN poison event will abort the process and
+// dump a stack trace. See --poison_stop.
+auto SetPoisonStop(llvm::StringRef s) -> void;
 #endif
 
 // A simple wrapper for accumulating values, providing IDs to later retrieve the

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -29,15 +29,11 @@ namespace Internal {
 class ValueStoreNotPrintable {};
 }  // namespace Internal
 
-// Setup our compile time condition controlling poisoning of value stores. This
-// is set to one by the Bazel flag `--features=poison_value_stores`.
-//
-// TODO: Eventually, this will always enabled when ASan is enabled, but we can't
-// do that until we clean up all of the latent bugs.
-#ifndef CARBON_POISON_VALUE_STORES
-#define CARBON_POISON_VALUE_STORES 0
-#elif !LLVM_ADDRESS_SANITIZER_BUILD
-#error "CARBON_POISON_VALUE_STORES requires address sanitizer"
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+namespace Internal {
+auto LogPoison(std::string_view label, int element) -> void;
+auto LogUnpoison(std::string_view label, int element) -> void;
+}  // namespace Internal
 #endif
 
 // A simple wrapper for accumulating values, providing IDs to later retrieve the
@@ -66,7 +62,7 @@ class ValueStore
   ValueStore() = default;
   ValueStore(ValueStore&& other) noexcept
       : values_((other.UnpoisonAll(), std::move(other.values_)))
-#if CARBON_POISON_VALUE_STORES
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
         ,
         all_poisoned_(false)
 #endif
@@ -77,7 +73,7 @@ class ValueStore
     UnpoisonAll();
     other.UnpoisonAll();
     values_ = std::move(other.values_);
-#if CARBON_POISON_VALUE_STORES
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
     all_poisoned_ = false;
 #endif
     PoisonAll();
@@ -98,15 +94,13 @@ class ValueStore
       // Unpoison everything if the push will reallocate, in order to allow the
       // vector to make a copy of the elements.
       UnpoisonAll();
-    } else {
-      PoisonAll();
     }
 
     values_.push_back(std::move(value));
 
-    if (realloc) {
-      PoisonAll();
-    } else {
+    if (!PoisonAll()) {
+      // If we did not realloc, and the store was already poisoned, the
+      // PoisonAll did nothing. So we poison the new element.
       PoisonElement(id.index);
     }
 
@@ -183,18 +177,22 @@ class ValueStore
   // Poison the entire contents of the value store. This is used to detect cases
   // where references to elements in a value store are used across calls that
   // might modify the store.
-  auto PoisonAll() const -> void {
-#if CARBON_POISON_VALUE_STORES
+  auto PoisonAll() const -> bool {
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
     if (!all_poisoned_) {
+      Internal::LogPoison(IdT::Label, -1);
       __asan_poison_memory_region(values_.data(),
                                   values_.size() * sizeof(values_[0]));
       all_poisoned_ = true;
+      return true;
     }
 #endif
+    return false;
   }
   // Unpoison the entire contents of the value store.
   auto UnpoisonAll() const -> void {
-#if CARBON_POISON_VALUE_STORES
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+    Internal::LogUnpoison(IdT::Label, -1);
     __asan_unpoison_memory_region(values_.data(),
                                   values_.size() * sizeof(values_[0]));
     all_poisoned_ = false;
@@ -202,13 +200,15 @@ class ValueStore
   }
   // Poison a single element.
   auto PoisonElement([[maybe_unused]] int element) const -> void {
-#if CARBON_POISON_VALUE_STORES
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+    Internal::LogPoison(IdT::Label, element);
     __asan_unpoison_memory_region(values_.data() + element, sizeof(values_[0]));
 #endif
   }
   // Unpoison a single element.
   auto UnpoisonElement([[maybe_unused]] int element) const -> void {
-#if CARBON_POISON_VALUE_STORES
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+    Internal::LogUnpoison(IdT::Label, element);
     __asan_unpoison_memory_region(values_.data() + element, sizeof(values_[0]));
     all_poisoned_ = false;
 #endif
@@ -218,7 +218,7 @@ class ValueStore
   // stack, while this does make File smaller.
   llvm::SmallVector<std::decay_t<ValueType>, 0> values_;
 
-#if CARBON_POISON_VALUE_STORES
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
   // Whether the vector is currently fully poisoned.
   //
   // We use this to avoid repeated re-poisoning of the entire store. Doing so is

--- a/toolchain/check/class.cpp
+++ b/toolchain/check/class.cpp
@@ -235,7 +235,9 @@ static auto CheckCompleteClassType(
   }
 
   if (class_info.is_dynamic) {
-    class_info.vtable_id = BuildVtable(
+    // This function imports, which can invalidate `class_info` and other
+    // pointers into value stores.
+    context.classes().Get(class_id).vtable_id = BuildVtable(
         context, node_id,
         defining_vptr ? SemIR::InstId::None : base_class_info->vtable_id,
         vtable_contents);

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -566,6 +566,8 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionStartId node_id)
       impl_decl_id, impl_info.scope_id,
       context.generics().GetSelfSpecific(impl_info.generic_id));
   StartGenericDefinition(context, impl_info.generic_id);
+  // This function imports, which can invalidate `impl_info` and other pointers
+  // into value stores.
   ImplWitnessStartDefinition(context, impl_info);
   context.inst_block_stack().Push();
   context.node_stack().Push(node_id, impl_id);
@@ -579,7 +581,8 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionStartId node_id)
   //
   // We may need to track a list of instruction blocks here, as we do for a
   // function.
-  impl_info.body_block_id = context.inst_block_stack().PeekOrAdd();
+  context.impls().Get(impl_id).body_block_id =
+      context.inst_block_stack().PeekOrAdd();
   return true;
 }
 

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -98,7 +98,9 @@ auto ImplWitnessForDeclaration(Context& context, const SemIR::Impl& impl,
       context.generics().GetSelfSpecific(impl.generic_id), has_definition);
 }
 
-auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
+// Note: `impl` is copied to avoid a pointer being invalidated when this
+// function imports.
+auto ImplWitnessStartDefinition(Context& context, SemIR::Impl impl) -> void {
   CARBON_CHECK(impl.is_being_defined());
   CARBON_CHECK(impl.witness_id.has_value());
   if (impl.witness_id == SemIR::ErrorInst::InstId) {
@@ -122,6 +124,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
       return;
     }
 
+    // This function imports, which can invalidate pointers into value stores.
     AllocateFacetTypeImplWitness(context, impl.interface.interface_id,
                                  witness_table.elements_id);
     witness_block = context.inst_blocks().GetMutable(witness_table.elements_id);
@@ -166,7 +169,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
 auto FinishImplWitness(Context& context, SemIR::ImplId impl_id) -> void {
   // Make a copy of the impl. We're going to reference it a lot, and `impl`s
   // could get invalidated by some of the things we do.
-  const auto impl = context.impls().Get(impl_id);
+  auto impl = context.impls().Get(impl_id);
 
   CARBON_CHECK(impl.is_being_defined());
   CARBON_CHECK(impl.witness_id.has_value());
@@ -183,6 +186,7 @@ auto FinishImplWitness(Context& context, SemIR::ImplId impl_id) -> void {
   const auto& interface = context.interfaces().Get(impl.interface.interface_id);
   auto assoc_entities =
       context.inst_blocks().Get(interface.associated_entities_id);
+  auto interface_name_id = interface.name_id;
   llvm::SmallVector<SemIR::InstId> used_decl_ids;
 
   for (auto [assoc_entity, witness_value] :
@@ -204,6 +208,8 @@ auto FinishImplWitness(Context& context, SemIR::ImplId impl_id) -> void {
           CARBON_FATAL("Unexpected type: {0}", type_inst);
         }
         auto& fn = context.functions().Get(fn_type->function_id);
+        // This function imports, which can invalidate `interface` and other
+        // pointers into value stores.
         auto lookup_result =
             LookupNameInExactScope(context, SemIR::LocId(decl_id), fn.name_id,
                                    impl.scope_id, impl_scope);
@@ -219,7 +225,7 @@ auto FinishImplWitness(Context& context, SemIR::ImplId impl_id) -> void {
               SemIR::NameId, SemIR::NameId);
           auto builder =
               context.emitter().Build(impl.definition_id, ImplMissingFunction,
-                                      fn.name_id, interface.name_id);
+                                      fn.name_id, interface_name_id);
           NoteAssociatedFunction(context, builder, fn_type->function_id);
           builder.Emit();
 

--- a/toolchain/check/impl.h
+++ b/toolchain/check/impl.h
@@ -18,7 +18,7 @@ auto ImplWitnessForDeclaration(Context& context, const SemIR::Impl& impl,
                                bool has_definition) -> SemIR::InstId;
 
 // Update `impl`'s witness at the start of a definition.
-auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void;
+auto ImplWitnessStartDefinition(Context& context, SemIR::Impl impl) -> void;
 
 // Adds the function members to the witness for `impl`.
 auto FinishImplWitness(Context& context, SemIR::ImplId impl_id) -> void;

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -265,8 +265,8 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
       break;
     }
     case CARBON_KIND(SemIR::ClassType inst): {
-      auto& class_info = context_->classes().Get(inst.class_id);
-      if (!class_info.is_complete()) {
+      auto* class_info = &context_->classes().Get(inst.class_id);
+      if (!class_info->is_complete()) {
         if (diagnoser_) {
           auto builder = diagnoser_();
           NoteIncompleteClass(*context_, inst.class_id, builder);
@@ -275,14 +275,17 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
         return false;
       }
       if (inst.specific_id.has_value()) {
+        // This function runs eval, which can import and invalidate `class_info`
+        // and other pointers into value stores.
         ResolveSpecificDefinition(*context_, loc_id_, inst.specific_id);
+        class_info = &context_->classes().Get(inst.class_id);
       }
       if (auto adapted_type_id =
-              class_info.GetAdaptedType(context_->sem_ir(), inst.specific_id);
+              class_info->GetAdaptedType(context_->sem_ir(), inst.specific_id);
           adapted_type_id.has_value()) {
         Push(adapted_type_id);
       } else {
-        Push(class_info.GetObjectRepr(context_->sem_ir(), inst.specific_id));
+        Push(class_info->GetObjectRepr(context_->sem_ir(), inst.specific_id));
       }
       break;
     }

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -685,6 +685,16 @@ minimal context for how the current function is reached, we use LLVM's
 `PrettyStackTrace` to include details about the state stack. The state stack
 will be above the function stack in crash output.
 
+#### ASAN stack trace quality
+
+In order to get a symbolized stack trace from ASAN (which is enabled in the
+default build), ensure that `llvm-symbolizer` is in your path or set the
+`LLVM_SYMBOLIZER_PATH` environment variable to point to the `llvm-symbolizer`
+binary.
+
+If the quality of the stack trace is low, it is possible to enable ASAN and
+debug symbols together by building under bazel with `--config=asan -c dbg`.
+
 ### Dumping objects in interactive debuggers
 
 We provide namespace-scoped `Dump` functions in several components, such as

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -19,15 +19,16 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Lower](#lower)
 -   [Tests and debugging](#tests-and-debugging)
     -   [Running tests](#running-tests)
-        -   [Debugging ASAN Poisoning](#debugging-asan-poisoning)
-            -   [Non-determinism in the poison log](#non-determinism-in-the-poison-log)
-            -   [malloc: nano zone abandoned](#malloc-nano-zone-abandoned)
     -   [Updating tests](#updating-tests)
         -   [Reviewing test deltas](#reviewing-test-deltas)
     -   [Minimal Core prelude](#minimal-core-prelude)
+    -   [Debugging ASAN Poisoning](#debugging-asan-poisoning)
+        -   [Non-determinism in the poison log](#non-determinism-in-the-poison-log)
     -   [Verbose output](#verbose-output)
     -   [Stack traces](#stack-traces)
+        -   [ASAN stack trace quality](#asan-stack-trace-quality)
     -   [Dumping objects in interactive debuggers](#dumping-objects-in-interactive-debuggers)
+    -   [ASAN error: `malloc: nano zone abandoned`](#asan-error-malloc-nano-zone-abandoned)
 
 <!-- tocstop -->
 
@@ -661,10 +662,10 @@ bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_t
 
 The counter in the poison log can be non-deterministic across runs,
 unfortunately, due to non-determinism in our data structures such as maps, and
-sorting. For example, if you used `--poison_abort=impl:911`, you might see on the
-next run that the last `impl` poison event is now `impl:908`. To help deal with
-this, `--poison_abort` will abort when the label matches and the counter value is
-any value equal to or greater than the one you specify. So using
+sorting. For example, if you used `--poison_abort=impl:911`, you might see on
+the next run that the last `impl` poison event is now `impl:908`. To help deal
+with this, `--poison_abort` will abort when the label matches and the counter
+value is any value equal to or greater than the one you specify. So using
 `--poison_abort=impl:908` would then catch the poison event whether it was
 recorded as `908` or `911` in the next run.
 
@@ -707,7 +708,8 @@ these will lack contextual information.
 
 ### ASAN error: `malloc: nano zone abandoned`
 
-On MacOS when running ASAN binaries directly, you will get this error message in stderr:
+On MacOS when running ASAN binaries directly, you will get this error message in
+stderr:
 
 ```
 file_test(61907,0x20b351f00) malloc: nano zone abandoned due to inability to reserve vm space.

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -478,7 +478,40 @@ example, with `toolchain/parse/testdata/basics/empty.carbon`:
     -   Runs using `-v` for verbose log output, and running through the `check`
         phase.
 
-#### Debugging ASAN Poisoning
+### Updating tests
+
+The `toolchain/autoupdate_testdata.py` script can be used to update output. It
+invokes the `file_test` autoupdate support. See
+[testing/file_test/README.md](/testing/file_test/README.md) for file syntax.
+
+#### Reviewing test deltas
+
+Using `autoupdate_testdata.py` can be useful to produce deltas during the
+development process because it allows `git status` and `git diff` to be used to
+examine what changed.
+
+### Minimal Core prelude
+
+For most file tests in `check/`, very little of the `Core` package is used, and
+the test is not intentionally testing the `Core` package itself. Compiling the
+entire `Core` package adds a lot of noise during interactive debugging, which
+can be avoided by using a minimal prelude.
+
+To replace the production `Core` package with a minimal one, add the path to a
+minimal `Core` package and `prelude` library to the file test with the
+`INCLUDE-FILE` directive, and tell the toolchain to avoid loading the production
+`Core` package by putting it in a `min_prelude` subdirectory. For example,
+`check/testdata/facet_types/min_prelude/my_test.carbon` might contain:
+
+```
+// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
+```
+
+We have a set of minimal `Core` preludes for testing different compiler feature
+areas in `//toolchain/testing/min_prelude/`. Each file begins with the line
+`package Core library "prelude";` to make it provide a prelude.
+
+### Debugging ASAN Poisoning
 
 If a pointer is held across a ValueStore being modified and then used afterward
 it may have been invalidated and this is a bug.
@@ -624,7 +657,7 @@ bazel build //toolchain/testing:file_test
 bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon
 ```
 
-##### Non-determinism in the poison log
+#### Non-determinism in the poison log
 
 The counter in the poison log can be non-deterministic across runs,
 unfortunately, due to non-determinism in our data structures such as maps, and
@@ -638,50 +671,6 @@ recorded as `908` or `911` in the next run.
 If a ValueStore is invalidated frequently (such as the `inst` store), this
 non-determinism may make the poison stack less reliable. It may require
 collecting a few poison logs to find the correct one (sorry).
-
-##### malloc: nano zone abandoned
-
-On MacOS when running ASAN binaries, you will get this error message in stderr:
-
-```
-file_test(61907,0x20b351f00) malloc: nano zone abandoned due to inability to reserve vm space.
-```
-
-To avoid this, set `MallocNanoZone=0` in your environment. This issue is tracked
-in https://github.com/google/sanitizers/issues/1666.
-
-### Updating tests
-
-The `toolchain/autoupdate_testdata.py` script can be used to update output. It
-invokes the `file_test` autoupdate support. See
-[testing/file_test/README.md](/testing/file_test/README.md) for file syntax.
-
-#### Reviewing test deltas
-
-Using `autoupdate_testdata.py` can be useful to produce deltas during the
-development process because it allows `git status` and `git diff` to be used to
-examine what changed.
-
-### Minimal Core prelude
-
-For most file tests in `check/`, very little of the `Core` package is used, and
-the test is not intentionally testing the `Core` package itself. Compiling the
-entire `Core` package adds a lot of noise during interactive debugging, which
-can be avoided by using a minimal prelude.
-
-To replace the production `Core` package with a minimal one, add the path to a
-minimal `Core` package and `prelude` library to the file test with the
-`INCLUDE-FILE` directive, and tell the toolchain to avoid loading the production
-`Core` package by putting it in a `min_prelude` subdirectory. For example,
-`check/testdata/facet_types/min_prelude/my_test.carbon` might contain:
-
-```
-// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-```
-
-We have a set of minimal `Core` preludes for testing different compiler feature
-areas in `//toolchain/testing/min_prelude/`. Each file begins with the line
-`package Core library "prelude";` to make it provide a prelude.
 
 ### Verbose output
 
@@ -705,3 +694,15 @@ regarding support.
 
 Objects which inherit from `Printable` also have `Dump` member functions, but
 these will lack contextual information.
+
+### ASAN error: `malloc: nano zone abandoned`
+
+On MacOS when running ASAN binaries directly, you will get this error message in stderr:
+
+```
+file_test(61907,0x20b351f00) malloc: nano zone abandoned due to inability to reserve vm space.
+```
+
+To avoid this, set `MallocNanoZone=0` in your environment. This issue is tracked
+in https://github.com/google/sanitizers/issues/1666. Note that when running
+binaries through bazel we set this environment variable for you.

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -21,6 +21,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Running tests](#running-tests)
         -   [Debugging ASAN Poisoning](#debugging-asan-poisoning)
             -   [Non-determinism in the poison log](#non-determinism-in-the-poison-log)
+            -   [malloc: nano zone abandoned](#malloc-nano-zone-abandoned)
     -   [Updating tests](#updating-tests)
         -   [Reviewing test deltas](#reviewing-test-deltas)
     -   [Minimal Core prelude](#minimal-core-prelude)
@@ -637,6 +638,17 @@ recorded as `908` or `911` in the next run.
 If a ValueStore is invalidated frequently (such as the `inst` store), this
 non-determinism may make the poison stack less reliable. It may require
 collecting a few poison logs to find the correct one (sorry).
+
+##### malloc: nano zone abandoned
+
+On MacOS when running ASAN binaries, you will get this error message in stderr:
+
+```
+file_test(61907,0x20b351f00) malloc: nano zone abandoned due to inability to reserve vm space.
+```
+
+To avoid this, set `MallocNanoZone=0` in your environment. This issue is tracked
+in https://github.com/google/sanitizers/issues/1666.
 
 ### Updating tests
 

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -537,9 +537,8 @@ debugging.
 Some suggested aliases for the common commands in this section:
 
 ```sh
-alias pbuild='bazel build //toolchain/testing:file_test'
 alias ptestall='bazel test //toolchain/testing:file_test --test_arg=--threads=1'
-alias ptestfile='bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests'
+alias ptestfile='bazel run //toolchain/testing:file_test -- --dump_output --poison_verbose --file_tests'
 ```
 
 If the test failed in the usual testing configuration, you will get a stack
@@ -582,7 +581,7 @@ We only do this for a single test at a time because it prints a _lot_ and will
 be too slow to run all the tests.
 
 ```sh
-bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon
+bazel run //toolchain/testing:file_test -- --dump_output --poison_verbose --file_tests -- --dump_output --poison_verbose --file_tests path/to/test.carbon
 ```
 
 This will print a lot of `Poison` and `Unpoison` log messages and eventually
@@ -621,7 +620,7 @@ get the stack trace of the poisoning event, in order to find out where the
 pointer was invalidated.
 
 ```sh
-bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon --poison_abort=impl:911
+bazel run //toolchain/testing:file_test -- --dump_output --poison_verbose --file_tests -- --dump_output --poison_verbose --file_tests path/to/test.carbon --poison_abort=impl:911
 ```
 
 If everything goes well, it will run up to this poison event and dump a stack
@@ -654,8 +653,7 @@ Then rebuild and run the test again to see if the issue was correctly resolved,
 and there are no further issues, iterating as needed:
 
 ```sh
-bazel build //toolchain/testing:file_test
-bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon
+bazel run //toolchain/testing:file_test -- --dump_output --poison_verbose --file_tests -- --dump_output --poison_verbose --file_tests path/to/test.carbon
 ```
 
 #### Non-determinism in the poison log

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -582,12 +582,12 @@ WRITE of size 4 at 0x50800006c06c thread T0
 ```
 
 From the poison log, we get the label and counter value of interest. In the
-example above that is `impl:911`, and we can use that with `--poison_stop` to
+example above that is `impl:911`, and we can use that with `--poison_abort` to
 get the stack trace of the poisoning event, in order to find out where the
 pointer was invalidated.
 
 ```sh
-bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon --poison_stop=impl:911
+bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon --poison_abort=impl:911
 ```
 
 If everything goes well, it will run up to this poison event and dump a stack
@@ -628,11 +628,11 @@ bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_t
 
 The counter in the poison log can be non-deterministic across runs,
 unfortunately, due to non-determinism in our data structures such as maps, and
-sorting. For example, if you used `--poison_stop=impl:911`, you might see on the
+sorting. For example, if you used `--poison_abort=impl:911`, you might see on the
 next run that the last `impl` poison event is now `impl:908`. To help deal with
-this, `--poison_stop` will abort when the label matches and the counter value is
+this, `--poison_abort` will abort when the label matches and the counter value is
 any value equal to or greater than the one you specify. So using
-`--poison_stop=impl:908` would then catch the poison event whether it was
+`--poison_abort=impl:908` would then catch the poison event whether it was
 recorded as `908` or `911` in the next run.
 
 If a ValueStore is invalidated frequently (such as the `inst` store), this

--- a/toolchain/docs/adding_features.md
+++ b/toolchain/docs/adding_features.md
@@ -19,6 +19,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Lower](#lower)
 -   [Tests and debugging](#tests-and-debugging)
     -   [Running tests](#running-tests)
+        -   [Debugging ASAN Poisoning](#debugging-asan-poisoning)
+            -   [Non-determinism in the poison log](#non-determinism-in-the-poison-log)
     -   [Updating tests](#updating-tests)
         -   [Reviewing test deltas](#reviewing-test-deltas)
     -   [Minimal Core prelude](#minimal-core-prelude)
@@ -474,6 +476,167 @@ example, with `toolchain/parse/testdata/basics/empty.carbon`:
 -   `bazel run //toolchain -- -v compile --phase=check toolchain/check/testdata/basics/run.carbon`
     -   Runs using `-v` for verbose log output, and running through the `check`
         phase.
+
+#### Debugging ASAN Poisoning
+
+If a pointer is held across a ValueStore being modified and then used afterward
+it may have been invalidated and this is a bug.
+
+Our default build enables ASAN, and with ASAN enabled we look for these bugs by
+poisoning ValueStores on modification. If a test fails due to ValueStore
+poisoning, it will give an ASAN stack trace that says `use-after-poison` and
+looks like this:
+
+```
+==12==ERROR: AddressSanitizer: use-after-poison on address 0x50800020feec at pc 0x55f9c9777abe bp 0x7fff51624df0 sp 0x7fff51624de8
+WRITE of size 4 at 0x50800020feec thread T0
+    #0 0x55f9c9777abd in Carbon::Check::HandleParseNode(Carbon::Check::Context&, Carbon::Parse::NodeIdForKind<Carbon::Parse::NodeKind::ImplDefinitionStart>) /proc/self/cwd/toolchain/check/handle_impl.cpp:584:27
+    #1 0x55f9c9717b1e in Carbon::Check::CheckUnit::ProcessNodeIds() /proc/self/cwd/./toolchain/parse/node_kind.def:357:1
+    #2 0x55f9c9712c0a in Carbon::Check::CheckUnit::Run() /proc/self/cwd/toolchain/check/check_unit.cpp:91:8
+```
+
+Debugging use-after-poison is a little tricky, as it takes some work to
+determine how the poisoning occurred. Here we will look at how to do this
+debugging.
+
+Some suggested aliases for the common commands in this section:
+
+```sh
+alias pbuild='bazel build //toolchain/testing:file_test'
+alias ptestall='bazel test //toolchain/testing:file_test --test_arg=--threads=1'
+alias ptestfile='bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests'
+```
+
+If the test failed in the usual testing configuration, you will get a stack
+trace but an ASAN stack does not display which test failed. To determine this,
+run the tests again with `--threads=1`, which will print the name of each test
+before running it:
+
+```sh
+bazel test //toolchain/testing:file_test --test_arg=--threads=1
+```
+
+In the failure log, it should now be clear which test failed, as it will be the
+last test name printed before the ASAN stack trace, like this:
+
+```
+TEST toolchain/check/testdata/poisoned.carbon =================================================================
+==12==ERROR: AddressSanitizer: use-after-poison on address 0x50800020feec at pc 0x55f9c9777abe bp 0x7fff51624df0 sp 0x7fff51624de8
+WRITE of size 4 at 0x50800020feec thread T0
+    #0 0x55f9c9777abd in Carbon::Check::HandleParseNode(Carbon::Check::Context&, Carbon::Parse::NodeIdForKind<Carbon::Parse::NodeKind::ImplDefinitionStart>) /proc/self/cwd/toolchain/check/handle_impl.cpp:584:27
+    #1 0x55f9c9717b1e in Carbon::Check::CheckUnit::ProcessNodeIds() /proc/self/cwd/./toolchain/parse/node_kind.def:357:1
+    #2 0x55f9c9712c0a in Carbon::Check::CheckUnit::Run() /proc/self/cwd/toolchain/check/check_unit.cpp:91:8
+```
+
+The ASAN stack trace printed on a use-after-poison includes two sections. To
+debug, we need to get information from each stack trace section:
+
+1. The use-after-poison stack, which shows the invalid use of a pointer.
+2. The allocation stack, which shows which `ValueStore<T>` the pointer is into.
+   For example, if the invalid pointer read was to an `Impl`, the allocation
+   stack will name `ValueStore<SemIR::Impl>` in the first few frames below the
+   `llvm::SmallVector` frames.
+
+Now we know which pointer is invalid and where from (1) above. But we don't know
+what invalidated it yet. To do that we need to get a stack trace for the
+poisoning event.
+
+We do know which value store type was poisoned from (2) above. Run the
+individual test that failed with `--poison_verbose` to list all poison events.
+We only do this for a single test at a time because it prints a _lot_ and will
+be too slow to run all the tests.
+
+```sh
+bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon
+```
+
+This will print a lot of `Poison` and `Unpoison` log messages and eventually
+crash again on the use-after-poison event. We use the information from (2) to
+look up through the logs and find the last `Poison` event for the type of value
+store from (2). For example, if the allocation stack showed
+`ValueStore<SemIR::Impl>` then we'd look for the last `Poison` event on `impl`.
+
+For example, if the log ended at the use-after-poison crash as follows, then we
+would be interested in the `++ impl PoisonAll (impl:911)` line:
+
+```
+-- inst UnpoisonElement 18
+-- interface UnpoisonElement 0
+-- inst_block UnpoisonElement 10
+++ facet_type PoisonAll (facet_type:910)
+++ impl PoisonAll (impl:911)
+++ interface PoisonAll (interface:912)
+-- inst UnpoisonElement 31
+-- inst_block UnpoisonElement 5
+-- inst_block UnpoisonElement 5
+-- inst_block UnpoisonElement 5
+-- interface UnpoisonElement 0
+-- inst_block UnpoisonElement 10
+-- inst UnpoisonElement 34
+++ inst_block PoisonAll (inst_block:913)
+=================================================================
+==554912==ERROR: AddressSanitizer: use-after-poison on address 0x50800006c06c at pc 0x55ee267f0abe bp 0x7fff197bdbf0 sp 0x7fff197bdbe8
+WRITE of size 4 at 0x50800006c06c thread T0
+    #0 0x55ee267f0abd in Carbon::Check::HandleParseNode(Carbon::Check::Context&, Carbon::Parse::NodeIdForKind<Carbon::Parse::NodeKind::ImplDefinitionStart>) /proc/self/cwd/toolchain/check/handle_impl.cpp:584:27
+```
+
+From the poison log, we get the label and counter value of interest. In the
+example above that is `impl:911`, and we can use that with `--poison_stop` to
+get the stack trace of the poisoning event, in order to find out where the
+pointer was invalidated.
+
+```sh
+bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon --poison_stop=impl:911
+```
+
+If everything goes well, it will run up to this poison event and dump a stack
+trace showing the source of the pointer invalidation:
+
+```
+-- interface UnpoisonElement 0
+-- inst UnpoisonElement 18
+-- interface UnpoisonElement 0
+-- inst_block UnpoisonElement 10
+++ facet_type PoisonAll (facet_type:910)
+++ impl PoisonAll (impl:911)
+*** Stopping on poison event. Stack trace below.
+...
+ #0 0x000055d7bb2b623a ___interceptor_backtrace (bazel-bin/toolchain/testing/file_test+0xbe9023a)
+ #1 0x000055d7c7c74d1d llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /proc/self/cwd/external/+llvm_project+llvm-project/llvm/lib/Support/Unix/Signals.inc:804:13
+...
+ 13 0x000055d7bd409b0a Invalidate /proc/self/cwd/./toolchain/sem_ir/impl.h:186:39
+#14 0x000055d7bd409b0a Carbon::Check::LoadImportRef(Carbon::Check::Context&, Carbon::SemIR::InstId) /proc/self/cwd/toolchain/check/import_ref.cpp:3217:19
+#15 0x000055d7bd38cf54 Carbon::Check::AllocateFacetTypeImplWitness(Carbon::Check::Context&, Carbon::SemIR::InterfaceId, Carbon::SemIR::InstBlockId) /proc/self/cwd/toolchain/check/facet_type.cpp:257:21
+```
+
+In this example, `AllocateFacetTypeImplWitness()` caused an import to occur, and
+imports can load arbitrary things and invalidate value stores. This shows use
+where we need to stop using the pointer. We document the function call that
+causes the invalidation and ensure code afterward avoids reusing the invalidated
+pointer.
+
+Then rebuild and run the test again to see if the issue was correctly resolved,
+and there are no further issues, iterating as needed:
+
+```sh
+bazel build //toolchain/testing:file_test
+bazel-bin/toolchain/testing/file_test -- --dump_output --poison_verbose --file_tests path/to/test.carbon
+```
+
+##### Non-determinism in the poison log
+
+The counter in the poison log can be non-deterministic across runs,
+unfortunately, due to non-determinism in our data structures such as maps, and
+sorting. For example, if you used `--poison_stop=impl:911`, you might see on the
+next run that the last `impl` poison event is now `impl:908`. To help deal with
+this, `--poison_stop` will abort when the label matches and the counter value is
+any value equal to or greater than the one you specify. So using
+`--poison_stop=impl:908` would then catch the poison event whether it was
+recorded as `908` or `911` in the next run.
+
+If a ValueStore is invalidated frequently (such as the `inst` store), this
+non-determinism may make the poison stack less reliable. It may require
+collecting a few poison logs to find the correct one (sorry).
 
 ### Updating tests
 

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -128,6 +128,7 @@ cc_library(
         "//toolchain/base:pretty_stack_trace_function",
         "//toolchain/base:shared_value_stores",
         "//toolchain/base:timings",
+        "//toolchain/base:value_store",
         "//toolchain/check",
         "//toolchain/codegen",
         "//toolchain/diagnostics:diagnostic_emitter",

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "toolchain/base/pretty_stack_trace_function.h"
 #include "toolchain/base/timings.h"
+#include "toolchain/base/value_store.h"
 #include "toolchain/check/check.h"
 #include "toolchain/codegen/codegen.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
@@ -294,6 +295,35 @@ Whether to emit DWARF debug information.
         arg_b.Default(true);
         arg_b.Set(&include_debug_info);
       });
+  b.AddFlag(
+      {
+          .name = "poison_verbose",
+          .help = R"""(
+Print verbose logs of ASAN poisoning events in the value stores. Used to debug
+ASAN use-after-poison crashes, and only has an effect when run with the ASAN
+sanitizer.
+)""",
+      },
+      [&](auto& arg_b) {
+        arg_b.Default(false);
+        arg_b.Set(&poison_verbose);
+      });
+  b.AddStringOption(
+      {
+          .name = "poison_stop",
+          .value_name = "LABEL:COUNTER",
+          .help = R"""(
+Set a condition after which the process will abort on the next ASAN poison
+event. The format is LABEL:COUNTER. Once the LABEL is poisoned with a counter
+value >= COUNTER, the process will abort and print the stack trace of the
+ASAN poisoning event. Note that the poison counter can vary slightly from run to
+run, so you can use a smaller number to catch the ASAN poison event that you
+want. The possible LABEL and COUNTER values are printed when --poison_verbose is
+used. Used to debug ASAN use-after-poison crashes, and only has an effect when
+run with the ASAN sanitizer.
+)""",
+      },
+      [&](auto& arg_b) { arg_b.Set(&poison_stop); });
 }
 
 static constexpr CommandLine::CommandInfo SubcommandInfo = {
@@ -855,6 +885,11 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   if (!ValidateOptions(driver_env.emitter)) {
     return {.success = false};
   }
+
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+  SetPoisonVerbose(options_.poison_verbose);
+  SetPoisonStop(options_.poison_stop);
+#endif
 
   // Find the files comprising the prelude if we are importing it.
   // TODO: Replace this with a search for library api files in a

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -301,7 +301,8 @@ Whether to emit DWARF debug information.
           .help = R"""(
 Print verbose logs of ASAN poisoning events in the value stores. Used to debug
 ASAN use-after-poison crashes, and only has an effect when run with the ASAN
-sanitizer.
+sanitizer. If used in a multi-thread environment, the same value should be
+specified on all threads to get deterministic behaviour.
 )""",
       },
       [&](auto& arg_b) {
@@ -320,7 +321,8 @@ ASAN poisoning event. Note that the poison counter can vary slightly from run to
 run, so you can use a smaller number to catch the ASAN poison event that you
 want. The possible LABEL and COUNTER values are printed when --poison_verbose is
 used. Used to debug ASAN use-after-poison crashes, and only has an effect when
-run with the ASAN sanitizer.
+run with the ASAN sanitizer. If used in a multi-thread environment, the same
+value should be specified on all threads to get deterministic behaviour.
 )""",
       },
       [&](auto& arg_b) { arg_b.Set(&poison_stop); });

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -311,7 +311,7 @@ specified on all threads to get deterministic behaviour.
       });
   b.AddStringOption(
       {
-          .name = "poison_stop",
+          .name = "poison_abort",
           .value_name = "LABEL:COUNTER",
           .help = R"""(
 Set a condition after which the process will abort on the next ASAN poison
@@ -325,7 +325,7 @@ run with the ASAN sanitizer. If used in a multi-thread environment, the same
 value should be specified on all threads to get deterministic behaviour.
 )""",
       },
-      [&](auto& arg_b) { arg_b.Set(&poison_stop); });
+      [&](auto& arg_b) { arg_b.Set(&poison_abort); });
 }
 
 static constexpr CommandLine::CommandInfo SubcommandInfo = {
@@ -890,7 +890,7 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
 #ifdef LLVM_ADDRESS_SANITIZER_BUILD
   SetPoisonVerbose(options_.poison_verbose);
-  SetPoisonStop(options_.poison_stop);
+  SetPoisonAbortCondition(options_.poison_abort);
 #endif
 
   // Find the files comprising the prelude if we are importing it.

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -68,7 +68,7 @@ struct CompileOptions {
   bool poison_verbose = false;
 
   llvm::StringRef exclude_dump_file_prefix;
-  llvm::StringRef poison_stop;
+  llvm::StringRef poison_abort;
 };
 
 // Implements the compile subcommand of the driver.

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -65,8 +65,10 @@ struct CompileOptions {
   bool builtin_sem_ir = false;
   bool prelude_import = false;
   bool include_debug_info = true;
+  bool poison_verbose = false;
 
   llvm::StringRef exclude_dump_file_prefix;
+  llvm::StringRef poison_stop;
 };
 
 // Implements the compile subcommand of the driver.

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -69,6 +69,7 @@ file_test(
         "//common:error",
         "//testing/file_test:file_test_base",
         "//toolchain/driver",
+        "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/strings",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/flags/flag.h"
 #include "absl/strings/str_replace.h"
 #include "common/error.h"
 #include "llvm/ADT/STLExtras.h"
@@ -20,6 +21,10 @@
 #include "llvm/Support/VirtualFileSystem.h"
 #include "testing/file_test/file_test_base.h"
 #include "toolchain/driver/driver.h"
+
+// Flags known by the driver that are passed through to it.
+ABSL_FLAG(bool, poison_verbose, false, "Passed through to the driver.");
+ABSL_FLAG(std::string, poison_abort, "", "Passed through to the driver.");
 
 namespace Carbon::Testing {
 namespace {
@@ -43,6 +48,9 @@ class ToolchainFileTest : public FileTestBase {
 
   // Sets different default flags based on the component being tested.
   auto GetDefaultArgs() const -> llvm::SmallVector<std::string> override;
+
+  // Returns the arguments that are being passed through to the driver.
+  auto GetAdditionalArgs() const -> llvm::SmallVector<std::string> override;
 
   // Generally uses the parent implementation, with special handling for lex.
   auto GetDefaultFileRE(llvm::ArrayRef<llvm::StringRef> filenames) const
@@ -219,6 +227,20 @@ auto ToolchainFileTest::GetDefaultArgs() const
   }
 
   args.push_back("%s");
+  return args;
+}
+
+auto ToolchainFileTest::GetAdditionalArgs() const
+    -> llvm::SmallVector<std::string> {
+  llvm::SmallVector<std::string> args;
+  if (absl::GetFlag(FLAGS_poison_verbose)) {
+    args.push_back("--poison_verbose");
+  }
+  if (auto value = absl::GetFlag(FLAGS_poison_abort); !value.empty()) {
+    std::string stop = "--poison_abort=";
+    stop += value;
+    args.push_back(std::move(stop));
+  }
   return args;
 }
 


### PR DESCRIPTION
ASAN crashes do not include which test file was running. Normally we inject the command line which includes the file, and any diagnostics, but https://github.com/llvm/llvm-project/issues/138759 prevents that with ASAN crashes. So, when `--threads=1` is given on the command line, we print each test name before running it in order to have some way to determine which test crashed.

ASAN use-after-poison crashes also do not contain a stack trace for where the poisoning occurred. So you know which pointer is invalid, but you don't know why. There's a long-standing bug about this here: https://github.com/google/sanitizers/issues/191.

We add two new command line flags for debugging use-after-poison:
* `--poison_verbose` which logs each poison and unpoison event, giving each poison event a unique identifier that includes the type of the value store.
* `--poison_abort` which takes an identifier from the log, and will cause the test to abort when that poisoning event (or any later-numbered one in the same value store type) occurs, giving a stack trace for the poisoning event.

Together these flags allow for pretty quick debugging of why a pointer was invalidated.

However `--poison_abort` can be unreliable because the identifiers in the log from `--poison_verbose` are not entirely stable across runs. For most stores, where invalidations are infrequent, this is okay, and `--poison_abort` helps deal with this by aborting on any event after the specified one. But for `inst` store this may make debugging harder, and require multiple runs to get the correct poison stack. While https://github.com/google/sanitizers/issues/191 would be ideal here, this is at least something to help us debug issues.

The use-after-poison bugs that are currently surfaced by our test cases are fixed. There's only a few caught by our tests, though it's likely there's many more such bugs lurking, where our test cases just do not yet happen to cause an import to happen in the many places that allow for importing or that run eval. We hope that fuzzers will help find more until we can provide some more structural way to help avoid these bugs.

The file_test framework also needs to know about these new flags so that it can pass them along to the driver. The driver usually uses names like `--poison-verbose` with a hyphen, but absl flags can't use hyphen separators. Rather than using different flags in file_test and the compiler, we use underscore separators.