### PR TITLE
Don't wrap an ErrorInst as a subpattern of another pattern

### DIFF
--- a/toolchain/check/testdata/var/min_prelude/var_pattern.carbon
+++ b/toolchain/check/testdata/var/min_prelude/var_pattern.carbon
@@ -691,7 +691,7 @@ fn G() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%.param: <error>);
+// CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- var_self.carbon
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
@@ -9,36 +11,31 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/var/no_prelude/fail_in_interface.carbon
 
 interface I {
-  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+8]]:7: error: found runtime binding pattern in associated constant declaration; expected a `:!` binding [ExpectedSymbolicBindingInAssociatedConstant]
-  // CHECK:STDERR:   var v: ();
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:11: error: found runtime binding pattern in associated constant declaration; expected a `:!` binding [ExpectedSymbolicBindingInAssociatedConstant]
+  // CHECK:STDERR:   let var a: ();
+  // CHECK:STDERR:           ^~~~~
+  // CHECK:STDERR:
+  let var a: ();
+
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:7: error: found runtime binding pattern in associated constant declaration; expected a `:!` binding [ExpectedSymbolicBindingInAssociatedConstant]
+  // CHECK:STDERR:   var b: ();
   // CHECK:STDERR:       ^~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:3: error: `var` declaration in interface [VarInInterfaceDecl]
-  // CHECK:STDERR:   var v: ();
-  // CHECK:STDERR:   ^~~~~~~~~~
-  // CHECK:STDERR:
-  var v: ();
-}
+  var b: ();
 
-// CHECK:STDOUT: --- fail_in_interface.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
-// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I = %I.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+8]]:11: error: semantics TODO: `handle invalid parse trees in `check`` [SemanticsTodo]
+  // CHECK:STDERR:   let var c:! ();
+  // CHECK:STDERR:           ^~~~~~
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:17: error: `var` pattern cannot declare a compile-time binding [CompileTimeBindingInVarDecl]
+  // CHECK:STDERR:   let var c:! ();
+  // CHECK:STDERR:                 ^
+  // CHECK:STDERR:
+  let var c:! ();
+
+  // CHECK:STDERR: fail_in_interface.carbon:[[@LINE+4]]:13: error: `var` pattern cannot declare a compile-time binding [CompileTimeBindingInVarDecl]
+  // CHECK:STDERR:   var d:! ();
+  // CHECK:STDERR:             ^
+  // CHECK:STDERR:
+  var d:! ();
+}

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -288,7 +288,6 @@ CARBON_DIAGNOSTIC_KIND(ExportPrevious)
 // Interface checking.
 CARBON_DIAGNOSTIC_KIND(InterfaceForwardDeclaredHere)
 CARBON_DIAGNOSTIC_KIND(InterfaceIncompleteWithinDefinition)
-CARBON_DIAGNOSTIC_KIND(VarInInterfaceDecl)
 
 // Impl checking.
 CARBON_DIAGNOSTIC_KIND(AssociatedConstantHere)


### PR DESCRIPTION
When a pattern is an error, avoid wrapping it as a subpattern in a RefParamPattern or VarPattern. This allows further error handling to observe the error occurred without having to unwrap it.

This avoids a crash when an invalid associated constant is written which has a VarPattern in it. The associated constant machinery expects an AssociatedConstantDecl but was getting a VarPattern with an ErrorInst inside. Now it receives an ErrorInst directly, which it is already looking for.

This choice means that `var` statements in an `interface` will always be diagnosed as being non-constant, or as being a constant with a `var`, so we don't need an extra diagnostic saying that `var` is not allowed in an interface, as this just leads to two diagnostics on the same thing.

This crash was found by a fuzzer.