### PR TITLE
Add range flag settings to impl files

### DIFF
--- a/toolchain/check/testdata/impl/assoc_const_self.carbon
+++ b/toolchain/check/testdata/impl/assoc_const_self.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/assoc_const_self.carbon

--- a/toolchain/check/testdata/impl/declaration.carbon
+++ b/toolchain/check/testdata/impl/declaration.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/declaration.carbon
@@ -43,16 +46,16 @@ impl i32 as I {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc13: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %I.ref.loc16: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (), @impl [concrete]
 // CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness]
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc15: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %int_32.loc18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %I.ref.loc18: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -64,7 +67,7 @@ impl i32 as I {}
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %i32.loc13 as %I.ref.loc13 {
+// CHECK:STDOUT: impl @impl: %i32.loc16 as %I.ref.loc16 {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   witness = file.%I.impl_witness
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/empty.carbon
+++ b/toolchain/check/testdata/impl/empty.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/empty.carbon

--- a/toolchain/check/testdata/impl/extend_impl.carbon
+++ b/toolchain/check/testdata/impl/extend_impl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/extend_impl.carbon
@@ -68,7 +71,7 @@ fn G(c: C) {
 // CHECK:STDOUT:     %c.param_patt: %pattern_type = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc21: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %c: %C = bind_name c, %c.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -121,14 +124,14 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%c.param: %C) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %C.ref.loc22: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %F.ref.loc22: %HasF.assoc_type = name_ref F, @HasF.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   %impl.elem0.loc22: %.a44 = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.ad8]
-// CHECK:STDOUT:   %F.call.loc22: init %empty_tuple.type = call %impl.elem0.loc22()
+// CHECK:STDOUT:   %C.ref.loc25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %F.ref.loc25: %HasF.assoc_type = name_ref F, @HasF.%assoc0 [concrete = constants.%assoc0]
+// CHECK:STDOUT:   %impl.elem0.loc25: %.a44 = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.ad8]
+// CHECK:STDOUT:   %F.call.loc25: init %empty_tuple.type = call %impl.elem0.loc25()
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
-// CHECK:STDOUT:   %F.ref.loc23: %HasF.assoc_type = name_ref F, @HasF.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:   %impl.elem0.loc23: %.a44 = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.ad8]
-// CHECK:STDOUT:   %F.call.loc23: init %empty_tuple.type = call %impl.elem0.loc23()
+// CHECK:STDOUT:   %F.ref.loc26: %HasF.assoc_type = name_ref F, @HasF.%assoc0 [concrete = constants.%assoc0]
+// CHECK:STDOUT:   %impl.elem0.loc26: %.a44 = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.ad8]
+// CHECK:STDOUT:   %F.call.loc26: init %empty_tuple.type = call %impl.elem0.loc26()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/extend_impl_generic.carbon
+++ b/toolchain/check/testdata/impl/extend_impl_generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/extend_impl_generic.carbon

--- a/toolchain/check/testdata/impl/fail_call_invalid.carbon
+++ b/toolchain/check/testdata/impl/fail_call_invalid.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_call_invalid.carbon
@@ -75,14 +78,14 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %Simple.ref: type = name_ref Simple, file.%Simple.decl [concrete = constants.%Simple.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Simple.impl_witness_table = impl_witness_table (@impl.006.%G.decl.loc20_27.2), @impl.006 [concrete]
+// CHECK:STDOUT:   %Simple.impl_witness_table = impl_witness_table (@impl.006.%G.decl.loc23_27.2), @impl.006 [concrete]
 // CHECK:STDOUT:   %Simple.impl_witness: <witness> = impl_witness %Simple.impl_witness_table [concrete = constants.%Simple.impl_witness]
 // CHECK:STDOUT:   %InstanceCall.decl: %InstanceCall.type = fn_decl @InstanceCall [concrete = constants.%InstanceCall] {
 // CHECK:STDOUT:     %n.patt: %pattern_type.7ce = binding_pattern n [concrete]
 // CHECK:STDOUT:     %n.param_patt: %pattern_type.7ce = value_param_pattern %n.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc23: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc26: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
@@ -96,13 +99,13 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:     %self.patt: @G.1.%pattern_type (%pattern_type.f88) = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: @G.1.%pattern_type (%pattern_type.f88) = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param: @G.1.%Self.as_type.loc12_14.1 (%Self.as_type.716) = value_param call_param0
-// CHECK:STDOUT:     %.loc12_14.1: type = splice_block %.loc12_14.2 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.716)] {
+// CHECK:STDOUT:     %self.param: @G.1.%Self.as_type.loc15_14.1 (%Self.as_type.716) = value_param call_param0
+// CHECK:STDOUT:     %.loc15_14.1: type = splice_block %.loc15_14.2 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.716)] {
 // CHECK:STDOUT:       %Self.ref: %Simple.type = name_ref Self, @Simple.%Self [symbolic = %Self (constants.%Self.3c9)]
-// CHECK:STDOUT:       %Self.as_type.loc12_14.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.716)]
-// CHECK:STDOUT:       %.loc12_14.2: type = converted %Self.ref, %Self.as_type.loc12_14.2 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.716)]
+// CHECK:STDOUT:       %Self.as_type.loc15_14.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.716)]
+// CHECK:STDOUT:       %.loc15_14.2: type = converted %Self.ref, %Self.as_type.loc15_14.2 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.716)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self: @G.1.%Self.as_type.loc12_14.1 (%Self.as_type.716) = bind_name self, %self.param
+// CHECK:STDOUT:     %self: @G.1.%Self.as_type.loc15_14.1 (%Self.as_type.716) = bind_name self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %Simple.assoc_type = assoc_entity element0, %G.decl [concrete = constants.%assoc0.db2]
 // CHECK:STDOUT:
@@ -113,7 +116,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.006: %i32 as %Simple.ref {
-// CHECK:STDOUT:   %G.decl.loc20_27.1: %G.type.c9825d.1 = fn_decl @G.2 [concrete = constants.%G.e73e91.1] {
+// CHECK:STDOUT:   %G.decl.loc23_27.1: %G.type.c9825d.1 = fn_decl @G.2 [concrete = constants.%G.e73e91.1] {
 // CHECK:STDOUT:     %self.patt: <error> = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: <error> = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
@@ -121,7 +124,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:     %Undeclared.ref: <error> = name_ref Undeclared, <error> [concrete = <error>]
 // CHECK:STDOUT:     %self: <error> = bind_name self, %self.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %G.decl.loc20_27.2: %G.type.c9825d.2 = fn_decl @G.3 [concrete = constants.%G.e73e91.2] {
+// CHECK:STDOUT:   %G.decl.loc23_27.2: %G.type.c9825d.2 = fn_decl @G.3 [concrete = constants.%G.e73e91.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.7ce = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.7ce = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
@@ -131,16 +134,16 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Undeclared = <poisoned>
-// CHECK:STDOUT:   .G = %G.decl.loc20_27.1
+// CHECK:STDOUT:   .G = %G.decl.loc23_27.1
 // CHECK:STDOUT:   witness = file.%Simple.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @G.1(@Simple.%Self: %Simple.type) {
 // CHECK:STDOUT:   %Self: %Simple.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.3c9)]
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.716)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc12_14.1 [symbolic = %pattern_type (constants.%pattern_type.f88)]
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.716)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc15_14.1 [symbolic = %pattern_type (constants.%pattern_type.f88)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @G.1.%Self.as_type.loc12_14.1 (%Self.as_type.716));
+// CHECK:STDOUT:   fn(%self.param: @G.1.%Self.as_type.loc15_14.1 (%Self.as_type.716));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G.2(%self.param: <error>);
@@ -148,7 +151,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT: fn @G.3(%self.param: %i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: %i32 = name_ref self, %self.param
-// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %self.ref, @impl.006.%G.decl.loc20_27.1
+// CHECK:STDOUT:   %G.bound: <bound method> = bound_method %self.ref, @impl.006.%G.decl.loc23_27.1
 // CHECK:STDOUT:   %G.call: init %empty_tuple.type = call %G.bound(<error>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -166,13 +169,13 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G.1(constants.%Self.3c9) {
 // CHECK:STDOUT:   %Self => constants.%Self.3c9
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1 => constants.%Self.as_type.716
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1 => constants.%Self.as_type.716
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.f88
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G.1(constants.%Simple.facet) {
 // CHECK:STDOUT:   %Self => constants.%Simple.facet
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1 => constants.%i32
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -63,21 +66,21 @@ class C {
 // CHECK:STDOUT:   %GenericInterface.decl: %GenericInterface.type.c92 = interface_decl @GenericInterface [concrete = constants.%GenericInterface.generic] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_28.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_28.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc14_28.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_28.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic interface @GenericInterface(%T.loc11_28.1: type) {
-// CHECK:STDOUT:   %T.loc11_28.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_28.2 (constants.%T)]
+// CHECK:STDOUT: generic interface @GenericInterface(%T.loc14_28.1: type) {
+// CHECK:STDOUT:   %T.loc14_28.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_28.2 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %GenericInterface.type: type = facet_type <@GenericInterface, @GenericInterface(%T.loc11_28.2)> [symbolic = %GenericInterface.type (constants.%GenericInterface.type.3fe)]
+// CHECK:STDOUT:   %GenericInterface.type: type = facet_type <@GenericInterface, @GenericInterface(%T.loc14_28.2)> [symbolic = %GenericInterface.type (constants.%GenericInterface.type.3fe)]
 // CHECK:STDOUT:   %Self.2: @GenericInterface.%GenericInterface.type (%GenericInterface.type.3fe) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
-// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @GenericInterface(%T.loc11_28.2) [symbolic = %F.type (constants.%F.type.a4b)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.1, @GenericInterface(%T.loc14_28.2) [symbolic = %F.type (constants.%F.type.a4b)]
 // CHECK:STDOUT:   %F: @GenericInterface.%F.type (%F.type.a4b) = struct_value () [symbolic = %F (constants.%F.3d9)]
-// CHECK:STDOUT:   %GenericInterface.assoc_type: type = assoc_entity_type @GenericInterface, @GenericInterface(%T.loc11_28.2) [symbolic = %GenericInterface.assoc_type (constants.%GenericInterface.assoc_type)]
-// CHECK:STDOUT:   %assoc0.loc12_13.2: @GenericInterface.%GenericInterface.assoc_type (%GenericInterface.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc12_13.2 (constants.%assoc0)]
+// CHECK:STDOUT:   %GenericInterface.assoc_type: type = assoc_entity_type @GenericInterface, @GenericInterface(%T.loc14_28.2) [symbolic = %GenericInterface.assoc_type (constants.%GenericInterface.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc15_13.2: @GenericInterface.%GenericInterface.assoc_type (%GenericInterface.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc15_13.2 (constants.%assoc0)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.1: @GenericInterface.%GenericInterface.type (%GenericInterface.type.3fe) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self)]
@@ -86,36 +89,36 @@ class C {
 // CHECK:STDOUT:       %x.param_patt: @F.1.%pattern_type (%pattern_type.7dc) = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %x.param: @F.1.%T (%T) = value_param call_param0
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @GenericInterface.%T.loc11_28.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @GenericInterface.%T.loc14_28.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %x: @F.1.%T (%T) = bind_name x, %x.param
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %assoc0.loc12_13.1: @GenericInterface.%GenericInterface.assoc_type (%GenericInterface.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc12_13.2 (constants.%assoc0)]
+// CHECK:STDOUT:     %assoc0.loc15_13.1: @GenericInterface.%GenericInterface.assoc_type (%GenericInterface.assoc_type) = assoc_entity element0, %F.decl [symbolic = %assoc0.loc15_13.2 (constants.%assoc0)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.1
 // CHECK:STDOUT:     .T = <poisoned>
-// CHECK:STDOUT:     .F = %assoc0.loc12_13.1
+// CHECK:STDOUT:     .F = %assoc0.loc15_13.1
 // CHECK:STDOUT:     witness = (%F.decl)
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @impl(%T.loc20_23.1: type) {
-// CHECK:STDOUT:   %T.loc20_23.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc20_23.2 (constants.%T)]
-// CHECK:STDOUT:   %GenericInterface.type.loc20_54.2: type = facet_type <@GenericInterface, @GenericInterface(%T.loc20_23.2)> [symbolic = %GenericInterface.type.loc20_54.2 (constants.%GenericInterface.type.3fe)]
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %GenericInterface.type.loc20_54.2 [symbolic = %require_complete (constants.%require_complete.70f)]
-// CHECK:STDOUT:   %GenericInterface.impl_witness: <witness> = impl_witness @C.%GenericInterface.impl_witness_table, @impl(%T.loc20_23.2) [symbolic = %GenericInterface.impl_witness (constants.%GenericInterface.impl_witness)]
+// CHECK:STDOUT: generic impl @impl(%T.loc23_23.1: type) {
+// CHECK:STDOUT:   %T.loc23_23.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc23_23.2 (constants.%T)]
+// CHECK:STDOUT:   %GenericInterface.type.loc23_54.2: type = facet_type <@GenericInterface, @GenericInterface(%T.loc23_23.2)> [symbolic = %GenericInterface.type.loc23_54.2 (constants.%GenericInterface.type.3fe)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %GenericInterface.type.loc23_54.2 [symbolic = %require_complete (constants.%require_complete.70f)]
+// CHECK:STDOUT:   %GenericInterface.impl_witness: <witness> = impl_witness @C.%GenericInterface.impl_witness_table, @impl(%T.loc23_23.2) [symbolic = %GenericInterface.impl_witness (constants.%GenericInterface.impl_witness)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %F.type: type = fn_type @F.2, @impl(%T.loc20_23.2) [symbolic = %F.type (constants.%F.type.2cb)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.2, @impl(%T.loc23_23.2) [symbolic = %F.type (constants.%F.type.2cb)]
 // CHECK:STDOUT:   %F: @impl.%F.type (%F.type.2cb) = struct_value () [symbolic = %F (constants.%F.4b1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: %Self.ref as %GenericInterface.type.loc20_54.1 {
+// CHECK:STDOUT:   impl: %Self.ref as %GenericInterface.type.loc23_54.1 {
 // CHECK:STDOUT:     %F.decl: @impl.%F.type (%F.type.2cb) = fn_decl @F.2 [symbolic = @impl.%F (constants.%F.4b1)] {
 // CHECK:STDOUT:       %x.patt: @F.2.%pattern_type (%pattern_type.7dc) = binding_pattern x [concrete]
 // CHECK:STDOUT:       %x.param_patt: @F.2.%pattern_type (%pattern_type.7dc) = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %x.param: @F.2.%T (%T) = value_param call_param0
-// CHECK:STDOUT:       %T.ref: type = name_ref T, @impl.%T.loc20_23.1 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @impl.%T.loc23_23.1 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %x: @F.2.%T (%T) = bind_name x, %x.param
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:
@@ -132,13 +135,13 @@ class C {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [concrete = constants.%C]
 // CHECK:STDOUT:     %GenericInterface.ref: %GenericInterface.type.c92 = name_ref GenericInterface, file.%GenericInterface.decl [concrete = constants.%GenericInterface.generic]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc20_23.1 [symbolic = %T.loc20_23.2 (constants.%T)]
-// CHECK:STDOUT:     %GenericInterface.type.loc20_54.1: type = facet_type <@GenericInterface, @GenericInterface(constants.%T)> [symbolic = %GenericInterface.type.loc20_54.2 (constants.%GenericInterface.type.3fe)]
-// CHECK:STDOUT:     %T.loc20_23.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc20_23.2 (constants.%T)]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc23_23.1 [symbolic = %T.loc23_23.2 (constants.%T)]
+// CHECK:STDOUT:     %GenericInterface.type.loc23_54.1: type = facet_type <@GenericInterface, @GenericInterface(constants.%T)> [symbolic = %GenericInterface.type.loc23_54.2 (constants.%GenericInterface.type.3fe)]
+// CHECK:STDOUT:     %T.loc23_23.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc23_23.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %GenericInterface.impl_witness_table = impl_witness_table (<error>), @impl [concrete]
 // CHECK:STDOUT:   %GenericInterface.impl_witness: <witness> = impl_witness %GenericInterface.impl_witness_table, @impl(constants.%T) [symbolic = @impl.%GenericInterface.impl_witness (constants.%GenericInterface.impl_witness)]
-// CHECK:STDOUT:   %.loc20: type = specific_constant @impl.%GenericInterface.type.loc20_54.1, @impl(constants.%T) [symbolic = constants.%GenericInterface.type.3fe]
+// CHECK:STDOUT:   %.loc23: type = specific_constant @impl.%GenericInterface.type.loc23_54.1, @impl(constants.%T) [symbolic = constants.%GenericInterface.type.3fe]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -149,14 +152,14 @@ class C {
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.1(@GenericInterface.%T.loc11_28.1: type, @GenericInterface.%Self.1: @GenericInterface.%GenericInterface.type (%GenericInterface.type.3fe)) {
+// CHECK:STDOUT: generic fn @F.1(@GenericInterface.%T.loc14_28.1: type, @GenericInterface.%Self.1: @GenericInterface.%GenericInterface.type (%GenericInterface.type.3fe)) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %T [symbolic = %pattern_type (constants.%pattern_type.7dc)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%x.param: @F.1.%T (%T));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.2(@impl.%T.loc20_23.1: type) {
+// CHECK:STDOUT: generic fn @F.2(@impl.%T.loc23_23.1: type) {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %T [symbolic = %pattern_type (constants.%pattern_type.7dc)]
 // CHECK:STDOUT:
@@ -170,7 +173,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @GenericInterface(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_28.2 => constants.%T
+// CHECK:STDOUT:   %T.loc14_28.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %GenericInterface.type => constants.%GenericInterface.type.3fe
@@ -178,7 +181,7 @@ class C {
 // CHECK:STDOUT:   %F.type => constants.%F.type.a4b
 // CHECK:STDOUT:   %F => constants.%F.3d9
 // CHECK:STDOUT:   %GenericInterface.assoc_type => constants.%GenericInterface.assoc_type
-// CHECK:STDOUT:   %assoc0.loc12_13.2 => constants.%assoc0
+// CHECK:STDOUT:   %assoc0.loc15_13.2 => constants.%assoc0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%T, constants.%Self) {
@@ -187,8 +190,8 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
-// CHECK:STDOUT:   %T.loc20_23.2 => constants.%T
-// CHECK:STDOUT:   %GenericInterface.type.loc20_54.2 => constants.%GenericInterface.type.3fe
+// CHECK:STDOUT:   %T.loc23_23.2 => constants.%T
+// CHECK:STDOUT:   %GenericInterface.type.loc23_54.2 => constants.%GenericInterface.type.3fe
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.70f
 // CHECK:STDOUT:   %GenericInterface.impl_witness => constants.%GenericInterface.impl_witness
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon

--- a/toolchain/check/testdata/impl/fail_extend_non_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_non_interface.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_extend_non_interface.carbon

--- a/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -77,7 +80,7 @@ interface I {
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %I.impl_witness_table = impl_witness_table (), @impl [concrete]
 // CHECK:STDOUT:     %I.impl_witness: <witness> = impl_witness %I.impl_witness_table, @impl(constants.%Self) [symbolic = @impl.%I.impl_witness (constants.%I.impl_witness)]
-// CHECK:STDOUT:     %.loc20: type = specific_constant @impl.%I.ref, @impl(constants.%Self) [concrete = constants.%I.type]
+// CHECK:STDOUT:     %.loc23: type = specific_constant @impl.%I.ref, @impl(constants.%Self) [concrete = constants.%I.type]
 // CHECK:STDOUT:     %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:     %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:     complete_type_witness = %complete_type

--- a/toolchain/check/testdata/impl/fail_extend_undefined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_undefined_interface.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_extend_undefined_interface.carbon
@@ -61,7 +64,7 @@ fn F(c: C) {
 // CHECK:STDOUT:     %c.param_patt: %pattern_type = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc27: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %c: %C = bind_name c, %c.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -90,10 +93,10 @@ fn F(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%c.param: %C) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %C.ref.loc25: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %F.ref.loc25: <error> = name_ref F, <error> [concrete = <error>]
+// CHECK:STDOUT:   %C.ref.loc28: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %F.ref.loc28: <error> = name_ref F, <error> [concrete = <error>]
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
-// CHECK:STDOUT:   %F.ref.loc26: <error> = name_ref F, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F.ref.loc29: <error> = name_ref F, <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -460,21 +463,21 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %return.patt: %pattern_type.831 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %bool.make_type.loc99_44: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc99_44.1: type = value_of_initializer %bool.make_type.loc99_44 [concrete = bool]
-// CHECK:STDOUT:     %.loc99_44.2: type = converted %bool.make_type.loc99_44, %.loc99_44.1 [concrete = bool]
+// CHECK:STDOUT:     %bool.make_type.loc102_44: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc102_44.1: type = value_of_initializer %bool.make_type.loc102_44 [concrete = bool]
+// CHECK:STDOUT:     %.loc102_44.2: type = converted %bool.make_type.loc102_44, %.loc102_44.1 [concrete = bool]
 // CHECK:STDOUT:     %self.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc99_26.1: type = splice_block %.loc99_26.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc99_26: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc99_26.2: type = value_of_initializer %bool.make_type.loc99_26 [concrete = bool]
-// CHECK:STDOUT:       %.loc99_26.3: type = converted %bool.make_type.loc99_26, %.loc99_26.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc102_26.1: type = splice_block %.loc102_26.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc102_26: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc102_26.2: type = value_of_initializer %bool.make_type.loc102_26 [concrete = bool]
+// CHECK:STDOUT:       %.loc102_26.3: type = converted %bool.make_type.loc102_26, %.loc102_26.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: bool = bind_name self, %self.param
 // CHECK:STDOUT:     %b.param: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc99_35.1: type = splice_block %.loc99_35.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc99_35: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc99_35.2: type = value_of_initializer %bool.make_type.loc99_35 [concrete = bool]
-// CHECK:STDOUT:       %.loc99_35.3: type = converted %bool.make_type.loc99_35, %.loc99_35.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc102_35.1: type = splice_block %.loc102_35.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc102_35: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc102_35.2: type = value_of_initializer %bool.make_type.loc102_35 [concrete = bool]
+// CHECK:STDOUT:       %.loc102_35.3: type = converted %bool.make_type.loc102_35, %.loc102_35.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param2
@@ -491,34 +494,34 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: interface @SelfNested {
 // CHECK:STDOUT:   %Self: %SelfNested.type = bind_symbolic_name Self, 0 [symbolic = constants.%Self.2ff]
 // CHECK:STDOUT:   %F.decl: %F.type.6ed = fn_decl @F.20 [concrete = constants.%F.998] {
-// CHECK:STDOUT:     %x.patt: @F.20.%pattern_type.loc207_8 (%pattern_type.ced) = binding_pattern x [concrete]
-// CHECK:STDOUT:     %x.param_patt: @F.20.%pattern_type.loc207_8 (%pattern_type.ced) = value_param_pattern %x.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %return.patt: @F.20.%pattern_type.loc207_41 (%pattern_type.c7e) = return_slot_pattern [concrete]
-// CHECK:STDOUT:     %return.param_patt: @F.20.%pattern_type.loc207_41 (%pattern_type.c7e) = out_param_pattern %return.patt, call_param1 [concrete]
+// CHECK:STDOUT:     %x.patt: @F.20.%pattern_type.loc210_8 (%pattern_type.ced) = binding_pattern x [concrete]
+// CHECK:STDOUT:     %x.param_patt: @F.20.%pattern_type.loc210_8 (%pattern_type.ced) = value_param_pattern %x.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %return.patt: @F.20.%pattern_type.loc210_41 (%pattern_type.c7e) = return_slot_pattern [concrete]
+// CHECK:STDOUT:     %return.param_patt: @F.20.%pattern_type.loc210_41 (%pattern_type.c7e) = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc207_50: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
+// CHECK:STDOUT:     %Self.ref.loc210_50: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
 // CHECK:STDOUT:     %int_4: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
-// CHECK:STDOUT:     %Self.as_type.loc207_50: type = facet_access_type %Self.ref.loc207_50 [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:     %.loc207_50: type = converted %Self.ref.loc207_50, %Self.as_type.loc207_50 [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:     %array_type.loc207_57.2: type = array_type %int_4, %.loc207_50 [symbolic = %array_type.loc207_57.1 (constants.%array_type.873)]
+// CHECK:STDOUT:     %Self.as_type.loc210_50: type = facet_access_type %Self.ref.loc210_50 [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:     %.loc210_50: type = converted %Self.ref.loc210_50, %Self.as_type.loc210_50 [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:     %array_type.loc210_57.2: type = array_type %int_4, %.loc210_50 [symbolic = %array_type.loc210_57.1 (constants.%array_type.873)]
 // CHECK:STDOUT:     %x.param: @F.20.%tuple.type (%tuple.type.229) = value_param call_param0
-// CHECK:STDOUT:     %.loc207_38.1: type = splice_block %.loc207_38.3 [symbolic = %tuple.type (constants.%tuple.type.229)] {
-// CHECK:STDOUT:       %Self.ref.loc207_12: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
-// CHECK:STDOUT:       %Self.as_type.loc207_16.2: type = facet_access_type %Self.ref.loc207_12 [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %.loc207_16: type = converted %Self.ref.loc207_12, %Self.as_type.loc207_16.2 [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %ptr.loc207_16.2: type = ptr_type %.loc207_16 [symbolic = %ptr.loc207_16.1 (constants.%ptr.e87)]
-// CHECK:STDOUT:       %Self.ref.loc207_24: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
-// CHECK:STDOUT:       %Self.as_type.loc207_24: type = facet_access_type %Self.ref.loc207_24 [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %.loc207_24: type = converted %Self.ref.loc207_24, %Self.as_type.loc207_24 [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:     %.loc210_38.1: type = splice_block %.loc210_38.3 [symbolic = %tuple.type (constants.%tuple.type.229)] {
+// CHECK:STDOUT:       %Self.ref.loc210_12: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
+// CHECK:STDOUT:       %Self.as_type.loc210_16.2: type = facet_access_type %Self.ref.loc210_12 [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %.loc210_16: type = converted %Self.ref.loc210_12, %Self.as_type.loc210_16.2 [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %ptr.loc210_16.2: type = ptr_type %.loc210_16 [symbolic = %ptr.loc210_16.1 (constants.%ptr.e87)]
+// CHECK:STDOUT:       %Self.ref.loc210_24: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
+// CHECK:STDOUT:       %Self.as_type.loc210_24: type = facet_access_type %Self.ref.loc210_24 [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %.loc210_24: type = converted %Self.ref.loc210_24, %Self.as_type.loc210_24 [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %struct_type.x.y.loc207_37.2: type = struct_type {.x: @F.20.%Self.as_type.loc207_16.1 (%Self.as_type.e1e), .y: %i32} [symbolic = %struct_type.x.y.loc207_37.1 (constants.%struct_type.x.y.81e)]
-// CHECK:STDOUT:       %.loc207_38.2: %tuple.type.24b = tuple_literal (%ptr.loc207_16.2, %struct_type.x.y.loc207_37.2)
-// CHECK:STDOUT:       %.loc207_38.3: type = converted %.loc207_38.2, constants.%tuple.type.229 [symbolic = %tuple.type (constants.%tuple.type.229)]
+// CHECK:STDOUT:       %struct_type.x.y.loc210_37.2: type = struct_type {.x: @F.20.%Self.as_type.loc210_16.1 (%Self.as_type.e1e), .y: %i32} [symbolic = %struct_type.x.y.loc210_37.1 (constants.%struct_type.x.y.81e)]
+// CHECK:STDOUT:       %.loc210_38.2: %tuple.type.24b = tuple_literal (%ptr.loc210_16.2, %struct_type.x.y.loc210_37.2)
+// CHECK:STDOUT:       %.loc210_38.3: type = converted %.loc210_38.2, constants.%tuple.type.229 [symbolic = %tuple.type (constants.%tuple.type.229)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: @F.20.%tuple.type (%tuple.type.229) = bind_name x, %x.param
-// CHECK:STDOUT:     %return.param: ref @F.20.%array_type.loc207_57.1 (%array_type.873) = out_param call_param1
-// CHECK:STDOUT:     %return: ref @F.20.%array_type.loc207_57.1 (%array_type.873) = return_slot %return.param
+// CHECK:STDOUT:     %return.param: ref @F.20.%array_type.loc210_57.1 (%array_type.873) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @F.20.%array_type.loc210_57.1 (%array_type.873) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %SelfNested.assoc_type = assoc_entity element0, %F.decl [concrete = constants.%assoc0.beb]
 // CHECK:STDOUT:
@@ -553,27 +556,27 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.ddd: %Self.ref as %I.ref {
-// CHECK:STDOUT:   %F.decl.loc65_18.1: %F.type.44ef8c.1 = fn_decl @F.2 [concrete = constants.%F.424e9e.1] {
+// CHECK:STDOUT:   %F.decl.loc68_18.1: %F.type.44ef8c.1 = fn_decl @F.2 [concrete = constants.%F.424e9e.1] {
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.831 = value_param_pattern %b.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %b.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc65_13.1: type = splice_block %.loc65_13.3 [concrete = bool] {
+// CHECK:STDOUT:     %.loc68_13.1: type = splice_block %.loc68_13.3 [concrete = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc65_13.2: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:       %.loc65_13.3: type = converted %bool.make_type, %.loc65_13.2 [concrete = bool]
+// CHECK:STDOUT:       %.loc68_13.2: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:       %.loc68_13.3: type = converted %bool.make_type, %.loc68_13.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc65_18.2: %F.type.44ef8c.2 = fn_decl @F.3 [concrete = constants.%F.424e9e.2] {} {}
+// CHECK:STDOUT:   %F.decl.loc68_18.2: %F.type.44ef8c.2 = fn_decl @F.3 [concrete = constants.%F.424e9e.2] {} {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc65_18.1
+// CHECK:STDOUT:   .F = %F.decl.loc68_18.1
 // CHECK:STDOUT:   witness = @FExtraParam.%I.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.698: %Self.ref as %I.ref {
-// CHECK:STDOUT:   %F.decl.loc81_23.1: %F.type.e1abdd.1 = fn_decl @F.4 [concrete = constants.%F.6ff574.1] {
+// CHECK:STDOUT:   %F.decl.loc84_23.1: %F.type.e1abdd.1 = fn_decl @F.4 [concrete = constants.%F.6ff574.1] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.8ae = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.8ae = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
@@ -581,10 +584,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FExtraImplicitParam [concrete = constants.%FExtraImplicitParam]
 // CHECK:STDOUT:     %self: %FExtraImplicitParam = bind_name self, %self.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc81_23.2: %F.type.e1abdd.2 = fn_decl @F.5 [concrete = constants.%F.6ff574.2] {} {}
+// CHECK:STDOUT:   %F.decl.loc84_23.2: %F.type.e1abdd.2 = fn_decl @F.5 [concrete = constants.%F.6ff574.2] {} {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc81_23.1
+// CHECK:STDOUT:   .F = %F.decl.loc84_23.1
 // CHECK:STDOUT:   witness = @FExtraImplicitParam.%I.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -594,8 +597,8 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc95_15.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc95_15.2: type = converted %bool.make_type, %.loc95_15.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc98_15.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc98_15.2: type = converted %bool.make_type, %.loc98_15.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -606,26 +609,26 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.5cf: %Self.ref as %J.ref {
-// CHECK:STDOUT:   %F.decl.loc113_31.1: %F.type.69596c.1 = fn_decl @F.8 [concrete = constants.%F.738f31.1] {
+// CHECK:STDOUT:   %F.decl.loc116_31.1: %F.type.69596c.1 = fn_decl @F.8 [concrete = constants.%F.738f31.1] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.831 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %bool.make_type.loc113_27: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc113_27.1: type = value_of_initializer %bool.make_type.loc113_27 [concrete = bool]
-// CHECK:STDOUT:     %.loc113_27.2: type = converted %bool.make_type.loc113_27, %.loc113_27.1 [concrete = bool]
+// CHECK:STDOUT:     %bool.make_type.loc116_27: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc116_27.1: type = value_of_initializer %bool.make_type.loc116_27 [concrete = bool]
+// CHECK:STDOUT:     %.loc116_27.2: type = converted %bool.make_type.loc116_27, %.loc116_27.1 [concrete = bool]
 // CHECK:STDOUT:     %self.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc113_16.1: type = splice_block %.loc113_16.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc113_16: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc113_16.2: type = value_of_initializer %bool.make_type.loc113_16 [concrete = bool]
-// CHECK:STDOUT:       %.loc113_16.3: type = converted %bool.make_type.loc113_16, %.loc113_16.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc116_16.1: type = splice_block %.loc116_16.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc116_16: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc116_16.2: type = value_of_initializer %bool.make_type.loc116_16 [concrete = bool]
+// CHECK:STDOUT:       %.loc116_16.3: type = converted %bool.make_type.loc116_16, %.loc116_16.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: bool = bind_name self, %self.param
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param1
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc113_31.2: %F.type.69596c.2 = fn_decl @F.9 [concrete = constants.%F.738f31.2] {
+// CHECK:STDOUT:   %F.decl.loc116_31.2: %F.type.69596c.2 = fn_decl @F.9 [concrete = constants.%F.738f31.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -642,31 +645,31 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc113_31.1
+// CHECK:STDOUT:   .F = %F.decl.loc116_31.1
 // CHECK:STDOUT:   witness = @FMissingParam.%J.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.bac: %Self.ref as %J.ref {
-// CHECK:STDOUT:   %F.decl.loc126_26.1: %F.type.d97cef.1 = fn_decl @F.10 [concrete = constants.%F.01de92.1] {
+// CHECK:STDOUT:   %F.decl.loc129_26.1: %F.type.d97cef.1 = fn_decl @F.10 [concrete = constants.%F.01de92.1] {
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.831 = value_param_pattern %b.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.831 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %bool.make_type.loc126_22: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc126_22.1: type = value_of_initializer %bool.make_type.loc126_22 [concrete = bool]
-// CHECK:STDOUT:     %.loc126_22.2: type = converted %bool.make_type.loc126_22, %.loc126_22.1 [concrete = bool]
+// CHECK:STDOUT:     %bool.make_type.loc129_22: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc129_22.1: type = value_of_initializer %bool.make_type.loc129_22 [concrete = bool]
+// CHECK:STDOUT:     %.loc129_22.2: type = converted %bool.make_type.loc129_22, %.loc129_22.1 [concrete = bool]
 // CHECK:STDOUT:     %b.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc126_13.1: type = splice_block %.loc126_13.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc126_13: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc126_13.2: type = value_of_initializer %bool.make_type.loc126_13 [concrete = bool]
-// CHECK:STDOUT:       %.loc126_13.3: type = converted %bool.make_type.loc126_13, %.loc126_13.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc129_13.1: type = splice_block %.loc129_13.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc129_13: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc129_13.2: type = value_of_initializer %bool.make_type.loc129_13 [concrete = bool]
+// CHECK:STDOUT:       %.loc129_13.3: type = converted %bool.make_type.loc129_13, %.loc129_13.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param1
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc126_26.2: %F.type.d97cef.2 = fn_decl @F.11 [concrete = constants.%F.01de92.2] {
+// CHECK:STDOUT:   %F.decl.loc129_26.2: %F.type.d97cef.2 = fn_decl @F.11 [concrete = constants.%F.01de92.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -683,33 +686,33 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc126_26.1
+// CHECK:STDOUT:   .F = %F.decl.loc129_26.1
 // CHECK:STDOUT:   witness = @FMissingImplicitParam.%J.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.1a7: %Self.ref as %J.ref {
-// CHECK:STDOUT:   %F.decl.loc148_30.1: %F.type.123d7a.1 = fn_decl @F.12 [concrete = constants.%F.c7d02d.1] {
+// CHECK:STDOUT:   %F.decl.loc151_30.1: %F.type.123d7a.1 = fn_decl @F.12 [concrete = constants.%F.c7d02d.1] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.831 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc148_16.1: type = splice_block %.loc148_16.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc148_16: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc148_16.2: type = value_of_initializer %bool.make_type.loc148_16 [concrete = bool]
-// CHECK:STDOUT:       %.loc148_16.3: type = converted %bool.make_type.loc148_16, %.loc148_16.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc151_16.1: type = splice_block %.loc151_16.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc151_16: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc151_16.2: type = value_of_initializer %bool.make_type.loc151_16 [concrete = bool]
+// CHECK:STDOUT:       %.loc151_16.3: type = converted %bool.make_type.loc151_16, %.loc151_16.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: bool = bind_name self, %self.param
 // CHECK:STDOUT:     %b.param: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc148_25.1: type = splice_block %.loc148_25.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc148_25: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc148_25.2: type = value_of_initializer %bool.make_type.loc148_25 [concrete = bool]
-// CHECK:STDOUT:       %.loc148_25.3: type = converted %bool.make_type.loc148_25, %.loc148_25.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc151_25.1: type = splice_block %.loc151_25.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc151_25: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc151_25.2: type = value_of_initializer %bool.make_type.loc151_25 [concrete = bool]
+// CHECK:STDOUT:       %.loc151_25.3: type = converted %bool.make_type.loc151_25, %.loc151_25.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc148_30.2: %F.type.123d7a.2 = fn_decl @F.13 [concrete = constants.%F.c7d02d.2] {
+// CHECK:STDOUT:   %F.decl.loc151_30.2: %F.type.123d7a.2 = fn_decl @F.13 [concrete = constants.%F.c7d02d.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -726,12 +729,12 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc148_30.1
+// CHECK:STDOUT:   .F = %F.decl.loc151_30.1
 // CHECK:STDOUT:   witness = @FMissingReturnType.%J.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.f2b: %Self.ref as %J.ref {
-// CHECK:STDOUT:   %F.decl.loc167_38.1: %F.type.6b537d.1 = fn_decl @F.14 [concrete = constants.%F.04313a.1] {
+// CHECK:STDOUT:   %F.decl.loc170_38.1: %F.type.6b537d.1 = fn_decl @F.14 [concrete = constants.%F.04313a.1] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.b90 = binding_pattern b [concrete]
@@ -739,14 +742,14 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %return.patt: %pattern_type.831 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %bool.make_type.loc167_34: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc167_34.1: type = value_of_initializer %bool.make_type.loc167_34 [concrete = bool]
-// CHECK:STDOUT:     %.loc167_34.2: type = converted %bool.make_type.loc167_34, %.loc167_34.1 [concrete = bool]
+// CHECK:STDOUT:     %bool.make_type.loc170_34: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc170_34.1: type = value_of_initializer %bool.make_type.loc170_34 [concrete = bool]
+// CHECK:STDOUT:     %.loc170_34.2: type = converted %bool.make_type.loc170_34, %.loc170_34.1 [concrete = bool]
 // CHECK:STDOUT:     %self.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc167_16.1: type = splice_block %.loc167_16.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc167_16: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc167_16.2: type = value_of_initializer %bool.make_type.loc167_16 [concrete = bool]
-// CHECK:STDOUT:       %.loc167_16.3: type = converted %bool.make_type.loc167_16, %.loc167_16.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc170_16.1: type = splice_block %.loc170_16.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc170_16: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc170_16.2: type = value_of_initializer %bool.make_type.loc170_16 [concrete = bool]
+// CHECK:STDOUT:       %.loc170_16.3: type = converted %bool.make_type.loc170_16, %.loc170_16.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: bool = bind_name self, %self.param
 // CHECK:STDOUT:     %b.param: %FDifferentParamType = value_param call_param1
@@ -755,7 +758,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param2
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc167_38.2: %F.type.6b537d.2 = fn_decl @F.15 [concrete = constants.%F.04313a.2] {
+// CHECK:STDOUT:   %F.decl.loc170_38.2: %F.type.6b537d.2 = fn_decl @F.15 [concrete = constants.%F.04313a.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -772,12 +775,12 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc167_38.1
+// CHECK:STDOUT:   .F = %F.decl.loc170_38.1
 // CHECK:STDOUT:   witness = @FDifferentParamType.%J.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.db4: %Self.ref as %J.ref {
-// CHECK:STDOUT:   %F.decl.loc180_38.1: %F.type.d6232a.1 = fn_decl @F.16 [concrete = constants.%F.886f70.1] {
+// CHECK:STDOUT:   %F.decl.loc183_38.1: %F.type.d6232a.1 = fn_decl @F.16 [concrete = constants.%F.886f70.1] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.9cc = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.9cc = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -785,23 +788,23 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %return.patt: %pattern_type.831 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %bool.make_type.loc180_34: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc180_34.1: type = value_of_initializer %bool.make_type.loc180_34 [concrete = bool]
-// CHECK:STDOUT:     %.loc180_34.2: type = converted %bool.make_type.loc180_34, %.loc180_34.1 [concrete = bool]
+// CHECK:STDOUT:     %bool.make_type.loc183_34: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc183_34.1: type = value_of_initializer %bool.make_type.loc183_34 [concrete = bool]
+// CHECK:STDOUT:     %.loc183_34.2: type = converted %bool.make_type.loc183_34, %.loc183_34.1 [concrete = bool]
 // CHECK:STDOUT:     %self.param: %FDifferentImplicitParamType = value_param call_param0
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentImplicitParamType [concrete = constants.%FDifferentImplicitParamType]
 // CHECK:STDOUT:     %self: %FDifferentImplicitParamType = bind_name self, %self.param
 // CHECK:STDOUT:     %b.param: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc180_25.1: type = splice_block %.loc180_25.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc180_25: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc180_25.2: type = value_of_initializer %bool.make_type.loc180_25 [concrete = bool]
-// CHECK:STDOUT:       %.loc180_25.3: type = converted %bool.make_type.loc180_25, %.loc180_25.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc183_25.1: type = splice_block %.loc183_25.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc183_25: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc183_25.2: type = value_of_initializer %bool.make_type.loc183_25 [concrete = bool]
+// CHECK:STDOUT:       %.loc183_25.3: type = converted %bool.make_type.loc183_25, %.loc183_25.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param2
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc180_38.2: %F.type.d6232a.2 = fn_decl @F.17 [concrete = constants.%F.886f70.2] {
+// CHECK:STDOUT:   %F.decl.loc183_38.2: %F.type.d6232a.2 = fn_decl @F.17 [concrete = constants.%F.886f70.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -818,12 +821,12 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc180_38.1
+// CHECK:STDOUT:   .F = %F.decl.loc183_38.1
 // CHECK:STDOUT:   witness = @FDifferentImplicitParamType.%J.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.fcc: %Self.ref as %J.ref {
-// CHECK:STDOUT:   %F.decl.loc196_38.1: %F.type.d3b58f.1 = fn_decl @F.18 [concrete = constants.%F.be86c9.1] {
+// CHECK:STDOUT:   %F.decl.loc199_38.1: %F.type.d3b58f.1 = fn_decl @F.18 [concrete = constants.%F.be86c9.1] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -833,23 +836,23 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentReturnType [concrete = constants.%FDifferentReturnType]
 // CHECK:STDOUT:     %self.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc196_16.1: type = splice_block %.loc196_16.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc196_16: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc196_16.2: type = value_of_initializer %bool.make_type.loc196_16 [concrete = bool]
-// CHECK:STDOUT:       %.loc196_16.3: type = converted %bool.make_type.loc196_16, %.loc196_16.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc199_16.1: type = splice_block %.loc199_16.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc199_16: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc199_16.2: type = value_of_initializer %bool.make_type.loc199_16 [concrete = bool]
+// CHECK:STDOUT:       %.loc199_16.3: type = converted %bool.make_type.loc199_16, %.loc199_16.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: bool = bind_name self, %self.param
 // CHECK:STDOUT:     %b.param: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc196_25.1: type = splice_block %.loc196_25.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc196_25: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc196_25.2: type = value_of_initializer %bool.make_type.loc196_25 [concrete = bool]
-// CHECK:STDOUT:       %.loc196_25.3: type = converted %bool.make_type.loc196_25, %.loc196_25.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc199_25.1: type = splice_block %.loc199_25.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc199_25: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc199_25.2: type = value_of_initializer %bool.make_type.loc199_25 [concrete = bool]
+// CHECK:STDOUT:       %.loc199_25.3: type = converted %bool.make_type.loc199_25, %.loc199_25.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %FDifferentReturnType = out_param call_param2
 // CHECK:STDOUT:     %return: ref %FDifferentReturnType = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc196_38.2: %F.type.d3b58f.2 = fn_decl @F.19 [concrete = constants.%F.be86c9.2] {
+// CHECK:STDOUT:   %F.decl.loc199_38.2: %F.type.d3b58f.2 = fn_decl @F.19 [concrete = constants.%F.be86c9.2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.831 = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.831 = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
@@ -866,37 +869,37 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = %F.decl.loc196_38.1
+// CHECK:STDOUT:   .F = %F.decl.loc199_38.1
 // CHECK:STDOUT:   witness = @FDifferentReturnType.%J.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.6a5: %Self.ref as %SelfNested.ref {
-// CHECK:STDOUT:   %F.decl.loc219_87.1: %F.type.f90165.1 = fn_decl @F.21 [concrete = constants.%F.fa8d04.1] {
+// CHECK:STDOUT:   %F.decl.loc222_87.1: %F.type.f90165.1 = fn_decl @F.21 [concrete = constants.%F.fa8d04.1] {
 // CHECK:STDOUT:     %x.patt: %pattern_type.714 = binding_pattern x [concrete]
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.714 = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.1f1 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.1f1 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc219_65: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [concrete = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc222_65: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [concrete = constants.%SelfNestedBadParam]
 // CHECK:STDOUT:     %int_4: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
-// CHECK:STDOUT:     %array_type: type = array_type %int_4, %SelfNestedBadParam.ref.loc219_65 [concrete = constants.%array_type.a41]
+// CHECK:STDOUT:     %array_type: type = array_type %int_4, %SelfNestedBadParam.ref.loc222_65 [concrete = constants.%array_type.a41]
 // CHECK:STDOUT:     %x.param: %tuple.type.a7d = value_param call_param0
-// CHECK:STDOUT:     %.loc219_53.1: type = splice_block %.loc219_53.3 [concrete = constants.%tuple.type.a7d] {
-// CHECK:STDOUT:       %SelfNestedBadParam.ref.loc219_14: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [concrete = constants.%SelfNestedBadParam]
-// CHECK:STDOUT:       %ptr: type = ptr_type %SelfNestedBadParam.ref.loc219_14 [concrete = constants.%ptr.4cd]
-// CHECK:STDOUT:       %int_32.loc219_40: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc219_40: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %int_32.loc219_49: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc219_49: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc222_53.1: type = splice_block %.loc222_53.3 [concrete = constants.%tuple.type.a7d] {
+// CHECK:STDOUT:       %SelfNestedBadParam.ref.loc222_14: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [concrete = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:       %ptr: type = ptr_type %SelfNestedBadParam.ref.loc222_14 [concrete = constants.%ptr.4cd]
+// CHECK:STDOUT:       %int_32.loc222_40: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc222_40: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %int_32.loc222_49: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc222_49: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:       %struct_type.x.y: type = struct_type {.x: %i32, .y: %i32} [concrete = constants.%struct_type.x.y.871]
-// CHECK:STDOUT:       %.loc219_53.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
-// CHECK:STDOUT:       %.loc219_53.3: type = converted %.loc219_53.2, constants.%tuple.type.a7d [concrete = constants.%tuple.type.a7d]
+// CHECK:STDOUT:       %.loc222_53.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
+// CHECK:STDOUT:       %.loc222_53.3: type = converted %.loc222_53.2, constants.%tuple.type.a7d [concrete = constants.%tuple.type.a7d]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: %tuple.type.a7d = bind_name x, %x.param
 // CHECK:STDOUT:     %return.param: ref %array_type.a41 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %array_type.a41 = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc219_87.2: %F.type.f90165.2 = fn_decl @F.22 [concrete = constants.%F.fa8d04.2] {
+// CHECK:STDOUT:   %F.decl.loc222_87.2: %F.type.f90165.2 = fn_decl @F.22 [concrete = constants.%F.fa8d04.2] {
 // CHECK:STDOUT:     %x.patt: %pattern_type.a5c = binding_pattern x [concrete]
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.a5c = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.1f1 = return_slot_pattern [concrete]
@@ -910,12 +913,12 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .SelfNestedBadParam = <poisoned>
-// CHECK:STDOUT:   .F = %F.decl.loc219_87.1
+// CHECK:STDOUT:   .F = %F.decl.loc222_87.1
 // CHECK:STDOUT:   witness = @SelfNestedBadParam.%SelfNested.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.bfc: %Self.ref as %SelfNested.ref {
-// CHECK:STDOUT:   %F.decl.loc235_112.1: %F.type.0e7d1d.1 = fn_decl @F.23 [concrete = constants.%F.0bc78a.1] {
+// CHECK:STDOUT:   %F.decl.loc238_112.1: %F.type.0e7d1d.1 = fn_decl @F.23 [concrete = constants.%F.0bc78a.1] {
 // CHECK:STDOUT:     %x.patt: %pattern_type.23f = binding_pattern x [concrete]
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.23f = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.1f1 = return_slot_pattern [concrete]
@@ -925,21 +928,21 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %int_4: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
 // CHECK:STDOUT:     %array_type: type = array_type %int_4, %SelfNestedBadParam.ref [concrete = constants.%array_type.a41]
 // CHECK:STDOUT:     %x.param: %tuple.type.eb9 = value_param call_param0
-// CHECK:STDOUT:     %.loc235_78.1: type = splice_block %.loc235_78.3 [concrete = constants.%tuple.type.eb9] {
-// CHECK:STDOUT:       %SelfNestedBadReturnType.ref.loc235_14: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [concrete = constants.%SelfNestedBadReturnType]
-// CHECK:STDOUT:       %ptr: type = ptr_type %SelfNestedBadReturnType.ref.loc235_14 [concrete = constants.%ptr.612]
-// CHECK:STDOUT:       %SelfNestedBadReturnType.ref.loc235_45: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [concrete = constants.%SelfNestedBadReturnType]
+// CHECK:STDOUT:     %.loc238_78.1: type = splice_block %.loc238_78.3 [concrete = constants.%tuple.type.eb9] {
+// CHECK:STDOUT:       %SelfNestedBadReturnType.ref.loc238_14: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [concrete = constants.%SelfNestedBadReturnType]
+// CHECK:STDOUT:       %ptr: type = ptr_type %SelfNestedBadReturnType.ref.loc238_14 [concrete = constants.%ptr.612]
+// CHECK:STDOUT:       %SelfNestedBadReturnType.ref.loc238_45: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [concrete = constants.%SelfNestedBadReturnType]
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:       %struct_type.x.y: type = struct_type {.x: %SelfNestedBadReturnType, .y: %i32} [concrete = constants.%struct_type.x.y.ac5]
-// CHECK:STDOUT:       %.loc235_78.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
-// CHECK:STDOUT:       %.loc235_78.3: type = converted %.loc235_78.2, constants.%tuple.type.eb9 [concrete = constants.%tuple.type.eb9]
+// CHECK:STDOUT:       %.loc238_78.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
+// CHECK:STDOUT:       %.loc238_78.3: type = converted %.loc238_78.2, constants.%tuple.type.eb9 [concrete = constants.%tuple.type.eb9]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: %tuple.type.eb9 = bind_name x, %x.param
 // CHECK:STDOUT:     %return.param: ref %array_type.a41 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %array_type.a41 = return_slot %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc235_112.2: %F.type.0e7d1d.2 = fn_decl @F.24 [concrete = constants.%F.0bc78a.2] {
+// CHECK:STDOUT:   %F.decl.loc238_112.2: %F.type.0e7d1d.2 = fn_decl @F.24 [concrete = constants.%F.0bc78a.2] {
 // CHECK:STDOUT:     %x.patt: %pattern_type.23f = binding_pattern x [concrete]
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.23f = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.f56 = return_slot_pattern [concrete]
@@ -954,7 +957,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .SelfNestedBadReturnType = <poisoned>
 // CHECK:STDOUT:   .SelfNestedBadParam = <poisoned>
-// CHECK:STDOUT:   .F = %F.decl.loc235_112.1
+// CHECK:STDOUT:   .F = %F.decl.loc238_112.1
 // CHECK:STDOUT:   witness = @SelfNestedBadReturnType.%SelfNested.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1014,7 +1017,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FExtraParam [concrete = constants.%FExtraParam]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (@impl.ddd.%F.decl.loc65_18.2), @impl.ddd [concrete]
+// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (@impl.ddd.%F.decl.loc68_18.2), @impl.ddd [concrete]
 // CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness.1f3]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1030,7 +1033,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FExtraImplicitParam [concrete = constants.%FExtraImplicitParam]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (@impl.698.%F.decl.loc81_23.2), @impl.698 [concrete]
+// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (@impl.698.%F.decl.loc84_23.2), @impl.698 [concrete]
 // CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness.a7b]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1062,7 +1065,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FMissingParam [concrete = constants.%FMissingParam]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.5cf.%F.decl.loc113_31.2), @impl.5cf [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.5cf.%F.decl.loc116_31.2), @impl.5cf [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness.4e9]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1078,7 +1081,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FMissingImplicitParam [concrete = constants.%FMissingImplicitParam]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.bac.%F.decl.loc126_26.2), @impl.bac [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.bac.%F.decl.loc129_26.2), @impl.bac [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness.841]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1094,7 +1097,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FMissingReturnType [concrete = constants.%FMissingReturnType]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.1a7.%F.decl.loc148_30.2), @impl.1a7 [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.1a7.%F.decl.loc151_30.2), @impl.1a7 [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness.e75]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1110,7 +1113,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentParamType [concrete = constants.%FDifferentParamType]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.f2b.%F.decl.loc167_38.2), @impl.f2b [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.f2b.%F.decl.loc170_38.2), @impl.f2b [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness.cbe]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1126,7 +1129,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentImplicitParamType [concrete = constants.%FDifferentImplicitParamType]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.db4.%F.decl.loc180_38.2), @impl.db4 [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.db4.%F.decl.loc183_38.2), @impl.db4 [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness.af2]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1142,7 +1145,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentReturnType [concrete = constants.%FDifferentReturnType]
 // CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.fcc.%F.decl.loc196_38.2), @impl.fcc [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (@impl.fcc.%F.decl.loc199_38.2), @impl.fcc [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness.bc1]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1158,7 +1161,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%SelfNestedBadParam [concrete = constants.%SelfNestedBadParam]
 // CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, file.%SelfNested.decl [concrete = constants.%SelfNested.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %SelfNested.impl_witness_table = impl_witness_table (@impl.6a5.%F.decl.loc219_87.2), @impl.6a5 [concrete]
+// CHECK:STDOUT:   %SelfNested.impl_witness_table = impl_witness_table (@impl.6a5.%F.decl.loc222_87.2), @impl.6a5 [concrete]
 // CHECK:STDOUT:   %SelfNested.impl_witness: <witness> = impl_witness %SelfNested.impl_witness_table [concrete = constants.%SelfNested.impl_witness.e31]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1175,7 +1178,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%SelfNestedBadReturnType [concrete = constants.%SelfNestedBadReturnType]
 // CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, file.%SelfNested.decl [concrete = constants.%SelfNested.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %SelfNested.impl_witness_table = impl_witness_table (@impl.bfc.%F.decl.loc235_112.2), @impl.bfc [concrete]
+// CHECK:STDOUT:   %SelfNested.impl_witness_table = impl_witness_table (@impl.bfc.%F.decl.loc238_112.2), @impl.bfc [concrete]
 // CHECK:STDOUT:   %SelfNested.impl_witness: <witness> = impl_witness %SelfNested.impl_witness_table [concrete = constants.%SelfNested.impl_witness.d5e]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]
@@ -1205,7 +1208,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.5() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call @impl.698.%F.decl.loc81_23.1(<error>)
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call @impl.698.%F.decl.loc84_23.1(<error>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1220,7 +1223,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.9(%self.param: bool, %b.param: bool) -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: bool = name_ref self, %self.param
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.5cf.%F.decl.loc113_31.1
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.5cf.%F.decl.loc116_31.1
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b.param
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -1231,10 +1234,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: bool = name_ref self, %self.param
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b.param
-// CHECK:STDOUT:   %F.call: init bool = call @impl.bac.%F.decl.loc126_26.1(%b.ref)
-// CHECK:STDOUT:   %.loc126_26.1: bool = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc126_26.2: bool = converted %F.call, %.loc126_26.1
-// CHECK:STDOUT:   return %.loc126_26.2
+// CHECK:STDOUT:   %F.call: init bool = call @impl.bac.%F.decl.loc129_26.1(%b.ref)
+// CHECK:STDOUT:   %.loc129_26.1: bool = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc129_26.2: bool = converted %F.call, %.loc129_26.1
+// CHECK:STDOUT:   return %.loc129_26.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.12(%self.param: bool, %b.param: bool);
@@ -1242,10 +1245,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.13(%self.param: bool, %b.param: bool) -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: bool = name_ref self, %self.param
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.1a7.%F.decl.loc148_30.1
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.1a7.%F.decl.loc151_30.1
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b.param
 // CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.bound(%self.ref, %b.ref)
-// CHECK:STDOUT:   %.loc148: bool = converted %F.call, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc151: bool = converted %F.call, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1254,13 +1257,13 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.15(%self.param: bool, %b.param: bool) -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: bool = name_ref self, %self.param
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.f2b.%F.decl.loc167_38.1
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.f2b.%F.decl.loc170_38.1
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b.param
-// CHECK:STDOUT:   %.loc99: %FDifferentParamType = converted %b.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc102: %FDifferentParamType = converted %b.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   %F.call: init bool = call %F.bound(%self.ref, <error>)
-// CHECK:STDOUT:   %.loc167_38.1: bool = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc167_38.2: bool = converted %F.call, %.loc167_38.1
-// CHECK:STDOUT:   return %.loc167_38.2
+// CHECK:STDOUT:   %.loc170_38.1: bool = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc170_38.2: bool = converted %F.call, %.loc170_38.1
+// CHECK:STDOUT:   return %.loc170_38.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.16(%self.param: %FDifferentImplicitParamType, %b.param: bool) -> bool;
@@ -1268,13 +1271,13 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.17(%self.param: bool, %b.param: bool) -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: bool = name_ref self, %self.param
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.db4.%F.decl.loc180_38.1
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.db4.%F.decl.loc183_38.1
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b.param
-// CHECK:STDOUT:   %.loc99: %FDifferentImplicitParamType = converted %self.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc102: %FDifferentImplicitParamType = converted %self.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   %F.call: init bool = call %F.bound(<error>, %b.ref)
-// CHECK:STDOUT:   %.loc180_38.1: bool = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc180_38.2: bool = converted %F.call, %.loc180_38.1
-// CHECK:STDOUT:   return %.loc180_38.2
+// CHECK:STDOUT:   %.loc183_38.1: bool = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc183_38.2: bool = converted %F.call, %.loc183_38.1
+// CHECK:STDOUT:   return %.loc183_38.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.18(%self.param: bool, %b.param: bool) -> %return.param: %FDifferentReturnType;
@@ -1282,25 +1285,25 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.19(%self.param: bool, %b.param: bool) -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: bool = name_ref self, %self.param
-// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.fcc.%F.decl.loc196_38.1
+// CHECK:STDOUT:   %F.bound: <bound method> = bound_method %self.ref, @impl.fcc.%F.decl.loc199_38.1
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b.param
-// CHECK:STDOUT:   %.loc196_38.1: ref %FDifferentReturnType = temporary_storage
-// CHECK:STDOUT:   %F.call: init %FDifferentReturnType = call %F.bound(%self.ref, %b.ref) to %.loc196_38.1
-// CHECK:STDOUT:   %.loc196_38.2: bool = converted %F.call, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc199_38.1: ref %FDifferentReturnType = temporary_storage
+// CHECK:STDOUT:   %F.call: init %FDifferentReturnType = call %F.bound(%self.ref, %b.ref) to %.loc199_38.1
+// CHECK:STDOUT:   %.loc199_38.2: bool = converted %F.call, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F.20(@SelfNested.%Self: %SelfNested.type) {
 // CHECK:STDOUT:   %Self: %SelfNested.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.2ff)]
-// CHECK:STDOUT:   %Self.as_type.loc207_16.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc207_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:   %ptr.loc207_16.1: type = ptr_type %Self.as_type.loc207_16.1 [symbolic = %ptr.loc207_16.1 (constants.%ptr.e87)]
-// CHECK:STDOUT:   %struct_type.x.y.loc207_37.1: type = struct_type {.x: @F.20.%Self.as_type.loc207_16.1 (%Self.as_type.e1e), .y: %i32} [symbolic = %struct_type.x.y.loc207_37.1 (constants.%struct_type.x.y.81e)]
-// CHECK:STDOUT:   %tuple.type: type = tuple_type (%ptr.loc207_16.1, %struct_type.x.y.loc207_37.1) [symbolic = %tuple.type (constants.%tuple.type.229)]
-// CHECK:STDOUT:   %pattern_type.loc207_8: type = pattern_type %tuple.type [symbolic = %pattern_type.loc207_8 (constants.%pattern_type.ced)]
-// CHECK:STDOUT:   %array_type.loc207_57.1: type = array_type constants.%int_4, %Self.as_type.loc207_16.1 [symbolic = %array_type.loc207_57.1 (constants.%array_type.873)]
-// CHECK:STDOUT:   %pattern_type.loc207_41: type = pattern_type %array_type.loc207_57.1 [symbolic = %pattern_type.loc207_41 (constants.%pattern_type.c7e)]
+// CHECK:STDOUT:   %Self.as_type.loc210_16.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc210_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:   %ptr.loc210_16.1: type = ptr_type %Self.as_type.loc210_16.1 [symbolic = %ptr.loc210_16.1 (constants.%ptr.e87)]
+// CHECK:STDOUT:   %struct_type.x.y.loc210_37.1: type = struct_type {.x: @F.20.%Self.as_type.loc210_16.1 (%Self.as_type.e1e), .y: %i32} [symbolic = %struct_type.x.y.loc210_37.1 (constants.%struct_type.x.y.81e)]
+// CHECK:STDOUT:   %tuple.type: type = tuple_type (%ptr.loc210_16.1, %struct_type.x.y.loc210_37.1) [symbolic = %tuple.type (constants.%tuple.type.229)]
+// CHECK:STDOUT:   %pattern_type.loc210_8: type = pattern_type %tuple.type [symbolic = %pattern_type.loc210_8 (constants.%pattern_type.ced)]
+// CHECK:STDOUT:   %array_type.loc210_57.1: type = array_type constants.%int_4, %Self.as_type.loc210_16.1 [symbolic = %array_type.loc210_57.1 (constants.%array_type.873)]
+// CHECK:STDOUT:   %pattern_type.loc210_41: type = pattern_type %array_type.loc210_57.1 [symbolic = %pattern_type.loc210_41 (constants.%pattern_type.c7e)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%x.param: @F.20.%tuple.type (%tuple.type.229)) -> @F.20.%array_type.loc207_57.1 (%array_type.873);
+// CHECK:STDOUT:   fn(%x.param: @F.20.%tuple.type (%tuple.type.229)) -> @F.20.%array_type.loc210_57.1 (%array_type.873);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.21(%x.param: %tuple.type.a7d) -> %return.param: %array_type.a41;
@@ -1308,12 +1311,12 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.22(%x.param: %tuple.type.9c9) -> %return.param: %array_type.a41 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.ref: %tuple.type.9c9 = name_ref x, %x.param
-// CHECK:STDOUT:   %.loc207_41: ref %array_type.a41 = splice_block %return {}
+// CHECK:STDOUT:   %.loc210_41: ref %array_type.a41 = splice_block %return {}
 // CHECK:STDOUT:   %tuple.elem0: %ptr.4cd = tuple_access %x.ref, element0
 // CHECK:STDOUT:   %tuple.elem1: %struct_type.x.y.a89 = tuple_access %x.ref, element1
-// CHECK:STDOUT:   %.loc207_9.1: %SelfNestedBadParam = struct_access %tuple.elem1, element0
-// CHECK:STDOUT:   %.loc207_9.2: %i32 = converted %.loc207_9.1, <error> [concrete = <error>]
-// CHECK:STDOUT:   %F.call: init %array_type.a41 = call @impl.6a5.%F.decl.loc219_87.1(<error>) to %.loc207_41
+// CHECK:STDOUT:   %.loc210_9.1: %SelfNestedBadParam = struct_access %tuple.elem1, element0
+// CHECK:STDOUT:   %.loc210_9.2: %i32 = converted %.loc210_9.1, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F.call: init %array_type.a41 = call @impl.6a5.%F.decl.loc222_87.1(<error>) to %.loc210_41
 // CHECK:STDOUT:   return %F.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1322,9 +1325,9 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: fn @F.24(%x.param: %tuple.type.eb9) -> %return.param: %array_type.126 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.ref: %tuple.type.eb9 = name_ref x, %x.param
-// CHECK:STDOUT:   %.loc235_112.1: ref %array_type.a41 = temporary_storage
-// CHECK:STDOUT:   %F.call: init %array_type.a41 = call @impl.bfc.%F.decl.loc235_112.1(%x.ref) to %.loc235_112.1
-// CHECK:STDOUT:   %.loc235_112.2: %array_type.126 = converted %F.call, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc238_112.1: ref %array_type.a41 = temporary_storage
+// CHECK:STDOUT:   %F.call: init %array_type.a41 = call @impl.bfc.%F.decl.loc238_112.1(%x.ref) to %.loc238_112.1
+// CHECK:STDOUT:   %.loc238_112.2: %array_type.126 = converted %F.call, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error> to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1352,34 +1355,34 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.20(constants.%Self.2ff) {
 // CHECK:STDOUT:   %Self => constants.%Self.2ff
-// CHECK:STDOUT:   %Self.as_type.loc207_16.1 => constants.%Self.as_type.e1e
-// CHECK:STDOUT:   %ptr.loc207_16.1 => constants.%ptr.e87
-// CHECK:STDOUT:   %struct_type.x.y.loc207_37.1 => constants.%struct_type.x.y.81e
+// CHECK:STDOUT:   %Self.as_type.loc210_16.1 => constants.%Self.as_type.e1e
+// CHECK:STDOUT:   %ptr.loc210_16.1 => constants.%ptr.e87
+// CHECK:STDOUT:   %struct_type.x.y.loc210_37.1 => constants.%struct_type.x.y.81e
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.229
-// CHECK:STDOUT:   %pattern_type.loc207_8 => constants.%pattern_type.ced
-// CHECK:STDOUT:   %array_type.loc207_57.1 => constants.%array_type.873
-// CHECK:STDOUT:   %pattern_type.loc207_41 => constants.%pattern_type.c7e
+// CHECK:STDOUT:   %pattern_type.loc210_8 => constants.%pattern_type.ced
+// CHECK:STDOUT:   %array_type.loc210_57.1 => constants.%array_type.873
+// CHECK:STDOUT:   %pattern_type.loc210_41 => constants.%pattern_type.c7e
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.20(constants.%SelfNested.facet.608) {
 // CHECK:STDOUT:   %Self => constants.%SelfNested.facet.608
-// CHECK:STDOUT:   %Self.as_type.loc207_16.1 => constants.%SelfNestedBadParam
-// CHECK:STDOUT:   %ptr.loc207_16.1 => constants.%ptr.4cd
-// CHECK:STDOUT:   %struct_type.x.y.loc207_37.1 => constants.%struct_type.x.y.a89
+// CHECK:STDOUT:   %Self.as_type.loc210_16.1 => constants.%SelfNestedBadParam
+// CHECK:STDOUT:   %ptr.loc210_16.1 => constants.%ptr.4cd
+// CHECK:STDOUT:   %struct_type.x.y.loc210_37.1 => constants.%struct_type.x.y.a89
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.9c9
-// CHECK:STDOUT:   %pattern_type.loc207_8 => constants.%pattern_type.a5c
-// CHECK:STDOUT:   %array_type.loc207_57.1 => constants.%array_type.a41
-// CHECK:STDOUT:   %pattern_type.loc207_41 => constants.%pattern_type.1f1
+// CHECK:STDOUT:   %pattern_type.loc210_8 => constants.%pattern_type.a5c
+// CHECK:STDOUT:   %array_type.loc210_57.1 => constants.%array_type.a41
+// CHECK:STDOUT:   %pattern_type.loc210_41 => constants.%pattern_type.1f1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.20(constants.%SelfNested.facet.766) {
 // CHECK:STDOUT:   %Self => constants.%SelfNested.facet.766
-// CHECK:STDOUT:   %Self.as_type.loc207_16.1 => constants.%SelfNestedBadReturnType
-// CHECK:STDOUT:   %ptr.loc207_16.1 => constants.%ptr.612
-// CHECK:STDOUT:   %struct_type.x.y.loc207_37.1 => constants.%struct_type.x.y.ac5
+// CHECK:STDOUT:   %Self.as_type.loc210_16.1 => constants.%SelfNestedBadReturnType
+// CHECK:STDOUT:   %ptr.loc210_16.1 => constants.%ptr.612
+// CHECK:STDOUT:   %struct_type.x.y.loc210_37.1 => constants.%struct_type.x.y.ac5
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.eb9
-// CHECK:STDOUT:   %pattern_type.loc207_8 => constants.%pattern_type.23f
-// CHECK:STDOUT:   %array_type.loc207_57.1 => constants.%array_type.126
-// CHECK:STDOUT:   %pattern_type.loc207_41 => constants.%pattern_type.f56
+// CHECK:STDOUT:   %pattern_type.loc210_8 => constants.%pattern_type.23f
+// CHECK:STDOUT:   %array_type.loc210_57.1 => constants.%array_type.126
+// CHECK:STDOUT:   %pattern_type.loc210_41 => constants.%pattern_type.f56
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_interface.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_impl_bad_interface.carbon

--- a/toolchain/check/testdata/impl/fail_redefinition.carbon
+++ b/toolchain/check/testdata/impl/fail_redefinition.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_redefinition.carbon

--- a/toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
+++ b/toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/fail_self_type_mismatch.carbon
@@ -63,7 +66,7 @@ impl i32 as I {
 // CHECK:STDOUT:   %assoc0.82e: %I.assoc_type = assoc_entity element0, @I.%F.decl [concrete]
 // CHECK:STDOUT:   %Bool.type: type = fn_type @Bool [concrete]
 // CHECK:STDOUT:   %Bool: %Bool.type = struct_value () [concrete]
-// CHECK:STDOUT:   %I.impl_witness.c21: <witness> = impl_witness file.%I.impl_witness_table.loc24 [concrete]
+// CHECK:STDOUT:   %I.impl_witness.c21: <witness> = impl_witness file.%I.impl_witness_table.loc27 [concrete]
 // CHECK:STDOUT:   %I.facet.e8a: %I.type = facet_value bool, (%I.impl_witness.c21) [concrete]
 // CHECK:STDOUT:   %C.7db: type = class_type @C, @C(%I.type, %I.facet.e8a) [concrete]
 // CHECK:STDOUT:   %pattern_type.225: type = pattern_type %C.7db [concrete]
@@ -73,7 +76,7 @@ impl i32 as I {
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
 // CHECK:STDOUT:   %Int.generic: %Int.type = struct_value () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
-// CHECK:STDOUT:   %I.impl_witness.863: <witness> = impl_witness file.%I.impl_witness_table.loc31 [concrete]
+// CHECK:STDOUT:   %I.impl_witness.863: <witness> = impl_witness file.%I.impl_witness_table.loc34 [concrete]
 // CHECK:STDOUT:   %C.6fb: type = class_type @C, @C(type, %i32) [concrete]
 // CHECK:STDOUT:   %pattern_type.52b: type = pattern_type %C.6fb [concrete]
 // CHECK:STDOUT:   %F.type.066a53.1: type = fn_type @F.3 [concrete]
@@ -111,26 +114,26 @@ impl i32 as I {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:     %X.patt: @C.%pattern_type (%pattern_type.7dcd0a.1) = symbolic_binding_pattern X, 1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc11_9.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_9.2 (constants.%T)]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_9.1 [symbolic = %T.loc11_9.2 (constants.%T)]
-// CHECK:STDOUT:     %X.loc11_19.1: @C.%T.loc11_9.2 (%T) = bind_symbolic_name X, 1 [symbolic = %X.loc11_19.2 (constants.%X)]
+// CHECK:STDOUT:     %T.loc14_9.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_9.2 (constants.%T)]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc14_9.1 [symbolic = %T.loc14_9.2 (constants.%T)]
+// CHECK:STDOUT:     %X.loc14_19.1: @C.%T.loc14_9.2 (%T) = bind_symbolic_name X, 1 [symbolic = %X.loc14_19.2 (constants.%X)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.049 [concrete] {} {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc24_6.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc24_6.2: type = converted %bool.make_type, %.loc24_6.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc27_6.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc27_6.2: type = converted %bool.make_type, %.loc27_6.1 [concrete = bool]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.impl_witness_table.loc24 = impl_witness_table (@impl.049.%F.decl), @impl.049 [concrete]
-// CHECK:STDOUT:   %I.impl_witness.loc24: <witness> = impl_witness %I.impl_witness_table.loc24 [concrete = constants.%I.impl_witness.c21]
+// CHECK:STDOUT:   %I.impl_witness_table.loc27 = impl_witness_table (@impl.049.%F.decl), @impl.049 [concrete]
+// CHECK:STDOUT:   %I.impl_witness.loc27: <witness> = impl_witness %I.impl_witness_table.loc27 [concrete = constants.%I.impl_witness.c21]
 // CHECK:STDOUT:   impl_decl @impl.a9a [concrete] {} {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %I.impl_witness_table.loc31 = impl_witness_table (@impl.a9a.%F.decl.loc39_18.2), @impl.a9a [concrete]
-// CHECK:STDOUT:   %I.impl_witness.loc31: <witness> = impl_witness %I.impl_witness_table.loc31 [concrete = constants.%I.impl_witness.863]
+// CHECK:STDOUT:   %I.impl_witness_table.loc34 = impl_witness_table (@impl.a9a.%F.decl.loc42_18.2), @impl.a9a [concrete]
+// CHECK:STDOUT:   %I.impl_witness.loc34: <witness> = impl_witness %I.impl_witness_table.loc34 [concrete = constants.%I.impl_witness.863]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
@@ -139,13 +142,13 @@ impl i32 as I {
 // CHECK:STDOUT:     %c.patt: @F.1.%pattern_type (%pattern_type.4fb) = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.param_patt: @F.1.%pattern_type (%pattern_type.4fb) = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %c.param: @F.1.%C.loc21_17.1 (%C.dbb) = value_param call_param0
-// CHECK:STDOUT:     %.loc21: type = splice_block %C.loc21_17.2 [symbolic = %C.loc21_17.1 (constants.%C.dbb)] {
+// CHECK:STDOUT:     %c.param: @F.1.%C.loc24_17.1 (%C.dbb) = value_param call_param0
+// CHECK:STDOUT:     %.loc24: type = splice_block %C.loc24_17.2 [symbolic = %C.loc24_17.1 (constants.%C.dbb)] {
 // CHECK:STDOUT:       %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
 // CHECK:STDOUT:       %Self.ref: %I.type = name_ref Self, @I.%Self [symbolic = %Self (constants.%Self.826)]
-// CHECK:STDOUT:       %C.loc21_17.2: type = class_type @C, @C(constants.%I.type, constants.%Self.826) [symbolic = %C.loc21_17.1 (constants.%C.dbb)]
+// CHECK:STDOUT:       %C.loc24_17.2: type = class_type @C, @C(constants.%I.type, constants.%Self.826) [symbolic = %C.loc24_17.1 (constants.%C.dbb)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %c: @F.1.%C.loc21_17.1 (%C.dbb) = bind_name c, %c.param
+// CHECK:STDOUT:     %c: @F.1.%C.loc24_17.1 (%C.dbb) = bind_name c, %c.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %I.assoc_type = assoc_entity element0, %F.decl [concrete = constants.%assoc0.82e]
 // CHECK:STDOUT:
@@ -156,18 +159,18 @@ impl i32 as I {
 // CHECK:STDOUT:   witness = (%F.decl)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl.049: %.loc24_6.2 as %I.ref {
+// CHECK:STDOUT: impl @impl.049: %.loc27_6.2 as %I.ref {
 // CHECK:STDOUT:   %F.decl: %F.type.8ba = fn_decl @F.2 [concrete = constants.%F.2cf] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.225 = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.param_patt: %pattern_type.225 = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %C.7db = value_param call_param0
-// CHECK:STDOUT:     %.loc28_22: type = splice_block %C [concrete = constants.%C.7db] {
+// CHECK:STDOUT:     %.loc31_22: type = splice_block %C [concrete = constants.%C.7db] {
 // CHECK:STDOUT:       %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [concrete = bool]
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:       %I.facet: %I.type = facet_value bool, (constants.%I.impl_witness.c21) [concrete = constants.%I.facet.e8a]
-// CHECK:STDOUT:       %.loc28_18: %I.type = converted %bool.make_type, %I.facet [concrete = constants.%I.facet.e8a]
+// CHECK:STDOUT:       %.loc31_18: %I.type = converted %bool.make_type, %I.facet [concrete = constants.%I.facet.e8a]
 // CHECK:STDOUT:       %C: type = class_type @C, @C(constants.%I.type, constants.%I.facet.e8a) [concrete = constants.%C.7db]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %C.7db = bind_name c, %c.param
@@ -177,16 +180,16 @@ impl i32 as I {
 // CHECK:STDOUT:   .C = <poisoned>
 // CHECK:STDOUT:   .I = <poisoned>
 // CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   witness = file.%I.impl_witness.loc24
+// CHECK:STDOUT:   witness = file.%I.impl_witness.loc27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.a9a: %i32 as %I.ref {
-// CHECK:STDOUT:   %F.decl.loc39_18.1: %F.type.066a53.1 = fn_decl @F.3 [concrete = constants.%F.9ec58f.1] {
+// CHECK:STDOUT:   %F.decl.loc42_18.1: %F.type.066a53.1 = fn_decl @F.3 [concrete = constants.%F.9ec58f.1] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.52b = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.param_patt: %pattern_type.52b = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %C.6fb = value_param call_param0
-// CHECK:STDOUT:     %.loc39: type = splice_block %C [concrete = constants.%C.6fb] {
+// CHECK:STDOUT:     %.loc42: type = splice_block %C [concrete = constants.%C.6fb] {
 // CHECK:STDOUT:       %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
@@ -194,7 +197,7 @@ impl i32 as I {
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: %C.6fb = bind_name c, %c.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.decl.loc39_18.2: %F.type.066a53.2 = fn_decl @F.4 [concrete = constants.%F.9ec58f.2] {
+// CHECK:STDOUT:   %F.decl.loc42_18.2: %F.type.066a53.2 = fn_decl @F.4 [concrete = constants.%F.9ec58f.2] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.c65 = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.param_patt: %pattern_type.c65 = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
@@ -204,14 +207,14 @@ impl i32 as I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .C = <poisoned>
-// CHECK:STDOUT:   .F = %F.decl.loc39_18.1
-// CHECK:STDOUT:   witness = file.%I.impl_witness.loc31
+// CHECK:STDOUT:   .F = %F.decl.loc42_18.1
+// CHECK:STDOUT:   witness = file.%I.impl_witness.loc34
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic class @C(%T.loc11_9.1: type, %X.loc11_19.1: @C.%T.loc11_9.2 (%T)) {
-// CHECK:STDOUT:   %T.loc11_9.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc11_9.2 (constants.%T)]
-// CHECK:STDOUT:   %X.loc11_19.2: @C.%T.loc11_9.2 (%T) = bind_symbolic_name X, 1 [symbolic = %X.loc11_19.2 (constants.%X)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc11_9.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
+// CHECK:STDOUT: generic class @C(%T.loc14_9.1: type, %X.loc14_19.1: @C.%T.loc14_9.2 (%T)) {
+// CHECK:STDOUT:   %T.loc14_9.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc14_9.2 (constants.%T)]
+// CHECK:STDOUT:   %X.loc14_19.2: @C.%T.loc14_9.2 (%T) = bind_symbolic_name X, 1 [symbolic = %X.loc14_19.2 (constants.%X)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc14_9.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -227,10 +230,10 @@ impl i32 as I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F.1(@I.%Self: %I.type) {
 // CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.826)]
-// CHECK:STDOUT:   %C.loc21_17.1: type = class_type @C, @C(constants.%I.type, %Self) [symbolic = %C.loc21_17.1 (constants.%C.dbb)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %C.loc21_17.1 [symbolic = %pattern_type (constants.%pattern_type.4fb)]
+// CHECK:STDOUT:   %C.loc24_17.1: type = class_type @C, @C(constants.%I.type, %Self) [symbolic = %C.loc24_17.1 (constants.%C.dbb)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %C.loc24_17.1 [symbolic = %pattern_type (constants.%pattern_type.4fb)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%c.param: @F.1.%C.loc21_17.1 (%C.dbb));
+// CHECK:STDOUT:   fn(%c.param: @F.1.%C.loc24_17.1 (%C.dbb));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%c.param: %C.7db);
@@ -240,44 +243,44 @@ impl i32 as I {
 // CHECK:STDOUT: fn @F.4(%c.param: %C.d88) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: %C.d88 = name_ref c, %c.param
-// CHECK:STDOUT:   %.loc21: %C.6fb = converted %c.ref, <error> [concrete = <error>]
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call @impl.a9a.%F.decl.loc39_18.1(<error>)
+// CHECK:STDOUT:   %.loc24: %C.6fb = converted %c.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call @impl.a9a.%F.decl.loc42_18.1(<error>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%T, constants.%X) {
-// CHECK:STDOUT:   %T.loc11_9.2 => constants.%T
-// CHECK:STDOUT:   %X.loc11_19.2 => constants.%X
+// CHECK:STDOUT:   %T.loc14_9.2 => constants.%T
+// CHECK:STDOUT:   %X.loc14_19.2 => constants.%X
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%I.type, constants.%Self.826) {
-// CHECK:STDOUT:   %T.loc11_9.2 => constants.%I.type
-// CHECK:STDOUT:   %X.loc11_19.2 => constants.%Self.826
+// CHECK:STDOUT:   %T.loc14_9.2 => constants.%I.type
+// CHECK:STDOUT:   %X.loc14_19.2 => constants.%Self.826
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2b5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Self.826) {
 // CHECK:STDOUT:   %Self => constants.%Self.826
-// CHECK:STDOUT:   %C.loc21_17.1 => constants.%C.dbb
+// CHECK:STDOUT:   %C.loc24_17.1 => constants.%C.dbb
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.4fb
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%I.type, constants.%I.facet.e8a) {
-// CHECK:STDOUT:   %T.loc11_9.2 => constants.%I.type
-// CHECK:STDOUT:   %X.loc11_19.2 => constants.%I.facet.e8a
+// CHECK:STDOUT:   %T.loc14_9.2 => constants.%I.type
+// CHECK:STDOUT:   %X.loc14_19.2 => constants.%I.facet.e8a
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2b5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%I.facet.e8a) {
 // CHECK:STDOUT:   %Self => constants.%I.facet.e8a
-// CHECK:STDOUT:   %C.loc21_17.1 => constants.%C.7db
+// CHECK:STDOUT:   %C.loc24_17.1 => constants.%C.7db
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.225
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(type, constants.%i32) {
-// CHECK:STDOUT:   %T.loc11_9.2 => type
-// CHECK:STDOUT:   %X.loc11_19.2 => constants.%i32
+// CHECK:STDOUT:   %T.loc14_9.2 => type
+// CHECK:STDOUT:   %X.loc14_19.2 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.98f
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
@@ -285,13 +288,13 @@ impl i32 as I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%I.facet.118) {
 // CHECK:STDOUT:   %Self => constants.%I.facet.118
-// CHECK:STDOUT:   %C.loc21_17.1 => constants.%C.d88
+// CHECK:STDOUT:   %C.loc24_17.1 => constants.%C.d88
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.c65
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C(constants.%I.type, constants.%I.facet.118) {
-// CHECK:STDOUT:   %T.loc11_9.2 => constants.%I.type
-// CHECK:STDOUT:   %X.loc11_19.2 => constants.%I.facet.118
+// CHECK:STDOUT:   %T.loc14_9.2 => constants.%I.type
+// CHECK:STDOUT:   %X.loc14_19.2 => constants.%I.facet.118
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2b5
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/impl_as.carbon
@@ -107,10 +110,10 @@ class C {
 // CHECK:STDOUT:     %c.var_patt: %pattern_type = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref %C = var %c.var_patt
-// CHECK:STDOUT:   %.loc19_19.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_19.2: init %C = class_init (), %c.var [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_7: init %C = converted %.loc19_19.1, %.loc19_19.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   assign %c.var, %.loc19_7
+// CHECK:STDOUT:   %.loc22_19.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_19.2: init %C = class_init (), %c.var [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_7: init %C = converted %.loc22_19.1, %.loc22_19.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   assign %c.var, %.loc22_7
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/impl/impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/impl_assoc_const.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/impl_assoc_const.carbon

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/impl_forall.carbon
@@ -50,9 +53,9 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   impl_decl @impl [concrete] {
 // CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc15_14.1 [symbolic = %T.loc15_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc18_14.1 [symbolic = %T.loc18_14.2 (constants.%T)]
 // CHECK:STDOUT:     %Simple.ref: type = name_ref Simple, file.%Simple.decl [concrete = constants.%Simple.type]
-// CHECK:STDOUT:     %T.loc15_14.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc15_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc18_14.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc18_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Simple.impl_witness_table = impl_witness_table (@impl.%F.decl), @impl [concrete]
 // CHECK:STDOUT:   %Simple.impl_witness: <witness> = impl_witness %Simple.impl_witness_table, @impl(constants.%T) [symbolic = @impl.%Simple.impl_witness (constants.%Simple.impl_witness)]
@@ -69,12 +72,12 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   witness = (%F.decl)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @impl(%T.loc15_14.1: type) {
-// CHECK:STDOUT:   %T.loc15_14.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc15_14.2 (constants.%T)]
-// CHECK:STDOUT:   %Simple.impl_witness: <witness> = impl_witness file.%Simple.impl_witness_table, @impl(%T.loc15_14.2) [symbolic = %Simple.impl_witness (constants.%Simple.impl_witness)]
+// CHECK:STDOUT: generic impl @impl(%T.loc18_14.1: type) {
+// CHECK:STDOUT:   %T.loc18_14.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc18_14.2 (constants.%T)]
+// CHECK:STDOUT:   %Simple.impl_witness: <witness> = impl_witness file.%Simple.impl_witness_table, @impl(%T.loc18_14.2) [symbolic = %Simple.impl_witness (constants.%Simple.impl_witness)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %F.type: type = fn_type @F.2, @impl(%T.loc15_14.2) [symbolic = %F.type (constants.%F.type.1e1)]
+// CHECK:STDOUT:   %F.type: type = fn_type @F.2, @impl(%T.loc18_14.2) [symbolic = %F.type (constants.%F.type.1e1)]
 // CHECK:STDOUT:   %F: @impl.%F.type (%F.type.1e1) = struct_value () [symbolic = %F (constants.%F.4c3)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   impl: %T.ref as %Simple.ref {
@@ -90,7 +93,7 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   fn();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F.2(@impl.%T.loc15_14.1: type) {
+// CHECK:STDOUT: generic fn @F.2(@impl.%T.loc18_14.1: type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
@@ -102,7 +105,7 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT: specific @F.1(constants.%Self) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @impl(constants.%T) {
-// CHECK:STDOUT:   %T.loc15_14.2 => constants.%T
+// CHECK:STDOUT:   %T.loc18_14.2 => constants.%T
 // CHECK:STDOUT:   %Simple.impl_witness => constants.%Simple.impl_witness
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/impl/lookup/alias.carbon
+++ b/toolchain/check/testdata/impl/lookup/alias.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/alias.carbon
@@ -76,7 +79,7 @@ fn G(c: C) {
 // CHECK:STDOUT:     %c.param_patt: %pattern_type = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc23: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %c: %C = bind_name c, %c.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -125,14 +128,14 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%c.param: %C) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %C.ref.loc24: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %G.ref.loc24: %HasF.assoc_type = name_ref G, @C.%G [concrete = constants.%assoc0]
-// CHECK:STDOUT:   %impl.elem0.loc24: %.fec = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.dc7]
-// CHECK:STDOUT:   %F.call.loc24: init %empty_tuple.type = call %impl.elem0.loc24()
+// CHECK:STDOUT:   %C.ref.loc27: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %G.ref.loc27: %HasF.assoc_type = name_ref G, @C.%G [concrete = constants.%assoc0]
+// CHECK:STDOUT:   %impl.elem0.loc27: %.fec = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.dc7]
+// CHECK:STDOUT:   %F.call.loc27: init %empty_tuple.type = call %impl.elem0.loc27()
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
-// CHECK:STDOUT:   %G.ref.loc25: %HasF.assoc_type = name_ref G, @C.%G [concrete = constants.%assoc0]
-// CHECK:STDOUT:   %impl.elem0.loc25: %.fec = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.dc7]
-// CHECK:STDOUT:   %F.call.loc25: init %empty_tuple.type = call %impl.elem0.loc25()
+// CHECK:STDOUT:   %G.ref.loc28: %HasF.assoc_type = name_ref G, @C.%G [concrete = constants.%assoc0]
+// CHECK:STDOUT:   %impl.elem0.loc28: %.fec = impl_witness_access constants.%HasF.impl_witness, element0 [concrete = constants.%F.dc7]
+// CHECK:STDOUT:   %F.call.loc28: init %empty_tuple.type = call %impl.elem0.loc28()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -68,7 +71,7 @@ fn F(c: C) {
 // CHECK:STDOUT:     %c.param_patt: %pattern_type = value_param_pattern %c.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %c.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc19: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc22: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %c: %C = bind_name c, %c.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -104,10 +107,10 @@ fn F(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%c.param: %C) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %C.ref.loc24: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %F.ref.loc24: %I.assoc_type = name_ref F, @C.%F [concrete = constants.%assoc0]
+// CHECK:STDOUT:   %C.ref.loc27: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %F.ref.loc27: %I.assoc_type = name_ref F, @C.%F [concrete = constants.%assoc0]
 // CHECK:STDOUT:   %c.ref: %C = name_ref c, %c
-// CHECK:STDOUT:   %F.ref.loc29: %I.assoc_type = name_ref F, @C.%F [concrete = constants.%assoc0]
+// CHECK:STDOUT:   %F.ref.loc32: %I.assoc_type = name_ref F, @C.%F [concrete = constants.%assoc0]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon

--- a/toolchain/check/testdata/impl/lookup/generic.carbon
+++ b/toolchain/check/testdata/impl/lookup/generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/generic.carbon

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -65,14 +68,14 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .C = %C.decl.loc11
+// CHECK:STDOUT:     .C = %C.decl.loc14
 // CHECK:STDOUT:     .I = %I.decl
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
-// CHECK:STDOUT:   %C.decl.loc11: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc14: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
-// CHECK:STDOUT:   %C.decl.loc17: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %C.decl.loc20: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type.b25 = fn_decl @F.3 [concrete = constants.%F.c41] {
 // CHECK:STDOUT:     %c.patt: %pattern_type.c48 = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.param_patt: %pattern_type.c48 = value_param_pattern %c.patt, call_param0 [concrete]
@@ -82,7 +85,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %c.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc11 [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc14 [concrete = constants.%C]
 // CHECK:STDOUT:     %c: %C = bind_name c, %c.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
@@ -99,13 +102,13 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %self.param: @F.1.%Self.as_type.loc14_14.1 (%Self.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc14_14.1: type = splice_block %.loc14_14.2 [symbolic = %Self.as_type.loc14_14.1 (constants.%Self.as_type)] {
+// CHECK:STDOUT:     %self.param: @F.1.%Self.as_type.loc17_14.1 (%Self.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc17_14.1: type = splice_block %.loc17_14.2 [symbolic = %Self.as_type.loc17_14.1 (constants.%Self.as_type)] {
 // CHECK:STDOUT:       %Self.ref: %I.type = name_ref Self, @I.%Self [symbolic = %Self (constants.%Self)]
-// CHECK:STDOUT:       %Self.as_type.loc14_14.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc14_14.1 (constants.%Self.as_type)]
-// CHECK:STDOUT:       %.loc14_14.2: type = converted %Self.ref, %Self.as_type.loc14_14.2 [symbolic = %Self.as_type.loc14_14.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       %Self.as_type.loc17_14.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc17_14.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:       %.loc17_14.2: type = converted %Self.ref, %Self.as_type.loc17_14.2 [symbolic = %Self.as_type.loc17_14.1 (constants.%Self.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self: @F.1.%Self.as_type.loc14_14.1 (%Self.as_type) = bind_name self, %self.param
+// CHECK:STDOUT:     %self: @F.1.%Self.as_type.loc17_14.1 (%Self.as_type) = bind_name self, %self.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -158,10 +161,10 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F.1(@I.%Self: %I.type) {
 // CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self)]
-// CHECK:STDOUT:   %Self.as_type.loc14_14.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc14_14.1 (constants.%Self.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc14_14.1 [symbolic = %pattern_type (constants.%pattern_type.6de)]
+// CHECK:STDOUT:   %Self.as_type.loc17_14.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc17_14.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc17_14.1 [symbolic = %pattern_type (constants.%pattern_type.6de)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @F.1.%Self.as_type.loc14_14.1 (%Self.as_type)) -> %i32;
+// CHECK:STDOUT:   fn(%self.param: @F.1.%Self.as_type.loc17_14.1 (%Self.as_type)) -> %i32;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%self.param: %C) -> %i32;
@@ -173,20 +176,20 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   %impl.elem0: %.832 = impl_witness_access constants.%I.impl_witness, element0 [concrete = constants.%F.4c3]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %c.ref, %impl.elem0
 // CHECK:STDOUT:   %F.call: init %i32 = call %bound_method(%c.ref)
-// CHECK:STDOUT:   %.loc24_15.1: %i32 = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc24_15.2: %i32 = converted %F.call, %.loc24_15.1
-// CHECK:STDOUT:   return %.loc24_15.2
+// CHECK:STDOUT:   %.loc27_15.1: %i32 = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc27_15.2: %i32 = converted %F.call, %.loc27_15.1
+// CHECK:STDOUT:   return %.loc27_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Self) {
 // CHECK:STDOUT:   %Self => constants.%Self
-// CHECK:STDOUT:   %Self.as_type.loc14_14.1 => constants.%Self.as_type
+// CHECK:STDOUT:   %Self.as_type.loc17_14.1 => constants.%Self.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.6de
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%I.facet) {
 // CHECK:STDOUT:   %Self => constants.%I.facet
-// CHECK:STDOUT:   %Self.as_type.loc14_14.1 => constants.%C
+// CHECK:STDOUT:   %Self.as_type.loc17_14.1 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.c48
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/canonical_query_self.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/canonical_query_self.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
 //
 // AUTOUPDATE
@@ -138,25 +140,25 @@ fn G() {
 // CHECK:STDOUT:     %t.patt: @F.%pattern_type (%pattern_type.a4f) = binding_pattern t [concrete]
 // CHECK:STDOUT:     %t.param_patt: @F.%pattern_type (%pattern_type.a4f) = value_param_pattern %t.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc20_12.1: type = splice_block %.loc20_12.3 [concrete = constants.%facet_type] {
-// CHECK:STDOUT:       %I.ref.loc20: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:       %J.ref.loc20: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:       %impl.elem0.loc20: %.518 = impl_witness_access constants.%BitAnd.impl_witness.0e5, element0 [concrete = constants.%Op.444]
-// CHECK:STDOUT:       %bound_method.loc20_12.1: <bound method> = bound_method %I.ref.loc20, %impl.elem0.loc20 [concrete = constants.%Op.bound]
-// CHECK:STDOUT:       %specific_fn: <specific function> = specific_function %impl.elem0.loc20, @Op.2(type) [concrete = constants.%Op.specific_fn]
-// CHECK:STDOUT:       %bound_method.loc20_12.2: <bound method> = bound_method %I.ref.loc20, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:       %type.and: init type = call %bound_method.loc20_12.2(%I.ref.loc20, %J.ref.loc20) [concrete = constants.%facet_type]
-// CHECK:STDOUT:       %.loc20_12.2: type = value_of_initializer %type.and [concrete = constants.%facet_type]
-// CHECK:STDOUT:       %.loc20_12.3: type = converted %type.and, %.loc20_12.2 [concrete = constants.%facet_type]
+// CHECK:STDOUT:     %.loc22_12.1: type = splice_block %.loc22_12.3 [concrete = constants.%facet_type] {
+// CHECK:STDOUT:       %I.ref.loc22: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:       %J.ref.loc22: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
+// CHECK:STDOUT:       %impl.elem0.loc22: %.518 = impl_witness_access constants.%BitAnd.impl_witness.0e5, element0 [concrete = constants.%Op.444]
+// CHECK:STDOUT:       %bound_method.loc22_12.1: <bound method> = bound_method %I.ref.loc22, %impl.elem0.loc22 [concrete = constants.%Op.bound]
+// CHECK:STDOUT:       %specific_fn: <specific function> = specific_function %impl.elem0.loc22, @Op.2(type) [concrete = constants.%Op.specific_fn]
+// CHECK:STDOUT:       %bound_method.loc22_12.2: <bound method> = bound_method %I.ref.loc22, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:       %type.and: init type = call %bound_method.loc22_12.2(%I.ref.loc22, %J.ref.loc22) [concrete = constants.%facet_type]
+// CHECK:STDOUT:       %.loc22_12.2: type = value_of_initializer %type.and [concrete = constants.%facet_type]
+// CHECK:STDOUT:       %.loc22_12.3: type = converted %type.and, %.loc22_12.2 [concrete = constants.%facet_type]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc20_6.1: %facet_type = bind_symbolic_name T, 0 [symbolic = %T.loc20_6.2 (constants.%T.527)]
-// CHECK:STDOUT:     %t.param: @F.%T.as_type.loc20_20.2 (%T.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc20_20.1: type = splice_block %.loc20_20.2 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)] {
-// CHECK:STDOUT:       %T.ref.loc20: %facet_type = name_ref T, %T.loc20_6.1 [symbolic = %T.loc20_6.2 (constants.%T.527)]
-// CHECK:STDOUT:       %T.as_type.loc20_20.1: type = facet_access_type %T.ref.loc20 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:       %.loc20_20.2: type = converted %T.ref.loc20, %T.as_type.loc20_20.1 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %T.loc22_6.1: %facet_type = bind_symbolic_name T, 0 [symbolic = %T.loc22_6.2 (constants.%T.527)]
+// CHECK:STDOUT:     %t.param: @F.%T.as_type.loc22_20.2 (%T.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc22_20.1: type = splice_block %.loc22_20.2 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref.loc22: %facet_type = name_ref T, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T.527)]
+// CHECK:STDOUT:       %T.as_type.loc22_20.1: type = facet_access_type %T.ref.loc22 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc22_20.2: type = converted %T.ref.loc22, %T.as_type.loc22_20.1 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %t: @F.%T.as_type.loc20_20.2 (%T.as_type) = bind_name t, %t.param
+// CHECK:STDOUT:     %t: @F.%T.as_type.loc22_20.2 (%T.as_type) = bind_name t, %t.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
 // CHECK:STDOUT: }
@@ -167,13 +169,13 @@ fn G() {
 // CHECK:STDOUT:     %self.patt: @II.1.%pattern_type (%pattern_type.6de) = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: @II.1.%pattern_type (%pattern_type.6de) = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param: @II.1.%Self.as_type.loc14_15.1 (%Self.as_type.b70) = value_param call_param0
-// CHECK:STDOUT:     %.loc14_15.1: type = splice_block %.loc14_15.2 [symbolic = %Self.as_type.loc14_15.1 (constants.%Self.as_type.b70)] {
+// CHECK:STDOUT:     %self.param: @II.1.%Self.as_type.loc16_15.1 (%Self.as_type.b70) = value_param call_param0
+// CHECK:STDOUT:     %.loc16_15.1: type = splice_block %.loc16_15.2 [symbolic = %Self.as_type.loc16_15.1 (constants.%Self.as_type.b70)] {
 // CHECK:STDOUT:       %Self.ref: %I.type = name_ref Self, @I.%Self [symbolic = %Self (constants.%Self.826)]
-// CHECK:STDOUT:       %Self.as_type.loc14_15.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc14_15.1 (constants.%Self.as_type.b70)]
-// CHECK:STDOUT:       %.loc14_15.2: type = converted %Self.ref, %Self.as_type.loc14_15.2 [symbolic = %Self.as_type.loc14_15.1 (constants.%Self.as_type.b70)]
+// CHECK:STDOUT:       %Self.as_type.loc16_15.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc16_15.1 (constants.%Self.as_type.b70)]
+// CHECK:STDOUT:       %.loc16_15.2: type = converted %Self.ref, %Self.as_type.loc16_15.2 [symbolic = %Self.as_type.loc16_15.1 (constants.%Self.as_type.b70)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self: @II.1.%Self.as_type.loc14_15.1 (%Self.as_type.b70) = bind_name self, %self.param
+// CHECK:STDOUT:     %self: @II.1.%Self.as_type.loc16_15.1 (%Self.as_type.b70) = bind_name self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %I.assoc_type = assoc_entity element0, %II.decl [concrete = constants.%assoc0.82e]
 // CHECK:STDOUT:
@@ -191,13 +193,13 @@ fn G() {
 // CHECK:STDOUT:     %self.patt: @JJ.1.%pattern_type (%pattern_type.4ca) = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: @JJ.1.%pattern_type (%pattern_type.4ca) = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %self.param: @JJ.1.%Self.as_type.loc17_15.1 (%Self.as_type.3df) = value_param call_param0
-// CHECK:STDOUT:     %.loc17_15.1: type = splice_block %.loc17_15.2 [symbolic = %Self.as_type.loc17_15.1 (constants.%Self.as_type.3df)] {
+// CHECK:STDOUT:     %self.param: @JJ.1.%Self.as_type.loc19_15.1 (%Self.as_type.3df) = value_param call_param0
+// CHECK:STDOUT:     %.loc19_15.1: type = splice_block %.loc19_15.2 [symbolic = %Self.as_type.loc19_15.1 (constants.%Self.as_type.3df)] {
 // CHECK:STDOUT:       %Self.ref: %J.type = name_ref Self, @J.%Self [symbolic = %Self (constants.%Self.ccd)]
-// CHECK:STDOUT:       %Self.as_type.loc17_15.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc17_15.1 (constants.%Self.as_type.3df)]
-// CHECK:STDOUT:       %.loc17_15.2: type = converted %Self.ref, %Self.as_type.loc17_15.2 [symbolic = %Self.as_type.loc17_15.1 (constants.%Self.as_type.3df)]
+// CHECK:STDOUT:       %Self.as_type.loc19_15.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc19_15.1 (constants.%Self.as_type.3df)]
+// CHECK:STDOUT:       %.loc19_15.2: type = converted %Self.ref, %Self.as_type.loc19_15.2 [symbolic = %Self.as_type.loc19_15.1 (constants.%Self.as_type.3df)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self: @JJ.1.%Self.as_type.loc17_15.1 (%Self.as_type.3df) = bind_name self, %self.param
+// CHECK:STDOUT:     %self: @JJ.1.%Self.as_type.loc19_15.1 (%Self.as_type.3df) = bind_name self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %J.assoc_type = assoc_entity element0, %JJ.decl [concrete = constants.%assoc0.78c]
 // CHECK:STDOUT:
@@ -265,68 +267,68 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @II.1(@I.%Self: %I.type) {
 // CHECK:STDOUT:   %Self: %I.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.826)]
-// CHECK:STDOUT:   %Self.as_type.loc14_15.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc14_15.1 (constants.%Self.as_type.b70)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc14_15.1 [symbolic = %pattern_type (constants.%pattern_type.6de)]
+// CHECK:STDOUT:   %Self.as_type.loc16_15.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc16_15.1 (constants.%Self.as_type.b70)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc16_15.1 [symbolic = %pattern_type (constants.%pattern_type.6de)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @II.1.%Self.as_type.loc14_15.1 (%Self.as_type.b70));
+// CHECK:STDOUT:   fn(%self.param: @II.1.%Self.as_type.loc16_15.1 (%Self.as_type.b70));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @JJ.1(@J.%Self: %J.type) {
 // CHECK:STDOUT:   %Self: %J.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.ccd)]
-// CHECK:STDOUT:   %Self.as_type.loc17_15.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc17_15.1 (constants.%Self.as_type.3df)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc17_15.1 [symbolic = %pattern_type (constants.%pattern_type.4ca)]
+// CHECK:STDOUT:   %Self.as_type.loc19_15.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc19_15.1 (constants.%Self.as_type.3df)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc19_15.1 [symbolic = %pattern_type (constants.%pattern_type.4ca)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @JJ.1.%Self.as_type.loc17_15.1 (%Self.as_type.3df));
+// CHECK:STDOUT:   fn(%self.param: @JJ.1.%Self.as_type.loc19_15.1 (%Self.as_type.3df));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc20_6.1: %facet_type) {
-// CHECK:STDOUT:   %T.loc20_6.2: %facet_type = bind_symbolic_name T, 0 [symbolic = %T.loc20_6.2 (constants.%T.527)]
-// CHECK:STDOUT:   %T.as_type.loc20_20.2: type = facet_access_type %T.loc20_6.2 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc20_20.2 [symbolic = %pattern_type (constants.%pattern_type.a4f)]
+// CHECK:STDOUT: generic fn @F(%T.loc22_6.1: %facet_type) {
+// CHECK:STDOUT:   %T.loc22_6.2: %facet_type = bind_symbolic_name T, 0 [symbolic = %T.loc22_6.2 (constants.%T.527)]
+// CHECK:STDOUT:   %T.as_type.loc22_20.2: type = facet_access_type %T.loc22_6.2 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc22_20.2 [symbolic = %pattern_type (constants.%pattern_type.a4f)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc20_20.2 [symbolic = %require_complete (constants.%require_complete.df2)]
-// CHECK:STDOUT:   %I.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc20_6.2, @I [symbolic = %I.lookup_impl_witness (constants.%I.lookup_impl_witness)]
-// CHECK:STDOUT:   %I.facet.loc24_18.2: %I.type = facet_value %T.as_type.loc20_20.2, (%I.lookup_impl_witness) [symbolic = %I.facet.loc24_18.2 (constants.%I.facet.e75)]
-// CHECK:STDOUT:   %J.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc20_6.2, @J [symbolic = %J.lookup_impl_witness (constants.%J.lookup_impl_witness)]
-// CHECK:STDOUT:   %J.facet.loc24_33.2: %J.type = facet_value %T.as_type.loc20_20.2, (%J.lookup_impl_witness) [symbolic = %J.facet.loc24_33.2 (constants.%J.facet.fa4)]
-// CHECK:STDOUT:   %.loc24_69.2: type = fn_type_with_self_type constants.%JJ.type.622, %J.facet.loc24_33.2 [symbolic = %.loc24_69.2 (constants.%.935)]
-// CHECK:STDOUT:   %impl.elem0.loc24_69.2: @F.%.loc24_69.2 (%.935) = impl_witness_access %J.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc24_69.2 (constants.%impl.elem0)]
-// CHECK:STDOUT:   %specific_impl_fn.loc24_69.2: <specific function> = specific_impl_function %impl.elem0.loc24_69.2, @JJ.1(%J.facet.loc24_33.2) [symbolic = %specific_impl_fn.loc24_69.2 (constants.%specific_impl_fn)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc22_20.2 [symbolic = %require_complete (constants.%require_complete.df2)]
+// CHECK:STDOUT:   %I.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc22_6.2, @I [symbolic = %I.lookup_impl_witness (constants.%I.lookup_impl_witness)]
+// CHECK:STDOUT:   %I.facet.loc26_18.2: %I.type = facet_value %T.as_type.loc22_20.2, (%I.lookup_impl_witness) [symbolic = %I.facet.loc26_18.2 (constants.%I.facet.e75)]
+// CHECK:STDOUT:   %J.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc22_6.2, @J [symbolic = %J.lookup_impl_witness (constants.%J.lookup_impl_witness)]
+// CHECK:STDOUT:   %J.facet.loc26_33.2: %J.type = facet_value %T.as_type.loc22_20.2, (%J.lookup_impl_witness) [symbolic = %J.facet.loc26_33.2 (constants.%J.facet.fa4)]
+// CHECK:STDOUT:   %.loc26_69.2: type = fn_type_with_self_type constants.%JJ.type.622, %J.facet.loc26_33.2 [symbolic = %.loc26_69.2 (constants.%.935)]
+// CHECK:STDOUT:   %impl.elem0.loc26_69.2: @F.%.loc26_69.2 (%.935) = impl_witness_access %J.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc26_69.2 (constants.%impl.elem0)]
+// CHECK:STDOUT:   %specific_impl_fn.loc26_69.2: <specific function> = specific_impl_function %impl.elem0.loc26_69.2, @JJ.1(%J.facet.loc26_33.2) [symbolic = %specific_impl_fn.loc26_69.2 (constants.%specific_impl_fn)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%t.param: @F.%T.as_type.loc20_20.2 (%T.as_type)) {
+// CHECK:STDOUT:   fn(%t.param: @F.%T.as_type.loc22_20.2 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %t.ref: @F.%T.as_type.loc20_20.2 (%T.as_type) = name_ref t, %t
-// CHECK:STDOUT:     %T.ref.loc24: %facet_type = name_ref T, %T.loc20_6.1 [symbolic = %T.loc20_6.2 (constants.%T.527)]
-// CHECK:STDOUT:     %I.ref.loc24_21: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:     %T.as_type.loc24_18: type = facet_access_type constants.%T.527 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %I.facet.loc24_18.1: %I.type = facet_value %T.as_type.loc24_18, (constants.%I.lookup_impl_witness) [symbolic = %I.facet.loc24_18.2 (constants.%I.facet.e75)]
-// CHECK:STDOUT:     %.loc24_18: %I.type = converted %T.ref.loc24, %I.facet.loc24_18.1 [symbolic = %I.facet.loc24_18.2 (constants.%I.facet.e75)]
-// CHECK:STDOUT:     %as_type.loc24_24: type = facet_access_type %.loc24_18 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc24_24: type = converted %.loc24_18, %as_type.loc24_24 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %J.ref.loc24_36: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:     %J.facet.loc24_33.1: %J.type = facet_value constants.%T.as_type, (constants.%J.lookup_impl_witness) [symbolic = %J.facet.loc24_33.2 (constants.%J.facet.fa4)]
-// CHECK:STDOUT:     %.loc24_33: %J.type = converted %.loc24_24, %J.facet.loc24_33.1 [symbolic = %J.facet.loc24_33.2 (constants.%J.facet.fa4)]
-// CHECK:STDOUT:     %as_type.loc24_39: type = facet_access_type %.loc24_33 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc24_39: type = converted %.loc24_33, %as_type.loc24_39 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %I.ref.loc24_51: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:     %I.facet.loc24_48: %I.type = facet_value constants.%T.as_type, (constants.%I.lookup_impl_witness) [symbolic = %I.facet.loc24_18.2 (constants.%I.facet.e75)]
-// CHECK:STDOUT:     %.loc24_48: %I.type = converted %.loc24_39, %I.facet.loc24_48 [symbolic = %I.facet.loc24_18.2 (constants.%I.facet.e75)]
-// CHECK:STDOUT:     %as_type.loc24_54: type = facet_access_type %.loc24_48 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc24_54: type = converted %.loc24_48, %as_type.loc24_54 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %J.ref.loc24_66: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:     %J.facet.loc24_63: %J.type = facet_value constants.%T.as_type, (constants.%J.lookup_impl_witness) [symbolic = %J.facet.loc24_33.2 (constants.%J.facet.fa4)]
-// CHECK:STDOUT:     %.loc24_63: %J.type = converted %.loc24_54, %J.facet.loc24_63 [symbolic = %J.facet.loc24_33.2 (constants.%J.facet.fa4)]
-// CHECK:STDOUT:     %as_type.loc24_67: type = facet_access_type %.loc24_63 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc24_67: type = converted %.loc24_63, %as_type.loc24_67 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %t.ref: @F.%T.as_type.loc22_20.2 (%T.as_type) = name_ref t, %t
+// CHECK:STDOUT:     %T.ref.loc26: %facet_type = name_ref T, %T.loc22_6.1 [symbolic = %T.loc22_6.2 (constants.%T.527)]
+// CHECK:STDOUT:     %I.ref.loc26_21: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %T.as_type.loc26_18: type = facet_access_type constants.%T.527 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %I.facet.loc26_18.1: %I.type = facet_value %T.as_type.loc26_18, (constants.%I.lookup_impl_witness) [symbolic = %I.facet.loc26_18.2 (constants.%I.facet.e75)]
+// CHECK:STDOUT:     %.loc26_18: %I.type = converted %T.ref.loc26, %I.facet.loc26_18.1 [symbolic = %I.facet.loc26_18.2 (constants.%I.facet.e75)]
+// CHECK:STDOUT:     %as_type.loc26_24: type = facet_access_type %.loc26_18 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc26_24: type = converted %.loc26_18, %as_type.loc26_24 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %J.ref.loc26_36: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
+// CHECK:STDOUT:     %J.facet.loc26_33.1: %J.type = facet_value constants.%T.as_type, (constants.%J.lookup_impl_witness) [symbolic = %J.facet.loc26_33.2 (constants.%J.facet.fa4)]
+// CHECK:STDOUT:     %.loc26_33: %J.type = converted %.loc26_24, %J.facet.loc26_33.1 [symbolic = %J.facet.loc26_33.2 (constants.%J.facet.fa4)]
+// CHECK:STDOUT:     %as_type.loc26_39: type = facet_access_type %.loc26_33 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc26_39: type = converted %.loc26_33, %as_type.loc26_39 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %I.ref.loc26_51: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %I.facet.loc26_48: %I.type = facet_value constants.%T.as_type, (constants.%I.lookup_impl_witness) [symbolic = %I.facet.loc26_18.2 (constants.%I.facet.e75)]
+// CHECK:STDOUT:     %.loc26_48: %I.type = converted %.loc26_39, %I.facet.loc26_48 [symbolic = %I.facet.loc26_18.2 (constants.%I.facet.e75)]
+// CHECK:STDOUT:     %as_type.loc26_54: type = facet_access_type %.loc26_48 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc26_54: type = converted %.loc26_48, %as_type.loc26_54 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %J.ref.loc26_66: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
+// CHECK:STDOUT:     %J.facet.loc26_63: %J.type = facet_value constants.%T.as_type, (constants.%J.lookup_impl_witness) [symbolic = %J.facet.loc26_33.2 (constants.%J.facet.fa4)]
+// CHECK:STDOUT:     %.loc26_63: %J.type = converted %.loc26_54, %J.facet.loc26_63 [symbolic = %J.facet.loc26_33.2 (constants.%J.facet.fa4)]
+// CHECK:STDOUT:     %as_type.loc26_67: type = facet_access_type %.loc26_63 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc26_67: type = converted %.loc26_63, %as_type.loc26_67 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
 // CHECK:STDOUT:     %JJ.ref: %J.assoc_type = name_ref JJ, @J.%assoc0 [concrete = constants.%assoc0.78c]
-// CHECK:STDOUT:     %T.as_type.loc24_69: type = facet_access_type constants.%T.527 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %.loc24_69.1: type = converted constants.%T.527, %T.as_type.loc24_69 [symbolic = %T.as_type.loc20_20.2 (constants.%T.as_type)]
-// CHECK:STDOUT:     %impl.elem0.loc24_69.1: @F.%.loc24_69.2 (%.935) = impl_witness_access constants.%J.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc24_69.2 (constants.%impl.elem0)]
-// CHECK:STDOUT:     %bound_method.loc24_69: <bound method> = bound_method %t.ref, %impl.elem0.loc24_69.1
-// CHECK:STDOUT:     %specific_impl_fn.loc24_69.1: <specific function> = specific_impl_function %impl.elem0.loc24_69.1, @JJ.1(constants.%J.facet.fa4) [symbolic = %specific_impl_fn.loc24_69.2 (constants.%specific_impl_fn)]
-// CHECK:STDOUT:     %bound_method.loc24_73: <bound method> = bound_method %t.ref, %specific_impl_fn.loc24_69.1
-// CHECK:STDOUT:     %.loc24_73: init %empty_tuple.type = call %bound_method.loc24_73(%t.ref)
+// CHECK:STDOUT:     %T.as_type.loc26_69: type = facet_access_type constants.%T.527 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc26_69.1: type = converted constants.%T.527, %T.as_type.loc26_69 [symbolic = %T.as_type.loc22_20.2 (constants.%T.as_type)]
+// CHECK:STDOUT:     %impl.elem0.loc26_69.1: @F.%.loc26_69.2 (%.935) = impl_witness_access constants.%J.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc26_69.2 (constants.%impl.elem0)]
+// CHECK:STDOUT:     %bound_method.loc26_69: <bound method> = bound_method %t.ref, %impl.elem0.loc26_69.1
+// CHECK:STDOUT:     %specific_impl_fn.loc26_69.1: <specific function> = specific_impl_function %impl.elem0.loc26_69.1, @JJ.1(constants.%J.facet.fa4) [symbolic = %specific_impl_fn.loc26_69.2 (constants.%specific_impl_fn)]
+// CHECK:STDOUT:     %bound_method.loc26_73: <bound method> = bound_method %t.ref, %specific_impl_fn.loc26_69.1
+// CHECK:STDOUT:     %.loc26_73: init %empty_tuple.type = call %bound_method.loc26_73(%t.ref)
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -334,55 +336,55 @@ fn G() {
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
-// CHECK:STDOUT:   %.loc38_6.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %C.ref.loc38_11: type = name_ref C, %C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc38_6.2: ref %C = temporary_storage
-// CHECK:STDOUT:   %.loc38_6.3: init %C = class_init (), %.loc38_6.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc38_6.4: ref %C = temporary %.loc38_6.2, %.loc38_6.3
-// CHECK:STDOUT:   %.loc38_8.1: ref %C = converted %.loc38_6.1, %.loc38_6.4
-// CHECK:STDOUT:   %C.ref.loc38_24: type = name_ref C, %C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %I.ref.loc38_29: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:   %I.facet.loc38_26: %I.type = facet_value constants.%C, (constants.%I.impl_witness) [concrete = constants.%I.facet.98f]
-// CHECK:STDOUT:   %.loc38_26: %I.type = converted %C.ref.loc38_24, %I.facet.loc38_26 [concrete = constants.%I.facet.98f]
-// CHECK:STDOUT:   %as_type.loc38_32: type = facet_access_type %.loc38_26 [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc38_32: type = converted %.loc38_26, %as_type.loc38_32 [concrete = constants.%C]
-// CHECK:STDOUT:   %J.ref.loc38_44: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:   %J.facet.loc38_41: %J.type = facet_value constants.%C, (constants.%J.impl_witness) [concrete = constants.%J.facet.5df]
-// CHECK:STDOUT:   %.loc38_41: %J.type = converted %.loc38_32, %J.facet.loc38_41 [concrete = constants.%J.facet.5df]
-// CHECK:STDOUT:   %as_type.loc38_47: type = facet_access_type %.loc38_41 [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc38_47: type = converted %.loc38_41, %as_type.loc38_47 [concrete = constants.%C]
-// CHECK:STDOUT:   %I.ref.loc38_59: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
-// CHECK:STDOUT:   %I.facet.loc38_56: %I.type = facet_value constants.%C, (constants.%I.impl_witness) [concrete = constants.%I.facet.98f]
-// CHECK:STDOUT:   %.loc38_56: %I.type = converted %.loc38_47, %I.facet.loc38_56 [concrete = constants.%I.facet.98f]
-// CHECK:STDOUT:   %as_type.loc38_62: type = facet_access_type %.loc38_56 [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc38_62: type = converted %.loc38_56, %as_type.loc38_62 [concrete = constants.%C]
-// CHECK:STDOUT:   %J.ref.loc38_74: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
-// CHECK:STDOUT:   %J.facet.loc38_71: %J.type = facet_value constants.%C, (constants.%J.impl_witness) [concrete = constants.%J.facet.5df]
-// CHECK:STDOUT:   %.loc38_71: %J.type = converted %.loc38_62, %J.facet.loc38_71 [concrete = constants.%J.facet.5df]
-// CHECK:STDOUT:   %as_type.loc38_75: type = facet_access_type %.loc38_71 [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc38_75: type = converted %.loc38_71, %as_type.loc38_75 [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc40_6.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %C.ref.loc40_11: type = name_ref C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc40_6.2: ref %C = temporary_storage
+// CHECK:STDOUT:   %.loc40_6.3: init %C = class_init (), %.loc40_6.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc40_6.4: ref %C = temporary %.loc40_6.2, %.loc40_6.3
+// CHECK:STDOUT:   %.loc40_8.1: ref %C = converted %.loc40_6.1, %.loc40_6.4
+// CHECK:STDOUT:   %C.ref.loc40_24: type = name_ref C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %I.ref.loc40_29: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:   %I.facet.loc40_26: %I.type = facet_value constants.%C, (constants.%I.impl_witness) [concrete = constants.%I.facet.98f]
+// CHECK:STDOUT:   %.loc40_26: %I.type = converted %C.ref.loc40_24, %I.facet.loc40_26 [concrete = constants.%I.facet.98f]
+// CHECK:STDOUT:   %as_type.loc40_32: type = facet_access_type %.loc40_26 [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc40_32: type = converted %.loc40_26, %as_type.loc40_32 [concrete = constants.%C]
+// CHECK:STDOUT:   %J.ref.loc40_44: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
+// CHECK:STDOUT:   %J.facet.loc40_41: %J.type = facet_value constants.%C, (constants.%J.impl_witness) [concrete = constants.%J.facet.5df]
+// CHECK:STDOUT:   %.loc40_41: %J.type = converted %.loc40_32, %J.facet.loc40_41 [concrete = constants.%J.facet.5df]
+// CHECK:STDOUT:   %as_type.loc40_47: type = facet_access_type %.loc40_41 [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc40_47: type = converted %.loc40_41, %as_type.loc40_47 [concrete = constants.%C]
+// CHECK:STDOUT:   %I.ref.loc40_59: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:   %I.facet.loc40_56: %I.type = facet_value constants.%C, (constants.%I.impl_witness) [concrete = constants.%I.facet.98f]
+// CHECK:STDOUT:   %.loc40_56: %I.type = converted %.loc40_47, %I.facet.loc40_56 [concrete = constants.%I.facet.98f]
+// CHECK:STDOUT:   %as_type.loc40_62: type = facet_access_type %.loc40_56 [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc40_62: type = converted %.loc40_56, %as_type.loc40_62 [concrete = constants.%C]
+// CHECK:STDOUT:   %J.ref.loc40_74: type = name_ref J, file.%J.decl [concrete = constants.%J.type]
+// CHECK:STDOUT:   %J.facet.loc40_71: %J.type = facet_value constants.%C, (constants.%J.impl_witness) [concrete = constants.%J.facet.5df]
+// CHECK:STDOUT:   %.loc40_71: %J.type = converted %.loc40_62, %J.facet.loc40_71 [concrete = constants.%J.facet.5df]
+// CHECK:STDOUT:   %as_type.loc40_75: type = facet_access_type %.loc40_71 [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc40_75: type = converted %.loc40_71, %as_type.loc40_75 [concrete = constants.%C]
 // CHECK:STDOUT:   %JJ.ref: %J.assoc_type = name_ref JJ, @J.%assoc0 [concrete = constants.%assoc0.78c]
 // CHECK:STDOUT:   %impl.elem0: %.638 = impl_witness_access constants.%J.impl_witness, element0 [concrete = constants.%JJ.9c9]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc38_8.1, %impl.elem0
-// CHECK:STDOUT:   %.loc38_8.2: %C = bind_value %.loc38_8.1
-// CHECK:STDOUT:   %JJ.call: init %empty_tuple.type = call %bound_method(%.loc38_8.2)
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc40_8.1, %impl.elem0
+// CHECK:STDOUT:   %.loc40_8.2: %C = bind_value %.loc40_8.1
+// CHECK:STDOUT:   %JJ.call: init %empty_tuple.type = call %bound_method(%.loc40_8.2)
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %C.ref.loc44_5: type = name_ref C, %C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc44_9.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %C.ref.loc44_14: type = name_ref C, %C.decl [concrete = constants.%C]
-// CHECK:STDOUT:   %.loc44_9.2: ref %C = temporary_storage
-// CHECK:STDOUT:   %.loc44_9.3: init %C = class_init (), %.loc44_9.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc44_9.4: ref %C = temporary %.loc44_9.2, %.loc44_9.3
-// CHECK:STDOUT:   %.loc44_11.1: ref %C = converted %.loc44_9.1, %.loc44_9.4
-// CHECK:STDOUT:   %facet_value.loc44_15.1: %facet_type = facet_value constants.%C, (constants.%I.impl_witness, constants.%J.impl_witness) [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %.loc44_15.1: %facet_type = converted %C.ref.loc44_5, %facet_value.loc44_15.1 [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %facet_value.loc44_15.2: %facet_type = facet_value constants.%C, (constants.%I.impl_witness, constants.%J.impl_witness) [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %.loc44_15.2: %facet_type = converted constants.%C, %facet_value.loc44_15.2 [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %facet_value.loc44_15.3: %facet_type = facet_value constants.%C, (constants.%I.impl_witness, constants.%J.impl_witness) [concrete = constants.%facet_value]
-// CHECK:STDOUT:   %.loc44_15.3: %facet_type = converted constants.%C, %facet_value.loc44_15.3 [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %C.ref.loc46_5: type = name_ref C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc46_9.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %C.ref.loc46_14: type = name_ref C, %C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc46_9.2: ref %C = temporary_storage
+// CHECK:STDOUT:   %.loc46_9.3: init %C = class_init (), %.loc46_9.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc46_9.4: ref %C = temporary %.loc46_9.2, %.loc46_9.3
+// CHECK:STDOUT:   %.loc46_11.1: ref %C = converted %.loc46_9.1, %.loc46_9.4
+// CHECK:STDOUT:   %facet_value.loc46_15.1: %facet_type = facet_value constants.%C, (constants.%I.impl_witness, constants.%J.impl_witness) [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %.loc46_15.1: %facet_type = converted %C.ref.loc46_5, %facet_value.loc46_15.1 [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %facet_value.loc46_15.2: %facet_type = facet_value constants.%C, (constants.%I.impl_witness, constants.%J.impl_witness) [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %.loc46_15.2: %facet_type = converted constants.%C, %facet_value.loc46_15.2 [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %facet_value.loc46_15.3: %facet_type = facet_value constants.%C, (constants.%I.impl_witness, constants.%J.impl_witness) [concrete = constants.%facet_value]
+// CHECK:STDOUT:   %.loc46_15.3: %facet_type = converted constants.%C, %facet_value.loc46_15.3 [concrete = constants.%facet_value]
 // CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F.ref, @F(constants.%facet_value) [concrete = constants.%F.specific_fn]
-// CHECK:STDOUT:   %.loc44_11.2: %C = bind_value %.loc44_11.1
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc44_11.2)
+// CHECK:STDOUT:   %.loc46_11.2: %C = bind_value %.loc46_11.1
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc46_11.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -398,53 +400,53 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @II.1(constants.%Self.826) {
 // CHECK:STDOUT:   %Self => constants.%Self.826
-// CHECK:STDOUT:   %Self.as_type.loc14_15.1 => constants.%Self.as_type.b70
+// CHECK:STDOUT:   %Self.as_type.loc16_15.1 => constants.%Self.as_type.b70
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.6de
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @JJ.1(constants.%Self.ccd) {
 // CHECK:STDOUT:   %Self => constants.%Self.ccd
-// CHECK:STDOUT:   %Self.as_type.loc17_15.1 => constants.%Self.as_type.3df
+// CHECK:STDOUT:   %Self.as_type.loc19_15.1 => constants.%Self.as_type.3df
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.4ca
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T.527) {
-// CHECK:STDOUT:   %T.loc20_6.2 => constants.%T.527
-// CHECK:STDOUT:   %T.as_type.loc20_20.2 => constants.%T.as_type
+// CHECK:STDOUT:   %T.loc22_6.2 => constants.%T.527
+// CHECK:STDOUT:   %T.as_type.loc22_20.2 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.a4f
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @JJ.1(constants.%J.facet.fa4) {
 // CHECK:STDOUT:   %Self => constants.%J.facet.fa4
-// CHECK:STDOUT:   %Self.as_type.loc17_15.1 => constants.%T.as_type
+// CHECK:STDOUT:   %Self.as_type.loc19_15.1 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.a4f
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @II.1(constants.%I.facet.98f) {
 // CHECK:STDOUT:   %Self => constants.%I.facet.98f
-// CHECK:STDOUT:   %Self.as_type.loc14_15.1 => constants.%C
+// CHECK:STDOUT:   %Self.as_type.loc16_15.1 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.893
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @JJ.1(constants.%J.facet.5df) {
 // CHECK:STDOUT:   %Self => constants.%J.facet.5df
-// CHECK:STDOUT:   %Self.as_type.loc17_15.1 => constants.%C
+// CHECK:STDOUT:   %Self.as_type.loc19_15.1 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.893
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%facet_value) {
-// CHECK:STDOUT:   %T.loc20_6.2 => constants.%facet_value
-// CHECK:STDOUT:   %T.as_type.loc20_20.2 => constants.%C
+// CHECK:STDOUT:   %T.loc22_6.2 => constants.%facet_value
+// CHECK:STDOUT:   %T.as_type.loc22_20.2 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.893
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.357
 // CHECK:STDOUT:   %I.lookup_impl_witness => constants.%I.impl_witness
-// CHECK:STDOUT:   %I.facet.loc24_18.2 => constants.%I.facet.98f
+// CHECK:STDOUT:   %I.facet.loc26_18.2 => constants.%I.facet.98f
 // CHECK:STDOUT:   %J.lookup_impl_witness => constants.%J.impl_witness
-// CHECK:STDOUT:   %J.facet.loc24_33.2 => constants.%J.facet.5df
-// CHECK:STDOUT:   %.loc24_69.2 => constants.%.638
-// CHECK:STDOUT:   %impl.elem0.loc24_69.2 => constants.%JJ.9c9
-// CHECK:STDOUT:   %specific_impl_fn.loc24_69.2 => constants.%JJ.9c9
+// CHECK:STDOUT:   %J.facet.loc26_33.2 => constants.%J.facet.5df
+// CHECK:STDOUT:   %.loc26_69.2 => constants.%.638
+// CHECK:STDOUT:   %impl.elem0.loc26_69.2 => constants.%JJ.9c9
+// CHECK:STDOUT:   %specific_impl_fn.loc26_69.2 => constants.%JJ.9c9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/fail_function_types.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/fail_function_types.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/find_in_final.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/find_in_final.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/impl_cycle.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/impl_forall.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/lookup/min_prelude/impl_overlap.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/impl_overlap.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/import.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/lookup/min_prelude/import_final.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/import_final.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/lookup_interface_with_enclosing_generic_inside_rewrite_constraint.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/lookup_interface_with_enclosing_generic_inside_rewrite_constraint.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/lookup/min_prelude/specialization.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/specialization.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/specialization_poison.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/specialization_poison.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/specialization_with_symbolic_rewrite.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/specialization_with_symbolic_rewrite.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/lookup/min_prelude/struct.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/struct.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/symbolic_lookup.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/symbolic_lookup.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/min_prelude/unused_generic_binding.carbon
+++ b/toolchain/check/testdata/impl/lookup/min_prelude/unused_generic_binding.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
+++ b/toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/no_prelude/specific_args.carbon

--- a/toolchain/check/testdata/impl/lookup/overlap_with_non_types.carbon
+++ b/toolchain/check/testdata/impl/lookup/overlap_with_non_types.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/lookup/transitive.carbon
+++ b/toolchain/check/testdata/impl/lookup/transitive.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/lookup/transitive.carbon

--- a/toolchain/check/testdata/impl/min_prelude/extend_final.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/extend_final.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/min_prelude/fail_extend_impl_scope.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/fail_extend_impl_scope.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/min_prelude/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/fail_impl_as_scope.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/min_prelude/forward_decls.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/forward_decls.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/min_prelude/generic_redeclaration.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/generic_redeclaration.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/min_prelude/impl_thunk.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/impl_thunk.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/min_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/import_self.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/min_prelude/interface_args.carbon
+++ b/toolchain/check/testdata/impl/min_prelude/interface_args.carbon
@@ -2,6 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/destroy.carbon
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/impl/multiple_extend.carbon
+++ b/toolchain/check/testdata/impl/multiple_extend.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/multiple_extend.carbon

--- a/toolchain/check/testdata/impl/no_prelude/basic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/basic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/basic.carbon

--- a/toolchain/check/testdata/impl/no_prelude/compound.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/compound.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/compound.carbon

--- a/toolchain/check/testdata/impl/no_prelude/error_recovery.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/error_recovery.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/error_recovery.carbon

--- a/toolchain/check/testdata/impl/no_prelude/fail_alias.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_alias.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/fail_alias.carbon

--- a/toolchain/check/testdata/impl/no_prelude/fail_impl_bad_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_impl_bad_assoc_const.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/fail_impl_bad_assoc_const.carbon
@@ -36,8 +39,8 @@ impl () as I {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %.loc20_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc20_7.2: type = converted %.loc20_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:     %.loc23_7.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:     %.loc23_7.2: type = converted %.loc23_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (<error>), @impl [concrete]
@@ -60,7 +63,7 @@ impl () as I {}
 // CHECK:STDOUT:   assoc_const T:! type;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %.loc20_7.2 as %I.ref {
+// CHECK:STDOUT: impl @impl: %.loc23_7.2 as %I.ref {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   witness = file.%I.impl_witness
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/fail_impl_bad_type.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_impl_bad_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/fail_impl_bad_type.carbon
@@ -31,7 +34,7 @@ impl true as I {}
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
 // CHECK:STDOUT:     %true: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:     %.loc17: type = converted %true, <error> [concrete = <error>]
+// CHECK:STDOUT:     %.loc20: type = converted %true, <error> [concrete = <error>]
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/fail_undefined_interface.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/fail_undefined_interface.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/fail_undefined_interface.carbon

--- a/toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/impl_assoc_const.carbon

--- a/toolchain/check/testdata/impl/no_prelude/impl_self_as.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_self_as.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/no_prelude/impl_thunk.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_thunk.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/impl_thunk.carbon

--- a/toolchain/check/testdata/impl/no_prelude/impl_where_redecl.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/impl_where_redecl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_builtin_call.carbon

--- a/toolchain/check/testdata/impl/no_prelude/import_compound.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_compound.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_compound.carbon

--- a/toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_extend_impl.carbon

--- a/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_generic.carbon

--- a/toolchain/check/testdata/impl/no_prelude/import_impl_with_no_interface.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_impl_with_no_interface.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/no_prelude/import_interface_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_interface_assoc_const.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_interface_assoc_const.carbon

--- a/toolchain/check/testdata/impl/no_prelude/import_thunk.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_thunk.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_thunk.carbon

--- a/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/import_use_generic.carbon

--- a/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/name_poisoning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/no_definition_in_impl_file.carbon

--- a/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
@@ -63,10 +66,10 @@ class A {
 // CHECK:STDOUT:     %return.param_patt: @Make.1.%pattern_type (%pattern_type.839) = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.ref: %DefaultConstructible.type = name_ref Self, @DefaultConstructible.%Self [symbolic = %Self (constants.%Self)]
-// CHECK:STDOUT:     %Self.as_type.loc12_16.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc12_16.1 (constants.%Self.as_type)]
-// CHECK:STDOUT:     %.loc12: type = converted %Self.ref, %Self.as_type.loc12_16.2 [symbolic = %Self.as_type.loc12_16.1 (constants.%Self.as_type)]
-// CHECK:STDOUT:     %return.param: ref @Make.1.%Self.as_type.loc12_16.1 (%Self.as_type) = out_param call_param0
-// CHECK:STDOUT:     %return: ref @Make.1.%Self.as_type.loc12_16.1 (%Self.as_type) = return_slot %return.param
+// CHECK:STDOUT:     %Self.as_type.loc15_16.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc15_16.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:     %.loc15: type = converted %Self.ref, %Self.as_type.loc15_16.2 [symbolic = %Self.as_type.loc15_16.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:     %return.param: ref @Make.1.%Self.as_type.loc15_16.1 (%Self.as_type) = out_param call_param0
+// CHECK:STDOUT:     %return: ref @Make.1.%Self.as_type.loc15_16.1 (%Self.as_type) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %DefaultConstructible.assoc_type = assoc_entity element0, %Make.decl [concrete = constants.%assoc0]
 // CHECK:STDOUT:
@@ -119,29 +122,29 @@ class A {
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @Make.1(@DefaultConstructible.%Self: %DefaultConstructible.type) {
 // CHECK:STDOUT:   %Self: %DefaultConstructible.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self)]
-// CHECK:STDOUT:   %Self.as_type.loc12_16.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc12_16.1 (constants.%Self.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc12_16.1 [symbolic = %pattern_type (constants.%pattern_type.839)]
+// CHECK:STDOUT:   %Self.as_type.loc15_16.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc15_16.1 (constants.%Self.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc15_16.1 [symbolic = %pattern_type (constants.%pattern_type.839)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn() -> @Make.1.%Self.as_type.loc12_16.1 (%Self.as_type);
+// CHECK:STDOUT:   fn() -> @Make.1.%Self.as_type.loc15_16.1 (%Self.as_type);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make.2() -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc21_33.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc21_33.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc21_34: init %C = converted %.loc21_33.1, %.loc21_33.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc21_34 to %return
+// CHECK:STDOUT:   %.loc24_33.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc24_33.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc24_34: init %C = converted %.loc24_33.1, %.loc24_33.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc24_34 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Make.1(constants.%Self) {
 // CHECK:STDOUT:   %Self => constants.%Self
-// CHECK:STDOUT:   %Self.as_type.loc12_16.1 => constants.%Self.as_type
+// CHECK:STDOUT:   %Self.as_type.loc15_16.1 => constants.%Self.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.839
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Make.1(constants.%DefaultConstructible.facet) {
 // CHECK:STDOUT:   %Self => constants.%DefaultConstructible.facet
-// CHECK:STDOUT:   %Self.as_type.loc12_16.1 => constants.%C
+// CHECK:STDOUT:   %Self.as_type.loc15_16.1 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.c48
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -52,13 +55,13 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
 // CHECK:STDOUT:   %D: type = class_type @D [concrete]
-// CHECK:STDOUT:   %UseSelf.impl_witness.b25: <witness> = impl_witness file.%UseSelf.impl_witness_table.loc19 [concrete]
+// CHECK:STDOUT:   %UseSelf.impl_witness.b25: <witness> = impl_witness file.%UseSelf.impl_witness_table.loc22 [concrete]
 // CHECK:STDOUT:   %pattern_type.c48: type = pattern_type %C [concrete]
 // CHECK:STDOUT:   %F.type.fc6: type = fn_type @F.2 [concrete]
 // CHECK:STDOUT:   %F.5e2: %F.type.fc6 = struct_value () [concrete]
 // CHECK:STDOUT:   %UseSelf.facet.727: %UseSelf.type = facet_value %C, (%UseSelf.impl_witness.b25) [concrete]
 // CHECK:STDOUT:   %C.val: %C = struct_value () [concrete]
-// CHECK:STDOUT:   %UseSelf.impl_witness.f90: <witness> = impl_witness file.%UseSelf.impl_witness_table.loc23 [concrete]
+// CHECK:STDOUT:   %UseSelf.impl_witness.f90: <witness> = impl_witness file.%UseSelf.impl_witness_table.loc26 [concrete]
 // CHECK:STDOUT:   %pattern_type.510: type = pattern_type %D [concrete]
 // CHECK:STDOUT:   %F.type.0aa: type = fn_type @F.3 [concrete]
 // CHECK:STDOUT:   %F.f71: %F.type.0aa = struct_value () [concrete]
@@ -76,7 +79,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %F.998: %F.type.6ed = struct_value () [concrete]
 // CHECK:STDOUT:   %SelfNested.assoc_type: type = assoc_entity_type @SelfNested [concrete]
 // CHECK:STDOUT:   %assoc0.beb: %SelfNested.assoc_type = assoc_entity element0, @SelfNested.%F.decl [concrete]
-// CHECK:STDOUT:   %SelfNested.impl_witness.5d5: <witness> = impl_witness file.%SelfNested.impl_witness_table.loc31 [concrete]
+// CHECK:STDOUT:   %SelfNested.impl_witness.5d5: <witness> = impl_witness file.%SelfNested.impl_witness_table.loc34 [concrete]
 // CHECK:STDOUT:   %ptr.019: type = ptr_type %C [concrete]
 // CHECK:STDOUT:   %struct_type.x.y.2f0: type = struct_type {.x: %C, .y: %empty_tuple.type} [concrete]
 // CHECK:STDOUT:   %tuple.type.a17: type = tuple_type (%ptr.019, %struct_type.x.y.2f0) [concrete]
@@ -84,7 +87,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %F.type.ef0: type = fn_type @F.5 [concrete]
 // CHECK:STDOUT:   %F.9a9: %F.type.ef0 = struct_value () [concrete]
 // CHECK:STDOUT:   %SelfNested.facet.2b2: %SelfNested.type = facet_value %C, (%SelfNested.impl_witness.5d5) [concrete]
-// CHECK:STDOUT:   %SelfNested.impl_witness.16b: <witness> = impl_witness file.%SelfNested.impl_witness_table.loc35 [concrete]
+// CHECK:STDOUT:   %SelfNested.impl_witness.16b: <witness> = impl_witness file.%SelfNested.impl_witness_table.loc38 [concrete]
 // CHECK:STDOUT:   %ptr.19c: type = ptr_type %D [concrete]
 // CHECK:STDOUT:   %struct_type.x.y.527: type = struct_type {.x: %D, .y: %empty_tuple.type} [concrete]
 // CHECK:STDOUT:   %tuple.type.a5f: type = tuple_type (%ptr.19c, %struct_type.x.y.527) [concrete]
@@ -108,27 +111,27 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %UseSelf.ref: type = name_ref UseSelf, file.%UseSelf.decl [concrete = constants.%UseSelf.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %UseSelf.impl_witness_table.loc19 = impl_witness_table (@impl.c4a.%F.decl), @impl.c4a [concrete]
-// CHECK:STDOUT:   %UseSelf.impl_witness.loc19: <witness> = impl_witness %UseSelf.impl_witness_table.loc19 [concrete = constants.%UseSelf.impl_witness.b25]
+// CHECK:STDOUT:   %UseSelf.impl_witness_table.loc22 = impl_witness_table (@impl.c4a.%F.decl), @impl.c4a [concrete]
+// CHECK:STDOUT:   %UseSelf.impl_witness.loc22: <witness> = impl_witness %UseSelf.impl_witness_table.loc22 [concrete = constants.%UseSelf.impl_witness.b25]
 // CHECK:STDOUT:   impl_decl @impl.659 [concrete] {} {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [concrete = constants.%D]
 // CHECK:STDOUT:     %UseSelf.ref: type = name_ref UseSelf, file.%UseSelf.decl [concrete = constants.%UseSelf.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %UseSelf.impl_witness_table.loc23 = impl_witness_table (@impl.659.%F.decl), @impl.659 [concrete]
-// CHECK:STDOUT:   %UseSelf.impl_witness.loc23: <witness> = impl_witness %UseSelf.impl_witness_table.loc23 [concrete = constants.%UseSelf.impl_witness.f90]
+// CHECK:STDOUT:   %UseSelf.impl_witness_table.loc26 = impl_witness_table (@impl.659.%F.decl), @impl.659 [concrete]
+// CHECK:STDOUT:   %UseSelf.impl_witness.loc26: <witness> = impl_witness %UseSelf.impl_witness_table.loc26 [concrete = constants.%UseSelf.impl_witness.f90]
 // CHECK:STDOUT:   %SelfNested.decl: type = interface_decl @SelfNested [concrete = constants.%SelfNested.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl.730 [concrete] {} {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, file.%SelfNested.decl [concrete = constants.%SelfNested.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %SelfNested.impl_witness_table.loc31 = impl_witness_table (@impl.730.%F.decl), @impl.730 [concrete]
-// CHECK:STDOUT:   %SelfNested.impl_witness.loc31: <witness> = impl_witness %SelfNested.impl_witness_table.loc31 [concrete = constants.%SelfNested.impl_witness.5d5]
+// CHECK:STDOUT:   %SelfNested.impl_witness_table.loc34 = impl_witness_table (@impl.730.%F.decl), @impl.730 [concrete]
+// CHECK:STDOUT:   %SelfNested.impl_witness.loc34: <witness> = impl_witness %SelfNested.impl_witness_table.loc34 [concrete = constants.%SelfNested.impl_witness.5d5]
 // CHECK:STDOUT:   impl_decl @impl.82d [concrete] {} {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [concrete = constants.%D]
 // CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, file.%SelfNested.decl [concrete = constants.%SelfNested.type]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %SelfNested.impl_witness_table.loc35 = impl_witness_table (@impl.82d.%F.decl), @impl.82d [concrete]
-// CHECK:STDOUT:   %SelfNested.impl_witness.loc35: <witness> = impl_witness %SelfNested.impl_witness_table.loc35 [concrete = constants.%SelfNested.impl_witness.16b]
+// CHECK:STDOUT:   %SelfNested.impl_witness_table.loc38 = impl_witness_table (@impl.82d.%F.decl), @impl.82d [concrete]
+// CHECK:STDOUT:   %SelfNested.impl_witness.loc38: <witness> = impl_witness %SelfNested.impl_witness_table.loc38 [concrete = constants.%SelfNested.impl_witness.16b]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @UseSelf {
@@ -141,25 +144,25 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %return.patt: @F.1.%pattern_type (%pattern_type.3ef) = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: @F.1.%pattern_type (%pattern_type.3ef) = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc12_32: %UseSelf.type = name_ref Self, @UseSelf.%Self [symbolic = %Self (constants.%Self.085)]
-// CHECK:STDOUT:     %Self.as_type.loc12_32: type = facet_access_type %Self.ref.loc12_32 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
-// CHECK:STDOUT:     %.loc12_32: type = converted %Self.ref.loc12_32, %Self.as_type.loc12_32 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
-// CHECK:STDOUT:     %self.param: @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599) = value_param call_param0
-// CHECK:STDOUT:     %.loc12_14.1: type = splice_block %.loc12_14.2 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)] {
-// CHECK:STDOUT:       %Self.ref.loc12_14: %UseSelf.type = name_ref Self, @UseSelf.%Self [symbolic = %Self (constants.%Self.085)]
-// CHECK:STDOUT:       %Self.as_type.loc12_14.2: type = facet_access_type %Self.ref.loc12_14 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
-// CHECK:STDOUT:       %.loc12_14.2: type = converted %Self.ref.loc12_14, %Self.as_type.loc12_14.2 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:     %Self.ref.loc15_32: %UseSelf.type = name_ref Self, @UseSelf.%Self [symbolic = %Self (constants.%Self.085)]
+// CHECK:STDOUT:     %Self.as_type.loc15_32: type = facet_access_type %Self.ref.loc15_32 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:     %.loc15_32: type = converted %Self.ref.loc15_32, %Self.as_type.loc15_32 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:     %self.param: @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599) = value_param call_param0
+// CHECK:STDOUT:     %.loc15_14.1: type = splice_block %.loc15_14.2 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)] {
+// CHECK:STDOUT:       %Self.ref.loc15_14: %UseSelf.type = name_ref Self, @UseSelf.%Self [symbolic = %Self (constants.%Self.085)]
+// CHECK:STDOUT:       %Self.as_type.loc15_14.2: type = facet_access_type %Self.ref.loc15_14 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:       %.loc15_14.2: type = converted %Self.ref.loc15_14, %Self.as_type.loc15_14.2 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %self: @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599) = bind_name self, %self.param
-// CHECK:STDOUT:     %x.param: @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599) = value_param call_param1
-// CHECK:STDOUT:     %.loc12_23.1: type = splice_block %.loc12_23.2 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)] {
-// CHECK:STDOUT:       %Self.ref.loc12_23: %UseSelf.type = name_ref Self, @UseSelf.%Self [symbolic = %Self (constants.%Self.085)]
-// CHECK:STDOUT:       %Self.as_type.loc12_23: type = facet_access_type %Self.ref.loc12_23 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
-// CHECK:STDOUT:       %.loc12_23.2: type = converted %Self.ref.loc12_23, %Self.as_type.loc12_23 [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:     %self: @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599) = bind_name self, %self.param
+// CHECK:STDOUT:     %x.param: @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599) = value_param call_param1
+// CHECK:STDOUT:     %.loc15_23.1: type = splice_block %.loc15_23.2 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)] {
+// CHECK:STDOUT:       %Self.ref.loc15_23: %UseSelf.type = name_ref Self, @UseSelf.%Self [symbolic = %Self (constants.%Self.085)]
+// CHECK:STDOUT:       %Self.as_type.loc15_23: type = facet_access_type %Self.ref.loc15_23 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:       %.loc15_23.2: type = converted %Self.ref.loc15_23, %Self.as_type.loc15_23 [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %x: @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599) = bind_name x, %x.param
-// CHECK:STDOUT:     %return.param: ref @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599) = out_param call_param2
-// CHECK:STDOUT:     %return: ref @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599) = return_slot %return.param
+// CHECK:STDOUT:     %x: @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599) = bind_name x, %x.param
+// CHECK:STDOUT:     %return.param: ref @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599) = out_param call_param2
+// CHECK:STDOUT:     %return: ref @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %UseSelf.assoc_type = assoc_entity element0, %F.decl [concrete = constants.%assoc0.24c]
 // CHECK:STDOUT:
@@ -176,19 +179,19 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %x.param_patt: @F.4.%pattern_type (%pattern_type.5a1) = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: @F.4.%tuple.type (%tuple.type.46b) = value_param call_param0
-// CHECK:STDOUT:     %.loc28_37.1: type = splice_block %.loc28_37.3 [symbolic = %tuple.type (constants.%tuple.type.46b)] {
-// CHECK:STDOUT:       %Self.ref.loc28_12: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
-// CHECK:STDOUT:       %Self.as_type.loc28_16.2: type = facet_access_type %Self.ref.loc28_12 [symbolic = %Self.as_type.loc28_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %.loc28_16: type = converted %Self.ref.loc28_12, %Self.as_type.loc28_16.2 [symbolic = %Self.as_type.loc28_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %ptr.loc28_16.2: type = ptr_type %.loc28_16 [symbolic = %ptr.loc28_16.1 (constants.%ptr.e87)]
-// CHECK:STDOUT:       %Self.ref.loc28_24: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
-// CHECK:STDOUT:       %Self.as_type.loc28_24: type = facet_access_type %Self.ref.loc28_24 [symbolic = %Self.as_type.loc28_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %.loc28_24: type = converted %Self.ref.loc28_24, %Self.as_type.loc28_24 [symbolic = %Self.as_type.loc28_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:       %.loc28_35.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:       %.loc28_35.2: type = converted %.loc28_35.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %struct_type.x.y.loc28_36.2: type = struct_type {.x: @F.4.%Self.as_type.loc28_16.1 (%Self.as_type.e1e), .y: %empty_tuple.type} [symbolic = %struct_type.x.y.loc28_36.1 (constants.%struct_type.x.y.270)]
-// CHECK:STDOUT:       %.loc28_37.2: %tuple.type.24b = tuple_literal (%ptr.loc28_16.2, %struct_type.x.y.loc28_36.2)
-// CHECK:STDOUT:       %.loc28_37.3: type = converted %.loc28_37.2, constants.%tuple.type.46b [symbolic = %tuple.type (constants.%tuple.type.46b)]
+// CHECK:STDOUT:     %.loc31_37.1: type = splice_block %.loc31_37.3 [symbolic = %tuple.type (constants.%tuple.type.46b)] {
+// CHECK:STDOUT:       %Self.ref.loc31_12: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
+// CHECK:STDOUT:       %Self.as_type.loc31_16.2: type = facet_access_type %Self.ref.loc31_12 [symbolic = %Self.as_type.loc31_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %.loc31_16: type = converted %Self.ref.loc31_12, %Self.as_type.loc31_16.2 [symbolic = %Self.as_type.loc31_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %ptr.loc31_16.2: type = ptr_type %.loc31_16 [symbolic = %ptr.loc31_16.1 (constants.%ptr.e87)]
+// CHECK:STDOUT:       %Self.ref.loc31_24: %SelfNested.type = name_ref Self, @SelfNested.%Self [symbolic = %Self (constants.%Self.2ff)]
+// CHECK:STDOUT:       %Self.as_type.loc31_24: type = facet_access_type %Self.ref.loc31_24 [symbolic = %Self.as_type.loc31_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %.loc31_24: type = converted %Self.ref.loc31_24, %Self.as_type.loc31_24 [symbolic = %Self.as_type.loc31_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:       %.loc31_35.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:       %.loc31_35.2: type = converted %.loc31_35.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:       %struct_type.x.y.loc31_36.2: type = struct_type {.x: @F.4.%Self.as_type.loc31_16.1 (%Self.as_type.e1e), .y: %empty_tuple.type} [symbolic = %struct_type.x.y.loc31_36.1 (constants.%struct_type.x.y.270)]
+// CHECK:STDOUT:       %.loc31_37.2: %tuple.type.24b = tuple_literal (%ptr.loc31_16.2, %struct_type.x.y.loc31_36.2)
+// CHECK:STDOUT:       %.loc31_37.3: type = converted %.loc31_37.2, constants.%tuple.type.46b [symbolic = %tuple.type (constants.%tuple.type.46b)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: @F.4.%tuple.type (%tuple.type.46b) = bind_name x, %x.param
 // CHECK:STDOUT:   }
@@ -209,12 +212,12 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc20_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc23_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc20_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc23_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %x.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc20_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %x: %C = bind_name x, %x.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -223,7 +226,7 @@ impl D as SelfNested {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .C = <poisoned>
 // CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   witness = file.%UseSelf.impl_witness.loc19
+// CHECK:STDOUT:   witness = file.%UseSelf.impl_witness.loc22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.659: %D.ref as %UseSelf.ref {
@@ -235,12 +238,12 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %return.patt: %pattern_type.510 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.510 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %Self.ref.loc24_32: type = name_ref Self, @impl.659.%D.ref [concrete = constants.%D]
+// CHECK:STDOUT:     %Self.ref.loc27_32: type = name_ref Self, @impl.659.%D.ref [concrete = constants.%D]
 // CHECK:STDOUT:     %self.param: %D = value_param call_param0
-// CHECK:STDOUT:     %Self.ref.loc24_14: type = name_ref Self, @impl.659.%D.ref [concrete = constants.%D]
+// CHECK:STDOUT:     %Self.ref.loc27_14: type = name_ref Self, @impl.659.%D.ref [concrete = constants.%D]
 // CHECK:STDOUT:     %self: %D = bind_name self, %self.param
 // CHECK:STDOUT:     %x.param: %D = value_param call_param1
-// CHECK:STDOUT:     %Self.ref.loc24_23: type = name_ref Self, @impl.659.%D.ref [concrete = constants.%D]
+// CHECK:STDOUT:     %Self.ref.loc27_23: type = name_ref Self, @impl.659.%D.ref [concrete = constants.%D]
 // CHECK:STDOUT:     %x: %D = bind_name x, %x.param
 // CHECK:STDOUT:     %return.param: ref %D = out_param call_param2
 // CHECK:STDOUT:     %return: ref %D = return_slot %return.param
@@ -248,7 +251,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   witness = file.%UseSelf.impl_witness.loc23
+// CHECK:STDOUT:   witness = file.%UseSelf.impl_witness.loc26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.730: %C.ref as %SelfNested.ref {
@@ -257,15 +260,15 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.809 = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: %tuple.type.a17 = value_param call_param0
-// CHECK:STDOUT:     %.loc32_31.1: type = splice_block %.loc32_31.3 [concrete = constants.%tuple.type.a17] {
-// CHECK:STDOUT:       %C.ref.loc32_12: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc32_12 [concrete = constants.%ptr.019]
-// CHECK:STDOUT:       %C.ref.loc32_21: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %.loc32_29.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:       %.loc32_29.2: type = converted %.loc32_29.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:     %.loc35_31.1: type = splice_block %.loc35_31.3 [concrete = constants.%tuple.type.a17] {
+// CHECK:STDOUT:       %C.ref.loc35_12: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc35_12 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:       %C.ref.loc35_21: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %.loc35_29.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:       %.loc35_29.2: type = converted %.loc35_29.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:       %struct_type.x.y: type = struct_type {.x: %C, .y: %empty_tuple.type} [concrete = constants.%struct_type.x.y.2f0]
-// CHECK:STDOUT:       %.loc32_31.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
-// CHECK:STDOUT:       %.loc32_31.3: type = converted %.loc32_31.2, constants.%tuple.type.a17 [concrete = constants.%tuple.type.a17]
+// CHECK:STDOUT:       %.loc35_31.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
+// CHECK:STDOUT:       %.loc35_31.3: type = converted %.loc35_31.2, constants.%tuple.type.a17 [concrete = constants.%tuple.type.a17]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: %tuple.type.a17 = bind_name x, %x.param
 // CHECK:STDOUT:   }
@@ -273,7 +276,7 @@ impl D as SelfNested {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .C = <poisoned>
 // CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   witness = file.%SelfNested.impl_witness.loc31
+// CHECK:STDOUT:   witness = file.%SelfNested.impl_witness.loc34
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.82d: %D.ref as %SelfNested.ref {
@@ -282,22 +285,22 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.b43 = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: %tuple.type.a5f = value_param call_param0
-// CHECK:STDOUT:     %.loc36_37.1: type = splice_block %.loc36_37.3 [concrete = constants.%tuple.type.a5f] {
-// CHECK:STDOUT:       %Self.ref.loc36_12: type = name_ref Self, @impl.82d.%D.ref [concrete = constants.%D]
-// CHECK:STDOUT:       %ptr: type = ptr_type %Self.ref.loc36_12 [concrete = constants.%ptr.19c]
-// CHECK:STDOUT:       %Self.ref.loc36_24: type = name_ref Self, @impl.82d.%D.ref [concrete = constants.%D]
-// CHECK:STDOUT:       %.loc36_35.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:       %.loc36_35.2: type = converted %.loc36_35.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:     %.loc39_37.1: type = splice_block %.loc39_37.3 [concrete = constants.%tuple.type.a5f] {
+// CHECK:STDOUT:       %Self.ref.loc39_12: type = name_ref Self, @impl.82d.%D.ref [concrete = constants.%D]
+// CHECK:STDOUT:       %ptr: type = ptr_type %Self.ref.loc39_12 [concrete = constants.%ptr.19c]
+// CHECK:STDOUT:       %Self.ref.loc39_24: type = name_ref Self, @impl.82d.%D.ref [concrete = constants.%D]
+// CHECK:STDOUT:       %.loc39_35.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:       %.loc39_35.2: type = converted %.loc39_35.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:       %struct_type.x.y: type = struct_type {.x: %D, .y: %empty_tuple.type} [concrete = constants.%struct_type.x.y.527]
-// CHECK:STDOUT:       %.loc36_37.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
-// CHECK:STDOUT:       %.loc36_37.3: type = converted %.loc36_37.2, constants.%tuple.type.a5f [concrete = constants.%tuple.type.a5f]
+// CHECK:STDOUT:       %.loc39_37.2: %tuple.type.24b = tuple_literal (%ptr, %struct_type.x.y)
+// CHECK:STDOUT:       %.loc39_37.3: type = converted %.loc39_37.2, constants.%tuple.type.a5f [concrete = constants.%tuple.type.a5f]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: %tuple.type.a5f = bind_name x, %x.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F.decl
-// CHECK:STDOUT:   witness = file.%SelfNested.impl_witness.loc35
+// CHECK:STDOUT:   witness = file.%SelfNested.impl_witness.loc38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
@@ -320,34 +323,34 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F.1(@UseSelf.%Self: %UseSelf.type) {
 // CHECK:STDOUT:   %Self: %UseSelf.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.085)]
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc12_14.1 (constants.%Self.as_type.599)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc12_14.1 [symbolic = %pattern_type (constants.%pattern_type.3ef)]
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc15_14.1 (constants.%Self.as_type.599)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc15_14.1 [symbolic = %pattern_type (constants.%pattern_type.3ef)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599), %x.param: @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599)) -> @F.1.%Self.as_type.loc12_14.1 (%Self.as_type.599);
+// CHECK:STDOUT:   fn(%self.param: @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599), %x.param: @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599)) -> @F.1.%Self.as_type.loc15_14.1 (%Self.as_type.599);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%self.param: %C, %x.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc20_38.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc20_38.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc20_39: init %C = converted %.loc20_38.1, %.loc20_38.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc20_39 to %return
+// CHECK:STDOUT:   %.loc23_38.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc23_38.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc23_39: init %C = converted %.loc23_38.1, %.loc23_38.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc23_39 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.3(%self.param: %D, %x.param: %D) -> %return.param: %D {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc24_47.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc24_47.2: init %D = class_init (), %return [concrete = constants.%D.val]
-// CHECK:STDOUT:   %.loc24_48: init %D = converted %.loc24_47.1, %.loc24_47.2 [concrete = constants.%D.val]
-// CHECK:STDOUT:   return %.loc24_48 to %return
+// CHECK:STDOUT:   %.loc27_47.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc27_47.2: init %D = class_init (), %return [concrete = constants.%D.val]
+// CHECK:STDOUT:   %.loc27_48: init %D = converted %.loc27_47.1, %.loc27_47.2 [concrete = constants.%D.val]
+// CHECK:STDOUT:   return %.loc27_48 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic fn @F.4(@SelfNested.%Self: %SelfNested.type) {
 // CHECK:STDOUT:   %Self: %SelfNested.type = bind_symbolic_name Self, 0 [symbolic = %Self (constants.%Self.2ff)]
-// CHECK:STDOUT:   %Self.as_type.loc28_16.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc28_16.1 (constants.%Self.as_type.e1e)]
-// CHECK:STDOUT:   %ptr.loc28_16.1: type = ptr_type %Self.as_type.loc28_16.1 [symbolic = %ptr.loc28_16.1 (constants.%ptr.e87)]
-// CHECK:STDOUT:   %struct_type.x.y.loc28_36.1: type = struct_type {.x: @F.4.%Self.as_type.loc28_16.1 (%Self.as_type.e1e), .y: %empty_tuple.type} [symbolic = %struct_type.x.y.loc28_36.1 (constants.%struct_type.x.y.270)]
-// CHECK:STDOUT:   %tuple.type: type = tuple_type (%ptr.loc28_16.1, %struct_type.x.y.loc28_36.1) [symbolic = %tuple.type (constants.%tuple.type.46b)]
+// CHECK:STDOUT:   %Self.as_type.loc31_16.1: type = facet_access_type %Self [symbolic = %Self.as_type.loc31_16.1 (constants.%Self.as_type.e1e)]
+// CHECK:STDOUT:   %ptr.loc31_16.1: type = ptr_type %Self.as_type.loc31_16.1 [symbolic = %ptr.loc31_16.1 (constants.%ptr.e87)]
+// CHECK:STDOUT:   %struct_type.x.y.loc31_36.1: type = struct_type {.x: @F.4.%Self.as_type.loc31_16.1 (%Self.as_type.e1e), .y: %empty_tuple.type} [symbolic = %struct_type.x.y.loc31_36.1 (constants.%struct_type.x.y.270)]
+// CHECK:STDOUT:   %tuple.type: type = tuple_type (%ptr.loc31_16.1, %struct_type.x.y.loc31_36.1) [symbolic = %tuple.type (constants.%tuple.type.46b)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %tuple.type [symbolic = %pattern_type (constants.%pattern_type.5a1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%x.param: @F.4.%tuple.type (%tuple.type.46b));
@@ -359,45 +362,45 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%Self.085) {
 // CHECK:STDOUT:   %Self => constants.%Self.085
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1 => constants.%Self.as_type.599
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1 => constants.%Self.as_type.599
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.3ef
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%UseSelf.facet.727) {
 // CHECK:STDOUT:   %Self => constants.%UseSelf.facet.727
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1 => constants.%C
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1 => constants.%C
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.c48
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.1(constants.%UseSelf.facet.d11) {
 // CHECK:STDOUT:   %Self => constants.%UseSelf.facet.d11
-// CHECK:STDOUT:   %Self.as_type.loc12_14.1 => constants.%D
+// CHECK:STDOUT:   %Self.as_type.loc15_14.1 => constants.%D
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.510
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.4(constants.%Self.2ff) {
 // CHECK:STDOUT:   %Self => constants.%Self.2ff
-// CHECK:STDOUT:   %Self.as_type.loc28_16.1 => constants.%Self.as_type.e1e
-// CHECK:STDOUT:   %ptr.loc28_16.1 => constants.%ptr.e87
-// CHECK:STDOUT:   %struct_type.x.y.loc28_36.1 => constants.%struct_type.x.y.270
+// CHECK:STDOUT:   %Self.as_type.loc31_16.1 => constants.%Self.as_type.e1e
+// CHECK:STDOUT:   %ptr.loc31_16.1 => constants.%ptr.e87
+// CHECK:STDOUT:   %struct_type.x.y.loc31_36.1 => constants.%struct_type.x.y.270
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.46b
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.5a1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.4(constants.%SelfNested.facet.2b2) {
 // CHECK:STDOUT:   %Self => constants.%SelfNested.facet.2b2
-// CHECK:STDOUT:   %Self.as_type.loc28_16.1 => constants.%C
-// CHECK:STDOUT:   %ptr.loc28_16.1 => constants.%ptr.019
-// CHECK:STDOUT:   %struct_type.x.y.loc28_36.1 => constants.%struct_type.x.y.2f0
+// CHECK:STDOUT:   %Self.as_type.loc31_16.1 => constants.%C
+// CHECK:STDOUT:   %ptr.loc31_16.1 => constants.%ptr.019
+// CHECK:STDOUT:   %struct_type.x.y.loc31_36.1 => constants.%struct_type.x.y.2f0
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.a17
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.809
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F.4(constants.%SelfNested.facet.f2c) {
 // CHECK:STDOUT:   %Self => constants.%SelfNested.facet.f2c
-// CHECK:STDOUT:   %Self.as_type.loc28_16.1 => constants.%D
-// CHECK:STDOUT:   %ptr.loc28_16.1 => constants.%ptr.19c
-// CHECK:STDOUT:   %struct_type.x.y.loc28_36.1 => constants.%struct_type.x.y.527
+// CHECK:STDOUT:   %Self.as_type.loc31_16.1 => constants.%D
+// CHECK:STDOUT:   %ptr.loc31_16.1 => constants.%ptr.19c
+// CHECK:STDOUT:   %struct_type.x.y.loc31_36.1 => constants.%struct_type.x.y.527
 // CHECK:STDOUT:   %tuple.type => constants.%tuple.type.a5f
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.b43
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/todo_impl_with_unrelated_fn.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/todo_impl_with_unrelated_fn.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/no_prelude/todo_impl_with_unrelated_fn.carbon

--- a/toolchain/check/testdata/impl/redeclaration.carbon
+++ b/toolchain/check/testdata/impl/redeclaration.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/redeclaration.carbon
@@ -51,17 +54,17 @@ impl i32 as I {}
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [concrete = constants.%I.type] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc13: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %I.ref.loc16: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (), @impl [concrete]
 // CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness]
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [concrete = constants.%X] {} {}
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %int_32.loc19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc19: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %int_32.loc22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %I.ref.loc22: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -73,16 +76,16 @@ impl i32 as I {}
 // CHECK:STDOUT:   witness = ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: %i32.loc13 as %I.ref.loc13 {
+// CHECK:STDOUT: impl @impl: %i32.loc16 as %I.ref.loc16 {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   witness = file.%I.impl_witness
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
 // CHECK:STDOUT:   impl_decl @impl [concrete] {} {
-// CHECK:STDOUT:     %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %I.ref.loc16: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     %int_32.loc19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %I.ref.loc19: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete = constants.%complete_type.357]

--- a/toolchain/check/testdata/impl/use_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/use_assoc_const.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/use_assoc_const.carbon


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.