### PR TITLE
Add range flag settings to if_expr files

### DIFF
--- a/toolchain/check/testdata/if_expr/basic.carbon
+++ b/toolchain/check/testdata/if_expr/basic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/basic.carbon
@@ -81,25 +84,25 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param3 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11_34: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11_34: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14_34: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14_34: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %b.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc11_9.1: type = splice_block %.loc11_9.3 [concrete = bool] {
+// CHECK:STDOUT:     %.loc14_9.1: type = splice_block %.loc14_9.3 [concrete = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc11_9.2: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:       %.loc11_9.3: type = converted %bool.make_type, %.loc11_9.2 [concrete = bool]
+// CHECK:STDOUT:       %.loc14_9.2: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:       %.loc14_9.3: type = converted %bool.make_type, %.loc14_9.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param1
-// CHECK:STDOUT:     %.loc11_18: type = splice_block %i32.loc11_18 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc11_18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc14_18: type = splice_block %i32.loc14_18 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc14_18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %n: %i32 = bind_name n, %n.param
 // CHECK:STDOUT:     %m.param: %i32 = value_param call_param2
-// CHECK:STDOUT:     %.loc11_26: type = splice_block %i32.loc11_26 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc11_26: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_26: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc14_26: type = splice_block %i32.loc14_26 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc14_26: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_26: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %m: %i32 = bind_name m, %m.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param3
@@ -114,50 +117,50 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT:     %x.var_patt: %pattern_type.a98 = var_pattern %x.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %x.var: ref %array_type = var %x.var_patt
-// CHECK:STDOUT:   %int_0.loc12_27: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
-// CHECK:STDOUT:   %.loc12_29.1: %tuple.type = tuple_literal (%int_0.loc12_27)
+// CHECK:STDOUT:   %int_0.loc15_27: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
+// CHECK:STDOUT:   %.loc15_29.1: %tuple.type = tuple_literal (%int_0.loc15_27)
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_29.1: <bound method> = bound_method %int_0.loc12_27, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc15_29.1: <bound method> = bound_method %int_0.loc15_27, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_29.2: <bound method> = bound_method %int_0.loc12_27, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_29.2(%int_0.loc12_27) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc12_29.2: init %i32 = converted %int_0.loc12_27, %int.convert_checked [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %int_0.loc12_29: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
-// CHECK:STDOUT:   %.loc12_29.3: ref %i32 = array_index %x.var, %int_0.loc12_29
-// CHECK:STDOUT:   %.loc12_29.4: init %i32 = initialize_from %.loc12_29.2 to %.loc12_29.3 [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc12_29.5: init %array_type = array_init (%.loc12_29.4) to %x.var [concrete = constants.%array]
-// CHECK:STDOUT:   %.loc12_3: init %array_type = converted %.loc12_29.1, %.loc12_29.5 [concrete = constants.%array]
-// CHECK:STDOUT:   assign %x.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_22: type = splice_block %array_type [concrete = constants.%array_type] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %bound_method.loc15_29.2: <bound method> = bound_method %int_0.loc15_27, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_29.2(%int_0.loc15_27) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc15_29.2: init %i32 = converted %int_0.loc15_27, %int.convert_checked [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %int_0.loc15_29: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
+// CHECK:STDOUT:   %.loc15_29.3: ref %i32 = array_index %x.var, %int_0.loc15_29
+// CHECK:STDOUT:   %.loc15_29.4: init %i32 = initialize_from %.loc15_29.2 to %.loc15_29.3 [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc15_29.5: init %array_type = array_init (%.loc15_29.4) to %x.var [concrete = constants.%array]
+// CHECK:STDOUT:   %.loc15_3: init %array_type = converted %.loc15_29.1, %.loc15_29.5 [concrete = constants.%array]
+// CHECK:STDOUT:   assign %x.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_22: type = splice_block %array_type [concrete = constants.%array_type] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1]
-// CHECK:STDOUT:     %array_type: type = array_type %int_1, %i32.loc12 [concrete = constants.%array_type]
+// CHECK:STDOUT:     %array_type: type = array_type %int_1, %i32.loc15 [concrete = constants.%array_type]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %x: ref %array_type = bind_name x, %x.var
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %x.ref.loc13_20: ref %array_type = name_ref x, %x
+// CHECK:STDOUT:   %x.ref.loc16_20: ref %array_type = name_ref x, %x
 // CHECK:STDOUT:   %m.ref: %i32 = name_ref m, %m
-// CHECK:STDOUT:   %int_32.loc13_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13_23.1: ref %i32 = array_index %x.ref.loc13_20, %m.ref
-// CHECK:STDOUT:   %.loc13_23.2: %i32 = bind_value %.loc13_23.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc13_23.2)
+// CHECK:STDOUT:   %int_32.loc16_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16_23.1: ref %i32 = array_index %x.ref.loc16_20, %m.ref
+// CHECK:STDOUT:   %.loc16_23.2: %i32 = bind_value %.loc16_23.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc16_23.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %x.ref.loc13_30: ref %array_type = name_ref x, %x
+// CHECK:STDOUT:   %x.ref.loc16_30: ref %array_type = name_ref x, %x
 // CHECK:STDOUT:   %n.ref: %i32 = name_ref n, %n
-// CHECK:STDOUT:   %int_32.loc13_33: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13_33: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc13_33.1: ref %i32 = array_index %x.ref.loc13_30, %n.ref
-// CHECK:STDOUT:   %.loc13_33.2: %i32 = bind_value %.loc13_33.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc13_33.2)
+// CHECK:STDOUT:   %int_32.loc16_33: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16_33: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc16_33.1: ref %i32 = array_index %x.ref.loc16_30, %n.ref
+// CHECK:STDOUT:   %.loc16_33.2: %i32 = bind_value %.loc16_33.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc16_33.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc13_10: %i32 = block_arg !if.expr.result
-// CHECK:STDOUT:   return %.loc13_10
+// CHECK:STDOUT:   %.loc16_10: %i32 = block_arg !if.expr.result
+// CHECK:STDOUT:   return %.loc16_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -143,8 +146,8 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc25: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc25: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param0
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -154,8 +157,8 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc28: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc28: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc31: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc31: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %t.param: type = value_param call_param0
 // CHECK:STDOUT:     %t: type = bind_name t, %t.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
@@ -167,26 +170,26 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc11_25.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %bound_method.loc14_25.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc11_25.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc11_25.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc11_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc11_25.2: %i32 = converted %int_1, %.loc11_25.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   return %.loc11_25.2
+// CHECK:STDOUT:   %bound_method.loc14_25.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc14_25.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc14_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc14_25.2: %i32 = converted %int_1, %.loc14_25.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   return %.loc14_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_25.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %bound_method.loc15_25.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Convert.bound.ef9]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_25.2: <bound method> = bound_method %int_2, %specific_fn [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_25.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_25.2: %i32 = converted %int_2, %.loc12_25.1 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   return %.loc12_25.2
+// CHECK:STDOUT:   %bound_method.loc15_25.2: <bound method> = bound_method %int_2, %specific_fn [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_25.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_25.2: %i32 = converted %int_2, %.loc15_25.1 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   return %.loc15_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %i32 {
@@ -197,20 +200,20 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT: !if.expr.then:
 // CHECK:STDOUT:   %A.ref: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:   %A.call: init %i32 = call %A.ref()
-// CHECK:STDOUT:   %.loc15_25.1: %i32 = value_of_initializer %A.call
-// CHECK:STDOUT:   %.loc15_25.2: %i32 = converted %A.call, %.loc15_25.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_25.2)
+// CHECK:STDOUT:   %.loc18_25.1: %i32 = value_of_initializer %A.call
+// CHECK:STDOUT:   %.loc18_25.2: %i32 = converted %A.call, %.loc18_25.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc18_25.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: %B.type = name_ref B, file.%B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %B.call: init %i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc15_27.1: %i32 = value_of_initializer %B.call
-// CHECK:STDOUT:   %.loc15_27.2: %i32 = converted %B.call, %.loc15_27.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_27.2)
+// CHECK:STDOUT:   %.loc18_27.1: %i32 = value_of_initializer %B.call
+// CHECK:STDOUT:   %.loc18_27.2: %i32 = converted %B.call, %.loc18_27.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc18_27.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc15_10: %i32 = block_arg !if.expr.result
-// CHECK:STDOUT:   return %.loc15_10
+// CHECK:STDOUT:   %.loc18_10: %i32 = block_arg !if.expr.result
+// CHECK:STDOUT:   return %.loc18_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %i32 {
@@ -221,20 +224,20 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT: !if.expr.then:
 // CHECK:STDOUT:   %A.ref: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:   %A.call: init %i32 = call %A.ref()
-// CHECK:STDOUT:   %.loc19_26.1: %i32 = value_of_initializer %A.call
-// CHECK:STDOUT:   %.loc19_26.2: %i32 = converted %A.call, %.loc19_26.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc19_26.2)
+// CHECK:STDOUT:   %.loc22_26.1: %i32 = value_of_initializer %A.call
+// CHECK:STDOUT:   %.loc22_26.2: %i32 = converted %A.call, %.loc22_26.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc22_26.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: %B.type = name_ref B, file.%B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %B.call: init %i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc19_28.1: %i32 = value_of_initializer %B.call
-// CHECK:STDOUT:   %.loc19_28.2: %i32 = converted %B.call, %.loc19_28.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc19_28.2)
+// CHECK:STDOUT:   %.loc22_28.1: %i32 = value_of_initializer %B.call
+// CHECK:STDOUT:   %.loc22_28.2: %i32 = converted %B.call, %.loc22_28.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc22_28.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc19_10: %i32 = block_arg !if.expr.result
-// CHECK:STDOUT:   return %.loc19_10
+// CHECK:STDOUT:   %.loc22_10: %i32 = block_arg !if.expr.result
+// CHECK:STDOUT:   return %.loc22_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Constant() -> %i32 {
@@ -246,34 +249,34 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:   %v.var: ref %i32 = var %v.var_patt
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc23_3.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %bound_method.loc26_3.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc23_3.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc23_3.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc23_3: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %v.var, %.loc23_3
-// CHECK:STDOUT:   br !.loc23_13
+// CHECK:STDOUT:   %bound_method.loc26_3.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc26_3.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc26_3: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %v.var, %.loc26_3
+// CHECK:STDOUT:   br !.loc26_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc23_13:
+// CHECK:STDOUT: !.loc26_13:
 // CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %true br !if.expr.then.loc23 else br !if.expr.else.loc23
+// CHECK:STDOUT:   if %true br !if.expr.then.loc26 else br !if.expr.else.loc26
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc23:
-// CHECK:STDOUT:   %int_32.loc23_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc23_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   br !if.expr.result.loc23(%i32.loc23_23)
+// CHECK:STDOUT: !if.expr.then.loc26:
+// CHECK:STDOUT:   %int_32.loc26_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc26_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   br !if.expr.result.loc26(%i32.loc26_23)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc23:
-// CHECK:STDOUT:   %int_32.loc23_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc23_32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %ptr.loc23: type = ptr_type %i32.loc23_32 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:   br !if.expr.result.loc23(%ptr.loc23)
+// CHECK:STDOUT: !if.expr.else.loc26:
+// CHECK:STDOUT:   %int_32.loc26_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc26_32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %ptr.loc26: type = ptr_type %i32.loc26_32 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   br !if.expr.result.loc26(%ptr.loc26)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc23:
-// CHECK:STDOUT:   %.loc23_10: type = block_arg !if.expr.result.loc23 [concrete = constants.%i32]
-// CHECK:STDOUT:   br !.loc23_7
+// CHECK:STDOUT: !if.expr.result.loc26:
+// CHECK:STDOUT:   %.loc26_10: type = block_arg !if.expr.result.loc26 [concrete = constants.%i32]
+// CHECK:STDOUT:   br !.loc26_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc23_7:
+// CHECK:STDOUT: !.loc26_7:
 // CHECK:STDOUT:   %v: ref %i32 = bind_name v, %v.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %w.patt: %pattern_type.fe8 = binding_pattern w [concrete]
@@ -283,34 +286,34 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:   %v.ref: ref %i32 = name_ref v, %v
 // CHECK:STDOUT:   %addr: %ptr.235 = addr_of %v.ref
 // CHECK:STDOUT:   assign %w.var, %addr
-// CHECK:STDOUT:   br !.loc24_13
+// CHECK:STDOUT:   br !.loc27_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc24_13:
+// CHECK:STDOUT: !.loc27_13:
 // CHECK:STDOUT:   %false: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %false br !if.expr.then.loc24 else br !if.expr.else.loc24
+// CHECK:STDOUT:   if %false br !if.expr.then.loc27 else br !if.expr.else.loc27
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc24:
-// CHECK:STDOUT:   %int_32.loc24_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc24_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   br !if.expr.result.loc24(%i32.loc24_24)
+// CHECK:STDOUT: !if.expr.then.loc27:
+// CHECK:STDOUT:   %int_32.loc27_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc27_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   br !if.expr.result.loc27(%i32.loc27_24)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc24:
-// CHECK:STDOUT:   %int_32.loc24_33: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc24_33: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %ptr.loc24: type = ptr_type %i32.loc24_33 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:   br !if.expr.result.loc24(%ptr.loc24)
+// CHECK:STDOUT: !if.expr.else.loc27:
+// CHECK:STDOUT:   %int_32.loc27_33: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc27_33: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %ptr.loc27: type = ptr_type %i32.loc27_33 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   br !if.expr.result.loc27(%ptr.loc27)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc24:
-// CHECK:STDOUT:   %.loc24: type = block_arg !if.expr.result.loc24 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:   br !.loc24_7
+// CHECK:STDOUT: !if.expr.result.loc27:
+// CHECK:STDOUT:   %.loc27: type = block_arg !if.expr.result.loc27 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   br !.loc27_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc24_7:
+// CHECK:STDOUT: !.loc27_7:
 // CHECK:STDOUT:   %w: ref %ptr.235 = bind_name w, %w.var
 // CHECK:STDOUT:   %w.ref: ref %ptr.235 = name_ref w, %w
-// CHECK:STDOUT:   %.loc25_11: %ptr.235 = bind_value %w.ref
-// CHECK:STDOUT:   %.loc25_10.1: ref %i32 = deref %.loc25_11
-// CHECK:STDOUT:   %.loc25_10.2: %i32 = bind_value %.loc25_10.1
-// CHECK:STDOUT:   return %.loc25_10.2
+// CHECK:STDOUT:   %.loc28_11: %ptr.235 = bind_value %w.ref
+// CHECK:STDOUT:   %.loc28_10.1: ref %i32 = deref %.loc28_11
+// CHECK:STDOUT:   %.loc28_10.2: %i32 = bind_value %.loc28_10.1
+// CHECK:STDOUT:   return %.loc28_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PartiallyConstant(%t.param: type) -> %i32 {
@@ -322,32 +325,32 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:   %v.var: ref %i32 = var %v.var_patt
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc29_3.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %bound_method.loc32_3.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc29_3.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc29_3.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc29_3: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %v.var, %.loc29_3
-// CHECK:STDOUT:   br !.loc29_13
+// CHECK:STDOUT:   %bound_method.loc32_3.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc32_3.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc32_3: init %i32 = converted %int_1, %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %v.var, %.loc32_3
+// CHECK:STDOUT:   br !.loc32_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc29_13:
+// CHECK:STDOUT: !.loc32_13:
 // CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %true br !if.expr.then.loc29 else br !if.expr.else.loc29
+// CHECK:STDOUT:   if %true br !if.expr.then.loc32 else br !if.expr.else.loc32
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc29:
-// CHECK:STDOUT:   %int_32.loc29: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc29: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   br !if.expr.result.loc29(%i32.loc29)
+// CHECK:STDOUT: !if.expr.then.loc32:
+// CHECK:STDOUT:   %int_32.loc32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   br !if.expr.result.loc32(%i32.loc32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc29:
-// CHECK:STDOUT:   %t.ref.loc29: type = name_ref t, %t
-// CHECK:STDOUT:   br !if.expr.result.loc29(%t.ref.loc29)
+// CHECK:STDOUT: !if.expr.else.loc32:
+// CHECK:STDOUT:   %t.ref.loc32: type = name_ref t, %t
+// CHECK:STDOUT:   br !if.expr.result.loc32(%t.ref.loc32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc29:
-// CHECK:STDOUT:   %.loc29_10: type = block_arg !if.expr.result.loc29 [concrete = constants.%i32]
-// CHECK:STDOUT:   br !.loc29_7
+// CHECK:STDOUT: !if.expr.result.loc32:
+// CHECK:STDOUT:   %.loc32_10: type = block_arg !if.expr.result.loc32 [concrete = constants.%i32]
+// CHECK:STDOUT:   br !.loc32_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc29_7:
+// CHECK:STDOUT: !.loc32_7:
 // CHECK:STDOUT:   %v: ref %i32 = bind_name v, %v.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %w.patt: %pattern_type.fe8 = binding_pattern w [concrete]
@@ -357,32 +360,32 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:   %v.ref: ref %i32 = name_ref v, %v
 // CHECK:STDOUT:   %addr: %ptr.235 = addr_of %v.ref
 // CHECK:STDOUT:   assign %w.var, %addr
-// CHECK:STDOUT:   br !.loc30_13
+// CHECK:STDOUT:   br !.loc33_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc30_13:
+// CHECK:STDOUT: !.loc33_13:
 // CHECK:STDOUT:   %false: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %false br !if.expr.then.loc30 else br !if.expr.else.loc30
+// CHECK:STDOUT:   if %false br !if.expr.then.loc33 else br !if.expr.else.loc33
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc30:
-// CHECK:STDOUT:   %t.ref.loc30: type = name_ref t, %t
-// CHECK:STDOUT:   br !if.expr.result.loc30(%t.ref.loc30)
+// CHECK:STDOUT: !if.expr.then.loc33:
+// CHECK:STDOUT:   %t.ref.loc33: type = name_ref t, %t
+// CHECK:STDOUT:   br !if.expr.result.loc33(%t.ref.loc33)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc30:
-// CHECK:STDOUT:   %int_32.loc30: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc30: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %ptr: type = ptr_type %i32.loc30 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:   br !if.expr.result.loc30(%ptr)
+// CHECK:STDOUT: !if.expr.else.loc33:
+// CHECK:STDOUT:   %int_32.loc33: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc33: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %ptr: type = ptr_type %i32.loc33 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   br !if.expr.result.loc33(%ptr)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc30:
-// CHECK:STDOUT:   %.loc30: type = block_arg !if.expr.result.loc30 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:   br !.loc30_7
+// CHECK:STDOUT: !if.expr.result.loc33:
+// CHECK:STDOUT:   %.loc33: type = block_arg !if.expr.result.loc33 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   br !.loc33_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc30_7:
+// CHECK:STDOUT: !.loc33_7:
 // CHECK:STDOUT:   %w: ref %ptr.235 = bind_name w, %w.var
 // CHECK:STDOUT:   %w.ref: ref %ptr.235 = name_ref w, %w
-// CHECK:STDOUT:   %.loc31_11: %ptr.235 = bind_value %w.ref
-// CHECK:STDOUT:   %.loc31_10.1: ref %i32 = deref %.loc31_11
-// CHECK:STDOUT:   %.loc31_10.2: %i32 = bind_value %.loc31_10.1
-// CHECK:STDOUT:   return %.loc31_10.2
+// CHECK:STDOUT:   %.loc34_11: %ptr.235 = bind_value %w.ref
+// CHECK:STDOUT:   %.loc34_10.1: ref %i32 = deref %.loc34_11
+// CHECK:STDOUT:   %.loc34_10.2: %i32 = bind_value %.loc34_10.1
+// CHECK:STDOUT:   return %.loc34_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/control_flow.carbon
+++ b/toolchain/check/testdata/if_expr/control_flow.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/control_flow.carbon
@@ -105,10 +108,10 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %b.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc14_9.1: type = splice_block %.loc14_9.3 [concrete = bool] {
+// CHECK:STDOUT:     %.loc17_9.1: type = splice_block %.loc17_9.3 [concrete = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc14_9.2: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:       %.loc14_9.3: type = converted %bool.make_type, %.loc14_9.2 [concrete = bool]
+// CHECK:STDOUT:       %.loc17_9.2: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:       %.loc17_9.3: type = converted %bool.make_type, %.loc17_9.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
@@ -120,26 +123,26 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc11_25.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %bound_method.loc14_25.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound.ab5]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc11_25.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc11_25.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc11_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc11_25.2: %i32 = converted %int_1, %.loc11_25.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   return %.loc11_25.2
+// CHECK:STDOUT:   %bound_method.loc14_25.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc14_25.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc14_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc14_25.2: %i32 = converted %int_1, %.loc14_25.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   return %.loc14_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_25.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %bound_method.loc15_25.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Convert.bound.ef9]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_25.2: <bound method> = bound_method %int_2, %specific_fn [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_25.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_25.2: %i32 = converted %int_2, %.loc12_25.1 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   return %.loc12_25.2
+// CHECK:STDOUT:   %bound_method.loc15_25.2: <bound method> = bound_method %int_2, %specific_fn [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_25.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_25.2: %i32 = converted %int_2, %.loc15_25.1 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   return %.loc15_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b.param: bool) -> %i32 {
@@ -150,19 +153,19 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: !if.expr.then:
 // CHECK:STDOUT:   %A.ref: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
 // CHECK:STDOUT:   %A.call: init %i32 = call %A.ref()
-// CHECK:STDOUT:   %.loc15_22.1: %i32 = value_of_initializer %A.call
-// CHECK:STDOUT:   %.loc15_22.2: %i32 = converted %A.call, %.loc15_22.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_22.2)
+// CHECK:STDOUT:   %.loc18_22.1: %i32 = value_of_initializer %A.call
+// CHECK:STDOUT:   %.loc18_22.2: %i32 = converted %A.call, %.loc18_22.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc18_22.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: %B.type = name_ref B, file.%B.decl [concrete = constants.%B]
 // CHECK:STDOUT:   %B.call: init %i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc15_24.1: %i32 = value_of_initializer %B.call
-// CHECK:STDOUT:   %.loc15_24.2: %i32 = converted %B.call, %.loc15_24.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_24.2)
+// CHECK:STDOUT:   %.loc18_24.1: %i32 = value_of_initializer %B.call
+// CHECK:STDOUT:   %.loc18_24.2: %i32 = converted %B.call, %.loc18_24.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc18_24.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc15_10: %i32 = block_arg !if.expr.result
-// CHECK:STDOUT:   return %.loc15_10
+// CHECK:STDOUT:   %.loc18_10: %i32 = block_arg !if.expr.result
+// CHECK:STDOUT:   return %.loc18_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/fail_not_in_function.carbon

--- a/toolchain/check/testdata/if_expr/fail_partial_constant.carbon
+++ b/toolchain/check/testdata/if_expr/fail_partial_constant.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/fail_partial_constant.carbon

--- a/toolchain/check/testdata/if_expr/nested.carbon
+++ b/toolchain/check/testdata/if_expr/nested.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/nested.carbon
@@ -87,27 +90,27 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param3 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %a.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc11_9.1: type = splice_block %.loc11_9.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc11_9: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc11_9.2: type = value_of_initializer %bool.make_type.loc11_9 [concrete = bool]
-// CHECK:STDOUT:       %.loc11_9.3: type = converted %bool.make_type.loc11_9, %.loc11_9.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_9.1: type = splice_block %.loc14_9.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc14_9: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc14_9.2: type = value_of_initializer %bool.make_type.loc14_9 [concrete = bool]
+// CHECK:STDOUT:       %.loc14_9.3: type = converted %bool.make_type.loc14_9, %.loc14_9.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: bool = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: bool = value_param call_param1
-// CHECK:STDOUT:     %.loc11_18.1: type = splice_block %.loc11_18.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc11_18: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc11_18.2: type = value_of_initializer %bool.make_type.loc11_18 [concrete = bool]
-// CHECK:STDOUT:       %.loc11_18.3: type = converted %bool.make_type.loc11_18, %.loc11_18.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_18.1: type = splice_block %.loc14_18.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc14_18: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc14_18.2: type = value_of_initializer %bool.make_type.loc14_18 [concrete = bool]
+// CHECK:STDOUT:       %.loc14_18.3: type = converted %bool.make_type.loc14_18, %.loc14_18.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %c.param: bool = value_param call_param2
-// CHECK:STDOUT:     %.loc11_27.1: type = splice_block %.loc11_27.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc11_27: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc11_27.2: type = value_of_initializer %bool.make_type.loc11_27 [concrete = bool]
-// CHECK:STDOUT:       %.loc11_27.3: type = converted %bool.make_type.loc11_27, %.loc11_27.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_27.1: type = splice_block %.loc14_27.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc14_27: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc14_27.2: type = value_of_initializer %bool.make_type.loc14_27 [concrete = bool]
+// CHECK:STDOUT:       %.loc14_27.3: type = converted %bool.make_type.loc14_27, %.loc14_27.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %c: bool = bind_name c, %c.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param3
@@ -118,74 +121,74 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT: fn @F(%a.param: bool, %b.param: bool, %c.param: bool) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: bool = name_ref a, %a
-// CHECK:STDOUT:   if %a.ref br !if.expr.then.loc12_10 else br !if.expr.else.loc12_10
+// CHECK:STDOUT:   if %a.ref br !if.expr.then.loc15_10 else br !if.expr.else.loc15_10
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc12_10:
+// CHECK:STDOUT: !if.expr.then.loc15_10:
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b
-// CHECK:STDOUT:   if %b.ref br !if.expr.then.loc12_20 else br !if.expr.else.loc12_20
+// CHECK:STDOUT:   if %b.ref br !if.expr.then.loc15_20 else br !if.expr.else.loc15_20
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc12_20:
+// CHECK:STDOUT: !if.expr.then.loc15_20:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_32.loc12_25: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12_25: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %impl.elem0.loc12_25: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_25.1: <bound method> = bound_method %int_1, %impl.elem0.loc12_25 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc12_25: <specific function> = specific_function %impl.elem0.loc12_25, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_25.2: <bound method> = bound_method %int_1, %specific_fn.loc12_25 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc12_25: init %i32 = call %bound_method.loc12_25.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_25.1: %i32 = value_of_initializer %int.convert_checked.loc12_25 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_25.2: %i32 = converted %int_1, %.loc12_25.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   br !if.expr.result.loc12_20(%.loc12_25.2)
+// CHECK:STDOUT:   %int_32.loc15_25: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15_25: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %impl.elem0.loc15_25: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_25.1: <bound method> = bound_method %int_1, %impl.elem0.loc15_25 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc15_25: <specific function> = specific_function %impl.elem0.loc15_25, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_25.2: <bound method> = bound_method %int_1, %specific_fn.loc15_25 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc15_25: init %i32 = call %bound_method.loc15_25.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_25.1: %i32 = value_of_initializer %int.convert_checked.loc15_25 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_25.2: %i32 = converted %int_1, %.loc15_25.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   br !if.expr.result.loc15_20(%.loc15_25.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc12_20:
+// CHECK:STDOUT: !if.expr.else.loc15_20:
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %impl.elem0.loc12_32: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_32.1: <bound method> = bound_method %int_2, %impl.elem0.loc12_32 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc12_32: <specific function> = specific_function %impl.elem0.loc12_32, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_32.2: <bound method> = bound_method %int_2, %specific_fn.loc12_32 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc12_32: init %i32 = call %bound_method.loc12_32.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_32.1: %i32 = value_of_initializer %int.convert_checked.loc12_32 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_32.2: %i32 = converted %int_2, %.loc12_32.1 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   br !if.expr.result.loc12_20(%.loc12_32.2)
+// CHECK:STDOUT:   %impl.elem0.loc15_32: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_32.1: <bound method> = bound_method %int_2, %impl.elem0.loc15_32 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc15_32: <specific function> = specific_function %impl.elem0.loc15_32, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_32.2: <bound method> = bound_method %int_2, %specific_fn.loc15_32 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc15_32: init %i32 = call %bound_method.loc15_32.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_32.1: %i32 = value_of_initializer %int.convert_checked.loc15_32 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_32.2: %i32 = converted %int_2, %.loc15_32.1 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   br !if.expr.result.loc15_20(%.loc15_32.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc12_20:
-// CHECK:STDOUT:   %.loc12_20: %i32 = block_arg !if.expr.result.loc12_20
-// CHECK:STDOUT:   br !if.expr.result.loc12_10(%.loc12_20)
+// CHECK:STDOUT: !if.expr.result.loc15_20:
+// CHECK:STDOUT:   %.loc15_20: %i32 = block_arg !if.expr.result.loc15_20
+// CHECK:STDOUT:   br !if.expr.result.loc15_10(%.loc15_20)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc12_10:
+// CHECK:STDOUT: !if.expr.else.loc15_10:
 // CHECK:STDOUT:   %c.ref: bool = name_ref c, %c
-// CHECK:STDOUT:   if %c.ref br !if.expr.then.loc12_44 else br !if.expr.else.loc12_44
+// CHECK:STDOUT:   if %c.ref br !if.expr.then.loc15_44 else br !if.expr.else.loc15_44
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc12_44:
+// CHECK:STDOUT: !if.expr.then.loc15_44:
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %int_32.loc12_49: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc12_49: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %impl.elem0.loc12_49: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_49.1: <bound method> = bound_method %int_3, %impl.elem0.loc12_49 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc12_49: <specific function> = specific_function %impl.elem0.loc12_49, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_49.2: <bound method> = bound_method %int_3, %specific_fn.loc12_49 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc12_49: init %i32 = call %bound_method.loc12_49.2(%int_3) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc12_49.1: %i32 = value_of_initializer %int.convert_checked.loc12_49 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc12_49.2: %i32 = converted %int_3, %.loc12_49.1 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   br !if.expr.result.loc12_44(%.loc12_49.2)
+// CHECK:STDOUT:   %int_32.loc15_49: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc15_49: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %impl.elem0.loc15_49: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_49.1: <bound method> = bound_method %int_3, %impl.elem0.loc15_49 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc15_49: <specific function> = specific_function %impl.elem0.loc15_49, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_49.2: <bound method> = bound_method %int_3, %specific_fn.loc15_49 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc15_49: init %i32 = call %bound_method.loc15_49.2(%int_3) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc15_49.1: %i32 = value_of_initializer %int.convert_checked.loc15_49 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc15_49.2: %i32 = converted %int_3, %.loc15_49.1 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   br !if.expr.result.loc15_44(%.loc15_49.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc12_44:
+// CHECK:STDOUT: !if.expr.else.loc15_44:
 // CHECK:STDOUT:   %int_4: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
-// CHECK:STDOUT:   %impl.elem0.loc12_56: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_56.1: <bound method> = bound_method %int_4, %impl.elem0.loc12_56 [concrete = constants.%Convert.bound.ac3]
-// CHECK:STDOUT:   %specific_fn.loc12_56: <specific function> = specific_function %impl.elem0.loc12_56, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_56.2: <bound method> = bound_method %int_4, %specific_fn.loc12_56 [concrete = constants.%bound_method.1da]
-// CHECK:STDOUT:   %int.convert_checked.loc12_56: init %i32 = call %bound_method.loc12_56.2(%int_4) [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc12_56.1: %i32 = value_of_initializer %int.convert_checked.loc12_56 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc12_56.2: %i32 = converted %int_4, %.loc12_56.1 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   br !if.expr.result.loc12_44(%.loc12_56.2)
+// CHECK:STDOUT:   %impl.elem0.loc15_56: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_56.1: <bound method> = bound_method %int_4, %impl.elem0.loc15_56 [concrete = constants.%Convert.bound.ac3]
+// CHECK:STDOUT:   %specific_fn.loc15_56: <specific function> = specific_function %impl.elem0.loc15_56, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_56.2: <bound method> = bound_method %int_4, %specific_fn.loc15_56 [concrete = constants.%bound_method.1da]
+// CHECK:STDOUT:   %int.convert_checked.loc15_56: init %i32 = call %bound_method.loc15_56.2(%int_4) [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc15_56.1: %i32 = value_of_initializer %int.convert_checked.loc15_56 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc15_56.2: %i32 = converted %int_4, %.loc15_56.1 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   br !if.expr.result.loc15_44(%.loc15_56.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc12_44:
-// CHECK:STDOUT:   %.loc12_44: %i32 = block_arg !if.expr.result.loc12_44
-// CHECK:STDOUT:   br !if.expr.result.loc12_10(%.loc12_44)
+// CHECK:STDOUT: !if.expr.result.loc15_44:
+// CHECK:STDOUT:   %.loc15_44: %i32 = block_arg !if.expr.result.loc15_44
+// CHECK:STDOUT:   br !if.expr.result.loc15_10(%.loc15_44)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc12_10:
-// CHECK:STDOUT:   %.loc12_10: %i32 = block_arg !if.expr.result.loc12_10
-// CHECK:STDOUT:   return %.loc12_10
+// CHECK:STDOUT: !if.expr.result.loc15_10:
+// CHECK:STDOUT:   %.loc15_10: %i32 = block_arg !if.expr.result.loc15_10
+// CHECK:STDOUT:   return %.loc15_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/struct.carbon
+++ b/toolchain/check/testdata/if_expr/struct.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/if_expr/struct.carbon
@@ -84,11 +87,11 @@ fn F(cond: bool) {
 // CHECK:STDOUT:     %s.param_patt: %pattern_type.851 = value_param_pattern %s.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %s.param: %struct_type.a.b.501 = value_param call_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %struct_type.a.b [concrete = constants.%struct_type.a.b.501] {
-// CHECK:STDOUT:       %int_32.loc11_14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %int_32.loc11_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc14: type = splice_block %struct_type.a.b [concrete = constants.%struct_type.a.b.501] {
+// CHECK:STDOUT:       %int_32.loc14_14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %int_32.loc14_23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:       %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %s: %struct_type.a.b.501 = bind_name s, %s.param
@@ -98,10 +101,10 @@ fn F(cond: bool) {
 // CHECK:STDOUT:     %cond.param_patt: %pattern_type.831 = value_param_pattern %cond.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %cond.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc13_12.1: type = splice_block %.loc13_12.3 [concrete = bool] {
+// CHECK:STDOUT:     %.loc16_12.1: type = splice_block %.loc16_12.3 [concrete = bool] {
 // CHECK:STDOUT:       %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc13_12.2: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:       %.loc13_12.3: type = converted %bool.make_type, %.loc13_12.2 [concrete = bool]
+// CHECK:STDOUT:       %.loc16_12.2: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:       %.loc16_12.3: type = converted %bool.make_type, %.loc16_12.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %cond: bool = bind_name cond, %cond.param
 // CHECK:STDOUT:   }
@@ -118,31 +121,31 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %a.var: ref %struct_type.a.b.501 = var %a.var_patt
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc14_46.1: %struct_type.a.b.cfd = struct_literal (%int_1, %int_2)
-// CHECK:STDOUT:   %impl.elem0.loc14_46.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc14_46.1: <bound method> = bound_method %int_1, %impl.elem0.loc14_46.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc14_46.1: <specific function> = specific_function %impl.elem0.loc14_46.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc14_46.2: <bound method> = bound_method %int_1, %specific_fn.loc14_46.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc14_46.1: init %i32 = call %bound_method.loc14_46.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc14_46.2: init %i32 = converted %int_1, %int.convert_checked.loc14_46.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc14_46.3: ref %i32 = struct_access %a.var, element0
-// CHECK:STDOUT:   %.loc14_46.4: init %i32 = initialize_from %.loc14_46.2 to %.loc14_46.3 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc14_46.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc14_46.3: <bound method> = bound_method %int_2, %impl.elem0.loc14_46.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc14_46.2: <specific function> = specific_function %impl.elem0.loc14_46.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc14_46.4: <bound method> = bound_method %int_2, %specific_fn.loc14_46.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc14_46.2: init %i32 = call %bound_method.loc14_46.4(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc14_46.5: init %i32 = converted %int_2, %int.convert_checked.loc14_46.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc14_46.6: ref %i32 = struct_access %a.var, element1
-// CHECK:STDOUT:   %.loc14_46.7: init %i32 = initialize_from %.loc14_46.5 to %.loc14_46.6 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc14_46.8: init %struct_type.a.b.501 = struct_init (%.loc14_46.4, %.loc14_46.7) to %a.var [concrete = constants.%struct]
-// CHECK:STDOUT:   %.loc14_3: init %struct_type.a.b.501 = converted %.loc14_46.1, %.loc14_46.8 [concrete = constants.%struct]
-// CHECK:STDOUT:   assign %a.var, %.loc14_3
-// CHECK:STDOUT:   %.loc14_27: type = splice_block %struct_type.a.b [concrete = constants.%struct_type.a.b.501] {
-// CHECK:STDOUT:     %int_32.loc14_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc14_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc17_46.1: %struct_type.a.b.cfd = struct_literal (%int_1, %int_2)
+// CHECK:STDOUT:   %impl.elem0.loc17_46.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc17_46.1: <bound method> = bound_method %int_1, %impl.elem0.loc17_46.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc17_46.1: <specific function> = specific_function %impl.elem0.loc17_46.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc17_46.2: <bound method> = bound_method %int_1, %specific_fn.loc17_46.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc17_46.1: init %i32 = call %bound_method.loc17_46.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc17_46.2: init %i32 = converted %int_1, %int.convert_checked.loc17_46.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc17_46.3: ref %i32 = struct_access %a.var, element0
+// CHECK:STDOUT:   %.loc17_46.4: init %i32 = initialize_from %.loc17_46.2 to %.loc17_46.3 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc17_46.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc17_46.3: <bound method> = bound_method %int_2, %impl.elem0.loc17_46.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc17_46.2: <specific function> = specific_function %impl.elem0.loc17_46.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc17_46.4: <bound method> = bound_method %int_2, %specific_fn.loc17_46.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc17_46.2: init %i32 = call %bound_method.loc17_46.4(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc17_46.5: init %i32 = converted %int_2, %int.convert_checked.loc17_46.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc17_46.6: ref %i32 = struct_access %a.var, element1
+// CHECK:STDOUT:   %.loc17_46.7: init %i32 = initialize_from %.loc17_46.5 to %.loc17_46.6 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc17_46.8: init %struct_type.a.b.501 = struct_init (%.loc17_46.4, %.loc17_46.7) to %a.var [concrete = constants.%struct]
+// CHECK:STDOUT:   %.loc17_3: init %struct_type.a.b.501 = converted %.loc17_46.1, %.loc17_46.8 [concrete = constants.%struct]
+// CHECK:STDOUT:   assign %a.var, %.loc17_3
+// CHECK:STDOUT:   %.loc17_27: type = splice_block %struct_type.a.b [concrete = constants.%struct_type.a.b.501] {
+// CHECK:STDOUT:     %int_32.loc17_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc17_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %struct_type.a.b.501 = bind_name a, %a.var
@@ -151,28 +154,28 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   if %cond.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %a.ref.loc15_18: ref %struct_type.a.b.501 = name_ref a, %a
-// CHECK:STDOUT:   %.loc15_18.1: ref %i32 = struct_access %a.ref.loc15_18, element0
-// CHECK:STDOUT:   %.loc15_18.2: %i32 = bind_value %.loc15_18.1
-// CHECK:STDOUT:   %.loc15_18.3: ref %i32 = struct_access %a.ref.loc15_18, element1
-// CHECK:STDOUT:   %.loc15_18.4: %i32 = bind_value %.loc15_18.3
-// CHECK:STDOUT:   %struct.loc15_18: %struct_type.a.b.501 = struct_value (%.loc15_18.2, %.loc15_18.4)
-// CHECK:STDOUT:   %.loc15_18.5: %struct_type.a.b.501 = converted %a.ref.loc15_18, %struct.loc15_18
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_18.5)
+// CHECK:STDOUT:   %a.ref.loc18_18: ref %struct_type.a.b.501 = name_ref a, %a
+// CHECK:STDOUT:   %.loc18_18.1: ref %i32 = struct_access %a.ref.loc18_18, element0
+// CHECK:STDOUT:   %.loc18_18.2: %i32 = bind_value %.loc18_18.1
+// CHECK:STDOUT:   %.loc18_18.3: ref %i32 = struct_access %a.ref.loc18_18, element1
+// CHECK:STDOUT:   %.loc18_18.4: %i32 = bind_value %.loc18_18.3
+// CHECK:STDOUT:   %struct.loc18_18: %struct_type.a.b.501 = struct_value (%.loc18_18.2, %.loc18_18.4)
+// CHECK:STDOUT:   %.loc18_18.5: %struct_type.a.b.501 = converted %a.ref.loc18_18, %struct.loc18_18
+// CHECK:STDOUT:   br !if.expr.result(%.loc18_18.5)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %a.ref.loc15_25: ref %struct_type.a.b.501 = name_ref a, %a
-// CHECK:STDOUT:   %.loc15_25.1: ref %i32 = struct_access %a.ref.loc15_25, element0
-// CHECK:STDOUT:   %.loc15_25.2: %i32 = bind_value %.loc15_25.1
-// CHECK:STDOUT:   %.loc15_25.3: ref %i32 = struct_access %a.ref.loc15_25, element1
-// CHECK:STDOUT:   %.loc15_25.4: %i32 = bind_value %.loc15_25.3
-// CHECK:STDOUT:   %struct.loc15_25: %struct_type.a.b.501 = struct_value (%.loc15_25.2, %.loc15_25.4)
-// CHECK:STDOUT:   %.loc15_20: %struct_type.a.b.501 = converted %a.ref.loc15_25, %struct.loc15_25
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_20)
+// CHECK:STDOUT:   %a.ref.loc18_25: ref %struct_type.a.b.501 = name_ref a, %a
+// CHECK:STDOUT:   %.loc18_25.1: ref %i32 = struct_access %a.ref.loc18_25, element0
+// CHECK:STDOUT:   %.loc18_25.2: %i32 = bind_value %.loc18_25.1
+// CHECK:STDOUT:   %.loc18_25.3: ref %i32 = struct_access %a.ref.loc18_25, element1
+// CHECK:STDOUT:   %.loc18_25.4: %i32 = bind_value %.loc18_25.3
+// CHECK:STDOUT:   %struct.loc18_25: %struct_type.a.b.501 = struct_value (%.loc18_25.2, %.loc18_25.4)
+// CHECK:STDOUT:   %.loc18_20: %struct_type.a.b.501 = converted %a.ref.loc18_25, %struct.loc18_25
+// CHECK:STDOUT:   br !if.expr.result(%.loc18_20)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc15_5: %struct_type.a.b.501 = block_arg !if.expr.result
-// CHECK:STDOUT:   %G.call: init %empty_tuple.type = call %G.ref(%.loc15_5)
+// CHECK:STDOUT:   %.loc18_5: %struct_type.a.b.501 = block_arg !if.expr.result
+// CHECK:STDOUT:   %G.call: init %empty_tuple.type = call %G.ref(%.loc18_5)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.