### PR TITLE
More closely mimic the Clang compilation

### DIFF
--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -62,6 +62,21 @@ cc_library(
 )
 
 cc_library(
+    name = "in_flight_clang",
+    srcs = ["in_flight_clang.cpp"],
+    hdrs = ["in_flight_clang.h"],
+    deps = [
+        "//common:check",
+        "@llvm-project//clang:ast",
+        "@llvm-project//clang:basic",
+        "@llvm-project//clang:driver",
+        "@llvm-project//clang:frontend",
+        "@llvm-project//clang:frontend_tool",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "kind_switch",
     hdrs = ["kind_switch.h"],
     deps = [

--- a/toolchain/base/in_flight_clang.cpp
+++ b/toolchain/base/in_flight_clang.cpp
@@ -1,0 +1,348 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/base/in_flight_clang.h"
+
+#include <memory>
+#include <mutex>
+
+#include "clang/Basic/Stack.h"
+#include "clang/CodeGen/CodeGenAction.h"
+#include "clang/Driver/Compilation.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Frontend/MultiplexConsumer.h"
+#include "clang/Frontend/TextDiagnostic.h"
+#include "clang/Sema/Lookup.h"
+#include "clang/include/clang/FrontendTool/Utils.h"
+#include "common/check.h"
+#include "llvm/IR/Module.h"
+
+namespace Carbon {
+
+// Facilitates communication between a dedicated producer thread that runs Clang
+// to build AST and do code generation, and a consumer thread that
+// interacts with AST during 'Check' and later consumes the resulting
+// `llvm::Module` during 'Lower'.
+//
+// The channel is essentially a state machine that moves forward, but not
+// backwards. Calls to functions in the API normally happens in the order of
+// declarations in the code, but some intermediate calls can be skipped in case
+// of errors.
+//
+// At any point after the first call, only one of the threads is actively
+// running and the data passed around can be used without extra synchronization,
+// as long as the API of the channel is being followed.
+struct InFlightClang::AstChannel {
+  // Called by producer thread when AST is ready.
+  // Can be skipped if AST could not be produced due to an error.
+  void reportASTAndWaitForCodeGenRequest(clang::CodeGenAction* action,
+                                         clang::Sema* sema) {
+    std::unique_lock<std::mutex> lock(mut_);
+    CARBON_CHECK(state_ == State::Created);
+
+    action_ = action;
+    sema_ = sema;
+
+    progressTo(State::AstReady);
+    waitUntil(lock, State::CodeGenFinishRequested);
+  }
+
+  struct AstAndAction {
+    clang::CodeGenAction* action = nullptr;
+    clang::Sema* sema = nullptr;
+  };
+  // Called by the consumer thread.
+  auto waitForAST() -> AstAndAction {
+    std::unique_lock<std::mutex> lock(mut_);
+    waitUntil(lock, State::AstReady);
+    return {.action = action_, .sema = sema_};
+  }
+
+  // Called by producer thread when CodeGen is finished and results can be
+  // consumed from the CodeGenAction passed in previous callbacks.
+  void notifyCodeGenFinished() {
+    std::unique_lock<std::mutex> lock(mut_);
+    progressTo(State::CodeGenFinished);
+    waitUntil(lock, State::WorkerFinishRequested);
+  }
+
+  // Called by consumer thread.
+  void waitForCodeGenFinished() {
+    std::unique_lock<std::mutex> lock(mut_);
+    progressTo(State::CodeGenFinishRequested);
+    waitUntil(lock, State::CodeGenFinished);
+  }
+
+  // Called by the consumer thread. AST and other data structures will be
+  // cleaned up after this call returns and should not be used.
+  void waitForWorkerFinished() {
+    std::unique_lock<std::mutex> lock(mut_);
+    progressTo(State::WorkerFinishRequested);
+    waitUntil(lock, State::WorkedFinished);
+  }
+
+  // Called by producer thread.
+  void nofityWorkerFinished() {
+    std::unique_lock<std::mutex> lock(mut_);
+    progressTo(State::WorkedFinished);
+  }
+
+ private:
+  std::mutex mut_;
+  std::condition_variable cond_;
+
+  clang::CodeGenAction* action_ = nullptr;
+  clang::Sema* sema_ = nullptr;
+
+  enum State {
+    Created = 0,
+    AstReady,
+    CodeGenFinishRequested,
+    CodeGenFinished,
+    WorkerFinishRequested,
+    WorkedFinished,
+  };
+  State state_ = State::Created;
+
+  void progressTo(State s) {
+    if (state_ < s) {
+      state_ = s;
+      cond_.notify_all();
+    }
+  }
+
+  void waitUntil(std::unique_lock<std::mutex>& lock, State s) {
+    cond_.wait(lock, [&] { return s <= state_; });
+  }
+};
+
+InFlightClang::InFlightClang(clang::Sema* sema, clang::CodeGenAction* action,
+                             std::unique_ptr<AstChannel> chan,
+                             std::thread worker)
+    : sema_(sema),
+      action_(action),
+      chan_(std::move(chan)),
+      worker_(std::move(worker)) {}
+
+auto InFlightClang::getASTContext() -> clang::ASTContext& {
+  return getSema().getASTContext();
+}
+
+auto InFlightClang::getSourceManager() -> clang::SourceManager& {
+  return getSema().getSourceManager();
+}
+
+auto InFlightClang::getSourceManager() const -> const clang::SourceManager& {
+  CARBON_CHECK(sema_ != nullptr);
+  return sema_->getSourceManager();
+}
+
+auto InFlightClang::getSema() -> clang::Sema& {
+  CARBON_CHECK(sema_ != nullptr);
+  return *sema_;
+}
+
+auto InFlightClang::takeLLVMContext() -> std::unique_ptr<llvm::LLVMContext> {
+  CARBON_CHECK(action_ != nullptr);
+  CARBON_CHECK(!llvm_context_taken_);
+  llvm_context_taken_ = true;
+  return std::unique_ptr<llvm::LLVMContext>(action_->takeLLVMContext());
+}
+
+auto InFlightClang::getCodeGenerator() const -> clang::CodeGenerator& {
+  CARBON_CHECK(action_ != nullptr, "action is null");
+  return *action_->getCodeGenerator();
+}
+
+auto InFlightClang::finishCompilation() && -> std::unique_ptr<llvm::Module> {
+  chan_->waitForCodeGenFinished();
+  return action_->takeModule();
+}
+
+namespace {
+// The minimal set of extensions points of Clang that Carbon needs.
+class ClangCallbacks {
+ public:
+  virtual void onOriginalFrontendActionCreated(
+      clang::FrontendAction& action) = 0;
+  virtual void handleTranslationUnit(clang::Sema& sema) = 0;
+  virtual void onCompilationFinished() = 0;
+};
+}  // namespace
+
+static auto PrepareCompilation(
+    llvm::ArrayRef<const char*> argv, llvm::StringRef target,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    std::unique_ptr<clang::DiagnosticConsumer> consumer)
+    -> std::unique_ptr<clang::CompilerInstance> {
+  auto compiler = std::make_unique<clang::CompilerInstance>();
+  compiler->createDiagnostics(*fs, consumer.release(), /*ShouldOwn=*/true);
+
+  clang::driver::Driver driver(argv[0], target, compiler->getDiagnostics(),
+                               "clang LLVM compiler", fs);
+  std::unique_ptr<clang::driver::Compilation> compilation(
+      driver.BuildCompilation(argv));
+  if (!compilation) {
+    return nullptr;
+  }
+  const clang::driver::JobList& jobs = compilation->getJobs();
+  if (jobs.size() != 1) {
+    // CARBON_VLOG("got multiple jobs with '{}'", argv);
+    return nullptr;
+  }
+  auto& job = *jobs.begin();
+  if (job.getSource().getKind() != clang::driver::Action::AssembleJobClass) {
+    // CARBON_VLOG("expected an assemble job class with '{}'", argv);
+    return nullptr;
+  }
+  if (!clang::CompilerInvocation::CreateFromArgs(
+          compiler->getInvocation(), job.getArguments(),
+          compiler->getDiagnostics(), argv[0])) {
+    return nullptr;
+  }
+  if (!compiler->createFileManager(clang::createVFSFromCompilerInvocation(
+          compiler->getInvocation(), compiler->getDiagnostics(), fs))) {
+    // CARBON_VLOG("failed to create a file manager with '{}'", argv);
+    return nullptr;
+  }
+  // Prevent compiler from outputing various status messages, e.g. '3 errors
+  // generated'.
+  compiler->setVerboseOutputStream(llvm::nulls());
+  // Do not produce the output, we will process the llvm::Module ourselves.
+  // TODO: prevent machine code generation from running completely.
+  compiler->setOutputStream(std::make_unique<llvm::raw_null_ostream>());
+  return compiler;
+}
+
+static auto RunCompilation(clang::CompilerInstance& compiler,
+                           ClangCallbacks& callbacks) {
+  class InFlightClangASTConsumer : public clang::SemaConsumer {
+   public:
+    explicit InFlightClangASTConsumer(ClangCallbacks& callbacks)
+        : callbacks_(callbacks), active_sema_(nullptr) {}
+
+    void InitializeSema(clang::Sema& sema) override { active_sema_ = &sema; }
+    void ForgetSema() override { active_sema_ = nullptr; }
+
+    void HandleTranslationUnit(clang::ASTContext& /*ast*/) override {
+      CARBON_CHECK(active_sema_ != nullptr);
+      callbacks_.handleTranslationUnit(*active_sema_);
+    }
+
+   private:
+    ClangCallbacks& callbacks_;
+    clang::Sema* active_sema_;
+  };
+
+  class InFlightClangFrontendAction : public clang::WrapperFrontendAction {
+   public:
+    explicit InFlightClangFrontendAction(
+        ClangCallbacks& callbacks, std::unique_ptr<FrontendAction> wrapped)
+        : clang::WrapperFrontendAction(std::move(wrapped)),
+          callbacks_(callbacks) {}
+
+    auto CreateASTConsumer(clang::CompilerInstance& compiler,
+                           llvm::StringRef file)
+        -> std::unique_ptr<clang::ASTConsumer> override {
+      std::vector<std::unique_ptr<clang::ASTConsumer>> consumers;
+      consumers.push_back(
+          std::make_unique<InFlightClangASTConsumer>(callbacks_));
+      if (auto c = WrapperFrontendAction::CreateASTConsumer(compiler, file)) {
+        consumers.push_back(std::move(c));
+      }
+      return std::make_unique<clang::MultiplexConsumer>(std::move(consumers));
+    }
+
+   private:
+    ClangCallbacks& callbacks_;
+  };
+
+  auto original_action = clang::CreateFrontendAction(compiler);
+  if (!original_action) {
+    return;
+  }
+  callbacks.onOriginalFrontendActionCreated(*original_action);
+
+  auto action = std::make_unique<InFlightClangFrontendAction>(
+      callbacks, std::move(original_action));
+  compiler.ExecuteAction(*action);
+
+  callbacks.onCompilationFinished();
+}
+
+auto InFlightClang::CompileFromArguments(
+    llvm::ArrayRef<const char*> argv, llvm::StringRef target,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    std::unique_ptr<clang::DiagnosticConsumer> consumer)
+    -> std::unique_ptr<InFlightClang> {
+  auto compiler = PrepareCompilation(argv, target, fs, std::move(consumer));
+  if (!compiler) {
+    return nullptr;
+  }
+
+  class Callbacks : public ClangCallbacks {
+   public:
+    explicit Callbacks(AstChannel& data) : chan_(data) {}
+
+    void onOriginalFrontendActionCreated(
+        clang::FrontendAction& action) override {
+      CARBON_CHECK(action_ == nullptr, "expected a single call");
+      action_ = dynamic_cast<clang::CodeGenAction*>(&action);
+      CARBON_CHECK(action_ != nullptr, "expected a CodeGenAction");
+    }
+
+    void handleTranslationUnit(clang::Sema& sema) override {
+      chan_.reportASTAndWaitForCodeGenRequest(action_, &sema);
+    }
+
+    virtual void onCompilationFinished() override {
+      chan_.notifyCodeGenFinished();
+    }
+
+   private:
+    AstChannel& chan_;
+    clang::CodeGenAction* action_ = nullptr;
+  };
+
+  auto data = std::make_unique<AstChannel>();
+  // Bridge the Clang's callback-based API into staged API by using a worker
+  // thread. The compilation on the worker will:
+  // 1. produce an AST and pass it back to us,
+  // 2. wait for signal from InFlightClang's destructor,
+  // 3. finish any necessary cleanups and terminate.
+  std::thread worker(
+      [compiler = std::move(compiler), data = data.get()]() mutable {
+        // TODO: ensure the created thread gets a large stack.
+        clang::noteBottomOfStack();
+
+        Callbacks callbacks(*data);
+        // In that call, callbacks will pass control to consumer thread.
+        RunCompilation(*compiler, callbacks);
+
+        // This cleans up AST and other Clang data structures.
+        // Note: Clang sets DisableFree by default, so most memory is leaked.
+        compiler.reset();
+
+        data->nofityWorkerFinished();
+      });
+
+  auto [action, sema] = data->waitForAST();
+  // The cleanup of the worker thread is in destructor of InFlightClang.
+  auto ret = std::unique_ptr<InFlightClang>(
+      new InFlightClang(sema, action, std::move(data), std::move(worker)));
+  if (!sema) {
+    // CARBON_VLOG("failed to create the AST");
+    return nullptr;
+  }
+  return ret;
+}
+
+InFlightClang::~InFlightClang() {
+  chan_->waitForWorkerFinished();
+  worker_.join();
+}
+
+}  // namespace Carbon

--- a/toolchain/base/in_flight_clang.h
+++ b/toolchain/base/in_flight_clang.h
@@ -1,0 +1,62 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_BASE_IN_FLIGHT_CLANG_H
+#define CARBON_TOOLCHAIN_BASE_IN_FLIGHT_CLANG_H
+
+#include <thread>
+
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/CodeGen/CodeGenAction.h"
+#include "clang/CodeGen/ModuleBuilder.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+
+namespace Carbon {
+class InFlightClang {
+ public:
+  ~InFlightClang();
+
+  // Runs the compiler on the passed code and stops it at a point suited for
+  // doing any additional operations on the frontend.
+  //
+  // The arguments must produce exactly one compile job.
+  static auto CompileFromArguments(
+      llvm::ArrayRef<const char*> argv, llvm::StringRef target,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+      std::unique_ptr<clang::DiagnosticConsumer> consumer)
+      -> std::unique_ptr<InFlightClang>;
+
+  auto getASTContext() -> clang::ASTContext&;
+  auto getSourceManager() -> clang::SourceManager&;
+  auto getSourceManager() const -> const clang::SourceManager&;
+  auto getSema() -> clang::Sema&;
+
+  // Take ownership of LLVMContext created by Clang.
+  // Clang will still keep a reference to it and use it for code generation.
+  auto takeLLVMContext() -> std::unique_ptr<llvm::LLVMContext>;
+
+  // TODO: do not expose this and instead interact with Clang through Sema.
+  auto getCodeGenerator() const -> clang::CodeGenerator&;
+
+  auto finishCompilation() && -> std::unique_ptr<llvm::Module>;
+
+ private:
+  struct AstChannel;
+  InFlightClang(clang::Sema* sema, clang::CodeGenAction* action,
+                std::unique_ptr<AstChannel> chan, std::thread worker);
+
+  clang::Sema* const sema_ = nullptr;
+  clang::CodeGenAction* const action_ = nullptr;
+  bool llvm_context_taken_ = false;
+
+  std::unique_ptr<AstChannel> chan_;
+  std::thread worker_;
+};
+
+}  // namespace Carbon
+
+#endif

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_CHECK_CHECK_H_
 
 #include "common/ostream.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/base/shared_value_stores.h"
 #include "toolchain/base/timings.h"
 #include "toolchain/check/diagnostic_emitter.h"
@@ -28,7 +29,7 @@ struct Unit {
 
   // Storage for the unit's Clang AST. The unique_ptr should start empty, and
   // can be assigned as part of checking.
-  std::unique_ptr<clang::ASTUnit>* cpp_ast;
+  std::unique_ptr<InFlightClang>* cpp_ast = nullptr;
 };
 
 struct CheckParseTreesOptions {

--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -16,7 +16,10 @@
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/check/class.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
@@ -182,6 +185,19 @@ class CarbonClangDiagnosticConsumer : public clang::DiagnosticConsumer {
 
 }  // namespace
 
+static auto OverlayFile(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> base,
+                        llvm::StringRef path, llvm::StringRef contents)
+    -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> single_file(
+      new llvm::vfs::InMemoryFileSystem);
+  single_file->addFile(path, 0, llvm::MemoryBuffer::getMemBufferCopy(contents));
+
+  llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> overlay(
+      new llvm::vfs::OverlayFileSystem(std::move(base)));
+  overlay->pushOverlay(single_file);
+  return overlay;
+}
+
 // Returns an AST for the C++ imports and a bool that represents whether
 // compilation errors where encountered or the generated AST is null due to an
 // error. Sets the AST in the context's `sem_ir`.
@@ -190,34 +206,45 @@ static auto GenerateAst(Context& context, llvm::StringRef importing_file_path,
                         llvm::ArrayRef<Parse::Tree::PackagingNames> imports,
                         llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
                         llvm::StringRef target)
-    -> std::pair<std::unique_ptr<clang::ASTUnit>, bool> {
-  CarbonClangDiagnosticConsumer diagnostics_consumer(&context);
+    -> std::pair<std::unique_ptr<InFlightClang>, bool> {
+  auto generated_imports_h =
+      (importing_file_path + ".generated.cpp_imports.h").str();
+  fs = OverlayFile(fs, generated_imports_h,
+                   GenerateCppIncludesHeaderCode(context, imports));
 
   // TODO: Share compilation flags with ClangRunner.
-  auto ast = clang::tooling::buildASTFromCodeWithArgs(
-      GenerateCppIncludesHeaderCode(context, imports),
+  std::string target_storage = target.str();
+  const char* args[]{
       // Parse C++ (and not C).
-      {
-          "-x",
-          "c++",
-          // Propagate the target to Clang.
-          "-target",
-          target.str(),
-          // Require PIE. Note its default is configurable in Clang.
-          "-fPIE",
-      },
-      (importing_file_path + ".generated.cpp_imports.h").str(), "clang-tool",
-      std::make_shared<clang::PCHContainerOperations>(),
-      clang::tooling::getClangStripDependencyFileAdjuster(),
-      clang::tooling::FileContentMappings(), &diagnostics_consumer, fs);
-  // Remove link to the diagnostics consumer before its deletion.
-  ast->getDiagnostics().setClient(nullptr);
+      "clang-tool", "-x", "c++",
+      // Do not emit compiler version metadata.
+      "-Qn",
+      // Flags to match LLVM IR output of default code generation options, which
+      // was used in an earlier version.
+      // TODO: remove them when sharing flags with ClangRunner.
+      "-fomit-frame-pointer", "-fno-unwind-tables",
+      "-fno-asynchronous-unwind-tables", "-fno-exceptions",
+      // TODO: is this really necessary now that target also gets passed?
+      // Propagate the target to Clang.
+      "-target", target_storage.c_str(),
+      // Require PIE. Note its default is configurable in Clang.
+      "-fPIE", "-c", generated_imports_h.c_str()};
+
+  // TODO: Use all import locations by referring each Clang diagnostic to the
+  // relevant import.
+  SemIR::LocId loc_id = imports.back().node_id;
+  auto owned_diagnostics_consumer =
+      std::make_unique<CarbonClangDiagnosticConsumer>(&context);
+  auto* diagnostics_consumer = owned_diagnostics_consumer.get();
+  auto ast = InFlightClang::CompileFromArguments(
+      args, target, fs, std::move(owned_diagnostics_consumer));
 
   // In order to emit diagnostics, we need the AST.
   context.sem_ir().set_cpp_ast(ast.get());
-  diagnostics_consumer.EmitDiagnostics();
+  diagnostics_consumer->EmitDiagnostics();
 
-  return {std::move(ast), !ast || diagnostics_consumer.getNumErrors() > 0};
+  bool has_errors = !ast || diagnostics_consumer->getNumErrors() > 0;
+  return {std::move(ast), has_errors};
 }
 
 // Adds a namespace for the `Cpp` import and returns its `NameScopeId`.
@@ -251,7 +278,7 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
 auto ImportCppFiles(Context& context, llvm::StringRef importing_file_path,
                     llvm::ArrayRef<Parse::Tree::PackagingNames> imports,
                     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-                    llvm::StringRef target) -> std::unique_ptr<clang::ASTUnit> {
+                    llvm::StringRef target) -> std::unique_ptr<InFlightClang> {
   if (imports.empty()) {
     return nullptr;
   }
@@ -293,7 +320,7 @@ static auto ClangLookup(Context& context, SemIR::NameScopeId scope_id,
     return std::nullopt;
   }
 
-  clang::ASTUnit* ast = context.sem_ir().cpp_ast();
+  InFlightClang* ast = context.sem_ir().cpp_ast();
   CARBON_CHECK(ast);
   clang::Sema& sema = ast->getSema();
 

--- a/toolchain/check/import_cpp.h
+++ b/toolchain/check/import_cpp.h
@@ -17,7 +17,7 @@ namespace Carbon::Check {
 auto ImportCppFiles(Context& context, llvm::StringRef importing_file_path,
                     llvm::ArrayRef<Parse::Tree::PackagingNames> imports,
                     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-                    llvm::StringRef target) -> std::unique_ptr<clang::ASTUnit>;
+                    llvm::StringRef target) -> std::unique_ptr<InFlightClang>;
 
 // Looks up the given name in the Clang AST generated when importing C++ code.
 // If successful, generates the instruction and returns the new `InstId`.

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "toolchain/base/timings.h"
 #include "toolchain/check/check.h"
+#include "toolchain/check/import_cpp.h"
 #include "toolchain/codegen/codegen.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/sorting_diagnostic_consumer.h"
@@ -478,7 +479,7 @@ class CompilationUnit {
   std::optional<std::function<auto()->const Parse::TreeAndSubtrees&>>
       tree_and_subtrees_getter_;
   std::optional<SemIR::File> sem_ir_;
-  std::unique_ptr<clang::ASTUnit> cpp_ast_;
+  std::unique_ptr<Carbon::InFlightClang> cpp_ast_;
   std::unique_ptr<llvm::LLVMContext> llvm_context_;
   std::unique_ptr<llvm::Module> module_;
 };
@@ -674,7 +675,12 @@ auto CompilationUnit::PostCheck() -> void {
 
 auto CompilationUnit::RunLower() -> void {
   LogCall("Lower::LowerToLLVM", "lower", [&] {
-    llvm_context_ = std::make_unique<llvm::LLVMContext>();
+    // Clang and Carbon must use the same LLVMContext.
+    if (cpp_ast_) {
+      llvm_context_ = cpp_ast_->takeLLVMContext();
+    } else {
+      llvm_context_ = std::make_unique<llvm::LLVMContext>();
+    }
     Lower::LowerToLLVMOptions options;
     options.llvm_verifier_stream =
         options_->run_llvm_verifier ? driver_env_->error_stream : nullptr;

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -11,6 +11,7 @@
 #include "common/check.h"
 #include "common/raw_string_ostream.h"
 #include "llvm/TargetParser/Host.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/base/shared_value_stores.h"
 #include "toolchain/check/check.h"
 #include "toolchain/diagnostics/diagnostic.h"
@@ -146,7 +147,7 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
 
   SemIR::File sem_ir(tree_.get(), SemIR::CheckIRId(0), tree_->packaging_decl(),
                      *value_stores_, uri_.file().str());
-  std::unique_ptr<clang::ASTUnit> cpp_ast;
+  std::unique_ptr<InFlightClang> cpp_ast;
   // TODO: Support cross-file checking when multiple files have edits.
   llvm::SmallVector<Check::Unit> units = {{{.consumer = &consumer,
                                             .value_stores = value_stores_.get(),

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Linker/Linker.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/lower/constant.h"
 #include "toolchain/lower/function_context.h"
@@ -55,21 +56,12 @@ FileContext::FileContext(Context& context, const SemIR::File& sem_ir,
           sem_ir.insts().size(), nullptr)),
       lowered_specifics_(sem_ir.generics(), {}),
       coalescer_(vlog_stream_, sem_ir.specifics()) {
-  // Initialization that relies on invariants of the class.
-  cpp_code_generator_ = CreateCppCodeGenerator();
   CARBON_CHECK(!sem_ir.has_errors(),
                "Generating LLVM IR from invalid SemIR::File is unsupported.");
 }
 
 // TODO: Move this to lower.cpp.
 auto FileContext::PrepareToLower() -> void {
-  if (cpp_code_generator_) {
-    // Clang code generation should not actually modify the AST, but isn't
-    // const-correct.
-    cpp_code_generator_->Initialize(
-        const_cast<clang::ASTContext&>(cpp_ast()->getASTContext()));
-  }
-
   // Lower all types that were required to be complete.
   for (auto type_id : sem_ir_->types().complete_types()) {
     if (type_id.index >= 0) {
@@ -147,15 +139,14 @@ auto FileContext::LowerDefinitions() -> void {
 }
 
 auto FileContext::Finalize() -> void {
-  if (cpp_code_generator_) {
+  if (cpp_ast()) {
     // Clang code generation should not actually modify the AST, but isn't
     // const-correct.
-    cpp_code_generator_->HandleTranslationUnit(
-        const_cast<clang::ASTContext&>(cpp_ast()->getASTContext()));
+    std::unique_ptr<llvm::Module> cpp_module =
+        std::move(*cpp_ast()).finishCompilation();
     bool link_error = llvm::Linker::linkModules(
         /*Dest=*/llvm_module(),
-        /*Src=*/std::unique_ptr<llvm::Module>(
-            cpp_code_generator_->ReleaseModule()));
+        /*Src=*/std::move(cpp_module));
     CARBON_CHECK(!link_error);
   }
 
@@ -163,25 +154,6 @@ auto FileContext::Finalize() -> void {
   // remove duplicately lowered function definitions.
   coalescer_.CoalesceEquivalentSpecifics(lowered_specifics_,
                                          specific_functions_);
-}
-
-auto FileContext::CreateCppCodeGenerator()
-    -> std::unique_ptr<clang::CodeGenerator> {
-  if (!cpp_ast()) {
-    return nullptr;
-  }
-
-  RawStringOstream clang_module_name_stream;
-  clang_module_name_stream << llvm_module().getName() << ".clang";
-
-  // Do not emit Clang's name and version as the creator of the output file.
-  cpp_code_gen_options_.EmitVersionIdentMetadata = false;
-
-  return std::unique_ptr<clang::CodeGenerator>(clang::CreateLLVMCodeGen(
-      cpp_ast()->getASTContext().getDiagnostics(),
-      clang_module_name_stream.TakeStr(), context().file_system(),
-      cpp_header_search_options_, cpp_preprocessor_options_,
-      cpp_code_gen_options_, llvm_context()));
 }
 
 auto FileContext::GetConstant(SemIR::ConstantId const_id,
@@ -374,12 +346,12 @@ auto FileContext::HandleReferencedCppFunction(clang::FunctionDecl* cpp_decl)
   // function name (`CodeGenModule::getMangledName()`), and will generate
   // its definition.
   llvm::Constant* function_address =
-      cpp_code_generator_->GetAddrOfGlobal(clang::GlobalDecl(cpp_def),
+      cpp_code_generator().GetAddrOfGlobal(clang::GlobalDecl(cpp_def),
                                            /*isForDefinition=*/false);
   CARBON_CHECK(function_address);
 
   // Emit the function code.
-  cpp_code_generator_->HandleTopLevelDecl(clang::DeclGroupRef(cpp_def));
+  cpp_code_generator().HandleTopLevelDecl(clang::DeclGroupRef(cpp_def));
 }
 
 auto FileContext::HandleReferencedSpecificFunction(

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -8,6 +8,7 @@
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "clang/Lex/PreprocessorOptions.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/lower/context.h"
 #include "toolchain/lower/specific_coalescer.h"
 #include "toolchain/parse/tree_and_subtrees.h"
@@ -26,10 +27,6 @@ class FileContext {
   explicit FileContext(Context& context, const SemIR::File& sem_ir,
                        const SemIR::InstNamer* inst_namer,
                        llvm::raw_ostream* vlog_stream);
-
-  // Creates the Clang `CodeGenerator` to generate LLVM module from imported C++
-  // code. Returns null when not importing C++.
-  auto CreateCppCodeGenerator() -> std::unique_ptr<clang::CodeGenerator>;
 
   // Prepares to lower code in this IR, by precomputing needed LLVM types,
   // constants, declarations, etc. Should only be called once, before we lower
@@ -93,11 +90,10 @@ class FileContext {
   auto llvm_context() -> llvm::LLVMContext& { return context().llvm_context(); }
   auto llvm_module() -> llvm::Module& { return context().llvm_module(); }
   auto cpp_code_generator() -> clang::CodeGenerator& {
-    CARBON_CHECK(cpp_code_generator_);
-    return *cpp_code_generator_;
+    return cpp_ast()->getCodeGenerator();
   }
   auto sem_ir() const -> const SemIR::File& { return *sem_ir_; }
-  auto cpp_ast() -> const clang::ASTUnit* { return sem_ir().cpp_ast(); }
+  auto cpp_ast() -> InFlightClang* { return sem_ir().cpp_ast(); }
   auto inst_namer() -> const SemIR::InstNamer* { return inst_namer_; }
   auto global_variables() -> const Map<SemIR::InstId, llvm::GlobalVariable*>& {
     return global_variables_;
@@ -198,16 +194,6 @@ class FileContext {
 
   // The input SemIR.
   const SemIR::File* const sem_ir_;
-
-  // The options used to create the Clang Code Generator.
-  clang::HeaderSearchOptions cpp_header_search_options_;
-  clang::PreprocessorOptions cpp_preprocessor_options_;
-  clang::CodeGenOptions cpp_code_gen_options_;
-
-  // The Clang `CodeGenerator` to generate LLVM module from imported C++
-  // code. Should be initialized using `CreateCppCodeGenerator()`. Can be null
-  // if no C++ code is imported.
-  std::unique_ptr<clang::CodeGenerator> cpp_code_generator_;
 
   // The instruction namer, if given.
   const SemIR::InstNamer* const inst_namer_;

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -9,6 +9,7 @@
 
 #include "common/vlog.h"
 #include "llvm/IR/Verifier.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/lower/context.h"
 #include "toolchain/lower/file_context.h"
 

--- a/toolchain/lower/lower.h
+++ b/toolchain/lower/lower.h
@@ -8,6 +8,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/parse/tree_and_subtrees.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/inst_namer.h"

--- a/toolchain/lower/testdata/interop/cpp/extern_c.carbon
+++ b/toolchain/lower/testdata/interop/cpp/extern_c.carbon
@@ -52,7 +52,6 @@ fn MyF() {
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @foo(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
@@ -80,7 +79,6 @@ fn MyF() {
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @bar(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/interop/cpp/function_decl.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function_decl.carbon
@@ -95,7 +95,7 @@ fn MyF() {
 inline void foo1() {}
 inline void foo2() { foo1(); }
 
-// --- todo_import_inline_recursive_function_decl.carbon
+// --- import_inline_recursive_function_decl.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -112,7 +112,6 @@ fn MyF() {
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Z3foov(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
@@ -142,18 +141,16 @@ fn MyF() {
 // CHECK:STDOUT: $_Z3foov = comdat any
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Z3foov(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z3foov() #0 comdat {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!5}
@@ -180,21 +177,19 @@ fn MyF() {
 // CHECK:STDOUT: @llvm.compiler.used = appending global [1 x ptr] [ptr @_Z3foov], section "llvm.metadata"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Z3foov(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z3foov() #0 comdat {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT: uselistorder ptr @_Z3foov, { 1, 0 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!5}
@@ -223,7 +218,6 @@ fn MyF() {
 // CHECK:STDOUT: $_Z4foo3v = comdat any
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Z4foo1v(), !dbg !10
 // CHECK:STDOUT:   call void @_Z4foo2v(), !dbg !11
 // CHECK:STDOUT:   call void @_Z4foo3v(), !dbg !12
@@ -232,23 +226,20 @@ fn MyF() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z4foo1v() #0 comdat {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z4foo2v() #0 comdat {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z4foo3v() #0 comdat {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!5}
@@ -267,30 +258,32 @@ fn MyF() {
 // CHECK:STDOUT: !11 = !DILocation(line: 8, column: 3, scope: !7)
 // CHECK:STDOUT: !12 = !DILocation(line: 9, column: 3, scope: !7)
 // CHECK:STDOUT: !13 = !DILocation(line: 6, column: 1, scope: !7)
-// CHECK:STDOUT: ; ModuleID = 'todo_import_inline_recursive_function_decl.carbon'
-// CHECK:STDOUT: source_filename = "todo_import_inline_recursive_function_decl.carbon"
+// CHECK:STDOUT: ; ModuleID = 'import_inline_recursive_function_decl.carbon'
+// CHECK:STDOUT: source_filename = "import_inline_recursive_function_decl.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
 // CHECK:STDOUT: $_Z4foo2v = comdat any
 // CHECK:STDOUT:
+// CHECK:STDOUT: $_Z4foo1v = comdat any
+// CHECK:STDOUT:
 // CHECK:STDOUT: define void @_CMyF.Main() !dbg !7 {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Z4foo2v(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: mustprogress noinline optnone
+// CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z4foo2v() #0 comdat {
-// CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Z4foo1v()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_Z4foo1v() #1
+// CHECK:STDOUT: ; Function Attrs: mustprogress noinline nounwind optnone
+// CHECK:STDOUT: define linkonce_odr dso_local void @_Z4foo1v() #0 comdat {
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { mustprogress noinline optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #1 = { "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!5}
@@ -301,7 +294,7 @@ fn MyF() {
 // CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 0}
 // CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
 // CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !6 = !DIFile(filename: "todo_import_inline_recursive_function_decl.carbon", directory: "")
+// CHECK:STDOUT: !6 = !DIFile(filename: "import_inline_recursive_function_decl.carbon", directory: "")
 // CHECK:STDOUT: !7 = distinct !DISubprogram(name: "MyF", linkageName: "_CMyF.Main", scope: null, file: !6, line: 6, type: !8, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
 // CHECK:STDOUT: !9 = !{}

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -137,6 +137,7 @@ cc_library(
         "//common:set",
         "//common:struct_reflection",
         "//toolchain/base:canonical_value_store",
+        "//toolchain/base:in_flight_clang",
         "//toolchain/base:index_base",
         "//toolchain/base:int",
         "//toolchain/base:kind_switch",

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -5,13 +5,13 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_FILE_H_
 #define CARBON_TOOLCHAIN_SEM_IR_FILE_H_
 
-#include "clang/Frontend/ASTUnit.h"
 #include "common/error.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "toolchain/base/canonical_value_store.h"
+#include "toolchain/base/in_flight_clang.h"
 #include "toolchain/base/int.h"
 #include "toolchain/base/relational_value_store.h"
 #include "toolchain/base/shared_value_stores.h"
@@ -191,12 +191,16 @@ class File : public Printable<File> {
   }
   auto import_cpps() -> ImportCppStore& { return import_cpps_; }
   auto import_cpps() const -> const ImportCppStore& { return import_cpps_; }
-  auto cpp_ast() -> clang::ASTUnit* { return cpp_ast_; }
-  auto cpp_ast() const -> const clang::ASTUnit* { return cpp_ast_; }
+  // TODO: Refactor to avoid exposing a non-const pointer from a const method.
+  // Currently FileContext.cpp accepts the SemIR::File as const, but the access
+  // to AST is always mutable.
+  auto cpp_ast() const -> Carbon::InFlightClang* { return cpp_ast_; }
   // TODO: When the AST can be created before creating `File`, initialize the
   // pointer in the constructor and remove this function. This is part of
   // https://github.com/carbon-language/carbon-lang/issues/4666
-  auto set_cpp_ast(clang::ASTUnit* cpp_ast) -> void { cpp_ast_ = cpp_ast; }
+  auto set_cpp_ast(Carbon::InFlightClang* cpp_ast) -> void {
+    cpp_ast_ = cpp_ast;
+  }
   auto clang_decls() -> ClangDeclStore& { return clang_decls_; }
   auto clang_decls() const -> const ClangDeclStore& { return clang_decls_; }
   auto names() const -> NameStoreWrapper {
@@ -325,7 +329,7 @@ class File : public Printable<File> {
 
   // The Clang AST to use when looking up `Cpp` names. Null if there are no
   // `Cpp` imports.
-  clang::ASTUnit* cpp_ast_ = nullptr;
+  Carbon::InFlightClang* cpp_ast_ = nullptr;
 
   // Clang AST declarations pointing to the AST and their mapped Carbon
   // instructions. When calling `Lookup()`, `inst_id` is ignored. `Add()` will


### PR DESCRIPTION
Instead of using ASTUnit and tooling APIs, directly mimic what Clang does during the compilation.

Run the Clang frontend until the translation unit parsing is done, at which point switch back to Carbon to finish the `Check` phase and interface with Clang through `ASTContext` and `Sema`. In lower, finish the corresponding Clang compilation phase, i.e. CodeGen.

Clang does not have the corresponding APIs and instead provides a callback-based mechanism. To map this back to Carbon APIs, we create a separate thread that gives control back to Carbon through the callbacks, and then finishes the compilation when the Carbon code is done.

Although essentially a hack, this allows to easily fit into the Carbon codebase quickly and we should have an option of refactoring Clang code in LLVM upstream if this approach proves fruitful.