### PR TITLE
Add range flag settings to facet files

### DIFF
--- a/toolchain/check/testdata/facet/min_prelude/access.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/access.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/facet/min_prelude/call_combined_impl_witness.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/call_combined_impl_witness.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
 //
 // AUTOUPDATE
@@ -165,33 +167,33 @@ fn F() {
 // CHECK:STDOUT:     %t.patt: @G.%pattern_type (%pattern_type.9a0) = binding_pattern t [concrete]
 // CHECK:STDOUT:     %t.param_patt: @G.%pattern_type (%pattern_type.9a0) = value_param_pattern %t.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc31_20.1: type = splice_block %.loc31_20.3 [concrete = constants.%facet_type.242] {
-// CHECK:STDOUT:       %A.ref.loc31: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
+// CHECK:STDOUT:     %.loc33_20.1: type = splice_block %.loc33_20.3 [concrete = constants.%facet_type.242] {
+// CHECK:STDOUT:       %A.ref.loc33: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
 // CHECK:STDOUT:       %Empty.ref: type = name_ref Empty, file.%Empty.decl [concrete = constants.%Empty.type]
-// CHECK:STDOUT:       %impl.elem0.loc31_12: %.518 = impl_witness_access constants.%BitAnd.impl_witness.0e5, element0 [concrete = constants.%Op.444]
-// CHECK:STDOUT:       %bound_method.loc31_12.1: <bound method> = bound_method %A.ref.loc31, %impl.elem0.loc31_12 [concrete = constants.%Op.bound.6b1]
-// CHECK:STDOUT:       %specific_fn.loc31_12: <specific function> = specific_function %impl.elem0.loc31_12, @Op.2(type) [concrete = constants.%Op.specific_fn]
-// CHECK:STDOUT:       %bound_method.loc31_12.2: <bound method> = bound_method %A.ref.loc31, %specific_fn.loc31_12 [concrete = constants.%bound_method.96c]
-// CHECK:STDOUT:       %type.and.loc31_12: init type = call %bound_method.loc31_12.2(%A.ref.loc31, %Empty.ref) [concrete = constants.%facet_type.d5f]
-// CHECK:STDOUT:       %B.ref.loc31: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
-// CHECK:STDOUT:       %impl.elem0.loc31_20: %.518 = impl_witness_access constants.%BitAnd.impl_witness.0e5, element0 [concrete = constants.%Op.444]
-// CHECK:STDOUT:       %bound_method.loc31_20.1: <bound method> = bound_method %type.and.loc31_12, %impl.elem0.loc31_20 [concrete = constants.%Op.bound.b5b]
-// CHECK:STDOUT:       %specific_fn.loc31_20: <specific function> = specific_function %impl.elem0.loc31_20, @Op.2(type) [concrete = constants.%Op.specific_fn]
-// CHECK:STDOUT:       %bound_method.loc31_20.2: <bound method> = bound_method %type.and.loc31_12, %specific_fn.loc31_20 [concrete = constants.%bound_method.cb6]
-// CHECK:STDOUT:       %.loc31_12.1: type = value_of_initializer %type.and.loc31_12 [concrete = constants.%facet_type.d5f]
-// CHECK:STDOUT:       %.loc31_12.2: type = converted %type.and.loc31_12, %.loc31_12.1 [concrete = constants.%facet_type.d5f]
-// CHECK:STDOUT:       %type.and.loc31_20: init type = call %bound_method.loc31_20.2(%.loc31_12.2, %B.ref.loc31) [concrete = constants.%facet_type.242]
-// CHECK:STDOUT:       %.loc31_20.2: type = value_of_initializer %type.and.loc31_20 [concrete = constants.%facet_type.242]
-// CHECK:STDOUT:       %.loc31_20.3: type = converted %type.and.loc31_20, %.loc31_20.2 [concrete = constants.%facet_type.242]
+// CHECK:STDOUT:       %impl.elem0.loc33_12: %.518 = impl_witness_access constants.%BitAnd.impl_witness.0e5, element0 [concrete = constants.%Op.444]
+// CHECK:STDOUT:       %bound_method.loc33_12.1: <bound method> = bound_method %A.ref.loc33, %impl.elem0.loc33_12 [concrete = constants.%Op.bound.6b1]
+// CHECK:STDOUT:       %specific_fn.loc33_12: <specific function> = specific_function %impl.elem0.loc33_12, @Op.2(type) [concrete = constants.%Op.specific_fn]
+// CHECK:STDOUT:       %bound_method.loc33_12.2: <bound method> = bound_method %A.ref.loc33, %specific_fn.loc33_12 [concrete = constants.%bound_method.96c]
+// CHECK:STDOUT:       %type.and.loc33_12: init type = call %bound_method.loc33_12.2(%A.ref.loc33, %Empty.ref) [concrete = constants.%facet_type.d5f]
+// CHECK:STDOUT:       %B.ref.loc33: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
+// CHECK:STDOUT:       %impl.elem0.loc33_20: %.518 = impl_witness_access constants.%BitAnd.impl_witness.0e5, element0 [concrete = constants.%Op.444]
+// CHECK:STDOUT:       %bound_method.loc33_20.1: <bound method> = bound_method %type.and.loc33_12, %impl.elem0.loc33_20 [concrete = constants.%Op.bound.b5b]
+// CHECK:STDOUT:       %specific_fn.loc33_20: <specific function> = specific_function %impl.elem0.loc33_20, @Op.2(type) [concrete = constants.%Op.specific_fn]
+// CHECK:STDOUT:       %bound_method.loc33_20.2: <bound method> = bound_method %type.and.loc33_12, %specific_fn.loc33_20 [concrete = constants.%bound_method.cb6]
+// CHECK:STDOUT:       %.loc33_12.1: type = value_of_initializer %type.and.loc33_12 [concrete = constants.%facet_type.d5f]
+// CHECK:STDOUT:       %.loc33_12.2: type = converted %type.and.loc33_12, %.loc33_12.1 [concrete = constants.%facet_type.d5f]
+// CHECK:STDOUT:       %type.and.loc33_20: init type = call %bound_method.loc33_20.2(%.loc33_12.2, %B.ref.loc33) [concrete = constants.%facet_type.242]
+// CHECK:STDOUT:       %.loc33_20.2: type = value_of_initializer %type.and.loc33_20 [concrete = constants.%facet_type.242]
+// CHECK:STDOUT:       %.loc33_20.3: type = converted %type.and.loc33_20, %.loc33_20.2 [concrete = constants.%facet_type.242]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc31_6.1: %facet_type.242 = bind_symbolic_name T, 0 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:     %t.param: @G.%T.as_type.loc31_28.2 (%T.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc31_28.1: type = splice_block %.loc31_28.2 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)] {
-// CHECK:STDOUT:       %T.ref.loc31: %facet_type.242 = name_ref T, %T.loc31_6.1 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:       %T.as_type.loc31_28.1: type = facet_access_type %T.ref.loc31 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:       %.loc31_28.2: type = converted %T.ref.loc31, %T.as_type.loc31_28.1 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %T.loc33_6.1: %facet_type.242 = bind_symbolic_name T, 0 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:     %t.param: @G.%T.as_type.loc33_28.2 (%T.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc33_28.1: type = splice_block %.loc33_28.2 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref.loc33: %facet_type.242 = name_ref T, %T.loc33_6.1 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:       %T.as_type.loc33_28.1: type = facet_access_type %T.ref.loc33 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc33_28.2: type = converted %T.ref.loc33, %T.as_type.loc33_28.1 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %t: @G.%T.as_type.loc31_28.2 (%T.as_type) = bind_name t, %t.param
+// CHECK:STDOUT:     %t: @G.%T.as_type.loc33_28.2 (%T.as_type) = bind_name t, %t.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
@@ -278,72 +280,72 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @G(%T.loc31_6.1: %facet_type.242) {
-// CHECK:STDOUT:   %T.loc31_6.2: %facet_type.242 = bind_symbolic_name T, 0 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:   %T.as_type.loc31_28.2: type = facet_access_type %T.loc31_6.2 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc31_28.2 [symbolic = %pattern_type (constants.%pattern_type.9a0)]
+// CHECK:STDOUT: generic fn @G(%T.loc33_6.1: %facet_type.242) {
+// CHECK:STDOUT:   %T.loc33_6.2: %facet_type.242 = bind_symbolic_name T, 0 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:   %T.as_type.loc33_28.2: type = facet_access_type %T.loc33_6.2 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc33_28.2 [symbolic = %pattern_type (constants.%pattern_type.9a0)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc31_28.2 [symbolic = %require_complete (constants.%require_complete.383)]
-// CHECK:STDOUT:   %A.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc31_6.2, @A [symbolic = %A.lookup_impl_witness (constants.%A.lookup_impl_witness)]
-// CHECK:STDOUT:   %A.facet.loc32: %A.type = facet_value %T.as_type.loc31_28.2, (%A.lookup_impl_witness) [symbolic = %A.facet.loc32 (constants.%A.facet.487)]
-// CHECK:STDOUT:   %.loc32_4.2: type = fn_type_with_self_type constants.%AA.type.b97, %A.facet.loc32 [symbolic = %.loc32_4.2 (constants.%.fde)]
-// CHECK:STDOUT:   %impl.elem0.loc32_4.2: @G.%.loc32_4.2 (%.fde) = impl_witness_access %A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc32_4.2 (constants.%impl.elem0.de2)]
-// CHECK:STDOUT:   %specific_impl_fn.loc32_4.2: <specific function> = specific_impl_function %impl.elem0.loc32_4.2, @AA.1(%A.facet.loc32) [symbolic = %specific_impl_fn.loc32_4.2 (constants.%specific_impl_fn.086)]
-// CHECK:STDOUT:   %B.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc31_6.2, @B [symbolic = %B.lookup_impl_witness (constants.%B.lookup_impl_witness)]
-// CHECK:STDOUT:   %B.facet.loc33: %B.type = facet_value %T.as_type.loc31_28.2, (%B.lookup_impl_witness) [symbolic = %B.facet.loc33 (constants.%B.facet.8d1)]
-// CHECK:STDOUT:   %.loc33_4.2: type = fn_type_with_self_type constants.%BB.type.64d, %B.facet.loc33 [symbolic = %.loc33_4.2 (constants.%.368)]
-// CHECK:STDOUT:   %impl.elem0.loc33_4.2: @G.%.loc33_4.2 (%.368) = impl_witness_access %B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc33_4.2 (constants.%impl.elem0.43b)]
-// CHECK:STDOUT:   %specific_impl_fn.loc33_4.2: <specific function> = specific_impl_function %impl.elem0.loc33_4.2, @BB.1(%B.facet.loc33) [symbolic = %specific_impl_fn.loc33_4.2 (constants.%specific_impl_fn.573)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc33_28.2 [symbolic = %require_complete (constants.%require_complete.383)]
+// CHECK:STDOUT:   %A.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc33_6.2, @A [symbolic = %A.lookup_impl_witness (constants.%A.lookup_impl_witness)]
+// CHECK:STDOUT:   %A.facet.loc34: %A.type = facet_value %T.as_type.loc33_28.2, (%A.lookup_impl_witness) [symbolic = %A.facet.loc34 (constants.%A.facet.487)]
+// CHECK:STDOUT:   %.loc34_4.2: type = fn_type_with_self_type constants.%AA.type.b97, %A.facet.loc34 [symbolic = %.loc34_4.2 (constants.%.fde)]
+// CHECK:STDOUT:   %impl.elem0.loc34_4.2: @G.%.loc34_4.2 (%.fde) = impl_witness_access %A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc34_4.2 (constants.%impl.elem0.de2)]
+// CHECK:STDOUT:   %specific_impl_fn.loc34_4.2: <specific function> = specific_impl_function %impl.elem0.loc34_4.2, @AA.1(%A.facet.loc34) [symbolic = %specific_impl_fn.loc34_4.2 (constants.%specific_impl_fn.086)]
+// CHECK:STDOUT:   %B.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc33_6.2, @B [symbolic = %B.lookup_impl_witness (constants.%B.lookup_impl_witness)]
+// CHECK:STDOUT:   %B.facet.loc35: %B.type = facet_value %T.as_type.loc33_28.2, (%B.lookup_impl_witness) [symbolic = %B.facet.loc35 (constants.%B.facet.8d1)]
+// CHECK:STDOUT:   %.loc35_4.2: type = fn_type_with_self_type constants.%BB.type.64d, %B.facet.loc35 [symbolic = %.loc35_4.2 (constants.%.368)]
+// CHECK:STDOUT:   %impl.elem0.loc35_4.2: @G.%.loc35_4.2 (%.368) = impl_witness_access %B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc35_4.2 (constants.%impl.elem0.43b)]
+// CHECK:STDOUT:   %specific_impl_fn.loc35_4.2: <specific function> = specific_impl_function %impl.elem0.loc35_4.2, @BB.1(%B.facet.loc35) [symbolic = %specific_impl_fn.loc35_4.2 (constants.%specific_impl_fn.573)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%t.param: @G.%T.as_type.loc31_28.2 (%T.as_type)) {
+// CHECK:STDOUT:   fn(%t.param: @G.%T.as_type.loc33_28.2 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %t.ref.loc32: @G.%T.as_type.loc31_28.2 (%T.as_type) = name_ref t, %t
-// CHECK:STDOUT:     %AA.ref.loc32: %A.assoc_type = name_ref AA, @A.%assoc0 [concrete = constants.%assoc0.6e7]
-// CHECK:STDOUT:     %T.as_type.loc32: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc32_4.1: type = converted constants.%T.2df, %T.as_type.loc32 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %impl.elem0.loc32_4.1: @G.%.loc32_4.2 (%.fde) = impl_witness_access constants.%A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc32_4.2 (constants.%impl.elem0.de2)]
-// CHECK:STDOUT:     %specific_impl_fn.loc32_4.1: <specific function> = specific_impl_function %impl.elem0.loc32_4.1, @AA.1(constants.%A.facet.487) [symbolic = %specific_impl_fn.loc32_4.2 (constants.%specific_impl_fn.086)]
-// CHECK:STDOUT:     %.loc32_8: init %empty_tuple.type = call %specific_impl_fn.loc32_4.1()
-// CHECK:STDOUT:     %t.ref.loc33: @G.%T.as_type.loc31_28.2 (%T.as_type) = name_ref t, %t
-// CHECK:STDOUT:     %BB.ref.loc33: %B.assoc_type = name_ref BB, @B.%assoc0 [concrete = constants.%assoc0.a29]
-// CHECK:STDOUT:     %T.as_type.loc33: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc33_4.1: type = converted constants.%T.2df, %T.as_type.loc33 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %impl.elem0.loc33_4.1: @G.%.loc33_4.2 (%.368) = impl_witness_access constants.%B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc33_4.2 (constants.%impl.elem0.43b)]
-// CHECK:STDOUT:     %specific_impl_fn.loc33_4.1: <specific function> = specific_impl_function %impl.elem0.loc33_4.1, @BB.1(constants.%B.facet.8d1) [symbolic = %specific_impl_fn.loc33_4.2 (constants.%specific_impl_fn.573)]
-// CHECK:STDOUT:     %.loc33_8: init %empty_tuple.type = call %specific_impl_fn.loc33_4.1()
-// CHECK:STDOUT:     %T.ref.loc35: %facet_type.242 = name_ref T, %T.loc31_6.1 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:     %AA.ref.loc35: %A.assoc_type = name_ref AA, @A.%assoc0 [concrete = constants.%assoc0.6e7]
-// CHECK:STDOUT:     %T.as_type.loc35: type = facet_access_type %T.ref.loc35 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc35_4: type = converted %T.ref.loc35, %T.as_type.loc35 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %impl.elem0.loc35: @G.%.loc32_4.2 (%.fde) = impl_witness_access constants.%A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc32_4.2 (constants.%impl.elem0.de2)]
-// CHECK:STDOUT:     %specific_impl_fn.loc35: <specific function> = specific_impl_function %impl.elem0.loc35, @AA.1(constants.%A.facet.487) [symbolic = %specific_impl_fn.loc32_4.2 (constants.%specific_impl_fn.086)]
-// CHECK:STDOUT:     %.loc35_8: init %empty_tuple.type = call %specific_impl_fn.loc35()
-// CHECK:STDOUT:     %T.ref.loc36: %facet_type.242 = name_ref T, %T.loc31_6.1 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:     %BB.ref.loc36: %B.assoc_type = name_ref BB, @B.%assoc0 [concrete = constants.%assoc0.a29]
-// CHECK:STDOUT:     %T.as_type.loc36: type = facet_access_type %T.ref.loc36 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc36_4: type = converted %T.ref.loc36, %T.as_type.loc36 [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %impl.elem0.loc36: @G.%.loc33_4.2 (%.368) = impl_witness_access constants.%B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc33_4.2 (constants.%impl.elem0.43b)]
-// CHECK:STDOUT:     %specific_impl_fn.loc36: <specific function> = specific_impl_function %impl.elem0.loc36, @BB.1(constants.%B.facet.8d1) [symbolic = %specific_impl_fn.loc33_4.2 (constants.%specific_impl_fn.573)]
-// CHECK:STDOUT:     %.loc36_8: init %empty_tuple.type = call %specific_impl_fn.loc36()
-// CHECK:STDOUT:     %T.ref.loc38: %facet_type.242 = name_ref T, %T.loc31_6.1 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:     %A.ref.loc38: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
-// CHECK:STDOUT:     %AA.ref.loc38: %A.assoc_type = name_ref AA, @A.%assoc0 [concrete = constants.%assoc0.6e7]
-// CHECK:STDOUT:     %T.as_type.loc38: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %A.facet.loc38: %A.type = facet_value %T.as_type.loc38, (constants.%A.lookup_impl_witness) [symbolic = %A.facet.loc32 (constants.%A.facet.487)]
-// CHECK:STDOUT:     %.loc38_4: %A.type = converted %T.ref.loc38, %A.facet.loc38 [symbolic = %A.facet.loc32 (constants.%A.facet.487)]
-// CHECK:STDOUT:     %impl.elem0.loc38: @G.%.loc32_4.2 (%.fde) = impl_witness_access constants.%A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc32_4.2 (constants.%impl.elem0.de2)]
-// CHECK:STDOUT:     %specific_impl_fn.loc38: <specific function> = specific_impl_function %impl.elem0.loc38, @AA.1(constants.%A.facet.487) [symbolic = %specific_impl_fn.loc32_4.2 (constants.%specific_impl_fn.086)]
-// CHECK:STDOUT:     %.loc38_12: init %empty_tuple.type = call %specific_impl_fn.loc38()
-// CHECK:STDOUT:     %T.ref.loc39: %facet_type.242 = name_ref T, %T.loc31_6.1 [symbolic = %T.loc31_6.2 (constants.%T.2df)]
-// CHECK:STDOUT:     %B.ref.loc39: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
-// CHECK:STDOUT:     %BB.ref.loc39: %B.assoc_type = name_ref BB, @B.%assoc0 [concrete = constants.%assoc0.a29]
-// CHECK:STDOUT:     %T.as_type.loc39: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc31_28.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %B.facet.loc39: %B.type = facet_value %T.as_type.loc39, (constants.%B.lookup_impl_witness) [symbolic = %B.facet.loc33 (constants.%B.facet.8d1)]
-// CHECK:STDOUT:     %.loc39_4: %B.type = converted %T.ref.loc39, %B.facet.loc39 [symbolic = %B.facet.loc33 (constants.%B.facet.8d1)]
-// CHECK:STDOUT:     %impl.elem0.loc39: @G.%.loc33_4.2 (%.368) = impl_witness_access constants.%B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc33_4.2 (constants.%impl.elem0.43b)]
-// CHECK:STDOUT:     %specific_impl_fn.loc39: <specific function> = specific_impl_function %impl.elem0.loc39, @BB.1(constants.%B.facet.8d1) [symbolic = %specific_impl_fn.loc33_4.2 (constants.%specific_impl_fn.573)]
-// CHECK:STDOUT:     %.loc39_12: init %empty_tuple.type = call %specific_impl_fn.loc39()
+// CHECK:STDOUT:     %t.ref.loc34: @G.%T.as_type.loc33_28.2 (%T.as_type) = name_ref t, %t
+// CHECK:STDOUT:     %AA.ref.loc34: %A.assoc_type = name_ref AA, @A.%assoc0 [concrete = constants.%assoc0.6e7]
+// CHECK:STDOUT:     %T.as_type.loc34: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc34_4.1: type = converted constants.%T.2df, %T.as_type.loc34 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %impl.elem0.loc34_4.1: @G.%.loc34_4.2 (%.fde) = impl_witness_access constants.%A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc34_4.2 (constants.%impl.elem0.de2)]
+// CHECK:STDOUT:     %specific_impl_fn.loc34_4.1: <specific function> = specific_impl_function %impl.elem0.loc34_4.1, @AA.1(constants.%A.facet.487) [symbolic = %specific_impl_fn.loc34_4.2 (constants.%specific_impl_fn.086)]
+// CHECK:STDOUT:     %.loc34_8: init %empty_tuple.type = call %specific_impl_fn.loc34_4.1()
+// CHECK:STDOUT:     %t.ref.loc35: @G.%T.as_type.loc33_28.2 (%T.as_type) = name_ref t, %t
+// CHECK:STDOUT:     %BB.ref.loc35: %B.assoc_type = name_ref BB, @B.%assoc0 [concrete = constants.%assoc0.a29]
+// CHECK:STDOUT:     %T.as_type.loc35: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc35_4.1: type = converted constants.%T.2df, %T.as_type.loc35 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %impl.elem0.loc35_4.1: @G.%.loc35_4.2 (%.368) = impl_witness_access constants.%B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc35_4.2 (constants.%impl.elem0.43b)]
+// CHECK:STDOUT:     %specific_impl_fn.loc35_4.1: <specific function> = specific_impl_function %impl.elem0.loc35_4.1, @BB.1(constants.%B.facet.8d1) [symbolic = %specific_impl_fn.loc35_4.2 (constants.%specific_impl_fn.573)]
+// CHECK:STDOUT:     %.loc35_8: init %empty_tuple.type = call %specific_impl_fn.loc35_4.1()
+// CHECK:STDOUT:     %T.ref.loc37: %facet_type.242 = name_ref T, %T.loc33_6.1 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:     %AA.ref.loc37: %A.assoc_type = name_ref AA, @A.%assoc0 [concrete = constants.%assoc0.6e7]
+// CHECK:STDOUT:     %T.as_type.loc37: type = facet_access_type %T.ref.loc37 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc37_4: type = converted %T.ref.loc37, %T.as_type.loc37 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %impl.elem0.loc37: @G.%.loc34_4.2 (%.fde) = impl_witness_access constants.%A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc34_4.2 (constants.%impl.elem0.de2)]
+// CHECK:STDOUT:     %specific_impl_fn.loc37: <specific function> = specific_impl_function %impl.elem0.loc37, @AA.1(constants.%A.facet.487) [symbolic = %specific_impl_fn.loc34_4.2 (constants.%specific_impl_fn.086)]
+// CHECK:STDOUT:     %.loc37_8: init %empty_tuple.type = call %specific_impl_fn.loc37()
+// CHECK:STDOUT:     %T.ref.loc38: %facet_type.242 = name_ref T, %T.loc33_6.1 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:     %BB.ref.loc38: %B.assoc_type = name_ref BB, @B.%assoc0 [concrete = constants.%assoc0.a29]
+// CHECK:STDOUT:     %T.as_type.loc38: type = facet_access_type %T.ref.loc38 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc38_4: type = converted %T.ref.loc38, %T.as_type.loc38 [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %impl.elem0.loc38: @G.%.loc35_4.2 (%.368) = impl_witness_access constants.%B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc35_4.2 (constants.%impl.elem0.43b)]
+// CHECK:STDOUT:     %specific_impl_fn.loc38: <specific function> = specific_impl_function %impl.elem0.loc38, @BB.1(constants.%B.facet.8d1) [symbolic = %specific_impl_fn.loc35_4.2 (constants.%specific_impl_fn.573)]
+// CHECK:STDOUT:     %.loc38_8: init %empty_tuple.type = call %specific_impl_fn.loc38()
+// CHECK:STDOUT:     %T.ref.loc40: %facet_type.242 = name_ref T, %T.loc33_6.1 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:     %A.ref.loc40: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
+// CHECK:STDOUT:     %AA.ref.loc40: %A.assoc_type = name_ref AA, @A.%assoc0 [concrete = constants.%assoc0.6e7]
+// CHECK:STDOUT:     %T.as_type.loc40: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %A.facet.loc40: %A.type = facet_value %T.as_type.loc40, (constants.%A.lookup_impl_witness) [symbolic = %A.facet.loc34 (constants.%A.facet.487)]
+// CHECK:STDOUT:     %.loc40_4: %A.type = converted %T.ref.loc40, %A.facet.loc40 [symbolic = %A.facet.loc34 (constants.%A.facet.487)]
+// CHECK:STDOUT:     %impl.elem0.loc40: @G.%.loc34_4.2 (%.fde) = impl_witness_access constants.%A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc34_4.2 (constants.%impl.elem0.de2)]
+// CHECK:STDOUT:     %specific_impl_fn.loc40: <specific function> = specific_impl_function %impl.elem0.loc40, @AA.1(constants.%A.facet.487) [symbolic = %specific_impl_fn.loc34_4.2 (constants.%specific_impl_fn.086)]
+// CHECK:STDOUT:     %.loc40_12: init %empty_tuple.type = call %specific_impl_fn.loc40()
+// CHECK:STDOUT:     %T.ref.loc41: %facet_type.242 = name_ref T, %T.loc33_6.1 [symbolic = %T.loc33_6.2 (constants.%T.2df)]
+// CHECK:STDOUT:     %B.ref.loc41: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
+// CHECK:STDOUT:     %BB.ref.loc41: %B.assoc_type = name_ref BB, @B.%assoc0 [concrete = constants.%assoc0.a29]
+// CHECK:STDOUT:     %T.as_type.loc41: type = facet_access_type constants.%T.2df [symbolic = %T.as_type.loc33_28.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %B.facet.loc41: %B.type = facet_value %T.as_type.loc41, (constants.%B.lookup_impl_witness) [symbolic = %B.facet.loc35 (constants.%B.facet.8d1)]
+// CHECK:STDOUT:     %.loc41_4: %B.type = converted %T.ref.loc41, %B.facet.loc41 [symbolic = %B.facet.loc35 (constants.%B.facet.8d1)]
+// CHECK:STDOUT:     %impl.elem0.loc41: @G.%.loc35_4.2 (%.368) = impl_witness_access constants.%B.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc35_4.2 (constants.%impl.elem0.43b)]
+// CHECK:STDOUT:     %specific_impl_fn.loc41: <specific function> = specific_impl_function %impl.elem0.loc41, @BB.1(constants.%B.facet.8d1) [symbolic = %specific_impl_fn.loc35_4.2 (constants.%specific_impl_fn.573)]
+// CHECK:STDOUT:     %.loc41_12: init %empty_tuple.type = call %specific_impl_fn.loc41()
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -351,19 +353,19 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %.loc43_6.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc45_6.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc43_6.2: ref %C = temporary_storage
-// CHECK:STDOUT:   %.loc43_6.3: init %C = class_init (), %.loc43_6.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc43_6.4: ref %C = temporary %.loc43_6.2, %.loc43_6.3
-// CHECK:STDOUT:   %.loc43_8.1: ref %C = converted %.loc43_6.1, %.loc43_6.4
-// CHECK:STDOUT:   %facet_value.loc43_12.1: %facet_type.242 = facet_value constants.%C, (constants.%Empty.impl_witness, constants.%A.impl_witness, constants.%B.impl_witness) [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %.loc43_12.1: %facet_type.242 = converted constants.%C, %facet_value.loc43_12.1 [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %facet_value.loc43_12.2: %facet_type.242 = facet_value constants.%C, (constants.%Empty.impl_witness, constants.%A.impl_witness, constants.%B.impl_witness) [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %.loc43_12.2: %facet_type.242 = converted constants.%C, %facet_value.loc43_12.2 [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %.loc45_6.2: ref %C = temporary_storage
+// CHECK:STDOUT:   %.loc45_6.3: init %C = class_init (), %.loc45_6.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc45_6.4: ref %C = temporary %.loc45_6.2, %.loc45_6.3
+// CHECK:STDOUT:   %.loc45_8.1: ref %C = converted %.loc45_6.1, %.loc45_6.4
+// CHECK:STDOUT:   %facet_value.loc45_12.1: %facet_type.242 = facet_value constants.%C, (constants.%Empty.impl_witness, constants.%A.impl_witness, constants.%B.impl_witness) [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %.loc45_12.1: %facet_type.242 = converted constants.%C, %facet_value.loc45_12.1 [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %facet_value.loc45_12.2: %facet_type.242 = facet_value constants.%C, (constants.%Empty.impl_witness, constants.%A.impl_witness, constants.%B.impl_witness) [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %.loc45_12.2: %facet_type.242 = converted constants.%C, %facet_value.loc45_12.2 [concrete = constants.%facet_value]
 // CHECK:STDOUT:   %G.specific_fn: <specific function> = specific_function %G.ref, @G(constants.%facet_value) [concrete = constants.%G.specific_fn]
-// CHECK:STDOUT:   %.loc43_8.2: %C = bind_value %.loc43_8.1
-// CHECK:STDOUT:   %G.call: init %empty_tuple.type = call %G.specific_fn(%.loc43_8.2)
+// CHECK:STDOUT:   %.loc45_8.2: %C = bind_value %.loc45_8.1
+// CHECK:STDOUT:   %G.call: init %empty_tuple.type = call %G.specific_fn(%.loc45_8.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -376,8 +378,8 @@ fn F() {
 // CHECK:STDOUT: specific @BB.1(constants.%B.facet.82f) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T.2df) {
-// CHECK:STDOUT:   %T.loc31_6.2 => constants.%T.2df
-// CHECK:STDOUT:   %T.as_type.loc31_28.2 => constants.%T.as_type
+// CHECK:STDOUT:   %T.loc33_6.2 => constants.%T.2df
+// CHECK:STDOUT:   %T.as_type.loc33_28.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.9a0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -386,21 +388,21 @@ fn F() {
 // CHECK:STDOUT: specific @BB.1(constants.%B.facet.8d1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%facet_value) {
-// CHECK:STDOUT:   %T.loc31_6.2 => constants.%facet_value
-// CHECK:STDOUT:   %T.as_type.loc31_28.2 => constants.%C
+// CHECK:STDOUT:   %T.loc33_6.2 => constants.%facet_value
+// CHECK:STDOUT:   %T.as_type.loc33_28.2 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.c48
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.357
 // CHECK:STDOUT:   %A.lookup_impl_witness => constants.%A.impl_witness
-// CHECK:STDOUT:   %A.facet.loc32 => constants.%A.facet.66c
-// CHECK:STDOUT:   %.loc32_4.2 => constants.%.7ab
-// CHECK:STDOUT:   %impl.elem0.loc32_4.2 => constants.%AA.95d
-// CHECK:STDOUT:   %specific_impl_fn.loc32_4.2 => constants.%AA.95d
+// CHECK:STDOUT:   %A.facet.loc34 => constants.%A.facet.66c
+// CHECK:STDOUT:   %.loc34_4.2 => constants.%.7ab
+// CHECK:STDOUT:   %impl.elem0.loc34_4.2 => constants.%AA.95d
+// CHECK:STDOUT:   %specific_impl_fn.loc34_4.2 => constants.%AA.95d
 // CHECK:STDOUT:   %B.lookup_impl_witness => constants.%B.impl_witness
-// CHECK:STDOUT:   %B.facet.loc33 => constants.%B.facet.82f
-// CHECK:STDOUT:   %.loc33_4.2 => constants.%.b43
-// CHECK:STDOUT:   %impl.elem0.loc33_4.2 => constants.%BB.fe8
-// CHECK:STDOUT:   %specific_impl_fn.loc33_4.2 => constants.%BB.fe8
+// CHECK:STDOUT:   %B.facet.loc35 => constants.%B.facet.82f
+// CHECK:STDOUT:   %.loc35_4.2 => constants.%.b43
+// CHECK:STDOUT:   %impl.elem0.loc35_4.2 => constants.%BB.fe8
+// CHECK:STDOUT:   %specific_impl_fn.loc35_4.2 => constants.%BB.fe8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/combine.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/combine.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/facet/min_prelude/convert_class_type_to_facet_type.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_class_type_to_facet_type.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -68,7 +70,7 @@ fn F() {
 // CHECK:STDOUT:     %A.patt: %pattern_type = symbolic_binding_pattern A, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %A.loc18_15.1: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc18_15.2 (constants.%A)]
+// CHECK:STDOUT:     %A.loc20_15.1: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc20_15.2 (constants.%A)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
@@ -95,8 +97,8 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @WalkAnimal(%A.loc18_15.1: %Animal.type) {
-// CHECK:STDOUT:   %A.loc18_15.2: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc18_15.2 (constants.%A)]
+// CHECK:STDOUT: generic fn @WalkAnimal(%A.loc20_15.1: %Animal.type) {
+// CHECK:STDOUT:   %A.loc20_15.2: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc20_15.2 (constants.%A)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -111,18 +113,18 @@ fn F() {
 // CHECK:STDOUT:   %WalkAnimal.ref: %WalkAnimal.type = name_ref WalkAnimal, file.%WalkAnimal.decl [concrete = constants.%WalkAnimal]
 // CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [concrete = constants.%Goat]
 // CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc21: %Animal.type = converted %Goat.ref, %Animal.facet [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc23: %Animal.type = converted %Goat.ref, %Animal.facet [concrete = constants.%Animal.facet]
 // CHECK:STDOUT:   %WalkAnimal.specific_fn: <specific function> = specific_function %WalkAnimal.ref, @WalkAnimal(constants.%Animal.facet) [concrete = constants.%WalkAnimal.specific_fn]
 // CHECK:STDOUT:   %WalkAnimal.call: init %empty_tuple.type = call %WalkAnimal.specific_fn()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WalkAnimal(constants.%A) {
-// CHECK:STDOUT:   %A.loc18_15.2 => constants.%A
+// CHECK:STDOUT:   %A.loc20_15.2 => constants.%A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WalkAnimal(constants.%Animal.facet) {
-// CHECK:STDOUT:   %A.loc18_15.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %A.loc20_15.2 => constants.%Animal.facet
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/facet/min_prelude/convert_class_type_to_generic_facet_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_class_type_to_generic_facet_value.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/facet/min_prelude/convert_class_value_to_facet_value_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_class_value_to_facet_value_value.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -68,14 +70,14 @@ fn F() {
 // CHECK:STDOUT:     %a.param_patt: @WalkAnimal.%pattern_type (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc15_15.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_15.2 (constants.%T)]
-// CHECK:STDOUT:     %a.param: @WalkAnimal.%T.as_type.loc15_30.2 (%T.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc15_30.1: type = splice_block %.loc15_30.2 [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)] {
-// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc15_15.1 [symbolic = %T.loc15_15.2 (constants.%T)]
-// CHECK:STDOUT:       %T.as_type.loc15_30.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)]
-// CHECK:STDOUT:       %.loc15_30.2: type = converted %T.ref, %T.as_type.loc15_30.1 [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %T.loc17_15.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_15.2 (constants.%T)]
+// CHECK:STDOUT:     %a.param: @WalkAnimal.%T.as_type.loc17_30.2 (%T.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc17_30.1: type = splice_block %.loc17_30.2 [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc17_15.1 [symbolic = %T.loc17_15.2 (constants.%T)]
+// CHECK:STDOUT:       %T.as_type.loc17_30.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc17_30.2: type = converted %T.ref, %T.as_type.loc17_30.1 [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a: @WalkAnimal.%T.as_type.loc15_30.2 (%T.as_type) = bind_name a, %a.param
+// CHECK:STDOUT:     %a: @WalkAnimal.%T.as_type.loc17_30.2 (%T.as_type) = bind_name a, %a.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [concrete = constants.%Goat] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
@@ -109,15 +111,15 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @WalkAnimal(%T.loc15_15.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc15_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_15.2 (constants.%T)]
-// CHECK:STDOUT:   %T.as_type.loc15_30.2: type = facet_access_type %T.loc15_15.2 [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc15_30.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
+// CHECK:STDOUT: generic fn @WalkAnimal(%T.loc17_15.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc17_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_15.2 (constants.%T)]
+// CHECK:STDOUT:   %T.as_type.loc17_30.2: type = facet_access_type %T.loc17_15.2 [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc17_30.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc15_30.2 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc17_30.2 [symbolic = %require_complete (constants.%require_complete)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%a.param: @WalkAnimal.%T.as_type.loc15_30.2 (%T.as_type)) {
+// CHECK:STDOUT:   fn(%a.param: @WalkAnimal.%T.as_type.loc17_30.2 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
@@ -126,31 +128,31 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %WalkAnimal.ref: %WalkAnimal.type = name_ref WalkAnimal, file.%WalkAnimal.decl [concrete = constants.%WalkAnimal]
-// CHECK:STDOUT:   %.loc21_15.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc23_15.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [concrete = constants.%Goat]
-// CHECK:STDOUT:   %.loc21_15.2: ref %Goat = temporary_storage
-// CHECK:STDOUT:   %.loc21_15.3: init %Goat = class_init (), %.loc21_15.2 [concrete = constants.%Goat.val]
-// CHECK:STDOUT:   %.loc21_15.4: ref %Goat = temporary %.loc21_15.2, %.loc21_15.3
-// CHECK:STDOUT:   %.loc21_17.1: ref %Goat = converted %.loc21_15.1, %.loc21_15.4
-// CHECK:STDOUT:   %Animal.facet.loc21_24.1: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc21_24.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc21_24.1 [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %Animal.facet.loc21_24.2: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc21_24.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc21_24.2 [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc23_15.2: ref %Goat = temporary_storage
+// CHECK:STDOUT:   %.loc23_15.3: init %Goat = class_init (), %.loc23_15.2 [concrete = constants.%Goat.val]
+// CHECK:STDOUT:   %.loc23_15.4: ref %Goat = temporary %.loc23_15.2, %.loc23_15.3
+// CHECK:STDOUT:   %.loc23_17.1: ref %Goat = converted %.loc23_15.1, %.loc23_15.4
+// CHECK:STDOUT:   %Animal.facet.loc23_24.1: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc23_24.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc23_24.1 [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %Animal.facet.loc23_24.2: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc23_24.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc23_24.2 [concrete = constants.%Animal.facet]
 // CHECK:STDOUT:   %WalkAnimal.specific_fn: <specific function> = specific_function %WalkAnimal.ref, @WalkAnimal(constants.%Animal.facet) [concrete = constants.%WalkAnimal.specific_fn]
-// CHECK:STDOUT:   %.loc21_17.2: %Goat = bind_value %.loc21_17.1
-// CHECK:STDOUT:   %WalkAnimal.call: init %empty_tuple.type = call %WalkAnimal.specific_fn(%.loc21_17.2)
+// CHECK:STDOUT:   %.loc23_17.2: %Goat = bind_value %.loc23_17.1
+// CHECK:STDOUT:   %WalkAnimal.call: init %empty_tuple.type = call %WalkAnimal.specific_fn(%.loc23_17.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WalkAnimal(constants.%T) {
-// CHECK:STDOUT:   %T.loc15_15.2 => constants.%T
-// CHECK:STDOUT:   %T.as_type.loc15_30.2 => constants.%T.as_type
+// CHECK:STDOUT:   %T.loc17_15.2 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc17_30.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.36a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WalkAnimal(constants.%Animal.facet) {
-// CHECK:STDOUT:   %T.loc15_15.2 => constants.%Animal.facet
-// CHECK:STDOUT:   %T.as_type.loc15_30.2 => constants.%Goat
+// CHECK:STDOUT:   %T.loc17_15.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.as_type.loc17_30.2 => constants.%Goat
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.ab7
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/facet/min_prelude/convert_class_value_to_generic_facet_value_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_class_value_to_generic_facet_value_value.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_type_to_facet_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_type_to_facet_value.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_as_type_knows_original_type.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_as_type_knows_original_type.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_to_facet_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_to_facet_value.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_to_itself.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_to_itself.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -68,13 +70,13 @@ fn F() {
 // CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc15_15.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_15.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc17_15.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_15.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [concrete = constants.%HandleAnimal] {
 // CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc17_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_17.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc19_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc19_17.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [concrete = constants.%Goat] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
@@ -108,8 +110,8 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @FeedAnimal(%T.loc15_15.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc15_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_15.2 (constants.%T)]
+// CHECK:STDOUT: generic fn @FeedAnimal(%T.loc17_15.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc17_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_15.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -119,18 +121,18 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc17_17.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc17_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_17.2 (constants.%T)]
+// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc19_17.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc19_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc19_17.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc17_31.2: <specific function> = specific_function constants.%FeedAnimal, @FeedAnimal(%T.loc17_17.2) [symbolic = %FeedAnimal.specific_fn.loc17_31.2 (constants.%FeedAnimal.specific_fn.ec8)]
+// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc19_31.2: <specific function> = specific_function constants.%FeedAnimal, @FeedAnimal(%T.loc19_17.2) [symbolic = %FeedAnimal.specific_fn.loc19_31.2 (constants.%FeedAnimal.specific_fn.ec8)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %FeedAnimal.ref: %FeedAnimal.type = name_ref FeedAnimal, file.%FeedAnimal.decl [concrete = constants.%FeedAnimal]
-// CHECK:STDOUT:     %T.ref: %Animal.type = name_ref T, %T.loc17_17.1 [symbolic = %T.loc17_17.2 (constants.%T)]
-// CHECK:STDOUT:     %FeedAnimal.specific_fn.loc17_31.1: <specific function> = specific_function %FeedAnimal.ref, @FeedAnimal(constants.%T) [symbolic = %FeedAnimal.specific_fn.loc17_31.2 (constants.%FeedAnimal.specific_fn.ec8)]
-// CHECK:STDOUT:     %FeedAnimal.call: init %empty_tuple.type = call %FeedAnimal.specific_fn.loc17_31.1()
+// CHECK:STDOUT:     %T.ref: %Animal.type = name_ref T, %T.loc19_17.1 [symbolic = %T.loc19_17.2 (constants.%T)]
+// CHECK:STDOUT:     %FeedAnimal.specific_fn.loc19_31.1: <specific function> = specific_function %FeedAnimal.ref, @FeedAnimal(constants.%T) [symbolic = %FeedAnimal.specific_fn.loc19_31.2 (constants.%FeedAnimal.specific_fn.ec8)]
+// CHECK:STDOUT:     %FeedAnimal.call: init %empty_tuple.type = call %FeedAnimal.specific_fn.loc19_31.1()
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -140,31 +142,31 @@ fn F() {
 // CHECK:STDOUT:   %HandleAnimal.ref: %HandleAnimal.type = name_ref HandleAnimal, file.%HandleAnimal.decl [concrete = constants.%HandleAnimal]
 // CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [concrete = constants.%Goat]
 // CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc23: %Animal.type = converted %Goat.ref, %Animal.facet [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc25: %Animal.type = converted %Goat.ref, %Animal.facet [concrete = constants.%Animal.facet]
 // CHECK:STDOUT:   %HandleAnimal.specific_fn: <specific function> = specific_function %HandleAnimal.ref, @HandleAnimal(constants.%Animal.facet) [concrete = constants.%HandleAnimal.specific_fn]
 // CHECK:STDOUT:   %HandleAnimal.call: init %empty_tuple.type = call %HandleAnimal.specific_fn()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @FeedAnimal(constants.%T) {
-// CHECK:STDOUT:   %T.loc15_15.2 => constants.%T
+// CHECK:STDOUT:   %T.loc17_15.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%T) {
-// CHECK:STDOUT:   %T.loc17_17.2 => constants.%T
+// CHECK:STDOUT:   %T.loc19_17.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%Animal.facet) {
-// CHECK:STDOUT:   %T.loc17_17.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.loc19_17.2 => constants.%Animal.facet
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc17_31.2 => constants.%FeedAnimal.specific_fn.82e
+// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc19_31.2 => constants.%FeedAnimal.specific_fn.82e
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @FeedAnimal(constants.%Animal.facet) {
-// CHECK:STDOUT:   %T.loc15_15.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.loc17_15.2 => constants.%Animal.facet
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_to_narrowed_facet_type.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_to_narrowed_facet_type.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_value_to_blanket_impl.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_value_to_blanket_impl.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -70,12 +72,12 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:   impl_decl @impl [concrete] {
 // CHECK:STDOUT:     %A.patt: %pattern_type.3b0 = symbolic_binding_pattern A, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %A.ref: %Animal.type = name_ref A, %A.loc16_14.1 [symbolic = %A.loc16_14.2 (constants.%A)]
-// CHECK:STDOUT:     %A.as_type.loc16_26.1: type = facet_access_type %A.ref [symbolic = %A.as_type.loc16_26.2 (constants.%A.as_type)]
-// CHECK:STDOUT:     %.loc16: type = converted %A.ref, %A.as_type.loc16_26.1 [symbolic = %A.as_type.loc16_26.2 (constants.%A.as_type)]
+// CHECK:STDOUT:     %A.ref: %Animal.type = name_ref A, %A.loc18_14.1 [symbolic = %A.loc18_14.2 (constants.%A)]
+// CHECK:STDOUT:     %A.as_type.loc18_26.1: type = facet_access_type %A.ref [symbolic = %A.as_type.loc18_26.2 (constants.%A.as_type)]
+// CHECK:STDOUT:     %.loc18: type = converted %A.ref, %A.as_type.loc18_26.1 [symbolic = %A.as_type.loc18_26.2 (constants.%A.as_type)]
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [concrete = constants.%Eats.type]
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %A.loc16_14.1: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc16_14.2 (constants.%A)]
+// CHECK:STDOUT:     %A.loc18_14.1: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc18_14.2 (constants.%A)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Eats.impl_witness_table = impl_witness_table (), @impl [concrete]
 // CHECK:STDOUT:   %Eats.impl_witness: <witness> = impl_witness %Eats.impl_witness_table, @impl(constants.%A) [symbolic = @impl.%Eats.impl_witness (constants.%Eats.impl_witness.8abeaf.1)]
@@ -85,14 +87,14 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:     %e.param_patt: @Feed.%pattern_type (%pattern_type.2b4) = value_param_pattern %e.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [concrete = constants.%Eats.type]
-// CHECK:STDOUT:     %T.loc18_9.1: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc18_9.2 (constants.%T.1b5)]
-// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc18_22.2 (%T.as_type.27d) = value_param call_param0
-// CHECK:STDOUT:     %.loc18_22.1: type = splice_block %.loc18_22.2 [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)] {
-// CHECK:STDOUT:       %T.ref: %Eats.type = name_ref T, %T.loc18_9.1 [symbolic = %T.loc18_9.2 (constants.%T.1b5)]
-// CHECK:STDOUT:       %T.as_type.loc18_22.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)]
-// CHECK:STDOUT:       %.loc18_22.2: type = converted %T.ref, %T.as_type.loc18_22.1 [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)]
+// CHECK:STDOUT:     %T.loc20_9.1: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc20_9.2 (constants.%T.1b5)]
+// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc20_22.2 (%T.as_type.27d) = value_param call_param0
+// CHECK:STDOUT:     %.loc20_22.1: type = splice_block %.loc20_22.2 [symbolic = %T.as_type.loc20_22.2 (constants.%T.as_type.27d)] {
+// CHECK:STDOUT:       %T.ref: %Eats.type = name_ref T, %T.loc20_9.1 [symbolic = %T.loc20_9.2 (constants.%T.1b5)]
+// CHECK:STDOUT:       %T.as_type.loc20_22.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc20_22.2 (constants.%T.as_type.27d)]
+// CHECK:STDOUT:       %.loc20_22.2: type = converted %T.ref, %T.as_type.loc20_22.1 [symbolic = %T.as_type.loc20_22.2 (constants.%T.as_type.27d)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc18_22.2 (%T.as_type.27d) = bind_name e, %e.param
+// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc20_22.2 (%T.as_type.27d) = bind_name e, %e.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [concrete = constants.%HandleAnimal] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.3b0 = symbolic_binding_pattern T, 0 [concrete]
@@ -100,14 +102,14 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:     %a.param_patt: @HandleAnimal.%pattern_type (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc20_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc20_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc20_32.2 (%T.as_type.2ad) = value_param call_param0
-// CHECK:STDOUT:     %.loc20_32.1: type = splice_block %.loc20_32.2 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)] {
-// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc20_17.1 [symbolic = %T.loc20_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:       %T.as_type.loc20_32.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:       %.loc20_32.2: type = converted %T.ref, %T.as_type.loc20_32.1 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %T.loc22_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc22_32.2 (%T.as_type.2ad) = value_param call_param0
+// CHECK:STDOUT:     %.loc22_32.1: type = splice_block %.loc22_32.2 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc22_17.1 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:       %T.as_type.loc22_32.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:       %.loc22_32.2: type = converted %T.ref, %T.as_type.loc22_32.1 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc20_32.2 (%T.as_type.2ad) = bind_name a, %a.param
+// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc22_32.2 (%T.as_type.2ad) = bind_name a, %a.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -127,93 +129,93 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @impl(%A.loc16_14.1: %Animal.type) {
-// CHECK:STDOUT:   %A.loc16_14.2: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc16_14.2 (constants.%A)]
-// CHECK:STDOUT:   %A.as_type.loc16_26.2: type = facet_access_type %A.loc16_14.2 [symbolic = %A.as_type.loc16_26.2 (constants.%A.as_type)]
-// CHECK:STDOUT:   %Eats.impl_witness: <witness> = impl_witness file.%Eats.impl_witness_table, @impl(%A.loc16_14.2) [symbolic = %Eats.impl_witness (constants.%Eats.impl_witness.8abeaf.1)]
+// CHECK:STDOUT: generic impl @impl(%A.loc18_14.1: %Animal.type) {
+// CHECK:STDOUT:   %A.loc18_14.2: %Animal.type = bind_symbolic_name A, 0 [symbolic = %A.loc18_14.2 (constants.%A)]
+// CHECK:STDOUT:   %A.as_type.loc18_26.2: type = facet_access_type %A.loc18_14.2 [symbolic = %A.as_type.loc18_26.2 (constants.%A.as_type)]
+// CHECK:STDOUT:   %Eats.impl_witness: <witness> = impl_witness file.%Eats.impl_witness_table, @impl(%A.loc18_14.2) [symbolic = %Eats.impl_witness (constants.%Eats.impl_witness.8abeaf.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: %.loc16 as %Eats.ref {
+// CHECK:STDOUT:   impl: %.loc18 as %Eats.ref {
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     witness = file.%Eats.impl_witness
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Feed(%T.loc18_9.1: %Eats.type) {
-// CHECK:STDOUT:   %T.loc18_9.2: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc18_9.2 (constants.%T.1b5)]
-// CHECK:STDOUT:   %T.as_type.loc18_22.2: type = facet_access_type %T.loc18_9.2 [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc18_22.2 [symbolic = %pattern_type (constants.%pattern_type.2b4)]
+// CHECK:STDOUT: generic fn @Feed(%T.loc20_9.1: %Eats.type) {
+// CHECK:STDOUT:   %T.loc20_9.2: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc20_9.2 (constants.%T.1b5)]
+// CHECK:STDOUT:   %T.as_type.loc20_22.2: type = facet_access_type %T.loc20_9.2 [symbolic = %T.as_type.loc20_22.2 (constants.%T.as_type.27d)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc20_22.2 [symbolic = %pattern_type (constants.%pattern_type.2b4)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc18_22.2 [symbolic = %require_complete (constants.%require_complete.c75)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc20_22.2 [symbolic = %require_complete (constants.%require_complete.c75)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%e.param: @Feed.%T.as_type.loc18_22.2 (%T.as_type.27d)) {
+// CHECK:STDOUT:   fn(%e.param: @Feed.%T.as_type.loc20_22.2 (%T.as_type.27d)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc20_17.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc20_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc20_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:   %T.as_type.loc20_32.2: type = facet_access_type %T.loc20_17.2 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc20_32.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
+// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc22_17.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc22_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   %T.as_type.loc22_32.2: type = facet_access_type %T.loc22_17.2 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc22_32.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc20_32.2 [symbolic = %require_complete (constants.%require_complete.234)]
-// CHECK:STDOUT:   %Eats.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc20_17.2, @Eats [symbolic = %Eats.lookup_impl_witness (constants.%Eats.lookup_impl_witness)]
-// CHECK:STDOUT:   %Eats.facet.loc20_43.3: %Eats.type = facet_value %T.as_type.loc20_32.2, (%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc20_43.3 (constants.%Eats.facet)]
-// CHECK:STDOUT:   %Feed.specific_fn.loc20_37.2: <specific function> = specific_function constants.%Feed, @Feed(%Eats.facet.loc20_43.3) [symbolic = %Feed.specific_fn.loc20_37.2 (constants.%Feed.specific_fn)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc22_32.2 [symbolic = %require_complete (constants.%require_complete.234)]
+// CHECK:STDOUT:   %Eats.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc22_17.2, @Eats [symbolic = %Eats.lookup_impl_witness (constants.%Eats.lookup_impl_witness)]
+// CHECK:STDOUT:   %Eats.facet.loc22_43.3: %Eats.type = facet_value %T.as_type.loc22_32.2, (%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc22_43.3 (constants.%Eats.facet)]
+// CHECK:STDOUT:   %Feed.specific_fn.loc22_37.2: <specific function> = specific_function constants.%Feed, @Feed(%Eats.facet.loc22_43.3) [symbolic = %Feed.specific_fn.loc22_37.2 (constants.%Feed.specific_fn)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc20_32.2 (%T.as_type.2ad)) {
+// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc22_32.2 (%T.as_type.2ad)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %Feed.ref: %Feed.type = name_ref Feed, file.%Feed.decl [concrete = constants.%Feed]
-// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc20_32.2 (%T.as_type.2ad) = name_ref a, %a
-// CHECK:STDOUT:     %T.as_type.loc20_43.1: type = facet_access_type constants.%T.fd4 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc20_43.1: type = converted constants.%T.fd4, %T.as_type.loc20_43.1 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc20_43.2: %Animal.type = converted %.loc20_43.1, constants.%T.fd4 [symbolic = %T.loc20_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:     %Eats.facet.loc20_43.1: %Eats.type = facet_value constants.%T.as_type.2ad, (constants.%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc20_43.3 (constants.%Eats.facet)]
-// CHECK:STDOUT:     %.loc20_43.3: %Eats.type = converted constants.%T.as_type.2ad, %Eats.facet.loc20_43.1 [symbolic = %Eats.facet.loc20_43.3 (constants.%Eats.facet)]
-// CHECK:STDOUT:     %T.as_type.loc20_43.2: type = facet_access_type constants.%T.fd4 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc20_43.4: type = converted constants.%T.fd4, %T.as_type.loc20_43.2 [symbolic = %T.as_type.loc20_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc20_43.5: %Animal.type = converted %.loc20_43.4, constants.%T.fd4 [symbolic = %T.loc20_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:     %Eats.facet.loc20_43.2: %Eats.type = facet_value constants.%T.as_type.2ad, (constants.%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc20_43.3 (constants.%Eats.facet)]
-// CHECK:STDOUT:     %.loc20_43.6: %Eats.type = converted constants.%T.as_type.2ad, %Eats.facet.loc20_43.2 [symbolic = %Eats.facet.loc20_43.3 (constants.%Eats.facet)]
-// CHECK:STDOUT:     %Feed.specific_fn.loc20_37.1: <specific function> = specific_function %Feed.ref, @Feed(constants.%Eats.facet) [symbolic = %Feed.specific_fn.loc20_37.2 (constants.%Feed.specific_fn)]
-// CHECK:STDOUT:     %Feed.call: init %empty_tuple.type = call %Feed.specific_fn.loc20_37.1(%a.ref)
+// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc22_32.2 (%T.as_type.2ad) = name_ref a, %a
+// CHECK:STDOUT:     %T.as_type.loc22_43.1: type = facet_access_type constants.%T.fd4 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc22_43.1: type = converted constants.%T.fd4, %T.as_type.loc22_43.1 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc22_43.2: %Animal.type = converted %.loc22_43.1, constants.%T.fd4 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %Eats.facet.loc22_43.1: %Eats.type = facet_value constants.%T.as_type.2ad, (constants.%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc22_43.3 (constants.%Eats.facet)]
+// CHECK:STDOUT:     %.loc22_43.3: %Eats.type = converted constants.%T.as_type.2ad, %Eats.facet.loc22_43.1 [symbolic = %Eats.facet.loc22_43.3 (constants.%Eats.facet)]
+// CHECK:STDOUT:     %T.as_type.loc22_43.2: type = facet_access_type constants.%T.fd4 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc22_43.4: type = converted constants.%T.fd4, %T.as_type.loc22_43.2 [symbolic = %T.as_type.loc22_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc22_43.5: %Animal.type = converted %.loc22_43.4, constants.%T.fd4 [symbolic = %T.loc22_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %Eats.facet.loc22_43.2: %Eats.type = facet_value constants.%T.as_type.2ad, (constants.%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc22_43.3 (constants.%Eats.facet)]
+// CHECK:STDOUT:     %.loc22_43.6: %Eats.type = converted constants.%T.as_type.2ad, %Eats.facet.loc22_43.2 [symbolic = %Eats.facet.loc22_43.3 (constants.%Eats.facet)]
+// CHECK:STDOUT:     %Feed.specific_fn.loc22_37.1: <specific function> = specific_function %Feed.ref, @Feed(constants.%Eats.facet) [symbolic = %Feed.specific_fn.loc22_37.2 (constants.%Feed.specific_fn)]
+// CHECK:STDOUT:     %Feed.call: init %empty_tuple.type = call %Feed.specific_fn.loc22_37.1(%a.ref)
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%A) {
-// CHECK:STDOUT:   %A.loc16_14.2 => constants.%A
-// CHECK:STDOUT:   %A.as_type.loc16_26.2 => constants.%A.as_type
+// CHECK:STDOUT:   %A.loc18_14.2 => constants.%A
+// CHECK:STDOUT:   %A.as_type.loc18_26.2 => constants.%A.as_type
 // CHECK:STDOUT:   %Eats.impl_witness => constants.%Eats.impl_witness.8abeaf.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%T.1b5) {
-// CHECK:STDOUT:   %T.loc18_9.2 => constants.%T.1b5
-// CHECK:STDOUT:   %T.as_type.loc18_22.2 => constants.%T.as_type.27d
+// CHECK:STDOUT:   %T.loc20_9.2 => constants.%T.1b5
+// CHECK:STDOUT:   %T.as_type.loc20_22.2 => constants.%T.as_type.27d
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2b4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%T.fd4) {
-// CHECK:STDOUT:   %T.loc20_17.2 => constants.%T.fd4
-// CHECK:STDOUT:   %T.as_type.loc20_32.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %T.loc22_17.2 => constants.%T.fd4
+// CHECK:STDOUT:   %T.as_type.loc22_32.2 => constants.%T.as_type.2ad
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.36a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T.fd4) {
-// CHECK:STDOUT:   %A.loc16_14.2 => constants.%T.fd4
-// CHECK:STDOUT:   %A.as_type.loc16_26.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %A.loc18_14.2 => constants.%T.fd4
+// CHECK:STDOUT:   %A.as_type.loc18_26.2 => constants.%T.as_type.2ad
 // CHECK:STDOUT:   %Eats.impl_witness => constants.%Eats.impl_witness.8abeaf.2
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%Eats.facet) {
-// CHECK:STDOUT:   %T.loc18_9.2 => constants.%Eats.facet
-// CHECK:STDOUT:   %T.as_type.loc18_22.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %T.loc20_9.2 => constants.%Eats.facet
+// CHECK:STDOUT:   %T.as_type.loc20_22.2 => constants.%T.as_type.2ad
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.36a
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_value_to_generic_facet_value_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_value_to_generic_facet_value_value.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -139,24 +141,24 @@ fn F() {
 // CHECK:STDOUT:   %Eats.decl: %Eats.type.ba2 = interface_decl @Eats [concrete = constants.%Eats.generic] {
 // CHECK:STDOUT:     %Food.patt: %pattern_type.98f = symbolic_binding_pattern Food, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Food.loc19_16.1: type = bind_symbolic_name Food, 0 [symbolic = %Food.loc19_16.2 (constants.%Food.8b3)]
+// CHECK:STDOUT:     %Food.loc21_16.1: type = bind_symbolic_name Food, 0 [symbolic = %Food.loc21_16.2 (constants.%Food.8b3)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.009 [concrete] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.3b0 = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:     %U.patt: %pattern_type.939 = symbolic_binding_pattern U, 1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref: %Animal.type = name_ref T, %T.loc24_14.1 [symbolic = %T.loc24_14.2 (constants.%T.fd4)]
-// CHECK:STDOUT:     %T.as_type.loc24_38.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc24_38.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc24_38: type = converted %T.ref, %T.as_type.loc24_38.1 [symbolic = %T.as_type.loc24_38.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %T.ref: %Animal.type = name_ref T, %T.loc26_14.1 [symbolic = %T.loc26_14.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %T.as_type.loc26_38.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc26_38.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc26_38: type = converted %T.ref, %T.as_type.loc26_38.1 [symbolic = %T.as_type.loc26_38.2 (constants.%T.as_type.2ad)]
 // CHECK:STDOUT:     %Eats.ref: %Eats.type.ba2 = name_ref Eats, file.%Eats.decl [concrete = constants.%Eats.generic]
-// CHECK:STDOUT:     %U.ref: %Edible.type = name_ref U, %U.loc24_26.1 [symbolic = %U.loc24_26.2 (constants.%U)]
-// CHECK:STDOUT:     %U.as_type.loc24_49.1: type = facet_access_type %U.ref [symbolic = %U.as_type.loc24_49.2 (constants.%U.as_type)]
-// CHECK:STDOUT:     %.loc24_49: type = converted %U.ref, %U.as_type.loc24_49.1 [symbolic = %U.as_type.loc24_49.2 (constants.%U.as_type)]
-// CHECK:STDOUT:     %Eats.type.loc24_49.1: type = facet_type <@Eats, @Eats(constants.%U.as_type)> [symbolic = %Eats.type.loc24_49.2 (constants.%Eats.type.f54c3d.1)]
+// CHECK:STDOUT:     %U.ref: %Edible.type = name_ref U, %U.loc26_26.1 [symbolic = %U.loc26_26.2 (constants.%U)]
+// CHECK:STDOUT:     %U.as_type.loc26_49.1: type = facet_access_type %U.ref [symbolic = %U.as_type.loc26_49.2 (constants.%U.as_type)]
+// CHECK:STDOUT:     %.loc26_49: type = converted %U.ref, %U.as_type.loc26_49.1 [symbolic = %U.as_type.loc26_49.2 (constants.%U.as_type)]
+// CHECK:STDOUT:     %Eats.type.loc26_49.1: type = facet_type <@Eats, @Eats(constants.%U.as_type)> [symbolic = %Eats.type.loc26_49.2 (constants.%Eats.type.f54c3d.1)]
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc24_14.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc24_14.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %T.loc26_14.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc26_14.2 (constants.%T.fd4)]
 // CHECK:STDOUT:     %Edible.ref: type = name_ref Edible, file.%Edible.decl [concrete = constants.%Edible.type]
-// CHECK:STDOUT:     %U.loc24_26.1: %Edible.type = bind_symbolic_name U, 1 [symbolic = %U.loc24_26.2 (constants.%U)]
+// CHECK:STDOUT:     %U.loc26_26.1: %Edible.type = bind_symbolic_name U, 1 [symbolic = %U.loc26_26.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Eats.impl_witness_table = impl_witness_table (), @impl.009 [concrete]
 // CHECK:STDOUT:   %Eats.impl_witness: <witness> = impl_witness %Eats.impl_witness_table, @impl.009(constants.%T.fd4, constants.%U) [symbolic = @impl.009.%Eats.impl_witness (constants.%Eats.impl_witness.fabf92.1)]
@@ -169,69 +171,69 @@ fn F() {
 // CHECK:STDOUT:   %Animal.impl_witness: <witness> = impl_witness %Animal.impl_witness_table [concrete = constants.%Animal.impl_witness]
 // CHECK:STDOUT:   %Feed.decl: %Feed.type = fn_decl @Feed [concrete = constants.%Feed] {
 // CHECK:STDOUT:     %Food.patt: %pattern_type.939 = symbolic_binding_pattern Food, 0 [concrete]
-// CHECK:STDOUT:     %T.patt: @Feed.%pattern_type.loc29_24 (%pattern_type.ed7) = symbolic_binding_pattern T, 1 [concrete]
-// CHECK:STDOUT:     %e.patt: @Feed.%pattern_type.loc29_40 (%pattern_type.1a1) = binding_pattern e [concrete]
-// CHECK:STDOUT:     %e.param_patt: @Feed.%pattern_type.loc29_40 (%pattern_type.1a1) = value_param_pattern %e.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %food.patt: @Feed.%pattern_type.loc29_46 (%pattern_type.54f) = binding_pattern food [concrete]
-// CHECK:STDOUT:     %food.param_patt: @Feed.%pattern_type.loc29_46 (%pattern_type.54f) = value_param_pattern %food.patt, call_param1 [concrete]
+// CHECK:STDOUT:     %T.patt: @Feed.%pattern_type.loc31_24 (%pattern_type.ed7) = symbolic_binding_pattern T, 1 [concrete]
+// CHECK:STDOUT:     %e.patt: @Feed.%pattern_type.loc31_40 (%pattern_type.1a1) = binding_pattern e [concrete]
+// CHECK:STDOUT:     %e.param_patt: @Feed.%pattern_type.loc31_40 (%pattern_type.1a1) = value_param_pattern %e.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %food.patt: @Feed.%pattern_type.loc31_46 (%pattern_type.54f) = binding_pattern food [concrete]
+// CHECK:STDOUT:     %food.param_patt: @Feed.%pattern_type.loc31_46 (%pattern_type.54f) = value_param_pattern %food.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Edible.ref: type = name_ref Edible, file.%Edible.decl [concrete = constants.%Edible.type]
-// CHECK:STDOUT:     %Food.loc29_9.1: %Edible.type = bind_symbolic_name Food, 0 [symbolic = %Food.loc29_9.2 (constants.%Food.9af)]
-// CHECK:STDOUT:     %.loc29_37.1: type = splice_block %Eats.type.loc29_37.1 [symbolic = %Eats.type.loc29_37.2 (constants.%Eats.type.b39)] {
+// CHECK:STDOUT:     %Food.loc31_9.1: %Edible.type = bind_symbolic_name Food, 0 [symbolic = %Food.loc31_9.2 (constants.%Food.9af)]
+// CHECK:STDOUT:     %.loc31_37.1: type = splice_block %Eats.type.loc31_37.1 [symbolic = %Eats.type.loc31_37.2 (constants.%Eats.type.b39)] {
 // CHECK:STDOUT:       %Eats.ref: %Eats.type.ba2 = name_ref Eats, file.%Eats.decl [concrete = constants.%Eats.generic]
-// CHECK:STDOUT:       %Food.ref.loc29_33: %Edible.type = name_ref Food, %Food.loc29_9.1 [symbolic = %Food.loc29_9.2 (constants.%Food.9af)]
-// CHECK:STDOUT:       %Food.as_type.loc29_37.1: type = facet_access_type %Food.ref.loc29_33 [symbolic = %Food.as_type.loc29_37.2 (constants.%Food.as_type.952)]
-// CHECK:STDOUT:       %.loc29_37.2: type = converted %Food.ref.loc29_33, %Food.as_type.loc29_37.1 [symbolic = %Food.as_type.loc29_37.2 (constants.%Food.as_type.952)]
-// CHECK:STDOUT:       %Eats.type.loc29_37.1: type = facet_type <@Eats, @Eats(constants.%Food.as_type.952)> [symbolic = %Eats.type.loc29_37.2 (constants.%Eats.type.b39)]
+// CHECK:STDOUT:       %Food.ref.loc31_33: %Edible.type = name_ref Food, %Food.loc31_9.1 [symbolic = %Food.loc31_9.2 (constants.%Food.9af)]
+// CHECK:STDOUT:       %Food.as_type.loc31_37.1: type = facet_access_type %Food.ref.loc31_33 [symbolic = %Food.as_type.loc31_37.2 (constants.%Food.as_type.952)]
+// CHECK:STDOUT:       %.loc31_37.2: type = converted %Food.ref.loc31_33, %Food.as_type.loc31_37.1 [symbolic = %Food.as_type.loc31_37.2 (constants.%Food.as_type.952)]
+// CHECK:STDOUT:       %Eats.type.loc31_37.1: type = facet_type <@Eats, @Eats(constants.%Food.as_type.952)> [symbolic = %Eats.type.loc31_37.2 (constants.%Eats.type.b39)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc29_24.1: @Feed.%Eats.type.loc29_37.2 (%Eats.type.b39) = bind_symbolic_name T, 1 [symbolic = %T.loc29_24.2 (constants.%T.223)]
-// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc29_43.2 (%T.as_type.212) = value_param call_param0
-// CHECK:STDOUT:     %.loc29_43.1: type = splice_block %.loc29_43.2 [symbolic = %T.as_type.loc29_43.2 (constants.%T.as_type.212)] {
-// CHECK:STDOUT:       %T.ref: @Feed.%Eats.type.loc29_37.2 (%Eats.type.b39) = name_ref T, %T.loc29_24.1 [symbolic = %T.loc29_24.2 (constants.%T.223)]
-// CHECK:STDOUT:       %T.as_type.loc29_43.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc29_43.2 (constants.%T.as_type.212)]
-// CHECK:STDOUT:       %.loc29_43.2: type = converted %T.ref, %T.as_type.loc29_43.1 [symbolic = %T.as_type.loc29_43.2 (constants.%T.as_type.212)]
+// CHECK:STDOUT:     %T.loc31_24.1: @Feed.%Eats.type.loc31_37.2 (%Eats.type.b39) = bind_symbolic_name T, 1 [symbolic = %T.loc31_24.2 (constants.%T.223)]
+// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc31_43.2 (%T.as_type.212) = value_param call_param0
+// CHECK:STDOUT:     %.loc31_43.1: type = splice_block %.loc31_43.2 [symbolic = %T.as_type.loc31_43.2 (constants.%T.as_type.212)] {
+// CHECK:STDOUT:       %T.ref: @Feed.%Eats.type.loc31_37.2 (%Eats.type.b39) = name_ref T, %T.loc31_24.1 [symbolic = %T.loc31_24.2 (constants.%T.223)]
+// CHECK:STDOUT:       %T.as_type.loc31_43.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc31_43.2 (constants.%T.as_type.212)]
+// CHECK:STDOUT:       %.loc31_43.2: type = converted %T.ref, %T.as_type.loc31_43.1 [symbolic = %T.as_type.loc31_43.2 (constants.%T.as_type.212)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc29_43.2 (%T.as_type.212) = bind_name e, %e.param
-// CHECK:STDOUT:     %food.param: @Feed.%Food.as_type.loc29_37.2 (%Food.as_type.952) = value_param call_param1
-// CHECK:STDOUT:     %.loc29_52.1: type = splice_block %.loc29_52.2 [symbolic = %Food.as_type.loc29_37.2 (constants.%Food.as_type.952)] {
-// CHECK:STDOUT:       %Food.ref.loc29_52: %Edible.type = name_ref Food, %Food.loc29_9.1 [symbolic = %Food.loc29_9.2 (constants.%Food.9af)]
-// CHECK:STDOUT:       %Food.as_type.loc29_52: type = facet_access_type %Food.ref.loc29_52 [symbolic = %Food.as_type.loc29_37.2 (constants.%Food.as_type.952)]
-// CHECK:STDOUT:       %.loc29_52.2: type = converted %Food.ref.loc29_52, %Food.as_type.loc29_52 [symbolic = %Food.as_type.loc29_37.2 (constants.%Food.as_type.952)]
+// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc31_43.2 (%T.as_type.212) = bind_name e, %e.param
+// CHECK:STDOUT:     %food.param: @Feed.%Food.as_type.loc31_37.2 (%Food.as_type.952) = value_param call_param1
+// CHECK:STDOUT:     %.loc31_52.1: type = splice_block %.loc31_52.2 [symbolic = %Food.as_type.loc31_37.2 (constants.%Food.as_type.952)] {
+// CHECK:STDOUT:       %Food.ref.loc31_52: %Edible.type = name_ref Food, %Food.loc31_9.1 [symbolic = %Food.loc31_9.2 (constants.%Food.9af)]
+// CHECK:STDOUT:       %Food.as_type.loc31_52: type = facet_access_type %Food.ref.loc31_52 [symbolic = %Food.as_type.loc31_37.2 (constants.%Food.as_type.952)]
+// CHECK:STDOUT:       %.loc31_52.2: type = converted %Food.ref.loc31_52, %Food.as_type.loc31_52 [symbolic = %Food.as_type.loc31_37.2 (constants.%Food.as_type.952)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %food: @Feed.%Food.as_type.loc29_37.2 (%Food.as_type.952) = bind_name food, %food.param
+// CHECK:STDOUT:     %food: @Feed.%Food.as_type.loc31_37.2 (%Food.as_type.952) = bind_name food, %food.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [concrete = constants.%HandleAnimal] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.3b0 = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:     %Food.patt: %pattern_type.939 = symbolic_binding_pattern Food, 1 [concrete]
-// CHECK:STDOUT:     %a.patt: @HandleAnimal.%pattern_type.loc30_44 (%pattern_type.36a) = binding_pattern a [concrete]
-// CHECK:STDOUT:     %a.param_patt: @HandleAnimal.%pattern_type.loc30_44 (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %food.patt: @HandleAnimal.%pattern_type.loc30_50 (%pattern_type.f86) = binding_pattern food [concrete]
-// CHECK:STDOUT:     %food.param_patt: @HandleAnimal.%pattern_type.loc30_50 (%pattern_type.f86) = value_param_pattern %food.patt, call_param1 [concrete]
+// CHECK:STDOUT:     %a.patt: @HandleAnimal.%pattern_type.loc32_44 (%pattern_type.36a) = binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.param_patt: @HandleAnimal.%pattern_type.loc32_44 (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %food.patt: @HandleAnimal.%pattern_type.loc32_50 (%pattern_type.f86) = binding_pattern food [concrete]
+// CHECK:STDOUT:     %food.param_patt: @HandleAnimal.%pattern_type.loc32_50 (%pattern_type.f86) = value_param_pattern %food.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc30_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc30_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %T.loc32_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc32_17.2 (constants.%T.fd4)]
 // CHECK:STDOUT:     %Edible.ref: type = name_ref Edible, file.%Edible.decl [concrete = constants.%Edible.type]
-// CHECK:STDOUT:     %Food.loc30_29.1: %Edible.type = bind_symbolic_name Food, 1 [symbolic = %Food.loc30_29.2 (constants.%Food.5fe)]
-// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc30_47.2 (%T.as_type.2ad) = value_param call_param0
-// CHECK:STDOUT:     %.loc30_47.1: type = splice_block %.loc30_47.2 [symbolic = %T.as_type.loc30_47.2 (constants.%T.as_type.2ad)] {
-// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc30_17.1 [symbolic = %T.loc30_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:       %T.as_type.loc30_47.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc30_47.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:       %.loc30_47.2: type = converted %T.ref, %T.as_type.loc30_47.1 [symbolic = %T.as_type.loc30_47.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %Food.loc32_29.1: %Edible.type = bind_symbolic_name Food, 1 [symbolic = %Food.loc32_29.2 (constants.%Food.5fe)]
+// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc32_47.2 (%T.as_type.2ad) = value_param call_param0
+// CHECK:STDOUT:     %.loc32_47.1: type = splice_block %.loc32_47.2 [symbolic = %T.as_type.loc32_47.2 (constants.%T.as_type.2ad)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc32_17.1 [symbolic = %T.loc32_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:       %T.as_type.loc32_47.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc32_47.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:       %.loc32_47.2: type = converted %T.ref, %T.as_type.loc32_47.1 [symbolic = %T.as_type.loc32_47.2 (constants.%T.as_type.2ad)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc30_47.2 (%T.as_type.2ad) = bind_name a, %a.param
-// CHECK:STDOUT:     %food.param: @HandleAnimal.%Food.as_type.loc30_56.2 (%Food.as_type.fae) = value_param call_param1
-// CHECK:STDOUT:     %.loc30_56.1: type = splice_block %.loc30_56.2 [symbolic = %Food.as_type.loc30_56.2 (constants.%Food.as_type.fae)] {
-// CHECK:STDOUT:       %Food.ref: %Edible.type = name_ref Food, %Food.loc30_29.1 [symbolic = %Food.loc30_29.2 (constants.%Food.5fe)]
-// CHECK:STDOUT:       %Food.as_type.loc30_56.1: type = facet_access_type %Food.ref [symbolic = %Food.as_type.loc30_56.2 (constants.%Food.as_type.fae)]
-// CHECK:STDOUT:       %.loc30_56.2: type = converted %Food.ref, %Food.as_type.loc30_56.1 [symbolic = %Food.as_type.loc30_56.2 (constants.%Food.as_type.fae)]
+// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc32_47.2 (%T.as_type.2ad) = bind_name a, %a.param
+// CHECK:STDOUT:     %food.param: @HandleAnimal.%Food.as_type.loc32_56.2 (%Food.as_type.fae) = value_param call_param1
+// CHECK:STDOUT:     %.loc32_56.1: type = splice_block %.loc32_56.2 [symbolic = %Food.as_type.loc32_56.2 (constants.%Food.as_type.fae)] {
+// CHECK:STDOUT:       %Food.ref: %Edible.type = name_ref Food, %Food.loc32_29.1 [symbolic = %Food.loc32_29.2 (constants.%Food.5fe)]
+// CHECK:STDOUT:       %Food.as_type.loc32_56.1: type = facet_access_type %Food.ref [symbolic = %Food.as_type.loc32_56.2 (constants.%Food.as_type.fae)]
+// CHECK:STDOUT:       %.loc32_56.2: type = converted %Food.ref, %Food.as_type.loc32_56.1 [symbolic = %Food.as_type.loc32_56.2 (constants.%Food.as_type.fae)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %food: @HandleAnimal.%Food.as_type.loc30_56.2 (%Food.as_type.fae) = bind_name food, %food.param
+// CHECK:STDOUT:     %food: @HandleAnimal.%Food.as_type.loc32_56.2 (%Food.as_type.fae) = bind_name food, %food.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT:   %Edible.facet: %Edible.type = facet_value constants.%Grass, (constants.%Edible.impl_witness) [concrete = constants.%Edible.facet]
-// CHECK:STDOUT:   %.loc30_76.1: %Edible.type = converted constants.%Grass, %Edible.facet [concrete = constants.%Edible.facet]
+// CHECK:STDOUT:   %.loc32_76.1: %Edible.type = converted constants.%Grass, %Edible.facet [concrete = constants.%Edible.facet]
 // CHECK:STDOUT:   %Animal.facet: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc30_76.2: %Animal.type = converted constants.%Goat, %Animal.facet [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc32_76.2: %Animal.type = converted constants.%Goat, %Animal.facet [concrete = constants.%Animal.facet]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Edible {
@@ -250,11 +252,11 @@ fn F() {
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic interface @Eats(%Food.loc19_16.1: type) {
-// CHECK:STDOUT:   %Food.loc19_16.2: type = bind_symbolic_name Food, 0 [symbolic = %Food.loc19_16.2 (constants.%Food.8b3)]
+// CHECK:STDOUT: generic interface @Eats(%Food.loc21_16.1: type) {
+// CHECK:STDOUT:   %Food.loc21_16.2: type = bind_symbolic_name Food, 0 [symbolic = %Food.loc21_16.2 (constants.%Food.8b3)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats, @Eats(%Food.loc19_16.2)> [symbolic = %Eats.type (constants.%Eats.type.6c0)]
+// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats, @Eats(%Food.loc21_16.2)> [symbolic = %Eats.type (constants.%Eats.type.6c0)]
 // CHECK:STDOUT:   %Self.2: @Eats.%Eats.type (%Eats.type.6c0) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.4eb)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
@@ -271,18 +273,18 @@ fn F() {
 // CHECK:STDOUT:   witness = file.%Edible.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @impl.009(%T.loc24_14.1: %Animal.type, %U.loc24_26.1: %Edible.type) {
-// CHECK:STDOUT:   %T.loc24_14.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc24_14.2 (constants.%T.fd4)]
-// CHECK:STDOUT:   %U.loc24_26.2: %Edible.type = bind_symbolic_name U, 1 [symbolic = %U.loc24_26.2 (constants.%U)]
-// CHECK:STDOUT:   %T.as_type.loc24_38.2: type = facet_access_type %T.loc24_14.2 [symbolic = %T.as_type.loc24_38.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:   %U.as_type.loc24_49.2: type = facet_access_type %U.loc24_26.2 [symbolic = %U.as_type.loc24_49.2 (constants.%U.as_type)]
-// CHECK:STDOUT:   %Eats.type.loc24_49.2: type = facet_type <@Eats, @Eats(%U.as_type.loc24_49.2)> [symbolic = %Eats.type.loc24_49.2 (constants.%Eats.type.f54c3d.1)]
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Eats.type.loc24_49.2 [symbolic = %require_complete (constants.%require_complete.42532a.1)]
-// CHECK:STDOUT:   %Eats.impl_witness: <witness> = impl_witness file.%Eats.impl_witness_table, @impl.009(%T.loc24_14.2, %U.loc24_26.2) [symbolic = %Eats.impl_witness (constants.%Eats.impl_witness.fabf92.1)]
+// CHECK:STDOUT: generic impl @impl.009(%T.loc26_14.1: %Animal.type, %U.loc26_26.1: %Edible.type) {
+// CHECK:STDOUT:   %T.loc26_14.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc26_14.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   %U.loc26_26.2: %Edible.type = bind_symbolic_name U, 1 [symbolic = %U.loc26_26.2 (constants.%U)]
+// CHECK:STDOUT:   %T.as_type.loc26_38.2: type = facet_access_type %T.loc26_14.2 [symbolic = %T.as_type.loc26_38.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:   %U.as_type.loc26_49.2: type = facet_access_type %U.loc26_26.2 [symbolic = %U.as_type.loc26_49.2 (constants.%U.as_type)]
+// CHECK:STDOUT:   %Eats.type.loc26_49.2: type = facet_type <@Eats, @Eats(%U.as_type.loc26_49.2)> [symbolic = %Eats.type.loc26_49.2 (constants.%Eats.type.f54c3d.1)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Eats.type.loc26_49.2 [symbolic = %require_complete (constants.%require_complete.42532a.1)]
+// CHECK:STDOUT:   %Eats.impl_witness: <witness> = impl_witness file.%Eats.impl_witness_table, @impl.009(%T.loc26_14.2, %U.loc26_26.2) [symbolic = %Eats.impl_witness (constants.%Eats.impl_witness.fabf92.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: %.loc24_38 as %Eats.type.loc24_49.1 {
+// CHECK:STDOUT:   impl: %.loc26_38 as %Eats.type.loc26_49.1 {
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     witness = file.%Eats.impl_witness
 // CHECK:STDOUT:   }
@@ -311,57 +313,57 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Feed(%Food.loc29_9.1: %Edible.type, %T.loc29_24.1: @Feed.%Eats.type.loc29_37.2 (%Eats.type.b39)) {
-// CHECK:STDOUT:   %Food.loc29_9.2: %Edible.type = bind_symbolic_name Food, 0 [symbolic = %Food.loc29_9.2 (constants.%Food.9af)]
-// CHECK:STDOUT:   %Food.as_type.loc29_37.2: type = facet_access_type %Food.loc29_9.2 [symbolic = %Food.as_type.loc29_37.2 (constants.%Food.as_type.952)]
-// CHECK:STDOUT:   %Eats.type.loc29_37.2: type = facet_type <@Eats, @Eats(%Food.as_type.loc29_37.2)> [symbolic = %Eats.type.loc29_37.2 (constants.%Eats.type.b39)]
-// CHECK:STDOUT:   %T.loc29_24.2: @Feed.%Eats.type.loc29_37.2 (%Eats.type.b39) = bind_symbolic_name T, 1 [symbolic = %T.loc29_24.2 (constants.%T.223)]
-// CHECK:STDOUT:   %pattern_type.loc29_24: type = pattern_type %Eats.type.loc29_37.2 [symbolic = %pattern_type.loc29_24 (constants.%pattern_type.ed7)]
-// CHECK:STDOUT:   %T.as_type.loc29_43.2: type = facet_access_type %T.loc29_24.2 [symbolic = %T.as_type.loc29_43.2 (constants.%T.as_type.212)]
-// CHECK:STDOUT:   %pattern_type.loc29_40: type = pattern_type %T.as_type.loc29_43.2 [symbolic = %pattern_type.loc29_40 (constants.%pattern_type.1a1)]
-// CHECK:STDOUT:   %pattern_type.loc29_46: type = pattern_type %Food.as_type.loc29_37.2 [symbolic = %pattern_type.loc29_46 (constants.%pattern_type.54f)]
+// CHECK:STDOUT: generic fn @Feed(%Food.loc31_9.1: %Edible.type, %T.loc31_24.1: @Feed.%Eats.type.loc31_37.2 (%Eats.type.b39)) {
+// CHECK:STDOUT:   %Food.loc31_9.2: %Edible.type = bind_symbolic_name Food, 0 [symbolic = %Food.loc31_9.2 (constants.%Food.9af)]
+// CHECK:STDOUT:   %Food.as_type.loc31_37.2: type = facet_access_type %Food.loc31_9.2 [symbolic = %Food.as_type.loc31_37.2 (constants.%Food.as_type.952)]
+// CHECK:STDOUT:   %Eats.type.loc31_37.2: type = facet_type <@Eats, @Eats(%Food.as_type.loc31_37.2)> [symbolic = %Eats.type.loc31_37.2 (constants.%Eats.type.b39)]
+// CHECK:STDOUT:   %T.loc31_24.2: @Feed.%Eats.type.loc31_37.2 (%Eats.type.b39) = bind_symbolic_name T, 1 [symbolic = %T.loc31_24.2 (constants.%T.223)]
+// CHECK:STDOUT:   %pattern_type.loc31_24: type = pattern_type %Eats.type.loc31_37.2 [symbolic = %pattern_type.loc31_24 (constants.%pattern_type.ed7)]
+// CHECK:STDOUT:   %T.as_type.loc31_43.2: type = facet_access_type %T.loc31_24.2 [symbolic = %T.as_type.loc31_43.2 (constants.%T.as_type.212)]
+// CHECK:STDOUT:   %pattern_type.loc31_40: type = pattern_type %T.as_type.loc31_43.2 [symbolic = %pattern_type.loc31_40 (constants.%pattern_type.1a1)]
+// CHECK:STDOUT:   %pattern_type.loc31_46: type = pattern_type %Food.as_type.loc31_37.2 [symbolic = %pattern_type.loc31_46 (constants.%pattern_type.54f)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc29_41: <witness> = require_complete_type %T.as_type.loc29_43.2 [symbolic = %require_complete.loc29_41 (constants.%require_complete.fe6)]
-// CHECK:STDOUT:   %require_complete.loc29_50: <witness> = require_complete_type %Food.as_type.loc29_37.2 [symbolic = %require_complete.loc29_50 (constants.%require_complete.005)]
+// CHECK:STDOUT:   %require_complete.loc31_41: <witness> = require_complete_type %T.as_type.loc31_43.2 [symbolic = %require_complete.loc31_41 (constants.%require_complete.fe6)]
+// CHECK:STDOUT:   %require_complete.loc31_50: <witness> = require_complete_type %Food.as_type.loc31_37.2 [symbolic = %require_complete.loc31_50 (constants.%require_complete.005)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%e.param: @Feed.%T.as_type.loc29_43.2 (%T.as_type.212), %food.param: @Feed.%Food.as_type.loc29_37.2 (%Food.as_type.952)) {
+// CHECK:STDOUT:   fn(%e.param: @Feed.%T.as_type.loc31_43.2 (%T.as_type.212), %food.param: @Feed.%Food.as_type.loc31_37.2 (%Food.as_type.952)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc30_17.1: %Animal.type, %Food.loc30_29.1: %Edible.type) {
-// CHECK:STDOUT:   %T.loc30_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc30_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:   %Food.loc30_29.2: %Edible.type = bind_symbolic_name Food, 1 [symbolic = %Food.loc30_29.2 (constants.%Food.5fe)]
-// CHECK:STDOUT:   %T.as_type.loc30_47.2: type = facet_access_type %T.loc30_17.2 [symbolic = %T.as_type.loc30_47.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:   %pattern_type.loc30_44: type = pattern_type %T.as_type.loc30_47.2 [symbolic = %pattern_type.loc30_44 (constants.%pattern_type.36a)]
-// CHECK:STDOUT:   %Food.as_type.loc30_56.2: type = facet_access_type %Food.loc30_29.2 [symbolic = %Food.as_type.loc30_56.2 (constants.%Food.as_type.fae)]
-// CHECK:STDOUT:   %pattern_type.loc30_50: type = pattern_type %Food.as_type.loc30_56.2 [symbolic = %pattern_type.loc30_50 (constants.%pattern_type.f86)]
+// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc32_17.1: %Animal.type, %Food.loc32_29.1: %Edible.type) {
+// CHECK:STDOUT:   %T.loc32_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc32_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   %Food.loc32_29.2: %Edible.type = bind_symbolic_name Food, 1 [symbolic = %Food.loc32_29.2 (constants.%Food.5fe)]
+// CHECK:STDOUT:   %T.as_type.loc32_47.2: type = facet_access_type %T.loc32_17.2 [symbolic = %T.as_type.loc32_47.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:   %pattern_type.loc32_44: type = pattern_type %T.as_type.loc32_47.2 [symbolic = %pattern_type.loc32_44 (constants.%pattern_type.36a)]
+// CHECK:STDOUT:   %Food.as_type.loc32_56.2: type = facet_access_type %Food.loc32_29.2 [symbolic = %Food.as_type.loc32_56.2 (constants.%Food.as_type.fae)]
+// CHECK:STDOUT:   %pattern_type.loc32_50: type = pattern_type %Food.as_type.loc32_56.2 [symbolic = %pattern_type.loc32_50 (constants.%pattern_type.f86)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc30_45: <witness> = require_complete_type %T.as_type.loc30_47.2 [symbolic = %require_complete.loc30_45 (constants.%require_complete.234)]
-// CHECK:STDOUT:   %require_complete.loc30_54: <witness> = require_complete_type %Food.as_type.loc30_56.2 [symbolic = %require_complete.loc30_54 (constants.%require_complete.444)]
-// CHECK:STDOUT:   %Eats.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc30_17.2, @Eats, @Eats(%Food.as_type.loc30_56.2) [symbolic = %Eats.lookup_impl_witness (constants.%Eats.lookup_impl_witness)]
-// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats, @Eats(%Food.as_type.loc30_56.2)> [symbolic = %Eats.type (constants.%Eats.type.f54c3d.2)]
-// CHECK:STDOUT:   %Eats.facet.loc30_76.2: @HandleAnimal.%Eats.type (%Eats.type.f54c3d.2) = facet_value %T.as_type.loc30_47.2, (%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc30_76.2 (constants.%Eats.facet.512)]
-// CHECK:STDOUT:   %Feed.specific_fn.loc30_64.2: <specific function> = specific_function constants.%Feed, @Feed(%Food.loc30_29.2, %Eats.facet.loc30_76.2) [symbolic = %Feed.specific_fn.loc30_64.2 (constants.%Feed.specific_fn.ea3)]
+// CHECK:STDOUT:   %require_complete.loc32_45: <witness> = require_complete_type %T.as_type.loc32_47.2 [symbolic = %require_complete.loc32_45 (constants.%require_complete.234)]
+// CHECK:STDOUT:   %require_complete.loc32_54: <witness> = require_complete_type %Food.as_type.loc32_56.2 [symbolic = %require_complete.loc32_54 (constants.%require_complete.444)]
+// CHECK:STDOUT:   %Eats.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc32_17.2, @Eats, @Eats(%Food.as_type.loc32_56.2) [symbolic = %Eats.lookup_impl_witness (constants.%Eats.lookup_impl_witness)]
+// CHECK:STDOUT:   %Eats.type: type = facet_type <@Eats, @Eats(%Food.as_type.loc32_56.2)> [symbolic = %Eats.type (constants.%Eats.type.f54c3d.2)]
+// CHECK:STDOUT:   %Eats.facet.loc32_76.2: @HandleAnimal.%Eats.type (%Eats.type.f54c3d.2) = facet_value %T.as_type.loc32_47.2, (%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc32_76.2 (constants.%Eats.facet.512)]
+// CHECK:STDOUT:   %Feed.specific_fn.loc32_64.2: <specific function> = specific_function constants.%Feed, @Feed(%Food.loc32_29.2, %Eats.facet.loc32_76.2) [symbolic = %Feed.specific_fn.loc32_64.2 (constants.%Feed.specific_fn.ea3)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc30_47.2 (%T.as_type.2ad), %food.param: @HandleAnimal.%Food.as_type.loc30_56.2 (%Food.as_type.fae)) {
+// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc32_47.2 (%T.as_type.2ad), %food.param: @HandleAnimal.%Food.as_type.loc32_56.2 (%Food.as_type.fae)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %Feed.ref: %Feed.type = name_ref Feed, file.%Feed.decl [concrete = constants.%Feed]
-// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc30_47.2 (%T.as_type.2ad) = name_ref a, %a
-// CHECK:STDOUT:     %food.ref: @HandleAnimal.%Food.as_type.loc30_56.2 (%Food.as_type.fae) = name_ref food, %food
-// CHECK:STDOUT:     %.loc30_76.1: %Edible.type = converted constants.%Food.as_type.fae, constants.%Food.5fe [symbolic = %Food.loc30_29.2 (constants.%Food.5fe)]
-// CHECK:STDOUT:     %.loc30_76.2: %Edible.type = converted constants.%Food.as_type.fae, constants.%Food.5fe [symbolic = %Food.loc30_29.2 (constants.%Food.5fe)]
-// CHECK:STDOUT:     %.loc30_76.3: %Edible.type = converted constants.%Food.as_type.fae, constants.%Food.5fe [symbolic = %Food.loc30_29.2 (constants.%Food.5fe)]
-// CHECK:STDOUT:     %T.as_type.loc30_76: type = facet_access_type constants.%T.fd4 [symbolic = %T.as_type.loc30_47.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc30_76.4: type = converted constants.%T.fd4, %T.as_type.loc30_76 [symbolic = %T.as_type.loc30_47.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:     %.loc30_76.5: %Animal.type = converted %.loc30_76.4, constants.%T.fd4 [symbolic = %T.loc30_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:     %Eats.facet.loc30_76.1: @HandleAnimal.%Eats.type (%Eats.type.f54c3d.2) = facet_value constants.%T.as_type.2ad, (constants.%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc30_76.2 (constants.%Eats.facet.512)]
-// CHECK:STDOUT:     %.loc30_76.6: @HandleAnimal.%Eats.type (%Eats.type.f54c3d.2) = converted constants.%T.as_type.2ad, %Eats.facet.loc30_76.1 [symbolic = %Eats.facet.loc30_76.2 (constants.%Eats.facet.512)]
-// CHECK:STDOUT:     %Feed.specific_fn.loc30_64.1: <specific function> = specific_function %Feed.ref, @Feed(constants.%Food.5fe, constants.%Eats.facet.512) [symbolic = %Feed.specific_fn.loc30_64.2 (constants.%Feed.specific_fn.ea3)]
-// CHECK:STDOUT:     %Feed.call: init %empty_tuple.type = call %Feed.specific_fn.loc30_64.1(%a.ref, %food.ref)
+// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc32_47.2 (%T.as_type.2ad) = name_ref a, %a
+// CHECK:STDOUT:     %food.ref: @HandleAnimal.%Food.as_type.loc32_56.2 (%Food.as_type.fae) = name_ref food, %food
+// CHECK:STDOUT:     %.loc32_76.1: %Edible.type = converted constants.%Food.as_type.fae, constants.%Food.5fe [symbolic = %Food.loc32_29.2 (constants.%Food.5fe)]
+// CHECK:STDOUT:     %.loc32_76.2: %Edible.type = converted constants.%Food.as_type.fae, constants.%Food.5fe [symbolic = %Food.loc32_29.2 (constants.%Food.5fe)]
+// CHECK:STDOUT:     %.loc32_76.3: %Edible.type = converted constants.%Food.as_type.fae, constants.%Food.5fe [symbolic = %Food.loc32_29.2 (constants.%Food.5fe)]
+// CHECK:STDOUT:     %T.as_type.loc32_76: type = facet_access_type constants.%T.fd4 [symbolic = %T.as_type.loc32_47.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc32_76.4: type = converted constants.%T.fd4, %T.as_type.loc32_76 [symbolic = %T.as_type.loc32_47.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %.loc32_76.5: %Animal.type = converted %.loc32_76.4, constants.%T.fd4 [symbolic = %T.loc32_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %Eats.facet.loc32_76.1: @HandleAnimal.%Eats.type (%Eats.type.f54c3d.2) = facet_value constants.%T.as_type.2ad, (constants.%Eats.lookup_impl_witness) [symbolic = %Eats.facet.loc32_76.2 (constants.%Eats.facet.512)]
+// CHECK:STDOUT:     %.loc32_76.6: @HandleAnimal.%Eats.type (%Eats.type.f54c3d.2) = converted constants.%T.as_type.2ad, %Eats.facet.loc32_76.1 [symbolic = %Eats.facet.loc32_76.2 (constants.%Eats.facet.512)]
+// CHECK:STDOUT:     %Feed.specific_fn.loc32_64.1: <specific function> = specific_function %Feed.ref, @Feed(constants.%Food.5fe, constants.%Eats.facet.512) [symbolic = %Feed.specific_fn.loc32_64.2 (constants.%Feed.specific_fn.ea3)]
+// CHECK:STDOUT:     %Feed.call: init %empty_tuple.type = call %Feed.specific_fn.loc32_64.1(%a.ref, %food.ref)
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -369,39 +371,39 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %HandleAnimal.ref: %HandleAnimal.type = name_ref HandleAnimal, file.%HandleAnimal.decl [concrete = constants.%HandleAnimal]
-// CHECK:STDOUT:   %.loc33_17.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc35_17.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [concrete = constants.%Goat]
-// CHECK:STDOUT:   %.loc33_17.2: ref %Goat = temporary_storage
-// CHECK:STDOUT:   %.loc33_17.3: init %Goat = class_init (), %.loc33_17.2 [concrete = constants.%Goat.val]
-// CHECK:STDOUT:   %.loc33_17.4: ref %Goat = temporary %.loc33_17.2, %.loc33_17.3
-// CHECK:STDOUT:   %.loc33_19.1: ref %Goat = converted %.loc33_17.1, %.loc33_17.4
-// CHECK:STDOUT:   %.loc33_29.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc35_17.2: ref %Goat = temporary_storage
+// CHECK:STDOUT:   %.loc35_17.3: init %Goat = class_init (), %.loc35_17.2 [concrete = constants.%Goat.val]
+// CHECK:STDOUT:   %.loc35_17.4: ref %Goat = temporary %.loc35_17.2, %.loc35_17.3
+// CHECK:STDOUT:   %.loc35_19.1: ref %Goat = converted %.loc35_17.1, %.loc35_17.4
+// CHECK:STDOUT:   %.loc35_29.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %Grass.ref: type = name_ref Grass, file.%Grass.decl [concrete = constants.%Grass]
-// CHECK:STDOUT:   %.loc33_29.2: ref %Grass = temporary_storage
-// CHECK:STDOUT:   %.loc33_29.3: init %Grass = class_init (), %.loc33_29.2 [concrete = constants.%Grass.val]
-// CHECK:STDOUT:   %.loc33_29.4: ref %Grass = temporary %.loc33_29.2, %.loc33_29.3
-// CHECK:STDOUT:   %.loc33_31.1: ref %Grass = converted %.loc33_29.1, %.loc33_29.4
-// CHECK:STDOUT:   %Animal.facet.loc33_39.1: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc33_39.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc33_39.1 [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %Animal.facet.loc33_39.2: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc33_39.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc33_39.2 [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %Edible.facet.loc33_39.1: %Edible.type = facet_value constants.%Grass, (constants.%Edible.impl_witness) [concrete = constants.%Edible.facet]
-// CHECK:STDOUT:   %.loc33_39.3: %Edible.type = converted constants.%Grass, %Edible.facet.loc33_39.1 [concrete = constants.%Edible.facet]
-// CHECK:STDOUT:   %Edible.facet.loc33_39.2: %Edible.type = facet_value constants.%Grass, (constants.%Edible.impl_witness) [concrete = constants.%Edible.facet]
-// CHECK:STDOUT:   %.loc33_39.4: %Edible.type = converted constants.%Grass, %Edible.facet.loc33_39.2 [concrete = constants.%Edible.facet]
+// CHECK:STDOUT:   %.loc35_29.2: ref %Grass = temporary_storage
+// CHECK:STDOUT:   %.loc35_29.3: init %Grass = class_init (), %.loc35_29.2 [concrete = constants.%Grass.val]
+// CHECK:STDOUT:   %.loc35_29.4: ref %Grass = temporary %.loc35_29.2, %.loc35_29.3
+// CHECK:STDOUT:   %.loc35_31.1: ref %Grass = converted %.loc35_29.1, %.loc35_29.4
+// CHECK:STDOUT:   %Animal.facet.loc35_39.1: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc35_39.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc35_39.1 [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %Animal.facet.loc35_39.2: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc35_39.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc35_39.2 [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %Edible.facet.loc35_39.1: %Edible.type = facet_value constants.%Grass, (constants.%Edible.impl_witness) [concrete = constants.%Edible.facet]
+// CHECK:STDOUT:   %.loc35_39.3: %Edible.type = converted constants.%Grass, %Edible.facet.loc35_39.1 [concrete = constants.%Edible.facet]
+// CHECK:STDOUT:   %Edible.facet.loc35_39.2: %Edible.type = facet_value constants.%Grass, (constants.%Edible.impl_witness) [concrete = constants.%Edible.facet]
+// CHECK:STDOUT:   %.loc35_39.4: %Edible.type = converted constants.%Grass, %Edible.facet.loc35_39.2 [concrete = constants.%Edible.facet]
 // CHECK:STDOUT:   %HandleAnimal.specific_fn: <specific function> = specific_function %HandleAnimal.ref, @HandleAnimal(constants.%Animal.facet, constants.%Edible.facet) [concrete = constants.%HandleAnimal.specific_fn]
-// CHECK:STDOUT:   %.loc33_19.2: %Goat = bind_value %.loc33_19.1
-// CHECK:STDOUT:   %.loc33_31.2: %Grass = bind_value %.loc33_31.1
-// CHECK:STDOUT:   %HandleAnimal.call: init %empty_tuple.type = call %HandleAnimal.specific_fn(%.loc33_19.2, %.loc33_31.2)
+// CHECK:STDOUT:   %.loc35_19.2: %Goat = bind_value %.loc35_19.1
+// CHECK:STDOUT:   %.loc35_31.2: %Grass = bind_value %.loc35_31.1
+// CHECK:STDOUT:   %HandleAnimal.call: init %empty_tuple.type = call %HandleAnimal.specific_fn(%.loc35_19.2, %.loc35_31.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Eats(constants.%Food.8b3) {
-// CHECK:STDOUT:   %Food.loc19_16.2 => constants.%Food.8b3
+// CHECK:STDOUT:   %Food.loc21_16.2 => constants.%Food.8b3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Eats(constants.%U.as_type) {
-// CHECK:STDOUT:   %Food.loc19_16.2 => constants.%U.as_type
+// CHECK:STDOUT:   %Food.loc21_16.2 => constants.%U.as_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Eats.type => constants.%Eats.type.f54c3d.1
@@ -409,49 +411,49 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.009(constants.%T.fd4, constants.%U) {
-// CHECK:STDOUT:   %T.loc24_14.2 => constants.%T.fd4
-// CHECK:STDOUT:   %U.loc24_26.2 => constants.%U
-// CHECK:STDOUT:   %T.as_type.loc24_38.2 => constants.%T.as_type.2ad
-// CHECK:STDOUT:   %U.as_type.loc24_49.2 => constants.%U.as_type
-// CHECK:STDOUT:   %Eats.type.loc24_49.2 => constants.%Eats.type.f54c3d.1
+// CHECK:STDOUT:   %T.loc26_14.2 => constants.%T.fd4
+// CHECK:STDOUT:   %U.loc26_26.2 => constants.%U
+// CHECK:STDOUT:   %T.as_type.loc26_38.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %U.as_type.loc26_49.2 => constants.%U.as_type
+// CHECK:STDOUT:   %Eats.type.loc26_49.2 => constants.%Eats.type.f54c3d.1
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.42532a.1
 // CHECK:STDOUT:   %Eats.impl_witness => constants.%Eats.impl_witness.fabf92.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Eats(constants.%Food.as_type.952) {
-// CHECK:STDOUT:   %Food.loc19_16.2 => constants.%Food.as_type.952
+// CHECK:STDOUT:   %Food.loc21_16.2 => constants.%Food.as_type.952
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%Food.9af, constants.%T.223) {
-// CHECK:STDOUT:   %Food.loc29_9.2 => constants.%Food.9af
-// CHECK:STDOUT:   %Food.as_type.loc29_37.2 => constants.%Food.as_type.952
-// CHECK:STDOUT:   %Eats.type.loc29_37.2 => constants.%Eats.type.b39
-// CHECK:STDOUT:   %T.loc29_24.2 => constants.%T.223
-// CHECK:STDOUT:   %pattern_type.loc29_24 => constants.%pattern_type.ed7
-// CHECK:STDOUT:   %T.as_type.loc29_43.2 => constants.%T.as_type.212
-// CHECK:STDOUT:   %pattern_type.loc29_40 => constants.%pattern_type.1a1
-// CHECK:STDOUT:   %pattern_type.loc29_46 => constants.%pattern_type.54f
+// CHECK:STDOUT:   %Food.loc31_9.2 => constants.%Food.9af
+// CHECK:STDOUT:   %Food.as_type.loc31_37.2 => constants.%Food.as_type.952
+// CHECK:STDOUT:   %Eats.type.loc31_37.2 => constants.%Eats.type.b39
+// CHECK:STDOUT:   %T.loc31_24.2 => constants.%T.223
+// CHECK:STDOUT:   %pattern_type.loc31_24 => constants.%pattern_type.ed7
+// CHECK:STDOUT:   %T.as_type.loc31_43.2 => constants.%T.as_type.212
+// CHECK:STDOUT:   %pattern_type.loc31_40 => constants.%pattern_type.1a1
+// CHECK:STDOUT:   %pattern_type.loc31_46 => constants.%pattern_type.54f
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%T.fd4, constants.%Food.5fe) {
-// CHECK:STDOUT:   %T.loc30_17.2 => constants.%T.fd4
-// CHECK:STDOUT:   %Food.loc30_29.2 => constants.%Food.5fe
-// CHECK:STDOUT:   %T.as_type.loc30_47.2 => constants.%T.as_type.2ad
-// CHECK:STDOUT:   %pattern_type.loc30_44 => constants.%pattern_type.36a
-// CHECK:STDOUT:   %Food.as_type.loc30_56.2 => constants.%Food.as_type.fae
-// CHECK:STDOUT:   %pattern_type.loc30_50 => constants.%pattern_type.f86
+// CHECK:STDOUT:   %T.loc32_17.2 => constants.%T.fd4
+// CHECK:STDOUT:   %Food.loc32_29.2 => constants.%Food.5fe
+// CHECK:STDOUT:   %T.as_type.loc32_47.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %pattern_type.loc32_44 => constants.%pattern_type.36a
+// CHECK:STDOUT:   %Food.as_type.loc32_56.2 => constants.%Food.as_type.fae
+// CHECK:STDOUT:   %pattern_type.loc32_50 => constants.%pattern_type.f86
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Eats(constants.%Food.as_type.fae) {
-// CHECK:STDOUT:   %Food.loc19_16.2 => constants.%Food.as_type.fae
+// CHECK:STDOUT:   %Food.loc21_16.2 => constants.%Food.as_type.fae
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.009(constants.%T.fd4, constants.%Food.5fe) {
-// CHECK:STDOUT:   %T.loc24_14.2 => constants.%T.fd4
-// CHECK:STDOUT:   %U.loc24_26.2 => constants.%Food.5fe
-// CHECK:STDOUT:   %T.as_type.loc24_38.2 => constants.%T.as_type.2ad
-// CHECK:STDOUT:   %U.as_type.loc24_49.2 => constants.%Food.as_type.fae
-// CHECK:STDOUT:   %Eats.type.loc24_49.2 => constants.%Eats.type.f54c3d.2
+// CHECK:STDOUT:   %T.loc26_14.2 => constants.%T.fd4
+// CHECK:STDOUT:   %U.loc26_26.2 => constants.%Food.5fe
+// CHECK:STDOUT:   %T.as_type.loc26_38.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %U.as_type.loc26_49.2 => constants.%Food.as_type.fae
+// CHECK:STDOUT:   %Eats.type.loc26_49.2 => constants.%Eats.type.f54c3d.2
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.42532a.2
 // CHECK:STDOUT:   %Eats.impl_witness => constants.%Eats.impl_witness.fabf92.2
 // CHECK:STDOUT:
@@ -459,39 +461,39 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%Food.5fe, constants.%Eats.facet.512) {
-// CHECK:STDOUT:   %Food.loc29_9.2 => constants.%Food.5fe
-// CHECK:STDOUT:   %Food.as_type.loc29_37.2 => constants.%Food.as_type.fae
-// CHECK:STDOUT:   %Eats.type.loc29_37.2 => constants.%Eats.type.f54c3d.2
-// CHECK:STDOUT:   %T.loc29_24.2 => constants.%Eats.facet.512
-// CHECK:STDOUT:   %pattern_type.loc29_24 => constants.%pattern_type.bb9
-// CHECK:STDOUT:   %T.as_type.loc29_43.2 => constants.%T.as_type.2ad
-// CHECK:STDOUT:   %pattern_type.loc29_40 => constants.%pattern_type.36a
-// CHECK:STDOUT:   %pattern_type.loc29_46 => constants.%pattern_type.f86
+// CHECK:STDOUT:   %Food.loc31_9.2 => constants.%Food.5fe
+// CHECK:STDOUT:   %Food.as_type.loc31_37.2 => constants.%Food.as_type.fae
+// CHECK:STDOUT:   %Eats.type.loc31_37.2 => constants.%Eats.type.f54c3d.2
+// CHECK:STDOUT:   %T.loc31_24.2 => constants.%Eats.facet.512
+// CHECK:STDOUT:   %pattern_type.loc31_24 => constants.%pattern_type.bb9
+// CHECK:STDOUT:   %T.as_type.loc31_43.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %pattern_type.loc31_40 => constants.%pattern_type.36a
+// CHECK:STDOUT:   %pattern_type.loc31_46 => constants.%pattern_type.f86
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc29_41 => constants.%require_complete.234
-// CHECK:STDOUT:   %require_complete.loc29_50 => constants.%require_complete.444
+// CHECK:STDOUT:   %require_complete.loc31_41 => constants.%require_complete.234
+// CHECK:STDOUT:   %require_complete.loc31_50 => constants.%require_complete.444
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%Animal.facet, constants.%Edible.facet) {
-// CHECK:STDOUT:   %T.loc30_17.2 => constants.%Animal.facet
-// CHECK:STDOUT:   %Food.loc30_29.2 => constants.%Edible.facet
-// CHECK:STDOUT:   %T.as_type.loc30_47.2 => constants.%Goat
-// CHECK:STDOUT:   %pattern_type.loc30_44 => constants.%pattern_type.ab7
-// CHECK:STDOUT:   %Food.as_type.loc30_56.2 => constants.%Grass
-// CHECK:STDOUT:   %pattern_type.loc30_50 => constants.%pattern_type.aff
+// CHECK:STDOUT:   %T.loc32_17.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %Food.loc32_29.2 => constants.%Edible.facet
+// CHECK:STDOUT:   %T.as_type.loc32_47.2 => constants.%Goat
+// CHECK:STDOUT:   %pattern_type.loc32_44 => constants.%pattern_type.ab7
+// CHECK:STDOUT:   %Food.as_type.loc32_56.2 => constants.%Grass
+// CHECK:STDOUT:   %pattern_type.loc32_50 => constants.%pattern_type.aff
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc30_45 => constants.%complete_type.357
-// CHECK:STDOUT:   %require_complete.loc30_54 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc32_45 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc32_54 => constants.%complete_type.357
 // CHECK:STDOUT:   %Eats.lookup_impl_witness => constants.%Eats.impl_witness.1cf
 // CHECK:STDOUT:   %Eats.type => constants.%Eats.type.1ae
-// CHECK:STDOUT:   %Eats.facet.loc30_76.2 => constants.%Eats.facet.cb1
-// CHECK:STDOUT:   %Feed.specific_fn.loc30_64.2 => constants.%Feed.specific_fn.86c
+// CHECK:STDOUT:   %Eats.facet.loc32_76.2 => constants.%Eats.facet.cb1
+// CHECK:STDOUT:   %Feed.specific_fn.loc32_64.2 => constants.%Feed.specific_fn.86c
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Eats(constants.%Grass) {
-// CHECK:STDOUT:   %Food.loc19_16.2 => constants.%Grass
+// CHECK:STDOUT:   %Food.loc21_16.2 => constants.%Grass
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Eats.type => constants.%Eats.type.1ae
@@ -499,11 +501,11 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl.009(constants.%Animal.facet, constants.%Edible.facet) {
-// CHECK:STDOUT:   %T.loc24_14.2 => constants.%Animal.facet
-// CHECK:STDOUT:   %U.loc24_26.2 => constants.%Edible.facet
-// CHECK:STDOUT:   %T.as_type.loc24_38.2 => constants.%Goat
-// CHECK:STDOUT:   %U.as_type.loc24_49.2 => constants.%Grass
-// CHECK:STDOUT:   %Eats.type.loc24_49.2 => constants.%Eats.type.1ae
+// CHECK:STDOUT:   %T.loc26_14.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %U.loc26_26.2 => constants.%Edible.facet
+// CHECK:STDOUT:   %T.as_type.loc26_38.2 => constants.%Goat
+// CHECK:STDOUT:   %U.as_type.loc26_49.2 => constants.%Grass
+// CHECK:STDOUT:   %Eats.type.loc26_49.2 => constants.%Eats.type.1ae
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.004
 // CHECK:STDOUT:   %Eats.impl_witness => constants.%Eats.impl_witness.1cf
 // CHECK:STDOUT:
@@ -511,17 +513,17 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%Edible.facet, constants.%Eats.facet.cb1) {
-// CHECK:STDOUT:   %Food.loc29_9.2 => constants.%Edible.facet
-// CHECK:STDOUT:   %Food.as_type.loc29_37.2 => constants.%Grass
-// CHECK:STDOUT:   %Eats.type.loc29_37.2 => constants.%Eats.type.1ae
-// CHECK:STDOUT:   %T.loc29_24.2 => constants.%Eats.facet.cb1
-// CHECK:STDOUT:   %pattern_type.loc29_24 => constants.%pattern_type.d77
-// CHECK:STDOUT:   %T.as_type.loc29_43.2 => constants.%Goat
-// CHECK:STDOUT:   %pattern_type.loc29_40 => constants.%pattern_type.ab7
-// CHECK:STDOUT:   %pattern_type.loc29_46 => constants.%pattern_type.aff
+// CHECK:STDOUT:   %Food.loc31_9.2 => constants.%Edible.facet
+// CHECK:STDOUT:   %Food.as_type.loc31_37.2 => constants.%Grass
+// CHECK:STDOUT:   %Eats.type.loc31_37.2 => constants.%Eats.type.1ae
+// CHECK:STDOUT:   %T.loc31_24.2 => constants.%Eats.facet.cb1
+// CHECK:STDOUT:   %pattern_type.loc31_24 => constants.%pattern_type.d77
+// CHECK:STDOUT:   %T.as_type.loc31_43.2 => constants.%Goat
+// CHECK:STDOUT:   %pattern_type.loc31_40 => constants.%pattern_type.ab7
+// CHECK:STDOUT:   %pattern_type.loc31_46 => constants.%pattern_type.aff
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc29_41 => constants.%complete_type.357
-// CHECK:STDOUT:   %require_complete.loc29_50 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc31_41 => constants.%complete_type.357
+// CHECK:STDOUT:   %require_complete.loc31_50 => constants.%complete_type.357
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/convert_facet_value_value_to_itself.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_facet_value_value_to_itself.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -75,14 +77,14 @@ fn F() {
 // CHECK:STDOUT:     %a.param_patt: @FeedAnimal.%pattern_type (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc15_15.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_15.2 (constants.%T)]
-// CHECK:STDOUT:     %a.param: @FeedAnimal.%T.as_type.loc15_30.2 (%T.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc15_30.1: type = splice_block %.loc15_30.2 [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)] {
-// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc15_15.1 [symbolic = %T.loc15_15.2 (constants.%T)]
-// CHECK:STDOUT:       %T.as_type.loc15_30.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)]
-// CHECK:STDOUT:       %.loc15_30.2: type = converted %T.ref, %T.as_type.loc15_30.1 [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %T.loc17_15.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_15.2 (constants.%T)]
+// CHECK:STDOUT:     %a.param: @FeedAnimal.%T.as_type.loc17_30.2 (%T.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc17_30.1: type = splice_block %.loc17_30.2 [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc17_15.1 [symbolic = %T.loc17_15.2 (constants.%T)]
+// CHECK:STDOUT:       %T.as_type.loc17_30.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc17_30.2: type = converted %T.ref, %T.as_type.loc17_30.1 [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a: @FeedAnimal.%T.as_type.loc15_30.2 (%T.as_type) = bind_name a, %a.param
+// CHECK:STDOUT:     %a: @FeedAnimal.%T.as_type.loc17_30.2 (%T.as_type) = bind_name a, %a.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [concrete = constants.%HandleAnimal] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.3b0 = symbolic_binding_pattern T, 0 [concrete]
@@ -90,14 +92,14 @@ fn F() {
 // CHECK:STDOUT:     %a.param_patt: @HandleAnimal.%pattern_type (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc17_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_17.2 (constants.%T)]
-// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc17_32.2 (%T.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc17_32.1: type = splice_block %.loc17_32.2 [symbolic = %T.as_type.loc17_32.2 (constants.%T.as_type)] {
-// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc17_17.1 [symbolic = %T.loc17_17.2 (constants.%T)]
-// CHECK:STDOUT:       %T.as_type.loc17_32.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc17_32.2 (constants.%T.as_type)]
-// CHECK:STDOUT:       %.loc17_32.2: type = converted %T.ref, %T.as_type.loc17_32.1 [symbolic = %T.as_type.loc17_32.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %T.loc19_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc19_17.2 (constants.%T)]
+// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc19_32.2 (%T.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc19_32.1: type = splice_block %.loc19_32.2 [symbolic = %T.as_type.loc19_32.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc19_17.1 [symbolic = %T.loc19_17.2 (constants.%T)]
+// CHECK:STDOUT:       %T.as_type.loc19_32.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc19_32.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc19_32.2: type = converted %T.ref, %T.as_type.loc19_32.1 [symbolic = %T.as_type.loc19_32.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc17_32.2 (%T.as_type) = bind_name a, %a.param
+// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc19_32.2 (%T.as_type) = bind_name a, %a.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Goat.decl: type = class_decl @Goat [concrete = constants.%Goat] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
@@ -131,37 +133,37 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @FeedAnimal(%T.loc15_15.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc15_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_15.2 (constants.%T)]
-// CHECK:STDOUT:   %T.as_type.loc15_30.2: type = facet_access_type %T.loc15_15.2 [symbolic = %T.as_type.loc15_30.2 (constants.%T.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc15_30.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
+// CHECK:STDOUT: generic fn @FeedAnimal(%T.loc17_15.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc17_15.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_15.2 (constants.%T)]
+// CHECK:STDOUT:   %T.as_type.loc17_30.2: type = facet_access_type %T.loc17_15.2 [symbolic = %T.as_type.loc17_30.2 (constants.%T.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc17_30.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc15_30.2 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc17_30.2 [symbolic = %require_complete (constants.%require_complete)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%a.param: @FeedAnimal.%T.as_type.loc15_30.2 (%T.as_type)) {
+// CHECK:STDOUT:   fn(%a.param: @FeedAnimal.%T.as_type.loc17_30.2 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc17_17.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc17_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_17.2 (constants.%T)]
-// CHECK:STDOUT:   %T.as_type.loc17_32.2: type = facet_access_type %T.loc17_17.2 [symbolic = %T.as_type.loc17_32.2 (constants.%T.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc17_32.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
+// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc19_17.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc19_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc19_17.2 (constants.%T)]
+// CHECK:STDOUT:   %T.as_type.loc19_32.2: type = facet_access_type %T.loc19_17.2 [symbolic = %T.as_type.loc19_32.2 (constants.%T.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc19_32.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc17_32.2 [symbolic = %require_complete (constants.%require_complete)]
-// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc17_37.2: <specific function> = specific_function constants.%FeedAnimal, @FeedAnimal(%T.loc17_17.2) [symbolic = %FeedAnimal.specific_fn.loc17_37.2 (constants.%FeedAnimal.specific_fn.ec8)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc19_32.2 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc19_37.2: <specific function> = specific_function constants.%FeedAnimal, @FeedAnimal(%T.loc19_17.2) [symbolic = %FeedAnimal.specific_fn.loc19_37.2 (constants.%FeedAnimal.specific_fn.ec8)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc17_32.2 (%T.as_type)) {
+// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc19_32.2 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %FeedAnimal.ref: %FeedAnimal.type = name_ref FeedAnimal, file.%FeedAnimal.decl [concrete = constants.%FeedAnimal]
-// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc17_32.2 (%T.as_type) = name_ref a, %a
-// CHECK:STDOUT:     %.loc17_49.1: %Animal.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc17_17.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc17_49.2: %Animal.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc17_17.2 (constants.%T)]
-// CHECK:STDOUT:     %FeedAnimal.specific_fn.loc17_37.1: <specific function> = specific_function %FeedAnimal.ref, @FeedAnimal(constants.%T) [symbolic = %FeedAnimal.specific_fn.loc17_37.2 (constants.%FeedAnimal.specific_fn.ec8)]
-// CHECK:STDOUT:     %FeedAnimal.call: init %empty_tuple.type = call %FeedAnimal.specific_fn.loc17_37.1(%a.ref)
+// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc19_32.2 (%T.as_type) = name_ref a, %a
+// CHECK:STDOUT:     %.loc19_49.1: %Animal.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc19_17.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc19_49.2: %Animal.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc19_17.2 (constants.%T)]
+// CHECK:STDOUT:     %FeedAnimal.specific_fn.loc19_37.1: <specific function> = specific_function %FeedAnimal.ref, @FeedAnimal(constants.%T) [symbolic = %FeedAnimal.specific_fn.loc19_37.2 (constants.%FeedAnimal.specific_fn.ec8)]
+// CHECK:STDOUT:     %FeedAnimal.call: init %empty_tuple.type = call %FeedAnimal.specific_fn.loc19_37.1(%a.ref)
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -169,25 +171,25 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %HandleAnimal.ref: %HandleAnimal.type = name_ref HandleAnimal, file.%HandleAnimal.decl [concrete = constants.%HandleAnimal]
-// CHECK:STDOUT:   %.loc23_17.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc25_17.1: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %Goat.ref: type = name_ref Goat, file.%Goat.decl [concrete = constants.%Goat]
-// CHECK:STDOUT:   %.loc23_17.2: ref %Goat = temporary_storage
-// CHECK:STDOUT:   %.loc23_17.3: init %Goat = class_init (), %.loc23_17.2 [concrete = constants.%Goat.val]
-// CHECK:STDOUT:   %.loc23_17.4: ref %Goat = temporary %.loc23_17.2, %.loc23_17.3
-// CHECK:STDOUT:   %.loc23_19.1: ref %Goat = converted %.loc23_17.1, %.loc23_17.4
-// CHECK:STDOUT:   %Animal.facet.loc23_26.1: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc23_26.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc23_26.1 [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %Animal.facet.loc23_26.2: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
-// CHECK:STDOUT:   %.loc23_26.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc23_26.2 [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc25_17.2: ref %Goat = temporary_storage
+// CHECK:STDOUT:   %.loc25_17.3: init %Goat = class_init (), %.loc25_17.2 [concrete = constants.%Goat.val]
+// CHECK:STDOUT:   %.loc25_17.4: ref %Goat = temporary %.loc25_17.2, %.loc25_17.3
+// CHECK:STDOUT:   %.loc25_19.1: ref %Goat = converted %.loc25_17.1, %.loc25_17.4
+// CHECK:STDOUT:   %Animal.facet.loc25_26.1: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc25_26.1: %Animal.type = converted constants.%Goat, %Animal.facet.loc25_26.1 [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %Animal.facet.loc25_26.2: %Animal.type = facet_value constants.%Goat, (constants.%Animal.impl_witness) [concrete = constants.%Animal.facet]
+// CHECK:STDOUT:   %.loc25_26.2: %Animal.type = converted constants.%Goat, %Animal.facet.loc25_26.2 [concrete = constants.%Animal.facet]
 // CHECK:STDOUT:   %HandleAnimal.specific_fn: <specific function> = specific_function %HandleAnimal.ref, @HandleAnimal(constants.%Animal.facet) [concrete = constants.%HandleAnimal.specific_fn]
-// CHECK:STDOUT:   %.loc23_19.2: %Goat = bind_value %.loc23_19.1
-// CHECK:STDOUT:   %HandleAnimal.call: init %empty_tuple.type = call %HandleAnimal.specific_fn(%.loc23_19.2)
+// CHECK:STDOUT:   %.loc25_19.2: %Goat = bind_value %.loc25_19.1
+// CHECK:STDOUT:   %HandleAnimal.call: init %empty_tuple.type = call %HandleAnimal.specific_fn(%.loc25_19.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @FeedAnimal(constants.%T) {
-// CHECK:STDOUT:   %T.loc15_15.2 => constants.%T
-// CHECK:STDOUT:   %T.as_type.loc15_30.2 => constants.%T.as_type
+// CHECK:STDOUT:   %T.loc17_15.2 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc17_30.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.36a
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
@@ -195,24 +197,24 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%T) {
-// CHECK:STDOUT:   %T.loc17_17.2 => constants.%T
-// CHECK:STDOUT:   %T.as_type.loc17_32.2 => constants.%T.as_type
+// CHECK:STDOUT:   %T.loc19_17.2 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc19_32.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.36a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%Animal.facet) {
-// CHECK:STDOUT:   %T.loc17_17.2 => constants.%Animal.facet
-// CHECK:STDOUT:   %T.as_type.loc17_32.2 => constants.%Goat
+// CHECK:STDOUT:   %T.loc19_17.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.as_type.loc19_32.2 => constants.%Goat
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.ab7
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type
-// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc17_37.2 => constants.%FeedAnimal.specific_fn.82e
+// CHECK:STDOUT:   %FeedAnimal.specific_fn.loc19_37.2 => constants.%FeedAnimal.specific_fn.82e
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @FeedAnimal(constants.%Animal.facet) {
-// CHECK:STDOUT:   %T.loc15_15.2 => constants.%Animal.facet
-// CHECK:STDOUT:   %T.as_type.loc15_30.2 => constants.%Goat
+// CHECK:STDOUT:   %T.loc17_15.2 => constants.%Animal.facet
+// CHECK:STDOUT:   %T.as_type.loc17_30.2 => constants.%Goat
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.ab7
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/facet/min_prelude/convert_interface.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/convert_interface.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -102,8 +104,8 @@ fn G() { F(Animal); }
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
 // CHECK:STDOUT:   %Eats.facet: %Eats.type = facet_value constants.%Animal.type, (constants.%Eats.impl_witness) [concrete = constants.%Eats.facet]
-// CHECK:STDOUT:   %.loc21: %Eats.type = converted %Animal.ref, %Eats.facet [concrete = constants.%Eats.facet]
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.ref(%.loc21)
+// CHECK:STDOUT:   %.loc23: %Eats.type = converted %Animal.ref, %Eats.facet [concrete = constants.%Eats.facet]
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.ref(%.loc23)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/fail_convert_class_type_to_generic_facet_value.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_convert_class_type_to_generic_facet_value.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -96,7 +98,7 @@ fn G() {
 // CHECK:STDOUT:   %Generic.decl: %Generic.type.c21 = interface_decl @Generic [concrete = constants.%Generic.generic] {
 // CHECK:STDOUT:     %Scalar.patt: %pattern_type.98f = symbolic_binding_pattern Scalar, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Scalar.loc13_19.1: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc13_19.2 (constants.%Scalar)]
+// CHECK:STDOUT:     %Scalar.loc15_19.1: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc15_19.2 (constants.%Scalar)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %GenericParam.decl: type = class_decl @GenericParam [concrete = constants.%GenericParam] {} {}
 // CHECK:STDOUT:   %WrongGenericParam.decl: type = class_decl @WrongGenericParam [concrete = constants.%WrongGenericParam] {} {}
@@ -113,36 +115,36 @@ fn G() {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:     %U.patt: @CallGenericMethod.%pattern_type (%pattern_type.80f) = symbolic_binding_pattern U, 1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc25_22.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc25_22.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc25: type = splice_block %Generic.type.loc25_45.1 [symbolic = %Generic.type.loc25_45.2 (constants.%Generic.type.91ccba.2)] {
+// CHECK:STDOUT:     %T.loc27_22.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc27_22.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc27: type = splice_block %Generic.type.loc27_45.1 [symbolic = %Generic.type.loc27_45.2 (constants.%Generic.type.91ccba.2)] {
 // CHECK:STDOUT:       %Generic.ref: %Generic.type.c21 = name_ref Generic, file.%Generic.decl [concrete = constants.%Generic.generic]
-// CHECK:STDOUT:       %T.ref: type = name_ref T, %T.loc25_22.1 [symbolic = %T.loc25_22.2 (constants.%T)]
-// CHECK:STDOUT:       %Generic.type.loc25_45.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc25_45.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, %T.loc27_22.1 [symbolic = %T.loc27_22.2 (constants.%T)]
+// CHECK:STDOUT:       %Generic.type.loc27_45.1: type = facet_type <@Generic, @Generic(constants.%T)> [symbolic = %Generic.type.loc27_45.2 (constants.%Generic.type.91ccba.2)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %U.loc25_32.1: @CallGenericMethod.%Generic.type.loc25_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1 [symbolic = %U.loc25_32.2 (constants.%U)]
+// CHECK:STDOUT:     %U.loc27_32.1: @CallGenericMethod.%Generic.type.loc27_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1 [symbolic = %U.loc27_32.2 (constants.%U)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic interface @Generic(%Scalar.loc13_19.1: type) {
-// CHECK:STDOUT:   %Scalar.loc13_19.2: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc13_19.2 (constants.%Scalar)]
+// CHECK:STDOUT: generic interface @Generic(%Scalar.loc15_19.1: type) {
+// CHECK:STDOUT:   %Scalar.loc15_19.2: type = bind_symbolic_name Scalar, 0 [symbolic = %Scalar.loc15_19.2 (constants.%Scalar)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Generic.type: type = facet_type <@Generic, @Generic(%Scalar.loc13_19.2)> [symbolic = %Generic.type (constants.%Generic.type.91ccba.1)]
+// CHECK:STDOUT:   %Generic.type: type = facet_type <@Generic, @Generic(%Scalar.loc15_19.2)> [symbolic = %Generic.type (constants.%Generic.type.91ccba.1)]
 // CHECK:STDOUT:   %Self.2: @Generic.%Generic.type (%Generic.type.91ccba.1) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.dee)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%Scalar.loc13_19.2) [symbolic = %F.type (constants.%F.type.f43)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @Generic(%Scalar.loc15_19.2) [symbolic = %F.type (constants.%F.type.f43)]
 // CHECK:STDOUT:   %F: @Generic.%F.type (%F.type.f43) = struct_value () [symbolic = %F (constants.%F.8a2)]
-// CHECK:STDOUT:   %Generic.assoc_type: type = assoc_entity_type @Generic, @Generic(%Scalar.loc13_19.2) [symbolic = %Generic.assoc_type (constants.%Generic.assoc_type.0fd)]
-// CHECK:STDOUT:   %assoc0.loc14_9.2: @Generic.%Generic.assoc_type (%Generic.assoc_type.0fd) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc14_9.2 (constants.%assoc0.296)]
+// CHECK:STDOUT:   %Generic.assoc_type: type = assoc_entity_type @Generic, @Generic(%Scalar.loc15_19.2) [symbolic = %Generic.assoc_type (constants.%Generic.assoc_type.0fd)]
+// CHECK:STDOUT:   %assoc0.loc16_9.2: @Generic.%Generic.assoc_type (%Generic.assoc_type.0fd) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_9.2 (constants.%assoc0.296)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.dee)]
 // CHECK:STDOUT:     %F.decl: @Generic.%F.type (%F.type.f43) = fn_decl @F.1 [symbolic = @Generic.%F (constants.%F.8a2)] {} {}
-// CHECK:STDOUT:     %assoc0.loc14_9.1: @Generic.%Generic.assoc_type (%Generic.assoc_type.0fd) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc14_9.2 (constants.%assoc0.296)]
+// CHECK:STDOUT:     %assoc0.loc16_9.1: @Generic.%Generic.assoc_type (%Generic.assoc_type.0fd) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc16_9.2 (constants.%assoc0.296)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.1
-// CHECK:STDOUT:     .F = %assoc0.loc14_9.1
+// CHECK:STDOUT:     .F = %assoc0.loc16_9.1
 // CHECK:STDOUT:     witness = (%F.decl)
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -182,7 +184,7 @@ fn G() {
 // CHECK:STDOUT:   .Self = constants.%ImplsGeneric
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.1(@Generic.%Scalar.loc13_19.1: type, @Generic.%Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1)) {
+// CHECK:STDOUT: generic fn @F.1(@Generic.%Scalar.loc15_19.1: type, @Generic.%Self.1: @Generic.%Generic.type (%Generic.type.91ccba.1)) {
 // CHECK:STDOUT:   fn();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -191,11 +193,11 @@ fn G() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @CallGenericMethod(%T.loc25_22.1: type, %U.loc25_32.1: @CallGenericMethod.%Generic.type.loc25_45.2 (%Generic.type.91ccba.2)) {
-// CHECK:STDOUT:   %T.loc25_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc25_22.2 (constants.%T)]
-// CHECK:STDOUT:   %Generic.type.loc25_45.2: type = facet_type <@Generic, @Generic(%T.loc25_22.2)> [symbolic = %Generic.type.loc25_45.2 (constants.%Generic.type.91ccba.2)]
-// CHECK:STDOUT:   %U.loc25_32.2: @CallGenericMethod.%Generic.type.loc25_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1 [symbolic = %U.loc25_32.2 (constants.%U)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Generic.type.loc25_45.2 [symbolic = %pattern_type (constants.%pattern_type.80f)]
+// CHECK:STDOUT: generic fn @CallGenericMethod(%T.loc27_22.1: type, %U.loc27_32.1: @CallGenericMethod.%Generic.type.loc27_45.2 (%Generic.type.91ccba.2)) {
+// CHECK:STDOUT:   %T.loc27_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc27_22.2 (constants.%T)]
+// CHECK:STDOUT:   %Generic.type.loc27_45.2: type = facet_type <@Generic, @Generic(%T.loc27_22.2)> [symbolic = %Generic.type.loc27_45.2 (constants.%Generic.type.91ccba.2)]
+// CHECK:STDOUT:   %U.loc27_32.2: @CallGenericMethod.%Generic.type.loc27_45.2 (%Generic.type.91ccba.2) = bind_symbolic_name U, 1 [symbolic = %U.loc27_32.2 (constants.%U)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Generic.type.loc27_45.2 [symbolic = %pattern_type (constants.%pattern_type.80f)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -216,13 +218,13 @@ fn G() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%Scalar) {
-// CHECK:STDOUT:   %Scalar.loc13_19.2 => constants.%Scalar
+// CHECK:STDOUT:   %Scalar.loc15_19.2 => constants.%Scalar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Scalar, constants.%Self.dee) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%GenericParam) {
-// CHECK:STDOUT:   %Scalar.loc13_19.2 => constants.%GenericParam
+// CHECK:STDOUT:   %Scalar.loc15_19.2 => constants.%GenericParam
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Generic.type => constants.%Generic.type.769
@@ -230,30 +232,30 @@ fn G() {
 // CHECK:STDOUT:   %F.type => constants.%F.type.4cf
 // CHECK:STDOUT:   %F => constants.%F.118
 // CHECK:STDOUT:   %Generic.assoc_type => constants.%Generic.assoc_type.713
-// CHECK:STDOUT:   %assoc0.loc14_9.2 => constants.%assoc0.9b7
+// CHECK:STDOUT:   %assoc0.loc16_9.2 => constants.%assoc0.9b7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%GenericParam, constants.%Generic.facet) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%T) {
-// CHECK:STDOUT:   %Scalar.loc13_19.2 => constants.%T
+// CHECK:STDOUT:   %Scalar.loc15_19.2 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallGenericMethod(constants.%T, constants.%U) {
-// CHECK:STDOUT:   %T.loc25_22.2 => constants.%T
-// CHECK:STDOUT:   %Generic.type.loc25_45.2 => constants.%Generic.type.91ccba.2
-// CHECK:STDOUT:   %U.loc25_32.2 => constants.%U
+// CHECK:STDOUT:   %T.loc27_22.2 => constants.%T
+// CHECK:STDOUT:   %Generic.type.loc27_45.2 => constants.%Generic.type.91ccba.2
+// CHECK:STDOUT:   %U.loc27_32.2 => constants.%U
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.80f
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%WrongGenericParam) {
-// CHECK:STDOUT:   %Scalar.loc13_19.2 => constants.%WrongGenericParam
+// CHECK:STDOUT:   %Scalar.loc15_19.2 => constants.%WrongGenericParam
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @CallGenericMethod(constants.%WrongGenericParam, <error>) {
-// CHECK:STDOUT:   %T.loc25_22.2 => constants.%WrongGenericParam
-// CHECK:STDOUT:   %Generic.type.loc25_45.2 => constants.%Generic.type.c3b
-// CHECK:STDOUT:   %U.loc25_32.2 => <error>
+// CHECK:STDOUT:   %T.loc27_22.2 => constants.%WrongGenericParam
+// CHECK:STDOUT:   %Generic.type.loc27_45.2 => constants.%Generic.type.c3b
+// CHECK:STDOUT:   %U.loc27_32.2 => <error>
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ae
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/fail_convert_facet_value_to_missing_impl.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_convert_facet_value_to_missing_impl.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -70,14 +72,14 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:     %e.param_patt: @Feed.%pattern_type (%pattern_type.2b4) = value_param_pattern %e.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Eats.ref: type = name_ref Eats, file.%Eats.decl [concrete = constants.%Eats.type]
-// CHECK:STDOUT:     %T.loc16_9.1: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc16_9.2 (constants.%T.1b5)]
-// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc16_22.2 (%T.as_type.27d) = value_param call_param0
-// CHECK:STDOUT:     %.loc16_22.1: type = splice_block %.loc16_22.2 [symbolic = %T.as_type.loc16_22.2 (constants.%T.as_type.27d)] {
-// CHECK:STDOUT:       %T.ref: %Eats.type = name_ref T, %T.loc16_9.1 [symbolic = %T.loc16_9.2 (constants.%T.1b5)]
-// CHECK:STDOUT:       %T.as_type.loc16_22.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc16_22.2 (constants.%T.as_type.27d)]
-// CHECK:STDOUT:       %.loc16_22.2: type = converted %T.ref, %T.as_type.loc16_22.1 [symbolic = %T.as_type.loc16_22.2 (constants.%T.as_type.27d)]
+// CHECK:STDOUT:     %T.loc18_9.1: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc18_9.2 (constants.%T.1b5)]
+// CHECK:STDOUT:     %e.param: @Feed.%T.as_type.loc18_22.2 (%T.as_type.27d) = value_param call_param0
+// CHECK:STDOUT:     %.loc18_22.1: type = splice_block %.loc18_22.2 [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)] {
+// CHECK:STDOUT:       %T.ref: %Eats.type = name_ref T, %T.loc18_9.1 [symbolic = %T.loc18_9.2 (constants.%T.1b5)]
+// CHECK:STDOUT:       %T.as_type.loc18_22.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)]
+// CHECK:STDOUT:       %.loc18_22.2: type = converted %T.ref, %T.as_type.loc18_22.1 [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc16_22.2 (%T.as_type.27d) = bind_name e, %e.param
+// CHECK:STDOUT:     %e: @Feed.%T.as_type.loc18_22.2 (%T.as_type.27d) = bind_name e, %e.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HandleAnimal.decl: %HandleAnimal.type = fn_decl @HandleAnimal [concrete = constants.%HandleAnimal] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.3b0 = symbolic_binding_pattern T, 0 [concrete]
@@ -85,14 +87,14 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:     %a.param_patt: @HandleAnimal.%pattern_type (%pattern_type.36a) = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %T.loc25_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc25_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc25_32.2 (%T.as_type.2ad) = value_param call_param0
-// CHECK:STDOUT:     %.loc25_32.1: type = splice_block %.loc25_32.2 [symbolic = %T.as_type.loc25_32.2 (constants.%T.as_type.2ad)] {
-// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc25_17.1 [symbolic = %T.loc25_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:       %T.as_type.loc25_32.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc25_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:       %.loc25_32.2: type = converted %T.ref, %T.as_type.loc25_32.1 [symbolic = %T.as_type.loc25_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:     %T.loc27_17.1: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc27_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:     %a.param: @HandleAnimal.%T.as_type.loc27_32.2 (%T.as_type.2ad) = value_param call_param0
+// CHECK:STDOUT:     %.loc27_32.1: type = splice_block %.loc27_32.2 [symbolic = %T.as_type.loc27_32.2 (constants.%T.as_type.2ad)] {
+// CHECK:STDOUT:       %T.ref: %Animal.type = name_ref T, %T.loc27_17.1 [symbolic = %T.loc27_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:       %T.as_type.loc27_32.1: type = facet_access_type %T.ref [symbolic = %T.as_type.loc27_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:       %.loc27_32.2: type = converted %T.ref, %T.as_type.loc27_32.1 [symbolic = %T.as_type.loc27_32.2 (constants.%T.as_type.2ad)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc25_32.2 (%T.as_type.2ad) = bind_name a, %a.param
+// CHECK:STDOUT:     %a: @HandleAnimal.%T.as_type.loc27_32.2 (%T.as_type.2ad) = bind_name a, %a.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -112,45 +114,45 @@ fn HandleAnimal[T:! Animal](a: T) { Feed(a); }
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Feed(%T.loc16_9.1: %Eats.type) {
-// CHECK:STDOUT:   %T.loc16_9.2: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc16_9.2 (constants.%T.1b5)]
-// CHECK:STDOUT:   %T.as_type.loc16_22.2: type = facet_access_type %T.loc16_9.2 [symbolic = %T.as_type.loc16_22.2 (constants.%T.as_type.27d)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc16_22.2 [symbolic = %pattern_type (constants.%pattern_type.2b4)]
+// CHECK:STDOUT: generic fn @Feed(%T.loc18_9.1: %Eats.type) {
+// CHECK:STDOUT:   %T.loc18_9.2: %Eats.type = bind_symbolic_name T, 0 [symbolic = %T.loc18_9.2 (constants.%T.1b5)]
+// CHECK:STDOUT:   %T.as_type.loc18_22.2: type = facet_access_type %T.loc18_9.2 [symbolic = %T.as_type.loc18_22.2 (constants.%T.as_type.27d)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc18_22.2 [symbolic = %pattern_type (constants.%pattern_type.2b4)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc16_22.2 [symbolic = %require_complete (constants.%require_complete.c75)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc18_22.2 [symbolic = %require_complete (constants.%require_complete.c75)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%e.param: @Feed.%T.as_type.loc16_22.2 (%T.as_type.27d)) {
+// CHECK:STDOUT:   fn(%e.param: @Feed.%T.as_type.loc18_22.2 (%T.as_type.27d)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc25_17.1: %Animal.type) {
-// CHECK:STDOUT:   %T.loc25_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc25_17.2 (constants.%T.fd4)]
-// CHECK:STDOUT:   %T.as_type.loc25_32.2: type = facet_access_type %T.loc25_17.2 [symbolic = %T.as_type.loc25_32.2 (constants.%T.as_type.2ad)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc25_32.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
+// CHECK:STDOUT: generic fn @HandleAnimal(%T.loc27_17.1: %Animal.type) {
+// CHECK:STDOUT:   %T.loc27_17.2: %Animal.type = bind_symbolic_name T, 0 [symbolic = %T.loc27_17.2 (constants.%T.fd4)]
+// CHECK:STDOUT:   %T.as_type.loc27_32.2: type = facet_access_type %T.loc27_17.2 [symbolic = %T.as_type.loc27_32.2 (constants.%T.as_type.2ad)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc27_32.2 [symbolic = %pattern_type (constants.%pattern_type.36a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc25_32.2 [symbolic = %require_complete (constants.%require_complete.234)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc27_32.2 [symbolic = %require_complete (constants.%require_complete.234)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc25_32.2 (%T.as_type.2ad)) {
+// CHECK:STDOUT:   fn(%a.param: @HandleAnimal.%T.as_type.loc27_32.2 (%T.as_type.2ad)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %Feed.ref: %Feed.type = name_ref Feed, file.%Feed.decl [concrete = constants.%Feed]
-// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc25_32.2 (%T.as_type.2ad) = name_ref a, %a
+// CHECK:STDOUT:     %a.ref: @HandleAnimal.%T.as_type.loc27_32.2 (%T.as_type.2ad) = name_ref a, %a
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Feed(constants.%T.1b5) {
-// CHECK:STDOUT:   %T.loc16_9.2 => constants.%T.1b5
-// CHECK:STDOUT:   %T.as_type.loc16_22.2 => constants.%T.as_type.27d
+// CHECK:STDOUT:   %T.loc18_9.2 => constants.%T.1b5
+// CHECK:STDOUT:   %T.as_type.loc18_22.2 => constants.%T.as_type.27d
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2b4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HandleAnimal(constants.%T.fd4) {
-// CHECK:STDOUT:   %T.loc25_17.2 => constants.%T.fd4
-// CHECK:STDOUT:   %T.as_type.loc25_32.2 => constants.%T.as_type.2ad
+// CHECK:STDOUT:   %T.loc27_17.2 => constants.%T.fd4
+// CHECK:STDOUT:   %T.as_type.loc27_32.2 => constants.%T.as_type.2ad
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.36a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/fail_convert_type_erased_type_to_facet.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_convert_type_erased_type_to_facet.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -75,7 +77,7 @@ fn F() {
 // CHECK:STDOUT:     %a.patt: %pattern_type.3b0 = symbolic_binding_pattern a, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Animal.ref: type = name_ref Animal, file.%Animal.decl [concrete = constants.%Animal.type]
-// CHECK:STDOUT:     %a.loc18_15.1: %Animal.type = bind_symbolic_name a, 0 [symbolic = %a.loc18_15.2 (constants.%a)]
+// CHECK:STDOUT:     %a.loc20_15.1: %Animal.type = bind_symbolic_name a, 0 [symbolic = %a.loc20_15.2 (constants.%a)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {} {}
 // CHECK:STDOUT: }
@@ -102,8 +104,8 @@ fn F() {
 // CHECK:STDOUT:   .Self = constants.%Goat
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @WalkAnimal(%a.loc18_15.1: %Animal.type) {
-// CHECK:STDOUT:   %a.loc18_15.2: %Animal.type = bind_symbolic_name a, 0 [symbolic = %a.loc18_15.2 (constants.%a)]
+// CHECK:STDOUT: generic fn @WalkAnimal(%a.loc20_15.1: %Animal.type) {
+// CHECK:STDOUT:   %a.loc20_15.2: %Animal.type = bind_symbolic_name a, 0 [symbolic = %a.loc20_15.2 (constants.%a)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -126,6 +128,6 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @WalkAnimal(constants.%a) {
-// CHECK:STDOUT:   %a.loc18_15.2 => constants.%a
+// CHECK:STDOUT:   %a.loc20_15.2 => constants.%a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/fail_deduction_uses_runtime_type_conversion.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_deduction_uses_runtime_type_conversion.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE
@@ -104,11 +106,11 @@ fn G(holds_to: HoldsType((RuntimeConvertTo, ))) {
 // CHECK:STDOUT:   %HoldsType.decl: %HoldsType.type = class_decl @HoldsType [concrete = constants.%HoldsType.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.f1e = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc15_28.1: type = splice_block %.loc15_28.3 [concrete = constants.%tuple.type] {
-// CHECK:STDOUT:       %.loc15_28.2: %tuple.type = tuple_literal (type)
-// CHECK:STDOUT:       %.loc15_28.3: type = converted %.loc15_28.2, constants.%tuple.type [concrete = constants.%tuple.type]
+// CHECK:STDOUT:     %.loc17_28.1: type = splice_block %.loc17_28.3 [concrete = constants.%tuple.type] {
+// CHECK:STDOUT:       %.loc17_28.2: %tuple.type = tuple_literal (type)
+// CHECK:STDOUT:       %.loc17_28.3: type = converted %.loc17_28.2, constants.%tuple.type [concrete = constants.%tuple.type]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc15_17.1: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_17.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc17_17.1: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_17.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %RuntimeConvertFrom.decl: type = class_decl @RuntimeConvertFrom [concrete = constants.%RuntimeConvertFrom] {} {}
 // CHECK:STDOUT:   %RuntimeConvertTo.decl: type = class_decl @RuntimeConvertTo [concrete = constants.%RuntimeConvertTo] {} {}
@@ -123,40 +125,40 @@ fn G(holds_to: HoldsType((RuntimeConvertTo, ))) {
 // CHECK:STDOUT:   %ImplicitAs.impl_witness: <witness> = impl_witness %ImplicitAs.impl_witness_table [concrete = constants.%ImplicitAs.impl_witness]
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.f1e = symbolic_binding_pattern T, 0 [concrete]
-// CHECK:STDOUT:     %A.patt: @F.%pattern_type.loc25_20 (%pattern_type.08e) = symbolic_binding_pattern A, 1 [concrete]
-// CHECK:STDOUT:     %x.patt: @F.%pattern_type.loc25_29 (%pattern_type.ec6) = binding_pattern x [concrete]
-// CHECK:STDOUT:     %x.param_patt: @F.%pattern_type.loc25_29 (%pattern_type.ec6) = value_param_pattern %x.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %A.patt: @F.%pattern_type.loc27_20 (%pattern_type.08e) = symbolic_binding_pattern A, 1 [concrete]
+// CHECK:STDOUT:     %x.patt: @F.%pattern_type.loc27_29 (%pattern_type.ec6) = binding_pattern x [concrete]
+// CHECK:STDOUT:     %x.param_patt: @F.%pattern_type.loc27_29 (%pattern_type.ec6) = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc25_17.1: type = splice_block %.loc25_17.3 [concrete = constants.%tuple.type] {
-// CHECK:STDOUT:       %.loc25_17.2: %tuple.type = tuple_literal (type)
-// CHECK:STDOUT:       %.loc25_17.3: type = converted %.loc25_17.2, constants.%tuple.type [concrete = constants.%tuple.type]
+// CHECK:STDOUT:     %.loc27_17.1: type = splice_block %.loc27_17.3 [concrete = constants.%tuple.type] {
+// CHECK:STDOUT:       %.loc27_17.2: %tuple.type = tuple_literal (type)
+// CHECK:STDOUT:       %.loc27_17.3: type = converted %.loc27_17.2, constants.%tuple.type [concrete = constants.%tuple.type]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc25_6.1: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:     %.loc25_25: type = splice_block %tuple.elem0.loc25_25.1 [symbolic = %tuple.elem0.loc25_25.2 (constants.%tuple.elem0)] {
-// CHECK:STDOUT:       %T.ref.loc25_24: %tuple.type = name_ref T, %T.loc25_6.1 [symbolic = %T.loc25_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc27_6.1: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc27_6.2 (constants.%T)]
+// CHECK:STDOUT:     %.loc27_25: type = splice_block %tuple.elem0.loc27_25.1 [symbolic = %tuple.elem0.loc27_25.2 (constants.%tuple.elem0)] {
+// CHECK:STDOUT:       %T.ref.loc27_24: %tuple.type = name_ref T, %T.loc27_6.1 [symbolic = %T.loc27_6.2 (constants.%T)]
 // CHECK:STDOUT:       %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
-// CHECK:STDOUT:       %tuple.elem0.loc25_25.1: type = tuple_access %T.ref.loc25_24, element0 [symbolic = %tuple.elem0.loc25_25.2 (constants.%tuple.elem0)]
+// CHECK:STDOUT:       %tuple.elem0.loc27_25.1: type = tuple_access %T.ref.loc27_24, element0 [symbolic = %tuple.elem0.loc27_25.2 (constants.%tuple.elem0)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %A.loc25_20.1: @F.%tuple.elem0.loc25_25.2 (%tuple.elem0) = bind_symbolic_name A, 1 [symbolic = %A.loc25_20.2 (constants.%A)]
-// CHECK:STDOUT:     %x.param: @F.%HoldsType.loc25_43.2 (%HoldsType.cc9) = value_param call_param0
-// CHECK:STDOUT:     %.loc25_43: type = splice_block %HoldsType.loc25_43.1 [symbolic = %HoldsType.loc25_43.2 (constants.%HoldsType.cc9)] {
+// CHECK:STDOUT:     %A.loc27_20.1: @F.%tuple.elem0.loc27_25.2 (%tuple.elem0) = bind_symbolic_name A, 1 [symbolic = %A.loc27_20.2 (constants.%A)]
+// CHECK:STDOUT:     %x.param: @F.%HoldsType.loc27_43.2 (%HoldsType.cc9) = value_param call_param0
+// CHECK:STDOUT:     %.loc27_43: type = splice_block %HoldsType.loc27_43.1 [symbolic = %HoldsType.loc27_43.2 (constants.%HoldsType.cc9)] {
 // CHECK:STDOUT:       %HoldsType.ref: %HoldsType.type = name_ref HoldsType, file.%HoldsType.decl [concrete = constants.%HoldsType.generic]
-// CHECK:STDOUT:       %T.ref.loc25_42: %tuple.type = name_ref T, %T.loc25_6.1 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:       %HoldsType.loc25_43.1: type = class_type @HoldsType, @HoldsType(constants.%T) [symbolic = %HoldsType.loc25_43.2 (constants.%HoldsType.cc9)]
+// CHECK:STDOUT:       %T.ref.loc27_42: %tuple.type = name_ref T, %T.loc27_6.1 [symbolic = %T.loc27_6.2 (constants.%T)]
+// CHECK:STDOUT:       %HoldsType.loc27_43.1: type = class_type @HoldsType, @HoldsType(constants.%T) [symbolic = %HoldsType.loc27_43.2 (constants.%HoldsType.cc9)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: @F.%HoldsType.loc25_43.2 (%HoldsType.cc9) = bind_name x, %x.param
+// CHECK:STDOUT:     %x: @F.%HoldsType.loc27_43.2 (%HoldsType.cc9) = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %holds_to.patt: %pattern_type.a13 = binding_pattern holds_to [concrete]
 // CHECK:STDOUT:     %holds_to.param_patt: %pattern_type.a13 = value_param_pattern %holds_to.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %holds_to.param: %HoldsType.066 = value_param call_param0
-// CHECK:STDOUT:     %.loc27_46.1: type = splice_block %HoldsType [concrete = constants.%HoldsType.066] {
+// CHECK:STDOUT:     %.loc29_46.1: type = splice_block %HoldsType [concrete = constants.%HoldsType.066] {
 // CHECK:STDOUT:       %HoldsType.ref: %HoldsType.type = name_ref HoldsType, file.%HoldsType.decl [concrete = constants.%HoldsType.generic]
 // CHECK:STDOUT:       %RuntimeConvertTo.ref: type = name_ref RuntimeConvertTo, file.%RuntimeConvertTo.decl [concrete = constants.%RuntimeConvertTo]
-// CHECK:STDOUT:       %.loc27_45: %tuple.type = tuple_literal (%RuntimeConvertTo.ref)
+// CHECK:STDOUT:       %.loc29_45: %tuple.type = tuple_literal (%RuntimeConvertTo.ref)
 // CHECK:STDOUT:       %tuple: %tuple.type = tuple_value (%RuntimeConvertTo.ref) [concrete = constants.%tuple]
-// CHECK:STDOUT:       %.loc27_46.2: %tuple.type = converted %.loc27_45, %tuple [concrete = constants.%tuple]
+// CHECK:STDOUT:       %.loc29_46.2: %tuple.type = converted %.loc29_45, %tuple [concrete = constants.%tuple]
 // CHECK:STDOUT:       %HoldsType: type = class_type @HoldsType, @HoldsType(constants.%tuple) [concrete = constants.%HoldsType.066]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %holds_to: %HoldsType.066 = bind_name holds_to, %holds_to.param
@@ -184,8 +186,8 @@ fn G(holds_to: HoldsType((RuntimeConvertTo, ))) {
 // CHECK:STDOUT:   witness = file.%ImplicitAs.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @HoldsType(%T.loc15_17.1: %tuple.type) {
-// CHECK:STDOUT:   %T.loc15_17.2: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc15_17.2 (constants.%T)]
+// CHECK:STDOUT: generic class @HoldsType(%T.loc17_17.1: %tuple.type) {
+// CHECK:STDOUT:   %T.loc17_17.2: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc17_17.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -219,24 +221,24 @@ fn G(holds_to: HoldsType((RuntimeConvertTo, ))) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Convert.2(%self.param: %RuntimeConvertFrom) -> %return.param: %RuntimeConvertTo {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc22_58.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc22_58.2: init %RuntimeConvertTo = class_init (), %return [concrete = constants.%RuntimeConvertTo.val]
-// CHECK:STDOUT:   %.loc22_59: init %RuntimeConvertTo = converted %.loc22_58.1, %.loc22_58.2 [concrete = constants.%RuntimeConvertTo.val]
-// CHECK:STDOUT:   return %.loc22_59 to %return
+// CHECK:STDOUT:   %.loc24_58.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc24_58.2: init %RuntimeConvertTo = class_init (), %return [concrete = constants.%RuntimeConvertTo.val]
+// CHECK:STDOUT:   %.loc24_59: init %RuntimeConvertTo = converted %.loc24_58.1, %.loc24_58.2 [concrete = constants.%RuntimeConvertTo.val]
+// CHECK:STDOUT:   return %.loc24_59 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc25_6.1: %tuple.type, %A.loc25_20.1: @F.%tuple.elem0.loc25_25.2 (%tuple.elem0)) {
-// CHECK:STDOUT:   %T.loc25_6.2: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:   %tuple.elem0.loc25_25.2: type = tuple_access %T.loc25_6.2, element0 [symbolic = %tuple.elem0.loc25_25.2 (constants.%tuple.elem0)]
-// CHECK:STDOUT:   %A.loc25_20.2: @F.%tuple.elem0.loc25_25.2 (%tuple.elem0) = bind_symbolic_name A, 1 [symbolic = %A.loc25_20.2 (constants.%A)]
-// CHECK:STDOUT:   %pattern_type.loc25_20: type = pattern_type %tuple.elem0.loc25_25.2 [symbolic = %pattern_type.loc25_20 (constants.%pattern_type.08e)]
-// CHECK:STDOUT:   %HoldsType.loc25_43.2: type = class_type @HoldsType, @HoldsType(%T.loc25_6.2) [symbolic = %HoldsType.loc25_43.2 (constants.%HoldsType.cc9)]
-// CHECK:STDOUT:   %pattern_type.loc25_29: type = pattern_type %HoldsType.loc25_43.2 [symbolic = %pattern_type.loc25_29 (constants.%pattern_type.ec6)]
+// CHECK:STDOUT: generic fn @F(%T.loc27_6.1: %tuple.type, %A.loc27_20.1: @F.%tuple.elem0.loc27_25.2 (%tuple.elem0)) {
+// CHECK:STDOUT:   %T.loc27_6.2: %tuple.type = bind_symbolic_name T, 0 [symbolic = %T.loc27_6.2 (constants.%T)]
+// CHECK:STDOUT:   %tuple.elem0.loc27_25.2: type = tuple_access %T.loc27_6.2, element0 [symbolic = %tuple.elem0.loc27_25.2 (constants.%tuple.elem0)]
+// CHECK:STDOUT:   %A.loc27_20.2: @F.%tuple.elem0.loc27_25.2 (%tuple.elem0) = bind_symbolic_name A, 1 [symbolic = %A.loc27_20.2 (constants.%A)]
+// CHECK:STDOUT:   %pattern_type.loc27_20: type = pattern_type %tuple.elem0.loc27_25.2 [symbolic = %pattern_type.loc27_20 (constants.%pattern_type.08e)]
+// CHECK:STDOUT:   %HoldsType.loc27_43.2: type = class_type @HoldsType, @HoldsType(%T.loc27_6.2) [symbolic = %HoldsType.loc27_43.2 (constants.%HoldsType.cc9)]
+// CHECK:STDOUT:   %pattern_type.loc27_29: type = pattern_type %HoldsType.loc27_43.2 [symbolic = %pattern_type.loc27_29 (constants.%pattern_type.ec6)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %HoldsType.loc25_43.2 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %HoldsType.loc27_43.2 [symbolic = %require_complete (constants.%require_complete)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%x.param: @F.%HoldsType.loc25_43.2 (%HoldsType.cc9)) {
+// CHECK:STDOUT:   fn(%x.param: @F.%HoldsType.loc27_43.2 (%HoldsType.cc9)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
@@ -247,56 +249,56 @@ fn G(holds_to: HoldsType((RuntimeConvertTo, ))) {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %from.patt: %pattern_type.f64 = symbolic_binding_pattern from, 0 [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc28_36.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %RuntimeConvertFrom.ref.loc28_41: type = name_ref RuntimeConvertFrom, file.%RuntimeConvertFrom.decl [concrete = constants.%RuntimeConvertFrom]
-// CHECK:STDOUT:   %.loc28_36.2: ref %RuntimeConvertFrom = temporary_storage
-// CHECK:STDOUT:   %.loc28_36.3: init %RuntimeConvertFrom = class_init (), %.loc28_36.2 [concrete = constants.%RuntimeConvertFrom.val]
-// CHECK:STDOUT:   %.loc28_36.4: ref %RuntimeConvertFrom = temporary %.loc28_36.2, %.loc28_36.3
-// CHECK:STDOUT:   %.loc28_38: ref %RuntimeConvertFrom = converted %.loc28_36.1, %.loc28_36.4
-// CHECK:STDOUT:   %RuntimeConvertFrom.ref.loc28_14: type = name_ref RuntimeConvertFrom, file.%RuntimeConvertFrom.decl [concrete = constants.%RuntimeConvertFrom]
-// CHECK:STDOUT:   %from: %RuntimeConvertFrom = bind_symbolic_name from, 0, %.loc28_38 [symbolic = constants.%from]
+// CHECK:STDOUT:   %.loc30_36.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %RuntimeConvertFrom.ref.loc30_41: type = name_ref RuntimeConvertFrom, file.%RuntimeConvertFrom.decl [concrete = constants.%RuntimeConvertFrom]
+// CHECK:STDOUT:   %.loc30_36.2: ref %RuntimeConvertFrom = temporary_storage
+// CHECK:STDOUT:   %.loc30_36.3: init %RuntimeConvertFrom = class_init (), %.loc30_36.2 [concrete = constants.%RuntimeConvertFrom.val]
+// CHECK:STDOUT:   %.loc30_36.4: ref %RuntimeConvertFrom = temporary %.loc30_36.2, %.loc30_36.3
+// CHECK:STDOUT:   %.loc30_38: ref %RuntimeConvertFrom = converted %.loc30_36.1, %.loc30_36.4
+// CHECK:STDOUT:   %RuntimeConvertFrom.ref.loc30_14: type = name_ref RuntimeConvertFrom, file.%RuntimeConvertFrom.decl [concrete = constants.%RuntimeConvertFrom]
+// CHECK:STDOUT:   %from: %RuntimeConvertFrom = bind_symbolic_name from, 0, %.loc30_38 [symbolic = constants.%from]
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %from.ref: %RuntimeConvertFrom = name_ref from, %from [symbolic = constants.%from]
 // CHECK:STDOUT:   %holds_to.ref: %HoldsType.066 = name_ref holds_to, %holds_to
 // CHECK:STDOUT:   %impl.elem0: %.f4e = impl_witness_access constants.%ImplicitAs.impl_witness, element0 [concrete = constants.%Convert.e81]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method constants.%from, %impl.elem0 [symbolic = constants.%Convert.bound]
-// CHECK:STDOUT:   %.loc39_19.1: ref %RuntimeConvertTo = temporary_storage
-// CHECK:STDOUT:   %Convert.call: init %RuntimeConvertTo = call %bound_method(constants.%from) to %.loc39_19.1
-// CHECK:STDOUT:   %.loc39_19.2: init %RuntimeConvertTo = converted constants.%from, %Convert.call
-// CHECK:STDOUT:   %.loc39_19.3: ref %RuntimeConvertTo = temporary %.loc39_19.1, %.loc39_19.2
-// CHECK:STDOUT:   %.loc39_19.4: %RuntimeConvertTo = bind_value %.loc39_19.3
+// CHECK:STDOUT:   %.loc41_19.1: ref %RuntimeConvertTo = temporary_storage
+// CHECK:STDOUT:   %Convert.call: init %RuntimeConvertTo = call %bound_method(constants.%from) to %.loc41_19.1
+// CHECK:STDOUT:   %.loc41_19.2: init %RuntimeConvertTo = converted constants.%from, %Convert.call
+// CHECK:STDOUT:   %.loc41_19.3: ref %RuntimeConvertTo = temporary %.loc41_19.1, %.loc41_19.2
+// CHECK:STDOUT:   %.loc41_19.4: %RuntimeConvertTo = bind_value %.loc41_19.3
 // CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F.ref, @F(constants.%tuple, <error>) [concrete = <error>]
 // CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%holds_to.ref) [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HoldsType(constants.%T) {
-// CHECK:STDOUT:   %T.loc15_17.2 => constants.%T
+// CHECK:STDOUT:   %T.loc17_17.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T, constants.%A) {
-// CHECK:STDOUT:   %T.loc25_6.2 => constants.%T
-// CHECK:STDOUT:   %tuple.elem0.loc25_25.2 => constants.%tuple.elem0
-// CHECK:STDOUT:   %A.loc25_20.2 => constants.%A
-// CHECK:STDOUT:   %pattern_type.loc25_20 => constants.%pattern_type.08e
-// CHECK:STDOUT:   %HoldsType.loc25_43.2 => constants.%HoldsType.cc9
-// CHECK:STDOUT:   %pattern_type.loc25_29 => constants.%pattern_type.ec6
+// CHECK:STDOUT:   %T.loc27_6.2 => constants.%T
+// CHECK:STDOUT:   %tuple.elem0.loc27_25.2 => constants.%tuple.elem0
+// CHECK:STDOUT:   %A.loc27_20.2 => constants.%A
+// CHECK:STDOUT:   %pattern_type.loc27_20 => constants.%pattern_type.08e
+// CHECK:STDOUT:   %HoldsType.loc27_43.2 => constants.%HoldsType.cc9
+// CHECK:STDOUT:   %pattern_type.loc27_29 => constants.%pattern_type.ec6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @HoldsType(constants.%tuple) {
-// CHECK:STDOUT:   %T.loc15_17.2 => constants.%tuple
+// CHECK:STDOUT:   %T.loc17_17.2 => constants.%tuple
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%tuple, <error>) {
-// CHECK:STDOUT:   %T.loc25_6.2 => constants.%tuple
-// CHECK:STDOUT:   %tuple.elem0.loc25_25.2 => constants.%RuntimeConvertTo
-// CHECK:STDOUT:   %A.loc25_20.2 => <error>
-// CHECK:STDOUT:   %pattern_type.loc25_20 => constants.%pattern_type.109
-// CHECK:STDOUT:   %HoldsType.loc25_43.2 => constants.%HoldsType.066
-// CHECK:STDOUT:   %pattern_type.loc25_29 => constants.%pattern_type.a13
+// CHECK:STDOUT:   %T.loc27_6.2 => constants.%tuple
+// CHECK:STDOUT:   %tuple.elem0.loc27_25.2 => constants.%RuntimeConvertTo
+// CHECK:STDOUT:   %A.loc27_20.2 => <error>
+// CHECK:STDOUT:   %pattern_type.loc27_20 => constants.%pattern_type.109
+// CHECK:STDOUT:   %HoldsType.loc27_43.2 => constants.%HoldsType.066
+// CHECK:STDOUT:   %pattern_type.loc27_29 => constants.%pattern_type.a13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/min_prelude/fail_incomplete.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_incomplete.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/facet/min_prelude/fail_namespace_type.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/fail_namespace_type.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/facet/min_prelude/tuple_and_struct_type_literal.carbon
+++ b/toolchain/check/testdata/facet/min_prelude/tuple_and_struct_type_literal.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.