### PR TITLE
Make `MatchContext::WorkItem`, `CalleeFunction`, `InitRepr`, `ReturnTypeInfo` `Printable` and print `ClassFields` when printing `Class`

### DIFF
--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -44,10 +44,15 @@ enum class MatchKind : uint8_t {
 // The collected state of a pattern-matching operation.
 class MatchContext {
  public:
-  struct WorkItem {
+  struct WorkItem : Printable<WorkItem> {
     SemIR::InstId pattern_id;
     // `None` when processing the callee side.
     SemIR::InstId scrutinee_id;
+
+    auto Print(llvm::raw_ostream& out) const -> void {
+      out << "{pattern_id: " << pattern_id << ", scrutinee_id: " << scrutinee_id
+          << "}";
+    }
   };
 
   // Constructs a MatchContext. If `callee_specific_id` is not `None`, this

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -63,6 +63,26 @@ struct ClassFields {
   // The virtual function table. `None` if the class has no (direct or
   // inherited) virtual functions.
   InstId vtable_id = InstId::None;
+
+  auto PrintClassFields(llvm::raw_ostream& out) const -> void {
+    out << "self_type_id: " << self_type_id << ", inheritance_kind: ";
+    switch (inheritance_kind) {
+      case Abstract:
+        out << "Abstract";
+        break;
+      case Base:
+        out << "Base";
+        break;
+      case Final:
+        out << "Final";
+        break;
+    }
+    out << ", is_dynamic: " << is_dynamic << ", scope_id: " << scope_id
+        << ", body_block_id: " << body_block_id << ", adapt_id: " << adapt_id
+        << ", base_id: " << base_id
+        << ", complete_type_witness_id: " << complete_type_witness_id
+        << ", vtable_id: " << vtable_id << "}";
+  }
 };
 
 // A class. See EntityWithParamsBase regarding the inheritance here.
@@ -72,6 +92,8 @@ struct Class : public EntityWithParamsBase,
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{";
     PrintBaseFields(out);
+    out << ", ";
+    PrintClassFields(out);
     out << "}";
   }
 

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -133,7 +133,7 @@ struct Function : public EntityWithParamsBase,
 
 class File;
 
-struct CalleeFunction {
+struct CalleeFunction : public Printable<CalleeFunction> {
   // The function. `None` if not a function.
   FunctionId function_id;
   // The specific that contains the function.
@@ -147,6 +147,17 @@ struct CalleeFunction {
   InstId self_id;
   // True if an error instruction was found.
   bool is_error;
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "{";
+    out << "function_id: " << function_id;
+    out << ", enclosing_specific_id: " << enclosing_specific_id;
+    out << ", resolved_specific_id: " << resolved_specific_id;
+    out << ", self_type_id: " << self_type_id;
+    out << ", self_id: " << self_id;
+    out << ", is_error: " << is_error;
+    out << "}";
+  }
 };
 
 // Returns information for the function corresponding to callee_id.

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -149,14 +149,11 @@ struct CalleeFunction : public Printable<CalleeFunction> {
   bool is_error;
 
   auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{";
-    out << "function_id: " << function_id;
-    out << ", enclosing_specific_id: " << enclosing_specific_id;
-    out << ", resolved_specific_id: " << resolved_specific_id;
-    out << ", self_type_id: " << self_type_id;
-    out << ", self_id: " << self_id;
-    out << ", is_error: " << is_error;
-    out << "}";
+    out << "{function_id: " << function_id
+        << ", enclosing_specific_id: " << enclosing_specific_id
+        << ", resolved_specific_id: " << resolved_specific_id
+        << ", self_type_id: " << self_type_id << ", self_id: " << self_id
+        << ", is_error: " << is_error << "}";
   }
 };
 

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -84,7 +84,7 @@ struct CompleteTypeInfo : public Printable<CompleteTypeInfo> {
 };
 
 // The initializing representation to use when returning by value.
-struct InitRepr {
+struct InitRepr : Printable<InitRepr> {
   // Returns information about the initializing representation to use for a
   // type.
   static auto ForType(const File& file, TypeId type_id) -> InitRepr;
@@ -116,10 +116,29 @@ struct InitRepr {
   // Returns whether the initializing representation is a copy of the object
   // representation of the type. Provided for symmetry with `ValueRepr`.
   auto IsCopyOfObjectRepr() const -> bool { return kind == ByCopy; }
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "{kind: ";
+    switch (kind) {
+      case None:
+        out << "None";
+        break;
+      case ByCopy:
+        out << "ByCopy";
+        break;
+      case InPlace:
+        out << "InPlace";
+        break;
+      case Incomplete:
+        out << "Incomplete";
+        break;
+    }
+    out << "}";
+  }
 };
 
 // Information about a function's return type.
-struct ReturnTypeInfo {
+struct ReturnTypeInfo : public Printable<ReturnTypeInfo> {
   // Builds return type information for a given declared return type.
   static auto ForType(const File& file, TypeId type_id) -> ReturnTypeInfo {
     return {.type_id = type_id,
@@ -143,6 +162,10 @@ struct ReturnTypeInfo {
   auto has_return_slot() const -> bool {
     CARBON_CHECK(is_valid());
     return init_repr.kind == InitRepr::InPlace;
+  }
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "{type_id: " << type_id << ", init_repr: " << init_repr << "}";
   }
 
   // The declared return type. `None` if no return type was specified.


### PR DESCRIPTION
Found these to be useful for debugging.