### PR TITLE
Fix formatting of forward declared generics

### DIFF
--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -113,9 +113,8 @@ class Formatter {
   auto ShouldIncludeInstByIR(InstId inst_id) -> bool;
 
   // Determines whether the specified entity should be included in the formatted
-  // output. `is_definition_start` should indicate whether, if `decl_id`'s
-  // `LocId` is a `NodeId`, it is expected to be a `DefinitionStart` kind.
-  auto ShouldFormatEntity(InstId decl_id, bool is_definition_start) -> bool;
+  // output.
+  auto ShouldFormatEntity(InstId decl_id) -> bool;
 
   auto ShouldFormatEntity(const EntityWithParamsBase& entity) -> bool;
 


### PR DESCRIPTION
Noticed this while working on class tests (crash bug). Forward declared generics have a decl_id of the forward declaration, not the definition. I'm giving up trying to have the caller know if it's a start node, and instead just choosing based on the node kind.