### PR TITLE
Add range flag settings to class files

### DIFF
--- a/toolchain/check/testdata/class/access_modifers.carbon
+++ b/toolchain/check/testdata/class/access_modifers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/access_modifers.carbon

--- a/toolchain/check/testdata/class/adapter/adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/adapt.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/adapt.carbon

--- a/toolchain/check/testdata/class/adapter/adapt_copy.carbon
+++ b/toolchain/check/testdata/class/adapter/adapt_copy.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/adapt_copy.carbon

--- a/toolchain/check/testdata/class/adapter/extend_adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/extend_adapt.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/extend_adapt.carbon

--- a/toolchain/check/testdata/class/adapter/fail_adapt_bad_decl.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_bad_decl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/fail_adapt_bad_decl.carbon

--- a/toolchain/check/testdata/class/adapter/fail_adapt_bad_type.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_bad_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/fail_adapt_bad_type.carbon

--- a/toolchain/check/testdata/class/adapter/fail_adapt_modifiers.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_modifiers.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/class/adapter/fail_adapt_with_base.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_with_base.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/fail_adapt_with_base.carbon

--- a/toolchain/check/testdata/class/adapter/fail_adapt_with_subobjects.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_with_subobjects.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/fail_adapt_with_subobjects.carbon

--- a/toolchain/check/testdata/class/adapter/init_adapt.carbon
+++ b/toolchain/check/testdata/class/adapter/init_adapt.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/adapter/init_adapt.carbon

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/base.carbon

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/base_field.carbon
@@ -76,11 +79,11 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc24_30: type = ptr_type %i32 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:     %ptr.loc27_30: type = ptr_type %i32 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc24: type = splice_block %ptr.loc24_21 [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:     %.loc27: type = splice_block %ptr.loc27_21 [concrete = constants.%ptr.404] {
 // CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
-// CHECK:STDOUT:       %ptr.loc24_21: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
+// CHECK:STDOUT:       %ptr.loc27_21: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.404 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.235 = out_param call_param1
@@ -89,35 +92,35 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Base.elem = field_decl a, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Base.elem = field_decl b, element1 [concrete]
-// CHECK:STDOUT:   %int_32.loc14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc14: %Base.elem = field_decl c, element2 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Base.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Base.elem = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc17: %Base.elem = field_decl c, element2 [concrete]
 // CHECK:STDOUT:   %struct_type.a.b.c: type = struct_type {.a: %i32, .b: %i32, .c: %i32} [concrete = constants.%struct_type.a.b.c]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.c [concrete = constants.%complete_type.ebc]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Base
-// CHECK:STDOUT:   .a = %.loc12
-// CHECK:STDOUT:   .b = %.loc13
-// CHECK:STDOUT:   .c = %.loc14
+// CHECK:STDOUT:   .a = %.loc15
+// CHECK:STDOUT:   .b = %.loc16
+// CHECK:STDOUT:   .c = %.loc17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %.loc18: %Derived.elem.69e = base_decl %Base.ref, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc20: %Derived.elem.344 = field_decl d, element1 [concrete]
-// CHECK:STDOUT:   %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc21: %Derived.elem.344 = field_decl e, element2 [concrete]
+// CHECK:STDOUT:   %.loc21: %Derived.elem.69e = base_decl %Base.ref, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc23: %Derived.elem.344 = field_decl d, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc24: %Derived.elem.344 = field_decl e, element2 [concrete]
 // CHECK:STDOUT:   %struct_type.base.d.e: type = struct_type {.base: %Base, .d: %i32, .e: %i32} [concrete = constants.%struct_type.base.d.e.6a7]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.e [concrete = constants.%complete_type.401]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -125,9 +128,9 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Derived
 // CHECK:STDOUT:   .Base = <poisoned>
-// CHECK:STDOUT:   .base = %.loc18
-// CHECK:STDOUT:   .d = %.loc20
-// CHECK:STDOUT:   .e = %.loc21
+// CHECK:STDOUT:   .base = %.loc21
+// CHECK:STDOUT:   .d = %.loc23
+// CHECK:STDOUT:   .e = %.loc24
 // CHECK:STDOUT:   .c = <poisoned>
 // CHECK:STDOUT:   extend %Base.ref
 // CHECK:STDOUT: }
@@ -135,12 +138,12 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: fn @Access(%p.param: %ptr.404) -> %ptr.235 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.404 = name_ref p, %p
-// CHECK:STDOUT:   %.loc25_12: ref %Derived = deref %p.ref
-// CHECK:STDOUT:   %c.ref: %Base.elem = name_ref c, @Base.%.loc14 [concrete = @Base.%.loc14]
-// CHECK:STDOUT:   %.loc25_15.1: ref %Base = class_element_access %.loc25_12, element0
-// CHECK:STDOUT:   %.loc25_15.2: ref %Base = converted %.loc25_12, %.loc25_15.1
-// CHECK:STDOUT:   %.loc25_15.3: ref %i32 = class_element_access %.loc25_15.2, element2
-// CHECK:STDOUT:   %addr: %ptr.235 = addr_of %.loc25_15.3
+// CHECK:STDOUT:   %.loc28_12: ref %Derived = deref %p.ref
+// CHECK:STDOUT:   %c.ref: %Base.elem = name_ref c, @Base.%.loc17 [concrete = @Base.%.loc17]
+// CHECK:STDOUT:   %.loc28_15.1: ref %Base = class_element_access %.loc28_12, element0
+// CHECK:STDOUT:   %.loc28_15.2: ref %Base = converted %.loc28_12, %.loc28_15.1
+// CHECK:STDOUT:   %.loc28_15.3: ref %i32 = class_element_access %.loc28_15.2, element2
+// CHECK:STDOUT:   %addr: %ptr.235 = addr_of %.loc28_15.3
 // CHECK:STDOUT:   return %addr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_function_unqualified.carbon
+++ b/toolchain/check/testdata/class/base_function_unqualified.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/base_function_unqualified.carbon
@@ -74,7 +77,7 @@ fn Derived.H() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %.loc16: %Derived.elem = base_decl %Base.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %Derived.elem = base_decl %Base.ref, element0 [concrete]
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {} {}
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %Base} [concrete = constants.%struct_type.base]
@@ -84,7 +87,7 @@ fn Derived.H() {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Derived
 // CHECK:STDOUT:   .Base = <poisoned>
-// CHECK:STDOUT:   .base = %.loc16
+// CHECK:STDOUT:   .base = %.loc19
 // CHECK:STDOUT:   .G = %G.decl
 // CHECK:STDOUT:   .H = %H.decl
 // CHECK:STDOUT:   .F = <poisoned>

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/base_method.carbon
@@ -95,14 +98,14 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.1b9 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.1b9 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc17_11: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc20_11: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc17: %ptr.11f = value_param call_param0
-// CHECK:STDOUT:     %.loc17_26: type = splice_block %ptr.loc17 [concrete = constants.%ptr.11f] {
-// CHECK:STDOUT:       %Self.ref.loc17: type = name_ref Self, constants.%Base [concrete = constants.%Base]
-// CHECK:STDOUT:       %ptr.loc17: type = ptr_type %Self.ref.loc17 [concrete = constants.%ptr.11f]
+// CHECK:STDOUT:     %self.param.loc20: %ptr.11f = value_param call_param0
+// CHECK:STDOUT:     %.loc20_26: type = splice_block %ptr.loc20 [concrete = constants.%ptr.11f] {
+// CHECK:STDOUT:       %Self.ref.loc20: type = name_ref Self, constants.%Base [concrete = constants.%Base]
+// CHECK:STDOUT:       %ptr.loc20: type = ptr_type %Self.ref.loc20 [concrete = constants.%ptr.11f]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc17: %ptr.11f = bind_name self, %self.param.loc17
+// CHECK:STDOUT:     %self.loc20: %ptr.11f = bind_name self, %self.param.loc20
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Derived.decl: type = class_decl @Derived [concrete = constants.%Derived] {} {}
 // CHECK:STDOUT:   %Call.decl: %Call.type = fn_decl @Call [concrete = constants.%Call] {
@@ -110,7 +113,7 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:     %p.param_patt: %pattern_type.605 = value_param_pattern %p.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc25: type = splice_block %ptr [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:     %.loc28: type = splice_block %ptr [concrete = constants.%ptr.404] {
 // CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
@@ -121,18 +124,18 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Base.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %Base.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.1b9 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.1b9 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc17_11: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc20_11: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc14: %ptr.11f = value_param call_param0
-// CHECK:STDOUT:     %.loc14: type = splice_block %ptr.loc14 [concrete = constants.%ptr.11f] {
-// CHECK:STDOUT:       %Self.ref.loc14: type = name_ref Self, constants.%Base [concrete = constants.%Base]
-// CHECK:STDOUT:       %ptr.loc14: type = ptr_type %Self.ref.loc14 [concrete = constants.%ptr.11f]
+// CHECK:STDOUT:     %self.param.loc17: %ptr.11f = value_param call_param0
+// CHECK:STDOUT:     %.loc17: type = splice_block %ptr.loc17 [concrete = constants.%ptr.11f] {
+// CHECK:STDOUT:       %Self.ref.loc17: type = name_ref Self, constants.%Base [concrete = constants.%Base]
+// CHECK:STDOUT:       %ptr.loc17: type = ptr_type %Self.ref.loc17 [concrete = constants.%ptr.11f]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc14: %ptr.11f = bind_name self, %self.param.loc14
+// CHECK:STDOUT:     %self.loc17: %ptr.11f = bind_name self, %self.param.loc17
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
@@ -140,13 +143,13 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Base
-// CHECK:STDOUT:   .a = %.loc12
+// CHECK:STDOUT:   .a = %.loc15
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %.loc22: %Derived.elem = base_decl %Base.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc25: %Derived.elem = base_decl %Base.ref, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %Base} [concrete = constants.%struct_type.base.b1e]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.15c]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -154,40 +157,40 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Derived
 // CHECK:STDOUT:   .Base = <poisoned>
-// CHECK:STDOUT:   .base = %.loc22
+// CHECK:STDOUT:   .base = %.loc25
 // CHECK:STDOUT:   .F = <poisoned>
 // CHECK:STDOUT:   extend %Base.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%self.param.loc17: %ptr.11f) {
+// CHECK:STDOUT: fn @F(%self.param.loc20: %ptr.11f) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref: %ptr.11f = name_ref self, %self.loc17
-// CHECK:STDOUT:   %.loc18_4: ref %Base = deref %self.ref
-// CHECK:STDOUT:   %a.ref: %Base.elem = name_ref a, @Base.%.loc12 [concrete = @Base.%.loc12]
-// CHECK:STDOUT:   %.loc18_10: ref %i32 = class_element_access %.loc18_4, element0
+// CHECK:STDOUT:   %self.ref: %ptr.11f = name_ref self, %self.loc20
+// CHECK:STDOUT:   %.loc21_4: ref %Base = deref %self.ref
+// CHECK:STDOUT:   %a.ref: %Base.elem = name_ref a, @Base.%.loc15 [concrete = @Base.%.loc15]
+// CHECK:STDOUT:   %.loc21_10: ref %i32 = class_element_access %.loc21_4, element0
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc18_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc21_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc18_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc18_13.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc18_13: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %.loc18_10, %.loc18_13
+// CHECK:STDOUT:   %bound_method.loc21_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc21_13.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc21_13: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %.loc21_10, %.loc21_13
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Call(%p.param: %ptr.404) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.404 = name_ref p, %p
-// CHECK:STDOUT:   %.loc26_4.1: ref %Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc29_4.1: ref %Derived = deref %p.ref
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Base.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc26_4.1, %F.ref
-// CHECK:STDOUT:   %addr.loc26_4.1: %ptr.404 = addr_of %.loc26_4.1
-// CHECK:STDOUT:   %.loc26_4.2: ref %Derived = deref %addr.loc26_4.1
-// CHECK:STDOUT:   %.loc26_4.3: ref %Base = class_element_access %.loc26_4.2, element0
-// CHECK:STDOUT:   %addr.loc26_4.2: %ptr.11f = addr_of %.loc26_4.3
-// CHECK:STDOUT:   %.loc26_4.4: %ptr.11f = converted %addr.loc26_4.1, %addr.loc26_4.2
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.bound(%.loc26_4.4)
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc29_4.1, %F.ref
+// CHECK:STDOUT:   %addr.loc29_4.1: %ptr.404 = addr_of %.loc29_4.1
+// CHECK:STDOUT:   %.loc29_4.2: ref %Derived = deref %addr.loc29_4.1
+// CHECK:STDOUT:   %.loc29_4.3: ref %Base = class_element_access %.loc29_4.2, element0
+// CHECK:STDOUT:   %addr.loc29_4.2: %ptr.11f = addr_of %.loc29_4.3
+// CHECK:STDOUT:   %.loc29_4.4: %ptr.11f = converted %addr.loc29_4.1, %addr.loc29_4.2
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.bound(%.loc29_4.4)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method_qualified.carbon
+++ b/toolchain/check/testdata/class/base_method_qualified.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/base_method_qualified.carbon
@@ -87,7 +90,7 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .Derived = %Derived.decl.loc11
+// CHECK:STDOUT:     .Derived = %Derived.decl.loc14
 // CHECK:STDOUT:     .Base = %Base.decl
 // CHECK:STDOUT:     .Call = %Call.decl
 // CHECK:STDOUT:     .CallIndirect = %CallIndirect.decl
@@ -95,9 +98,9 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:     .PassDerivedToBaseIndirect = %PassDerivedToBaseIndirect.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %Derived.decl.loc11: type = class_decl @Derived [concrete = constants.%Derived] {} {}
+// CHECK:STDOUT:   %Derived.decl.loc14: type = class_decl @Derived [concrete = constants.%Derived] {} {}
 // CHECK:STDOUT:   %Base.decl: type = class_decl @Base [concrete = constants.%Base] {} {}
-// CHECK:STDOUT:   %Derived.decl.loc18: type = class_decl @Derived [concrete = constants.%Derived] {} {}
+// CHECK:STDOUT:   %Derived.decl.loc21: type = class_decl @Derived [concrete = constants.%Derived] {} {}
 // CHECK:STDOUT:   %Call.decl: %Call.type = fn_decl @Call [concrete = constants.%Call] {
 // CHECK:STDOUT:     %a.patt: %pattern_type.fb9 = binding_pattern a [concrete]
 // CHECK:STDOUT:     %a.param_patt: %pattern_type.fb9 = value_param_pattern %a.patt, call_param0 [concrete]
@@ -107,7 +110,7 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %a.param: %Derived = value_param call_param0
-// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc11 [concrete = constants.%Derived]
+// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc14 [concrete = constants.%Derived]
 // CHECK:STDOUT:     %a: %Derived = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
@@ -121,8 +124,8 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc29: type = splice_block %ptr [concrete = constants.%ptr.404] {
-// CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc11 [concrete = constants.%Derived]
+// CHECK:STDOUT:     %.loc32: type = splice_block %ptr [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc14 [concrete = constants.%Derived]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.404 = bind_name p, %p.param
@@ -138,7 +141,7 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %a.param: %Derived = value_param call_param0
-// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc11 [concrete = constants.%Derived]
+// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc14 [concrete = constants.%Derived]
 // CHECK:STDOUT:     %a: %Derived = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
@@ -152,8 +155,8 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc37: type = splice_block %ptr [concrete = constants.%ptr.404] {
-// CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc11 [concrete = constants.%Derived]
+// CHECK:STDOUT:     %.loc40: type = splice_block %ptr [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc14 [concrete = constants.%Derived]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.404 = bind_name p, %p.param
@@ -164,7 +167,7 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %.loc19: %Derived.elem = base_decl %Base.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc22: %Derived.elem = base_decl %Base.ref, element0 [concrete]
 // CHECK:STDOUT:   %F.decl: %F.type.5da = fn_decl @F.2 [concrete = constants.%F.fa3] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.fb9 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.fb9 = value_param_pattern %self.patt, call_param0 [concrete]
@@ -188,7 +191,7 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Derived
 // CHECK:STDOUT:   .Base = <poisoned>
-// CHECK:STDOUT:   .base = %.loc19
+// CHECK:STDOUT:   .base = %.loc22
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   .G = %G.decl
 // CHECK:STDOUT:   extend %Base.ref
@@ -218,7 +221,7 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %self.param: %Derived = value_param call_param0
-// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc11 [concrete = constants.%Derived]
+// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc14 [concrete = constants.%Derived]
 // CHECK:STDOUT:     %self: %Derived = bind_name self, %self.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
@@ -248,13 +251,13 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
 // CHECK:STDOUT:   %F.ref: %F.type.7c6 = name_ref F, @Base.%F.decl [concrete = constants.%F.d17]
 // CHECK:STDOUT:   %F.bound: <bound method> = bound_method %a.ref, %F.ref
-// CHECK:STDOUT:   %.loc26_10.1: ref %Base = class_element_access %a.ref, element0
-// CHECK:STDOUT:   %.loc26_10.2: ref %Base = converted %a.ref, %.loc26_10.1
-// CHECK:STDOUT:   %.loc26_10.3: %Base = bind_value %.loc26_10.2
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc26_10.3)
-// CHECK:STDOUT:   %.loc26_22.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc26_22.2: %i32 = converted %F.call, %.loc26_22.1
-// CHECK:STDOUT:   return %.loc26_22.2
+// CHECK:STDOUT:   %.loc29_10.1: ref %Base = class_element_access %a.ref, element0
+// CHECK:STDOUT:   %.loc29_10.2: ref %Base = converted %a.ref, %.loc29_10.1
+// CHECK:STDOUT:   %.loc29_10.3: %Base = bind_value %.loc29_10.2
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc29_10.3)
+// CHECK:STDOUT:   %.loc29_22.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc29_22.2: %i32 = converted %F.call, %.loc29_22.1
+// CHECK:STDOUT:   return %.loc29_22.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallIndirect(%p.param: %ptr.404) -> %i32 {
@@ -262,15 +265,15 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %p.ref: %ptr.404 = name_ref p, %p
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
 // CHECK:STDOUT:   %F.ref: %F.type.7c6 = name_ref F, @Base.%F.decl [concrete = constants.%F.d17]
-// CHECK:STDOUT:   %.loc30_11.1: ref %Derived = deref %p.ref
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc30_11.1, %F.ref
-// CHECK:STDOUT:   %.loc30_11.2: ref %Base = class_element_access %.loc30_11.1, element0
-// CHECK:STDOUT:   %.loc30_11.3: ref %Base = converted %.loc30_11.1, %.loc30_11.2
-// CHECK:STDOUT:   %.loc30_11.4: %Base = bind_value %.loc30_11.3
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc30_11.4)
-// CHECK:STDOUT:   %.loc30_23.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc30_23.2: %i32 = converted %F.call, %.loc30_23.1
-// CHECK:STDOUT:   return %.loc30_23.2
+// CHECK:STDOUT:   %.loc33_11.1: ref %Derived = deref %p.ref
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc33_11.1, %F.ref
+// CHECK:STDOUT:   %.loc33_11.2: ref %Base = class_element_access %.loc33_11.1, element0
+// CHECK:STDOUT:   %.loc33_11.3: ref %Base = converted %.loc33_11.1, %.loc33_11.2
+// CHECK:STDOUT:   %.loc33_11.4: %Base = bind_value %.loc33_11.3
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc33_11.4)
+// CHECK:STDOUT:   %.loc33_23.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc33_23.2: %i32 = converted %F.call, %.loc33_23.1
+// CHECK:STDOUT:   return %.loc33_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PassDerivedToBase(%a.param: %Derived) -> %i32 {
@@ -280,9 +283,9 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %G.ref: %G.type.6ee = name_ref G, @Base.%G.decl [concrete = constants.%G.663]
 // CHECK:STDOUT:   %G.bound: <bound method> = bound_method %a.ref, %G.ref
 // CHECK:STDOUT:   %G.call: init %i32 = call %G.bound(%a.ref)
-// CHECK:STDOUT:   %.loc34_22.1: %i32 = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc34_22.2: %i32 = converted %G.call, %.loc34_22.1
-// CHECK:STDOUT:   return %.loc34_22.2
+// CHECK:STDOUT:   %.loc37_22.1: %i32 = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc37_22.2: %i32 = converted %G.call, %.loc37_22.1
+// CHECK:STDOUT:   return %.loc37_22.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PassDerivedToBaseIndirect(%p.param: %ptr.404) -> %i32 {
@@ -290,12 +293,12 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %p.ref: %ptr.404 = name_ref p, %p
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
 // CHECK:STDOUT:   %G.ref: %G.type.6ee = name_ref G, @Base.%G.decl [concrete = constants.%G.663]
-// CHECK:STDOUT:   %.loc38_11.1: ref %Derived = deref %p.ref
-// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %.loc38_11.1, %G.ref
-// CHECK:STDOUT:   %.loc38_11.2: %Derived = bind_value %.loc38_11.1
-// CHECK:STDOUT:   %G.call: init %i32 = call %G.bound(%.loc38_11.2)
-// CHECK:STDOUT:   %.loc38_23.1: %i32 = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc38_23.2: %i32 = converted %G.call, %.loc38_23.1
-// CHECK:STDOUT:   return %.loc38_23.2
+// CHECK:STDOUT:   %.loc41_11.1: ref %Derived = deref %p.ref
+// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %.loc41_11.1, %G.ref
+// CHECK:STDOUT:   %.loc41_11.2: %Derived = bind_value %.loc41_11.1
+// CHECK:STDOUT:   %G.call: init %i32 = call %G.bound(%.loc41_11.2)
+// CHECK:STDOUT:   %.loc41_23.1: %i32 = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc41_23.2: %i32 = converted %G.call, %.loc41_23.1
+// CHECK:STDOUT:   return %.loc41_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method_shadow.carbon
+++ b/toolchain/check/testdata/class/base_method_shadow.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/base_method_shadow.carbon
@@ -101,27 +104,27 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT:     %d.param_patt: %pattern_type.a94 = value_param_pattern %d.patt, call_param3 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.6db = value_param call_param0
-// CHECK:STDOUT:     %.loc29_13: type = splice_block %ptr.loc29_13 [concrete = constants.%ptr.6db] {
+// CHECK:STDOUT:     %.loc32_13: type = splice_block %ptr.loc32_13 [concrete = constants.%ptr.6db] {
 // CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:       %ptr.loc29_13: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
+// CHECK:STDOUT:       %ptr.loc32_13: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.6db = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %ptr.e79 = value_param call_param1
-// CHECK:STDOUT:     %.loc29_20: type = splice_block %ptr.loc29_20 [concrete = constants.%ptr.e79] {
+// CHECK:STDOUT:     %.loc32_20: type = splice_block %ptr.loc32_20 [concrete = constants.%ptr.e79] {
 // CHECK:STDOUT:       %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:       %ptr.loc29_20: type = ptr_type %B.ref [concrete = constants.%ptr.e79]
+// CHECK:STDOUT:       %ptr.loc32_20: type = ptr_type %B.ref [concrete = constants.%ptr.e79]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: %ptr.e79 = bind_name b, %b.param
 // CHECK:STDOUT:     %c.param: %ptr.019 = value_param call_param2
-// CHECK:STDOUT:     %.loc29_27: type = splice_block %ptr.loc29_27 [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc32_27: type = splice_block %ptr.loc32_27 [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr.loc29_27: type = ptr_type %C.ref [concrete = constants.%ptr.019]
+// CHECK:STDOUT:       %ptr.loc32_27: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %ptr.019 = bind_name c, %c.param
 // CHECK:STDOUT:     %d.param: %ptr.19c = value_param call_param3
-// CHECK:STDOUT:     %.loc29_34: type = splice_block %ptr.loc29_34 [concrete = constants.%ptr.19c] {
+// CHECK:STDOUT:     %.loc32_34: type = splice_block %ptr.loc32_34 [concrete = constants.%ptr.19c] {
 // CHECK:STDOUT:       %D.ref: type = name_ref D, file.%D.decl [concrete = constants.%D]
-// CHECK:STDOUT:       %ptr.loc29_34: type = ptr_type %D.ref [concrete = constants.%ptr.19c]
+// CHECK:STDOUT:       %ptr.loc32_34: type = ptr_type %D.ref [concrete = constants.%ptr.19c]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %d: %ptr.19c = bind_name d, %d.param
 // CHECK:STDOUT:   }
@@ -131,10 +134,10 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT:   %F.decl: %F.type.649 = fn_decl @F.1 [concrete = constants.%F.485] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.5f8 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.5f8 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc12_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc15_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.6db = value_param call_param0
-// CHECK:STDOUT:     %.loc12_23: type = splice_block %ptr [concrete = constants.%ptr.6db] {
+// CHECK:STDOUT:     %.loc15_23: type = splice_block %ptr [concrete = constants.%ptr.6db] {
 // CHECK:STDOUT:       %Self.ref: type = name_ref Self, constants.%A [concrete = constants.%A]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Self.ref [concrete = constants.%ptr.6db]
 // CHECK:STDOUT:     }
@@ -151,14 +154,14 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc16: %B.elem = base_decl %A.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %B.elem = base_decl %A.ref, element0 [concrete]
 // CHECK:STDOUT:   %F.decl: %F.type.8c6 = fn_decl @F.2 [concrete = constants.%F.92a] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.960 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.960 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc17_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc20_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.e79 = value_param call_param0
-// CHECK:STDOUT:     %.loc17_23: type = splice_block %ptr [concrete = constants.%ptr.e79] {
+// CHECK:STDOUT:     %.loc20_23: type = splice_block %ptr [concrete = constants.%ptr.e79] {
 // CHECK:STDOUT:       %Self.ref: type = name_ref Self, constants.%B [concrete = constants.%B]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Self.ref [concrete = constants.%ptr.e79]
 // CHECK:STDOUT:     }
@@ -171,21 +174,21 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   .base = %.loc16
+// CHECK:STDOUT:   .base = %.loc19
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   extend %A.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc21: %C.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc24: %C.elem = base_decl %B.ref, element0 [concrete]
 // CHECK:STDOUT:   %F.decl: %F.type.c29 = fn_decl @F.3 [concrete = constants.%F.437] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc22_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc25_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc22_23: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc25_23: type = splice_block %ptr [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %Self.ref: type = name_ref Self, constants.%C [concrete = constants.%C]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Self.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
@@ -198,14 +201,14 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc21
+// CHECK:STDOUT:   .base = %.loc24
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   extend %B.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc26: %D.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc29: %D.elem = base_decl %B.ref, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B} [concrete = constants.%struct_type.base.0ff]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -213,7 +216,7 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%D
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc26
+// CHECK:STDOUT:   .base = %.loc29
 // CHECK:STDOUT:   .F = <poisoned>
 // CHECK:STDOUT:   extend %B.ref
 // CHECK:STDOUT: }
@@ -227,33 +230,33 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: fn @Call(%a.param: %ptr.6db, %b.param: %ptr.e79, %c.param: %ptr.019, %d.param: %ptr.19c) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.6db = name_ref a, %a
-// CHECK:STDOUT:   %.loc30: ref %A = deref %a.ref
-// CHECK:STDOUT:   %F.ref.loc30: %F.type.649 = name_ref F, @A.%F.decl [concrete = constants.%F.485]
-// CHECK:STDOUT:   %F.bound.loc30: <bound method> = bound_method %.loc30, %F.ref.loc30
-// CHECK:STDOUT:   %addr.loc30: %ptr.6db = addr_of %.loc30
-// CHECK:STDOUT:   %F.call.loc30: init %empty_tuple.type = call %F.bound.loc30(%addr.loc30)
+// CHECK:STDOUT:   %.loc33: ref %A = deref %a.ref
+// CHECK:STDOUT:   %F.ref.loc33: %F.type.649 = name_ref F, @A.%F.decl [concrete = constants.%F.485]
+// CHECK:STDOUT:   %F.bound.loc33: <bound method> = bound_method %.loc33, %F.ref.loc33
+// CHECK:STDOUT:   %addr.loc33: %ptr.6db = addr_of %.loc33
+// CHECK:STDOUT:   %F.call.loc33: init %empty_tuple.type = call %F.bound.loc33(%addr.loc33)
 // CHECK:STDOUT:   %b.ref: %ptr.e79 = name_ref b, %b
-// CHECK:STDOUT:   %.loc31: ref %B = deref %b.ref
-// CHECK:STDOUT:   %F.ref.loc31: %F.type.8c6 = name_ref F, @B.%F.decl [concrete = constants.%F.92a]
-// CHECK:STDOUT:   %F.bound.loc31: <bound method> = bound_method %.loc31, %F.ref.loc31
-// CHECK:STDOUT:   %addr.loc31: %ptr.e79 = addr_of %.loc31
-// CHECK:STDOUT:   %F.call.loc31: init %empty_tuple.type = call %F.bound.loc31(%addr.loc31)
+// CHECK:STDOUT:   %.loc34: ref %B = deref %b.ref
+// CHECK:STDOUT:   %F.ref.loc34: %F.type.8c6 = name_ref F, @B.%F.decl [concrete = constants.%F.92a]
+// CHECK:STDOUT:   %F.bound.loc34: <bound method> = bound_method %.loc34, %F.ref.loc34
+// CHECK:STDOUT:   %addr.loc34: %ptr.e79 = addr_of %.loc34
+// CHECK:STDOUT:   %F.call.loc34: init %empty_tuple.type = call %F.bound.loc34(%addr.loc34)
 // CHECK:STDOUT:   %c.ref: %ptr.019 = name_ref c, %c
-// CHECK:STDOUT:   %.loc32: ref %C = deref %c.ref
-// CHECK:STDOUT:   %F.ref.loc32: %F.type.c29 = name_ref F, @C.%F.decl [concrete = constants.%F.437]
-// CHECK:STDOUT:   %F.bound.loc32: <bound method> = bound_method %.loc32, %F.ref.loc32
-// CHECK:STDOUT:   %addr.loc32: %ptr.019 = addr_of %.loc32
-// CHECK:STDOUT:   %F.call.loc32: init %empty_tuple.type = call %F.bound.loc32(%addr.loc32)
+// CHECK:STDOUT:   %.loc35: ref %C = deref %c.ref
+// CHECK:STDOUT:   %F.ref.loc35: %F.type.c29 = name_ref F, @C.%F.decl [concrete = constants.%F.437]
+// CHECK:STDOUT:   %F.bound.loc35: <bound method> = bound_method %.loc35, %F.ref.loc35
+// CHECK:STDOUT:   %addr.loc35: %ptr.019 = addr_of %.loc35
+// CHECK:STDOUT:   %F.call.loc35: init %empty_tuple.type = call %F.bound.loc35(%addr.loc35)
 // CHECK:STDOUT:   %d.ref: %ptr.19c = name_ref d, %d
-// CHECK:STDOUT:   %.loc33_4.1: ref %D = deref %d.ref
-// CHECK:STDOUT:   %F.ref.loc33: %F.type.8c6 = name_ref F, @B.%F.decl [concrete = constants.%F.92a]
-// CHECK:STDOUT:   %F.bound.loc33: <bound method> = bound_method %.loc33_4.1, %F.ref.loc33
-// CHECK:STDOUT:   %addr.loc33_4.1: %ptr.19c = addr_of %.loc33_4.1
-// CHECK:STDOUT:   %.loc33_4.2: ref %D = deref %addr.loc33_4.1
-// CHECK:STDOUT:   %.loc33_4.3: ref %B = class_element_access %.loc33_4.2, element0
-// CHECK:STDOUT:   %addr.loc33_4.2: %ptr.e79 = addr_of %.loc33_4.3
-// CHECK:STDOUT:   %.loc33_4.4: %ptr.e79 = converted %addr.loc33_4.1, %addr.loc33_4.2
-// CHECK:STDOUT:   %F.call.loc33: init %empty_tuple.type = call %F.bound.loc33(%.loc33_4.4)
+// CHECK:STDOUT:   %.loc36_4.1: ref %D = deref %d.ref
+// CHECK:STDOUT:   %F.ref.loc36: %F.type.8c6 = name_ref F, @B.%F.decl [concrete = constants.%F.92a]
+// CHECK:STDOUT:   %F.bound.loc36: <bound method> = bound_method %.loc36_4.1, %F.ref.loc36
+// CHECK:STDOUT:   %addr.loc36_4.1: %ptr.19c = addr_of %.loc36_4.1
+// CHECK:STDOUT:   %.loc36_4.2: ref %D = deref %addr.loc36_4.1
+// CHECK:STDOUT:   %.loc36_4.3: ref %B = class_element_access %.loc36_4.2, element0
+// CHECK:STDOUT:   %addr.loc36_4.2: %ptr.e79 = addr_of %.loc36_4.3
+// CHECK:STDOUT:   %.loc36_4.4: %ptr.e79 = converted %addr.loc36_4.1, %addr.loc36_4.2
+// CHECK:STDOUT:   %F.call.loc36: init %empty_tuple.type = call %F.bound.loc36(%.loc36_4.4)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/basic.carbon
@@ -90,16 +93,16 @@ fn Run() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc21_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %n.param.loc21: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc21: type = splice_block %i32.loc21_15 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc21_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc21_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc24_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %n.param.loc24: %i32 = value_param call_param0
+// CHECK:STDOUT:     %.loc24: type = splice_block %i32.loc24_15 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc24_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc24_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %n.loc21: %i32 = bind_name n, %n.param.loc21
-// CHECK:STDOUT:     %return.param.loc21: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc21: ref %i32 = return_slot %return.param.loc21
+// CHECK:STDOUT:     %n.loc24: %i32 = bind_name n, %n.param.loc24
+// CHECK:STDOUT:     %return.param.loc24: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc24: ref %i32 = return_slot %return.param.loc24
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Run.decl: %Run.type = fn_decl @Run [concrete = constants.%Run] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
@@ -121,12 +124,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc12_19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc15_19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc12: type = splice_block %i32.loc12_11 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc12_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc12_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc15: type = splice_block %i32.loc15_11 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc15_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc15_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %n: %i32 = bind_name n, %n.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
@@ -138,20 +141,20 @@ fn Run() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc16_19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc16_19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %n.param.loc16: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc16: type = splice_block %i32.loc16_11 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc16_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc16_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc19_19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc19_19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %n.param.loc19: %i32 = value_param call_param0
+// CHECK:STDOUT:     %.loc19: type = splice_block %i32.loc19_11 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc19_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc19_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %n.loc16: %i32 = bind_name n, %n.param.loc16
-// CHECK:STDOUT:     %return.param.loc16: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc16: ref %i32 = return_slot %return.param.loc16
+// CHECK:STDOUT:     %n.loc19: %i32 = bind_name n, %n.param.loc19
+// CHECK:STDOUT:     %return.param.loc19: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc19: ref %i32 = return_slot %return.param.loc19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc18: %Class.elem = field_decl k, element0 [concrete]
+// CHECK:STDOUT:   %.loc21: %Class.elem = field_decl k, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.k: type = struct_type {.k: %i32} [concrete = constants.%struct_type.k]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.k [concrete = constants.%complete_type.954]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -160,7 +163,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   .Self = constants.%Class
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   .G = %G.decl
-// CHECK:STDOUT:   .k = %.loc18
+// CHECK:STDOUT:   .k = %.loc21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%n.param: %i32) -> %i32 {
@@ -169,9 +172,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G(%n.param.loc21: %i32) -> %i32 {
+// CHECK:STDOUT: fn @G(%n.param.loc24: %i32) -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %n.ref: %i32 = name_ref n, %n.loc21
+// CHECK:STDOUT:   %n.ref: %i32 = name_ref n, %n.loc24
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -181,15 +184,15 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %int_4: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc26_18.1: <bound method> = bound_method %int_4, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc29_18.1: <bound method> = bound_method %int_4, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc26_18.2: <bound method> = bound_method %int_4, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc26_18.2(%int_4) [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc26_18.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc26_18.2: %i32 = converted %int_4, %.loc26_18.1 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.ref(%.loc26_18.2)
-// CHECK:STDOUT:   %.loc26_20.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc26_20.2: %i32 = converted %F.call, %.loc26_20.1
-// CHECK:STDOUT:   return %.loc26_20.2
+// CHECK:STDOUT:   %bound_method.loc29_18.2: <bound method> = bound_method %int_4, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc29_18.2(%int_4) [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc29_18.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc29_18.2: %i32 = converted %int_4, %.loc29_18.1 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.ref(%.loc29_18.2)
+// CHECK:STDOUT:   %.loc29_20.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc29_20.2: %i32 = converted %F.call, %.loc29_20.1
+// CHECK:STDOUT:   return %.loc29_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/complete_in_member_fn.carbon
+++ b/toolchain/check/testdata/class/complete_in_member_fn.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/complete_in_member_fn.carbon
@@ -66,7 +69,7 @@ class C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc14: %C.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc17: %C.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -75,15 +78,15 @@ class C {
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .C = <poisoned>
 // CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   .a = %.loc14
+// CHECK:STDOUT:   .a = %.loc17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%c.param: %C) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
-// CHECK:STDOUT:   %a.ref: %C.elem = name_ref a, @C.%.loc14 [concrete = @C.%.loc14]
-// CHECK:STDOUT:   %.loc12_31.1: ref %i32 = class_element_access %c.ref, element0
-// CHECK:STDOUT:   %.loc12_31.2: %i32 = bind_value %.loc12_31.1
-// CHECK:STDOUT:   return %.loc12_31.2
+// CHECK:STDOUT:   %a.ref: %C.elem = name_ref a, @C.%.loc17 [concrete = @C.%.loc17]
+// CHECK:STDOUT:   %.loc15_31.1: ref %i32 = class_element_access %c.ref, element0
+// CHECK:STDOUT:   %.loc15_31.2: %i32 = bind_value %.loc15_31.1
+// CHECK:STDOUT:   return %.loc15_31.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/compound_field.carbon
+++ b/toolchain/check/testdata/class/compound_field.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/compound_field.carbon
@@ -100,7 +103,7 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %d.param: %Derived = value_param call_param0
-// CHECK:STDOUT:     %Derived.ref.loc24: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
+// CHECK:STDOUT:     %Derived.ref.loc27: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
 // CHECK:STDOUT:     %d: %Derived = bind_name d, %d.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
@@ -127,11 +130,11 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc32_45: type = ptr_type %i32 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:     %ptr.loc35_45: type = ptr_type %i32 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc32: type = splice_block %ptr.loc32_36 [concrete = constants.%ptr.404] {
-// CHECK:STDOUT:       %Derived.ref.loc32: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
-// CHECK:STDOUT:       %ptr.loc32_36: type = ptr_type %Derived.ref.loc32 [concrete = constants.%ptr.404]
+// CHECK:STDOUT:     %.loc35: type = splice_block %ptr.loc35_36 [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:       %Derived.ref.loc35: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
+// CHECK:STDOUT:       %ptr.loc35_36: type = ptr_type %Derived.ref.loc35 [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.404 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.235 = out_param call_param1
@@ -145,11 +148,11 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc36_42: type = ptr_type %i32 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:     %ptr.loc39_42: type = ptr_type %i32 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc36: type = splice_block %ptr.loc36_33 [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:     %.loc39: type = splice_block %ptr.loc39_33 [concrete = constants.%ptr.404] {
 // CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
-// CHECK:STDOUT:       %ptr.loc36_33: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
+// CHECK:STDOUT:       %ptr.loc39_33: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.404 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.235 = out_param call_param1
@@ -158,35 +161,35 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Base.elem = field_decl a, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Base.elem = field_decl b, element1 [concrete]
-// CHECK:STDOUT:   %int_32.loc14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc14: %Base.elem = field_decl c, element2 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Base.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Base.elem = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc17: %Base.elem = field_decl c, element2 [concrete]
 // CHECK:STDOUT:   %struct_type.a.b.c: type = struct_type {.a: %i32, .b: %i32, .c: %i32} [concrete = constants.%struct_type.a.b.c]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b.c [concrete = constants.%complete_type.ebc]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Base
-// CHECK:STDOUT:   .a = %.loc12
-// CHECK:STDOUT:   .b = %.loc13
-// CHECK:STDOUT:   .c = %.loc14
+// CHECK:STDOUT:   .a = %.loc15
+// CHECK:STDOUT:   .b = %.loc16
+// CHECK:STDOUT:   .c = %.loc17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %.loc18: %Derived.elem.69e = base_decl %Base.ref, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc20: %Derived.elem.344 = field_decl d, element1 [concrete]
-// CHECK:STDOUT:   %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc21: %Derived.elem.344 = field_decl e, element2 [concrete]
+// CHECK:STDOUT:   %.loc21: %Derived.elem.69e = base_decl %Base.ref, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc23: %Derived.elem.344 = field_decl d, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc24: %Derived.elem.344 = field_decl e, element2 [concrete]
 // CHECK:STDOUT:   %struct_type.base.d.e: type = struct_type {.base: %Base, .d: %i32, .e: %i32} [concrete = constants.%struct_type.base.d.e.6a7]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.d.e [concrete = constants.%complete_type.401]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -194,42 +197,42 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Derived
 // CHECK:STDOUT:   .Base = <poisoned>
-// CHECK:STDOUT:   .base = %.loc18
-// CHECK:STDOUT:   .d = %.loc20
-// CHECK:STDOUT:   .e = %.loc21
+// CHECK:STDOUT:   .base = %.loc21
+// CHECK:STDOUT:   .d = %.loc23
+// CHECK:STDOUT:   .e = %.loc24
 // CHECK:STDOUT:   extend %Base.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessDerived(%d.param: %Derived) -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %d.ref.loc25_10: %Derived = name_ref d, %d
-// CHECK:STDOUT:   %Derived.ref.loc25: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
-// CHECK:STDOUT:   %d.ref.loc25_20: %Derived.elem.344 = name_ref d, @Derived.%.loc20 [concrete = @Derived.%.loc20]
-// CHECK:STDOUT:   %.loc25_11.1: ref %i32 = class_element_access %d.ref.loc25_10, element1
-// CHECK:STDOUT:   %.loc25_11.2: %i32 = bind_value %.loc25_11.1
-// CHECK:STDOUT:   return %.loc25_11.2
+// CHECK:STDOUT:   %d.ref.loc28_10: %Derived = name_ref d, %d
+// CHECK:STDOUT:   %Derived.ref.loc28: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
+// CHECK:STDOUT:   %d.ref.loc28_20: %Derived.elem.344 = name_ref d, @Derived.%.loc23 [concrete = @Derived.%.loc23]
+// CHECK:STDOUT:   %.loc28_11.1: ref %i32 = class_element_access %d.ref.loc28_10, element1
+// CHECK:STDOUT:   %.loc28_11.2: %i32 = bind_value %.loc28_11.1
+// CHECK:STDOUT:   return %.loc28_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessBase(%d.param: %Derived) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %d.ref: %Derived = name_ref d, %d
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %b.ref: %Base.elem = name_ref b, @Base.%.loc13 [concrete = @Base.%.loc13]
-// CHECK:STDOUT:   %.loc29_11.1: ref %Base = class_element_access %d.ref, element0
-// CHECK:STDOUT:   %.loc29_11.2: ref %Base = converted %d.ref, %.loc29_11.1
-// CHECK:STDOUT:   %.loc29_11.3: ref %i32 = class_element_access %.loc29_11.2, element1
-// CHECK:STDOUT:   %.loc29_11.4: %i32 = bind_value %.loc29_11.3
-// CHECK:STDOUT:   return %.loc29_11.4
+// CHECK:STDOUT:   %b.ref: %Base.elem = name_ref b, @Base.%.loc16 [concrete = @Base.%.loc16]
+// CHECK:STDOUT:   %.loc32_11.1: ref %Base = class_element_access %d.ref, element0
+// CHECK:STDOUT:   %.loc32_11.2: ref %Base = converted %d.ref, %.loc32_11.1
+// CHECK:STDOUT:   %.loc32_11.3: ref %i32 = class_element_access %.loc32_11.2, element1
+// CHECK:STDOUT:   %.loc32_11.4: %i32 = bind_value %.loc32_11.3
+// CHECK:STDOUT:   return %.loc32_11.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessDerivedIndirect(%p.param: %ptr.404) -> %ptr.235 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.404 = name_ref p, %p
-// CHECK:STDOUT:   %Derived.ref.loc33: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
-// CHECK:STDOUT:   %d.ref: %Derived.elem.344 = name_ref d, @Derived.%.loc20 [concrete = @Derived.%.loc20]
-// CHECK:STDOUT:   %.loc33_12.1: ref %Derived = deref %p.ref
-// CHECK:STDOUT:   %.loc33_12.2: ref %i32 = class_element_access %.loc33_12.1, element1
-// CHECK:STDOUT:   %addr: %ptr.235 = addr_of %.loc33_12.2
+// CHECK:STDOUT:   %Derived.ref.loc36: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
+// CHECK:STDOUT:   %d.ref: %Derived.elem.344 = name_ref d, @Derived.%.loc23 [concrete = @Derived.%.loc23]
+// CHECK:STDOUT:   %.loc36_12.1: ref %Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc36_12.2: ref %i32 = class_element_access %.loc36_12.1, element1
+// CHECK:STDOUT:   %addr: %ptr.235 = addr_of %.loc36_12.2
 // CHECK:STDOUT:   return %addr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -237,12 +240,12 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.404 = name_ref p, %p
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %b.ref: %Base.elem = name_ref b, @Base.%.loc13 [concrete = @Base.%.loc13]
-// CHECK:STDOUT:   %.loc37_12.1: ref %Derived = deref %p.ref
-// CHECK:STDOUT:   %.loc37_12.2: ref %Base = class_element_access %.loc37_12.1, element0
-// CHECK:STDOUT:   %.loc37_12.3: ref %Base = converted %.loc37_12.1, %.loc37_12.2
-// CHECK:STDOUT:   %.loc37_12.4: ref %i32 = class_element_access %.loc37_12.3, element1
-// CHECK:STDOUT:   %addr: %ptr.235 = addr_of %.loc37_12.4
+// CHECK:STDOUT:   %b.ref: %Base.elem = name_ref b, @Base.%.loc16 [concrete = @Base.%.loc16]
+// CHECK:STDOUT:   %.loc40_12.1: ref %Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc40_12.2: ref %Base = class_element_access %.loc40_12.1, element0
+// CHECK:STDOUT:   %.loc40_12.3: ref %Base = converted %.loc40_12.1, %.loc40_12.2
+// CHECK:STDOUT:   %.loc40_12.4: ref %i32 = class_element_access %.loc40_12.3, element1
+// CHECK:STDOUT:   %addr: %ptr.235 = addr_of %.loc40_12.4
 // CHECK:STDOUT:   return %addr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/cross_package_import.carbon

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/derived_to_base.carbon
@@ -149,11 +152,11 @@ fn ConvertInit() {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.960 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:     %ptr.loc25_27: type = ptr_type %B.ref [concrete = constants.%ptr.e79]
+// CHECK:STDOUT:     %ptr.loc28_27: type = ptr_type %B.ref [concrete = constants.%ptr.e79]
 // CHECK:STDOUT:     %p.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc25_20: type = splice_block %ptr.loc25_20 [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc28_20: type = splice_block %ptr.loc28_20 [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr.loc25_20: type = ptr_type %C.ref [concrete = constants.%ptr.019]
+// CHECK:STDOUT:       %ptr.loc28_20: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.019 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.e79 = out_param call_param1
@@ -166,11 +169,11 @@ fn ConvertInit() {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.5f8 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:     %ptr.loc26_27: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
+// CHECK:STDOUT:     %ptr.loc29_27: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
 // CHECK:STDOUT:     %p.param: %ptr.e79 = value_param call_param0
-// CHECK:STDOUT:     %.loc26_20: type = splice_block %ptr.loc26_20 [concrete = constants.%ptr.e79] {
+// CHECK:STDOUT:     %.loc29_20: type = splice_block %ptr.loc29_20 [concrete = constants.%ptr.e79] {
 // CHECK:STDOUT:       %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:       %ptr.loc26_20: type = ptr_type %B.ref [concrete = constants.%ptr.e79]
+// CHECK:STDOUT:       %ptr.loc29_20: type = ptr_type %B.ref [concrete = constants.%ptr.e79]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.e79 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.6db = out_param call_param1
@@ -183,11 +186,11 @@ fn ConvertInit() {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.5f8 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:     %ptr.loc27_27: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
+// CHECK:STDOUT:     %ptr.loc30_27: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
 // CHECK:STDOUT:     %p.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc27_20: type = splice_block %ptr.loc27_20 [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc30_20: type = splice_block %ptr.loc30_20 [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr.loc27_20: type = ptr_type %C.ref [concrete = constants.%ptr.019]
+// CHECK:STDOUT:       %ptr.loc30_20: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.019 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.6db = out_param call_param1
@@ -207,12 +210,12 @@ fn ConvertInit() {
 // CHECK:STDOUT:     %return.patt: %pattern_type.5f8 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.5f8 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %A.ref.loc33: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:     %ptr.loc33_26: type = ptr_type %A.ref.loc33 [concrete = constants.%ptr.6db]
+// CHECK:STDOUT:     %A.ref.loc36: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:     %ptr.loc36_26: type = ptr_type %A.ref.loc36 [concrete = constants.%ptr.6db]
 // CHECK:STDOUT:     %c.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc33: type = splice_block %ptr.loc33_19 [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc36: type = splice_block %ptr.loc36_19 [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr.loc33_19: type = ptr_type %C.ref [concrete = constants.%ptr.019]
+// CHECK:STDOUT:       %ptr.loc36_19: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %ptr.019 = bind_name c, %c.param
 // CHECK:STDOUT:     %return.param: ref %ptr.6db = out_param call_param1
@@ -224,22 +227,22 @@ fn ConvertInit() {
 // CHECK:STDOUT: class @A {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %A.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %A.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a.ba9]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A
-// CHECK:STDOUT:   .a = %.loc12
+// CHECK:STDOUT:   .a = %.loc15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc16: %B.elem.e38 = base_decl %A.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %B.elem.e38 = base_decl %A.ref, element0 [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc17: %B.elem.5c3 = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %.loc20: %B.elem.5c3 = field_decl b, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.base.b: type = struct_type {.base: %A, .b: %i32} [concrete = constants.%struct_type.base.b.b44]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.b [concrete = constants.%complete_type.725]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -247,17 +250,17 @@ fn ConvertInit() {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   .base = %.loc16
-// CHECK:STDOUT:   .b = %.loc17
+// CHECK:STDOUT:   .base = %.loc19
+// CHECK:STDOUT:   .b = %.loc20
 // CHECK:STDOUT:   extend %A.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc21: %C.elem.f0c = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc24: %C.elem.f0c = base_decl %B.ref, element0 [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc22: %C.elem.646 = field_decl c, element1 [concrete]
+// CHECK:STDOUT:   %.loc25: %C.elem.646 = field_decl c, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.base.c: type = struct_type {.base: %B, .c: %i32} [concrete = constants.%struct_type.base.c.8e2]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.c [concrete = constants.%complete_type.58a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -265,40 +268,40 @@ fn ConvertInit() {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc21
-// CHECK:STDOUT:   .c = %.loc22
+// CHECK:STDOUT:   .base = %.loc24
+// CHECK:STDOUT:   .c = %.loc25
 // CHECK:STDOUT:   extend %B.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertCToB(%p.param: %ptr.019) -> %ptr.e79 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.019 = name_ref p, %p
-// CHECK:STDOUT:   %.loc25_39.1: ref %C = deref %p.ref
-// CHECK:STDOUT:   %.loc25_39.2: ref %B = class_element_access %.loc25_39.1, element0
-// CHECK:STDOUT:   %addr: %ptr.e79 = addr_of %.loc25_39.2
-// CHECK:STDOUT:   %.loc25_39.3: %ptr.e79 = converted %p.ref, %addr
-// CHECK:STDOUT:   return %.loc25_39.3
+// CHECK:STDOUT:   %.loc28_39.1: ref %C = deref %p.ref
+// CHECK:STDOUT:   %.loc28_39.2: ref %B = class_element_access %.loc28_39.1, element0
+// CHECK:STDOUT:   %addr: %ptr.e79 = addr_of %.loc28_39.2
+// CHECK:STDOUT:   %.loc28_39.3: %ptr.e79 = converted %p.ref, %addr
+// CHECK:STDOUT:   return %.loc28_39.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertBToA(%p.param: %ptr.e79) -> %ptr.6db {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.e79 = name_ref p, %p
-// CHECK:STDOUT:   %.loc26_39.1: ref %B = deref %p.ref
-// CHECK:STDOUT:   %.loc26_39.2: ref %A = class_element_access %.loc26_39.1, element0
-// CHECK:STDOUT:   %addr: %ptr.6db = addr_of %.loc26_39.2
-// CHECK:STDOUT:   %.loc26_39.3: %ptr.6db = converted %p.ref, %addr
-// CHECK:STDOUT:   return %.loc26_39.3
+// CHECK:STDOUT:   %.loc29_39.1: ref %B = deref %p.ref
+// CHECK:STDOUT:   %.loc29_39.2: ref %A = class_element_access %.loc29_39.1, element0
+// CHECK:STDOUT:   %addr: %ptr.6db = addr_of %.loc29_39.2
+// CHECK:STDOUT:   %.loc29_39.3: %ptr.6db = converted %p.ref, %addr
+// CHECK:STDOUT:   return %.loc29_39.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertCToA(%p.param: %ptr.019) -> %ptr.6db {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.019 = name_ref p, %p
-// CHECK:STDOUT:   %.loc27_39.1: ref %C = deref %p.ref
-// CHECK:STDOUT:   %.loc27_39.2: ref %B = class_element_access %.loc27_39.1, element0
-// CHECK:STDOUT:   %.loc27_39.3: ref %A = class_element_access %.loc27_39.2, element0
-// CHECK:STDOUT:   %addr: %ptr.6db = addr_of %.loc27_39.3
-// CHECK:STDOUT:   %.loc27_39.4: %ptr.6db = converted %p.ref, %addr
-// CHECK:STDOUT:   return %.loc27_39.4
+// CHECK:STDOUT:   %.loc30_39.1: ref %C = deref %p.ref
+// CHECK:STDOUT:   %.loc30_39.2: ref %B = class_element_access %.loc30_39.1, element0
+// CHECK:STDOUT:   %.loc30_39.3: ref %A = class_element_access %.loc30_39.2, element0
+// CHECK:STDOUT:   %addr: %ptr.6db = addr_of %.loc30_39.3
+// CHECK:STDOUT:   %.loc30_39.4: %ptr.6db = converted %p.ref, %addr
+// CHECK:STDOUT:   return %.loc30_39.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertValue(%c.param: %C) {
@@ -308,22 +311,22 @@ fn ConvertInit() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc30_14.1: ref %B = class_element_access %c.ref, element0
-// CHECK:STDOUT:   %.loc30_14.2: ref %A = class_element_access %.loc30_14.1, element0
-// CHECK:STDOUT:   %.loc30_14.3: ref %A = converted %c.ref, %.loc30_14.2
-// CHECK:STDOUT:   %a: ref %A = bind_name a, %.loc30_14.3
+// CHECK:STDOUT:   %.loc33_14.1: ref %B = class_element_access %c.ref, element0
+// CHECK:STDOUT:   %.loc33_14.2: ref %A = class_element_access %.loc33_14.1, element0
+// CHECK:STDOUT:   %.loc33_14.3: ref %A = converted %c.ref, %.loc33_14.2
+// CHECK:STDOUT:   %a: ref %A = bind_name a, %.loc33_14.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertRef(%c.param: %ptr.019) -> %ptr.6db {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: %ptr.019 = name_ref c, %c
-// CHECK:STDOUT:   %.loc34_12: ref %C = deref %c.ref
-// CHECK:STDOUT:   %A.ref.loc34: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc34_15.1: ref %B = class_element_access %.loc34_12, element0
-// CHECK:STDOUT:   %.loc34_15.2: ref %A = class_element_access %.loc34_15.1, element0
-// CHECK:STDOUT:   %.loc34_15.3: ref %A = converted %.loc34_12, %.loc34_15.2
-// CHECK:STDOUT:   %addr: %ptr.6db = addr_of %.loc34_15.3
+// CHECK:STDOUT:   %.loc37_12: ref %C = deref %c.ref
+// CHECK:STDOUT:   %A.ref.loc37: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:   %.loc37_15.1: ref %B = class_element_access %.loc37_12, element0
+// CHECK:STDOUT:   %.loc37_15.2: ref %A = class_element_access %.loc37_15.1, element0
+// CHECK:STDOUT:   %.loc37_15.3: ref %A = converted %.loc37_12, %.loc37_15.2
+// CHECK:STDOUT:   %addr: %ptr.6db = addr_of %.loc37_15.3
 // CHECK:STDOUT:   return %addr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -333,51 +336,51 @@ fn ConvertInit() {
 // CHECK:STDOUT:     %a.patt: %pattern_type.c10 = binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc38_39.1: %struct_type.a.a6c = struct_literal (%int_1)
+// CHECK:STDOUT:   %.loc41_39.1: %struct_type.a.a6c = struct_literal (%int_1)
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc38_48.1: %struct_type.base.b.bf0 = struct_literal (%.loc38_39.1, %int_2)
+// CHECK:STDOUT:   %.loc41_48.1: %struct_type.base.b.bf0 = struct_literal (%.loc41_39.1, %int_2)
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %.loc38_57.1: %struct_type.base.c.136 = struct_literal (%.loc38_48.1, %int_3)
+// CHECK:STDOUT:   %.loc41_57.1: %struct_type.base.c.136 = struct_literal (%.loc41_48.1, %int_3)
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %impl.elem0.loc38_39: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc38_39.1: <bound method> = bound_method %int_1, %impl.elem0.loc38_39 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc38_39: <specific function> = specific_function %impl.elem0.loc38_39, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc38_39.2: <bound method> = bound_method %int_1, %specific_fn.loc38_39 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc38_39: init %i32 = call %bound_method.loc38_39.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc38_39.2: init %i32 = converted %int_1, %int.convert_checked.loc38_39 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc38_57.2: ref %C = temporary_storage
-// CHECK:STDOUT:   %.loc38_57.3: ref %B = class_element_access %.loc38_57.2, element0
-// CHECK:STDOUT:   %.loc38_48.2: ref %A = class_element_access %.loc38_57.3, element0
-// CHECK:STDOUT:   %.loc38_39.3: ref %i32 = class_element_access %.loc38_48.2, element0
-// CHECK:STDOUT:   %.loc38_39.4: init %i32 = initialize_from %.loc38_39.2 to %.loc38_39.3 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc38_39.5: init %A = class_init (%.loc38_39.4), %.loc38_48.2 [concrete = constants.%A.val]
-// CHECK:STDOUT:   %.loc38_48.3: init %A = converted %.loc38_39.1, %.loc38_39.5 [concrete = constants.%A.val]
-// CHECK:STDOUT:   %impl.elem0.loc38_48: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc38_48.1: <bound method> = bound_method %int_2, %impl.elem0.loc38_48 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc38_48: <specific function> = specific_function %impl.elem0.loc38_48, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc38_48.2: <bound method> = bound_method %int_2, %specific_fn.loc38_48 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc38_48: init %i32 = call %bound_method.loc38_48.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc38_48.4: init %i32 = converted %int_2, %int.convert_checked.loc38_48 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc38_48.5: ref %i32 = class_element_access %.loc38_57.3, element1
-// CHECK:STDOUT:   %.loc38_48.6: init %i32 = initialize_from %.loc38_48.4 to %.loc38_48.5 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc38_48.7: init %B = class_init (%.loc38_48.3, %.loc38_48.6), %.loc38_57.3 [concrete = constants.%B.val]
-// CHECK:STDOUT:   %.loc38_57.4: init %B = converted %.loc38_48.1, %.loc38_48.7 [concrete = constants.%B.val]
-// CHECK:STDOUT:   %impl.elem0.loc38_57: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc38_57.1: <bound method> = bound_method %int_3, %impl.elem0.loc38_57 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc38_57: <specific function> = specific_function %impl.elem0.loc38_57, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc38_57.2: <bound method> = bound_method %int_3, %specific_fn.loc38_57 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc38_57: init %i32 = call %bound_method.loc38_57.2(%int_3) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc38_57.5: init %i32 = converted %int_3, %int.convert_checked.loc38_57 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc38_57.6: ref %i32 = class_element_access %.loc38_57.2, element1
-// CHECK:STDOUT:   %.loc38_57.7: init %i32 = initialize_from %.loc38_57.5 to %.loc38_57.6 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc38_57.8: init %C = class_init (%.loc38_57.4, %.loc38_57.7), %.loc38_57.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc38_57.9: ref %C = temporary %.loc38_57.2, %.loc38_57.8
-// CHECK:STDOUT:   %.loc38_59.1: ref %C = converted %.loc38_57.1, %.loc38_57.9
+// CHECK:STDOUT:   %impl.elem0.loc41_39: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc41_39.1: <bound method> = bound_method %int_1, %impl.elem0.loc41_39 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc41_39: <specific function> = specific_function %impl.elem0.loc41_39, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc41_39.2: <bound method> = bound_method %int_1, %specific_fn.loc41_39 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc41_39: init %i32 = call %bound_method.loc41_39.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc41_39.2: init %i32 = converted %int_1, %int.convert_checked.loc41_39 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc41_57.2: ref %C = temporary_storage
+// CHECK:STDOUT:   %.loc41_57.3: ref %B = class_element_access %.loc41_57.2, element0
+// CHECK:STDOUT:   %.loc41_48.2: ref %A = class_element_access %.loc41_57.3, element0
+// CHECK:STDOUT:   %.loc41_39.3: ref %i32 = class_element_access %.loc41_48.2, element0
+// CHECK:STDOUT:   %.loc41_39.4: init %i32 = initialize_from %.loc41_39.2 to %.loc41_39.3 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc41_39.5: init %A = class_init (%.loc41_39.4), %.loc41_48.2 [concrete = constants.%A.val]
+// CHECK:STDOUT:   %.loc41_48.3: init %A = converted %.loc41_39.1, %.loc41_39.5 [concrete = constants.%A.val]
+// CHECK:STDOUT:   %impl.elem0.loc41_48: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc41_48.1: <bound method> = bound_method %int_2, %impl.elem0.loc41_48 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc41_48: <specific function> = specific_function %impl.elem0.loc41_48, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc41_48.2: <bound method> = bound_method %int_2, %specific_fn.loc41_48 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc41_48: init %i32 = call %bound_method.loc41_48.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc41_48.4: init %i32 = converted %int_2, %int.convert_checked.loc41_48 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc41_48.5: ref %i32 = class_element_access %.loc41_57.3, element1
+// CHECK:STDOUT:   %.loc41_48.6: init %i32 = initialize_from %.loc41_48.4 to %.loc41_48.5 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc41_48.7: init %B = class_init (%.loc41_48.3, %.loc41_48.6), %.loc41_57.3 [concrete = constants.%B.val]
+// CHECK:STDOUT:   %.loc41_57.4: init %B = converted %.loc41_48.1, %.loc41_48.7 [concrete = constants.%B.val]
+// CHECK:STDOUT:   %impl.elem0.loc41_57: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc41_57.1: <bound method> = bound_method %int_3, %impl.elem0.loc41_57 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc41_57: <specific function> = specific_function %impl.elem0.loc41_57, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc41_57.2: <bound method> = bound_method %int_3, %specific_fn.loc41_57 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc41_57: init %i32 = call %bound_method.loc41_57.2(%int_3) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc41_57.5: init %i32 = converted %int_3, %int.convert_checked.loc41_57 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc41_57.6: ref %i32 = class_element_access %.loc41_57.2, element1
+// CHECK:STDOUT:   %.loc41_57.7: init %i32 = initialize_from %.loc41_57.5 to %.loc41_57.6 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc41_57.8: init %C = class_init (%.loc41_57.4, %.loc41_57.7), %.loc41_57.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc41_57.9: ref %C = temporary %.loc41_57.2, %.loc41_57.8
+// CHECK:STDOUT:   %.loc41_59.1: ref %C = converted %.loc41_57.1, %.loc41_57.9
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc38_59.2: ref %B = class_element_access %.loc38_59.1, element0
-// CHECK:STDOUT:   %.loc38_59.3: ref %A = class_element_access %.loc38_59.2, element0
-// CHECK:STDOUT:   %.loc38_59.4: ref %A = converted %.loc38_59.1, %.loc38_59.3
-// CHECK:STDOUT:   %a: ref %A = bind_name a, %.loc38_59.4
+// CHECK:STDOUT:   %.loc41_59.2: ref %B = class_element_access %.loc41_59.1, element0
+// CHECK:STDOUT:   %.loc41_59.3: ref %A = class_element_access %.loc41_59.2, element0
+// CHECK:STDOUT:   %.loc41_59.4: ref %A = converted %.loc41_59.1, %.loc41_59.3
+// CHECK:STDOUT:   %a: ref %A = bind_name a, %.loc41_59.4
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -57,18 +60,18 @@ class Class {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %a.patt: %pattern_type = symbolic_binding_pattern a, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc16: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:     %.loc19: type = splice_block %ptr [concrete = constants.%ptr] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a.loc16_13.2: %ptr = bind_symbolic_name a, 0 [symbolic = %a.loc16_13.1 (constants.%a)]
+// CHECK:STDOUT:     %a.loc19_13.2: %ptr = bind_symbolic_name a, 0 [symbolic = %a.loc19_13.1 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %b.patt: %pattern_type = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.param_patt: %pattern_type = value_param_pattern %b.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %b.param: %ptr = value_param call_param0
-// CHECK:STDOUT:     %.loc22: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:     %.loc25: type = splice_block %ptr [concrete = constants.%ptr] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr]
 // CHECK:STDOUT:     }
@@ -85,8 +88,8 @@ class Class {
 // CHECK:STDOUT:   .G = %G.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%a.loc16_13.2: %ptr) {
-// CHECK:STDOUT:   %a.loc16_13.1: %ptr = bind_symbolic_name a, 0 [symbolic = %a.loc16_13.1 (constants.%a)]
+// CHECK:STDOUT: generic fn @F(%a.loc19_13.2: %ptr) {
+// CHECK:STDOUT:   %a.loc19_13.1: %ptr = bind_symbolic_name a, 0 [symbolic = %a.loc19_13.1 (constants.%a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn();
 // CHECK:STDOUT: }
@@ -94,6 +97,6 @@ class Class {
 // CHECK:STDOUT: fn @G(%b.param: %ptr);
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%a) {
-// CHECK:STDOUT:   %a.loc16_13.1 => constants.%a
+// CHECK:STDOUT:   %a.loc19_13.1 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_addr_self.carbon
@@ -76,12 +79,12 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT:     %p.param_patt: %pattern_type.796 = value_param_pattern %p.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %Class = value_param call_param0
-// CHECK:STDOUT:     %Class.ref.loc20_9: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:     %Class.ref.loc23_9: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:     %c: %Class = bind_name c, %c.param
 // CHECK:STDOUT:     %p.param: %ptr.e71 = value_param call_param1
-// CHECK:STDOUT:     %.loc20: type = splice_block %ptr [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:       %Class.ref.loc20_19: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref.loc20_19 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:     %.loc23: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:       %Class.ref.loc23_19: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref.loc23_19 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.e71 = bind_name p, %p.param
 // CHECK:STDOUT:   }
@@ -91,10 +94,10 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT:   %F.decl: %F.type.f1b = fn_decl @F.1 [concrete = constants.%F.1f2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.796 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.796 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc12_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc15_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc12_24: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %.loc15_24: type = splice_block %ptr [concrete = constants.%ptr.e71] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
@@ -125,28 +128,28 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%c.param: %Class, %p.param: %ptr.e71) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %c.ref.loc28: %Class = name_ref c, %c
-// CHECK:STDOUT:   %F.ref.loc28: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
-// CHECK:STDOUT:   %F.bound.loc28: <bound method> = bound_method %c.ref.loc28, %F.ref.loc28
-// CHECK:STDOUT:   %.loc28: ref %Class = temporary_storage
-// CHECK:STDOUT:   %addr.loc28: %ptr.e71 = addr_of %.loc28
-// CHECK:STDOUT:   %F.call.loc28: init %empty_tuple.type = call %F.bound.loc28(%addr.loc28)
-// CHECK:STDOUT:   %c.ref.loc30: %Class = name_ref c, %c
-// CHECK:STDOUT:   %G.ref.loc30: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %G.bound.loc30: <bound method> = bound_method %c.ref.loc30, %G.ref.loc30
-// CHECK:STDOUT:   %G.call.loc30: init %empty_tuple.type = call %G.bound.loc30(%c.ref.loc30)
-// CHECK:STDOUT:   %p.ref.loc33: %ptr.e71 = name_ref p, %p
-// CHECK:STDOUT:   %.loc33: ref %Class = deref %p.ref.loc33
-// CHECK:STDOUT:   %F.ref.loc33: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
-// CHECK:STDOUT:   %F.bound.loc33: <bound method> = bound_method %.loc33, %F.ref.loc33
-// CHECK:STDOUT:   %addr.loc33: %ptr.e71 = addr_of %.loc33
-// CHECK:STDOUT:   %F.call.loc33: init %empty_tuple.type = call %F.bound.loc33(%addr.loc33)
-// CHECK:STDOUT:   %p.ref.loc35: %ptr.e71 = name_ref p, %p
-// CHECK:STDOUT:   %.loc35_4.1: ref %Class = deref %p.ref.loc35
-// CHECK:STDOUT:   %G.ref.loc35: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %G.bound.loc35: <bound method> = bound_method %.loc35_4.1, %G.ref.loc35
-// CHECK:STDOUT:   %.loc35_4.2: %Class = bind_value %.loc35_4.1
-// CHECK:STDOUT:   %G.call.loc35: init %empty_tuple.type = call %G.bound.loc35(%.loc35_4.2)
+// CHECK:STDOUT:   %c.ref.loc31: %Class = name_ref c, %c
+// CHECK:STDOUT:   %F.ref.loc31: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
+// CHECK:STDOUT:   %F.bound.loc31: <bound method> = bound_method %c.ref.loc31, %F.ref.loc31
+// CHECK:STDOUT:   %.loc31: ref %Class = temporary_storage
+// CHECK:STDOUT:   %addr.loc31: %ptr.e71 = addr_of %.loc31
+// CHECK:STDOUT:   %F.call.loc31: init %empty_tuple.type = call %F.bound.loc31(%addr.loc31)
+// CHECK:STDOUT:   %c.ref.loc33: %Class = name_ref c, %c
+// CHECK:STDOUT:   %G.ref.loc33: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
+// CHECK:STDOUT:   %G.bound.loc33: <bound method> = bound_method %c.ref.loc33, %G.ref.loc33
+// CHECK:STDOUT:   %G.call.loc33: init %empty_tuple.type = call %G.bound.loc33(%c.ref.loc33)
+// CHECK:STDOUT:   %p.ref.loc36: %ptr.e71 = name_ref p, %p
+// CHECK:STDOUT:   %.loc36: ref %Class = deref %p.ref.loc36
+// CHECK:STDOUT:   %F.ref.loc36: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
+// CHECK:STDOUT:   %F.bound.loc36: <bound method> = bound_method %.loc36, %F.ref.loc36
+// CHECK:STDOUT:   %addr.loc36: %ptr.e71 = addr_of %.loc36
+// CHECK:STDOUT:   %F.call.loc36: init %empty_tuple.type = call %F.bound.loc36(%addr.loc36)
+// CHECK:STDOUT:   %p.ref.loc38: %ptr.e71 = name_ref p, %p
+// CHECK:STDOUT:   %.loc38_4.1: ref %Class = deref %p.ref.loc38
+// CHECK:STDOUT:   %G.ref.loc38: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
+// CHECK:STDOUT:   %G.bound.loc38: <bound method> = bound_method %.loc38_4.1, %G.ref.loc38
+// CHECK:STDOUT:   %.loc38_4.2: %Class = bind_value %.loc38_4.1
+// CHECK:STDOUT:   %G.call.loc38: init %empty_tuple.type = call %G.bound.loc38(%.loc38_4.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_as_declared_name.carbon
+++ b/toolchain/check/testdata/class/fail_base_as_declared_name.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_as_declared_name.carbon

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_bad_type.carbon

--- a/toolchain/check/testdata/class/fail_base_method_define.carbon
+++ b/toolchain/check/testdata/class/fail_base_method_define.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_method_define.carbon
@@ -69,8 +72,8 @@ fn D.C.F() {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [concrete = constants.%D] {} {}
-// CHECK:STDOUT:   %F.decl.loc27: %F.type.31906b.1 = fn_decl @F.3 [concrete = constants.%F.34b733.1] {} {}
-// CHECK:STDOUT:   %F.decl.loc33: %F.type.31906b.2 = fn_decl @F.4 [concrete = constants.%F.34b733.2] {} {}
+// CHECK:STDOUT:   %F.decl.loc30: %F.type.31906b.1 = fn_decl @F.3 [concrete = constants.%F.34b733.1] {} {}
+// CHECK:STDOUT:   %F.decl.loc36: %F.type.31906b.2 = fn_decl @F.4 [concrete = constants.%F.34b733.2] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
@@ -99,7 +102,7 @@ fn D.C.F() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc20: %D.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc23: %D.elem = base_decl %B.ref, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B} [concrete = constants.%struct_type.base]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -107,8 +110,8 @@ fn D.C.F() {}
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%D
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc20
-// CHECK:STDOUT:   .F = file.%F.decl.loc27
+// CHECK:STDOUT:   .base = %.loc23
+// CHECK:STDOUT:   .F = file.%F.decl.loc30
 // CHECK:STDOUT:   extend %B.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_misplaced.carbon
+++ b/toolchain/check/testdata/class/fail_base_misplaced.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_misplaced.carbon

--- a/toolchain/check/testdata/class/fail_base_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_base_modifiers.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/class/fail_base_no_extend.carbon
+++ b/toolchain/check/testdata/class/fail_base_no_extend.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_no_extend.carbon
@@ -59,7 +62,7 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc18: %C.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc21: %C.elem = base_decl %B.ref, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B} [concrete = constants.%struct_type.base]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -67,6 +70,6 @@ class C {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc18
+// CHECK:STDOUT:   .base = %.loc21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_repeated.carbon
+++ b/toolchain/check/testdata/class/fail_base_repeated.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_repeated.carbon
@@ -95,7 +98,7 @@ class D {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %B1.ref: type = name_ref B1, file.%B1.decl [concrete = constants.%B1]
-// CHECK:STDOUT:   %.loc15: %C.elem = base_decl %B1.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc18: %C.elem = base_decl %B1.ref, element0 [concrete]
 // CHECK:STDOUT:   %B2.ref: type = name_ref B2, file.%B2.decl [concrete = constants.%B2]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B1} [concrete = constants.%struct_type.base]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.5ac]
@@ -104,15 +107,15 @@ class D {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .B1 = <poisoned>
-// CHECK:STDOUT:   .base = %.loc15
+// CHECK:STDOUT:   .base = %.loc18
 // CHECK:STDOUT:   .B2 = <poisoned>
 // CHECK:STDOUT:   extend %B1.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
-// CHECK:STDOUT:   %B1.ref.loc28: type = name_ref B1, file.%B1.decl [concrete = constants.%B1]
-// CHECK:STDOUT:   %.loc28: %D.elem = base_decl %B1.ref.loc28, element0 [concrete]
-// CHECK:STDOUT:   %B1.ref.loc36: type = name_ref B1, file.%B1.decl [concrete = constants.%B1]
+// CHECK:STDOUT:   %B1.ref.loc31: type = name_ref B1, file.%B1.decl [concrete = constants.%B1]
+// CHECK:STDOUT:   %.loc31: %D.elem = base_decl %B1.ref.loc31, element0 [concrete]
+// CHECK:STDOUT:   %B1.ref.loc39: type = name_ref B1, file.%B1.decl [concrete = constants.%B1]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B1} [concrete = constants.%struct_type.base]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.5ac]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -120,7 +123,7 @@ class D {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%D
 // CHECK:STDOUT:   .B1 = <poisoned>
-// CHECK:STDOUT:   .base = %.loc28
-// CHECK:STDOUT:   extend %B1.ref.loc28
+// CHECK:STDOUT:   .base = %.loc31
+// CHECK:STDOUT:   extend %B1.ref.loc31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_unbound.carbon
+++ b/toolchain/check/testdata/class/fail_base_unbound.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_base_unbound.carbon
@@ -68,7 +71,7 @@ let b: B = C.base;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc14: %C.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc17: %C.elem = base_decl %B.ref, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B} [concrete = constants.%struct_type.base.0ff]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.98e]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -76,14 +79,14 @@ let b: B = C.base;
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc14
+// CHECK:STDOUT:   .base = %.loc17
 // CHECK:STDOUT:   extend %B.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %base.ref: %C.elem = name_ref base, @C.%.loc14 [concrete = @C.%.loc14]
+// CHECK:STDOUT:   %base.ref: %C.elem = name_ref base, @C.%.loc17 [concrete = @C.%.loc17]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_compound_type_mismatch.carbon
+++ b/toolchain/check/testdata/class/fail_compound_type_mismatch.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_compound_type_mismatch.carbon
@@ -90,36 +93,36 @@ fn AccessBInA(a: A) -> i32 {
 // CHECK:STDOUT: class @A {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %A.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %A.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A
-// CHECK:STDOUT:   .a = %.loc12
+// CHECK:STDOUT:   .a = %.loc15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc16: %B.elem = field_decl b, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %B.elem = field_decl b, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.b: type = struct_type {.b: %i32} [concrete = constants.%struct_type.b]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b [concrete = constants.%complete_type.ba8]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
-// CHECK:STDOUT:   .b = %.loc16
+// CHECK:STDOUT:   .b = %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessBInA(%a.param: %A) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %A = name_ref a, %a
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %b.ref: %B.elem = name_ref b, @B.%.loc16 [concrete = @B.%.loc16]
-// CHECK:STDOUT:   %.loc27_11.1: %B = converted %a.ref, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc27_11.2: %i32 = class_element_access <error>, element0 [concrete = <error>]
+// CHECK:STDOUT:   %b.ref: %B.elem = name_ref b, @B.%.loc19 [concrete = @B.%.loc19]
+// CHECK:STDOUT:   %.loc30_11.1: %B = converted %a.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc30_11.2: %i32 = class_element_access <error>, element0 [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_convert_to_invalid.carbon
+++ b/toolchain/check/testdata/class/fail_convert_to_invalid.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_convert_to_invalid.carbon
@@ -59,7 +62,7 @@ fn Make() -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %NoSuchType.ref: <error> = name_ref NoSuchType, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc16: <error> = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: <error> = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: <error>} [concrete = <error>]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = <error>]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -67,13 +70,13 @@ fn Make() -> C {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .NoSuchType = <poisoned>
-// CHECK:STDOUT:   .a = %.loc16
+// CHECK:STDOUT:   .a = %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return.param: %C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_123: Core.IntLiteral = int_value 123 [concrete = constants.%int_123]
-// CHECK:STDOUT:   %.loc20: %struct_type.a = struct_literal (%int_123)
+// CHECK:STDOUT:   %.loc23: %struct_type.a = struct_literal (%int_123)
 // CHECK:STDOUT:   return <error> to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_derived_to_base.carbon
+++ b/toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -108,11 +111,11 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.d72 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %A1.ref: type = name_ref A1, file.%A1.decl [concrete = constants.%A1]
-// CHECK:STDOUT:     %ptr.loc31_34: type = ptr_type %A1.ref [concrete = constants.%ptr.678]
+// CHECK:STDOUT:     %ptr.loc34_34: type = ptr_type %A1.ref [concrete = constants.%ptr.678]
 // CHECK:STDOUT:     %p.param: %ptr.afe = value_param call_param0
-// CHECK:STDOUT:     %.loc31_26: type = splice_block %ptr.loc31_26 [concrete = constants.%ptr.afe] {
+// CHECK:STDOUT:     %.loc34_26: type = splice_block %ptr.loc34_26 [concrete = constants.%ptr.afe] {
 // CHECK:STDOUT:       %B2.ref: type = name_ref B2, file.%B2.decl [concrete = constants.%B2]
-// CHECK:STDOUT:       %ptr.loc31_26: type = ptr_type %B2.ref [concrete = constants.%ptr.afe]
+// CHECK:STDOUT:       %ptr.loc34_26: type = ptr_type %B2.ref [concrete = constants.%ptr.afe]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.afe = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.678 = out_param call_param1
@@ -126,11 +129,11 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.2c5 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %A2.ref: type = name_ref A2, file.%A2.decl [concrete = constants.%A2]
-// CHECK:STDOUT:     %ptr.loc42_43: type = ptr_type %A2.ref [concrete = constants.%ptr.590]
+// CHECK:STDOUT:     %ptr.loc45_43: type = ptr_type %A2.ref [concrete = constants.%ptr.590]
 // CHECK:STDOUT:     %p.param: %ptr.c62 = value_param call_param0
-// CHECK:STDOUT:     %.loc42_35: type = splice_block %ptr.loc42_35 [concrete = constants.%ptr.c62] {
+// CHECK:STDOUT:     %.loc45_35: type = splice_block %ptr.loc45_35 [concrete = constants.%ptr.c62] {
 // CHECK:STDOUT:       %Incomplete.ref: type = name_ref Incomplete, file.%Incomplete.decl [concrete = constants.%Incomplete]
-// CHECK:STDOUT:       %ptr.loc42_35: type = ptr_type %Incomplete.ref [concrete = constants.%ptr.c62]
+// CHECK:STDOUT:       %ptr.loc45_35: type = ptr_type %Incomplete.ref [concrete = constants.%ptr.c62]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.c62 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.590 = out_param call_param1
@@ -141,35 +144,35 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT: class @A1 {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %A1.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %A1.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A1
-// CHECK:STDOUT:   .a = %.loc12
+// CHECK:STDOUT:   .a = %.loc15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A2 {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc16: %A2.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %A2.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A2
-// CHECK:STDOUT:   .a = %.loc16
+// CHECK:STDOUT:   .a = %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B2 {
 // CHECK:STDOUT:   %A2.ref: type = name_ref A2, file.%A2.decl [concrete = constants.%A2]
-// CHECK:STDOUT:   %.loc20: %B2.elem.a92 = base_decl %A2.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc23: %B2.elem.a92 = base_decl %A2.ref, element0 [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc21: %B2.elem.4b2 = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %.loc24: %B2.elem.4b2 = field_decl b, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.base.b: type = struct_type {.base: %A2, .b: %i32} [concrete = constants.%struct_type.base.b.618]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.b [concrete = constants.%complete_type.92f]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -177,8 +180,8 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B2
 // CHECK:STDOUT:   .A2 = <poisoned>
-// CHECK:STDOUT:   .base = %.loc20
-// CHECK:STDOUT:   .b = %.loc21
+// CHECK:STDOUT:   .base = %.loc23
+// CHECK:STDOUT:   .b = %.loc24
 // CHECK:STDOUT:   extend %A2.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -187,14 +190,14 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT: fn @ConvertUnrelated(%p.param: %ptr.afe) -> %ptr.678 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.afe = name_ref p, %p
-// CHECK:STDOUT:   %.loc31_46: %ptr.678 = converted %p.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc34_46: %ptr.678 = converted %p.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertIncomplete(%p.param: %ptr.c62) -> %ptr.590 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.c62 = name_ref p, %p
-// CHECK:STDOUT:   %.loc42_55: %ptr.590 = converted %p.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc45_55: %ptr.590 = converted %p.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_extend_cycle.carbon
+++ b/toolchain/check/testdata/class/fail_extend_cycle.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_extend_cycle.carbon
@@ -56,14 +59,14 @@ base class A {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .A = %A.decl.loc11
+// CHECK:STDOUT:     .A = %A.decl.loc14
 // CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:     .C = <poisoned>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %A.decl.loc11: type = class_decl @A.1 [concrete = constants.%A.466950.1] {} {}
+// CHECK:STDOUT:   %A.decl.loc14: type = class_decl @A.1 [concrete = constants.%A.466950.1] {} {}
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
-// CHECK:STDOUT:   %A.decl.loc26: type = class_decl @A.2 [concrete = constants.%A.466950.2] {} {}
+// CHECK:STDOUT:   %A.decl.loc29: type = class_decl @A.2 [concrete = constants.%A.466950.2] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A.1 {
@@ -77,8 +80,8 @@ base class A {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl.loc11 [concrete = constants.%A.466950.1]
-// CHECK:STDOUT:   %.loc16: %B.elem = base_decl %A.ref, element0 [concrete]
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl.loc14 [concrete = constants.%A.466950.1]
+// CHECK:STDOUT:   %.loc19: %B.elem = base_decl %A.ref, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %A.466950.1} [concrete = constants.%struct_type.base]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.020]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -86,15 +89,15 @@ base class A {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   .base = %.loc16
+// CHECK:STDOUT:   .base = %.loc19
 // CHECK:STDOUT:   extend %A.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A.2 {
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl.loc11 [concrete = constants.%A.466950.1]
-// CHECK:STDOUT:   %.loc27: %A.elem = base_decl %A.ref, element0 [concrete]
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl.loc14 [concrete = constants.%A.466950.1]
+// CHECK:STDOUT:   %.loc30: %A.elem = base_decl %A.ref, element0 [concrete]
 // CHECK:STDOUT:   %C.ref: <error> = name_ref C, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc32: <error> = field_decl c, element1 [concrete]
+// CHECK:STDOUT:   %.loc35: <error> = field_decl c, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.base.c: type = struct_type {.base: %A.466950.1, .c: <error>} [concrete = <error>]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base.c [concrete = <error>]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -102,9 +105,9 @@ base class A {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%A.466950.2
 // CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   .base = %.loc27
+// CHECK:STDOUT:   .base = %.loc30
 // CHECK:STDOUT:   .C = <poisoned>
-// CHECK:STDOUT:   .c = %.loc32
+// CHECK:STDOUT:   .c = %.loc35
 // CHECK:STDOUT:   extend %A.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_field_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -93,52 +96,52 @@ class Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %int_32.loc17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc17: %Class.elem = field_decl j, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc23: %Class.elem = field_decl k, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc20: %Class.elem = field_decl j, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc26: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc26: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc26: %Class.elem = field_decl k, element1 [concrete]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %l.patt: %pattern_type.7ce = binding_pattern l [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
-// CHECK:STDOUT:   %.loc29_18: type = splice_block %i32.loc29 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc29: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc29: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc32_18: type = splice_block %i32.loc32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc29: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc29_24.1: <bound method> = bound_method %int_0, %impl.elem0.loc29 [concrete = constants.%Convert.bound.d04]
-// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem0.loc29, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc29_24.2: <bound method> = bound_method %int_0, %specific_fn.loc29 [concrete = constants.%bound_method.b6e]
-// CHECK:STDOUT:   %int.convert_checked.loc29: init %i32 = call %bound_method.loc29_24.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc29_24.1: %i32 = value_of_initializer %int.convert_checked.loc29 [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc29_24.2: %i32 = converted %int_0, %.loc29_24.1 [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %l: %i32 = bind_name l, %.loc29_24.2
+// CHECK:STDOUT:   %impl.elem0.loc32: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc32_24.1: <bound method> = bound_method %int_0, %impl.elem0.loc32 [concrete = constants.%Convert.bound.d04]
+// CHECK:STDOUT:   %specific_fn.loc32: <specific function> = specific_function %impl.elem0.loc32, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc32_24.2: <bound method> = bound_method %int_0, %specific_fn.loc32 [concrete = constants.%bound_method.b6e]
+// CHECK:STDOUT:   %int.convert_checked.loc32: init %i32 = call %bound_method.loc32_24.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc32_24.1: %i32 = value_of_initializer %int.convert_checked.loc32 [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc32_24.2: %i32 = converted %int_0, %.loc32_24.1 [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %l: %i32 = bind_name l, %.loc32_24.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %m.patt: %pattern_type.7ce = binding_pattern m [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc35_16: type = splice_block %i32.loc35 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc35: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc35: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc38_16: type = splice_block %i32.loc38 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc38: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc38: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc35: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc35_22.1: <bound method> = bound_method %int_1, %impl.elem0.loc35 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc35: <specific function> = specific_function %impl.elem0.loc35, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc35_22.2: <bound method> = bound_method %int_1, %specific_fn.loc35 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc35: init %i32 = call %bound_method.loc35_22.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc35_22.1: %i32 = value_of_initializer %int.convert_checked.loc35 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc35_22.2: %i32 = converted %int_1, %.loc35_22.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %m: %i32 = bind_name m, %.loc35_22.2
+// CHECK:STDOUT:   %impl.elem0.loc38: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc38_22.1: <bound method> = bound_method %int_1, %impl.elem0.loc38 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc38: <specific function> = specific_function %impl.elem0.loc38, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc38_22.2: <bound method> = bound_method %int_1, %specific_fn.loc38 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc38: init %i32 = call %bound_method.loc38_22.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc38_22.1: %i32 = value_of_initializer %int.convert_checked.loc38 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc38_22.2: %i32 = converted %int_1, %.loc38_22.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %m: %i32 = bind_name m, %.loc38_22.2
 // CHECK:STDOUT:   %struct_type.j.k: type = struct_type {.j: %i32, .k: %i32} [concrete = constants.%struct_type.j.k]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.j.k [concrete = constants.%complete_type.cf7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .j = %.loc17
-// CHECK:STDOUT:   .k = %.loc23
+// CHECK:STDOUT:   .j = %.loc20
+// CHECK:STDOUT:   .k = %.loc26
 // CHECK:STDOUT:   .l = %l
 // CHECK:STDOUT:   .m = %m
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_generic_method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_generic_method.carbon
@@ -76,7 +79,7 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type.b25 = fn_decl @F.2 [concrete = constants.%F.c41] {
 // CHECK:STDOUT:     %self.patt: <error> = binding_pattern self [concrete]
@@ -84,11 +87,11 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:     %n.patt: <error> = binding_pattern n [concrete]
 // CHECK:STDOUT:     %n.param_patt: <error> = value_param_pattern %n.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc33: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc36: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %N.loc33_10.1: %i32 = bind_symbolic_name N, 0 [symbolic = %N.loc33_10.2 (constants.%N.51e)]
+// CHECK:STDOUT:     %N.loc36_10.1: %i32 = bind_symbolic_name N, 0 [symbolic = %N.loc36_10.2 (constants.%N.51e)]
 // CHECK:STDOUT:     %self.param: <error> = value_param call_param0
 // CHECK:STDOUT:     %Self.ref: <error> = name_ref Self, <error> [concrete = <error>]
 // CHECK:STDOUT:     %self: <error> = bind_name self, %self.param
@@ -98,60 +101,60 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Class(%T.loc11_13.1: type) {
-// CHECK:STDOUT:   %T.loc11_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Class(%T.loc14_13.1: type) {
+// CHECK:STDOUT:   %T.loc14_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc11_13.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc11_13.2) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc11_13.2 [symbolic = %Class.elem (constants.%Class.elem)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Class(%T.loc11_13.2) [symbolic = %F.type (constants.%F.type.6d6)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc14_13.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc14_13.2) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc14_13.2 [symbolic = %Class.elem (constants.%Class.elem)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Class(%T.loc14_13.2) [symbolic = %F.type (constants.%F.type.6d6)]
 // CHECK:STDOUT:   %F: @Class.%F.type (%F.type.6d6) = struct_value () [symbolic = %F (constants.%F.cca)]
-// CHECK:STDOUT:   %struct_type.a.loc14_1.2: type = struct_type {.a: @Class.%T.loc11_13.2 (%T)} [symbolic = %struct_type.a.loc14_1.2 (constants.%struct_type.a)]
-// CHECK:STDOUT:   %complete_type.loc14_1.2: <witness> = complete_type_witness %struct_type.a.loc14_1.2 [symbolic = %complete_type.loc14_1.2 (constants.%complete_type.f1b)]
+// CHECK:STDOUT:   %struct_type.a.loc17_1.2: type = struct_type {.a: @Class.%T.loc14_13.2 (%T)} [symbolic = %struct_type.a.loc17_1.2 (constants.%struct_type.a)]
+// CHECK:STDOUT:   %complete_type.loc17_1.2: <witness> = complete_type_witness %struct_type.a.loc17_1.2 [symbolic = %complete_type.loc17_1.2 (constants.%complete_type.f1b)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_13.1 [symbolic = %T.loc11_13.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc12: @Class.%Class.elem (%Class.elem) = field_decl a, element0 [concrete]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_13.1 [symbolic = %T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc15: @Class.%Class.elem (%Class.elem) = field_decl a, element0 [concrete]
 // CHECK:STDOUT:     %F.decl: @Class.%F.type (%F.type.6d6) = fn_decl @F.1 [symbolic = @Class.%F (constants.%F.cca)] {
-// CHECK:STDOUT:       %self.patt: @F.1.%pattern_type.loc13_8 (%pattern_type.3c1) = binding_pattern self [concrete]
-// CHECK:STDOUT:       %self.param_patt: @F.1.%pattern_type.loc13_8 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:       %n.patt: @F.1.%pattern_type.loc13_20 (%pattern_type.7dc) = binding_pattern n [concrete]
-// CHECK:STDOUT:       %n.param_patt: @F.1.%pattern_type.loc13_20 (%pattern_type.7dc) = value_param_pattern %n.patt, call_param1 [concrete]
+// CHECK:STDOUT:       %self.patt: @F.1.%pattern_type.loc16_8 (%pattern_type.3c1) = binding_pattern self [concrete]
+// CHECK:STDOUT:       %self.param_patt: @F.1.%pattern_type.loc16_8 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %n.patt: @F.1.%pattern_type.loc16_20 (%pattern_type.7dc) = binding_pattern n [concrete]
+// CHECK:STDOUT:       %n.param_patt: @F.1.%pattern_type.loc16_20 (%pattern_type.7dc) = value_param_pattern %n.patt, call_param1 [concrete]
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %self.param: @F.1.%Class (%Class) = value_param call_param0
-// CHECK:STDOUT:       %.loc13_14.1: type = splice_block %Self.ref [symbolic = %Class (constants.%Class)] {
-// CHECK:STDOUT:         %.loc13_14.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc13_14.2 [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:       %.loc16_14.1: type = splice_block %Self.ref [symbolic = %Class (constants.%Class)] {
+// CHECK:STDOUT:         %.loc16_14.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc16_14.2 [symbolic = %Class (constants.%Class)]
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:       %self: @F.1.%Class (%Class) = bind_name self, %self.param
 // CHECK:STDOUT:       %n.param: @F.1.%T (%T) = value_param call_param1
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc11_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %n: @F.1.%T (%T) = bind_name n, %n.param
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %struct_type.a.loc14_1.1: type = struct_type {.a: %T} [symbolic = %struct_type.a.loc14_1.2 (constants.%struct_type.a)]
-// CHECK:STDOUT:     %complete_type.loc14_1.1: <witness> = complete_type_witness %struct_type.a.loc14_1.1 [symbolic = %complete_type.loc14_1.2 (constants.%complete_type.f1b)]
-// CHECK:STDOUT:     complete_type_witness = %complete_type.loc14_1.1
+// CHECK:STDOUT:     %struct_type.a.loc17_1.1: type = struct_type {.a: %T} [symbolic = %struct_type.a.loc17_1.2 (constants.%struct_type.a)]
+// CHECK:STDOUT:     %complete_type.loc17_1.1: <witness> = complete_type_witness %struct_type.a.loc17_1.1 [symbolic = %complete_type.loc17_1.2 (constants.%complete_type.f1b)]
+// CHECK:STDOUT:     complete_type_witness = %complete_type.loc17_1.1
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = constants.%Class
 // CHECK:STDOUT:     .T = <poisoned>
-// CHECK:STDOUT:     .a = %.loc12
+// CHECK:STDOUT:     .a = %.loc15
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.1(@Class.%T.loc11_13.1: type) {
+// CHECK:STDOUT: generic fn @F.1(@Class.%T.loc14_13.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %pattern_type.loc13_8: type = pattern_type %Class [symbolic = %pattern_type.loc13_8 (constants.%pattern_type.3c1)]
-// CHECK:STDOUT:   %pattern_type.loc13_20: type = pattern_type %T [symbolic = %pattern_type.loc13_20 (constants.%pattern_type.7dc)]
+// CHECK:STDOUT:   %pattern_type.loc16_8: type = pattern_type %Class [symbolic = %pattern_type.loc16_8 (constants.%pattern_type.3c1)]
+// CHECK:STDOUT:   %pattern_type.loc16_20: type = pattern_type %T [symbolic = %pattern_type.loc16_20 (constants.%pattern_type.7dc)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%self.param: @F.1.%Class (%Class), %n.param: @F.1.%T (%T));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.2(%N.loc33_10.1: %i32) {
-// CHECK:STDOUT:   %N.loc33_10.2: %i32 = bind_symbolic_name N, 0 [symbolic = %N.loc33_10.2 (constants.%N.51e)]
+// CHECK:STDOUT: generic fn @F.2(%N.loc36_10.1: %i32) {
+// CHECK:STDOUT:   %N.loc36_10.2: %i32 = bind_symbolic_name N, 0 [symbolic = %N.loc36_10.2 (constants.%N.51e)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -162,17 +165,17 @@ fn Class(N:! i32).F[self: Self](n: T) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
-// CHECK:STDOUT:   %pattern_type.loc13_8 => constants.%pattern_type.3c1
-// CHECK:STDOUT:   %pattern_type.loc13_20 => constants.%pattern_type.7dc
+// CHECK:STDOUT:   %pattern_type.loc16_8 => constants.%pattern_type.3c1
+// CHECK:STDOUT:   %pattern_type.loc16_20 => constants.%pattern_type.7dc
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.2(constants.%N.51e) {
-// CHECK:STDOUT:   %N.loc33_10.2 => constants.%N.51e
+// CHECK:STDOUT:   %N.loc36_10.2 => constants.%N.51e
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_import_misuses.carbon

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_incomplete.carbon

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_init.carbon
@@ -93,53 +96,53 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl a, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Class.elem = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Class.elem = field_decl b, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [concrete = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .a = %.loc12
-// CHECK:STDOUT:   .b = %.loc13
+// CHECK:STDOUT:   .a = %.loc15
+// CHECK:STDOUT:   .b = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc21_10.1: %struct_type.a = struct_literal (%int_1.loc21)
-// CHECK:STDOUT:   %Class.ref.loc21: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %.loc21_10.2: ref %Class = temporary_storage
-// CHECK:STDOUT:   %.loc21_10.3: ref %Class = temporary %.loc21_10.2, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc21_12: ref %Class = converted %.loc21_10.1, %.loc21_10.3 [concrete = <error>]
-// CHECK:STDOUT:   %int_1.loc26: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc26: Core.IntLiteral = int_value 2 [concrete = constants.%int_2]
-// CHECK:STDOUT:   %.loc26_18.1: %struct_type.a.c = struct_literal (%int_1.loc26, %int_2.loc26)
-// CHECK:STDOUT:   %Class.ref.loc26: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %int_1.loc24: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc24_10.1: %struct_type.a = struct_literal (%int_1.loc24)
+// CHECK:STDOUT:   %Class.ref.loc24: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %.loc24_10.2: ref %Class = temporary_storage
+// CHECK:STDOUT:   %.loc24_10.3: ref %Class = temporary %.loc24_10.2, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc24_12: ref %Class = converted %.loc24_10.1, %.loc24_10.3 [concrete = <error>]
+// CHECK:STDOUT:   %int_1.loc29: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc29: Core.IntLiteral = int_value 2 [concrete = constants.%int_2]
+// CHECK:STDOUT:   %.loc29_18.1: %struct_type.a.c = struct_literal (%int_1.loc29, %int_2.loc29)
+// CHECK:STDOUT:   %Class.ref.loc29: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc26_18.1: <bound method> = bound_method %int_1.loc26, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc29_18.1: <bound method> = bound_method %int_1.loc29, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc26_18.2: <bound method> = bound_method %int_1.loc26, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc26_18.2(%int_1.loc26) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc26_18.2: init %i32 = converted %int_1.loc26, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc26_18.3: ref %Class = temporary_storage
-// CHECK:STDOUT:   %.loc26_18.4: ref %i32 = class_element_access %.loc26_18.3, element0
-// CHECK:STDOUT:   %.loc26_18.5: init %i32 = initialize_from %.loc26_18.2 to %.loc26_18.4 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc26_18.6: ref %Class = temporary %.loc26_18.3, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc26_20: ref %Class = converted %.loc26_18.1, %.loc26_18.6 [concrete = <error>]
-// CHECK:STDOUT:   %int_1.loc31: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc31: Core.IntLiteral = int_value 2 [concrete = constants.%int_2]
+// CHECK:STDOUT:   %bound_method.loc29_18.2: <bound method> = bound_method %int_1.loc29, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc29_18.2(%int_1.loc29) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc29_18.2: init %i32 = converted %int_1.loc29, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc29_18.3: ref %Class = temporary_storage
+// CHECK:STDOUT:   %.loc29_18.4: ref %i32 = class_element_access %.loc29_18.3, element0
+// CHECK:STDOUT:   %.loc29_18.5: init %i32 = initialize_from %.loc29_18.2 to %.loc29_18.4 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc29_18.6: ref %Class = temporary %.loc29_18.3, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc29_20: ref %Class = converted %.loc29_18.1, %.loc29_18.6 [concrete = <error>]
+// CHECK:STDOUT:   %int_1.loc34: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc34: Core.IntLiteral = int_value 2 [concrete = constants.%int_2]
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3]
-// CHECK:STDOUT:   %.loc31_26.1: %struct_type.a.b.c = struct_literal (%int_1.loc31, %int_2.loc31, %int_3)
-// CHECK:STDOUT:   %Class.ref.loc31: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %.loc31_26.2: ref %Class = temporary_storage
-// CHECK:STDOUT:   %.loc31_26.3: ref %Class = temporary %.loc31_26.2, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc31_28: ref %Class = converted %.loc31_26.1, %.loc31_26.3 [concrete = <error>]
+// CHECK:STDOUT:   %.loc34_26.1: %struct_type.a.b.c = struct_literal (%int_1.loc34, %int_2.loc34, %int_3)
+// CHECK:STDOUT:   %Class.ref.loc34: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %.loc34_26.2: ref %Class = temporary_storage
+// CHECK:STDOUT:   %.loc34_26.3: ref %Class = temporary %.loc34_26.2, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc34_28: ref %Class = converted %.loc34_26.1, %.loc34_26.3 [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -98,7 +101,7 @@ fn F() {
 // CHECK:STDOUT:     %p.param_patt: %pattern_type.796 = value_param_pattern %p.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %p.param: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc16: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %.loc19: type = splice_block %ptr [concrete = constants.%ptr.e71] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
@@ -108,20 +111,20 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl a, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Class.elem = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Class.elem = field_decl b, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [concrete = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .a = %.loc12
-// CHECK:STDOUT:   .b = %.loc13
+// CHECK:STDOUT:   .a = %.loc15
+// CHECK:STDOUT:   .b = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%p.param: %ptr.e71);
@@ -135,31 +138,31 @@ fn F() {
 // CHECK:STDOUT:   %c.var: ref %Class = var %c.var_patt
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc26_33.1: %struct_type.a.b.cfd = struct_literal (%int_1, %int_2)
-// CHECK:STDOUT:   %Class.ref.loc26_38: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %impl.elem0.loc26_33.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc26_33.1: <bound method> = bound_method %int_1, %impl.elem0.loc26_33.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc26_33.1: <specific function> = specific_function %impl.elem0.loc26_33.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc26_33.2: <bound method> = bound_method %int_1, %specific_fn.loc26_33.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc26_33.1: init %i32 = call %bound_method.loc26_33.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc26_33.2: init %i32 = converted %int_1, %int.convert_checked.loc26_33.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc26_33.3: ref %Class = temporary_storage
-// CHECK:STDOUT:   %.loc26_33.4: ref %i32 = class_element_access %.loc26_33.3, element0
-// CHECK:STDOUT:   %.loc26_33.5: init %i32 = initialize_from %.loc26_33.2 to %.loc26_33.4 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc26_33.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc26_33.3: <bound method> = bound_method %int_2, %impl.elem0.loc26_33.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc26_33.2: <specific function> = specific_function %impl.elem0.loc26_33.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc26_33.4: <bound method> = bound_method %int_2, %specific_fn.loc26_33.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc26_33.2: init %i32 = call %bound_method.loc26_33.4(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc26_33.6: init %i32 = converted %int_2, %int.convert_checked.loc26_33.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc26_33.7: ref %i32 = class_element_access %.loc26_33.3, element1
-// CHECK:STDOUT:   %.loc26_33.8: init %i32 = initialize_from %.loc26_33.6 to %.loc26_33.7 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc26_33.9: init %Class = class_init (%.loc26_33.5, %.loc26_33.8), %.loc26_33.3 [concrete = constants.%Class.val]
-// CHECK:STDOUT:   %.loc26_33.10: ref %Class = temporary %.loc26_33.3, %.loc26_33.9
-// CHECK:STDOUT:   %.loc26_35.1: ref %Class = converted %.loc26_33.1, %.loc26_33.10
-// CHECK:STDOUT:   %.loc26_35.2: %Class = bind_value %.loc26_35.1
+// CHECK:STDOUT:   %.loc29_33.1: %struct_type.a.b.cfd = struct_literal (%int_1, %int_2)
+// CHECK:STDOUT:   %Class.ref.loc29_38: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %impl.elem0.loc29_33.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc29_33.1: <bound method> = bound_method %int_1, %impl.elem0.loc29_33.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc29_33.1: <specific function> = specific_function %impl.elem0.loc29_33.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc29_33.2: <bound method> = bound_method %int_1, %specific_fn.loc29_33.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc29_33.1: init %i32 = call %bound_method.loc29_33.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc29_33.2: init %i32 = converted %int_1, %int.convert_checked.loc29_33.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc29_33.3: ref %Class = temporary_storage
+// CHECK:STDOUT:   %.loc29_33.4: ref %i32 = class_element_access %.loc29_33.3, element0
+// CHECK:STDOUT:   %.loc29_33.5: init %i32 = initialize_from %.loc29_33.2 to %.loc29_33.4 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc29_33.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc29_33.3: <bound method> = bound_method %int_2, %impl.elem0.loc29_33.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc29_33.2: <specific function> = specific_function %impl.elem0.loc29_33.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc29_33.4: <bound method> = bound_method %int_2, %specific_fn.loc29_33.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc29_33.2: init %i32 = call %bound_method.loc29_33.4(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc29_33.6: init %i32 = converted %int_2, %int.convert_checked.loc29_33.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc29_33.7: ref %i32 = class_element_access %.loc29_33.3, element1
+// CHECK:STDOUT:   %.loc29_33.8: init %i32 = initialize_from %.loc29_33.6 to %.loc29_33.7 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc29_33.9: init %Class = class_init (%.loc29_33.5, %.loc29_33.8), %.loc29_33.3 [concrete = constants.%Class.val]
+// CHECK:STDOUT:   %.loc29_33.10: ref %Class = temporary %.loc29_33.3, %.loc29_33.9
+// CHECK:STDOUT:   %.loc29_35.1: ref %Class = converted %.loc29_33.1, %.loc29_33.10
+// CHECK:STDOUT:   %.loc29_35.2: %Class = bind_value %.loc29_35.1
 // CHECK:STDOUT:   assign %c.var, <error>
-// CHECK:STDOUT:   %Class.ref.loc26_10: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %Class.ref.loc29_10: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %c: ref %Class = bind_name c, %c.var
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%G.decl [concrete = constants.%G]
 // CHECK:STDOUT:   %c.ref: ref %Class = name_ref c, %c

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -85,7 +88,7 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.049 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %s.param: %struct_type.a.72c = value_param call_param0
-// CHECK:STDOUT:     %.loc19: type = splice_block %struct_type.a [concrete = constants.%struct_type.a.72c] {
+// CHECK:STDOUT:     %.loc22: type = splice_block %struct_type.a [concrete = constants.%struct_type.a.72c] {
 // CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:       %struct_type.a: type = struct_type {.a: %A} [concrete = constants.%struct_type.a.72c]
 // CHECK:STDOUT:     }
@@ -100,10 +103,10 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:   %F.decl: %F.type.649 = fn_decl @F.1 [concrete = constants.%F.485] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.5f8 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.5f8 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc12_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc15_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.6db = value_param call_param0
-// CHECK:STDOUT:     %.loc12_20: type = splice_block %ptr [concrete = constants.%ptr.6db] {
+// CHECK:STDOUT:     %.loc15_20: type = splice_block %ptr [concrete = constants.%ptr.6db] {
 // CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:       %ptr: type = ptr_type %A.ref [concrete = constants.%ptr.6db]
 // CHECK:STDOUT:     }
@@ -121,7 +124,7 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc16: %B.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %B.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %A} [concrete = constants.%struct_type.a.72c]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.2b9]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -129,7 +132,7 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   .a = %.loc16
+// CHECK:STDOUT:   .a = %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1(%self.param: %ptr.6db);
@@ -137,21 +140,21 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: fn @F.2(%s.param: %struct_type.a.72c, %b.param: %B) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %s.ref: %struct_type.a.72c = name_ref s, %s
-// CHECK:STDOUT:   %.loc28_4.1: %A = struct_access %s.ref, element0
-// CHECK:STDOUT:   %F.ref.loc28: %F.type.649 = name_ref F, @A.%F.decl [concrete = constants.%F.485]
-// CHECK:STDOUT:   %F.bound.loc28: <bound method> = bound_method %.loc28_4.1, %F.ref.loc28
-// CHECK:STDOUT:   %.loc28_4.2: ref %A = temporary_storage
-// CHECK:STDOUT:   %addr.loc28: %ptr.6db = addr_of %.loc28_4.2
-// CHECK:STDOUT:   %F.call.loc28: init %empty_tuple.type = call %F.bound.loc28(%addr.loc28)
+// CHECK:STDOUT:   %.loc31_4.1: %A = struct_access %s.ref, element0
+// CHECK:STDOUT:   %F.ref.loc31: %F.type.649 = name_ref F, @A.%F.decl [concrete = constants.%F.485]
+// CHECK:STDOUT:   %F.bound.loc31: <bound method> = bound_method %.loc31_4.1, %F.ref.loc31
+// CHECK:STDOUT:   %.loc31_4.2: ref %A = temporary_storage
+// CHECK:STDOUT:   %addr.loc31: %ptr.6db = addr_of %.loc31_4.2
+// CHECK:STDOUT:   %F.call.loc31: init %empty_tuple.type = call %F.bound.loc31(%addr.loc31)
 // CHECK:STDOUT:   %b.ref: %B = name_ref b, %b
-// CHECK:STDOUT:   %a.ref: %B.elem = name_ref a, @B.%.loc16 [concrete = @B.%.loc16]
-// CHECK:STDOUT:   %.loc39_4.1: ref %A = class_element_access %b.ref, element0
-// CHECK:STDOUT:   %.loc39_4.2: %A = bind_value %.loc39_4.1
-// CHECK:STDOUT:   %F.ref.loc39: %F.type.649 = name_ref F, @A.%F.decl [concrete = constants.%F.485]
-// CHECK:STDOUT:   %F.bound.loc39: <bound method> = bound_method %.loc39_4.2, %F.ref.loc39
-// CHECK:STDOUT:   %.loc39_4.3: ref %A = temporary_storage
-// CHECK:STDOUT:   %addr.loc39: %ptr.6db = addr_of %.loc39_4.3
-// CHECK:STDOUT:   %F.call.loc39: init %empty_tuple.type = call %F.bound.loc39(%addr.loc39)
+// CHECK:STDOUT:   %a.ref: %B.elem = name_ref a, @B.%.loc19 [concrete = @B.%.loc19]
+// CHECK:STDOUT:   %.loc42_4.1: ref %A = class_element_access %b.ref, element0
+// CHECK:STDOUT:   %.loc42_4.2: %A = bind_value %.loc42_4.1
+// CHECK:STDOUT:   %F.ref.loc42: %F.type.649 = name_ref F, @A.%F.decl [concrete = constants.%F.485]
+// CHECK:STDOUT:   %F.bound.loc42: <bound method> = bound_method %.loc42_4.2, %F.ref.loc42
+// CHECK:STDOUT:   %.loc42_4.3: ref %A = temporary_storage
+// CHECK:STDOUT:   %addr.loc42: %ptr.6db = addr_of %.loc42_4.3
+// CHECK:STDOUT:   %F.call.loc42: init %empty_tuple.type = call %F.bound.loc42(%addr.loc42)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_member_of_let.carbon

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_method.carbon
@@ -87,7 +90,7 @@ fn F(c: Class) {
 // CHECK:STDOUT:     %c.param_patt: %pattern_type = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %Class = value_param call_param0
-// CHECK:STDOUT:     %Class.ref.loc18: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:     %Class.ref.loc21: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:     %c: %Class = bind_name c, %c.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -119,24 +122,24 @@ fn F(c: Class) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%c.param: %Class) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %c.ref.loc19: %Class = name_ref c, %c
-// CHECK:STDOUT:   %NoSelf.ref.loc19: %NoSelf.type = name_ref NoSelf, @Class.%NoSelf.decl [concrete = constants.%NoSelf]
-// CHECK:STDOUT:   %NoSelf.call.loc19: init %empty_tuple.type = call %NoSelf.ref.loc19()
-// CHECK:STDOUT:   %c.ref.loc20: %Class = name_ref c, %c
-// CHECK:STDOUT:   %WithSelf.ref.loc20: %WithSelf.type = name_ref WithSelf, @Class.%WithSelf.decl [concrete = constants.%WithSelf]
-// CHECK:STDOUT:   %WithSelf.bound: <bound method> = bound_method %c.ref.loc20, %WithSelf.ref.loc20
-// CHECK:STDOUT:   %WithSelf.call.loc20: init %empty_tuple.type = call %WithSelf.bound(%c.ref.loc20)
-// CHECK:STDOUT:   %Class.ref.loc22: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %c.ref.loc22: %Class = name_ref c, %c
 // CHECK:STDOUT:   %NoSelf.ref.loc22: %NoSelf.type = name_ref NoSelf, @Class.%NoSelf.decl [concrete = constants.%NoSelf]
 // CHECK:STDOUT:   %NoSelf.call.loc22: init %empty_tuple.type = call %NoSelf.ref.loc22()
-// CHECK:STDOUT:   %Class.ref.loc30: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %WithSelf.ref.loc30: %WithSelf.type = name_ref WithSelf, @Class.%WithSelf.decl [concrete = constants.%WithSelf]
-// CHECK:STDOUT:   %WithSelf.call.loc30: init %empty_tuple.type = call %WithSelf.ref.loc30(<error>)
-// CHECK:STDOUT:   %Class.ref.loc38: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %WithSelf.ref.loc38: %WithSelf.type = name_ref WithSelf, @Class.%WithSelf.decl [concrete = constants.%WithSelf]
-// CHECK:STDOUT:   %c.ref.loc38: %Class = name_ref c, %c
+// CHECK:STDOUT:   %c.ref.loc23: %Class = name_ref c, %c
+// CHECK:STDOUT:   %WithSelf.ref.loc23: %WithSelf.type = name_ref WithSelf, @Class.%WithSelf.decl [concrete = constants.%WithSelf]
+// CHECK:STDOUT:   %WithSelf.bound: <bound method> = bound_method %c.ref.loc23, %WithSelf.ref.loc23
+// CHECK:STDOUT:   %WithSelf.call.loc23: init %empty_tuple.type = call %WithSelf.bound(%c.ref.loc23)
+// CHECK:STDOUT:   %Class.ref.loc25: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %NoSelf.ref.loc25: %NoSelf.type = name_ref NoSelf, @Class.%NoSelf.decl [concrete = constants.%NoSelf]
+// CHECK:STDOUT:   %NoSelf.call.loc25: init %empty_tuple.type = call %NoSelf.ref.loc25()
+// CHECK:STDOUT:   %Class.ref.loc33: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %WithSelf.ref.loc33: %WithSelf.type = name_ref WithSelf, @Class.%WithSelf.decl [concrete = constants.%WithSelf]
+// CHECK:STDOUT:   %WithSelf.call.loc33: init %empty_tuple.type = call %WithSelf.ref.loc33(<error>)
+// CHECK:STDOUT:   %Class.ref.loc41: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %WithSelf.ref.loc41: %WithSelf.type = name_ref WithSelf, @Class.%WithSelf.decl [concrete = constants.%WithSelf]
+// CHECK:STDOUT:   %c.ref.loc41: %Class = name_ref c, %c
 // CHECK:STDOUT:   %A.ref: %WithSelf.type = name_ref A, file.%A [concrete = constants.%WithSelf]
-// CHECK:STDOUT:   %WithSelf.call.loc47: init %empty_tuple.type = call %A.ref(<error>)
+// CHECK:STDOUT:   %WithSelf.call.loc50: init %empty_tuple.type = call %A.ref(<error>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_method_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_method_modifiers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_method_modifiers.carbon

--- a/toolchain/check/testdata/class/fail_method_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_method_redefinition.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_method_redefinition.carbon
@@ -49,15 +52,15 @@ class Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F.decl.loc12: %F.type.f1baa3.1 = fn_decl @F.1 [concrete = constants.%F.1f2582.1] {} {}
-// CHECK:STDOUT:   %F.decl.loc20: %F.type.f1baa3.2 = fn_decl @F.2 [concrete = constants.%F.1f2582.2] {} {}
+// CHECK:STDOUT:   %F.decl.loc15: %F.type.f1baa3.1 = fn_decl @F.1 [concrete = constants.%F.1f2582.1] {} {}
+// CHECK:STDOUT:   %F.decl.loc23: %F.type.f1baa3.2 = fn_decl @F.2 [concrete = constants.%F.1f2582.2] {} {}
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .F = %F.decl.loc12
+// CHECK:STDOUT:   .F = %F.decl.loc15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1() {

--- a/toolchain/check/testdata/class/fail_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_modifiers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_modifiers.carbon
@@ -156,9 +159,9 @@ fn AbstractWithDefinition.G[self: Self]() {
 // CHECK:STDOUT:     %self.patt: %pattern_type = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc97: %AbstractWithDefinition = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc97: type = name_ref Self, constants.%AbstractWithDefinition [concrete = constants.%AbstractWithDefinition]
-// CHECK:STDOUT:     %self.loc97: %AbstractWithDefinition = bind_name self, %self.param.loc97
+// CHECK:STDOUT:     %self.param.loc100: %AbstractWithDefinition = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc100: type = name_ref Self, constants.%AbstractWithDefinition [concrete = constants.%AbstractWithDefinition]
+// CHECK:STDOUT:     %self.loc100: %AbstractWithDefinition = bind_name self, %self.param.loc100
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -219,11 +222,11 @@ fn AbstractWithDefinition.G[self: Self]() {
 // CHECK:STDOUT:     %self.patt: %pattern_type = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc91: %AbstractWithDefinition = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc91: type = name_ref Self, constants.%AbstractWithDefinition [concrete = constants.%AbstractWithDefinition]
-// CHECK:STDOUT:     %self.loc91: %AbstractWithDefinition = bind_name self, %self.param.loc91
+// CHECK:STDOUT:     %self.param.loc94: %AbstractWithDefinition = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc94: type = name_ref Self, constants.%AbstractWithDefinition [concrete = constants.%AbstractWithDefinition]
+// CHECK:STDOUT:     %self.loc94: %AbstractWithDefinition = bind_name self, %self.param.loc94
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc92: <vtable> = vtable (%F.decl, %G.decl) [concrete = constants.%.9a5]
+// CHECK:STDOUT:   %.loc95: <vtable> = vtable (%F.decl, %G.decl) [concrete = constants.%.9a5]
 // CHECK:STDOUT:   %struct_type.vptr: type = struct_type {.<vptr>: %ptr.454} [concrete = constants.%struct_type.vptr]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.vptr [concrete = constants.%complete_type.513]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -239,7 +242,7 @@ fn AbstractWithDefinition.G[self: Self]() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: abstract fn @G(%self.param.loc97: %AbstractWithDefinition) {
+// CHECK:STDOUT: abstract fn @G(%self.param.loc100: %AbstractWithDefinition) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_out_of_line_decl.carbon
+++ b/toolchain/check/testdata/class/fail_out_of_line_decl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_out_of_line_decl.carbon

--- a/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_redeclaration_scope.carbon
@@ -50,14 +53,14 @@ class Y {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .A = %A.decl.loc11
+// CHECK:STDOUT:     .A = %A.decl.loc14
 // CHECK:STDOUT:     .X = %X.decl
 // CHECK:STDOUT:     .Y = %Y.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %A.decl.loc11: type = class_decl @A.1 [concrete = constants.%A.466] {} {}
+// CHECK:STDOUT:   %A.decl.loc14: type = class_decl @A.1 [concrete = constants.%A.466] {} {}
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [concrete = constants.%X] {} {}
-// CHECK:STDOUT:   %A.decl.loc19: type = class_decl @A.1 [concrete = constants.%A.466] {} {}
+// CHECK:STDOUT:   %A.decl.loc22: type = class_decl @A.1 [concrete = constants.%A.466] {} {}
 // CHECK:STDOUT:   %Y.decl: type = class_decl @Y [concrete = constants.%Y] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_redefinition.carbon
@@ -78,11 +81,11 @@ fn Class.I() {}
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .Class = %Class.decl.loc11
+// CHECK:STDOUT:     .Class = %Class.decl.loc14
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %Class.decl.loc11: type = class_decl @Class.1 [concrete = constants.%Class.301e72.1] {} {}
-// CHECK:STDOUT:   %Class.decl.loc24: type = class_decl @Class.2 [concrete = constants.%Class.301e72.2] {} {}
+// CHECK:STDOUT:   %Class.decl.loc14: type = class_decl @Class.1 [concrete = constants.%Class.301e72.1] {} {}
+// CHECK:STDOUT:   %Class.decl.loc27: type = class_decl @Class.2 [concrete = constants.%Class.301e72.2] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT:   %G.decl: %G.type.621c12.2 = fn_decl @G.2 [concrete = constants.%G.f0cac0.2] {} {}
 // CHECK:STDOUT:   %H.decl: %H.type.91d18a.1 = fn_decl @H.1 [concrete = constants.%H.d38c33.1] {} {}

--- a/toolchain/check/testdata/class/fail_scope.carbon
+++ b/toolchain/check/testdata/class/fail_scope.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_scope.carbon
@@ -112,13 +115,13 @@ fn G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc13_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc16_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc13_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc13_13.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc13_13.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc13_13.2: %i32 = converted %int_1, %.loc13_13.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   return %.loc13_13.2
+// CHECK:STDOUT:   %bound_method.loc16_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc16_13.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc16_13.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc16_13.2: %i32 = converted %int_1, %.loc16_13.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   return %.loc16_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %i32 {

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_self.carbon
@@ -100,17 +103,17 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:     %self.patt: %pattern_type.761 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.761 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc25: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc25: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc25: %Class = bind_name self, %self.param.loc25
+// CHECK:STDOUT:     %self.param.loc28: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc28: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc28: %Class = bind_name self, %self.param.loc28
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.761 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.761 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc28: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %return.param.loc28: ref %Class = out_param call_param0
-// CHECK:STDOUT:     %return.loc28: ref %Class = return_slot %return.param.loc28
+// CHECK:STDOUT:     %Self.ref.loc31: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %return.param.loc31: ref %Class = out_param call_param0
+// CHECK:STDOUT:     %return.loc31: ref %Class = return_slot %return.param.loc31
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %WrongSelf.decl: type = class_decl @WrongSelf [concrete = constants.%WrongSelf] {} {}
 // CHECK:STDOUT:   %CallWrongSelf.decl: %CallWrongSelf.type = fn_decl @CallWrongSelf [concrete = constants.%CallWrongSelf] {
@@ -128,17 +131,17 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:     %self.patt: %pattern_type.761 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.761 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc16: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc16: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc16: %Class = bind_name self, %self.param.loc16
+// CHECK:STDOUT:     %self.param.loc19: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc19: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc19: %Class = bind_name self, %self.param.loc19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.761 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.761 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc18: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %return.param.loc18: ref %Class = out_param call_param0
-// CHECK:STDOUT:     %return.loc18: ref %Class = return_slot %return.param.loc18
+// CHECK:STDOUT:     %Self.ref.loc21: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %return.param.loc21: ref %Class = out_param call_param0
+// CHECK:STDOUT:     %return.loc21: ref %Class = return_slot %return.param.loc21
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
@@ -169,23 +172,23 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.1(%self.param.loc25: %Class) {
+// CHECK:STDOUT: fn @F.1(%self.param.loc28: %Class) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G() -> %return.param.loc28: %Class {
+// CHECK:STDOUT: fn @G() -> %return.param.loc31: %Class {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %self.patt: %pattern_type.761 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.var_patt: %pattern_type.761 = var_pattern %self.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %self.var: ref %Class = var %self.var_patt
-// CHECK:STDOUT:   %Self.ref.loc33: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:   %Self.ref.loc36: type = name_ref Self, constants.%Class [concrete = constants.%Class]
 // CHECK:STDOUT:   %self: ref %Class = bind_name self, %self.var
 // CHECK:STDOUT:   %self.ref: ref %Class = name_ref self, %self
-// CHECK:STDOUT:   %.loc38: %Class = bind_value %self.ref
-// CHECK:STDOUT:   return <error> to %return.loc28
+// CHECK:STDOUT:   %.loc41: %Class = bind_value %self.ref
+// CHECK:STDOUT:   return <error> to %return.loc31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%self.param: %Class);
@@ -195,7 +198,7 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:   %ws.ref: %WrongSelf = name_ref ws, %ws
 // CHECK:STDOUT:   %F.ref: %F.type.25f = name_ref F, @WrongSelf.%F.decl [concrete = constants.%F.3a3]
 // CHECK:STDOUT:   %F.bound: <bound method> = bound_method %ws.ref, %F.ref
-// CHECK:STDOUT:   %.loc56: %Class = converted %ws.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc59: %Class = converted %ws.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.bound(<error>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_self_param.carbon
+++ b/toolchain/check/testdata/class/fail_self_param.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_self_param.carbon

--- a/toolchain/check/testdata/class/fail_self_type_member.carbon
+++ b/toolchain/check/testdata/class/fail_self_type_member.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_self_type_member.carbon
@@ -39,16 +42,16 @@ fn F() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc12_10.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:   %.loc12_10.2: type = converted %bool.make_type, %.loc12_10.1 [concrete = bool]
-// CHECK:STDOUT:   %.loc12_8: %Class.elem = field_decl b, element0 [concrete]
+// CHECK:STDOUT:   %.loc15_10.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:   %.loc15_10.2: type = converted %bool.make_type, %.loc15_10.1 [concrete = bool]
+// CHECK:STDOUT:   %.loc15_8: %Class.elem = field_decl b, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.b: type = struct_type {.b: bool} [concrete = constants.%struct_type.b]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .b = %.loc12_8
+// CHECK:STDOUT:   .b = %.loc15_8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool;

--- a/toolchain/check/testdata/class/fail_todo_field_initializer.carbon
+++ b/toolchain/check/testdata/class/fail_todo_field_initializer.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_todo_field_initializer.carbon
@@ -51,7 +54,7 @@ class Class {
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc16: %Class.elem = field_decl field, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %Class.elem = field_decl field, element0 [concrete]
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
 // CHECK:STDOUT:   %struct_type.field: type = struct_type {.field: %i32} [concrete = constants.%struct_type.field]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.field [concrete = constants.%complete_type.d48]
@@ -59,6 +62,6 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .field = %.loc16
+// CHECK:STDOUT:   .field = %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -76,7 +79,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl field, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl field, element0 [concrete]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
@@ -92,20 +95,20 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .field = %.loc12
+// CHECK:STDOUT:   .field = %.loc15
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %field.ref: %Class.elem = name_ref field, @Class.%.loc12 [concrete = @Class.%.loc12]
+// CHECK:STDOUT:   %field.ref: %Class.elem = name_ref field, @Class.%.loc15 [concrete = @Class.%.loc15]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %field.ref: %Class.elem = name_ref field, @Class.%.loc12 [concrete = @Class.%.loc12]
+// CHECK:STDOUT:   %field.ref: %Class.elem = name_ref field, @Class.%.loc15 [concrete = @Class.%.loc15]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -74,14 +77,14 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl n, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl n, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.n: type = struct_type {.n: %i32} [concrete = constants.%struct_type.n]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [concrete = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .n = %.loc12
+// CHECK:STDOUT:   .n = %.loc15
 // CHECK:STDOUT:   .something = <poisoned>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/field_access.carbon
@@ -84,20 +87,20 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl j, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Class.elem = field_decl k, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl j, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Class.elem = field_decl k, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.j.k: type = struct_type {.j: %i32, .k: %i32} [concrete = constants.%struct_type.j.k]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.j.k [concrete = constants.%complete_type.cf7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .j = %.loc12
-// CHECK:STDOUT:   .k = %.loc13
+// CHECK:STDOUT:   .j = %.loc15
+// CHECK:STDOUT:   .k = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -109,41 +112,41 @@ fn Run() {
 // CHECK:STDOUT:   %c.var: ref %Class = var %c.var_patt
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %c: ref %Class = bind_name c, %c.var
-// CHECK:STDOUT:   %c.ref.loc18: ref %Class = name_ref c, %c
-// CHECK:STDOUT:   %j.ref.loc18: %Class.elem = name_ref j, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:   %.loc18_4: ref %i32 = class_element_access %c.ref.loc18, element0
+// CHECK:STDOUT:   %c.ref.loc21: ref %Class = name_ref c, %c
+// CHECK:STDOUT:   %j.ref.loc21: %Class.elem = name_ref j, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:   %.loc21_4: ref %i32 = class_element_access %c.ref.loc21, element0
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %impl.elem0.loc18: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc18_7.1: <bound method> = bound_method %int_1, %impl.elem0.loc18 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem0.loc18, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc18_7.2: <bound method> = bound_method %int_1, %specific_fn.loc18 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc18: init %i32 = call %bound_method.loc18_7.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc18_7: init %i32 = converted %int_1, %int.convert_checked.loc18 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %.loc18_4, %.loc18_7
-// CHECK:STDOUT:   %c.ref.loc19: ref %Class = name_ref c, %c
-// CHECK:STDOUT:   %k.ref.loc19: %Class.elem = name_ref k, @Class.%.loc13 [concrete = @Class.%.loc13]
-// CHECK:STDOUT:   %.loc19_4: ref %i32 = class_element_access %c.ref.loc19, element1
+// CHECK:STDOUT:   %impl.elem0.loc21: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc21_7.1: <bound method> = bound_method %int_1, %impl.elem0.loc21 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem0.loc21, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc21_7.2: <bound method> = bound_method %int_1, %specific_fn.loc21 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc21: init %i32 = call %bound_method.loc21_7.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc21_7: init %i32 = converted %int_1, %int.convert_checked.loc21 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %.loc21_4, %.loc21_7
+// CHECK:STDOUT:   %c.ref.loc22: ref %Class = name_ref c, %c
+// CHECK:STDOUT:   %k.ref.loc22: %Class.elem = name_ref k, @Class.%.loc16 [concrete = @Class.%.loc16]
+// CHECK:STDOUT:   %.loc22_4: ref %i32 = class_element_access %c.ref.loc22, element1
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %impl.elem0.loc19: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc19_7.1: <bound method> = bound_method %int_2, %impl.elem0.loc19 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem0.loc19, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc19_7.2: <bound method> = bound_method %int_2, %specific_fn.loc19 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc19: init %i32 = call %bound_method.loc19_7.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc19_7: init %i32 = converted %int_2, %int.convert_checked.loc19 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   assign %.loc19_4, %.loc19_7
+// CHECK:STDOUT:   %impl.elem0.loc22: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc22_7.1: <bound method> = bound_method %int_2, %impl.elem0.loc22 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc22: <specific function> = specific_function %impl.elem0.loc22, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc22_7.2: <bound method> = bound_method %int_2, %specific_fn.loc22 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc22: init %i32 = call %bound_method.loc22_7.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc22_7: init %i32 = converted %int_2, %int.convert_checked.loc22 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   assign %.loc22_4, %.loc22_7
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %cj.patt: %pattern_type.7ce = binding_pattern cj [concrete]
 // CHECK:STDOUT:     %cj.var_patt: %pattern_type.7ce = var_pattern %cj.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %cj.var: ref %i32 = var %cj.var_patt
-// CHECK:STDOUT:   %c.ref.loc20: ref %Class = name_ref c, %c
-// CHECK:STDOUT:   %j.ref.loc20: %Class.elem = name_ref j, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:   %.loc20_18.1: ref %i32 = class_element_access %c.ref.loc20, element0
-// CHECK:STDOUT:   %.loc20_18.2: %i32 = bind_value %.loc20_18.1
-// CHECK:STDOUT:   assign %cj.var, %.loc20_18.2
-// CHECK:STDOUT:   %.loc20_11: type = splice_block %i32.loc20 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %c.ref.loc23: ref %Class = name_ref c, %c
+// CHECK:STDOUT:   %j.ref.loc23: %Class.elem = name_ref j, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:   %.loc23_18.1: ref %i32 = class_element_access %c.ref.loc23, element0
+// CHECK:STDOUT:   %.loc23_18.2: %i32 = bind_value %.loc23_18.1
+// CHECK:STDOUT:   assign %cj.var, %.loc23_18.2
+// CHECK:STDOUT:   %.loc23_11: type = splice_block %i32.loc23 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %cj: ref %i32 = bind_name cj, %cj.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -151,14 +154,14 @@ fn Run() {
 // CHECK:STDOUT:     %ck.var_patt: %pattern_type.7ce = var_pattern %ck.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ck.var: ref %i32 = var %ck.var_patt
-// CHECK:STDOUT:   %c.ref.loc21: ref %Class = name_ref c, %c
-// CHECK:STDOUT:   %k.ref.loc21: %Class.elem = name_ref k, @Class.%.loc13 [concrete = @Class.%.loc13]
-// CHECK:STDOUT:   %.loc21_18.1: ref %i32 = class_element_access %c.ref.loc21, element1
-// CHECK:STDOUT:   %.loc21_18.2: %i32 = bind_value %.loc21_18.1
-// CHECK:STDOUT:   assign %ck.var, %.loc21_18.2
-// CHECK:STDOUT:   %.loc21_11: type = splice_block %i32.loc21 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %c.ref.loc24: ref %Class = name_ref c, %c
+// CHECK:STDOUT:   %k.ref.loc24: %Class.elem = name_ref k, @Class.%.loc16 [concrete = @Class.%.loc16]
+// CHECK:STDOUT:   %.loc24_18.1: ref %i32 = class_element_access %c.ref.loc24, element1
+// CHECK:STDOUT:   %.loc24_18.2: %i32 = bind_value %.loc24_18.1
+// CHECK:STDOUT:   assign %ck.var, %.loc24_18.2
+// CHECK:STDOUT:   %.loc24_11: type = splice_block %i32.loc24 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ck: ref %i32 = bind_name ck, %ck.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/field_access_in_value.carbon
@@ -85,20 +88,20 @@ fn Test() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl j, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Class.elem = field_decl k, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl j, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Class.elem = field_decl k, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.j.k: type = struct_type {.j: %i32, .k: %i32} [concrete = constants.%struct_type.j.k]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.j.k [concrete = constants.%complete_type.cf7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .j = %.loc12
-// CHECK:STDOUT:   .k = %.loc13
+// CHECK:STDOUT:   .j = %.loc15
+// CHECK:STDOUT:   .k = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {
@@ -108,49 +111,49 @@ fn Test() {
 // CHECK:STDOUT:     %cv.var_patt: %pattern_type.761 = var_pattern %cv.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %cv.var: ref %Class = var %cv.var_patt
-// CHECK:STDOUT:   %Class.ref.loc17: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %Class.ref.loc20: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %cv: ref %Class = bind_name cv, %cv.var
-// CHECK:STDOUT:   %cv.ref.loc18: ref %Class = name_ref cv, %cv
-// CHECK:STDOUT:   %j.ref.loc18: %Class.elem = name_ref j, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:   %.loc18_5: ref %i32 = class_element_access %cv.ref.loc18, element0
+// CHECK:STDOUT:   %cv.ref.loc21: ref %Class = name_ref cv, %cv
+// CHECK:STDOUT:   %j.ref.loc21: %Class.elem = name_ref j, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:   %.loc21_5: ref %i32 = class_element_access %cv.ref.loc21, element0
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %impl.elem0.loc18: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc18_8.1: <bound method> = bound_method %int_1, %impl.elem0.loc18 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem0.loc18, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc18_8.2: <bound method> = bound_method %int_1, %specific_fn.loc18 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc18: init %i32 = call %bound_method.loc18_8.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc18_8: init %i32 = converted %int_1, %int.convert_checked.loc18 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %.loc18_5, %.loc18_8
-// CHECK:STDOUT:   %cv.ref.loc19: ref %Class = name_ref cv, %cv
-// CHECK:STDOUT:   %k.ref.loc19: %Class.elem = name_ref k, @Class.%.loc13 [concrete = @Class.%.loc13]
-// CHECK:STDOUT:   %.loc19_5: ref %i32 = class_element_access %cv.ref.loc19, element1
+// CHECK:STDOUT:   %impl.elem0.loc21: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc21_8.1: <bound method> = bound_method %int_1, %impl.elem0.loc21 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem0.loc21, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc21_8.2: <bound method> = bound_method %int_1, %specific_fn.loc21 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc21: init %i32 = call %bound_method.loc21_8.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc21_8: init %i32 = converted %int_1, %int.convert_checked.loc21 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %.loc21_5, %.loc21_8
+// CHECK:STDOUT:   %cv.ref.loc22: ref %Class = name_ref cv, %cv
+// CHECK:STDOUT:   %k.ref.loc22: %Class.elem = name_ref k, @Class.%.loc16 [concrete = @Class.%.loc16]
+// CHECK:STDOUT:   %.loc22_5: ref %i32 = class_element_access %cv.ref.loc22, element1
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %impl.elem0.loc19: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc19_8.1: <bound method> = bound_method %int_2, %impl.elem0.loc19 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem0.loc19, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc19_8.2: <bound method> = bound_method %int_2, %specific_fn.loc19 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc19: init %i32 = call %bound_method.loc19_8.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc19_8: init %i32 = converted %int_2, %int.convert_checked.loc19 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   assign %.loc19_5, %.loc19_8
+// CHECK:STDOUT:   %impl.elem0.loc22: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc22_8.1: <bound method> = bound_method %int_2, %impl.elem0.loc22 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc22: <specific function> = specific_function %impl.elem0.loc22, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc22_8.2: <bound method> = bound_method %int_2, %specific_fn.loc22 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc22: init %i32 = call %bound_method.loc22_8.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc22_8: init %i32 = converted %int_2, %int.convert_checked.loc22 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   assign %.loc22_5, %.loc22_8
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.761 = binding_pattern c [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %cv.ref.loc20: ref %Class = name_ref cv, %cv
-// CHECK:STDOUT:   %Class.ref.loc20: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %c: ref %Class = bind_name c, %cv.ref.loc20
+// CHECK:STDOUT:   %cv.ref.loc23: ref %Class = name_ref cv, %cv
+// CHECK:STDOUT:   %Class.ref.loc23: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:   %c: ref %Class = bind_name c, %cv.ref.loc23
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %cj.patt: %pattern_type.7ce = binding_pattern cj [concrete]
 // CHECK:STDOUT:     %cj.var_patt: %pattern_type.7ce = var_pattern %cj.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %cj.var: ref %i32 = var %cj.var_patt
-// CHECK:STDOUT:   %c.ref.loc21: ref %Class = name_ref c, %c
-// CHECK:STDOUT:   %j.ref.loc21: %Class.elem = name_ref j, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:   %.loc21_18.1: ref %i32 = class_element_access %c.ref.loc21, element0
-// CHECK:STDOUT:   %.loc21_18.2: %i32 = bind_value %.loc21_18.1
-// CHECK:STDOUT:   assign %cj.var, %.loc21_18.2
-// CHECK:STDOUT:   %.loc21_11: type = splice_block %i32.loc21 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %c.ref.loc24: ref %Class = name_ref c, %c
+// CHECK:STDOUT:   %j.ref.loc24: %Class.elem = name_ref j, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:   %.loc24_18.1: ref %i32 = class_element_access %c.ref.loc24, element0
+// CHECK:STDOUT:   %.loc24_18.2: %i32 = bind_value %.loc24_18.1
+// CHECK:STDOUT:   assign %cj.var, %.loc24_18.2
+// CHECK:STDOUT:   %.loc24_11: type = splice_block %i32.loc24 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %cj: ref %i32 = bind_name cj, %cj.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -158,14 +161,14 @@ fn Test() {
 // CHECK:STDOUT:     %ck.var_patt: %pattern_type.7ce = var_pattern %ck.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ck.var: ref %i32 = var %ck.var_patt
-// CHECK:STDOUT:   %c.ref.loc22: ref %Class = name_ref c, %c
-// CHECK:STDOUT:   %k.ref.loc22: %Class.elem = name_ref k, @Class.%.loc13 [concrete = @Class.%.loc13]
-// CHECK:STDOUT:   %.loc22_18.1: ref %i32 = class_element_access %c.ref.loc22, element1
-// CHECK:STDOUT:   %.loc22_18.2: %i32 = bind_value %.loc22_18.1
-// CHECK:STDOUT:   assign %ck.var, %.loc22_18.2
-// CHECK:STDOUT:   %.loc22_11: type = splice_block %i32.loc22 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %c.ref.loc25: ref %Class = name_ref c, %c
+// CHECK:STDOUT:   %k.ref.loc25: %Class.elem = name_ref k, @Class.%.loc16 [concrete = @Class.%.loc16]
+// CHECK:STDOUT:   %.loc25_18.1: ref %i32 = class_element_access %c.ref.loc25, element1
+// CHECK:STDOUT:   %.loc25_18.2: %i32 = bind_value %.loc25_18.1
+// CHECK:STDOUT:   assign %ck.var, %.loc25_18.2
+// CHECK:STDOUT:   %.loc25_11: type = splice_block %i32.loc25 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc25: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc25: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ck: ref %i32 = bind_name ck, %ck.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/forward_declared.carbon
+++ b/toolchain/check/testdata/class/forward_declared.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/forward_declared.carbon
@@ -43,12 +46,12 @@ fn F(p: Class*) -> Class* { return p; }
 // CHECK:STDOUT:     %return.patt: %pattern_type = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Class.ref.loc13_20: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:     %ptr.loc13_25: type = ptr_type %Class.ref.loc13_20 [concrete = constants.%ptr]
+// CHECK:STDOUT:     %Class.ref.loc16_20: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:     %ptr.loc16_25: type = ptr_type %Class.ref.loc16_20 [concrete = constants.%ptr]
 // CHECK:STDOUT:     %p.param: %ptr = value_param call_param0
-// CHECK:STDOUT:     %.loc13: type = splice_block %ptr.loc13_14 [concrete = constants.%ptr] {
-// CHECK:STDOUT:       %Class.ref.loc13_9: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:       %ptr.loc13_14: type = ptr_type %Class.ref.loc13_9 [concrete = constants.%ptr]
+// CHECK:STDOUT:     %.loc16: type = splice_block %ptr.loc16_14 [concrete = constants.%ptr] {
+// CHECK:STDOUT:       %Class.ref.loc16_9: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:       %ptr.loc16_14: type = ptr_type %Class.ref.loc16_9 [concrete = constants.%ptr]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr = out_param call_param1

--- a/toolchain/check/testdata/class/generic.carbon
+++ b/toolchain/check/testdata/class/generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic.carbon

--- a/toolchain/check/testdata/class/generic/adapt.carbon
+++ b/toolchain/check/testdata/class/generic/adapt.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/adapt.carbon

--- a/toolchain/check/testdata/class/generic/base_is_generic.carbon
+++ b/toolchain/check/testdata/class/generic/base_is_generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/base_is_generic.carbon

--- a/toolchain/check/testdata/class/generic/basic.carbon
+++ b/toolchain/check/testdata/class/generic/basic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/basic.carbon
@@ -70,134 +73,134 @@ class Declaration(T:! type);
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Declaration.decl: %Declaration.type = class_decl @Declaration [concrete = constants.%Declaration.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc24_19.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc24_19.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc27_19.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc27_19.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Class(%T.loc11_13.1: type) {
-// CHECK:STDOUT:   %T.loc11_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Class(%T.loc14_13.1: type) {
+// CHECK:STDOUT:   %T.loc14_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %GetAddr.type: type = fn_type @GetAddr, @Class(%T.loc11_13.2) [symbolic = %GetAddr.type (constants.%GetAddr.type)]
+// CHECK:STDOUT:   %GetAddr.type: type = fn_type @GetAddr, @Class(%T.loc14_13.2) [symbolic = %GetAddr.type (constants.%GetAddr.type)]
 // CHECK:STDOUT:   %GetAddr: @Class.%GetAddr.type (%GetAddr.type) = struct_value () [symbolic = %GetAddr (constants.%GetAddr)]
-// CHECK:STDOUT:   %GetValue.type: type = fn_type @GetValue, @Class(%T.loc11_13.2) [symbolic = %GetValue.type (constants.%GetValue.type)]
+// CHECK:STDOUT:   %GetValue.type: type = fn_type @GetValue, @Class(%T.loc14_13.2) [symbolic = %GetValue.type (constants.%GetValue.type)]
 // CHECK:STDOUT:   %GetValue: @Class.%GetValue.type (%GetValue.type) = struct_value () [symbolic = %GetValue (constants.%GetValue)]
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc11_13.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc11_13.2) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc11_13.2 [symbolic = %Class.elem (constants.%Class.elem)]
-// CHECK:STDOUT:   %struct_type.k.loc22_1.2: type = struct_type {.k: @Class.%T.loc11_13.2 (%T)} [symbolic = %struct_type.k.loc22_1.2 (constants.%struct_type.k)]
-// CHECK:STDOUT:   %complete_type.loc22_1.2: <witness> = complete_type_witness %struct_type.k.loc22_1.2 [symbolic = %complete_type.loc22_1.2 (constants.%complete_type)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc14_13.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc14_13.2) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc14_13.2 [symbolic = %Class.elem (constants.%Class.elem)]
+// CHECK:STDOUT:   %struct_type.k.loc25_1.2: type = struct_type {.k: @Class.%T.loc14_13.2 (%T)} [symbolic = %struct_type.k.loc25_1.2 (constants.%struct_type.k)]
+// CHECK:STDOUT:   %complete_type.loc25_1.2: <witness> = complete_type_witness %struct_type.k.loc25_1.2 [symbolic = %complete_type.loc25_1.2 (constants.%complete_type)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %GetAddr.decl: @Class.%GetAddr.type (%GetAddr.type) = fn_decl @GetAddr [symbolic = @Class.%GetAddr (constants.%GetAddr)] {
-// CHECK:STDOUT:       %self.patt: @GetAddr.%pattern_type.loc12_19 (%pattern_type.9e0) = binding_pattern self [concrete]
-// CHECK:STDOUT:       %self.param_patt: @GetAddr.%pattern_type.loc12_19 (%pattern_type.9e0) = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:       %.loc12_14: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
-// CHECK:STDOUT:       %return.patt: @GetAddr.%pattern_type.loc12_34 (%pattern_type.afe) = return_slot_pattern [concrete]
-// CHECK:STDOUT:       %return.param_patt: @GetAddr.%pattern_type.loc12_34 (%pattern_type.afe) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:       %self.patt: @GetAddr.%pattern_type.loc15_19 (%pattern_type.9e0) = binding_pattern self [concrete]
+// CHECK:STDOUT:       %self.param_patt: @GetAddr.%pattern_type.loc15_19 (%pattern_type.9e0) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %.loc15_14: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:       %return.patt: @GetAddr.%pattern_type.loc15_34 (%pattern_type.afe) = return_slot_pattern [concrete]
+// CHECK:STDOUT:       %return.param_patt: @GetAddr.%pattern_type.loc15_34 (%pattern_type.afe) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc11_13.1 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:       %ptr.loc12_38.2: type = ptr_type %T.ref [symbolic = %ptr.loc12_38.1 (constants.%ptr.79f)]
-// CHECK:STDOUT:       %self.param: @GetAddr.%ptr.loc12_29.1 (%ptr.955) = value_param call_param0
-// CHECK:STDOUT:       %.loc12_29: type = splice_block %ptr.loc12_29.2 [symbolic = %ptr.loc12_29.1 (constants.%ptr.955)] {
-// CHECK:STDOUT:         %.loc12_25: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc12_25 [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:         %ptr.loc12_29.2: type = ptr_type %Self.ref [symbolic = %ptr.loc12_29.1 (constants.%ptr.955)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %ptr.loc15_38.2: type = ptr_type %T.ref [symbolic = %ptr.loc15_38.1 (constants.%ptr.79f)]
+// CHECK:STDOUT:       %self.param: @GetAddr.%ptr.loc15_29.1 (%ptr.955) = value_param call_param0
+// CHECK:STDOUT:       %.loc15_29: type = splice_block %ptr.loc15_29.2 [symbolic = %ptr.loc15_29.1 (constants.%ptr.955)] {
+// CHECK:STDOUT:         %.loc15_25: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc15_25 [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:         %ptr.loc15_29.2: type = ptr_type %Self.ref [symbolic = %ptr.loc15_29.1 (constants.%ptr.955)]
 // CHECK:STDOUT:       }
-// CHECK:STDOUT:       %self: @GetAddr.%ptr.loc12_29.1 (%ptr.955) = bind_name self, %self.param
-// CHECK:STDOUT:       %return.param: ref @GetAddr.%ptr.loc12_38.1 (%ptr.79f) = out_param call_param1
-// CHECK:STDOUT:       %return: ref @GetAddr.%ptr.loc12_38.1 (%ptr.79f) = return_slot %return.param
+// CHECK:STDOUT:       %self: @GetAddr.%ptr.loc15_29.1 (%ptr.955) = bind_name self, %self.param
+// CHECK:STDOUT:       %return.param: ref @GetAddr.%ptr.loc15_38.1 (%ptr.79f) = out_param call_param1
+// CHECK:STDOUT:       %return: ref @GetAddr.%ptr.loc15_38.1 (%ptr.79f) = return_slot %return.param
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %GetValue.decl: @Class.%GetValue.type (%GetValue.type) = fn_decl @GetValue [symbolic = @Class.%GetValue (constants.%GetValue)] {
-// CHECK:STDOUT:       %self.patt: @GetValue.%pattern_type.loc17_15 (%pattern_type.3c1) = binding_pattern self [concrete]
-// CHECK:STDOUT:       %self.param_patt: @GetValue.%pattern_type.loc17_15 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:       %return.patt: @GetValue.%pattern_type.loc17_29 (%pattern_type.7dc) = return_slot_pattern [concrete]
-// CHECK:STDOUT:       %return.param_patt: @GetValue.%pattern_type.loc17_29 (%pattern_type.7dc) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:       %self.patt: @GetValue.%pattern_type.loc20_15 (%pattern_type.3c1) = binding_pattern self [concrete]
+// CHECK:STDOUT:       %self.param_patt: @GetValue.%pattern_type.loc20_15 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %return.patt: @GetValue.%pattern_type.loc20_29 (%pattern_type.7dc) = return_slot_pattern [concrete]
+// CHECK:STDOUT:       %return.param_patt: @GetValue.%pattern_type.loc20_29 (%pattern_type.7dc) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc11_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %self.param: @GetValue.%Class (%Class) = value_param call_param0
-// CHECK:STDOUT:       %.loc17_21.1: type = splice_block %Self.ref [symbolic = %Class (constants.%Class)] {
-// CHECK:STDOUT:         %.loc17_21.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc17_21.2 [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:       %.loc20_21.1: type = splice_block %Self.ref [symbolic = %Class (constants.%Class)] {
+// CHECK:STDOUT:         %.loc20_21.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc20_21.2 [symbolic = %Class (constants.%Class)]
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:       %self: @GetValue.%Class (%Class) = bind_name self, %self.param
 // CHECK:STDOUT:       %return.param: ref @GetValue.%T (%T) = out_param call_param1
 // CHECK:STDOUT:       %return: ref @GetValue.%T (%T) = return_slot %return.param
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_13.1 [symbolic = %T.loc11_13.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc21: @Class.%Class.elem (%Class.elem) = field_decl k, element0 [concrete]
-// CHECK:STDOUT:     %struct_type.k.loc22_1.1: type = struct_type {.k: %T} [symbolic = %struct_type.k.loc22_1.2 (constants.%struct_type.k)]
-// CHECK:STDOUT:     %complete_type.loc22_1.1: <witness> = complete_type_witness %struct_type.k.loc22_1.1 [symbolic = %complete_type.loc22_1.2 (constants.%complete_type)]
-// CHECK:STDOUT:     complete_type_witness = %complete_type.loc22_1.1
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_13.1 [symbolic = %T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc24: @Class.%Class.elem (%Class.elem) = field_decl k, element0 [concrete]
+// CHECK:STDOUT:     %struct_type.k.loc25_1.1: type = struct_type {.k: %T} [symbolic = %struct_type.k.loc25_1.2 (constants.%struct_type.k)]
+// CHECK:STDOUT:     %complete_type.loc25_1.1: <witness> = complete_type_witness %struct_type.k.loc25_1.1 [symbolic = %complete_type.loc25_1.2 (constants.%complete_type)]
+// CHECK:STDOUT:     complete_type_witness = %complete_type.loc25_1.1
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = constants.%Class
 // CHECK:STDOUT:     .T = <poisoned>
 // CHECK:STDOUT:     .GetAddr = %GetAddr.decl
 // CHECK:STDOUT:     .GetValue = %GetValue.decl
-// CHECK:STDOUT:     .k = %.loc21
+// CHECK:STDOUT:     .k = %.loc24
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Declaration(%T.loc24_19.1: type) {
-// CHECK:STDOUT:   %T.loc24_19.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc24_19.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Declaration(%T.loc27_19.1: type) {
+// CHECK:STDOUT:   %T.loc27_19.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc27_19.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @GetAddr(@Class.%T.loc11_13.1: type) {
+// CHECK:STDOUT: generic fn @GetAddr(@Class.%T.loc14_13.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %ptr.loc12_29.1: type = ptr_type %Class [symbolic = %ptr.loc12_29.1 (constants.%ptr.955)]
-// CHECK:STDOUT:   %pattern_type.loc12_19: type = pattern_type %ptr.loc12_29.1 [symbolic = %pattern_type.loc12_19 (constants.%pattern_type.9e0)]
-// CHECK:STDOUT:   %ptr.loc12_38.1: type = ptr_type %T [symbolic = %ptr.loc12_38.1 (constants.%ptr.79f)]
-// CHECK:STDOUT:   %pattern_type.loc12_34: type = pattern_type %ptr.loc12_38.1 [symbolic = %pattern_type.loc12_34 (constants.%pattern_type.afe)]
+// CHECK:STDOUT:   %ptr.loc15_29.1: type = ptr_type %Class [symbolic = %ptr.loc15_29.1 (constants.%ptr.955)]
+// CHECK:STDOUT:   %pattern_type.loc15_19: type = pattern_type %ptr.loc15_29.1 [symbolic = %pattern_type.loc15_19 (constants.%pattern_type.9e0)]
+// CHECK:STDOUT:   %ptr.loc15_38.1: type = ptr_type %T [symbolic = %ptr.loc15_38.1 (constants.%ptr.79f)]
+// CHECK:STDOUT:   %pattern_type.loc15_34: type = pattern_type %ptr.loc15_38.1 [symbolic = %pattern_type.loc15_34 (constants.%pattern_type.afe)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc12_34: <witness> = require_complete_type %ptr.loc12_38.1 [symbolic = %require_complete.loc12_34 (constants.%require_complete.6e5)]
-// CHECK:STDOUT:   %require_complete.loc12_23: <witness> = require_complete_type %ptr.loc12_29.1 [symbolic = %require_complete.loc12_23 (constants.%require_complete.2ae)]
-// CHECK:STDOUT:   %require_complete.loc13: <witness> = require_complete_type %Class [symbolic = %require_complete.loc13 (constants.%require_complete.4f8)]
+// CHECK:STDOUT:   %require_complete.loc15_34: <witness> = require_complete_type %ptr.loc15_38.1 [symbolic = %require_complete.loc15_34 (constants.%require_complete.6e5)]
+// CHECK:STDOUT:   %require_complete.loc15_23: <witness> = require_complete_type %ptr.loc15_29.1 [symbolic = %require_complete.loc15_23 (constants.%require_complete.2ae)]
+// CHECK:STDOUT:   %require_complete.loc16: <witness> = require_complete_type %Class [symbolic = %require_complete.loc16 (constants.%require_complete.4f8)]
 // CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T [symbolic = %Class.elem (constants.%Class.elem)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @GetAddr.%ptr.loc12_29.1 (%ptr.955)) -> @GetAddr.%ptr.loc12_38.1 (%ptr.79f) {
+// CHECK:STDOUT:   fn(%self.param: @GetAddr.%ptr.loc15_29.1 (%ptr.955)) -> @GetAddr.%ptr.loc15_38.1 (%ptr.79f) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %self.ref: @GetAddr.%ptr.loc12_29.1 (%ptr.955) = name_ref self, %self
-// CHECK:STDOUT:     %.loc13_17.1: ref @GetAddr.%Class (%Class) = deref %self.ref
-// CHECK:STDOUT:     %k.ref: @GetAddr.%Class.elem (%Class.elem) = name_ref k, @Class.%.loc21 [concrete = @Class.%.loc21]
-// CHECK:STDOUT:     %.loc13_17.2: ref @GetAddr.%T (%T) = class_element_access %.loc13_17.1, element0
-// CHECK:STDOUT:     %addr: @GetAddr.%ptr.loc12_38.1 (%ptr.79f) = addr_of %.loc13_17.2
+// CHECK:STDOUT:     %self.ref: @GetAddr.%ptr.loc15_29.1 (%ptr.955) = name_ref self, %self
+// CHECK:STDOUT:     %.loc16_17.1: ref @GetAddr.%Class (%Class) = deref %self.ref
+// CHECK:STDOUT:     %k.ref: @GetAddr.%Class.elem (%Class.elem) = name_ref k, @Class.%.loc24 [concrete = @Class.%.loc24]
+// CHECK:STDOUT:     %.loc16_17.2: ref @GetAddr.%T (%T) = class_element_access %.loc16_17.1, element0
+// CHECK:STDOUT:     %addr: @GetAddr.%ptr.loc15_38.1 (%ptr.79f) = addr_of %.loc16_17.2
 // CHECK:STDOUT:     return %addr
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @GetValue(@Class.%T.loc11_13.1: type) {
+// CHECK:STDOUT: generic fn @GetValue(@Class.%T.loc14_13.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %pattern_type.loc17_15: type = pattern_type %Class [symbolic = %pattern_type.loc17_15 (constants.%pattern_type.3c1)]
-// CHECK:STDOUT:   %pattern_type.loc17_29: type = pattern_type %T [symbolic = %pattern_type.loc17_29 (constants.%pattern_type.7dc)]
+// CHECK:STDOUT:   %pattern_type.loc20_15: type = pattern_type %Class [symbolic = %pattern_type.loc20_15 (constants.%pattern_type.3c1)]
+// CHECK:STDOUT:   %pattern_type.loc20_29: type = pattern_type %T [symbolic = %pattern_type.loc20_29 (constants.%pattern_type.7dc)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc17: <witness> = require_complete_type %Class [symbolic = %require_complete.loc17 (constants.%require_complete.4f8)]
+// CHECK:STDOUT:   %require_complete.loc20: <witness> = require_complete_type %Class [symbolic = %require_complete.loc20 (constants.%require_complete.4f8)]
 // CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T [symbolic = %Class.elem (constants.%Class.elem)]
-// CHECK:STDOUT:   %require_complete.loc18: <witness> = require_complete_type %T [symbolic = %require_complete.loc18 (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %require_complete.loc21: <witness> = require_complete_type %T [symbolic = %require_complete.loc21 (constants.%require_complete.4ae)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%self.param: @GetValue.%Class (%Class)) -> @GetValue.%T (%T) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %self.ref: @GetValue.%Class (%Class) = name_ref self, %self
-// CHECK:STDOUT:     %k.ref: @GetValue.%Class.elem (%Class.elem) = name_ref k, @Class.%.loc21 [concrete = @Class.%.loc21]
-// CHECK:STDOUT:     %.loc18_16.1: ref @GetValue.%T (%T) = class_element_access %self.ref, element0
-// CHECK:STDOUT:     %.loc18_16.2: @GetValue.%T (%T) = bind_value %.loc18_16.1
-// CHECK:STDOUT:     return %.loc18_16.2
+// CHECK:STDOUT:     %k.ref: @GetValue.%Class.elem (%Class.elem) = name_ref k, @Class.%.loc24 [concrete = @Class.%.loc24]
+// CHECK:STDOUT:     %.loc21_16.1: ref @GetValue.%T (%T) = class_element_access %self.ref, element0
+// CHECK:STDOUT:     %.loc21_16.2: @GetValue.%T (%T) = bind_value %.loc21_16.1
+// CHECK:STDOUT:     return %.loc21_16.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %GetAddr.type => constants.%GetAddr.type
@@ -207,27 +210,27 @@ class Declaration(T:! type);
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.4ae
 // CHECK:STDOUT:   %Class => constants.%Class
 // CHECK:STDOUT:   %Class.elem => constants.%Class.elem
-// CHECK:STDOUT:   %struct_type.k.loc22_1.2 => constants.%struct_type.k
-// CHECK:STDOUT:   %complete_type.loc22_1.2 => constants.%complete_type
+// CHECK:STDOUT:   %struct_type.k.loc25_1.2 => constants.%struct_type.k
+// CHECK:STDOUT:   %complete_type.loc25_1.2 => constants.%complete_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetAddr(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
-// CHECK:STDOUT:   %ptr.loc12_29.1 => constants.%ptr.955
-// CHECK:STDOUT:   %pattern_type.loc12_19 => constants.%pattern_type.9e0
-// CHECK:STDOUT:   %ptr.loc12_38.1 => constants.%ptr.79f
-// CHECK:STDOUT:   %pattern_type.loc12_34 => constants.%pattern_type.afe
+// CHECK:STDOUT:   %ptr.loc15_29.1 => constants.%ptr.955
+// CHECK:STDOUT:   %pattern_type.loc15_19 => constants.%pattern_type.9e0
+// CHECK:STDOUT:   %ptr.loc15_38.1 => constants.%ptr.79f
+// CHECK:STDOUT:   %pattern_type.loc15_34 => constants.%pattern_type.afe
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetValue(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
-// CHECK:STDOUT:   %pattern_type.loc17_15 => constants.%pattern_type.3c1
-// CHECK:STDOUT:   %pattern_type.loc17_29 => constants.%pattern_type.7dc
+// CHECK:STDOUT:   %pattern_type.loc20_15 => constants.%pattern_type.3c1
+// CHECK:STDOUT:   %pattern_type.loc20_29 => constants.%pattern_type.7dc
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Declaration(constants.%T) {
-// CHECK:STDOUT:   %T.loc24_19.2 => constants.%T
+// CHECK:STDOUT:   %T.loc27_19.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/call.carbon
+++ b/toolchain/check/testdata/class/generic/call.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/call.carbon

--- a/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
+++ b/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/complete_in_conversion.carbon

--- a/toolchain/check/testdata/class/generic/field.carbon
+++ b/toolchain/check/testdata/class/generic/field.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/field.carbon
@@ -89,7 +92,7 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.0fa = binding_pattern c [concrete]
@@ -97,13 +100,13 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc15_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc18_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %c.param: %Class.247 = value_param call_param0
-// CHECK:STDOUT:     %.loc15: type = splice_block %Class [concrete = constants.%Class.247] {
+// CHECK:STDOUT:     %.loc18: type = splice_block %Class [concrete = constants.%Class.247] {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %int_32.loc15_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc15_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %int_32.loc18_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc18_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:       %Class: type = class_type @Class, @Class(constants.%i32) [concrete = constants.%Class.247]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %Class.247 = bind_name c, %c.param
@@ -112,163 +115,163 @@ fn H(U:! type, c: Class(U)) -> U {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
-// CHECK:STDOUT:     %c.patt: @G.%pattern_type.loc19_16 (%pattern_type.3c18fb.1) = binding_pattern c [concrete]
-// CHECK:STDOUT:     %c.param_patt: @G.%pattern_type.loc19_16 (%pattern_type.3c18fb.1) = value_param_pattern %c.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %return.patt: @G.%pattern_type.loc19_29 (%pattern_type.7dcd0a.1) = return_slot_pattern [concrete]
-// CHECK:STDOUT:     %return.param_patt: @G.%pattern_type.loc19_29 (%pattern_type.7dcd0a.1) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:     %c.patt: @G.%pattern_type.loc22_16 (%pattern_type.3c18fb.1) = binding_pattern c [concrete]
+// CHECK:STDOUT:     %c.param_patt: @G.%pattern_type.loc22_16 (%pattern_type.3c18fb.1) = value_param_pattern %c.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %return.patt: @G.%pattern_type.loc22_29 (%pattern_type.7dcd0a.1) = return_slot_pattern [concrete]
+// CHECK:STDOUT:     %return.param_patt: @G.%pattern_type.loc22_29 (%pattern_type.7dcd0a.1) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref.loc19_32: type = name_ref T, %T.loc19_6.1 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.loc19_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:     %c.param: @G.%Class.loc19_26.2 (%Class.fe1b2d.1) = value_param call_param0
-// CHECK:STDOUT:     %.loc19: type = splice_block %Class.loc19_26.1 [symbolic = %Class.loc19_26.2 (constants.%Class.fe1b2d.1)] {
+// CHECK:STDOUT:     %T.ref.loc22_32: type = name_ref T, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc22_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:     %c.param: @G.%Class.loc22_26.2 (%Class.fe1b2d.1) = value_param call_param0
+// CHECK:STDOUT:     %.loc22: type = splice_block %Class.loc22_26.1 [symbolic = %Class.loc22_26.2 (constants.%Class.fe1b2d.1)] {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %T.ref.loc19_25: type = name_ref T, %T.loc19_6.1 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:       %Class.loc19_26.1: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc19_26.2 (constants.%Class.fe1b2d.1)]
+// CHECK:STDOUT:       %T.ref.loc22_25: type = name_ref T, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:       %Class.loc22_26.1: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc22_26.2 (constants.%Class.fe1b2d.1)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %c: @G.%Class.loc19_26.2 (%Class.fe1b2d.1) = bind_name c, %c.param
-// CHECK:STDOUT:     %return.param: ref @G.%T.loc19_6.2 (%T) = out_param call_param1
-// CHECK:STDOUT:     %return: ref @G.%T.loc19_6.2 (%T) = return_slot %return.param
+// CHECK:STDOUT:     %c: @G.%Class.loc22_26.2 (%Class.fe1b2d.1) = bind_name c, %c.param
+// CHECK:STDOUT:     %return.param: ref @G.%T.loc22_6.2 (%T) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @G.%T.loc22_6.2 (%T) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {
 // CHECK:STDOUT:     %U.patt: %pattern_type.98f = symbolic_binding_pattern U, 0 [concrete]
-// CHECK:STDOUT:     %c.patt: @H.%pattern_type.loc23_16 (%pattern_type.3c18fb.2) = binding_pattern c [concrete]
-// CHECK:STDOUT:     %c.param_patt: @H.%pattern_type.loc23_16 (%pattern_type.3c18fb.2) = value_param_pattern %c.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %return.patt: @H.%pattern_type.loc23_29 (%pattern_type.7dcd0a.2) = return_slot_pattern [concrete]
-// CHECK:STDOUT:     %return.param_patt: @H.%pattern_type.loc23_29 (%pattern_type.7dcd0a.2) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:     %c.patt: @H.%pattern_type.loc26_16 (%pattern_type.3c18fb.2) = binding_pattern c [concrete]
+// CHECK:STDOUT:     %c.param_patt: @H.%pattern_type.loc26_16 (%pattern_type.3c18fb.2) = value_param_pattern %c.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %return.patt: @H.%pattern_type.loc26_29 (%pattern_type.7dcd0a.2) = return_slot_pattern [concrete]
+// CHECK:STDOUT:     %return.param_patt: @H.%pattern_type.loc26_29 (%pattern_type.7dcd0a.2) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %U.ref.loc23_32: type = name_ref U, %U.loc23_6.1 [symbolic = %U.loc23_6.2 (constants.%U)]
-// CHECK:STDOUT:     %U.loc23_6.1: type = bind_symbolic_name U, 0 [symbolic = %U.loc23_6.2 (constants.%U)]
-// CHECK:STDOUT:     %c.param: @H.%Class.loc23_26.2 (%Class.fe1b2d.2) = value_param call_param0
-// CHECK:STDOUT:     %.loc23: type = splice_block %Class.loc23_26.1 [symbolic = %Class.loc23_26.2 (constants.%Class.fe1b2d.2)] {
+// CHECK:STDOUT:     %U.ref.loc26_32: type = name_ref U, %U.loc26_6.1 [symbolic = %U.loc26_6.2 (constants.%U)]
+// CHECK:STDOUT:     %U.loc26_6.1: type = bind_symbolic_name U, 0 [symbolic = %U.loc26_6.2 (constants.%U)]
+// CHECK:STDOUT:     %c.param: @H.%Class.loc26_26.2 (%Class.fe1b2d.2) = value_param call_param0
+// CHECK:STDOUT:     %.loc26: type = splice_block %Class.loc26_26.1 [symbolic = %Class.loc26_26.2 (constants.%Class.fe1b2d.2)] {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %U.ref.loc23_25: type = name_ref U, %U.loc23_6.1 [symbolic = %U.loc23_6.2 (constants.%U)]
-// CHECK:STDOUT:       %Class.loc23_26.1: type = class_type @Class, @Class(constants.%U) [symbolic = %Class.loc23_26.2 (constants.%Class.fe1b2d.2)]
+// CHECK:STDOUT:       %U.ref.loc26_25: type = name_ref U, %U.loc26_6.1 [symbolic = %U.loc26_6.2 (constants.%U)]
+// CHECK:STDOUT:       %Class.loc26_26.1: type = class_type @Class, @Class(constants.%U) [symbolic = %Class.loc26_26.2 (constants.%Class.fe1b2d.2)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %c: @H.%Class.loc23_26.2 (%Class.fe1b2d.2) = bind_name c, %c.param
-// CHECK:STDOUT:     %return.param: ref @H.%U.loc23_6.2 (%U) = out_param call_param1
-// CHECK:STDOUT:     %return: ref @H.%U.loc23_6.2 (%U) = return_slot %return.param
+// CHECK:STDOUT:     %c: @H.%Class.loc26_26.2 (%Class.fe1b2d.2) = bind_name c, %c.param
+// CHECK:STDOUT:     %return.param: ref @H.%U.loc26_6.2 (%U) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @H.%U.loc26_6.2 (%U) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Class(%T.loc11_13.1: type) {
-// CHECK:STDOUT:   %T.loc11_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Class(%T.loc14_13.1: type) {
+// CHECK:STDOUT:   %T.loc14_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc11_13.2 [symbolic = %require_complete (constants.%require_complete.4aeca8.1)]
-// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc11_13.2) [symbolic = %Class (constants.%Class.fe1b2d.1)]
-// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc11_13.2 [symbolic = %Class.elem (constants.%Class.elem.e262de.1)]
-// CHECK:STDOUT:   %struct_type.x.loc13_1.2: type = struct_type {.x: @Class.%T.loc11_13.2 (%T)} [symbolic = %struct_type.x.loc13_1.2 (constants.%struct_type.x.2ac3f0.1)]
-// CHECK:STDOUT:   %complete_type.loc13_1.2: <witness> = complete_type_witness %struct_type.x.loc13_1.2 [symbolic = %complete_type.loc13_1.2 (constants.%complete_type.4339b3.1)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc14_13.2 [symbolic = %require_complete (constants.%require_complete.4aeca8.1)]
+// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc14_13.2) [symbolic = %Class (constants.%Class.fe1b2d.1)]
+// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc14_13.2 [symbolic = %Class.elem (constants.%Class.elem.e262de.1)]
+// CHECK:STDOUT:   %struct_type.x.loc16_1.2: type = struct_type {.x: @Class.%T.loc14_13.2 (%T)} [symbolic = %struct_type.x.loc16_1.2 (constants.%struct_type.x.2ac3f0.1)]
+// CHECK:STDOUT:   %complete_type.loc16_1.2: <witness> = complete_type_witness %struct_type.x.loc16_1.2 [symbolic = %complete_type.loc16_1.2 (constants.%complete_type.4339b3.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_13.1 [symbolic = %T.loc11_13.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc12: @Class.%Class.elem (%Class.elem.e262de.1) = field_decl x, element0 [concrete]
-// CHECK:STDOUT:     %struct_type.x.loc13_1.1: type = struct_type {.x: %T} [symbolic = %struct_type.x.loc13_1.2 (constants.%struct_type.x.2ac3f0.1)]
-// CHECK:STDOUT:     %complete_type.loc13_1.1: <witness> = complete_type_witness %struct_type.x.loc13_1.1 [symbolic = %complete_type.loc13_1.2 (constants.%complete_type.4339b3.1)]
-// CHECK:STDOUT:     complete_type_witness = %complete_type.loc13_1.1
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_13.1 [symbolic = %T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc15: @Class.%Class.elem (%Class.elem.e262de.1) = field_decl x, element0 [concrete]
+// CHECK:STDOUT:     %struct_type.x.loc16_1.1: type = struct_type {.x: %T} [symbolic = %struct_type.x.loc16_1.2 (constants.%struct_type.x.2ac3f0.1)]
+// CHECK:STDOUT:     %complete_type.loc16_1.1: <witness> = complete_type_witness %struct_type.x.loc16_1.1 [symbolic = %complete_type.loc16_1.2 (constants.%complete_type.4339b3.1)]
+// CHECK:STDOUT:     complete_type_witness = %complete_type.loc16_1.1
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = constants.%Class.fe1b2d.1
 // CHECK:STDOUT:     .T = <poisoned>
-// CHECK:STDOUT:     .x = %.loc12
+// CHECK:STDOUT:     .x = %.loc15
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%c.param: %Class.247) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: %Class.247 = name_ref c, %c
-// CHECK:STDOUT:   %x.ref: %Class.elem.2d8 = name_ref x, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:   %.loc16_11.1: ref %i32 = class_element_access %c.ref, element0
-// CHECK:STDOUT:   %.loc16_11.2: %i32 = bind_value %.loc16_11.1
-// CHECK:STDOUT:   return %.loc16_11.2
+// CHECK:STDOUT:   %x.ref: %Class.elem.2d8 = name_ref x, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:   %.loc19_11.1: ref %i32 = class_element_access %c.ref, element0
+// CHECK:STDOUT:   %.loc19_11.2: %i32 = bind_value %.loc19_11.1
+// CHECK:STDOUT:   return %.loc19_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @G(%T.loc19_6.1: type) {
-// CHECK:STDOUT:   %T.loc19_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:   %Class.loc19_26.2: type = class_type @Class, @Class(%T.loc19_6.2) [symbolic = %Class.loc19_26.2 (constants.%Class.fe1b2d.1)]
-// CHECK:STDOUT:   %pattern_type.loc19_16: type = pattern_type %Class.loc19_26.2 [symbolic = %pattern_type.loc19_16 (constants.%pattern_type.3c18fb.1)]
-// CHECK:STDOUT:   %pattern_type.loc19_29: type = pattern_type %T.loc19_6.2 [symbolic = %pattern_type.loc19_29 (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT: generic fn @G(%T.loc22_6.1: type) {
+// CHECK:STDOUT:   %T.loc22_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:   %Class.loc22_26.2: type = class_type @Class, @Class(%T.loc22_6.2) [symbolic = %Class.loc22_26.2 (constants.%Class.fe1b2d.1)]
+// CHECK:STDOUT:   %pattern_type.loc22_16: type = pattern_type %Class.loc22_26.2 [symbolic = %pattern_type.loc22_16 (constants.%pattern_type.3c18fb.1)]
+// CHECK:STDOUT:   %pattern_type.loc22_29: type = pattern_type %T.loc22_6.2 [symbolic = %pattern_type.loc22_29 (constants.%pattern_type.7dcd0a.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc19: <witness> = require_complete_type %Class.loc19_26.2 [symbolic = %require_complete.loc19 (constants.%require_complete.4f8a42.1)]
-// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class.loc19_26.2, %T.loc19_6.2 [symbolic = %Class.elem (constants.%Class.elem.e262de.1)]
-// CHECK:STDOUT:   %require_complete.loc20: <witness> = require_complete_type %T.loc19_6.2 [symbolic = %require_complete.loc20 (constants.%require_complete.4aeca8.1)]
+// CHECK:STDOUT:   %require_complete.loc22: <witness> = require_complete_type %Class.loc22_26.2 [symbolic = %require_complete.loc22 (constants.%require_complete.4f8a42.1)]
+// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class.loc22_26.2, %T.loc22_6.2 [symbolic = %Class.elem (constants.%Class.elem.e262de.1)]
+// CHECK:STDOUT:   %require_complete.loc23: <witness> = require_complete_type %T.loc22_6.2 [symbolic = %require_complete.loc23 (constants.%require_complete.4aeca8.1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%c.param: @G.%Class.loc19_26.2 (%Class.fe1b2d.1)) -> @G.%T.loc19_6.2 (%T) {
+// CHECK:STDOUT:   fn(%c.param: @G.%Class.loc22_26.2 (%Class.fe1b2d.1)) -> @G.%T.loc22_6.2 (%T) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %c.ref: @G.%Class.loc19_26.2 (%Class.fe1b2d.1) = name_ref c, %c
-// CHECK:STDOUT:     %x.ref: @G.%Class.elem (%Class.elem.e262de.1) = name_ref x, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:     %.loc20_11.1: ref @G.%T.loc19_6.2 (%T) = class_element_access %c.ref, element0
-// CHECK:STDOUT:     %.loc20_11.2: @G.%T.loc19_6.2 (%T) = bind_value %.loc20_11.1
-// CHECK:STDOUT:     return %.loc20_11.2
+// CHECK:STDOUT:     %c.ref: @G.%Class.loc22_26.2 (%Class.fe1b2d.1) = name_ref c, %c
+// CHECK:STDOUT:     %x.ref: @G.%Class.elem (%Class.elem.e262de.1) = name_ref x, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:     %.loc23_11.1: ref @G.%T.loc22_6.2 (%T) = class_element_access %c.ref, element0
+// CHECK:STDOUT:     %.loc23_11.2: @G.%T.loc22_6.2 (%T) = bind_value %.loc23_11.1
+// CHECK:STDOUT:     return %.loc23_11.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @H(%U.loc23_6.1: type) {
-// CHECK:STDOUT:   %U.loc23_6.2: type = bind_symbolic_name U, 0 [symbolic = %U.loc23_6.2 (constants.%U)]
-// CHECK:STDOUT:   %Class.loc23_26.2: type = class_type @Class, @Class(%U.loc23_6.2) [symbolic = %Class.loc23_26.2 (constants.%Class.fe1b2d.2)]
-// CHECK:STDOUT:   %pattern_type.loc23_16: type = pattern_type %Class.loc23_26.2 [symbolic = %pattern_type.loc23_16 (constants.%pattern_type.3c18fb.2)]
-// CHECK:STDOUT:   %pattern_type.loc23_29: type = pattern_type %U.loc23_6.2 [symbolic = %pattern_type.loc23_29 (constants.%pattern_type.7dcd0a.2)]
+// CHECK:STDOUT: generic fn @H(%U.loc26_6.1: type) {
+// CHECK:STDOUT:   %U.loc26_6.2: type = bind_symbolic_name U, 0 [symbolic = %U.loc26_6.2 (constants.%U)]
+// CHECK:STDOUT:   %Class.loc26_26.2: type = class_type @Class, @Class(%U.loc26_6.2) [symbolic = %Class.loc26_26.2 (constants.%Class.fe1b2d.2)]
+// CHECK:STDOUT:   %pattern_type.loc26_16: type = pattern_type %Class.loc26_26.2 [symbolic = %pattern_type.loc26_16 (constants.%pattern_type.3c18fb.2)]
+// CHECK:STDOUT:   %pattern_type.loc26_29: type = pattern_type %U.loc26_6.2 [symbolic = %pattern_type.loc26_29 (constants.%pattern_type.7dcd0a.2)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc23_29: <witness> = require_complete_type %U.loc23_6.2 [symbolic = %require_complete.loc23_29 (constants.%require_complete.4aeca8.2)]
-// CHECK:STDOUT:   %require_complete.loc23_17: <witness> = require_complete_type %Class.loc23_26.2 [symbolic = %require_complete.loc23_17 (constants.%require_complete.4f8a42.2)]
-// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class.loc23_26.2, %U.loc23_6.2 [symbolic = %Class.elem (constants.%Class.elem.e262de.2)]
+// CHECK:STDOUT:   %require_complete.loc26_29: <witness> = require_complete_type %U.loc26_6.2 [symbolic = %require_complete.loc26_29 (constants.%require_complete.4aeca8.2)]
+// CHECK:STDOUT:   %require_complete.loc26_17: <witness> = require_complete_type %Class.loc26_26.2 [symbolic = %require_complete.loc26_17 (constants.%require_complete.4f8a42.2)]
+// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class.loc26_26.2, %U.loc26_6.2 [symbolic = %Class.elem (constants.%Class.elem.e262de.2)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%c.param: @H.%Class.loc23_26.2 (%Class.fe1b2d.2)) -> @H.%U.loc23_6.2 (%U) {
+// CHECK:STDOUT:   fn(%c.param: @H.%Class.loc26_26.2 (%Class.fe1b2d.2)) -> @H.%U.loc26_6.2 (%U) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %c.ref: @H.%Class.loc23_26.2 (%Class.fe1b2d.2) = name_ref c, %c
-// CHECK:STDOUT:     %x.ref: @H.%Class.elem (%Class.elem.e262de.2) = name_ref x, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:     %.loc24_11.1: ref @H.%U.loc23_6.2 (%U) = class_element_access %c.ref, element0
-// CHECK:STDOUT:     %.loc24_11.2: @H.%U.loc23_6.2 (%U) = bind_value %.loc24_11.1
-// CHECK:STDOUT:     return %.loc24_11.2
+// CHECK:STDOUT:     %c.ref: @H.%Class.loc26_26.2 (%Class.fe1b2d.2) = name_ref c, %c
+// CHECK:STDOUT:     %x.ref: @H.%Class.elem (%Class.elem.e262de.2) = name_ref x, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:     %.loc27_11.1: ref @H.%U.loc26_6.2 (%U) = class_element_access %c.ref, element0
+// CHECK:STDOUT:     %.loc27_11.2: @H.%U.loc26_6.2 (%U) = bind_value %.loc27_11.1
+// CHECK:STDOUT:     return %.loc27_11.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.4aeca8.1
 // CHECK:STDOUT:   %Class => constants.%Class.fe1b2d.1
 // CHECK:STDOUT:   %Class.elem => constants.%Class.elem.e262de.1
-// CHECK:STDOUT:   %struct_type.x.loc13_1.2 => constants.%struct_type.x.2ac3f0.1
-// CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.4339b3.1
+// CHECK:STDOUT:   %struct_type.x.loc16_1.2 => constants.%struct_type.x.2ac3f0.1
+// CHECK:STDOUT:   %complete_type.loc16_1.2 => constants.%complete_type.4339b3.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%i32) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%i32
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%i32
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
 // CHECK:STDOUT:   %Class => constants.%Class.247
 // CHECK:STDOUT:   %Class.elem => constants.%Class.elem.2d8
-// CHECK:STDOUT:   %struct_type.x.loc13_1.2 => constants.%struct_type.x.ed6
-// CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.1ec
+// CHECK:STDOUT:   %struct_type.x.loc16_1.2 => constants.%struct_type.x.ed6
+// CHECK:STDOUT:   %complete_type.loc16_1.2 => constants.%complete_type.1ec
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T) {
-// CHECK:STDOUT:   %T.loc19_6.2 => constants.%T
-// CHECK:STDOUT:   %Class.loc19_26.2 => constants.%Class.fe1b2d.1
-// CHECK:STDOUT:   %pattern_type.loc19_16 => constants.%pattern_type.3c18fb.1
-// CHECK:STDOUT:   %pattern_type.loc19_29 => constants.%pattern_type.7dcd0a.1
+// CHECK:STDOUT:   %T.loc22_6.2 => constants.%T
+// CHECK:STDOUT:   %Class.loc22_26.2 => constants.%Class.fe1b2d.1
+// CHECK:STDOUT:   %pattern_type.loc22_16 => constants.%pattern_type.3c18fb.1
+// CHECK:STDOUT:   %pattern_type.loc22_29 => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%U) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%U
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%U
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.4aeca8.2
 // CHECK:STDOUT:   %Class => constants.%Class.fe1b2d.2
 // CHECK:STDOUT:   %Class.elem => constants.%Class.elem.e262de.2
-// CHECK:STDOUT:   %struct_type.x.loc13_1.2 => constants.%struct_type.x.2ac3f0.2
-// CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.4339b3.2
+// CHECK:STDOUT:   %struct_type.x.loc16_1.2 => constants.%struct_type.x.2ac3f0.2
+// CHECK:STDOUT:   %complete_type.loc16_1.2 => constants.%complete_type.4339b3.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%U) {
-// CHECK:STDOUT:   %U.loc23_6.2 => constants.%U
-// CHECK:STDOUT:   %Class.loc23_26.2 => constants.%Class.fe1b2d.2
-// CHECK:STDOUT:   %pattern_type.loc23_16 => constants.%pattern_type.3c18fb.2
-// CHECK:STDOUT:   %pattern_type.loc23_29 => constants.%pattern_type.7dcd0a.2
+// CHECK:STDOUT:   %U.loc26_6.2 => constants.%U
+// CHECK:STDOUT:   %Class.loc26_26.2 => constants.%Class.fe1b2d.2
+// CHECK:STDOUT:   %pattern_type.loc26_16 => constants.%pattern_type.3c18fb.2
+// CHECK:STDOUT:   %pattern_type.loc26_29 => constants.%pattern_type.7dcd0a.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/import.carbon
+++ b/toolchain/check/testdata/class/generic/import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/import.carbon

--- a/toolchain/check/testdata/class/generic/init.carbon
+++ b/toolchain/check/testdata/class/generic/init.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/init.carbon

--- a/toolchain/check/testdata/class/generic/member_access.carbon
+++ b/toolchain/check/testdata/class/generic/member_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/member_access.carbon

--- a/toolchain/check/testdata/class/generic/member_inline.carbon
+++ b/toolchain/check/testdata/class/generic/member_inline.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/member_inline.carbon

--- a/toolchain/check/testdata/class/generic/member_lookup.carbon
+++ b/toolchain/check/testdata/class/generic/member_lookup.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/member_lookup.carbon

--- a/toolchain/check/testdata/class/generic/member_out_of_line.carbon
+++ b/toolchain/check/testdata/class/generic/member_out_of_line.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/member_out_of_line.carbon

--- a/toolchain/check/testdata/class/generic/member_type.carbon
+++ b/toolchain/check/testdata/class/generic/member_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/member_type.carbon

--- a/toolchain/check/testdata/class/generic/method_deduce.carbon
+++ b/toolchain/check/testdata/class/generic/method_deduce.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/method_deduce.carbon
@@ -90,7 +93,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc17_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc17_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallGenericMethod.decl: %CallGenericMethod.type = fn_decl @CallGenericMethod [concrete = constants.%CallGenericMethod] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.827 = binding_pattern c [concrete]
@@ -98,14 +101,14 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.edc = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.edc = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %A.ref.loc19_39: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:     %B.ref.loc19: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:     %.loc19_43.1: %tuple.type.24b = tuple_literal (%A.ref.loc19_39, %B.ref.loc19)
-// CHECK:STDOUT:     %.loc19_43.2: type = converted %.loc19_43.1, constants.%tuple.type.cc6 [concrete = constants.%tuple.type.cc6]
+// CHECK:STDOUT:     %A.ref.loc22_39: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:     %B.ref.loc22: type = name_ref B, file.%B.decl [concrete = constants.%B]
+// CHECK:STDOUT:     %.loc22_43.1: %tuple.type.24b = tuple_literal (%A.ref.loc22_39, %B.ref.loc22)
+// CHECK:STDOUT:     %.loc22_43.2: type = converted %.loc22_43.1, constants.%tuple.type.cc6 [concrete = constants.%tuple.type.cc6]
 // CHECK:STDOUT:     %c.param: %Class.480 = value_param call_param0
-// CHECK:STDOUT:     %.loc19_32: type = splice_block %Class [concrete = constants.%Class.480] {
+// CHECK:STDOUT:     %.loc22_32: type = splice_block %Class [concrete = constants.%Class.480] {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %A.ref.loc19_31: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:       %A.ref.loc22_31: type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:       %Class: type = class_type @Class, @Class(constants.%A) [concrete = constants.%Class.480]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %Class.480 = bind_name c, %c.param
@@ -118,14 +121,14 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.edc = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.edc = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %A.ref.loc23_58: type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:     %B.ref.loc23: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:     %.loc23_62.1: %tuple.type.24b = tuple_literal (%A.ref.loc23_58, %B.ref.loc23)
-// CHECK:STDOUT:     %.loc23_62.2: type = converted %.loc23_62.1, constants.%tuple.type.cc6 [concrete = constants.%tuple.type.cc6]
+// CHECK:STDOUT:     %A.ref.loc26_58: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:     %B.ref.loc26: type = name_ref B, file.%B.decl [concrete = constants.%B]
+// CHECK:STDOUT:     %.loc26_62.1: %tuple.type.24b = tuple_literal (%A.ref.loc26_58, %B.ref.loc26)
+// CHECK:STDOUT:     %.loc26_62.2: type = converted %.loc26_62.1, constants.%tuple.type.cc6 [concrete = constants.%tuple.type.cc6]
 // CHECK:STDOUT:     %c.param: %Class.480 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_51: type = splice_block %Class [concrete = constants.%Class.480] {
+// CHECK:STDOUT:     %.loc26_51: type = splice_block %Class [concrete = constants.%Class.480] {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %A.ref.loc23_50: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:       %A.ref.loc26_50: type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:       %Class: type = class_type @Class, @Class(constants.%A) [concrete = constants.%Class.480]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %Class.480 = bind_name c, %c.param
@@ -152,13 +155,13 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Class(%T.loc14_13.1: type) {
-// CHECK:STDOUT:   %T.loc14_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Class(%T.loc17_13.1: type) {
+// CHECK:STDOUT:   %T.loc17_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc17_13.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Get.type: type = fn_type @Get, @Class(%T.loc14_13.2) [symbolic = %Get.type (constants.%Get.type.fd9)]
+// CHECK:STDOUT:   %Get.type: type = fn_type @Get, @Class(%T.loc17_13.2) [symbolic = %Get.type (constants.%Get.type.fd9)]
 // CHECK:STDOUT:   %Get: @Class.%Get.type (%Get.type.fd9) = struct_value () [symbolic = %Get (constants.%Get.cf9)]
-// CHECK:STDOUT:   %GetNoDeduce.type: type = fn_type @GetNoDeduce, @Class(%T.loc14_13.2) [symbolic = %GetNoDeduce.type (constants.%GetNoDeduce.type.766)]
+// CHECK:STDOUT:   %GetNoDeduce.type: type = fn_type @GetNoDeduce, @Class(%T.loc17_13.2) [symbolic = %GetNoDeduce.type (constants.%GetNoDeduce.type.766)]
 // CHECK:STDOUT:   %GetNoDeduce: @Class.%GetNoDeduce.type (%GetNoDeduce.type.766) = struct_value () [symbolic = %GetNoDeduce (constants.%GetNoDeduce.c9a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
@@ -167,29 +170,29 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:       %return.patt: @Get.%pattern_type (%pattern_type.65c) = return_slot_pattern [concrete]
 // CHECK:STDOUT:       %return.param_patt: @Get.%pattern_type (%pattern_type.65c) = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:       %U.ref.loc15_27: type = name_ref U, %U.loc15_10.2 [symbolic = %U.loc15_10.1 (constants.%U)]
-// CHECK:STDOUT:       %.loc15_28.1: %tuple.type.24b = tuple_literal (%T.ref, %U.ref.loc15_27)
-// CHECK:STDOUT:       %.loc15_28.2: type = converted %.loc15_28.1, constants.%tuple.type.30b [symbolic = %tuple.type (constants.%tuple.type.30b)]
-// CHECK:STDOUT:       %U.loc15_10.2: type = bind_symbolic_name U, 1 [symbolic = %U.loc15_10.1 (constants.%U)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc17_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %U.ref.loc18_27: type = name_ref U, %U.loc18_10.2 [symbolic = %U.loc18_10.1 (constants.%U)]
+// CHECK:STDOUT:       %.loc18_28.1: %tuple.type.24b = tuple_literal (%T.ref, %U.ref.loc18_27)
+// CHECK:STDOUT:       %.loc18_28.2: type = converted %.loc18_28.1, constants.%tuple.type.30b [symbolic = %tuple.type (constants.%tuple.type.30b)]
+// CHECK:STDOUT:       %U.loc18_10.2: type = bind_symbolic_name U, 1 [symbolic = %U.loc18_10.1 (constants.%U)]
 // CHECK:STDOUT:       %return.param: ref @Get.%tuple.type (%tuple.type.30b) = out_param call_param0
 // CHECK:STDOUT:       %return: ref @Get.%tuple.type (%tuple.type.30b) = return_slot %return.param
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %GetNoDeduce.decl: @Class.%GetNoDeduce.type (%GetNoDeduce.type.766) = fn_decl @GetNoDeduce [symbolic = @Class.%GetNoDeduce (constants.%GetNoDeduce.c9a)] {
-// CHECK:STDOUT:       %x.patt: @GetNoDeduce.%pattern_type.loc16_18 (%pattern_type.7dc) = binding_pattern x [concrete]
-// CHECK:STDOUT:       %x.param_patt: @GetNoDeduce.%pattern_type.loc16_18 (%pattern_type.7dc) = value_param_pattern %x.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %x.patt: @GetNoDeduce.%pattern_type.loc19_18 (%pattern_type.7dc) = binding_pattern x [concrete]
+// CHECK:STDOUT:       %x.param_patt: @GetNoDeduce.%pattern_type.loc19_18 (%pattern_type.7dc) = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:       %U.patt: %pattern_type.98f = symbolic_binding_pattern U, 1 [concrete]
-// CHECK:STDOUT:       %return.patt: @GetNoDeduce.%pattern_type.loc16_34 (%pattern_type.65c) = return_slot_pattern [concrete]
-// CHECK:STDOUT:       %return.param_patt: @GetNoDeduce.%pattern_type.loc16_34 (%pattern_type.65c) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:       %return.patt: @GetNoDeduce.%pattern_type.loc19_34 (%pattern_type.65c) = return_slot_pattern [concrete]
+// CHECK:STDOUT:       %return.param_patt: @GetNoDeduce.%pattern_type.loc19_34 (%pattern_type.65c) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %T.ref.loc16_38: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:       %U.ref.loc16_41: type = name_ref U, %U.loc16_24.2 [symbolic = %U.loc16_24.1 (constants.%U)]
-// CHECK:STDOUT:       %.loc16_42.1: %tuple.type.24b = tuple_literal (%T.ref.loc16_38, %U.ref.loc16_41)
-// CHECK:STDOUT:       %.loc16_42.2: type = converted %.loc16_42.1, constants.%tuple.type.30b [symbolic = %tuple.type (constants.%tuple.type.30b)]
+// CHECK:STDOUT:       %T.ref.loc19_38: type = name_ref T, @Class.%T.loc17_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %U.ref.loc19_41: type = name_ref U, %U.loc19_24.2 [symbolic = %U.loc19_24.1 (constants.%U)]
+// CHECK:STDOUT:       %.loc19_42.1: %tuple.type.24b = tuple_literal (%T.ref.loc19_38, %U.ref.loc19_41)
+// CHECK:STDOUT:       %.loc19_42.2: type = converted %.loc19_42.1, constants.%tuple.type.30b [symbolic = %tuple.type (constants.%tuple.type.30b)]
 // CHECK:STDOUT:       %x.param: @GetNoDeduce.%T (%T) = value_param call_param0
-// CHECK:STDOUT:       %T.ref.loc16_21: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %T.ref.loc19_21: type = name_ref T, @Class.%T.loc17_13.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %x: @GetNoDeduce.%T (%T) = bind_name x, %x.param
-// CHECK:STDOUT:       %U.loc16_24.2: type = bind_symbolic_name U, 1 [symbolic = %U.loc16_24.1 (constants.%U)]
+// CHECK:STDOUT:       %U.loc19_24.2: type = bind_symbolic_name U, 1 [symbolic = %U.loc19_24.1 (constants.%U)]
 // CHECK:STDOUT:       %return.param: ref @GetNoDeduce.%tuple.type (%tuple.type.30b) = out_param call_param1
 // CHECK:STDOUT:       %return: ref @GetNoDeduce.%tuple.type (%tuple.type.30b) = return_slot %return.param
 // CHECK:STDOUT:     }
@@ -205,53 +208,53 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Get(@Class.%T.loc14_13.1: type, %U.loc15_10.2: type) {
-// CHECK:STDOUT:   %U.loc15_10.1: type = bind_symbolic_name U, 1 [symbolic = %U.loc15_10.1 (constants.%U)]
+// CHECK:STDOUT: generic fn @Get(@Class.%T.loc17_13.1: type, %U.loc18_10.2: type) {
+// CHECK:STDOUT:   %U.loc18_10.1: type = bind_symbolic_name U, 1 [symbolic = %U.loc18_10.1 (constants.%U)]
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:   %tuple.type: type = tuple_type (%T, %U.loc15_10.1) [symbolic = %tuple.type (constants.%tuple.type.30b)]
+// CHECK:STDOUT:   %tuple.type: type = tuple_type (%T, %U.loc18_10.1) [symbolic = %tuple.type (constants.%tuple.type.30b)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %tuple.type [symbolic = %pattern_type (constants.%pattern_type.65c)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %tuple.type [symbolic = %require_complete (constants.%require_complete.fe1)]
 // CHECK:STDOUT:   %Get.type: type = fn_type @Get, @Class(%T) [symbolic = %Get.type (constants.%Get.type.fd9)]
 // CHECK:STDOUT:   %Get: @Get.%Get.type (%Get.type.fd9) = struct_value () [symbolic = %Get (constants.%Get.cf9)]
-// CHECK:STDOUT:   %Get.specific_fn.loc15_39.2: <specific function> = specific_function %Get, @Get(%T, %U.loc15_10.1) [symbolic = %Get.specific_fn.loc15_39.2 (constants.%Get.specific_fn.f73)]
+// CHECK:STDOUT:   %Get.specific_fn.loc18_39.2: <specific function> = specific_function %Get, @Get(%T, %U.loc18_10.1) [symbolic = %Get.specific_fn.loc18_39.2 (constants.%Get.specific_fn.f73)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() -> %return.param: @Get.%tuple.type (%tuple.type.30b) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc15_39: @Get.%Get.type (%Get.type.fd9) = specific_constant @Class.%Get.decl, @Class(constants.%T) [symbolic = %Get (constants.%Get.cf9)]
-// CHECK:STDOUT:     %Get.ref: @Get.%Get.type (%Get.type.fd9) = name_ref Get, %.loc15_39 [symbolic = %Get (constants.%Get.cf9)]
-// CHECK:STDOUT:     %U.ref.loc15_43: type = name_ref U, %U.loc15_10.2 [symbolic = %U.loc15_10.1 (constants.%U)]
-// CHECK:STDOUT:     %Get.specific_fn.loc15_39.1: <specific function> = specific_function %Get.ref, @Get(constants.%T, constants.%U) [symbolic = %Get.specific_fn.loc15_39.2 (constants.%Get.specific_fn.f73)]
-// CHECK:STDOUT:     %.loc15_20: ref @Get.%tuple.type (%tuple.type.30b) = splice_block %return {}
-// CHECK:STDOUT:     %Get.call: init @Get.%tuple.type (%tuple.type.30b) = call %Get.specific_fn.loc15_39.1() to %.loc15_20
+// CHECK:STDOUT:     %.loc18_39: @Get.%Get.type (%Get.type.fd9) = specific_constant @Class.%Get.decl, @Class(constants.%T) [symbolic = %Get (constants.%Get.cf9)]
+// CHECK:STDOUT:     %Get.ref: @Get.%Get.type (%Get.type.fd9) = name_ref Get, %.loc18_39 [symbolic = %Get (constants.%Get.cf9)]
+// CHECK:STDOUT:     %U.ref.loc18_43: type = name_ref U, %U.loc18_10.2 [symbolic = %U.loc18_10.1 (constants.%U)]
+// CHECK:STDOUT:     %Get.specific_fn.loc18_39.1: <specific function> = specific_function %Get.ref, @Get(constants.%T, constants.%U) [symbolic = %Get.specific_fn.loc18_39.2 (constants.%Get.specific_fn.f73)]
+// CHECK:STDOUT:     %.loc18_20: ref @Get.%tuple.type (%tuple.type.30b) = splice_block %return {}
+// CHECK:STDOUT:     %Get.call: init @Get.%tuple.type (%tuple.type.30b) = call %Get.specific_fn.loc18_39.1() to %.loc18_20
 // CHECK:STDOUT:     return %Get.call to %return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @GetNoDeduce(@Class.%T.loc14_13.1: type, %U.loc16_24.2: type) {
+// CHECK:STDOUT: generic fn @GetNoDeduce(@Class.%T.loc17_13.1: type, %U.loc19_24.2: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:   %pattern_type.loc16_18: type = pattern_type %T [symbolic = %pattern_type.loc16_18 (constants.%pattern_type.7dc)]
-// CHECK:STDOUT:   %U.loc16_24.1: type = bind_symbolic_name U, 1 [symbolic = %U.loc16_24.1 (constants.%U)]
-// CHECK:STDOUT:   %tuple.type: type = tuple_type (%T, %U.loc16_24.1) [symbolic = %tuple.type (constants.%tuple.type.30b)]
-// CHECK:STDOUT:   %pattern_type.loc16_34: type = pattern_type %tuple.type [symbolic = %pattern_type.loc16_34 (constants.%pattern_type.65c)]
+// CHECK:STDOUT:   %pattern_type.loc19_18: type = pattern_type %T [symbolic = %pattern_type.loc19_18 (constants.%pattern_type.7dc)]
+// CHECK:STDOUT:   %U.loc19_24.1: type = bind_symbolic_name U, 1 [symbolic = %U.loc19_24.1 (constants.%U)]
+// CHECK:STDOUT:   %tuple.type: type = tuple_type (%T, %U.loc19_24.1) [symbolic = %tuple.type (constants.%tuple.type.30b)]
+// CHECK:STDOUT:   %pattern_type.loc19_34: type = pattern_type %tuple.type [symbolic = %pattern_type.loc19_34 (constants.%pattern_type.65c)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc16_19: <witness> = require_complete_type %T [symbolic = %require_complete.loc16_19 (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %require_complete.loc19_19: <witness> = require_complete_type %T [symbolic = %require_complete.loc19_19 (constants.%require_complete.4ae)]
 // CHECK:STDOUT:   %GetNoDeduce.type: type = fn_type @GetNoDeduce, @Class(%T) [symbolic = %GetNoDeduce.type (constants.%GetNoDeduce.type.766)]
 // CHECK:STDOUT:   %GetNoDeduce: @GetNoDeduce.%GetNoDeduce.type (%GetNoDeduce.type.766) = struct_value () [symbolic = %GetNoDeduce (constants.%GetNoDeduce.c9a)]
-// CHECK:STDOUT:   %GetNoDeduce.specific_fn.loc16_53.2: <specific function> = specific_function %GetNoDeduce, @GetNoDeduce(%T, %U.loc16_24.1) [symbolic = %GetNoDeduce.specific_fn.loc16_53.2 (constants.%GetNoDeduce.specific_fn.536)]
-// CHECK:STDOUT:   %require_complete.loc16_70: <witness> = require_complete_type %tuple.type [symbolic = %require_complete.loc16_70 (constants.%require_complete.fe1)]
+// CHECK:STDOUT:   %GetNoDeduce.specific_fn.loc19_53.2: <specific function> = specific_function %GetNoDeduce, @GetNoDeduce(%T, %U.loc19_24.1) [symbolic = %GetNoDeduce.specific_fn.loc19_53.2 (constants.%GetNoDeduce.specific_fn.536)]
+// CHECK:STDOUT:   %require_complete.loc19_70: <witness> = require_complete_type %tuple.type [symbolic = %require_complete.loc19_70 (constants.%require_complete.fe1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%x.param: @GetNoDeduce.%T (%T)) -> %return.param: @GetNoDeduce.%tuple.type (%tuple.type.30b) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc16_53: @GetNoDeduce.%GetNoDeduce.type (%GetNoDeduce.type.766) = specific_constant @Class.%GetNoDeduce.decl, @Class(constants.%T) [symbolic = %GetNoDeduce (constants.%GetNoDeduce.c9a)]
-// CHECK:STDOUT:     %GetNoDeduce.ref: @GetNoDeduce.%GetNoDeduce.type (%GetNoDeduce.type.766) = name_ref GetNoDeduce, %.loc16_53 [symbolic = %GetNoDeduce (constants.%GetNoDeduce.c9a)]
+// CHECK:STDOUT:     %.loc19_53: @GetNoDeduce.%GetNoDeduce.type (%GetNoDeduce.type.766) = specific_constant @Class.%GetNoDeduce.decl, @Class(constants.%T) [symbolic = %GetNoDeduce (constants.%GetNoDeduce.c9a)]
+// CHECK:STDOUT:     %GetNoDeduce.ref: @GetNoDeduce.%GetNoDeduce.type (%GetNoDeduce.type.766) = name_ref GetNoDeduce, %.loc19_53 [symbolic = %GetNoDeduce (constants.%GetNoDeduce.c9a)]
 // CHECK:STDOUT:     %x.ref: @GetNoDeduce.%T (%T) = name_ref x, %x
-// CHECK:STDOUT:     %U.ref.loc16_68: type = name_ref U, %U.loc16_24.2 [symbolic = %U.loc16_24.1 (constants.%U)]
-// CHECK:STDOUT:     %GetNoDeduce.specific_fn.loc16_53.1: <specific function> = specific_function %GetNoDeduce.ref, @GetNoDeduce(constants.%T, constants.%U) [symbolic = %GetNoDeduce.specific_fn.loc16_53.2 (constants.%GetNoDeduce.specific_fn.536)]
-// CHECK:STDOUT:     %.loc16_34: ref @GetNoDeduce.%tuple.type (%tuple.type.30b) = splice_block %return {}
-// CHECK:STDOUT:     %GetNoDeduce.call: init @GetNoDeduce.%tuple.type (%tuple.type.30b) = call %GetNoDeduce.specific_fn.loc16_53.1(%x.ref) to %.loc16_34
+// CHECK:STDOUT:     %U.ref.loc19_68: type = name_ref U, %U.loc19_24.2 [symbolic = %U.loc19_24.1 (constants.%U)]
+// CHECK:STDOUT:     %GetNoDeduce.specific_fn.loc19_53.1: <specific function> = specific_function %GetNoDeduce.ref, @GetNoDeduce(constants.%T, constants.%U) [symbolic = %GetNoDeduce.specific_fn.loc19_53.2 (constants.%GetNoDeduce.specific_fn.536)]
+// CHECK:STDOUT:     %.loc19_34: ref @GetNoDeduce.%tuple.type (%tuple.type.30b) = splice_block %return {}
+// CHECK:STDOUT:     %GetNoDeduce.call: init @GetNoDeduce.%tuple.type (%tuple.type.30b) = call %GetNoDeduce.specific_fn.loc19_53.1(%x.ref) to %.loc19_34
 // CHECK:STDOUT:     return %GetNoDeduce.call to %return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -259,35 +262,35 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT: fn @CallGenericMethod(%c.param: %Class.480) -> %return.param: %tuple.type.cc6 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: %Class.480 = name_ref c, %c
-// CHECK:STDOUT:   %.loc20: %Get.type.501 = specific_constant @Class.%Get.decl, @Class(constants.%A) [concrete = constants.%Get.f37]
-// CHECK:STDOUT:   %Get.ref: %Get.type.501 = name_ref Get, %.loc20 [concrete = constants.%Get.f37]
-// CHECK:STDOUT:   %B.ref.loc20: type = name_ref B, file.%B.decl [concrete = constants.%B]
+// CHECK:STDOUT:   %.loc23: %Get.type.501 = specific_constant @Class.%Get.decl, @Class(constants.%A) [concrete = constants.%Get.f37]
+// CHECK:STDOUT:   %Get.ref: %Get.type.501 = name_ref Get, %.loc23 [concrete = constants.%Get.f37]
+// CHECK:STDOUT:   %B.ref.loc23: type = name_ref B, file.%B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %Get.specific_fn: <specific function> = specific_function %Get.ref, @Get(constants.%A, constants.%B) [concrete = constants.%Get.specific_fn.213]
-// CHECK:STDOUT:   %.loc19_35: ref %tuple.type.cc6 = splice_block %return {}
-// CHECK:STDOUT:   %Get.call: init %tuple.type.cc6 = call %Get.specific_fn() to %.loc19_35
+// CHECK:STDOUT:   %.loc22_35: ref %tuple.type.cc6 = splice_block %return {}
+// CHECK:STDOUT:   %Get.call: init %tuple.type.cc6 = call %Get.specific_fn() to %.loc22_35
 // CHECK:STDOUT:   return %Get.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGenericMethodWithNonDeducedParam(%c.param: %Class.480) -> %return.param: %tuple.type.cc6 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: %Class.480 = name_ref c, %c
-// CHECK:STDOUT:   %.loc24_11: %GetNoDeduce.type.5d6 = specific_constant @Class.%GetNoDeduce.decl, @Class(constants.%A) [concrete = constants.%GetNoDeduce.162]
-// CHECK:STDOUT:   %GetNoDeduce.ref: %GetNoDeduce.type.5d6 = name_ref GetNoDeduce, %.loc24_11 [concrete = constants.%GetNoDeduce.162]
-// CHECK:STDOUT:   %.loc24_25.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %B.ref.loc24: type = name_ref B, file.%B.decl [concrete = constants.%B]
+// CHECK:STDOUT:   %.loc27_11: %GetNoDeduce.type.5d6 = specific_constant @Class.%GetNoDeduce.decl, @Class(constants.%A) [concrete = constants.%GetNoDeduce.162]
+// CHECK:STDOUT:   %GetNoDeduce.ref: %GetNoDeduce.type.5d6 = name_ref GetNoDeduce, %.loc27_11 [concrete = constants.%GetNoDeduce.162]
+// CHECK:STDOUT:   %.loc27_25.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %B.ref.loc27: type = name_ref B, file.%B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %GetNoDeduce.specific_fn: <specific function> = specific_function %GetNoDeduce.ref, @GetNoDeduce(constants.%A, constants.%B) [concrete = constants.%GetNoDeduce.specific_fn.438]
-// CHECK:STDOUT:   %.loc23_54: ref %tuple.type.cc6 = splice_block %return {}
-// CHECK:STDOUT:   %.loc24_25.2: ref %A = temporary_storage
-// CHECK:STDOUT:   %.loc24_25.3: init %A = class_init (), %.loc24_25.2 [concrete = constants.%A.val]
-// CHECK:STDOUT:   %.loc24_25.4: ref %A = temporary %.loc24_25.2, %.loc24_25.3
-// CHECK:STDOUT:   %.loc24_25.5: ref %A = converted %.loc24_25.1, %.loc24_25.4
-// CHECK:STDOUT:   %.loc24_25.6: %A = bind_value %.loc24_25.5
-// CHECK:STDOUT:   %GetNoDeduce.call: init %tuple.type.cc6 = call %GetNoDeduce.specific_fn(%.loc24_25.6) to %.loc23_54
+// CHECK:STDOUT:   %.loc26_54: ref %tuple.type.cc6 = splice_block %return {}
+// CHECK:STDOUT:   %.loc27_25.2: ref %A = temporary_storage
+// CHECK:STDOUT:   %.loc27_25.3: init %A = class_init (), %.loc27_25.2 [concrete = constants.%A.val]
+// CHECK:STDOUT:   %.loc27_25.4: ref %A = temporary %.loc27_25.2, %.loc27_25.3
+// CHECK:STDOUT:   %.loc27_25.5: ref %A = converted %.loc27_25.1, %.loc27_25.4
+// CHECK:STDOUT:   %.loc27_25.6: %A = bind_value %.loc27_25.5
+// CHECK:STDOUT:   %GetNoDeduce.call: init %tuple.type.cc6 = call %GetNoDeduce.specific_fn(%.loc27_25.6) to %.loc26_54
 // CHECK:STDOUT:   return %GetNoDeduce.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%T) {
-// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
+// CHECK:STDOUT:   %T.loc17_13.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Get.type => constants.%Get.type.fd9
@@ -297,7 +300,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Get(constants.%T, constants.%U) {
-// CHECK:STDOUT:   %U.loc15_10.1 => constants.%U
+// CHECK:STDOUT:   %U.loc18_10.1 => constants.%U
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.30b
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.65c
@@ -306,26 +309,26 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.fe1
 // CHECK:STDOUT:   %Get.type => constants.%Get.type.fd9
 // CHECK:STDOUT:   %Get => constants.%Get.cf9
-// CHECK:STDOUT:   %Get.specific_fn.loc15_39.2 => constants.%Get.specific_fn.f73
+// CHECK:STDOUT:   %Get.specific_fn.loc18_39.2 => constants.%Get.specific_fn.f73
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetNoDeduce(constants.%T, constants.%U) {
 // CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %pattern_type.loc16_18 => constants.%pattern_type.7dc
-// CHECK:STDOUT:   %U.loc16_24.1 => constants.%U
+// CHECK:STDOUT:   %pattern_type.loc19_18 => constants.%pattern_type.7dc
+// CHECK:STDOUT:   %U.loc19_24.1 => constants.%U
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.30b
-// CHECK:STDOUT:   %pattern_type.loc16_34 => constants.%pattern_type.65c
+// CHECK:STDOUT:   %pattern_type.loc19_34 => constants.%pattern_type.65c
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc16_19 => constants.%require_complete.4ae
+// CHECK:STDOUT:   %require_complete.loc19_19 => constants.%require_complete.4ae
 // CHECK:STDOUT:   %GetNoDeduce.type => constants.%GetNoDeduce.type.766
 // CHECK:STDOUT:   %GetNoDeduce => constants.%GetNoDeduce.c9a
-// CHECK:STDOUT:   %GetNoDeduce.specific_fn.loc16_53.2 => constants.%GetNoDeduce.specific_fn.536
-// CHECK:STDOUT:   %require_complete.loc16_70 => constants.%require_complete.fe1
+// CHECK:STDOUT:   %GetNoDeduce.specific_fn.loc19_53.2 => constants.%GetNoDeduce.specific_fn.536
+// CHECK:STDOUT:   %require_complete.loc19_70 => constants.%require_complete.fe1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%A) {
-// CHECK:STDOUT:   %T.loc14_13.2 => constants.%A
+// CHECK:STDOUT:   %T.loc17_13.2 => constants.%A
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Get.type => constants.%Get.type.501
@@ -335,7 +338,7 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Get(constants.%A, constants.%B) {
-// CHECK:STDOUT:   %U.loc15_10.1 => constants.%B
+// CHECK:STDOUT:   %U.loc18_10.1 => constants.%B
 // CHECK:STDOUT:   %T => constants.%A
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.cc6
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.edc
@@ -344,21 +347,21 @@ fn CallGenericMethodWithNonDeducedParam(c: Class(A)) -> (A, B) {
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.56a
 // CHECK:STDOUT:   %Get.type => constants.%Get.type.501
 // CHECK:STDOUT:   %Get => constants.%Get.f37
-// CHECK:STDOUT:   %Get.specific_fn.loc15_39.2 => constants.%Get.specific_fn.213
+// CHECK:STDOUT:   %Get.specific_fn.loc18_39.2 => constants.%Get.specific_fn.213
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GetNoDeduce(constants.%A, constants.%B) {
 // CHECK:STDOUT:   %T => constants.%A
-// CHECK:STDOUT:   %pattern_type.loc16_18 => constants.%pattern_type.c10
-// CHECK:STDOUT:   %U.loc16_24.1 => constants.%B
+// CHECK:STDOUT:   %pattern_type.loc19_18 => constants.%pattern_type.c10
+// CHECK:STDOUT:   %U.loc19_24.1 => constants.%B
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.cc6
-// CHECK:STDOUT:   %pattern_type.loc16_34 => constants.%pattern_type.edc
+// CHECK:STDOUT:   %pattern_type.loc19_34 => constants.%pattern_type.edc
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc16_19 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc19_19 => constants.%complete_type.357
 // CHECK:STDOUT:   %GetNoDeduce.type => constants.%GetNoDeduce.type.5d6
 // CHECK:STDOUT:   %GetNoDeduce => constants.%GetNoDeduce.162
-// CHECK:STDOUT:   %GetNoDeduce.specific_fn.loc16_53.2 => constants.%GetNoDeduce.specific_fn.438
-// CHECK:STDOUT:   %require_complete.loc16_70 => constants.%complete_type.56a
+// CHECK:STDOUT:   %GetNoDeduce.specific_fn.loc19_53.2 => constants.%GetNoDeduce.specific_fn.438
+// CHECK:STDOUT:   %require_complete.loc19_70 => constants.%complete_type.56a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/generic/redeclare.carbon
+++ b/toolchain/check/testdata/class/generic/redeclare.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/redeclare.carbon

--- a/toolchain/check/testdata/class/generic/self.carbon
+++ b/toolchain/check/testdata/class/generic/self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/self.carbon
@@ -58,19 +61,19 @@ class Class(T:! type) {
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Class(%T.loc11_13.1: type) {
-// CHECK:STDOUT:   %T.loc11_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Class(%T.loc14_13.1: type) {
+// CHECK:STDOUT:   %T.loc14_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %MakeSelf.type: type = fn_type @MakeSelf, @Class(%T.loc11_13.2) [symbolic = %MakeSelf.type (constants.%MakeSelf.type)]
+// CHECK:STDOUT:   %MakeSelf.type: type = fn_type @MakeSelf, @Class(%T.loc14_13.2) [symbolic = %MakeSelf.type (constants.%MakeSelf.type)]
 // CHECK:STDOUT:   %MakeSelf: @Class.%MakeSelf.type (%MakeSelf.type) = struct_value () [symbolic = %MakeSelf (constants.%MakeSelf)]
-// CHECK:STDOUT:   %MakeClass.type: type = fn_type @MakeClass, @Class(%T.loc11_13.2) [symbolic = %MakeClass.type (constants.%MakeClass.type)]
+// CHECK:STDOUT:   %MakeClass.type: type = fn_type @MakeClass, @Class(%T.loc14_13.2) [symbolic = %MakeClass.type (constants.%MakeClass.type)]
 // CHECK:STDOUT:   %MakeClass: @Class.%MakeClass.type (%MakeClass.type) = struct_value () [symbolic = %MakeClass (constants.%MakeClass)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F, @Class(%T.loc11_13.2) [symbolic = %F.type (constants.%F.type)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F, @Class(%T.loc14_13.2) [symbolic = %F.type (constants.%F.type)]
 // CHECK:STDOUT:   %F: @Class.%F.type (%F.type) = struct_value () [symbolic = %F (constants.%F)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
@@ -78,8 +81,8 @@ class Class(T:! type) {
 // CHECK:STDOUT:       %return.patt: @MakeSelf.%pattern_type (%pattern_type.3c1) = return_slot_pattern [concrete]
 // CHECK:STDOUT:       %return.param_patt: @MakeSelf.%pattern_type (%pattern_type.3c1) = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %.loc14_20: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:       %Self.ref: type = name_ref Self, %.loc14_20 [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:       %.loc17_20: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:       %Self.ref: type = name_ref Self, %.loc17_20 [symbolic = %Class (constants.%Class)]
 // CHECK:STDOUT:       %return.param: ref @MakeSelf.%Class (%Class) = out_param call_param0
 // CHECK:STDOUT:       %return: ref @MakeSelf.%Class (%Class) = return_slot %return.param
 // CHECK:STDOUT:     }
@@ -88,10 +91,10 @@ class Class(T:! type) {
 // CHECK:STDOUT:       %return.param_patt: @MakeClass.%pattern_type (%pattern_type.3c1) = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc11_13.1 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:       %Class.loc15_28.2: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc15_28.1 (constants.%Class)]
-// CHECK:STDOUT:       %return.param: ref @MakeClass.%Class.loc15_28.1 (%Class) = out_param call_param0
-// CHECK:STDOUT:       %return: ref @MakeClass.%Class.loc15_28.1 (%Class) = return_slot %return.param
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %Class.loc18_28.2: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc18_28.1 (constants.%Class)]
+// CHECK:STDOUT:       %return.param: ref @MakeClass.%Class.loc18_28.1 (%Class) = out_param call_param0
+// CHECK:STDOUT:       %return: ref @MakeClass.%Class.loc18_28.1 (%Class) = return_slot %return.param
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %F.decl: @Class.%F.type (%F.type) = fn_decl @F [symbolic = @Class.%F (constants.%F)] {} {}
 // CHECK:STDOUT:     %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
@@ -108,7 +111,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @MakeSelf(@Class.%T.loc11_13.1: type) {
+// CHECK:STDOUT: generic fn @MakeSelf(@Class.%T.loc14_13.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T) [symbolic = %Class (constants.%Class)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %Class [symbolic = %pattern_type (constants.%pattern_type.3c1)]
@@ -119,43 +122,43 @@ class Class(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() -> %return.param: @MakeSelf.%Class (%Class) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc14_35.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc14_35.2: init @MakeSelf.%Class (%Class) = class_init (), %return [symbolic = %Class.val (constants.%Class.val)]
-// CHECK:STDOUT:     %.loc14_36: init @MakeSelf.%Class (%Class) = converted %.loc14_35.1, %.loc14_35.2 [symbolic = %Class.val (constants.%Class.val)]
-// CHECK:STDOUT:     return %.loc14_36 to %return
+// CHECK:STDOUT:     %.loc17_35.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:     %.loc17_35.2: init @MakeSelf.%Class (%Class) = class_init (), %return [symbolic = %Class.val (constants.%Class.val)]
+// CHECK:STDOUT:     %.loc17_36: init @MakeSelf.%Class (%Class) = converted %.loc17_35.1, %.loc17_35.2 [symbolic = %Class.val (constants.%Class.val)]
+// CHECK:STDOUT:     return %.loc17_36 to %return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @MakeClass(@Class.%T.loc11_13.1: type) {
+// CHECK:STDOUT: generic fn @MakeClass(@Class.%T.loc14_13.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:   %Class.loc15_28.1: type = class_type @Class, @Class(%T) [symbolic = %Class.loc15_28.1 (constants.%Class)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Class.loc15_28.1 [symbolic = %pattern_type (constants.%pattern_type.3c1)]
+// CHECK:STDOUT:   %Class.loc18_28.1: type = class_type @Class, @Class(%T) [symbolic = %Class.loc18_28.1 (constants.%Class)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Class.loc18_28.1 [symbolic = %pattern_type (constants.%pattern_type.3c1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Class.loc15_28.1 [symbolic = %require_complete (constants.%require_complete)]
-// CHECK:STDOUT:   %Class.val: @MakeClass.%Class.loc15_28.1 (%Class) = struct_value () [symbolic = %Class.val (constants.%Class.val)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Class.loc18_28.1 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %Class.val: @MakeClass.%Class.loc18_28.1 (%Class) = struct_value () [symbolic = %Class.val (constants.%Class.val)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn() -> %return.param: @MakeClass.%Class.loc15_28.1 (%Class) {
+// CHECK:STDOUT:   fn() -> %return.param: @MakeClass.%Class.loc18_28.1 (%Class) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc15_40.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc15_40.2: init @MakeClass.%Class.loc15_28.1 (%Class) = class_init (), %return [symbolic = %Class.val (constants.%Class.val)]
-// CHECK:STDOUT:     %.loc15_41: init @MakeClass.%Class.loc15_28.1 (%Class) = converted %.loc15_40.1, %.loc15_40.2 [symbolic = %Class.val (constants.%Class.val)]
-// CHECK:STDOUT:     return %.loc15_41 to %return
+// CHECK:STDOUT:     %.loc18_40.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:     %.loc18_40.2: init @MakeClass.%Class.loc18_28.1 (%Class) = class_init (), %return [symbolic = %Class.val (constants.%Class.val)]
+// CHECK:STDOUT:     %.loc18_41: init @MakeClass.%Class.loc18_28.1 (%Class) = converted %.loc18_40.1, %.loc18_40.2 [symbolic = %Class.val (constants.%Class.val)]
+// CHECK:STDOUT:     return %.loc18_41 to %return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(@Class.%T.loc11_13.1: type) {
+// CHECK:STDOUT: generic fn @F(@Class.%T.loc14_13.1: type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:   %Class.loc17_19.2: type = class_type @Class, @Class(%T) [symbolic = %Class.loc17_19.2 (constants.%Class)]
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Class.loc17_19.2 [symbolic = %require_complete (constants.%require_complete)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Class.loc17_19.2 [symbolic = %pattern_type (constants.%pattern_type.3c1)]
+// CHECK:STDOUT:   %Class.loc20_19.2: type = class_type @Class, @Class(%T) [symbolic = %Class.loc20_19.2 (constants.%Class)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Class.loc20_19.2 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Class.loc20_19.2 [symbolic = %pattern_type (constants.%pattern_type.3c1)]
 // CHECK:STDOUT:   %MakeSelf.type: type = fn_type @MakeSelf, @Class(%T) [symbolic = %MakeSelf.type (constants.%MakeSelf.type)]
 // CHECK:STDOUT:   %MakeSelf: @F.%MakeSelf.type (%MakeSelf.type) = struct_value () [symbolic = %MakeSelf (constants.%MakeSelf)]
-// CHECK:STDOUT:   %MakeSelf.specific_fn.loc17_23.2: <specific function> = specific_function %MakeSelf, @MakeSelf(%T) [symbolic = %MakeSelf.specific_fn.loc17_23.2 (constants.%MakeSelf.specific_fn)]
+// CHECK:STDOUT:   %MakeSelf.specific_fn.loc20_23.2: <specific function> = specific_function %MakeSelf, @MakeSelf(%T) [symbolic = %MakeSelf.specific_fn.loc20_23.2 (constants.%MakeSelf.specific_fn)]
 // CHECK:STDOUT:   %MakeClass.type: type = fn_type @MakeClass, @Class(%T) [symbolic = %MakeClass.type (constants.%MakeClass.type)]
 // CHECK:STDOUT:   %MakeClass: @F.%MakeClass.type (%MakeClass.type) = struct_value () [symbolic = %MakeClass (constants.%MakeClass)]
-// CHECK:STDOUT:   %MakeClass.specific_fn.loc18_19.2: <specific function> = specific_function %MakeClass, @MakeClass(%T) [symbolic = %MakeClass.specific_fn.loc18_19.2 (constants.%MakeClass.specific_fn)]
+// CHECK:STDOUT:   %MakeClass.specific_fn.loc21_19.2: <specific function> = specific_function %MakeClass, @MakeClass(%T) [symbolic = %MakeClass.specific_fn.loc21_19.2 (constants.%MakeClass.specific_fn)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
 // CHECK:STDOUT:   !entry:
@@ -163,41 +166,41 @@ class Class(T:! type) {
 // CHECK:STDOUT:       %c.patt: @F.%pattern_type (%pattern_type.3c1) = binding_pattern c [concrete]
 // CHECK:STDOUT:       %c.var_patt: @F.%pattern_type (%pattern_type.3c1) = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %c.var: ref @F.%Class.loc17_19.2 (%Class) = var %c.var_patt
-// CHECK:STDOUT:     %.loc17_23: @F.%MakeSelf.type (%MakeSelf.type) = specific_constant @Class.%MakeSelf.decl, @Class(constants.%T) [symbolic = %MakeSelf (constants.%MakeSelf)]
-// CHECK:STDOUT:     %MakeSelf.ref: @F.%MakeSelf.type (%MakeSelf.type) = name_ref MakeSelf, %.loc17_23 [symbolic = %MakeSelf (constants.%MakeSelf)]
-// CHECK:STDOUT:     %MakeSelf.specific_fn.loc17_23.1: <specific function> = specific_function %MakeSelf.ref, @MakeSelf(constants.%T) [symbolic = %MakeSelf.specific_fn.loc17_23.2 (constants.%MakeSelf.specific_fn)]
-// CHECK:STDOUT:     %.loc17_5: ref @F.%Class.loc17_19.2 (%Class) = splice_block %c.var {}
-// CHECK:STDOUT:     %MakeSelf.call: init @F.%Class.loc17_19.2 (%Class) = call %MakeSelf.specific_fn.loc17_23.1() to %.loc17_5
+// CHECK:STDOUT:     %c.var: ref @F.%Class.loc20_19.2 (%Class) = var %c.var_patt
+// CHECK:STDOUT:     %.loc20_23: @F.%MakeSelf.type (%MakeSelf.type) = specific_constant @Class.%MakeSelf.decl, @Class(constants.%T) [symbolic = %MakeSelf (constants.%MakeSelf)]
+// CHECK:STDOUT:     %MakeSelf.ref: @F.%MakeSelf.type (%MakeSelf.type) = name_ref MakeSelf, %.loc20_23 [symbolic = %MakeSelf (constants.%MakeSelf)]
+// CHECK:STDOUT:     %MakeSelf.specific_fn.loc20_23.1: <specific function> = specific_function %MakeSelf.ref, @MakeSelf(constants.%T) [symbolic = %MakeSelf.specific_fn.loc20_23.2 (constants.%MakeSelf.specific_fn)]
+// CHECK:STDOUT:     %.loc20_5: ref @F.%Class.loc20_19.2 (%Class) = splice_block %c.var {}
+// CHECK:STDOUT:     %MakeSelf.call: init @F.%Class.loc20_19.2 (%Class) = call %MakeSelf.specific_fn.loc20_23.1() to %.loc20_5
 // CHECK:STDOUT:     assign %c.var, %MakeSelf.call
-// CHECK:STDOUT:     %.loc17_19: type = splice_block %Class.loc17_19.1 [symbolic = %Class.loc17_19.2 (constants.%Class)] {
+// CHECK:STDOUT:     %.loc20_19: type = splice_block %Class.loc20_19.1 [symbolic = %Class.loc20_19.2 (constants.%Class)] {
 // CHECK:STDOUT:       %Class.ref: %Class.type = name_ref Class, file.%Class.decl [concrete = constants.%Class.generic]
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc11_13.1 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:       %Class.loc17_19.1: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc17_19.2 (constants.%Class)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %Class.loc20_19.1: type = class_type @Class, @Class(constants.%T) [symbolic = %Class.loc20_19.2 (constants.%Class)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %c: ref @F.%Class.loc17_19.2 (%Class) = bind_name c, %c.var
+// CHECK:STDOUT:     %c: ref @F.%Class.loc20_19.2 (%Class) = bind_name c, %c.var
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %s.patt: @F.%pattern_type (%pattern_type.3c1) = binding_pattern s [concrete]
 // CHECK:STDOUT:       %s.var_patt: @F.%pattern_type (%pattern_type.3c1) = var_pattern %s.patt [concrete]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %s.var: ref @F.%Class.loc17_19.2 (%Class) = var %s.var_patt
-// CHECK:STDOUT:     %.loc18_19: @F.%MakeClass.type (%MakeClass.type) = specific_constant @Class.%MakeClass.decl, @Class(constants.%T) [symbolic = %MakeClass (constants.%MakeClass)]
-// CHECK:STDOUT:     %MakeClass.ref: @F.%MakeClass.type (%MakeClass.type) = name_ref MakeClass, %.loc18_19 [symbolic = %MakeClass (constants.%MakeClass)]
-// CHECK:STDOUT:     %MakeClass.specific_fn.loc18_19.1: <specific function> = specific_function %MakeClass.ref, @MakeClass(constants.%T) [symbolic = %MakeClass.specific_fn.loc18_19.2 (constants.%MakeClass.specific_fn)]
-// CHECK:STDOUT:     %.loc18_5: ref @F.%Class.loc17_19.2 (%Class) = splice_block %s.var {}
-// CHECK:STDOUT:     %MakeClass.call: init @F.%Class.loc17_19.2 (%Class) = call %MakeClass.specific_fn.loc18_19.1() to %.loc18_5
+// CHECK:STDOUT:     %s.var: ref @F.%Class.loc20_19.2 (%Class) = var %s.var_patt
+// CHECK:STDOUT:     %.loc21_19: @F.%MakeClass.type (%MakeClass.type) = specific_constant @Class.%MakeClass.decl, @Class(constants.%T) [symbolic = %MakeClass (constants.%MakeClass)]
+// CHECK:STDOUT:     %MakeClass.ref: @F.%MakeClass.type (%MakeClass.type) = name_ref MakeClass, %.loc21_19 [symbolic = %MakeClass (constants.%MakeClass)]
+// CHECK:STDOUT:     %MakeClass.specific_fn.loc21_19.1: <specific function> = specific_function %MakeClass.ref, @MakeClass(constants.%T) [symbolic = %MakeClass.specific_fn.loc21_19.2 (constants.%MakeClass.specific_fn)]
+// CHECK:STDOUT:     %.loc21_5: ref @F.%Class.loc20_19.2 (%Class) = splice_block %s.var {}
+// CHECK:STDOUT:     %MakeClass.call: init @F.%Class.loc20_19.2 (%Class) = call %MakeClass.specific_fn.loc21_19.1() to %.loc21_5
 // CHECK:STDOUT:     assign %s.var, %MakeClass.call
-// CHECK:STDOUT:     %.loc18_12.1: type = splice_block %Self.ref [symbolic = %Class.loc17_19.2 (constants.%Class)] {
-// CHECK:STDOUT:       %.loc18_12.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class.loc17_19.2 (constants.%Class)]
-// CHECK:STDOUT:       %Self.ref: type = name_ref Self, %.loc18_12.2 [symbolic = %Class.loc17_19.2 (constants.%Class)]
+// CHECK:STDOUT:     %.loc21_12.1: type = splice_block %Self.ref [symbolic = %Class.loc20_19.2 (constants.%Class)] {
+// CHECK:STDOUT:       %.loc21_12.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class.loc20_19.2 (constants.%Class)]
+// CHECK:STDOUT:       %Self.ref: type = name_ref Self, %.loc21_12.2 [symbolic = %Class.loc20_19.2 (constants.%Class)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %s: ref @F.%Class.loc17_19.2 (%Class) = bind_name s, %s.var
+// CHECK:STDOUT:     %s: ref @F.%Class.loc20_19.2 (%Class) = bind_name s, %s.var
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %MakeSelf.type => constants.%MakeSelf.type
@@ -220,7 +223,7 @@ class Class(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @MakeClass(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
-// CHECK:STDOUT:   %Class.loc15_28.1 => constants.%Class
+// CHECK:STDOUT:   %Class.loc18_28.1 => constants.%Class
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.3c1
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/class/generic/stringify.carbon
+++ b/toolchain/check/testdata/class/generic/stringify.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic/stringify.carbon

--- a/toolchain/check/testdata/class/generic_method.carbon
+++ b/toolchain/check/testdata/class/generic_method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/generic_method.carbon
@@ -50,88 +53,88 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Class.decl: %Class.type = class_decl @Class [concrete = constants.%Class.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc14_13.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [symbolic = constants.%F] {
-// CHECK:STDOUT:     %self.patt: @F.%pattern_type.loc13_8 (%pattern_type.3c1) = binding_pattern self [concrete]
-// CHECK:STDOUT:     %self.param_patt: @F.%pattern_type.loc13_8 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %n.patt: @F.%pattern_type.loc13_20 (%pattern_type.7dc) = binding_pattern n [concrete]
-// CHECK:STDOUT:     %n.param_patt: @F.%pattern_type.loc13_20 (%pattern_type.7dc) = value_param_pattern %n.patt, call_param1 [concrete]
+// CHECK:STDOUT:     %self.patt: @F.%pattern_type.loc16_8 (%pattern_type.3c1) = binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: @F.%pattern_type.loc16_8 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %n.patt: @F.%pattern_type.loc16_20 (%pattern_type.7dc) = binding_pattern n [concrete]
+// CHECK:STDOUT:     %n.param_patt: @F.%pattern_type.loc16_20 (%pattern_type.7dc) = value_param_pattern %n.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc16: type = bind_symbolic_name T, 0 [symbolic = @Class.%T.loc11_13.2 (constants.%T)]
-// CHECK:STDOUT:     %self.param.loc16: @F.%Class (%Class) = value_param call_param0
-// CHECK:STDOUT:     %.loc16_28.1: type = splice_block %Self.ref.loc16 [symbolic = %Class (constants.%Class)] {
-// CHECK:STDOUT:       %.loc16_28.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:       %Self.ref.loc16: type = name_ref Self, %.loc16_28.2 [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:     %T.loc19: type = bind_symbolic_name T, 0 [symbolic = @Class.%T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT:     %self.param.loc19: @F.%Class (%Class) = value_param call_param0
+// CHECK:STDOUT:     %.loc19_28.1: type = splice_block %Self.ref.loc19 [symbolic = %Class (constants.%Class)] {
+// CHECK:STDOUT:       %.loc19_28.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:       %Self.ref.loc19: type = name_ref Self, %.loc19_28.2 [symbolic = %Class (constants.%Class)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc16: @F.%Class (%Class) = bind_name self, %self.param.loc16
-// CHECK:STDOUT:     %n.param.loc16: @F.%T.loc13 (%T) = value_param call_param1
-// CHECK:STDOUT:     %T.ref.loc16: type = name_ref T, %T.loc16 [symbolic = %T.loc13 (constants.%T)]
-// CHECK:STDOUT:     %n.loc16: @F.%T.loc13 (%T) = bind_name n, %n.param.loc16
+// CHECK:STDOUT:     %self.loc19: @F.%Class (%Class) = bind_name self, %self.param.loc19
+// CHECK:STDOUT:     %n.param.loc19: @F.%T.loc16 (%T) = value_param call_param1
+// CHECK:STDOUT:     %T.ref.loc19: type = name_ref T, %T.loc19 [symbolic = %T.loc16 (constants.%T)]
+// CHECK:STDOUT:     %n.loc19: @F.%T.loc16 (%T) = bind_name n, %n.param.loc19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @Class(%T.loc11_13.1: type) {
-// CHECK:STDOUT:   %T.loc11_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_13.2 (constants.%T)]
+// CHECK:STDOUT: generic class @Class(%T.loc14_13.1: type) {
+// CHECK:STDOUT:   %T.loc14_13.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_13.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc11_13.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc11_13.2) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc11_13.2 [symbolic = %Class.elem (constants.%Class.elem)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F, @Class(%T.loc11_13.2) [symbolic = %F.type (constants.%F.type)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc14_13.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc14_13.2) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:   %Class.elem: type = unbound_element_type %Class, %T.loc14_13.2 [symbolic = %Class.elem (constants.%Class.elem)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F, @Class(%T.loc14_13.2) [symbolic = %F.type (constants.%F.type)]
 // CHECK:STDOUT:   %F: @Class.%F.type (%F.type) = struct_value () [symbolic = %F (constants.%F)]
-// CHECK:STDOUT:   %struct_type.a.loc14_1.2: type = struct_type {.a: @Class.%T.loc11_13.2 (%T)} [symbolic = %struct_type.a.loc14_1.2 (constants.%struct_type.a)]
-// CHECK:STDOUT:   %complete_type.loc14_1.2: <witness> = complete_type_witness %struct_type.a.loc14_1.2 [symbolic = %complete_type.loc14_1.2 (constants.%complete_type)]
+// CHECK:STDOUT:   %struct_type.a.loc17_1.2: type = struct_type {.a: @Class.%T.loc14_13.2 (%T)} [symbolic = %struct_type.a.loc17_1.2 (constants.%struct_type.a)]
+// CHECK:STDOUT:   %complete_type.loc17_1.2: <witness> = complete_type_witness %struct_type.a.loc17_1.2 [symbolic = %complete_type.loc17_1.2 (constants.%complete_type)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_13.1 [symbolic = %T.loc11_13.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc12: @Class.%Class.elem (%Class.elem) = field_decl a, element0 [concrete]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_13.1 [symbolic = %T.loc14_13.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc15: @Class.%Class.elem (%Class.elem) = field_decl a, element0 [concrete]
 // CHECK:STDOUT:     %F.decl: @Class.%F.type (%F.type) = fn_decl @F [symbolic = @Class.%F (constants.%F)] {
-// CHECK:STDOUT:       %self.patt: @F.%pattern_type.loc13_8 (%pattern_type.3c1) = binding_pattern self [concrete]
-// CHECK:STDOUT:       %self.param_patt: @F.%pattern_type.loc13_8 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:       %n.patt: @F.%pattern_type.loc13_20 (%pattern_type.7dc) = binding_pattern n [concrete]
-// CHECK:STDOUT:       %n.param_patt: @F.%pattern_type.loc13_20 (%pattern_type.7dc) = value_param_pattern %n.patt, call_param1 [concrete]
+// CHECK:STDOUT:       %self.patt: @F.%pattern_type.loc16_8 (%pattern_type.3c1) = binding_pattern self [concrete]
+// CHECK:STDOUT:       %self.param_patt: @F.%pattern_type.loc16_8 (%pattern_type.3c1) = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:       %n.patt: @F.%pattern_type.loc16_20 (%pattern_type.7dc) = binding_pattern n [concrete]
+// CHECK:STDOUT:       %n.param_patt: @F.%pattern_type.loc16_20 (%pattern_type.7dc) = value_param_pattern %n.patt, call_param1 [concrete]
 // CHECK:STDOUT:     } {
-// CHECK:STDOUT:       %self.param.loc13: @F.%Class (%Class) = value_param call_param0
-// CHECK:STDOUT:       %.loc13_14.1: type = splice_block %Self.ref.loc13 [symbolic = %Class (constants.%Class)] {
-// CHECK:STDOUT:         %.loc13_14.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:         %Self.ref.loc13: type = name_ref Self, %.loc13_14.2 [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:       %self.param.loc16: @F.%Class (%Class) = value_param call_param0
+// CHECK:STDOUT:       %.loc16_14.1: type = splice_block %Self.ref.loc16 [symbolic = %Class (constants.%Class)] {
+// CHECK:STDOUT:         %.loc16_14.2: type = specific_constant constants.%Class, @Class(constants.%T) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:         %Self.ref.loc16: type = name_ref Self, %.loc16_14.2 [symbolic = %Class (constants.%Class)]
 // CHECK:STDOUT:       }
-// CHECK:STDOUT:       %self.loc13: @F.%Class (%Class) = bind_name self, %self.param.loc13
-// CHECK:STDOUT:       %n.param.loc13: @F.%T.loc13 (%T) = value_param call_param1
-// CHECK:STDOUT:       %T.ref.loc13: type = name_ref T, @Class.%T.loc11_13.1 [symbolic = %T.loc13 (constants.%T)]
-// CHECK:STDOUT:       %n.loc13: @F.%T.loc13 (%T) = bind_name n, %n.param.loc13
+// CHECK:STDOUT:       %self.loc16: @F.%Class (%Class) = bind_name self, %self.param.loc16
+// CHECK:STDOUT:       %n.param.loc16: @F.%T.loc16 (%T) = value_param call_param1
+// CHECK:STDOUT:       %T.ref.loc16: type = name_ref T, @Class.%T.loc14_13.1 [symbolic = %T.loc16 (constants.%T)]
+// CHECK:STDOUT:       %n.loc16: @F.%T.loc16 (%T) = bind_name n, %n.param.loc16
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %struct_type.a.loc14_1.1: type = struct_type {.a: %T} [symbolic = %struct_type.a.loc14_1.2 (constants.%struct_type.a)]
-// CHECK:STDOUT:     %complete_type.loc14_1.1: <witness> = complete_type_witness %struct_type.a.loc14_1.1 [symbolic = %complete_type.loc14_1.2 (constants.%complete_type)]
-// CHECK:STDOUT:     complete_type_witness = %complete_type.loc14_1.1
+// CHECK:STDOUT:     %struct_type.a.loc17_1.1: type = struct_type {.a: %T} [symbolic = %struct_type.a.loc17_1.2 (constants.%struct_type.a)]
+// CHECK:STDOUT:     %complete_type.loc17_1.1: <witness> = complete_type_witness %struct_type.a.loc17_1.1 [symbolic = %complete_type.loc17_1.2 (constants.%complete_type)]
+// CHECK:STDOUT:     complete_type_witness = %complete_type.loc17_1.1
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = constants.%Class
 // CHECK:STDOUT:     .T = <poisoned>
-// CHECK:STDOUT:     .a = %.loc12
+// CHECK:STDOUT:     .a = %.loc15
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(@Class.%T.loc11_13.1: type) {
-// CHECK:STDOUT:   %T.loc13: type = bind_symbolic_name T, 0 [symbolic = %T.loc13 (constants.%T)]
-// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc13) [symbolic = %Class (constants.%Class)]
-// CHECK:STDOUT:   %pattern_type.loc13_8: type = pattern_type %Class [symbolic = %pattern_type.loc13_8 (constants.%pattern_type.3c1)]
-// CHECK:STDOUT:   %pattern_type.loc13_20: type = pattern_type %T.loc13 [symbolic = %pattern_type.loc13_20 (constants.%pattern_type.7dc)]
+// CHECK:STDOUT: generic fn @F(@Class.%T.loc14_13.1: type) {
+// CHECK:STDOUT:   %T.loc16: type = bind_symbolic_name T, 0 [symbolic = %T.loc16 (constants.%T)]
+// CHECK:STDOUT:   %Class: type = class_type @Class, @Class(%T.loc16) [symbolic = %Class (constants.%Class)]
+// CHECK:STDOUT:   %pattern_type.loc16_8: type = pattern_type %Class [symbolic = %pattern_type.loc16_8 (constants.%pattern_type.3c1)]
+// CHECK:STDOUT:   %pattern_type.loc16_20: type = pattern_type %T.loc16 [symbolic = %pattern_type.loc16_20 (constants.%pattern_type.7dc)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc16_26: <witness> = require_complete_type %Class [symbolic = %require_complete.loc16_26 (constants.%require_complete.4f8)]
-// CHECK:STDOUT:   %require_complete.loc16_35: <witness> = require_complete_type %T.loc13 [symbolic = %require_complete.loc16_35 (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %require_complete.loc19_26: <witness> = require_complete_type %Class [symbolic = %require_complete.loc19_26 (constants.%require_complete.4f8)]
+// CHECK:STDOUT:   %require_complete.loc19_35: <witness> = require_complete_type %T.loc16 [symbolic = %require_complete.loc19_35 (constants.%require_complete.4ae)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param.loc16: @F.%Class (%Class), %n.param.loc16: @F.%T.loc13 (%T)) {
+// CHECK:STDOUT:   fn(%self.param.loc19: @F.%Class (%Class), %n.param.loc19: @F.%T.loc16 (%T)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Class(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_13.2 => constants.%T
+// CHECK:STDOUT:   %T.loc14_13.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.4ae
@@ -139,14 +142,14 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Class.elem => constants.%Class.elem
 // CHECK:STDOUT:   %F.type => constants.%F.type
 // CHECK:STDOUT:   %F => constants.%F
-// CHECK:STDOUT:   %struct_type.a.loc14_1.2 => constants.%struct_type.a
-// CHECK:STDOUT:   %complete_type.loc14_1.2 => constants.%complete_type
+// CHECK:STDOUT:   %struct_type.a.loc17_1.2 => constants.%struct_type.a
+// CHECK:STDOUT:   %complete_type.loc17_1.2 => constants.%complete_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
-// CHECK:STDOUT:   %T.loc13 => constants.%T
+// CHECK:STDOUT:   %T.loc16 => constants.%T
 // CHECK:STDOUT:   %Class => constants.%Class
-// CHECK:STDOUT:   %pattern_type.loc13_8 => constants.%pattern_type.3c1
-// CHECK:STDOUT:   %pattern_type.loc13_20 => constants.%pattern_type.7dc
+// CHECK:STDOUT:   %pattern_type.loc16_8 => constants.%pattern_type.3c1
+// CHECK:STDOUT:   %pattern_type.loc16_20 => constants.%pattern_type.7dc
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/import.carbon

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/import_base.carbon

--- a/toolchain/check/testdata/class/import_forward_decl.carbon
+++ b/toolchain/check/testdata/class/import_forward_decl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/import_forward_decl.carbon

--- a/toolchain/check/testdata/class/import_indirect.carbon
+++ b/toolchain/check/testdata/class/import_indirect.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/import_indirect.carbon

--- a/toolchain/check/testdata/class/import_member_cycle.carbon
+++ b/toolchain/check/testdata/class/import_member_cycle.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/import_member_cycle.carbon

--- a/toolchain/check/testdata/class/import_struct_cyle.carbon
+++ b/toolchain/check/testdata/class/import_struct_cyle.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/import_struct_cyle.carbon

--- a/toolchain/check/testdata/class/inheritance_access.carbon
+++ b/toolchain/check/testdata/class/inheritance_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/inheritance_access.carbon

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/init.carbon
@@ -70,17 +73,17 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT:     %return.patt: %pattern_type.761 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.761 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Class.ref.loc16_34: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:     %Class.ref.loc19_34: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc16_12: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc19_12: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %n: %i32 = bind_name n, %n.param
 // CHECK:STDOUT:     %next.param: %ptr.e71 = value_param call_param1
-// CHECK:STDOUT:     %.loc16_28: type = splice_block %ptr [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:       %Class.ref.loc16_23: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref.loc16_23 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:     %.loc19_28: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:       %Class.ref.loc19_23: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref.loc19_23 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %next: %ptr.e71 = bind_name next, %next.param
 // CHECK:STDOUT:     %return.param: ref %Class = out_param call_param2
@@ -94,17 +97,17 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT:     %return.patt: %pattern_type.761 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.761 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Class.ref.loc20_41: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:     %Class.ref.loc23_41: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc20_19: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc23_19: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %n: %i32 = bind_name n, %n.param
 // CHECK:STDOUT:     %next.param: %ptr.e71 = value_param call_param1
-// CHECK:STDOUT:     %.loc20_35: type = splice_block %ptr [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:       %Class.ref.loc20_30: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref.loc20_30 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:     %.loc23_35: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:       %Class.ref.loc23_30: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
+// CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref.loc23_30 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %next: %ptr.e71 = bind_name next, %next.param
 // CHECK:STDOUT:     %return.param: ref %Class = out_param call_param2
@@ -115,46 +118,46 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem.c91 = field_decl n, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %Class.elem.c91 = field_decl n, element0 [concrete]
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr.e71]
-// CHECK:STDOUT:   %.loc13: %Class.elem.0c0 = field_decl next, element1 [concrete]
+// CHECK:STDOUT:   %.loc16: %Class.elem.0c0 = field_decl next, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.n.next: type = struct_type {.n: %i32, .next: %ptr.e71} [concrete = constants.%struct_type.n.next]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n.next [concrete = constants.%complete_type.78f]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .n = %.loc12
+// CHECK:STDOUT:   .n = %.loc15
 // CHECK:STDOUT:   .Class = <poisoned>
-// CHECK:STDOUT:   .next = %.loc13
+// CHECK:STDOUT:   .next = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make(%n.param: %i32, %next.param: %ptr.e71) -> %return.param: %Class {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: %i32 = name_ref n, %n
 // CHECK:STDOUT:   %next.ref: %ptr.e71 = name_ref next, %next
-// CHECK:STDOUT:   %.loc17_31.1: %struct_type.n.next = struct_literal (%n.ref, %next.ref)
-// CHECK:STDOUT:   %.loc17_31.2: ref %i32 = class_element_access %return, element0
-// CHECK:STDOUT:   %.loc17_31.3: init %i32 = initialize_from %n.ref to %.loc17_31.2
-// CHECK:STDOUT:   %.loc17_31.4: ref %ptr.e71 = class_element_access %return, element1
-// CHECK:STDOUT:   %.loc17_31.5: init %ptr.e71 = initialize_from %next.ref to %.loc17_31.4
-// CHECK:STDOUT:   %.loc17_31.6: init %Class = class_init (%.loc17_31.3, %.loc17_31.5), %return
-// CHECK:STDOUT:   %.loc17_32: init %Class = converted %.loc17_31.1, %.loc17_31.6
-// CHECK:STDOUT:   return %.loc17_32 to %return
+// CHECK:STDOUT:   %.loc20_31.1: %struct_type.n.next = struct_literal (%n.ref, %next.ref)
+// CHECK:STDOUT:   %.loc20_31.2: ref %i32 = class_element_access %return, element0
+// CHECK:STDOUT:   %.loc20_31.3: init %i32 = initialize_from %n.ref to %.loc20_31.2
+// CHECK:STDOUT:   %.loc20_31.4: ref %ptr.e71 = class_element_access %return, element1
+// CHECK:STDOUT:   %.loc20_31.5: init %ptr.e71 = initialize_from %next.ref to %.loc20_31.4
+// CHECK:STDOUT:   %.loc20_31.6: init %Class = class_init (%.loc20_31.3, %.loc20_31.5), %return
+// CHECK:STDOUT:   %.loc20_32: init %Class = converted %.loc20_31.1, %.loc20_31.6
+// CHECK:STDOUT:   return %.loc20_32 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeReorder(%n.param: %i32, %next.param: %ptr.e71) -> %return.param: %Class {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %next.ref: %ptr.e71 = name_ref next, %next
 // CHECK:STDOUT:   %n.ref: %i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc21_31.1: %struct_type.next.n = struct_literal (%next.ref, %n.ref)
-// CHECK:STDOUT:   %.loc21_31.2: ref %i32 = class_element_access %return, element1
-// CHECK:STDOUT:   %.loc21_31.3: init %i32 = initialize_from %n.ref to %.loc21_31.2
-// CHECK:STDOUT:   %.loc21_31.4: ref %ptr.e71 = class_element_access %return, element0
-// CHECK:STDOUT:   %.loc21_31.5: init %ptr.e71 = initialize_from %next.ref to %.loc21_31.4
-// CHECK:STDOUT:   %.loc21_31.6: init %Class = class_init (%.loc21_31.3, %.loc21_31.5), %return
-// CHECK:STDOUT:   %.loc21_32: init %Class = converted %.loc21_31.1, %.loc21_31.6
-// CHECK:STDOUT:   return %.loc21_32 to %return
+// CHECK:STDOUT:   %.loc24_31.1: %struct_type.next.n = struct_literal (%next.ref, %n.ref)
+// CHECK:STDOUT:   %.loc24_31.2: ref %i32 = class_element_access %return, element1
+// CHECK:STDOUT:   %.loc24_31.3: init %i32 = initialize_from %n.ref to %.loc24_31.2
+// CHECK:STDOUT:   %.loc24_31.4: ref %ptr.e71 = class_element_access %return, element0
+// CHECK:STDOUT:   %.loc24_31.5: init %ptr.e71 = initialize_from %next.ref to %.loc24_31.4
+// CHECK:STDOUT:   %.loc24_31.6: init %Class = class_init (%.loc24_31.3, %.loc24_31.5), %return
+// CHECK:STDOUT:   %.loc24_32: init %Class = converted %.loc24_31.1, %.loc24_31.6
+// CHECK:STDOUT:   return %.loc24_32 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/init_as.carbon
@@ -89,51 +92,51 @@ fn F() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Class.elem = field_decl a, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Class.elem = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Class.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Class.elem = field_decl b, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [concrete = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .a = %.loc12
-// CHECK:STDOUT:   .b = %.loc13
+// CHECK:STDOUT:   .a = %.loc15
+// CHECK:STDOUT:   .b = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc17_26.1: %struct_type.a.b.cfd = struct_literal (%int_1, %int_2)
+// CHECK:STDOUT:   %.loc20_26.1: %struct_type.a.b.cfd = struct_literal (%int_1, %int_2)
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %impl.elem0.loc17_26.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc17_26.1: <bound method> = bound_method %int_1, %impl.elem0.loc17_26.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc17_26.1: <specific function> = specific_function %impl.elem0.loc17_26.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc17_26.2: <bound method> = bound_method %int_1, %specific_fn.loc17_26.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc17_26.1: init %i32 = call %bound_method.loc17_26.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc17_26.2: init %i32 = converted %int_1, %int.convert_checked.loc17_26.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc17_26.3: ref %Class = temporary_storage
-// CHECK:STDOUT:   %.loc17_26.4: ref %i32 = class_element_access %.loc17_26.3, element0
-// CHECK:STDOUT:   %.loc17_26.5: init %i32 = initialize_from %.loc17_26.2 to %.loc17_26.4 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc17_26.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc17_26.3: <bound method> = bound_method %int_2, %impl.elem0.loc17_26.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc17_26.2: <specific function> = specific_function %impl.elem0.loc17_26.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc17_26.4: <bound method> = bound_method %int_2, %specific_fn.loc17_26.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc17_26.2: init %i32 = call %bound_method.loc17_26.4(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc17_26.6: init %i32 = converted %int_2, %int.convert_checked.loc17_26.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc17_26.7: ref %i32 = class_element_access %.loc17_26.3, element1
-// CHECK:STDOUT:   %.loc17_26.8: init %i32 = initialize_from %.loc17_26.6 to %.loc17_26.7 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc17_26.9: init %Class = class_init (%.loc17_26.5, %.loc17_26.8), %.loc17_26.3 [concrete = constants.%Class.val]
-// CHECK:STDOUT:   %.loc17_26.10: ref %Class = temporary %.loc17_26.3, %.loc17_26.9
-// CHECK:STDOUT:   %.loc17_28: ref %Class = converted %.loc17_26.1, %.loc17_26.10
-// CHECK:STDOUT:   %a.ref: %Class.elem = name_ref a, @Class.%.loc12 [concrete = @Class.%.loc12]
-// CHECK:STDOUT:   %.loc17_37.1: ref %i32 = class_element_access %.loc17_28, element0
-// CHECK:STDOUT:   %.loc17_37.2: %i32 = bind_value %.loc17_37.1
-// CHECK:STDOUT:   return %.loc17_37.2
+// CHECK:STDOUT:   %impl.elem0.loc20_26.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc20_26.1: <bound method> = bound_method %int_1, %impl.elem0.loc20_26.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc20_26.1: <specific function> = specific_function %impl.elem0.loc20_26.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc20_26.2: <bound method> = bound_method %int_1, %specific_fn.loc20_26.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc20_26.1: init %i32 = call %bound_method.loc20_26.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc20_26.2: init %i32 = converted %int_1, %int.convert_checked.loc20_26.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc20_26.3: ref %Class = temporary_storage
+// CHECK:STDOUT:   %.loc20_26.4: ref %i32 = class_element_access %.loc20_26.3, element0
+// CHECK:STDOUT:   %.loc20_26.5: init %i32 = initialize_from %.loc20_26.2 to %.loc20_26.4 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc20_26.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc20_26.3: <bound method> = bound_method %int_2, %impl.elem0.loc20_26.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc20_26.2: <specific function> = specific_function %impl.elem0.loc20_26.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc20_26.4: <bound method> = bound_method %int_2, %specific_fn.loc20_26.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc20_26.2: init %i32 = call %bound_method.loc20_26.4(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc20_26.6: init %i32 = converted %int_2, %int.convert_checked.loc20_26.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc20_26.7: ref %i32 = class_element_access %.loc20_26.3, element1
+// CHECK:STDOUT:   %.loc20_26.8: init %i32 = initialize_from %.loc20_26.6 to %.loc20_26.7 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc20_26.9: init %Class = class_init (%.loc20_26.5, %.loc20_26.8), %.loc20_26.3 [concrete = constants.%Class.val]
+// CHECK:STDOUT:   %.loc20_26.10: ref %Class = temporary %.loc20_26.3, %.loc20_26.9
+// CHECK:STDOUT:   %.loc20_28: ref %Class = converted %.loc20_26.1, %.loc20_26.10
+// CHECK:STDOUT:   %a.ref: %Class.elem = name_ref a, @Class.%.loc15 [concrete = @Class.%.loc15]
+// CHECK:STDOUT:   %.loc20_37.1: ref %i32 = class_element_access %.loc20_28, element0
+// CHECK:STDOUT:   %.loc20_37.2: %i32 = bind_value %.loc20_37.1
+// CHECK:STDOUT:   return %.loc20_37.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/init_nested.carbon
@@ -86,27 +89,27 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
-// CHECK:STDOUT:   %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Inner.elem = field_decl a, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Inner.elem = field_decl b, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: %Inner.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16: %Inner.elem = field_decl b, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a.b [concrete = constants.%complete_type.705]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Inner
-// CHECK:STDOUT:   .a = %.loc12
-// CHECK:STDOUT:   .b = %.loc13
+// CHECK:STDOUT:   .a = %.loc15
+// CHECK:STDOUT:   .b = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
-// CHECK:STDOUT:   %Inner.ref.loc19: type = name_ref Inner, file.%Inner.decl [concrete = constants.%Inner]
-// CHECK:STDOUT:   %.loc19: %Outer.elem = field_decl c, element0 [concrete]
-// CHECK:STDOUT:   %Inner.ref.loc20: type = name_ref Inner, file.%Inner.decl [concrete = constants.%Inner]
-// CHECK:STDOUT:   %.loc20: %Outer.elem = field_decl d, element1 [concrete]
+// CHECK:STDOUT:   %Inner.ref.loc22: type = name_ref Inner, file.%Inner.decl [concrete = constants.%Inner]
+// CHECK:STDOUT:   %.loc22: %Outer.elem = field_decl c, element0 [concrete]
+// CHECK:STDOUT:   %Inner.ref.loc23: type = name_ref Inner, file.%Inner.decl [concrete = constants.%Inner]
+// CHECK:STDOUT:   %.loc23: %Outer.elem = field_decl d, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.c.d: type = struct_type {.c: %Inner, .d: %Inner} [concrete = constants.%struct_type.c.d.dce]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.c.d [concrete = constants.%complete_type.8b6]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -114,23 +117,23 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Outer
 // CHECK:STDOUT:   .Inner = <poisoned>
-// CHECK:STDOUT:   .c = %.loc19
-// CHECK:STDOUT:   .d = %.loc20
+// CHECK:STDOUT:   .c = %.loc22
+// CHECK:STDOUT:   .d = %.loc23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeInner() -> %return.param: %Inner;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeOuter() -> %return.param: %Outer {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %MakeInner.ref.loc24_16: %MakeInner.type = name_ref MakeInner, file.%MakeInner.decl [concrete = constants.%MakeInner]
-// CHECK:STDOUT:   %.loc24_45.1: ref %Inner = class_element_access %return, element0
-// CHECK:STDOUT:   %MakeInner.call.loc24_26: init %Inner = call %MakeInner.ref.loc24_16() to %.loc24_45.1
-// CHECK:STDOUT:   %MakeInner.ref.loc24_34: %MakeInner.type = name_ref MakeInner, file.%MakeInner.decl [concrete = constants.%MakeInner]
-// CHECK:STDOUT:   %.loc24_45.2: ref %Inner = class_element_access %return, element1
-// CHECK:STDOUT:   %MakeInner.call.loc24_44: init %Inner = call %MakeInner.ref.loc24_34() to %.loc24_45.2
-// CHECK:STDOUT:   %.loc24_45.3: %struct_type.c.d.dce = struct_literal (%MakeInner.call.loc24_26, %MakeInner.call.loc24_44)
-// CHECK:STDOUT:   %.loc24_45.4: init %Outer = class_init (%MakeInner.call.loc24_26, %MakeInner.call.loc24_44), %return
-// CHECK:STDOUT:   %.loc24_46: init %Outer = converted %.loc24_45.3, %.loc24_45.4
-// CHECK:STDOUT:   return %.loc24_46 to %return
+// CHECK:STDOUT:   %MakeInner.ref.loc27_16: %MakeInner.type = name_ref MakeInner, file.%MakeInner.decl [concrete = constants.%MakeInner]
+// CHECK:STDOUT:   %.loc27_45.1: ref %Inner = class_element_access %return, element0
+// CHECK:STDOUT:   %MakeInner.call.loc27_26: init %Inner = call %MakeInner.ref.loc27_16() to %.loc27_45.1
+// CHECK:STDOUT:   %MakeInner.ref.loc27_34: %MakeInner.type = name_ref MakeInner, file.%MakeInner.decl [concrete = constants.%MakeInner]
+// CHECK:STDOUT:   %.loc27_45.2: ref %Inner = class_element_access %return, element1
+// CHECK:STDOUT:   %MakeInner.call.loc27_44: init %Inner = call %MakeInner.ref.loc27_34() to %.loc27_45.2
+// CHECK:STDOUT:   %.loc27_45.3: %struct_type.c.d.dce = struct_literal (%MakeInner.call.loc27_26, %MakeInner.call.loc27_44)
+// CHECK:STDOUT:   %.loc27_45.4: init %Outer = class_init (%MakeInner.call.loc27_26, %MakeInner.call.loc27_44), %return
+// CHECK:STDOUT:   %.loc27_46: init %Outer = converted %.loc27_45.3, %.loc27_45.4
+// CHECK:STDOUT:   return %.loc27_46 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/local.carbon
+++ b/toolchain/check/testdata/class/local.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/local.carbon
@@ -110,13 +113,13 @@ class A {
 // CHECK:STDOUT:     %return.patt: %pattern_type.971 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.971 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc14: type = name_ref Self, constants.%B [concrete = constants.%B]
+// CHECK:STDOUT:     %Self.ref.loc17: type = name_ref Self, constants.%B [concrete = constants.%B]
 // CHECK:STDOUT:     %return.param: ref %B = out_param call_param0
 // CHECK:STDOUT:     %return: ref %B = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc19: %B.elem = field_decl n, element0 [concrete]
+// CHECK:STDOUT:   %.loc22: %B.elem = field_decl n, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.n: type = struct_type {.n: %i32} [concrete = constants.%struct_type.n.033]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [concrete = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -124,7 +127,7 @@ class A {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT:   .Make = %Make.decl
-// CHECK:STDOUT:   .n = %.loc19
+// CHECK:STDOUT:   .n = %.loc22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %i32 {
@@ -132,13 +135,13 @@ class A {
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
 // CHECK:STDOUT:   %B.ref: type = name_ref B, %B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %Make.ref: %Make.type = name_ref Make, @B.%Make.decl [concrete = constants.%Make]
-// CHECK:STDOUT:   %.loc22_19.1: ref %B = temporary_storage
-// CHECK:STDOUT:   %Make.call: init %B = call %Make.ref() to %.loc22_19.1
-// CHECK:STDOUT:   %.loc22_19.2: ref %B = temporary %.loc22_19.1, %Make.call
-// CHECK:STDOUT:   %n.ref: %B.elem = name_ref n, @B.%.loc19 [concrete = @B.%.loc19]
-// CHECK:STDOUT:   %.loc22_20.1: ref %i32 = class_element_access %.loc22_19.2, element0
-// CHECK:STDOUT:   %.loc22_20.2: %i32 = bind_value %.loc22_20.1
-// CHECK:STDOUT:   return %.loc22_20.2
+// CHECK:STDOUT:   %.loc25_19.1: ref %B = temporary_storage
+// CHECK:STDOUT:   %Make.call: init %B = call %Make.ref() to %.loc25_19.1
+// CHECK:STDOUT:   %.loc25_19.2: ref %B = temporary %.loc25_19.1, %Make.call
+// CHECK:STDOUT:   %n.ref: %B.elem = name_ref n, @B.%.loc22 [concrete = @B.%.loc22]
+// CHECK:STDOUT:   %.loc25_20.1: ref %i32 = class_element_access %.loc25_19.2, element0
+// CHECK:STDOUT:   %.loc25_20.2: %i32 = bind_value %.loc25_20.1
+// CHECK:STDOUT:   return %.loc25_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return.param: %B {
@@ -148,19 +151,19 @@ class A {
 // CHECK:STDOUT:     %b.var_patt: %pattern_type.971 = var_pattern %b.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc15_39.1: %struct_type.n.44a = struct_literal (%int_1)
+// CHECK:STDOUT:   %.loc18_39.1: %struct_type.n.44a = struct_literal (%int_1)
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc15_39.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc18_39.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc15_39.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_39.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc15_39.2: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc15_39.3: ref %i32 = class_element_access %return, element0
-// CHECK:STDOUT:   %.loc15_39.4: init %i32 = initialize_from %.loc15_39.2 to %.loc15_39.3 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc15_39.5: init %B = class_init (%.loc15_39.4), %return [concrete = constants.%B.val]
-// CHECK:STDOUT:   %.loc15_18: init %B = converted %.loc15_39.1, %.loc15_39.5 [concrete = constants.%B.val]
-// CHECK:STDOUT:   assign %return, %.loc15_18
-// CHECK:STDOUT:   %Self.ref.loc15: type = name_ref Self, constants.%B [concrete = constants.%B]
+// CHECK:STDOUT:   %bound_method.loc18_39.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc18_39.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc18_39.2: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc18_39.3: ref %i32 = class_element_access %return, element0
+// CHECK:STDOUT:   %.loc18_39.4: init %i32 = initialize_from %.loc18_39.2 to %.loc18_39.3 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc18_39.5: init %B = class_init (%.loc18_39.4), %return [concrete = constants.%B.val]
+// CHECK:STDOUT:   %.loc18_18: init %B = converted %.loc18_39.1, %.loc18_39.5 [concrete = constants.%B.val]
+// CHECK:STDOUT:   assign %return, %.loc18_18
+// CHECK:STDOUT:   %Self.ref.loc18: type = name_ref Self, constants.%B [concrete = constants.%B]
 // CHECK:STDOUT:   %b: ref %B = bind_name b, %return
 // CHECK:STDOUT:   return %b to %return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/method.carbon
@@ -152,13 +155,13 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param.loc20: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc20: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc20: %Class = bind_name self, %self.param.loc20
-// CHECK:STDOUT:     %return.param.loc20: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc20: ref %i32 = return_slot %return.param.loc20
+// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.param.loc23: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc23: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc23: %Class = bind_name self, %self.param.loc23
+// CHECK:STDOUT:     %return.param.loc23: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc23: ref %i32 = return_slot %return.param.loc23
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Call.decl: %Call.type = fn_decl @Call [concrete = constants.%Call] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.761 = binding_pattern c [concrete]
@@ -215,7 +218,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %p.param: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc43: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %.loc46: type = splice_block %ptr [concrete = constants.%ptr.e71] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
@@ -232,7 +235,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %p.param: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc47: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %.loc50: type = splice_block %ptr [concrete = constants.%ptr.e71] {
 // CHECK:STDOUT:       %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Class.ref [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
@@ -275,25 +278,25 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param.loc12: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc12: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc12: %Class = bind_name self, %self.param.loc12
-// CHECK:STDOUT:     %return.param.loc12: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc12: ref %i32 = return_slot %return.param.loc12
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.param.loc15: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc15: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc15: %Class = bind_name self, %self.param.loc15
+// CHECK:STDOUT:     %return.param.loc15: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc15: ref %i32 = return_slot %return.param.loc15
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.796 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.796 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc13_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc16_8: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %self.param: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc13_23: type = splice_block %ptr [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %.loc16_23: type = splice_block %ptr [concrete = constants.%ptr.e71] {
 // CHECK:STDOUT:       %Self.ref: type = name_ref Self, constants.%Class [concrete = constants.%Class]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Self.ref [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
@@ -305,7 +308,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %A: %F.type = bind_alias A, %F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc17: %Class.elem = field_decl k, element0 [concrete]
+// CHECK:STDOUT:   %.loc20: %Class.elem = field_decl k, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.k: type = struct_type {.k: %i32} [concrete = constants.%struct_type.k.0bf]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.k [concrete = constants.%complete_type.954]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -315,16 +318,16 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   .G = %G.decl
 // CHECK:STDOUT:   .A = %A
-// CHECK:STDOUT:   .k = %.loc17
+// CHECK:STDOUT:   .k = %.loc20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%self.param.loc20: %Class) -> %i32 {
+// CHECK:STDOUT: fn @F(%self.param.loc23: %Class) -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref: %Class = name_ref self, %self.loc20
-// CHECK:STDOUT:   %k.ref: %Class.elem = name_ref k, @Class.%.loc17 [concrete = @Class.%.loc17]
-// CHECK:STDOUT:   %.loc21_14.1: ref %i32 = class_element_access %self.ref, element0
-// CHECK:STDOUT:   %.loc21_14.2: %i32 = bind_value %.loc21_14.1
-// CHECK:STDOUT:   return %.loc21_14.2
+// CHECK:STDOUT:   %self.ref: %Class = name_ref self, %self.loc23
+// CHECK:STDOUT:   %k.ref: %Class.elem = name_ref k, @Class.%.loc20 [concrete = @Class.%.loc20]
+// CHECK:STDOUT:   %.loc24_14.1: ref %i32 = class_element_access %self.ref, element0
+// CHECK:STDOUT:   %.loc24_14.2: %i32 = bind_value %.loc24_14.1
+// CHECK:STDOUT:   return %.loc24_14.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%self.param: %ptr.e71) -> %i32;
@@ -335,9 +338,9 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.bound: <bound method> = bound_method %c.ref, %F.ref
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%c.ref)
-// CHECK:STDOUT:   %.loc27_15.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc27_15.2: %i32 = converted %F.call, %.loc27_15.1
-// CHECK:STDOUT:   return %.loc27_15.2
+// CHECK:STDOUT:   %.loc30_15.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc30_15.2: %i32 = converted %F.call, %.loc30_15.1
+// CHECK:STDOUT:   return %.loc30_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallAlias(%c.param: %Class) -> %i32 {
@@ -346,35 +349,35 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %A.ref: %F.type = name_ref A, @Class.%A [concrete = constants.%F]
 // CHECK:STDOUT:   %F.bound: <bound method> = bound_method %c.ref, %A.ref
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%c.ref)
-// CHECK:STDOUT:   %.loc31_15.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc31_15.2: %i32 = converted %F.call, %.loc31_15.1
-// CHECK:STDOUT:   return %.loc31_15.2
+// CHECK:STDOUT:   %.loc34_15.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc34_15.2: %i32 = converted %F.call, %.loc34_15.1
+// CHECK:STDOUT:   return %.loc34_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallOnConstBoundMethod() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc35_18.1: %struct_type.k.240 = struct_literal (%int_1)
+// CHECK:STDOUT:   %.loc38_18.1: %struct_type.k.240 = struct_literal (%int_1)
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc35_18.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc38_18.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc35_18.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc35_18.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc35_18.2: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc35_18.3: ref %Class = temporary_storage
-// CHECK:STDOUT:   %.loc35_18.4: ref %i32 = class_element_access %.loc35_18.3, element0
-// CHECK:STDOUT:   %.loc35_18.5: init %i32 = initialize_from %.loc35_18.2 to %.loc35_18.4 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc35_18.6: init %Class = class_init (%.loc35_18.5), %.loc35_18.3 [concrete = constants.%Class.val]
-// CHECK:STDOUT:   %.loc35_18.7: ref %Class = temporary %.loc35_18.3, %.loc35_18.6
-// CHECK:STDOUT:   %.loc35_20.1: ref %Class = converted %.loc35_18.1, %.loc35_18.7
+// CHECK:STDOUT:   %bound_method.loc38_18.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc38_18.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc38_18.2: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc38_18.3: ref %Class = temporary_storage
+// CHECK:STDOUT:   %.loc38_18.4: ref %i32 = class_element_access %.loc38_18.3, element0
+// CHECK:STDOUT:   %.loc38_18.5: init %i32 = initialize_from %.loc38_18.2 to %.loc38_18.4 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc38_18.6: init %Class = class_init (%.loc38_18.5), %.loc38_18.3 [concrete = constants.%Class.val]
+// CHECK:STDOUT:   %.loc38_18.7: ref %Class = temporary %.loc38_18.3, %.loc38_18.6
+// CHECK:STDOUT:   %.loc38_20.1: ref %Class = converted %.loc38_18.1, %.loc38_18.7
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc35_20.1, %F.ref
-// CHECK:STDOUT:   %.loc35_20.2: %Class = bind_value %.loc35_20.1
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc35_20.2)
-// CHECK:STDOUT:   %.loc35_33.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc35_33.2: %i32 = converted %F.call, %.loc35_33.1
-// CHECK:STDOUT:   return %.loc35_33.2
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc38_20.1, %F.ref
+// CHECK:STDOUT:   %.loc38_20.2: %Class = bind_value %.loc38_20.1
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc38_20.2)
+// CHECK:STDOUT:   %.loc38_33.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc38_33.2: %i32 = converted %F.call, %.loc38_33.1
+// CHECK:STDOUT:   return %.loc38_33.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallWithAddr() -> %i32 {
@@ -391,35 +394,35 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %G.bound: <bound method> = bound_method %c.ref, %G.ref
 // CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %c.ref
 // CHECK:STDOUT:   %G.call: init %i32 = call %G.bound(%addr)
-// CHECK:STDOUT:   %.loc40_15.1: %i32 = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc40_15.2: %i32 = converted %G.call, %.loc40_15.1
-// CHECK:STDOUT:   return %.loc40_15.2
+// CHECK:STDOUT:   %.loc43_15.1: %i32 = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc43_15.2: %i32 = converted %G.call, %.loc43_15.1
+// CHECK:STDOUT:   return %.loc43_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallFThroughPointer(%p.param: %ptr.e71) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.e71 = name_ref p, %p
-// CHECK:STDOUT:   %.loc44_11.1: ref %Class = deref %p.ref
+// CHECK:STDOUT:   %.loc47_11.1: ref %Class = deref %p.ref
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc44_11.1, %F.ref
-// CHECK:STDOUT:   %.loc44_11.2: %Class = bind_value %.loc44_11.1
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc44_11.2)
-// CHECK:STDOUT:   %.loc44_18.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc44_18.2: %i32 = converted %F.call, %.loc44_18.1
-// CHECK:STDOUT:   return %.loc44_18.2
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc47_11.1, %F.ref
+// CHECK:STDOUT:   %.loc47_11.2: %Class = bind_value %.loc47_11.1
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc47_11.2)
+// CHECK:STDOUT:   %.loc47_18.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc47_18.2: %i32 = converted %F.call, %.loc47_18.1
+// CHECK:STDOUT:   return %.loc47_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGThroughPointer(%p.param: %ptr.e71) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.e71 = name_ref p, %p
-// CHECK:STDOUT:   %.loc48_11: ref %Class = deref %p.ref
+// CHECK:STDOUT:   %.loc51_11: ref %Class = deref %p.ref
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %.loc48_11, %G.ref
-// CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %.loc48_11
+// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %.loc51_11, %G.ref
+// CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %.loc51_11
 // CHECK:STDOUT:   %G.call: init %i32 = call %G.bound(%addr)
-// CHECK:STDOUT:   %.loc48_18.1: %i32 = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc48_18.2: %i32 = converted %G.call, %.loc48_18.1
-// CHECK:STDOUT:   return %.loc48_18.2
+// CHECK:STDOUT:   %.loc51_18.1: %i32 = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc51_18.2: %i32 = converted %G.call, %.loc51_18.1
+// CHECK:STDOUT:   return %.loc51_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return.param: %Class;
@@ -427,30 +430,30 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: fn @CallFOnInitializingExpr() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Make.ref: %Make.type = name_ref Make, file.%Make.decl [concrete = constants.%Make]
-// CHECK:STDOUT:   %.loc54_15.1: ref %Class = temporary_storage
-// CHECK:STDOUT:   %Make.call: init %Class = call %Make.ref() to %.loc54_15.1
-// CHECK:STDOUT:   %.loc54_15.2: ref %Class = temporary %.loc54_15.1, %Make.call
+// CHECK:STDOUT:   %.loc57_15.1: ref %Class = temporary_storage
+// CHECK:STDOUT:   %Make.call: init %Class = call %Make.ref() to %.loc57_15.1
+// CHECK:STDOUT:   %.loc57_15.2: ref %Class = temporary %.loc57_15.1, %Make.call
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc54_15.2, %F.ref
-// CHECK:STDOUT:   %.loc54_15.3: %Class = bind_value %.loc54_15.2
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc54_15.3)
-// CHECK:STDOUT:   %.loc54_20.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc54_20.2: %i32 = converted %F.call, %.loc54_20.1
-// CHECK:STDOUT:   return %.loc54_20.2
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc57_15.2, %F.ref
+// CHECK:STDOUT:   %.loc57_15.3: %Class = bind_value %.loc57_15.2
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc57_15.3)
+// CHECK:STDOUT:   %.loc57_20.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc57_20.2: %i32 = converted %F.call, %.loc57_20.1
+// CHECK:STDOUT:   return %.loc57_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGOnInitializingExpr() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Make.ref: %Make.type = name_ref Make, file.%Make.decl [concrete = constants.%Make]
-// CHECK:STDOUT:   %.loc58_15.1: ref %Class = temporary_storage
-// CHECK:STDOUT:   %Make.call: init %Class = call %Make.ref() to %.loc58_15.1
-// CHECK:STDOUT:   %.loc58_15.2: ref %Class = temporary %.loc58_15.1, %Make.call
+// CHECK:STDOUT:   %.loc61_15.1: ref %Class = temporary_storage
+// CHECK:STDOUT:   %Make.call: init %Class = call %Make.ref() to %.loc61_15.1
+// CHECK:STDOUT:   %.loc61_15.2: ref %Class = temporary %.loc61_15.1, %Make.call
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %.loc58_15.2, %G.ref
-// CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %.loc58_15.2
+// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %.loc61_15.2, %G.ref
+// CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %.loc61_15.2
 // CHECK:STDOUT:   %G.call: init %i32 = call %G.bound(%addr)
-// CHECK:STDOUT:   %.loc58_20.1: %i32 = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc58_20.2: %i32 = converted %G.call, %.loc58_20.1
-// CHECK:STDOUT:   return %.loc58_20.2
+// CHECK:STDOUT:   %.loc61_20.1: %i32 = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc61_20.2: %i32 = converted %G.call, %.loc61_20.1
+// CHECK:STDOUT:   return %.loc61_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/min_prelude/destroy_decl.carbon
+++ b/toolchain/check/testdata/class/min_prelude/destroy_decl.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/nested.carbon
@@ -98,9 +101,9 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:     %a.param_patt: %pattern_type.95c = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.5df = value_param call_param0
-// CHECK:STDOUT:     %.loc41: type = splice_block %ptr.loc41 [concrete = constants.%ptr.5df] {
-// CHECK:STDOUT:       %Outer.ref.loc41: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
-// CHECK:STDOUT:       %ptr.loc41: type = ptr_type %Outer.ref.loc41 [concrete = constants.%ptr.5df]
+// CHECK:STDOUT:     %.loc44: type = splice_block %ptr.loc44 [concrete = constants.%ptr.5df] {
+// CHECK:STDOUT:       %Outer.ref.loc44: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
+// CHECK:STDOUT:       %ptr.loc44: type = ptr_type %Outer.ref.loc44 [concrete = constants.%ptr.5df]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.5df = bind_name a, %a.param
 // CHECK:STDOUT:   }
@@ -111,14 +114,14 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   %Inner.decl: type = class_decl @Inner [concrete = constants.%Inner] {} {}
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {} {}
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Outer [concrete = constants.%Outer]
-// CHECK:STDOUT:   %ptr.loc36: type = ptr_type %Self.ref [concrete = constants.%ptr.5df]
-// CHECK:STDOUT:   %.loc36: %Outer.elem.a16 = field_decl po, element0 [concrete]
+// CHECK:STDOUT:   %ptr.loc39: type = ptr_type %Self.ref [concrete = constants.%ptr.5df]
+// CHECK:STDOUT:   %.loc39: %Outer.elem.a16 = field_decl po, element0 [concrete]
 // CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
-// CHECK:STDOUT:   %ptr.loc37: type = ptr_type %Outer.ref [concrete = constants.%ptr.5df]
-// CHECK:STDOUT:   %.loc37: %Outer.elem.a16 = field_decl qo, element1 [concrete]
+// CHECK:STDOUT:   %ptr.loc40: type = ptr_type %Outer.ref [concrete = constants.%ptr.5df]
+// CHECK:STDOUT:   %.loc40: %Outer.elem.a16 = field_decl qo, element1 [concrete]
 // CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, %Inner.decl [concrete = constants.%Inner]
-// CHECK:STDOUT:   %ptr.loc38: type = ptr_type %Inner.ref [concrete = constants.%ptr.36a]
-// CHECK:STDOUT:   %.loc38: %Outer.elem.fe9 = field_decl pi, element2 [concrete]
+// CHECK:STDOUT:   %ptr.loc41: type = ptr_type %Inner.ref [concrete = constants.%ptr.36a]
+// CHECK:STDOUT:   %.loc41: %Outer.elem.fe9 = field_decl pi, element2 [concrete]
 // CHECK:STDOUT:   %struct_type.po.qo.pi: type = struct_type {.po: %ptr.5df, .qo: %ptr.5df, .pi: %ptr.36a} [concrete = constants.%struct_type.po.qo.pi]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.po.qo.pi [concrete = constants.%complete_type.e99]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -129,21 +132,21 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   .Inner = %Inner.decl
 // CHECK:STDOUT:   .Outer = <poisoned>
 // CHECK:STDOUT:   .H = %H.decl
-// CHECK:STDOUT:   .po = %.loc36
-// CHECK:STDOUT:   .qo = %.loc37
-// CHECK:STDOUT:   .pi = %.loc38
+// CHECK:STDOUT:   .po = %.loc39
+// CHECK:STDOUT:   .qo = %.loc40
+// CHECK:STDOUT:   .pi = %.loc41
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Inner [concrete = constants.%Inner]
-// CHECK:STDOUT:   %ptr.loc19: type = ptr_type %Self.ref [concrete = constants.%ptr.36a]
-// CHECK:STDOUT:   %.loc19: %Inner.elem.640 = field_decl pi, element0 [concrete]
+// CHECK:STDOUT:   %ptr.loc22: type = ptr_type %Self.ref [concrete = constants.%ptr.36a]
+// CHECK:STDOUT:   %.loc22: %Inner.elem.640 = field_decl pi, element0 [concrete]
 // CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
-// CHECK:STDOUT:   %ptr.loc20: type = ptr_type %Outer.ref [concrete = constants.%ptr.5df]
-// CHECK:STDOUT:   %.loc20: %Inner.elem.c30 = field_decl po, element1 [concrete]
+// CHECK:STDOUT:   %ptr.loc23: type = ptr_type %Outer.ref [concrete = constants.%ptr.5df]
+// CHECK:STDOUT:   %.loc23: %Inner.elem.c30 = field_decl po, element1 [concrete]
 // CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, @Outer.%Inner.decl [concrete = constants.%Inner]
-// CHECK:STDOUT:   %ptr.loc21: type = ptr_type %Inner.ref [concrete = constants.%ptr.36a]
-// CHECK:STDOUT:   %.loc21: %Inner.elem.640 = field_decl qi, element2 [concrete]
+// CHECK:STDOUT:   %ptr.loc24: type = ptr_type %Inner.ref [concrete = constants.%ptr.36a]
+// CHECK:STDOUT:   %.loc24: %Inner.elem.640 = field_decl qi, element2 [concrete]
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
 // CHECK:STDOUT:   %struct_type.pi.po.qi: type = struct_type {.pi: %ptr.36a, .po: %ptr.5df, .qi: %ptr.36a} [concrete = constants.%struct_type.pi.po.qi]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.pi.po.qi [concrete = constants.%complete_type.7ae]
@@ -151,11 +154,11 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Inner
-// CHECK:STDOUT:   .pi = %.loc19
+// CHECK:STDOUT:   .pi = %.loc22
 // CHECK:STDOUT:   .Outer = <poisoned>
-// CHECK:STDOUT:   .po = %.loc20
+// CHECK:STDOUT:   .po = %.loc23
 // CHECK:STDOUT:   .Inner = <poisoned>
-// CHECK:STDOUT:   .qi = %.loc21
+// CHECK:STDOUT:   .qi = %.loc24
 // CHECK:STDOUT:   .G = %G.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -221,67 +224,67 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.27f = binding_pattern b [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %a.ref.loc42: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc42_26: ref %Outer = deref %a.ref.loc42
-// CHECK:STDOUT:   %pi.ref.loc42: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc38 [concrete = @Outer.%.loc38]
-// CHECK:STDOUT:   %.loc42_29: ref %ptr.36a = class_element_access %.loc42_26, element2
-// CHECK:STDOUT:   %.loc42_21: type = splice_block %ptr.loc42 [concrete = constants.%ptr.36a] {
-// CHECK:STDOUT:     %Outer.ref.loc42: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
+// CHECK:STDOUT:   %a.ref.loc45: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc45_26: ref %Outer = deref %a.ref.loc45
+// CHECK:STDOUT:   %pi.ref.loc45: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc41 [concrete = @Outer.%.loc41]
+// CHECK:STDOUT:   %.loc45_29: ref %ptr.36a = class_element_access %.loc45_26, element2
+// CHECK:STDOUT:   %.loc45_21: type = splice_block %ptr.loc45 [concrete = constants.%ptr.36a] {
+// CHECK:STDOUT:     %Outer.ref.loc45: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
 // CHECK:STDOUT:     %Inner.ref: type = name_ref Inner, @Outer.%Inner.decl [concrete = constants.%Inner]
-// CHECK:STDOUT:     %ptr.loc42: type = ptr_type %Inner.ref [concrete = constants.%ptr.36a]
+// CHECK:STDOUT:     %ptr.loc45: type = ptr_type %Inner.ref [concrete = constants.%ptr.36a]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %b: ref %ptr.36a = bind_name b, %.loc42_29
-// CHECK:STDOUT:   %a.ref.loc44_3: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc44_4.1: ref %Outer = deref %a.ref.loc44_3
-// CHECK:STDOUT:   %po.ref.loc44: %Outer.elem.a16 = name_ref po, @Outer.%.loc36 [concrete = @Outer.%.loc36]
-// CHECK:STDOUT:   %.loc44_4.2: ref %ptr.5df = class_element_access %.loc44_4.1, element0
-// CHECK:STDOUT:   %a.ref.loc44_11: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   assign %.loc44_4.2, %a.ref.loc44_11
-// CHECK:STDOUT:   %a.ref.loc45_3: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc45_4.1: ref %Outer = deref %a.ref.loc45_3
-// CHECK:STDOUT:   %qo.ref: %Outer.elem.a16 = name_ref qo, @Outer.%.loc37 [concrete = @Outer.%.loc37]
-// CHECK:STDOUT:   %.loc45_4.2: ref %ptr.5df = class_element_access %.loc45_4.1, element1
-// CHECK:STDOUT:   %a.ref.loc45_11: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   assign %.loc45_4.2, %a.ref.loc45_11
-// CHECK:STDOUT:   %a.ref.loc46_3: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc46_4.1: ref %Outer = deref %a.ref.loc46_3
-// CHECK:STDOUT:   %pi.ref.loc46_4: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc38 [concrete = @Outer.%.loc38]
-// CHECK:STDOUT:   %.loc46_4.2: ref %ptr.36a = class_element_access %.loc46_4.1, element2
-// CHECK:STDOUT:   %a.ref.loc46_11: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc46_12.1: ref %Outer = deref %a.ref.loc46_11
-// CHECK:STDOUT:   %pi.ref.loc46_12: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc38 [concrete = @Outer.%.loc38]
-// CHECK:STDOUT:   %.loc46_12.2: ref %ptr.36a = class_element_access %.loc46_12.1, element2
-// CHECK:STDOUT:   %.loc46_12.3: %ptr.36a = bind_value %.loc46_12.2
-// CHECK:STDOUT:   assign %.loc46_4.2, %.loc46_12.3
-// CHECK:STDOUT:   %b.ref.loc47: ref %ptr.36a = name_ref b, %b
-// CHECK:STDOUT:   %.loc47_3: %ptr.36a = bind_value %b.ref.loc47
-// CHECK:STDOUT:   %.loc47_4.1: ref %Inner = deref %.loc47_3
-// CHECK:STDOUT:   %po.ref.loc47: %Inner.elem.c30 = name_ref po, @Inner.%.loc20 [concrete = @Inner.%.loc20]
-// CHECK:STDOUT:   %.loc47_4.2: ref %ptr.5df = class_element_access %.loc47_4.1, element1
-// CHECK:STDOUT:   %a.ref.loc47: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   assign %.loc47_4.2, %a.ref.loc47
-// CHECK:STDOUT:   %b.ref.loc48: ref %ptr.36a = name_ref b, %b
-// CHECK:STDOUT:   %.loc48_3: %ptr.36a = bind_value %b.ref.loc48
-// CHECK:STDOUT:   %.loc48_4.1: ref %Inner = deref %.loc48_3
-// CHECK:STDOUT:   %pi.ref.loc48_4: %Inner.elem.640 = name_ref pi, @Inner.%.loc19 [concrete = @Inner.%.loc19]
-// CHECK:STDOUT:   %.loc48_4.2: ref %ptr.36a = class_element_access %.loc48_4.1, element0
-// CHECK:STDOUT:   %a.ref.loc48: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc48_12.1: ref %Outer = deref %a.ref.loc48
-// CHECK:STDOUT:   %pi.ref.loc48_12: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc38 [concrete = @Outer.%.loc38]
-// CHECK:STDOUT:   %.loc48_12.2: ref %ptr.36a = class_element_access %.loc48_12.1, element2
-// CHECK:STDOUT:   %.loc48_12.3: %ptr.36a = bind_value %.loc48_12.2
-// CHECK:STDOUT:   assign %.loc48_4.2, %.loc48_12.3
-// CHECK:STDOUT:   %b.ref.loc49: ref %ptr.36a = name_ref b, %b
-// CHECK:STDOUT:   %.loc49_3: %ptr.36a = bind_value %b.ref.loc49
-// CHECK:STDOUT:   %.loc49_4.1: ref %Inner = deref %.loc49_3
-// CHECK:STDOUT:   %qi.ref: %Inner.elem.640 = name_ref qi, @Inner.%.loc21 [concrete = @Inner.%.loc21]
+// CHECK:STDOUT:   %b: ref %ptr.36a = bind_name b, %.loc45_29
+// CHECK:STDOUT:   %a.ref.loc47_3: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc47_4.1: ref %Outer = deref %a.ref.loc47_3
+// CHECK:STDOUT:   %po.ref.loc47: %Outer.elem.a16 = name_ref po, @Outer.%.loc39 [concrete = @Outer.%.loc39]
+// CHECK:STDOUT:   %.loc47_4.2: ref %ptr.5df = class_element_access %.loc47_4.1, element0
+// CHECK:STDOUT:   %a.ref.loc47_11: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   assign %.loc47_4.2, %a.ref.loc47_11
+// CHECK:STDOUT:   %a.ref.loc48_3: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc48_4.1: ref %Outer = deref %a.ref.loc48_3
+// CHECK:STDOUT:   %qo.ref: %Outer.elem.a16 = name_ref qo, @Outer.%.loc40 [concrete = @Outer.%.loc40]
+// CHECK:STDOUT:   %.loc48_4.2: ref %ptr.5df = class_element_access %.loc48_4.1, element1
+// CHECK:STDOUT:   %a.ref.loc48_11: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   assign %.loc48_4.2, %a.ref.loc48_11
+// CHECK:STDOUT:   %a.ref.loc49_3: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc49_4.1: ref %Outer = deref %a.ref.loc49_3
+// CHECK:STDOUT:   %pi.ref.loc49_4: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc41 [concrete = @Outer.%.loc41]
 // CHECK:STDOUT:   %.loc49_4.2: ref %ptr.36a = class_element_access %.loc49_4.1, element2
-// CHECK:STDOUT:   %a.ref.loc49: %ptr.5df = name_ref a, %a
-// CHECK:STDOUT:   %.loc49_12.1: ref %Outer = deref %a.ref.loc49
-// CHECK:STDOUT:   %pi.ref.loc49: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc38 [concrete = @Outer.%.loc38]
+// CHECK:STDOUT:   %a.ref.loc49_11: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc49_12.1: ref %Outer = deref %a.ref.loc49_11
+// CHECK:STDOUT:   %pi.ref.loc49_12: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc41 [concrete = @Outer.%.loc41]
 // CHECK:STDOUT:   %.loc49_12.2: ref %ptr.36a = class_element_access %.loc49_12.1, element2
 // CHECK:STDOUT:   %.loc49_12.3: %ptr.36a = bind_value %.loc49_12.2
 // CHECK:STDOUT:   assign %.loc49_4.2, %.loc49_12.3
+// CHECK:STDOUT:   %b.ref.loc50: ref %ptr.36a = name_ref b, %b
+// CHECK:STDOUT:   %.loc50_3: %ptr.36a = bind_value %b.ref.loc50
+// CHECK:STDOUT:   %.loc50_4.1: ref %Inner = deref %.loc50_3
+// CHECK:STDOUT:   %po.ref.loc50: %Inner.elem.c30 = name_ref po, @Inner.%.loc23 [concrete = @Inner.%.loc23]
+// CHECK:STDOUT:   %.loc50_4.2: ref %ptr.5df = class_element_access %.loc50_4.1, element1
+// CHECK:STDOUT:   %a.ref.loc50: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   assign %.loc50_4.2, %a.ref.loc50
+// CHECK:STDOUT:   %b.ref.loc51: ref %ptr.36a = name_ref b, %b
+// CHECK:STDOUT:   %.loc51_3: %ptr.36a = bind_value %b.ref.loc51
+// CHECK:STDOUT:   %.loc51_4.1: ref %Inner = deref %.loc51_3
+// CHECK:STDOUT:   %pi.ref.loc51_4: %Inner.elem.640 = name_ref pi, @Inner.%.loc22 [concrete = @Inner.%.loc22]
+// CHECK:STDOUT:   %.loc51_4.2: ref %ptr.36a = class_element_access %.loc51_4.1, element0
+// CHECK:STDOUT:   %a.ref.loc51: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc51_12.1: ref %Outer = deref %a.ref.loc51
+// CHECK:STDOUT:   %pi.ref.loc51_12: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc41 [concrete = @Outer.%.loc41]
+// CHECK:STDOUT:   %.loc51_12.2: ref %ptr.36a = class_element_access %.loc51_12.1, element2
+// CHECK:STDOUT:   %.loc51_12.3: %ptr.36a = bind_value %.loc51_12.2
+// CHECK:STDOUT:   assign %.loc51_4.2, %.loc51_12.3
+// CHECK:STDOUT:   %b.ref.loc52: ref %ptr.36a = name_ref b, %b
+// CHECK:STDOUT:   %.loc52_3: %ptr.36a = bind_value %b.ref.loc52
+// CHECK:STDOUT:   %.loc52_4.1: ref %Inner = deref %.loc52_3
+// CHECK:STDOUT:   %qi.ref: %Inner.elem.640 = name_ref qi, @Inner.%.loc24 [concrete = @Inner.%.loc24]
+// CHECK:STDOUT:   %.loc52_4.2: ref %ptr.36a = class_element_access %.loc52_4.1, element2
+// CHECK:STDOUT:   %a.ref.loc52: %ptr.5df = name_ref a, %a
+// CHECK:STDOUT:   %.loc52_12.1: ref %Outer = deref %a.ref.loc52
+// CHECK:STDOUT:   %pi.ref.loc52: %Outer.elem.fe9 = name_ref pi, @Outer.%.loc41 [concrete = @Outer.%.loc41]
+// CHECK:STDOUT:   %.loc52_12.2: ref %ptr.36a = class_element_access %.loc52_12.1, element2
+// CHECK:STDOUT:   %.loc52_12.3: %ptr.36a = bind_value %.loc52_12.2
+// CHECK:STDOUT:   assign %.loc52_4.2, %.loc52_12.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/nested_name.carbon
@@ -72,7 +75,7 @@ fn G(o: Outer) {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %oi.param: %Inner = value_param call_param0
-// CHECK:STDOUT:     %.loc17: type = splice_block %Inner.ref [concrete = constants.%Inner] {
+// CHECK:STDOUT:     %.loc20: type = splice_block %Inner.ref [concrete = constants.%Inner] {
 // CHECK:STDOUT:       %Outer.ref: type = name_ref Outer, file.%Outer.decl [concrete = constants.%Outer]
 // CHECK:STDOUT:       %Inner.ref: type = name_ref Inner, @Outer.%Inner.decl [concrete = constants.%Inner]
 // CHECK:STDOUT:     }
@@ -104,23 +107,23 @@ fn G(o: Outer) {
 // CHECK:STDOUT: class @Inner {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13: %Inner.elem = field_decl n, element0 [concrete]
+// CHECK:STDOUT:   %.loc16: %Inner.elem = field_decl n, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.n: type = struct_type {.n: %i32} [concrete = constants.%struct_type.n]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [concrete = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Inner
-// CHECK:STDOUT:   .n = %.loc13
+// CHECK:STDOUT:   .n = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%oi.param: %Inner) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %oi.ref: %Inner = name_ref oi, %oi
-// CHECK:STDOUT:   %n.ref: %Inner.elem = name_ref n, @Inner.%.loc13 [concrete = @Inner.%.loc13]
-// CHECK:STDOUT:   %.loc18_12.1: ref %i32 = class_element_access %oi.ref, element0
-// CHECK:STDOUT:   %.loc18_12.2: %i32 = bind_value %.loc18_12.1
-// CHECK:STDOUT:   return %.loc18_12.2
+// CHECK:STDOUT:   %n.ref: %Inner.elem = name_ref n, @Inner.%.loc16 [concrete = @Inner.%.loc16]
+// CHECK:STDOUT:   %.loc21_12.1: ref %i32 = class_element_access %oi.ref, element0
+// CHECK:STDOUT:   %.loc21_12.2: %i32 = bind_value %.loc21_12.1
+// CHECK:STDOUT:   return %.loc21_12.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%o.param: %Outer) {
@@ -130,7 +133,7 @@ fn G(o: Outer) {
 // CHECK:STDOUT:     %i.var_patt: %pattern_type.906 = var_pattern %i.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %i.var: ref %Inner = var %i.var_patt
-// CHECK:STDOUT:   %.loc22: type = splice_block %Inner.ref [concrete = constants.%Inner] {
+// CHECK:STDOUT:   %.loc25: type = splice_block %Inner.ref [concrete = constants.%Inner] {
 // CHECK:STDOUT:     %o.ref: %Outer = name_ref o, %o
 // CHECK:STDOUT:     %Inner.ref: type = name_ref Inner, @Outer.%Inner.decl [concrete = constants.%Inner]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/no_prelude/comp_time_field.carbon
+++ b/toolchain/check/testdata/class/no_prelude/comp_time_field.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/comp_time_field.carbon

--- a/toolchain/check/testdata/class/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/class/no_prelude/export_name.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/export_name.carbon

--- a/toolchain/check/testdata/class/no_prelude/extern.carbon
+++ b/toolchain/check/testdata/class/no_prelude/extern.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/extern.carbon

--- a/toolchain/check/testdata/class/no_prelude/extern_library.carbon
+++ b/toolchain/check/testdata/class/no_prelude/extern_library.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/extern_library.carbon

--- a/toolchain/check/testdata/class/no_prelude/fail_abstract_in_struct.carbon
+++ b/toolchain/check/testdata/class/no_prelude/fail_abstract_in_struct.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/fail_abstract_in_struct.carbon

--- a/toolchain/check/testdata/class/no_prelude/fail_error_recovery.carbon
+++ b/toolchain/check/testdata/class/no_prelude/fail_error_recovery.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/fail_error_recovery.carbon

--- a/toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon
+++ b/toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/generic_vs_params.carbon

--- a/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
+++ b/toolchain/check/testdata/class/no_prelude/implicit_import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/implicit_import.carbon

--- a/toolchain/check/testdata/class/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/class/no_prelude/import_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/import_access.carbon

--- a/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
+++ b/toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/indirect_import_member.carbon

--- a/toolchain/check/testdata/class/no_prelude/method_access.carbon
+++ b/toolchain/check/testdata/class/no_prelude/method_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/method_access.carbon

--- a/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/no_prelude/name_poisoning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/no_definition_in_impl_file.carbon

--- a/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
+++ b/toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/no_prelude/syntactic_merge.carbon

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/raw_self.carbon
@@ -64,103 +67,103 @@ fn Class.G[self: Self](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [concrete = constants.%Class] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %self.patt.loc17_17: %pattern_type.796 = binding_pattern self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc17_21: %pattern_type.796 = value_param_pattern %self.patt.loc17_17, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc17_12: %pattern_type.f6d = addr_pattern %self.param_patt.loc17_21 [concrete]
-// CHECK:STDOUT:     %self.patt.loc17_30: %pattern_type.7ce = binding_pattern r#self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc17_36: %pattern_type.7ce = value_param_pattern %self.patt.loc17_30, call_param1 [concrete]
+// CHECK:STDOUT:     %self.patt.loc20_17: %pattern_type.796 = binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc20_21: %pattern_type.796 = value_param_pattern %self.patt.loc20_17, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc20_12: %pattern_type.f6d = addr_pattern %self.param_patt.loc20_21 [concrete]
+// CHECK:STDOUT:     %self.patt.loc20_30: %pattern_type.7ce = binding_pattern r#self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc20_36: %pattern_type.7ce = value_param_pattern %self.patt.loc20_30, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc17_21: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc17_27: type = splice_block %ptr.loc17 [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:       %Self.ref.loc17: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:       %ptr.loc17: type = ptr_type %Self.ref.loc17 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:     %self.param.loc20_21: %ptr.e71 = value_param call_param0
+// CHECK:STDOUT:     %.loc20_27: type = splice_block %ptr.loc20 [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:       %Self.ref.loc20: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:       %ptr.loc20: type = ptr_type %Self.ref.loc20 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc17_17: %ptr.e71 = bind_name self, %self.param.loc17_21
-// CHECK:STDOUT:     %self.param.loc17_36: %i32 = value_param call_param1
-// CHECK:STDOUT:     %.loc17_38: type = splice_block %i32.loc17 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.loc20_17: %ptr.e71 = bind_name self, %self.param.loc20_21
+// CHECK:STDOUT:     %self.param.loc20_36: %i32 = value_param call_param1
+// CHECK:STDOUT:     %.loc20_38: type = splice_block %i32.loc20 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc17_30: %i32 = bind_name r#self, %self.param.loc17_36
+// CHECK:STDOUT:     %self.loc20_30: %i32 = bind_name r#self, %self.param.loc20_36
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
-// CHECK:STDOUT:     %self.patt.loc21_12: %pattern_type.761 = binding_pattern self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc21_16: %pattern_type.761 = value_param_pattern %self.patt.loc21_12, call_param0 [concrete]
-// CHECK:STDOUT:     %self.patt.loc21_24: %pattern_type.7ce = binding_pattern r#self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc21_30: %pattern_type.7ce = value_param_pattern %self.patt.loc21_24, call_param1 [concrete]
+// CHECK:STDOUT:     %self.patt.loc24_12: %pattern_type.761 = binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc24_16: %pattern_type.761 = value_param_pattern %self.patt.loc24_12, call_param0 [concrete]
+// CHECK:STDOUT:     %self.patt.loc24_24: %pattern_type.7ce = binding_pattern r#self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc24_30: %pattern_type.7ce = value_param_pattern %self.patt.loc24_24, call_param1 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.511 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.511 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc21_41: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21_41: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc21_46: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21_46: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc21_49.1: %tuple.type.24b = tuple_literal (%i32.loc21_41, %i32.loc21_46)
-// CHECK:STDOUT:     %.loc21_49.2: type = converted %.loc21_49.1, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
-// CHECK:STDOUT:     %self.param.loc21_16: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc21: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc21_12: %Class = bind_name self, %self.param.loc21_16
-// CHECK:STDOUT:     %self.param.loc21_30: %i32 = value_param call_param1
-// CHECK:STDOUT:     %.loc21_32: type = splice_block %i32.loc21_32 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc21_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc21_32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc24_41: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24_41: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc24_46: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24_46: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc24_49.1: %tuple.type.24b = tuple_literal (%i32.loc24_41, %i32.loc24_46)
+// CHECK:STDOUT:     %.loc24_49.2: type = converted %.loc24_49.1, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
+// CHECK:STDOUT:     %self.param.loc24_16: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc24: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc24_12: %Class = bind_name self, %self.param.loc24_16
+// CHECK:STDOUT:     %self.param.loc24_30: %i32 = value_param call_param1
+// CHECK:STDOUT:     %.loc24_32: type = splice_block %i32.loc24_32 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc24_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc24_32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc21_24: %i32 = bind_name r#self, %self.param.loc21_30
-// CHECK:STDOUT:     %return.param.loc21: ref %tuple.type.d07 = out_param call_param2
-// CHECK:STDOUT:     %return.loc21: ref %tuple.type.d07 = return_slot %return.param.loc21
+// CHECK:STDOUT:     %self.loc24_24: %i32 = bind_name r#self, %self.param.loc24_30
+// CHECK:STDOUT:     %return.param.loc24: ref %tuple.type.d07 = out_param call_param2
+// CHECK:STDOUT:     %return.loc24: ref %tuple.type.d07 = return_slot %return.param.loc24
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %self.patt.loc17_17: %pattern_type.796 = binding_pattern self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc17_21: %pattern_type.796 = value_param_pattern %self.patt.loc17_17, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc17_12: %pattern_type.f6d = addr_pattern %self.param_patt.loc17_21 [concrete]
-// CHECK:STDOUT:     %self.patt.loc17_30: %pattern_type.7ce = binding_pattern r#self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc17_36: %pattern_type.7ce = value_param_pattern %self.patt.loc17_30, call_param1 [concrete]
+// CHECK:STDOUT:     %self.patt.loc20_17: %pattern_type.796 = binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc20_21: %pattern_type.796 = value_param_pattern %self.patt.loc20_17, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc20_12: %pattern_type.f6d = addr_pattern %self.param_patt.loc20_21 [concrete]
+// CHECK:STDOUT:     %self.patt.loc20_30: %pattern_type.7ce = binding_pattern r#self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc20_36: %pattern_type.7ce = value_param_pattern %self.patt.loc20_30, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc12_17: %ptr.e71 = value_param call_param0
-// CHECK:STDOUT:     %.loc12_23: type = splice_block %ptr.loc12 [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:       %Self.ref.loc12: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:       %ptr.loc12: type = ptr_type %Self.ref.loc12 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:     %self.param.loc15_17: %ptr.e71 = value_param call_param0
+// CHECK:STDOUT:     %.loc15_23: type = splice_block %ptr.loc15 [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:       %Self.ref.loc15: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:       %ptr.loc15: type = ptr_type %Self.ref.loc15 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc12_13: %ptr.e71 = bind_name self, %self.param.loc12_17
-// CHECK:STDOUT:     %self.param.loc12_32: %i32 = value_param call_param1
-// CHECK:STDOUT:     %.loc12_34: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.loc15_13: %ptr.e71 = bind_name self, %self.param.loc15_17
+// CHECK:STDOUT:     %self.param.loc15_32: %i32 = value_param call_param1
+// CHECK:STDOUT:     %.loc15_34: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc12_26: %i32 = bind_name r#self, %self.param.loc12_32
+// CHECK:STDOUT:     %self.loc15_26: %i32 = bind_name r#self, %self.param.loc15_32
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
-// CHECK:STDOUT:     %self.patt.loc21_12: %pattern_type.761 = binding_pattern self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc21_16: %pattern_type.761 = value_param_pattern %self.patt.loc21_12, call_param0 [concrete]
-// CHECK:STDOUT:     %self.patt.loc21_24: %pattern_type.7ce = binding_pattern r#self [concrete]
-// CHECK:STDOUT:     %self.param_patt.loc21_30: %pattern_type.7ce = value_param_pattern %self.patt.loc21_24, call_param1 [concrete]
+// CHECK:STDOUT:     %self.patt.loc24_12: %pattern_type.761 = binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc24_16: %pattern_type.761 = value_param_pattern %self.patt.loc24_12, call_param0 [concrete]
+// CHECK:STDOUT:     %self.patt.loc24_24: %pattern_type.7ce = binding_pattern r#self [concrete]
+// CHECK:STDOUT:     %self.param_patt.loc24_30: %pattern_type.7ce = value_param_pattern %self.patt.loc24_24, call_param1 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.511 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.511 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc13_37: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc13_37: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc13_42: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc13_42: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc13_45.1: %tuple.type.24b = tuple_literal (%i32.loc13_37, %i32.loc13_42)
-// CHECK:STDOUT:     %.loc13_45.2: type = converted %.loc13_45.1, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
-// CHECK:STDOUT:     %self.param.loc13_12: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc13: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc13_8: %Class = bind_name self, %self.param.loc13_12
-// CHECK:STDOUT:     %self.param.loc13_26: %i32 = value_param call_param1
-// CHECK:STDOUT:     %.loc13_28: type = splice_block %i32.loc13_28 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc13_28: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc13_28: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc16_37: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc16_37: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc16_42: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc16_42: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc16_45.1: %tuple.type.24b = tuple_literal (%i32.loc16_37, %i32.loc16_42)
+// CHECK:STDOUT:     %.loc16_45.2: type = converted %.loc16_45.1, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
+// CHECK:STDOUT:     %self.param.loc16_12: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc16: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc16_8: %Class = bind_name self, %self.param.loc16_12
+// CHECK:STDOUT:     %self.param.loc16_26: %i32 = value_param call_param1
+// CHECK:STDOUT:     %.loc16_28: type = splice_block %i32.loc16_28 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc16_28: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc16_28: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc13_20: %i32 = bind_name r#self, %self.param.loc13_26
-// CHECK:STDOUT:     %return.param.loc13: ref %tuple.type.d07 = out_param call_param2
-// CHECK:STDOUT:     %return.loc13: ref %tuple.type.d07 = return_slot %return.param.loc13
+// CHECK:STDOUT:     %self.loc16_20: %i32 = bind_name r#self, %self.param.loc16_26
+// CHECK:STDOUT:     %return.param.loc16: ref %tuple.type.d07 = out_param call_param2
+// CHECK:STDOUT:     %return.loc16: ref %tuple.type.d07 = return_slot %return.param.loc16
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc14: %Class.elem = field_decl n, element0 [concrete]
+// CHECK:STDOUT:   %.loc17: %Class.elem = field_decl n, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.n: type = struct_type {.n: %i32} [concrete = constants.%struct_type.n]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [concrete = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -169,34 +172,34 @@ fn Class.G[self: Self](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT:   .Self = constants.%Class
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   .G = %G.decl
-// CHECK:STDOUT:   .n = %.loc14
+// CHECK:STDOUT:   .n = %.loc17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%self.param.loc17_21: %ptr.e71, %self.param.loc17_36: %i32) {
+// CHECK:STDOUT: fn @F(%self.param.loc20_21: %ptr.e71, %self.param.loc20_36: %i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref.loc18_5: %ptr.e71 = name_ref self, %self.loc17_17
-// CHECK:STDOUT:   %.loc18_4: ref %Class = deref %self.ref.loc18_5
-// CHECK:STDOUT:   %n.ref: %Class.elem = name_ref n, @Class.%.loc14 [concrete = @Class.%.loc14]
-// CHECK:STDOUT:   %.loc18_10: ref %i32 = class_element_access %.loc18_4, element0
-// CHECK:STDOUT:   %self.ref.loc18_15: %i32 = name_ref r#self, %self.loc17_30
-// CHECK:STDOUT:   assign %.loc18_10, %self.ref.loc18_15
+// CHECK:STDOUT:   %self.ref.loc21_5: %ptr.e71 = name_ref self, %self.loc20_17
+// CHECK:STDOUT:   %.loc21_4: ref %Class = deref %self.ref.loc21_5
+// CHECK:STDOUT:   %n.ref: %Class.elem = name_ref n, @Class.%.loc17 [concrete = @Class.%.loc17]
+// CHECK:STDOUT:   %.loc21_10: ref %i32 = class_element_access %.loc21_4, element0
+// CHECK:STDOUT:   %self.ref.loc21_15: %i32 = name_ref r#self, %self.loc20_30
+// CHECK:STDOUT:   assign %.loc21_10, %self.ref.loc21_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G(%self.param.loc21_16: %Class, %self.param.loc21_30: %i32) -> %return.param.loc21: %tuple.type.d07 {
+// CHECK:STDOUT: fn @G(%self.param.loc24_16: %Class, %self.param.loc24_30: %i32) -> %return.param.loc24: %tuple.type.d07 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref.loc22_11: %Class = name_ref self, %self.loc21_12
-// CHECK:STDOUT:   %n.ref: %Class.elem = name_ref n, @Class.%.loc14 [concrete = @Class.%.loc14]
-// CHECK:STDOUT:   %.loc22_15.1: ref %i32 = class_element_access %self.ref.loc22_11, element0
-// CHECK:STDOUT:   %.loc22_15.2: %i32 = bind_value %.loc22_15.1
-// CHECK:STDOUT:   %self.ref.loc22_19: %i32 = name_ref r#self, %self.loc21_24
-// CHECK:STDOUT:   %.loc22_25.1: %tuple.type.d07 = tuple_literal (%.loc22_15.2, %self.ref.loc22_19)
-// CHECK:STDOUT:   %tuple.elem0: ref %i32 = tuple_access %return.loc21, element0
-// CHECK:STDOUT:   %.loc22_25.2: init %i32 = initialize_from %.loc22_15.2 to %tuple.elem0
-// CHECK:STDOUT:   %tuple.elem1: ref %i32 = tuple_access %return.loc21, element1
-// CHECK:STDOUT:   %.loc22_25.3: init %i32 = initialize_from %self.ref.loc22_19 to %tuple.elem1
-// CHECK:STDOUT:   %.loc22_25.4: init %tuple.type.d07 = tuple_init (%.loc22_25.2, %.loc22_25.3) to %return.loc21
-// CHECK:STDOUT:   %.loc22_26: init %tuple.type.d07 = converted %.loc22_25.1, %.loc22_25.4
-// CHECK:STDOUT:   return %.loc22_26 to %return.loc21
+// CHECK:STDOUT:   %self.ref.loc25_11: %Class = name_ref self, %self.loc24_12
+// CHECK:STDOUT:   %n.ref: %Class.elem = name_ref n, @Class.%.loc17 [concrete = @Class.%.loc17]
+// CHECK:STDOUT:   %.loc25_15.1: ref %i32 = class_element_access %self.ref.loc25_11, element0
+// CHECK:STDOUT:   %.loc25_15.2: %i32 = bind_value %.loc25_15.1
+// CHECK:STDOUT:   %self.ref.loc25_19: %i32 = name_ref r#self, %self.loc24_24
+// CHECK:STDOUT:   %.loc25_25.1: %tuple.type.d07 = tuple_literal (%.loc25_15.2, %self.ref.loc25_19)
+// CHECK:STDOUT:   %tuple.elem0: ref %i32 = tuple_access %return.loc24, element0
+// CHECK:STDOUT:   %.loc25_25.2: init %i32 = initialize_from %.loc25_15.2 to %tuple.elem0
+// CHECK:STDOUT:   %tuple.elem1: ref %i32 = tuple_access %return.loc24, element1
+// CHECK:STDOUT:   %.loc25_25.3: init %i32 = initialize_from %self.ref.loc25_19 to %tuple.elem1
+// CHECK:STDOUT:   %.loc25_25.4: init %tuple.type.d07 = tuple_init (%.loc25_25.2, %.loc25_25.3) to %return.loc24
+// CHECK:STDOUT:   %.loc25_26: init %tuple.type.d07 = converted %.loc25_25.1, %.loc25_25.4
+// CHECK:STDOUT:   return %.loc25_26 to %return.loc24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/raw_self_type.carbon
+++ b/toolchain/check/testdata/class/raw_self_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/raw_self_type.carbon
@@ -63,12 +66,12 @@ fn MemberNamedSelf.F(x: Self, y: r#Self) {}
 // CHECK:STDOUT:     %y.patt: %pattern_type.c06 = binding_pattern y [concrete]
 // CHECK:STDOUT:     %y.param_patt: %pattern_type.c06 = value_param_pattern %y.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param.loc24: %MemberNamedSelf = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc24_25: type = name_ref Self, constants.%MemberNamedSelf [concrete = constants.%MemberNamedSelf]
-// CHECK:STDOUT:     %x.loc24: %MemberNamedSelf = bind_name x, %x.param.loc24
-// CHECK:STDOUT:     %y.param.loc24: %Self = value_param call_param1
-// CHECK:STDOUT:     %Self.ref.loc24_34: type = name_ref r#Self, @MemberNamedSelf.%Self.decl [concrete = constants.%Self]
-// CHECK:STDOUT:     %y.loc24: %Self = bind_name y, %y.param.loc24
+// CHECK:STDOUT:     %x.param.loc27: %MemberNamedSelf = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc27_25: type = name_ref Self, constants.%MemberNamedSelf [concrete = constants.%MemberNamedSelf]
+// CHECK:STDOUT:     %x.loc27: %MemberNamedSelf = bind_name x, %x.param.loc27
+// CHECK:STDOUT:     %y.param.loc27: %Self = value_param call_param1
+// CHECK:STDOUT:     %Self.ref.loc27_34: type = name_ref r#Self, @MemberNamedSelf.%Self.decl [concrete = constants.%Self]
+// CHECK:STDOUT:     %y.loc27: %Self = bind_name y, %y.param.loc27
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -91,12 +94,12 @@ fn MemberNamedSelf.F(x: Self, y: r#Self) {}
 // CHECK:STDOUT:     %y.patt: %pattern_type.c06 = binding_pattern y [concrete]
 // CHECK:STDOUT:     %y.param_patt: %pattern_type.c06 = value_param_pattern %y.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %x.param.loc21: %MemberNamedSelf = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc21_11: type = name_ref Self, constants.%MemberNamedSelf [concrete = constants.%MemberNamedSelf]
-// CHECK:STDOUT:     %x.loc21: %MemberNamedSelf = bind_name x, %x.param.loc21
-// CHECK:STDOUT:     %y.param.loc21: %Self = value_param call_param1
-// CHECK:STDOUT:     %Self.ref.loc21_20: type = name_ref r#Self, @MemberNamedSelf.%Self.decl [concrete = constants.%Self]
-// CHECK:STDOUT:     %y.loc21: %Self = bind_name y, %y.param.loc21
+// CHECK:STDOUT:     %x.param.loc24: %MemberNamedSelf = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc24_11: type = name_ref Self, constants.%MemberNamedSelf [concrete = constants.%MemberNamedSelf]
+// CHECK:STDOUT:     %x.loc24: %MemberNamedSelf = bind_name x, %x.param.loc24
+// CHECK:STDOUT:     %y.param.loc24: %Self = value_param call_param1
+// CHECK:STDOUT:     %Self.ref.loc24_20: type = name_ref r#Self, @MemberNamedSelf.%Self.decl [concrete = constants.%Self]
+// CHECK:STDOUT:     %y.loc24: %Self = bind_name y, %y.param.loc24
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
@@ -124,9 +127,9 @@ fn MemberNamedSelf.F(x: Self, y: r#Self) {}
 // CHECK:STDOUT:     %Self.var_patt: %pattern_type.796 = var_pattern %Self.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Self.var: ref %ptr.e71 = var %Self.var_patt
-// CHECK:STDOUT:   %.loc13: type = splice_block %ptr.loc13 [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:     %Self.ref.loc13: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %ptr.loc13: type = ptr_type %Self.ref.loc13 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:   %.loc16: type = splice_block %ptr.loc16 [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %Self.ref.loc16: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %ptr.loc16: type = ptr_type %Self.ref.loc16 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Self: ref %ptr.e71 = bind_name r#Self, %Self.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -134,18 +137,18 @@ fn MemberNamedSelf.F(x: Self, y: r#Self) {}
 // CHECK:STDOUT:     %p.var_patt: %pattern_type.796 = var_pattern %p.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p.var: ref %ptr.e71 = var %p.var_patt
-// CHECK:STDOUT:   %Self.ref.loc14_20: ref %ptr.e71 = name_ref r#Self, %Self
-// CHECK:STDOUT:   %.loc14_20: %ptr.e71 = bind_value %Self.ref.loc14_20
-// CHECK:STDOUT:   assign %p.var, %.loc14_20
-// CHECK:STDOUT:   %.loc14_16: type = splice_block %ptr.loc14 [concrete = constants.%ptr.e71] {
-// CHECK:STDOUT:     %Self.ref.loc14_12: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %ptr.loc14: type = ptr_type %Self.ref.loc14_12 [concrete = constants.%ptr.e71]
+// CHECK:STDOUT:   %Self.ref.loc17_20: ref %ptr.e71 = name_ref r#Self, %Self
+// CHECK:STDOUT:   %.loc17_20: %ptr.e71 = bind_value %Self.ref.loc17_20
+// CHECK:STDOUT:   assign %p.var, %.loc17_20
+// CHECK:STDOUT:   %.loc17_16: type = splice_block %ptr.loc17 [concrete = constants.%ptr.e71] {
+// CHECK:STDOUT:     %Self.ref.loc17_12: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %ptr.loc17: type = ptr_type %Self.ref.loc17_12 [concrete = constants.%ptr.e71]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p: ref %ptr.e71 = bind_name p, %p.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2(%x.param.loc24: %MemberNamedSelf, %y.param.loc24: %Self) {
+// CHECK:STDOUT: fn @F.2(%x.param.loc27: %MemberNamedSelf, %y.param.loc27: %Self) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/redeclaration.carbon
+++ b/toolchain/check/testdata/class/redeclaration.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/redeclaration.carbon
@@ -42,27 +45,27 @@ fn Class.F[self: Self](b: bool) {}
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .Class = %Class.decl.loc11
+// CHECK:STDOUT:     .Class = %Class.decl.loc14
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %Class.decl.loc11: type = class_decl @Class [concrete = constants.%Class] {} {}
-// CHECK:STDOUT:   %Class.decl.loc13: type = class_decl @Class [concrete = constants.%Class] {} {}
+// CHECK:STDOUT:   %Class.decl.loc14: type = class_decl @Class [concrete = constants.%Class] {} {}
+// CHECK:STDOUT:   %Class.decl.loc16: type = class_decl @Class [concrete = constants.%Class] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.761 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.761 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.831 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc17: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc17: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc17: %Class = bind_name self, %self.param.loc17
-// CHECK:STDOUT:     %b.param.loc17: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc17_27.1: type = splice_block %.loc17_27.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc17: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc17_27.2: type = value_of_initializer %bool.make_type.loc17 [concrete = bool]
-// CHECK:STDOUT:       %.loc17_27.3: type = converted %bool.make_type.loc17, %.loc17_27.2 [concrete = bool]
+// CHECK:STDOUT:     %self.param.loc20: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc20: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc20: %Class = bind_name self, %self.param.loc20
+// CHECK:STDOUT:     %b.param.loc20: bool = value_param call_param1
+// CHECK:STDOUT:     %.loc20_27.1: type = splice_block %.loc20_27.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc20: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc20_27.2: type = value_of_initializer %bool.make_type.loc20 [concrete = bool]
+// CHECK:STDOUT:       %.loc20_27.3: type = converted %bool.make_type.loc20, %.loc20_27.2 [concrete = bool]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %b.loc17: bool = bind_name b, %b.param.loc17
+// CHECK:STDOUT:     %b.loc20: bool = bind_name b, %b.param.loc20
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -73,16 +76,16 @@ fn Class.F[self: Self](b: bool) {}
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.831 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc14: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc14: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc14: %Class = bind_name self, %self.param.loc14
-// CHECK:STDOUT:     %b.param.loc14: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc14_23.1: type = splice_block %.loc14_23.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc14: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc14_23.2: type = value_of_initializer %bool.make_type.loc14 [concrete = bool]
-// CHECK:STDOUT:       %.loc14_23.3: type = converted %bool.make_type.loc14, %.loc14_23.2 [concrete = bool]
+// CHECK:STDOUT:     %self.param.loc17: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc17: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc17: %Class = bind_name self, %self.param.loc17
+// CHECK:STDOUT:     %b.param.loc17: bool = value_param call_param1
+// CHECK:STDOUT:     %.loc17_23.1: type = splice_block %.loc17_23.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc17: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc17_23.2: type = value_of_initializer %bool.make_type.loc17 [concrete = bool]
+// CHECK:STDOUT:       %.loc17_23.3: type = converted %bool.make_type.loc17, %.loc17_23.2 [concrete = bool]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %b.loc14: bool = bind_name b, %b.param.loc14
+// CHECK:STDOUT:     %b.loc17: bool = bind_name b, %b.param.loc17
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
@@ -93,7 +96,7 @@ fn Class.F[self: Self](b: bool) {}
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%self.param.loc17: %Class, %b.param.loc17: bool) {
+// CHECK:STDOUT: fn @F(%self.param.loc20: %Class, %b.param.loc20: bool) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/redeclaration_introducer.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/redeclaration_introducer.carbon
@@ -36,17 +39,17 @@ abstract class C {}
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .A = %A.decl.loc11
-// CHECK:STDOUT:     .B = %B.decl.loc12
-// CHECK:STDOUT:     .C = %C.decl.loc13
+// CHECK:STDOUT:     .A = %A.decl.loc14
+// CHECK:STDOUT:     .B = %B.decl.loc15
+// CHECK:STDOUT:     .C = %C.decl.loc16
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %A.decl.loc11: type = class_decl @A [concrete = constants.%A] {} {}
-// CHECK:STDOUT:   %B.decl.loc12: type = class_decl @B [concrete = constants.%B] {} {}
-// CHECK:STDOUT:   %C.decl.loc13: type = class_decl @C [concrete = constants.%C] {} {}
-// CHECK:STDOUT:   %A.decl.loc15: type = class_decl @A [concrete = constants.%A] {} {}
-// CHECK:STDOUT:   %B.decl.loc16: type = class_decl @B [concrete = constants.%B] {} {}
-// CHECK:STDOUT:   %C.decl.loc17: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %A.decl.loc14: type = class_decl @A [concrete = constants.%A] {} {}
+// CHECK:STDOUT:   %B.decl.loc15: type = class_decl @B [concrete = constants.%B] {} {}
+// CHECK:STDOUT:   %C.decl.loc16: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %A.decl.loc18: type = class_decl @A [concrete = constants.%A] {} {}
+// CHECK:STDOUT:   %B.decl.loc19: type = class_decl @B [concrete = constants.%B] {} {}
+// CHECK:STDOUT:   %C.decl.loc20: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {

--- a/toolchain/check/testdata/class/reenter_scope.carbon
+++ b/toolchain/check/testdata/class/reenter_scope.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/reenter_scope.carbon
@@ -55,10 +58,10 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %return.param.loc16: ref %i32 = out_param call_param0
-// CHECK:STDOUT:     %return.loc16: ref %i32 = return_slot %return.param.loc16
+// CHECK:STDOUT:     %int_32.loc19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %return.param.loc19: ref %i32 = out_param call_param0
+// CHECK:STDOUT:     %return.loc19: ref %i32 = return_slot %return.param.loc19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -67,10 +70,10 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %return.param.loc12: ref %i32 = out_param call_param0
-// CHECK:STDOUT:     %return.loc12: ref %i32 = return_slot %return.param.loc12
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %return.param.loc15: ref %i32 = out_param call_param0
+// CHECK:STDOUT:     %return.loc15: ref %i32 = return_slot %return.param.loc15
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
@@ -94,13 +97,13 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT: fn @F() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:   %G.ref.loc17: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %G.call.loc17: init %i32 = call %G.ref.loc17()
-// CHECK:STDOUT:   %G.ref.loc18: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %G.call.loc18: init %i32 = call %G.ref.loc18()
-// CHECK:STDOUT:   %.loc18_13.1: %i32 = value_of_initializer %G.call.loc18
-// CHECK:STDOUT:   %.loc18_13.2: %i32 = converted %G.call.loc18, %.loc18_13.1
-// CHECK:STDOUT:   return %.loc18_13.2
+// CHECK:STDOUT:   %G.ref.loc20: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
+// CHECK:STDOUT:   %G.call.loc20: init %i32 = call %G.ref.loc20()
+// CHECK:STDOUT:   %G.ref.loc21: %G.type = name_ref G, @Class.%G.decl [concrete = constants.%G]
+// CHECK:STDOUT:   %G.call.loc21: init %i32 = call %G.ref.loc21()
+// CHECK:STDOUT:   %.loc21_13.1: %i32 = value_of_initializer %G.call.loc21
+// CHECK:STDOUT:   %.loc21_13.2: %i32 = converted %G.call.loc21, %.loc21_13.1
+// CHECK:STDOUT:   return %.loc21_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %i32;

--- a/toolchain/check/testdata/class/reorder.carbon
+++ b/toolchain/check/testdata/class/reorder.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/reorder.carbon
@@ -109,21 +112,21 @@ class Class {
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc13_21.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc13_21.2: %i32 = converted %F.call, %.loc13_21.1
-// CHECK:STDOUT:   return %.loc13_21.2
+// CHECK:STDOUT:   %.loc16_21.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc16_21.2: %i32 = converted %F.call, %.loc16_21.1
+// CHECK:STDOUT:   return %.loc16_21.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc17_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc20_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc17_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc17_13.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc17_13.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc17_13.2: %i32 = converted %int_1, %.loc17_13.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   return %.loc17_13.2
+// CHECK:STDOUT:   %bound_method.loc20_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc20_13.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc20_13.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc20_13.2: %i32 = converted %int_1, %.loc20_13.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   return %.loc20_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/reorder_qualified.carbon
+++ b/toolchain/check/testdata/class/reorder_qualified.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/reorder_qualified.carbon
@@ -151,7 +154,7 @@ class A {
 // CHECK:STDOUT:   %AF.decl: %AF.type = fn_decl @AF [concrete = constants.%AF] {} {}
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc46: %A.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc49: %A.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a.ba9]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -160,7 +163,7 @@ class A {
 // CHECK:STDOUT:   .Self = constants.%A
 // CHECK:STDOUT:   .B = %B.decl
 // CHECK:STDOUT:   .AF = %AF.decl
-// CHECK:STDOUT:   .a = %.loc46
+// CHECK:STDOUT:   .a = %.loc49
 // CHECK:STDOUT:   .A = <poisoned>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -169,7 +172,7 @@ class A {
 // CHECK:STDOUT:   %BF.decl: %BF.type = fn_decl @BF [concrete = constants.%BF] {} {}
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc16: %B.elem = field_decl b, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %B.elem = field_decl b, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.b: type = struct_type {.b: %i32} [concrete = constants.%struct_type.b.0a3]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.b [concrete = constants.%complete_type.ba8]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -178,7 +181,7 @@ class A {
 // CHECK:STDOUT:   .Self = constants.%B
 // CHECK:STDOUT:   .C = %C.decl
 // CHECK:STDOUT:   .BF = %BF.decl
-// CHECK:STDOUT:   .b = %.loc16
+// CHECK:STDOUT:   .b = %.loc19
 // CHECK:STDOUT:   .A = <poisoned>
 // CHECK:STDOUT:   .B = <poisoned>
 // CHECK:STDOUT:   .AF = <poisoned>
@@ -190,7 +193,7 @@ class A {
 // CHECK:STDOUT:   %CF.decl: %CF.type = fn_decl @CF [concrete = constants.%CF] {} {}
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc42: %C.elem = field_decl c, element0 [concrete]
+// CHECK:STDOUT:   %.loc45: %C.elem = field_decl c, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.c: type = struct_type {.c: %i32} [concrete = constants.%struct_type.c.b66]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.c [concrete = constants.%complete_type.836]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -199,7 +202,7 @@ class A {
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .D = %D.decl
 // CHECK:STDOUT:   .CF = %CF.decl
-// CHECK:STDOUT:   .c = %.loc42
+// CHECK:STDOUT:   .c = %.loc45
 // CHECK:STDOUT:   .A = <poisoned>
 // CHECK:STDOUT:   .B = <poisoned>
 // CHECK:STDOUT:   .C = <poisoned>
@@ -212,7 +215,7 @@ class A {
 // CHECK:STDOUT:   %DF.decl: %DF.type = fn_decl @DF [concrete = constants.%DF] {} {}
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc24: %D.elem = field_decl d, element0 [concrete]
+// CHECK:STDOUT:   %.loc27: %D.elem = field_decl d, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.d: type = struct_type {.d: %i32} [concrete = constants.%struct_type.d.b7b]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.d [concrete = constants.%complete_type.860]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -221,7 +224,7 @@ class A {
 // CHECK:STDOUT:   .Self = constants.%D
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   .DF = %DF.decl
-// CHECK:STDOUT:   .d = %.loc24
+// CHECK:STDOUT:   .d = %.loc27
 // CHECK:STDOUT:   .A = <poisoned>
 // CHECK:STDOUT:   .B = <poisoned>
 // CHECK:STDOUT:   .C = <poisoned>
@@ -243,18 +246,18 @@ class A {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %A = var %a.var_patt
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc29_25.1: %struct_type.a.a6c = struct_literal (%int_1)
-// CHECK:STDOUT:   %impl.elem0.loc29: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc29_25.1: <bound method> = bound_method %int_1, %impl.elem0.loc29 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem0.loc29, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc29_25.2: <bound method> = bound_method %int_1, %specific_fn.loc29 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc29: init %i32 = call %bound_method.loc29_25.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc29_25.2: init %i32 = converted %int_1, %int.convert_checked.loc29 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc29_25.3: ref %i32 = class_element_access %a.var, element0
-// CHECK:STDOUT:   %.loc29_25.4: init %i32 = initialize_from %.loc29_25.2 to %.loc29_25.3 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc29_25.5: init %A = class_init (%.loc29_25.4), %a.var [concrete = constants.%A.val]
-// CHECK:STDOUT:   %.loc29_7: init %A = converted %.loc29_25.1, %.loc29_25.5 [concrete = constants.%A.val]
-// CHECK:STDOUT:   assign %a.var, %.loc29_7
+// CHECK:STDOUT:   %.loc32_25.1: %struct_type.a.a6c = struct_literal (%int_1)
+// CHECK:STDOUT:   %impl.elem0.loc32: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc32_25.1: <bound method> = bound_method %int_1, %impl.elem0.loc32 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc32: <specific function> = specific_function %impl.elem0.loc32, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc32_25.2: <bound method> = bound_method %int_1, %specific_fn.loc32 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc32: init %i32 = call %bound_method.loc32_25.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc32_25.2: init %i32 = converted %int_1, %int.convert_checked.loc32 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc32_25.3: ref %i32 = class_element_access %a.var, element0
+// CHECK:STDOUT:   %.loc32_25.4: init %i32 = initialize_from %.loc32_25.2 to %.loc32_25.3 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc32_25.5: init %A = class_init (%.loc32_25.4), %a.var [concrete = constants.%A.val]
+// CHECK:STDOUT:   %.loc32_7: init %A = converted %.loc32_25.1, %.loc32_25.5 [concrete = constants.%A.val]
+// CHECK:STDOUT:   assign %a.var, %.loc32_7
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:   %a: ref %A = bind_name a, %a.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -263,18 +266,18 @@ class A {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b.var: ref %B = var %b.var_patt
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc30_25.1: %struct_type.b.a15 = struct_literal (%int_2)
-// CHECK:STDOUT:   %impl.elem0.loc30: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc30_25.1: <bound method> = bound_method %int_2, %impl.elem0.loc30 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc30: <specific function> = specific_function %impl.elem0.loc30, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc30_25.2: <bound method> = bound_method %int_2, %specific_fn.loc30 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc30: init %i32 = call %bound_method.loc30_25.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc30_25.2: init %i32 = converted %int_2, %int.convert_checked.loc30 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc30_25.3: ref %i32 = class_element_access %b.var, element0
-// CHECK:STDOUT:   %.loc30_25.4: init %i32 = initialize_from %.loc30_25.2 to %.loc30_25.3 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc30_25.5: init %B = class_init (%.loc30_25.4), %b.var [concrete = constants.%B.val]
-// CHECK:STDOUT:   %.loc30_7: init %B = converted %.loc30_25.1, %.loc30_25.5 [concrete = constants.%B.val]
-// CHECK:STDOUT:   assign %b.var, %.loc30_7
+// CHECK:STDOUT:   %.loc33_25.1: %struct_type.b.a15 = struct_literal (%int_2)
+// CHECK:STDOUT:   %impl.elem0.loc33: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc33_25.1: <bound method> = bound_method %int_2, %impl.elem0.loc33 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc33: <specific function> = specific_function %impl.elem0.loc33, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc33_25.2: <bound method> = bound_method %int_2, %specific_fn.loc33 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc33: init %i32 = call %bound_method.loc33_25.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc33_25.2: init %i32 = converted %int_2, %int.convert_checked.loc33 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc33_25.3: ref %i32 = class_element_access %b.var, element0
+// CHECK:STDOUT:   %.loc33_25.4: init %i32 = initialize_from %.loc33_25.2 to %.loc33_25.3 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc33_25.5: init %B = class_init (%.loc33_25.4), %b.var [concrete = constants.%B.val]
+// CHECK:STDOUT:   %.loc33_7: init %B = converted %.loc33_25.1, %.loc33_25.5 [concrete = constants.%B.val]
+// CHECK:STDOUT:   assign %b.var, %.loc33_7
 // CHECK:STDOUT:   %B.ref: type = name_ref B, @A.%B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %b: ref %B = bind_name b, %b.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -283,18 +286,18 @@ class A {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref %C = var %c.var_patt
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %.loc31_25.1: %struct_type.c.5b8 = struct_literal (%int_3)
-// CHECK:STDOUT:   %impl.elem0.loc31: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc31_25.1: <bound method> = bound_method %int_3, %impl.elem0.loc31 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc31: <specific function> = specific_function %impl.elem0.loc31, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc31_25.2: <bound method> = bound_method %int_3, %specific_fn.loc31 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc31: init %i32 = call %bound_method.loc31_25.2(%int_3) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc31_25.2: init %i32 = converted %int_3, %int.convert_checked.loc31 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc31_25.3: ref %i32 = class_element_access %c.var, element0
-// CHECK:STDOUT:   %.loc31_25.4: init %i32 = initialize_from %.loc31_25.2 to %.loc31_25.3 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc31_25.5: init %C = class_init (%.loc31_25.4), %c.var [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc31_7: init %C = converted %.loc31_25.1, %.loc31_25.5 [concrete = constants.%C.val]
-// CHECK:STDOUT:   assign %c.var, %.loc31_7
+// CHECK:STDOUT:   %.loc34_25.1: %struct_type.c.5b8 = struct_literal (%int_3)
+// CHECK:STDOUT:   %impl.elem0.loc34: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc34_25.1: <bound method> = bound_method %int_3, %impl.elem0.loc34 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc34: <specific function> = specific_function %impl.elem0.loc34, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc34_25.2: <bound method> = bound_method %int_3, %specific_fn.loc34 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc34: init %i32 = call %bound_method.loc34_25.2(%int_3) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc34_25.2: init %i32 = converted %int_3, %int.convert_checked.loc34 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc34_25.3: ref %i32 = class_element_access %c.var, element0
+// CHECK:STDOUT:   %.loc34_25.4: init %i32 = initialize_from %.loc34_25.2 to %.loc34_25.3 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc34_25.5: init %C = class_init (%.loc34_25.4), %c.var [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc34_7: init %C = converted %.loc34_25.1, %.loc34_25.5 [concrete = constants.%C.val]
+// CHECK:STDOUT:   assign %c.var, %.loc34_7
 // CHECK:STDOUT:   %C.ref: type = name_ref C, @B.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -303,18 +306,18 @@ class A {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %d.var: ref %D = var %d.var_patt
 // CHECK:STDOUT:   %int_4: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
-// CHECK:STDOUT:   %.loc32_25.1: %struct_type.d.3ea = struct_literal (%int_4)
-// CHECK:STDOUT:   %impl.elem0.loc32: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc32_25.1: <bound method> = bound_method %int_4, %impl.elem0.loc32 [concrete = constants.%Convert.bound.ac3]
-// CHECK:STDOUT:   %specific_fn.loc32: <specific function> = specific_function %impl.elem0.loc32, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc32_25.2: <bound method> = bound_method %int_4, %specific_fn.loc32 [concrete = constants.%bound_method.1da]
-// CHECK:STDOUT:   %int.convert_checked.loc32: init %i32 = call %bound_method.loc32_25.2(%int_4) [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc32_25.2: init %i32 = converted %int_4, %int.convert_checked.loc32 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc32_25.3: ref %i32 = class_element_access %d.var, element0
-// CHECK:STDOUT:   %.loc32_25.4: init %i32 = initialize_from %.loc32_25.2 to %.loc32_25.3 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc32_25.5: init %D = class_init (%.loc32_25.4), %d.var [concrete = constants.%D.val]
-// CHECK:STDOUT:   %.loc32_7: init %D = converted %.loc32_25.1, %.loc32_25.5 [concrete = constants.%D.val]
-// CHECK:STDOUT:   assign %d.var, %.loc32_7
+// CHECK:STDOUT:   %.loc35_25.1: %struct_type.d.3ea = struct_literal (%int_4)
+// CHECK:STDOUT:   %impl.elem0.loc35: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc35_25.1: <bound method> = bound_method %int_4, %impl.elem0.loc35 [concrete = constants.%Convert.bound.ac3]
+// CHECK:STDOUT:   %specific_fn.loc35: <specific function> = specific_function %impl.elem0.loc35, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc35_25.2: <bound method> = bound_method %int_4, %specific_fn.loc35 [concrete = constants.%bound_method.1da]
+// CHECK:STDOUT:   %int.convert_checked.loc35: init %i32 = call %bound_method.loc35_25.2(%int_4) [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc35_25.2: init %i32 = converted %int_4, %int.convert_checked.loc35 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc35_25.3: ref %i32 = class_element_access %d.var, element0
+// CHECK:STDOUT:   %.loc35_25.4: init %i32 = initialize_from %.loc35_25.2 to %.loc35_25.3 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc35_25.5: init %D = class_init (%.loc35_25.4), %d.var [concrete = constants.%D.val]
+// CHECK:STDOUT:   %.loc35_7: init %D = converted %.loc35_25.1, %.loc35_25.5 [concrete = constants.%D.val]
+// CHECK:STDOUT:   assign %d.var, %.loc35_7
 // CHECK:STDOUT:   %D.ref: type = name_ref D, @C.%D.decl [concrete = constants.%D]
 // CHECK:STDOUT:   %d: ref %D = bind_name d, %d.var
 // CHECK:STDOUT:   %AF.ref: %AF.type = name_ref AF, @A.%AF.decl [concrete = constants.%AF]

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/scope.carbon
@@ -136,35 +139,35 @@ fn Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc13_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %bound_method.loc16_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc13_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc13_13.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc13_13.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc13_13.2: %i32 = converted %int_1, %.loc13_13.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   return %.loc13_13.2
+// CHECK:STDOUT:   %bound_method.loc16_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc16_13.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc16_13.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc16_13.2: %i32 = converted %int_1, %.loc16_13.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   return %.loc16_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc17_15.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc17_15.2: %i32 = converted %F.call, %.loc17_15.1
-// CHECK:STDOUT:   return %.loc17_15.2
+// CHECK:STDOUT:   %.loc20_15.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc20_15.2: %i32 = converted %F.call, %.loc20_15.1
+// CHECK:STDOUT:   return %.loc20_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc22_11.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %bound_method.loc25_11.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Convert.bound.ef9]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc22_11.2: <bound method> = bound_method %int_2, %specific_fn [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc22_11.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc22_11.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc22_11.2: %i32 = converted %int_2, %.loc22_11.1 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   return %.loc22_11.2
+// CHECK:STDOUT:   %bound_method.loc25_11.2: <bound method> = bound_method %int_2, %specific_fn [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc25_11.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc25_11.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc25_11.2: %i32 = converted %int_2, %.loc25_11.1 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   return %.loc25_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -174,12 +177,12 @@ fn Run() {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.7ce = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %i32 = var %a.var_patt
-// CHECK:STDOUT:   %F.ref.loc26: %F.type.b25 = name_ref F, file.%F.decl [concrete = constants.%F.c41]
-// CHECK:STDOUT:   %F.call.loc26: init %i32 = call %F.ref.loc26()
-// CHECK:STDOUT:   assign %a.var, %F.call.loc26
-// CHECK:STDOUT:   %.loc26: type = splice_block %i32.loc26 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc26: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc26: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %F.ref.loc29: %F.type.b25 = name_ref F, file.%F.decl [concrete = constants.%F.c41]
+// CHECK:STDOUT:   %F.call.loc29: init %i32 = call %F.ref.loc29()
+// CHECK:STDOUT:   assign %a.var, %F.call.loc29
+// CHECK:STDOUT:   %.loc29: type = splice_block %i32.loc29 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc29: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc29: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %i32 = bind_name a, %a.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -188,12 +191,12 @@ fn Run() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b.var: ref %i32 = var %b.var_patt
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %F.ref.loc27: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
-// CHECK:STDOUT:   %F.call.loc27: init %i32 = call %F.ref.loc27()
-// CHECK:STDOUT:   assign %b.var, %F.call.loc27
-// CHECK:STDOUT:   %.loc27: type = splice_block %i32.loc27 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc27: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc27: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %F.ref.loc30: %F.type.f1b = name_ref F, @Class.%F.decl [concrete = constants.%F.1f2]
+// CHECK:STDOUT:   %F.call.loc30: init %i32 = call %F.ref.loc30()
+// CHECK:STDOUT:   assign %b.var, %F.call.loc30
+// CHECK:STDOUT:   %.loc30: type = splice_block %i32.loc30 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc30: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc30: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b: ref %i32 = bind_name b, %b.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/self.carbon

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/self_conversion.carbon
@@ -109,25 +112,25 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param.loc22: %Base = value_param call_param0
-// CHECK:STDOUT:     %Base.ref.loc22: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:     %self.loc22: %Base = bind_name self, %self.param.loc22
-// CHECK:STDOUT:     %return.param.loc22: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc22: ref %i32 = return_slot %return.param.loc22
+// CHECK:STDOUT:     %int_32.loc25: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc25: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.param.loc25: %Base = value_param call_param0
+// CHECK:STDOUT:     %Base.ref.loc25: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
+// CHECK:STDOUT:     %self.loc25: %Base = bind_name self, %self.param.loc25
+// CHECK:STDOUT:     %return.param.loc25: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc25: ref %i32 = return_slot %return.param.loc25
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AddrSelfBase.decl: %AddrSelfBase.type = fn_decl @AddrSelfBase [concrete = constants.%AddrSelfBase] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.1b9 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.1b9 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc26_25: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc29_25: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc26: %ptr.11f = value_param call_param0
-// CHECK:STDOUT:     %.loc26_40: type = splice_block %ptr.loc26 [concrete = constants.%ptr.11f] {
-// CHECK:STDOUT:       %Base.ref.loc26: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:       %ptr.loc26: type = ptr_type %Base.ref.loc26 [concrete = constants.%ptr.11f]
+// CHECK:STDOUT:     %self.param.loc29: %ptr.11f = value_param call_param0
+// CHECK:STDOUT:     %.loc29_40: type = splice_block %ptr.loc29 [concrete = constants.%ptr.11f] {
+// CHECK:STDOUT:       %Base.ref.loc29: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
+// CHECK:STDOUT:       %ptr.loc29: type = ptr_type %Base.ref.loc29 [concrete = constants.%ptr.11f]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc26: %ptr.11f = bind_name self, %self.param.loc26
+// CHECK:STDOUT:     %self.loc29: %ptr.11f = bind_name self, %self.param.loc29
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Call.decl: %Call.type = fn_decl @Call [concrete = constants.%Call] {
 // CHECK:STDOUT:     %p.patt: %pattern_type.605 = binding_pattern p [concrete]
@@ -138,7 +141,7 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %p.param: %ptr.404 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.404] {
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.404] {
 // CHECK:STDOUT:       %Derived.ref: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
 // CHECK:STDOUT:       %ptr: type = ptr_type %Derived.ref [concrete = constants.%ptr.404]
 // CHECK:STDOUT:     }
@@ -151,45 +154,45 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %Base.elem = field_decl a, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %Base.elem = field_decl a, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.a: type = struct_type {.a: %i32} [concrete = constants.%struct_type.a]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.a [concrete = constants.%complete_type.fd7]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Base
-// CHECK:STDOUT:   .a = %.loc12
+// CHECK:STDOUT:   .a = %.loc15
 // CHECK:STDOUT:   .Base = <poisoned>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:   %.loc16: %Derived.elem = base_decl %Base.ref, element0 [concrete]
+// CHECK:STDOUT:   %.loc19: %Derived.elem = base_decl %Base.ref, element0 [concrete]
 // CHECK:STDOUT:   %SelfBase.decl: %SelfBase.type = fn_decl @SelfBase [concrete = constants.%SelfBase] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.bcc = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.bcc = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param.loc18: %Base = value_param call_param0
-// CHECK:STDOUT:     %Base.ref.loc18: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:     %self.loc18: %Base = bind_name self, %self.param.loc18
-// CHECK:STDOUT:     %return.param.loc18: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc18: ref %i32 = return_slot %return.param.loc18
+// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.param.loc21: %Base = value_param call_param0
+// CHECK:STDOUT:     %Base.ref.loc21: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
+// CHECK:STDOUT:     %self.loc21: %Base = bind_name self, %self.param.loc21
+// CHECK:STDOUT:     %return.param.loc21: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc21: ref %i32 = return_slot %return.param.loc21
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AddrSelfBase.decl: %AddrSelfBase.type = fn_decl @AddrSelfBase [concrete = constants.%AddrSelfBase] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.1b9 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.1b9 = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc26_25: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc29_25: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param.loc19: %ptr.11f = value_param call_param0
-// CHECK:STDOUT:     %.loc19: type = splice_block %ptr.loc19 [concrete = constants.%ptr.11f] {
-// CHECK:STDOUT:       %Base.ref.loc19: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
-// CHECK:STDOUT:       %ptr.loc19: type = ptr_type %Base.ref.loc19 [concrete = constants.%ptr.11f]
+// CHECK:STDOUT:     %self.param.loc22: %ptr.11f = value_param call_param0
+// CHECK:STDOUT:     %.loc22: type = splice_block %ptr.loc22 [concrete = constants.%ptr.11f] {
+// CHECK:STDOUT:       %Base.ref.loc22: type = name_ref Base, file.%Base.decl [concrete = constants.%Base]
+// CHECK:STDOUT:       %ptr.loc22: type = ptr_type %Base.ref.loc22 [concrete = constants.%ptr.11f]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self.loc19: %ptr.11f = bind_name self, %self.param.loc19
+// CHECK:STDOUT:     %self.loc22: %ptr.11f = bind_name self, %self.param.loc22
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %Base} [concrete = constants.%struct_type.base.b1e]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.15c]
@@ -198,60 +201,60 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Derived
 // CHECK:STDOUT:   .Base = <poisoned>
-// CHECK:STDOUT:   .base = %.loc16
+// CHECK:STDOUT:   .base = %.loc19
 // CHECK:STDOUT:   .SelfBase = %SelfBase.decl
 // CHECK:STDOUT:   .AddrSelfBase = %AddrSelfBase.decl
 // CHECK:STDOUT:   extend %Base.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @SelfBase(%self.param.loc22: %Base) -> %i32 {
+// CHECK:STDOUT: fn @SelfBase(%self.param.loc25: %Base) -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref: %Base = name_ref self, %self.loc22
-// CHECK:STDOUT:   %a.ref: %Base.elem = name_ref a, @Base.%.loc12 [concrete = @Base.%.loc12]
-// CHECK:STDOUT:   %.loc23_14.1: ref %i32 = class_element_access %self.ref, element0
-// CHECK:STDOUT:   %.loc23_14.2: %i32 = bind_value %.loc23_14.1
-// CHECK:STDOUT:   return %.loc23_14.2
+// CHECK:STDOUT:   %self.ref: %Base = name_ref self, %self.loc25
+// CHECK:STDOUT:   %a.ref: %Base.elem = name_ref a, @Base.%.loc15 [concrete = @Base.%.loc15]
+// CHECK:STDOUT:   %.loc26_14.1: ref %i32 = class_element_access %self.ref, element0
+// CHECK:STDOUT:   %.loc26_14.2: %i32 = bind_value %.loc26_14.1
+// CHECK:STDOUT:   return %.loc26_14.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @AddrSelfBase(%self.param.loc26: %ptr.11f) {
+// CHECK:STDOUT: fn @AddrSelfBase(%self.param.loc29: %ptr.11f) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref: %ptr.11f = name_ref self, %self.loc26
-// CHECK:STDOUT:   %.loc27_4: ref %Base = deref %self.ref
-// CHECK:STDOUT:   %a.ref: %Base.elem = name_ref a, @Base.%.loc12 [concrete = @Base.%.loc12]
-// CHECK:STDOUT:   %.loc27_10: ref %i32 = class_element_access %.loc27_4, element0
+// CHECK:STDOUT:   %self.ref: %ptr.11f = name_ref self, %self.loc29
+// CHECK:STDOUT:   %.loc30_4: ref %Base = deref %self.ref
+// CHECK:STDOUT:   %a.ref: %Base.elem = name_ref a, @Base.%.loc15 [concrete = @Base.%.loc15]
+// CHECK:STDOUT:   %.loc30_10: ref %i32 = class_element_access %.loc30_4, element0
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc27_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc30_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc27_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc27_13.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc27_13: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %.loc27_10, %.loc27_13
+// CHECK:STDOUT:   %bound_method.loc30_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc30_13.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc30_13: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %.loc30_10, %.loc30_13
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Call(%p.param: %ptr.404) -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %p.ref.loc31: %ptr.404 = name_ref p, %p
-// CHECK:STDOUT:   %.loc31_4.1: ref %Derived = deref %p.ref.loc31
+// CHECK:STDOUT:   %p.ref.loc34: %ptr.404 = name_ref p, %p
+// CHECK:STDOUT:   %.loc34_4.1: ref %Derived = deref %p.ref.loc34
 // CHECK:STDOUT:   %AddrSelfBase.ref: %AddrSelfBase.type = name_ref AddrSelfBase, @Derived.%AddrSelfBase.decl [concrete = constants.%AddrSelfBase]
-// CHECK:STDOUT:   %AddrSelfBase.bound: <bound method> = bound_method %.loc31_4.1, %AddrSelfBase.ref
-// CHECK:STDOUT:   %addr.loc31_4.1: %ptr.404 = addr_of %.loc31_4.1
-// CHECK:STDOUT:   %.loc31_4.2: ref %Derived = deref %addr.loc31_4.1
-// CHECK:STDOUT:   %.loc31_4.3: ref %Base = class_element_access %.loc31_4.2, element0
-// CHECK:STDOUT:   %addr.loc31_4.2: %ptr.11f = addr_of %.loc31_4.3
-// CHECK:STDOUT:   %.loc31_4.4: %ptr.11f = converted %addr.loc31_4.1, %addr.loc31_4.2
-// CHECK:STDOUT:   %AddrSelfBase.call: init %empty_tuple.type = call %AddrSelfBase.bound(%.loc31_4.4)
-// CHECK:STDOUT:   %p.ref.loc32: %ptr.404 = name_ref p, %p
-// CHECK:STDOUT:   %.loc32_11.1: ref %Derived = deref %p.ref.loc32
+// CHECK:STDOUT:   %AddrSelfBase.bound: <bound method> = bound_method %.loc34_4.1, %AddrSelfBase.ref
+// CHECK:STDOUT:   %addr.loc34_4.1: %ptr.404 = addr_of %.loc34_4.1
+// CHECK:STDOUT:   %.loc34_4.2: ref %Derived = deref %addr.loc34_4.1
+// CHECK:STDOUT:   %.loc34_4.3: ref %Base = class_element_access %.loc34_4.2, element0
+// CHECK:STDOUT:   %addr.loc34_4.2: %ptr.11f = addr_of %.loc34_4.3
+// CHECK:STDOUT:   %.loc34_4.4: %ptr.11f = converted %addr.loc34_4.1, %addr.loc34_4.2
+// CHECK:STDOUT:   %AddrSelfBase.call: init %empty_tuple.type = call %AddrSelfBase.bound(%.loc34_4.4)
+// CHECK:STDOUT:   %p.ref.loc35: %ptr.404 = name_ref p, %p
+// CHECK:STDOUT:   %.loc35_11.1: ref %Derived = deref %p.ref.loc35
 // CHECK:STDOUT:   %SelfBase.ref: %SelfBase.type = name_ref SelfBase, @Derived.%SelfBase.decl [concrete = constants.%SelfBase]
-// CHECK:STDOUT:   %SelfBase.bound: <bound method> = bound_method %.loc32_11.1, %SelfBase.ref
-// CHECK:STDOUT:   %.loc32_11.2: ref %Base = class_element_access %.loc32_11.1, element0
-// CHECK:STDOUT:   %.loc32_11.3: ref %Base = converted %.loc32_11.1, %.loc32_11.2
-// CHECK:STDOUT:   %.loc32_11.4: %Base = bind_value %.loc32_11.3
-// CHECK:STDOUT:   %SelfBase.call: init %i32 = call %SelfBase.bound(%.loc32_11.4)
-// CHECK:STDOUT:   %.loc32_25.1: %i32 = value_of_initializer %SelfBase.call
-// CHECK:STDOUT:   %.loc32_25.2: %i32 = converted %SelfBase.call, %.loc32_25.1
-// CHECK:STDOUT:   return %.loc32_25.2
+// CHECK:STDOUT:   %SelfBase.bound: <bound method> = bound_method %.loc35_11.1, %SelfBase.ref
+// CHECK:STDOUT:   %.loc35_11.2: ref %Base = class_element_access %.loc35_11.1, element0
+// CHECK:STDOUT:   %.loc35_11.3: ref %Base = converted %.loc35_11.1, %.loc35_11.2
+// CHECK:STDOUT:   %.loc35_11.4: %Base = bind_value %.loc35_11.3
+// CHECK:STDOUT:   %SelfBase.call: init %i32 = call %SelfBase.bound(%.loc35_11.4)
+// CHECK:STDOUT:   %.loc35_25.1: %i32 = value_of_initializer %SelfBase.call
+// CHECK:STDOUT:   %.loc35_25.2: %i32 = converted %SelfBase.call, %.loc35_25.1
+// CHECK:STDOUT:   return %.loc35_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/self_type.carbon
@@ -64,13 +67,13 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param.loc21: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc21: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc21: %Class = bind_name self, %self.param.loc21
-// CHECK:STDOUT:     %return.param.loc21: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc21: ref %i32 = return_slot %return.param.loc21
+// CHECK:STDOUT:     %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.param.loc24: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc24: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc24: %Class = bind_name self, %self.param.loc24
+// CHECK:STDOUT:     %return.param.loc24: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc24: ref %i32 = return_slot %return.param.loc24
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -81,25 +84,25 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param.loc12: %Class = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc12: type = name_ref Self, constants.%Class [concrete = constants.%Class]
-// CHECK:STDOUT:     %self.loc12: %Class = bind_name self, %self.param.loc12
-// CHECK:STDOUT:     %return.param.loc12: ref %i32 = out_param call_param1
-// CHECK:STDOUT:     %return.loc12: ref %i32 = return_slot %return.param.loc12
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %self.param.loc15: %Class = value_param call_param0
+// CHECK:STDOUT:     %Self.ref.loc15: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %self.loc15: %Class = bind_name self, %self.param.loc15
+// CHECK:STDOUT:     %return.param.loc15: ref %i32 = out_param call_param1
+// CHECK:STDOUT:     %return.loc15: ref %i32 = return_slot %return.param.loc15
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Make.decl: %Make.type = fn_decl @Make [concrete = constants.%Make] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.761 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.761 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc13: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:     %Self.ref.loc16: type = name_ref Self, constants.%Class [concrete = constants.%Class]
 // CHECK:STDOUT:     %return.param: ref %Class = out_param call_param0
 // CHECK:STDOUT:     %return: ref %Class = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Class [concrete = constants.%Class]
 // CHECK:STDOUT:   %ptr: type = ptr_type %Self.ref [concrete = constants.%ptr.e71]
-// CHECK:STDOUT:   %.loc18: %Class.elem = field_decl p, element0 [concrete]
+// CHECK:STDOUT:   %.loc21: %Class.elem = field_decl p, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.p: type = struct_type {.p: %ptr.e71} [concrete = constants.%struct_type.p]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.p [concrete = constants.%complete_type.56d]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -108,23 +111,23 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:   .Self = constants.%Class
 // CHECK:STDOUT:   .F = %F.decl
 // CHECK:STDOUT:   .Make = %Make.decl
-// CHECK:STDOUT:   .p = %.loc18
+// CHECK:STDOUT:   .p = %.loc21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F(%self.param.loc21: %Class) -> %i32 {
+// CHECK:STDOUT: fn @F(%self.param.loc24: %Class) -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %self.ref: %Class = name_ref self, %self.loc21
-// CHECK:STDOUT:   %p.ref: %Class.elem = name_ref p, @Class.%.loc18 [concrete = @Class.%.loc18]
-// CHECK:STDOUT:   %.loc22_16.1: ref %ptr.e71 = class_element_access %self.ref, element0
-// CHECK:STDOUT:   %.loc22_16.2: %ptr.e71 = bind_value %.loc22_16.1
-// CHECK:STDOUT:   %.loc22_11.1: ref %Class = deref %.loc22_16.2
+// CHECK:STDOUT:   %self.ref: %Class = name_ref self, %self.loc24
+// CHECK:STDOUT:   %p.ref: %Class.elem = name_ref p, @Class.%.loc21 [concrete = @Class.%.loc21]
+// CHECK:STDOUT:   %.loc25_16.1: ref %ptr.e71 = class_element_access %self.ref, element0
+// CHECK:STDOUT:   %.loc25_16.2: %ptr.e71 = bind_value %.loc25_16.1
+// CHECK:STDOUT:   %.loc25_11.1: ref %Class = deref %.loc25_16.2
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc22_11.1, %F.ref
-// CHECK:STDOUT:   %.loc22_11.2: %Class = bind_value %.loc22_11.1
-// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc22_11.2)
-// CHECK:STDOUT:   %.loc22_23.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc22_23.2: %i32 = converted %F.call, %.loc22_23.1
-// CHECK:STDOUT:   return %.loc22_23.2
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %.loc25_11.1, %F.ref
+// CHECK:STDOUT:   %.loc25_11.2: %Class = bind_value %.loc25_11.1
+// CHECK:STDOUT:   %F.call: init %i32 = call %F.bound(%.loc25_11.2)
+// CHECK:STDOUT:   %.loc25_23.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc25_23.2: %i32 = converted %F.call, %.loc25_23.1
+// CHECK:STDOUT:   return %.loc25_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return.param: %Class {
@@ -133,17 +136,17 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:     %s.patt: %pattern_type.761 = binding_pattern s [concrete]
 // CHECK:STDOUT:     %s.var_patt: %pattern_type.761 = var_pattern %s.patt [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Self.ref.loc14: type = name_ref Self, constants.%Class [concrete = constants.%Class]
+// CHECK:STDOUT:   %Self.ref.loc17: type = name_ref Self, constants.%Class [concrete = constants.%Class]
 // CHECK:STDOUT:   %s: ref %Class = bind_name s, %return
-// CHECK:STDOUT:   %s.ref.loc15_5: ref %Class = name_ref s, %s
-// CHECK:STDOUT:   %s.ref.loc15_16: ref %Class = name_ref s, %s
-// CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %s.ref.loc15_16
-// CHECK:STDOUT:   %.loc15_17.1: %struct_type.p = struct_literal (%addr)
-// CHECK:STDOUT:   %.loc15_17.2: ref %ptr.e71 = class_element_access %s.ref.loc15_5, element0
-// CHECK:STDOUT:   %.loc15_17.3: init %ptr.e71 = initialize_from %addr to %.loc15_17.2
-// CHECK:STDOUT:   %.loc15_17.4: init %Class = class_init (%.loc15_17.3), %s.ref.loc15_5
-// CHECK:STDOUT:   %.loc15_7: init %Class = converted %.loc15_17.1, %.loc15_17.4
-// CHECK:STDOUT:   assign %s.ref.loc15_5, %.loc15_7
+// CHECK:STDOUT:   %s.ref.loc18_5: ref %Class = name_ref s, %s
+// CHECK:STDOUT:   %s.ref.loc18_16: ref %Class = name_ref s, %s
+// CHECK:STDOUT:   %addr: %ptr.e71 = addr_of %s.ref.loc18_16
+// CHECK:STDOUT:   %.loc18_17.1: %struct_type.p = struct_literal (%addr)
+// CHECK:STDOUT:   %.loc18_17.2: ref %ptr.e71 = class_element_access %s.ref.loc18_5, element0
+// CHECK:STDOUT:   %.loc18_17.3: init %ptr.e71 = initialize_from %addr to %.loc18_17.2
+// CHECK:STDOUT:   %.loc18_17.4: init %Class = class_init (%.loc18_17.3), %s.ref.loc18_5
+// CHECK:STDOUT:   %.loc18_7: init %Class = converted %.loc18_17.1, %.loc18_17.4
+// CHECK:STDOUT:   assign %s.ref.loc18_5, %.loc18_7
 // CHECK:STDOUT:   return %s to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/static_method.carbon
@@ -98,8 +101,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %c.ref: ref %Class = name_ref c, %c
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, @Class.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc17_15.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc17_15.2: %i32 = converted %F.call, %.loc17_15.1
-// CHECK:STDOUT:   return %.loc17_15.2
+// CHECK:STDOUT:   %.loc20_15.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc20_15.2: %i32 = converted %F.call, %.loc20_15.1
+// CHECK:STDOUT:   return %.loc20_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/syntactic_merge_literal.carbon
+++ b/toolchain/check/testdata/class/syntactic_merge_literal.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/syntactic_merge_literal.carbon

--- a/toolchain/check/testdata/class/todo_access_modifiers.carbon
+++ b/toolchain/check/testdata/class/todo_access_modifiers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/todo_access_modifiers.carbon
@@ -57,12 +60,12 @@ class Access {
 // CHECK:STDOUT: class @Access {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
-// CHECK:STDOUT:   %int_32.loc17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc17: %Access.elem = field_decl k, element0 [concrete]
-// CHECK:STDOUT:   %int_32.loc19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc19: %Access.elem = field_decl l, element1 [concrete]
+// CHECK:STDOUT:   %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc20: %Access.elem = field_decl k, element0 [concrete]
+// CHECK:STDOUT:   %int_32.loc22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc22: %Access.elem = field_decl l, element1 [concrete]
 // CHECK:STDOUT:   %struct_type.k.l: type = struct_type {.k: %i32, .l: %i32} [concrete = constants.%struct_type.k.l]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.k.l [concrete = constants.%complete_type.48a]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -71,8 +74,8 @@ class Access {
 // CHECK:STDOUT:   .Self = constants.%Access
 // CHECK:STDOUT:   .F [private] = %F.decl
 // CHECK:STDOUT:   .G [protected] = %G.decl
-// CHECK:STDOUT:   .k [private] = %.loc17
-// CHECK:STDOUT:   .l [protected] = %.loc19
+// CHECK:STDOUT:   .k [private] = %.loc20
+// CHECK:STDOUT:   .l [protected] = %.loc22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();

--- a/toolchain/check/testdata/class/virtual_modifiers.carbon
+++ b/toolchain/check/testdata/class/virtual_modifiers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/class/virtual_modifiers.carbon


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.