### PR TITLE
Add range flag settings to generic files

### DIFF
--- a/toolchain/check/testdata/generic/call_basic_depth.carbon
+++ b/toolchain/check/testdata/generic/call_basic_depth.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/call_basic_depth.carbon
@@ -123,10 +126,10 @@ fn M() {
 // CHECK:STDOUT:     %x.patt: @F.%pattern_type (%pattern_type.7dcd0a.1) = binding_pattern x [concrete]
 // CHECK:STDOUT:     %x.param_patt: @F.%pattern_type (%pattern_type.7dcd0a.1) = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc16_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc16_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @F.%T.loc16_6.2 (%T) = value_param call_param0
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc16_6.1 [symbolic = %T.loc16_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x: @F.%T.loc16_6.2 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:     %T.loc19_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc19_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @F.%T.loc19_6.2 (%T) = value_param call_param0
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc19_6.1 [symbolic = %T.loc19_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x: @F.%T.loc19_6.2 (%T) = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
@@ -135,13 +138,13 @@ fn M() {
 // CHECK:STDOUT:     %return.patt: @H.%pattern_type (%pattern_type.7dcd0a.1) = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: @H.%pattern_type (%pattern_type.7dcd0a.1) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref.loc19_25: type = name_ref T, %T.loc19_6.1 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.loc19_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @H.%T.loc19_6.2 (%T) = value_param call_param0
-// CHECK:STDOUT:     %T.ref.loc19_19: type = name_ref T, %T.loc19_6.1 [symbolic = %T.loc19_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x: @H.%T.loc19_6.2 (%T) = bind_name x, %x.param
-// CHECK:STDOUT:     %return.param: ref @H.%T.loc19_6.2 (%T) = out_param call_param1
-// CHECK:STDOUT:     %return: ref @H.%T.loc19_6.2 (%T) = return_slot %return.param
+// CHECK:STDOUT:     %T.ref.loc22_25: type = name_ref T, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc22_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @H.%T.loc22_6.2 (%T) = value_param call_param0
+// CHECK:STDOUT:     %T.ref.loc22_19: type = name_ref T, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x: @H.%T.loc22_6.2 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:     %return.param: ref @H.%T.loc22_6.2 (%T) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @H.%T.loc22_6.2 (%T) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
@@ -150,13 +153,13 @@ fn M() {
 // CHECK:STDOUT:     %return.patt: @G.%pattern_type (%pattern_type.7dcd0a.1) = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: @G.%pattern_type (%pattern_type.7dcd0a.1) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref.loc25_25: type = name_ref T, %T.loc25_6.1 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:     %T.loc25_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @G.%T.loc25_6.2 (%T) = value_param call_param0
-// CHECK:STDOUT:     %T.ref.loc25_19: type = name_ref T, %T.loc25_6.1 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:     %x: @G.%T.loc25_6.2 (%T) = bind_name x, %x.param
-// CHECK:STDOUT:     %return.param: ref @G.%T.loc25_6.2 (%T) = out_param call_param1
-// CHECK:STDOUT:     %return: ref @G.%T.loc25_6.2 (%T) = return_slot %return.param
+// CHECK:STDOUT:     %T.ref.loc28_25: type = name_ref T, %T.loc28_6.1 [symbolic = %T.loc28_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc28_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc28_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @G.%T.loc28_6.2 (%T) = value_param call_param0
+// CHECK:STDOUT:     %T.ref.loc28_19: type = name_ref T, %T.loc28_6.1 [symbolic = %T.loc28_6.2 (constants.%T)]
+// CHECK:STDOUT:     %x: @G.%T.loc28_6.2 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:     %return.param: ref @G.%T.loc28_6.2 (%T) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @G.%T.loc28_6.2 (%T) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %M.decl: %M.type = fn_decl @M [concrete = constants.%M] {} {}
 // CHECK:STDOUT: }
@@ -172,10 +175,10 @@ fn M() {
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
-// CHECK:STDOUT:     %T.loc12_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc12_22.1 (constants.%T)]
-// CHECK:STDOUT:     %x.param: @Cfn.%T.loc12_22.1 (%T) = value_param call_param1
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc12_22.2 [symbolic = %T.loc12_22.1 (constants.%T)]
-// CHECK:STDOUT:     %x: @Cfn.%T.loc12_22.1 (%T) = bind_name x, %x.param
+// CHECK:STDOUT:     %T.loc15_22.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc15_22.1 (constants.%T)]
+// CHECK:STDOUT:     %x.param: @Cfn.%T.loc15_22.1 (%T) = value_param call_param1
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc15_22.2 [symbolic = %T.loc15_22.1 (constants.%T)]
+// CHECK:STDOUT:     %x: @Cfn.%T.loc15_22.1 (%T) = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -186,71 +189,71 @@ fn M() {
 // CHECK:STDOUT:   .Cfn = %Cfn.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Cfn(%T.loc12_22.2: type) {
-// CHECK:STDOUT:   %T.loc12_22.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc12_22.1 (constants.%T)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc12_22.1 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT: generic fn @Cfn(%T.loc15_22.2: type) {
+// CHECK:STDOUT:   %T.loc15_22.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc15_22.1 (constants.%T)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc15_22.1 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc12_22.1 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc15_22.1 [symbolic = %require_complete (constants.%require_complete.4ae)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: %C, %x.param: @Cfn.%T.loc12_22.1 (%T)) {
+// CHECK:STDOUT:   fn(%self.param: %C, %x.param: @Cfn.%T.loc15_22.1 (%T)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc16_6.1: type) {
-// CHECK:STDOUT:   %T.loc16_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc16_6.2 (constants.%T)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc16_6.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc16_6.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%x.param: @F.%T.loc16_6.2 (%T)) {
-// CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     return
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @H(%T.loc19_6.1: type) {
+// CHECK:STDOUT: generic fn @F(%T.loc19_6.1: type) {
 // CHECK:STDOUT:   %T.loc19_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc19_6.2 (constants.%T)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc19_6.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc19_6.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:   %F.specific_fn.loc21_3.2: <specific function> = specific_function constants.%F, @F(%T.loc19_6.2) [symbolic = %F.specific_fn.loc21_3.2 (constants.%F.specific_fn.ef1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%x.param: @H.%T.loc19_6.2 (%T)) -> @H.%T.loc19_6.2 (%T) {
+// CHECK:STDOUT:   fn(%x.param: @F.%T.loc19_6.2 (%T)) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:     %x.ref.loc21: @H.%T.loc19_6.2 (%T) = name_ref x, %x
-// CHECK:STDOUT:     %F.specific_fn.loc21_3.1: <specific function> = specific_function %F.ref, @F(constants.%T) [symbolic = %F.specific_fn.loc21_3.2 (constants.%F.specific_fn.ef1)]
-// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc21_3.1(%x.ref.loc21)
-// CHECK:STDOUT:     %x.ref.loc22: @H.%T.loc19_6.2 (%T) = name_ref x, %x
-// CHECK:STDOUT:     return %x.ref.loc22
+// CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @G(%T.loc25_6.1: type) {
-// CHECK:STDOUT:   %T.loc25_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc25_6.2 (constants.%T)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc25_6.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT: generic fn @H(%T.loc22_6.1: type) {
+// CHECK:STDOUT:   %T.loc22_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc22_6.2 (constants.%T)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc22_6.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc25_6.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:   %H.specific_fn.loc26_3.2: <specific function> = specific_function constants.%H, @H(%T.loc25_6.2) [symbolic = %H.specific_fn.loc26_3.2 (constants.%H.specific_fn.1ed)]
-// CHECK:STDOUT:   %F.specific_fn.loc27_3.2: <specific function> = specific_function constants.%F, @F(%T.loc25_6.2) [symbolic = %F.specific_fn.loc27_3.2 (constants.%F.specific_fn.ef1)]
-// CHECK:STDOUT:   %Cfn.specific_fn.loc30_4.2: <specific function> = specific_function constants.%Cfn, @Cfn(%T.loc25_6.2) [symbolic = %Cfn.specific_fn.loc30_4.2 (constants.%Cfn.specific_fn.53f)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc22_6.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %F.specific_fn.loc24_3.2: <specific function> = specific_function constants.%F, @F(%T.loc22_6.2) [symbolic = %F.specific_fn.loc24_3.2 (constants.%F.specific_fn.ef1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%x.param: @G.%T.loc25_6.2 (%T)) -> @G.%T.loc25_6.2 (%T) {
+// CHECK:STDOUT:   fn(%x.param: @H.%T.loc22_6.2 (%T)) -> @H.%T.loc22_6.2 (%T) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:     %x.ref.loc24: @H.%T.loc22_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %F.specific_fn.loc24_3.1: <specific function> = specific_function %F.ref, @F(constants.%T) [symbolic = %F.specific_fn.loc24_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc24_3.1(%x.ref.loc24)
+// CHECK:STDOUT:     %x.ref.loc25: @H.%T.loc22_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     return %x.ref.loc25
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @G(%T.loc28_6.1: type) {
+// CHECK:STDOUT:   %T.loc28_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc28_6.2 (constants.%T)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc28_6.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc28_6.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %H.specific_fn.loc29_3.2: <specific function> = specific_function constants.%H, @H(%T.loc28_6.2) [symbolic = %H.specific_fn.loc29_3.2 (constants.%H.specific_fn.1ed)]
+// CHECK:STDOUT:   %F.specific_fn.loc30_3.2: <specific function> = specific_function constants.%F, @F(%T.loc28_6.2) [symbolic = %F.specific_fn.loc30_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:   %Cfn.specific_fn.loc33_4.2: <specific function> = specific_function constants.%Cfn, @Cfn(%T.loc28_6.2) [symbolic = %Cfn.specific_fn.loc33_4.2 (constants.%Cfn.specific_fn.53f)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param: @G.%T.loc28_6.2 (%T)) -> @G.%T.loc28_6.2 (%T) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %H.ref: %H.type = name_ref H, file.%H.decl [concrete = constants.%H]
-// CHECK:STDOUT:     %x.ref.loc26: @G.%T.loc25_6.2 (%T) = name_ref x, %x
-// CHECK:STDOUT:     %H.specific_fn.loc26_3.1: <specific function> = specific_function %H.ref, @H(constants.%T) [symbolic = %H.specific_fn.loc26_3.2 (constants.%H.specific_fn.1ed)]
-// CHECK:STDOUT:     %H.call: init @G.%T.loc25_6.2 (%T) = call %H.specific_fn.loc26_3.1(%x.ref.loc26)
+// CHECK:STDOUT:     %x.ref.loc29: @G.%T.loc28_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %H.specific_fn.loc29_3.1: <specific function> = specific_function %H.ref, @H(constants.%T) [symbolic = %H.specific_fn.loc29_3.2 (constants.%H.specific_fn.1ed)]
+// CHECK:STDOUT:     %H.call: init @G.%T.loc28_6.2 (%T) = call %H.specific_fn.loc29_3.1(%x.ref.loc29)
 // CHECK:STDOUT:     %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:     %x.ref.loc27: @G.%T.loc25_6.2 (%T) = name_ref x, %x
-// CHECK:STDOUT:     %F.specific_fn.loc27_3.1: <specific function> = specific_function %F.ref, @F(constants.%T) [symbolic = %F.specific_fn.loc27_3.2 (constants.%F.specific_fn.ef1)]
-// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc27_3.1(%x.ref.loc27)
+// CHECK:STDOUT:     %x.ref.loc30: @G.%T.loc28_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %F.specific_fn.loc30_3.1: <specific function> = specific_function %F.ref, @F(constants.%T) [symbolic = %F.specific_fn.loc30_3.2 (constants.%F.specific_fn.ef1)]
+// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn.loc30_3.1(%x.ref.loc30)
 // CHECK:STDOUT:     name_binding_decl {
 // CHECK:STDOUT:       %c.patt: %pattern_type.c48 = binding_pattern c [concrete]
 // CHECK:STDOUT:       %c.var_patt: %pattern_type.c48 = var_pattern %c.patt [concrete]
@@ -261,13 +264,13 @@ fn M() {
 // CHECK:STDOUT:     %c.ref: ref %C = name_ref c, %c
 // CHECK:STDOUT:     %Cfn.ref: %Cfn.type = name_ref Cfn, @C.%Cfn.decl [concrete = constants.%Cfn]
 // CHECK:STDOUT:     %Cfn.bound: <bound method> = bound_method %c.ref, %Cfn.ref
-// CHECK:STDOUT:     %x.ref.loc30: @G.%T.loc25_6.2 (%T) = name_ref x, %x
-// CHECK:STDOUT:     %Cfn.specific_fn.loc30_4.1: <specific function> = specific_function %Cfn.ref, @Cfn(constants.%T) [symbolic = %Cfn.specific_fn.loc30_4.2 (constants.%Cfn.specific_fn.53f)]
-// CHECK:STDOUT:     %bound_method: <bound method> = bound_method %c.ref, %Cfn.specific_fn.loc30_4.1
-// CHECK:STDOUT:     %.loc30: %C = bind_value %c.ref
-// CHECK:STDOUT:     %Cfn.call: init %empty_tuple.type = call %bound_method(%.loc30, %x.ref.loc30)
-// CHECK:STDOUT:     %x.ref.loc31: @G.%T.loc25_6.2 (%T) = name_ref x, %x
-// CHECK:STDOUT:     return %x.ref.loc31
+// CHECK:STDOUT:     %x.ref.loc33: @G.%T.loc28_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     %Cfn.specific_fn.loc33_4.1: <specific function> = specific_function %Cfn.ref, @Cfn(constants.%T) [symbolic = %Cfn.specific_fn.loc33_4.2 (constants.%Cfn.specific_fn.53f)]
+// CHECK:STDOUT:     %bound_method: <bound method> = bound_method %c.ref, %Cfn.specific_fn.loc33_4.1
+// CHECK:STDOUT:     %.loc33: %C = bind_value %c.ref
+// CHECK:STDOUT:     %Cfn.call: init %empty_tuple.type = call %bound_method(%.loc33, %x.ref.loc33)
+// CHECK:STDOUT:     %x.ref.loc34: @G.%T.loc28_6.2 (%T) = name_ref x, %x
+// CHECK:STDOUT:     return %x.ref.loc34
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -280,15 +283,15 @@ fn M() {
 // CHECK:STDOUT:   %n.var: ref %i32 = var %n.var_patt
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc35_3.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc38_3.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc35_3.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc35_3.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc35_3: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   assign %n.var, %.loc35_3
-// CHECK:STDOUT:   %.loc35_10: type = splice_block %i32.loc35 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc35: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc35: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %bound_method.loc38_3.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc38_3.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc38_3: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   assign %n.var, %.loc38_3
+// CHECK:STDOUT:   %.loc38_10: type = splice_block %i32.loc38 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc38: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc38: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n: ref %i32 = bind_name n, %n.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -296,28 +299,28 @@ fn M() {
 // CHECK:STDOUT:     %m.var_patt: %pattern_type.7ce = var_pattern %m.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %m.var: ref %i32 = var %m.var_patt
-// CHECK:STDOUT:   %.loc36: type = splice_block %i32.loc36 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc36: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc36: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc39: type = splice_block %i32.loc39 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc39: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc39: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %m: ref %i32 = bind_name m, %m.var
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %n.ref.loc38: ref %i32 = name_ref n, %n
+// CHECK:STDOUT:   %n.ref.loc41: ref %i32 = name_ref n, %n
 // CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F.ref, @F(constants.%i32) [concrete = constants.%F.specific_fn.501]
-// CHECK:STDOUT:   %.loc38: %i32 = bind_value %n.ref.loc38
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc38)
+// CHECK:STDOUT:   %.loc41: %i32 = bind_value %n.ref.loc41
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc41)
 // CHECK:STDOUT:   %m.ref: ref %i32 = name_ref m, %m
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%G.decl [concrete = constants.%G]
-// CHECK:STDOUT:   %n.ref.loc39: ref %i32 = name_ref n, %n
+// CHECK:STDOUT:   %n.ref.loc42: ref %i32 = name_ref n, %n
 // CHECK:STDOUT:   %G.specific_fn: <specific function> = specific_function %G.ref, @G(constants.%i32) [concrete = constants.%G.specific_fn]
-// CHECK:STDOUT:   %.loc39: %i32 = bind_value %n.ref.loc39
-// CHECK:STDOUT:   %G.call: init %i32 = call %G.specific_fn(%.loc39)
+// CHECK:STDOUT:   %.loc42: %i32 = bind_value %n.ref.loc42
+// CHECK:STDOUT:   %G.call: init %i32 = call %G.specific_fn(%.loc42)
 // CHECK:STDOUT:   assign %m.ref, %G.call
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Cfn(constants.%T) {
-// CHECK:STDOUT:   %T.loc12_22.1 => constants.%T
+// CHECK:STDOUT:   %T.loc15_22.1 => constants.%T
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
@@ -325,7 +328,7 @@ fn M() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
-// CHECK:STDOUT:   %T.loc16_6.2 => constants.%T
+// CHECK:STDOUT:   %T.loc19_6.2 => constants.%T
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
@@ -333,21 +336,21 @@ fn M() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%T) {
-// CHECK:STDOUT:   %T.loc19_6.2 => constants.%T
+// CHECK:STDOUT:   %T.loc22_6.2 => constants.%T
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.4ae
-// CHECK:STDOUT:   %F.specific_fn.loc21_3.2 => constants.%F.specific_fn.ef1
+// CHECK:STDOUT:   %F.specific_fn.loc24_3.2 => constants.%F.specific_fn.ef1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T) {
-// CHECK:STDOUT:   %T.loc25_6.2 => constants.%T
+// CHECK:STDOUT:   %T.loc28_6.2 => constants.%T
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%i32) {
-// CHECK:STDOUT:   %T.loc16_6.2 => constants.%i32
+// CHECK:STDOUT:   %T.loc19_6.2 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
@@ -355,27 +358,27 @@ fn M() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%i32) {
-// CHECK:STDOUT:   %T.loc25_6.2 => constants.%i32
+// CHECK:STDOUT:   %T.loc28_6.2 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
-// CHECK:STDOUT:   %H.specific_fn.loc26_3.2 => constants.%H.specific_fn.aac
-// CHECK:STDOUT:   %F.specific_fn.loc27_3.2 => constants.%F.specific_fn.501
-// CHECK:STDOUT:   %Cfn.specific_fn.loc30_4.2 => constants.%Cfn.specific_fn.7b2
+// CHECK:STDOUT:   %H.specific_fn.loc29_3.2 => constants.%H.specific_fn.aac
+// CHECK:STDOUT:   %F.specific_fn.loc30_3.2 => constants.%F.specific_fn.501
+// CHECK:STDOUT:   %Cfn.specific_fn.loc33_4.2 => constants.%Cfn.specific_fn.7b2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%i32) {
-// CHECK:STDOUT:   %T.loc19_6.2 => constants.%i32
+// CHECK:STDOUT:   %T.loc22_6.2 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
-// CHECK:STDOUT:   %F.specific_fn.loc21_3.2 => constants.%F.specific_fn.501
+// CHECK:STDOUT:   %F.specific_fn.loc24_3.2 => constants.%F.specific_fn.501
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Cfn(constants.%i32) {
-// CHECK:STDOUT:   %T.loc12_22.1 => constants.%i32
+// CHECK:STDOUT:   %T.loc15_22.1 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/generic/complete_type.carbon
+++ b/toolchain/check/testdata/generic/complete_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/complete_type.carbon

--- a/toolchain/check/testdata/generic/dependent_param.carbon
+++ b/toolchain/check/testdata/generic/dependent_param.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/dependent_param.carbon

--- a/toolchain/check/testdata/generic/forward_decl.carbon
+++ b/toolchain/check/testdata/generic/forward_decl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/generic/local.carbon
+++ b/toolchain/check/testdata/generic/local.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/local.carbon

--- a/toolchain/check/testdata/generic/template/convert.carbon
+++ b/toolchain/check/testdata/generic/template/convert.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/template/convert.carbon

--- a/toolchain/check/testdata/generic/template/member_access.carbon
+++ b/toolchain/check/testdata/generic/template/member_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/template/member_access.carbon

--- a/toolchain/check/testdata/generic/template/unimplemented.carbon
+++ b/toolchain/check/testdata/generic/template/unimplemented.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/template/unimplemented.carbon

--- a/toolchain/check/testdata/generic/template_dependence.carbon
+++ b/toolchain/check/testdata/generic/template_dependence.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/template_dependence.carbon


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.