### PR TITLE
Add range flag settings to let files

### DIFF
--- a/toolchain/check/testdata/let/compile_time_bindings.carbon
+++ b/toolchain/check/testdata/let/compile_time_bindings.carbon
@@ -3,6 +3,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // This is mostly checking against crashes for compile time bindings in
 // difficult contexts.
 //

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/convert.carbon
@@ -80,8 +83,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param0
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -94,67 +97,67 @@ fn F() -> i32 {
 // CHECK:STDOUT:     %v.var_patt: %pattern_type.b5a = var_pattern %v.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %v.var: ref %tuple.type.189 = var %v.var_patt
-// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %.loc12_36.1: %tuple.type.37f = tuple_literal (%int_1.loc12, %int_2, %int_3)
-// CHECK:STDOUT:   %impl.elem0.loc12_36.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_36.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_36.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc12_36.1: <specific function> = specific_function %impl.elem0.loc12_36.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_36.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_36.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc12_36.1: init %i32 = call %bound_method.loc12_36.2(%int_1.loc12) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_36.2: init %i32 = converted %int_1.loc12, %int.convert_checked.loc12_36.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_36.1: %tuple.type.37f = tuple_literal (%int_1.loc15, %int_2, %int_3)
+// CHECK:STDOUT:   %impl.elem0.loc15_36.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_36.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_36.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc15_36.1: <specific function> = specific_function %impl.elem0.loc15_36.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_36.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_36.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc15_36.1: init %i32 = call %bound_method.loc15_36.2(%int_1.loc15) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_36.2: init %i32 = converted %int_1.loc15, %int.convert_checked.loc15_36.1 [concrete = constants.%int_1.5d2]
 // CHECK:STDOUT:   %tuple.elem0: ref %i32 = tuple_access %v.var, element0
-// CHECK:STDOUT:   %.loc12_36.3: init %i32 = initialize_from %.loc12_36.2 to %tuple.elem0 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc12_36.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_36.3: <bound method> = bound_method %int_2, %impl.elem0.loc12_36.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc12_36.2: <specific function> = specific_function %impl.elem0.loc12_36.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_36.4: <bound method> = bound_method %int_2, %specific_fn.loc12_36.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc12_36.2: init %i32 = call %bound_method.loc12_36.4(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_36.4: init %i32 = converted %int_2, %int.convert_checked.loc12_36.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %tuple.elem1.loc12: ref %i32 = tuple_access %v.var, element1
-// CHECK:STDOUT:   %.loc12_36.5: init %i32 = initialize_from %.loc12_36.4 to %tuple.elem1.loc12 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %impl.elem0.loc12_36.3: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_36.5: <bound method> = bound_method %int_3, %impl.elem0.loc12_36.3 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc12_36.3: <specific function> = specific_function %impl.elem0.loc12_36.3, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_36.6: <bound method> = bound_method %int_3, %specific_fn.loc12_36.3 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc12_36.3: init %i32 = call %bound_method.loc12_36.6(%int_3) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc12_36.6: init %i32 = converted %int_3, %int.convert_checked.loc12_36.3 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc15_36.3: init %i32 = initialize_from %.loc15_36.2 to %tuple.elem0 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc15_36.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_36.3: <bound method> = bound_method %int_2, %impl.elem0.loc15_36.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc15_36.2: <specific function> = specific_function %impl.elem0.loc15_36.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_36.4: <bound method> = bound_method %int_2, %specific_fn.loc15_36.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc15_36.2: init %i32 = call %bound_method.loc15_36.4(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_36.4: init %i32 = converted %int_2, %int.convert_checked.loc15_36.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %tuple.elem1.loc15: ref %i32 = tuple_access %v.var, element1
+// CHECK:STDOUT:   %.loc15_36.5: init %i32 = initialize_from %.loc15_36.4 to %tuple.elem1.loc15 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %impl.elem0.loc15_36.3: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_36.5: <bound method> = bound_method %int_3, %impl.elem0.loc15_36.3 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc15_36.3: <specific function> = specific_function %impl.elem0.loc15_36.3, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_36.6: <bound method> = bound_method %int_3, %specific_fn.loc15_36.3 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc15_36.3: init %i32 = call %bound_method.loc15_36.6(%int_3) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc15_36.6: init %i32 = converted %int_3, %int.convert_checked.loc15_36.3 [concrete = constants.%int_3.822]
 // CHECK:STDOUT:   %tuple.elem2: ref %i32 = tuple_access %v.var, element2
-// CHECK:STDOUT:   %.loc12_36.7: init %i32 = initialize_from %.loc12_36.6 to %tuple.elem2 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc12_36.8: init %tuple.type.189 = tuple_init (%.loc12_36.3, %.loc12_36.5, %.loc12_36.7) to %v.var [concrete = constants.%tuple]
-// CHECK:STDOUT:   %.loc12_3: init %tuple.type.189 = converted %.loc12_36.1, %.loc12_36.8 [concrete = constants.%tuple]
-// CHECK:STDOUT:   assign %v.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_24.1: type = splice_block %.loc12_24.3 [concrete = constants.%tuple.type.189] {
-// CHECK:STDOUT:     %int_32.loc12_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc12_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc12_21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc12_24.2: %tuple.type.ff9 = tuple_literal (%i32.loc12_11, %i32.loc12_16, %i32.loc12_21)
-// CHECK:STDOUT:     %.loc12_24.3: type = converted %.loc12_24.2, constants.%tuple.type.189 [concrete = constants.%tuple.type.189]
+// CHECK:STDOUT:   %.loc15_36.7: init %i32 = initialize_from %.loc15_36.6 to %tuple.elem2 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc15_36.8: init %tuple.type.189 = tuple_init (%.loc15_36.3, %.loc15_36.5, %.loc15_36.7) to %v.var [concrete = constants.%tuple]
+// CHECK:STDOUT:   %.loc15_3: init %tuple.type.189 = converted %.loc15_36.1, %.loc15_36.8 [concrete = constants.%tuple]
+// CHECK:STDOUT:   assign %v.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_24.1: type = splice_block %.loc15_24.3 [concrete = constants.%tuple.type.189] {
+// CHECK:STDOUT:     %int_32.loc15_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc15_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc15_21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc15_24.2: %tuple.type.ff9 = tuple_literal (%i32.loc15_11, %i32.loc15_16, %i32.loc15_21)
+// CHECK:STDOUT:     %.loc15_24.3: type = converted %.loc15_24.2, constants.%tuple.type.189 [concrete = constants.%tuple.type.189]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %v: ref %tuple.type.189 = bind_name v, %v.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %w.patt: %pattern_type.b5a = binding_pattern w [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %v.ref: ref %tuple.type.189 = name_ref v, %v
-// CHECK:STDOUT:   %.loc14_24.1: type = splice_block %.loc14_24.3 [concrete = constants.%tuple.type.189] {
-// CHECK:STDOUT:     %int_32.loc14_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc14_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc14_21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc14_24.2: %tuple.type.ff9 = tuple_literal (%i32.loc14_11, %i32.loc14_16, %i32.loc14_21)
-// CHECK:STDOUT:     %.loc14_24.3: type = converted %.loc14_24.2, constants.%tuple.type.189 [concrete = constants.%tuple.type.189]
+// CHECK:STDOUT:   %.loc17_24.1: type = splice_block %.loc17_24.3 [concrete = constants.%tuple.type.189] {
+// CHECK:STDOUT:     %int_32.loc17_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc17_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc17_21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc17_24.2: %tuple.type.ff9 = tuple_literal (%i32.loc17_11, %i32.loc17_16, %i32.loc17_21)
+// CHECK:STDOUT:     %.loc17_24.3: type = converted %.loc17_24.2, constants.%tuple.type.189 [concrete = constants.%tuple.type.189]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %w: ref %tuple.type.189 = bind_name w, %v.ref
 // CHECK:STDOUT:   %w.ref: ref %tuple.type.189 = name_ref w, %w
-// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %tuple.elem1.loc15: ref %i32 = tuple_access %w.ref, element1
-// CHECK:STDOUT:   %.loc15: %i32 = bind_value %tuple.elem1.loc15
-// CHECK:STDOUT:   return %.loc15
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %tuple.elem1.loc18: ref %i32 = tuple_access %w.ref, element1
+// CHECK:STDOUT:   %.loc18: %i32 = bind_value %tuple.elem1.loc18
+// CHECK:STDOUT:   return %.loc18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -78,37 +81,37 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %a.patt.loc12: %pattern_type.7ce = binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.patt.loc15: %pattern_type.7ce = binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15_10: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc12: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_16.1: <bound method> = bound_method %int_1, %impl.elem0.loc12 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc12: <specific function> = specific_function %impl.elem0.loc12, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_16.2: <bound method> = bound_method %int_1, %specific_fn.loc12 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc12: init %i32 = call %bound_method.loc12_16.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_16.1: %i32 = value_of_initializer %int.convert_checked.loc12 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_16.2: %i32 = converted %int_1, %.loc12_16.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %a.loc12: %i32 = bind_name a, %.loc12_16.2
+// CHECK:STDOUT:   %impl.elem0.loc15: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_16.1: <bound method> = bound_method %int_1, %impl.elem0.loc15 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc15: <specific function> = specific_function %impl.elem0.loc15, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_16.2: <bound method> = bound_method %int_1, %specific_fn.loc15 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc15: init %i32 = call %bound_method.loc15_16.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_16.1: %i32 = value_of_initializer %int.convert_checked.loc15 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_16.2: %i32 = converted %int_1, %.loc15_16.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %a.loc15: %i32 = bind_name a, %.loc15_16.2
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %a.patt.loc20: %pattern_type.7ce = binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.patt.loc23: %pattern_type.7ce = binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc20_10: type = splice_block %i32.loc20 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc23_10: type = splice_block %i32.loc23 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc20: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc20_16.1: <bound method> = bound_method %int_2, %impl.elem0.loc20 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem0.loc20, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc20_16.2: <bound method> = bound_method %int_2, %specific_fn.loc20 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc20: init %i32 = call %bound_method.loc20_16.2(%int_2) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc20_16.1: %i32 = value_of_initializer %int.convert_checked.loc20 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc20_16.2: %i32 = converted %int_2, %.loc20_16.1 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %a.loc20: %i32 = bind_name a, %.loc20_16.2
+// CHECK:STDOUT:   %impl.elem0.loc23: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc23_16.1: <bound method> = bound_method %int_2, %impl.elem0.loc23 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc23: <specific function> = specific_function %impl.elem0.loc23, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc23_16.2: <bound method> = bound_method %int_2, %specific_fn.loc23 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc23: init %i32 = call %bound_method.loc23_16.2(%int_2) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc23_16.1: %i32 = value_of_initializer %int.convert_checked.loc23 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc23_16.2: %i32 = converted %int_2, %.loc23_16.1 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %a.loc23: %i32 = bind_name a, %.loc23_16.2
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/fail_generic.carbon
@@ -81,12 +84,12 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc12_17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc15_17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %a.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc12: type = splice_block %i32.loc12_9 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc12_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc12_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc15: type = splice_block %i32.loc15_9 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc15_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc15_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %i32 = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
@@ -99,21 +102,21 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0, %i32.loc13 [symbolic = constants.%T]
+// CHECK:STDOUT:   %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, 0, %i32.loc16 [symbolic = constants.%T]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %x.patt: %pattern_type.7dcd0a.1 = binding_pattern x [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_5: Core.IntLiteral = int_value 5 [concrete = constants.%int_5]
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%T)> [symbolic = constants.%ImplicitAs.type.d628ce.2]
-// CHECK:STDOUT:   %.loc21_14.1: %ImplicitAs.assoc_type.ca0d85.2 = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%T) [symbolic = constants.%assoc0.9f5e6b.2]
-// CHECK:STDOUT:   %Convert.ref: %ImplicitAs.assoc_type.ca0d85.2 = name_ref Convert, %.loc21_14.1 [symbolic = constants.%assoc0.9f5e6b.2]
-// CHECK:STDOUT:   %.loc21_14.2: %T = converted %int_5, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc24_14.1: %ImplicitAs.assoc_type.ca0d85.2 = specific_constant imports.%Core.import_ref.492, @ImplicitAs(constants.%T) [symbolic = constants.%assoc0.9f5e6b.2]
+// CHECK:STDOUT:   %Convert.ref: %ImplicitAs.assoc_type.ca0d85.2 = name_ref Convert, %.loc24_14.1 [symbolic = constants.%assoc0.9f5e6b.2]
+// CHECK:STDOUT:   %.loc24_14.2: %T = converted %int_5, <error> [concrete = <error>]
 // CHECK:STDOUT:   %x: %T = bind_name x, <error>
 // CHECK:STDOUT:   %x.ref: %T = name_ref x, %x
-// CHECK:STDOUT:   %.loc29: %i32 = converted %x.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc32: %i32 = converted %x.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/fail_generic_import.carbon

--- a/toolchain/check/testdata/let/fail_missing_value.carbon
+++ b/toolchain/check/testdata/let/fail_missing_value.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/fail_missing_value.carbon
@@ -46,7 +49,7 @@ fn F() {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
-// CHECK:STDOUT:     .n = <unexpected>.inst44.loc15_5
+// CHECK:STDOUT:     .n = <unexpected>.inst44.loc18_5
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core

--- a/toolchain/check/testdata/let/fail_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_modifiers.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/fail_modifiers.carbon
@@ -140,135 +143,135 @@ protected protected let i: i32 = 1;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.7ce = binding_pattern b [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc15_18: type = splice_block %i32.loc15 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc18_18: type = splice_block %i32.loc18 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc15: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc15_24.1: <bound method> = bound_method @__global_init.%int_1.loc15, %impl.elem0.loc15 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc15: <specific function> = specific_function %impl.elem0.loc15, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc15_24.2: <bound method> = bound_method @__global_init.%int_1.loc15, %specific_fn.loc15 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc15: init %i32 = call %bound_method.loc15_24.2(@__global_init.%int_1.loc15) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc15_24.1: %i32 = value_of_initializer %int.convert_checked.loc15 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc15_24.2: %i32 = converted @__global_init.%int_1.loc15, %.loc15_24.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %b: %i32 = bind_name b, %.loc15_24.2
+// CHECK:STDOUT:   %impl.elem0.loc18: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc18_24.1: <bound method> = bound_method @__global_init.%int_1.loc18, %impl.elem0.loc18 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem0.loc18, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc18_24.2: <bound method> = bound_method @__global_init.%int_1.loc18, %specific_fn.loc18 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc18: init %i32 = call %bound_method.loc18_24.2(@__global_init.%int_1.loc18) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc18_24.1: %i32 = value_of_initializer %int.convert_checked.loc18 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc18_24.2: %i32 = converted @__global_init.%int_1.loc18, %.loc18_24.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %b: %i32 = bind_name b, %.loc18_24.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.7ce = binding_pattern c [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc21_16: type = splice_block %i32.loc21 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc24_16: type = splice_block %i32.loc24 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc21: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc21_22.1: <bound method> = bound_method @__global_init.%int_1.loc21, %impl.elem0.loc21 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem0.loc21, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc21_22.2: <bound method> = bound_method @__global_init.%int_1.loc21, %specific_fn.loc21 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc21: init %i32 = call %bound_method.loc21_22.2(@__global_init.%int_1.loc21) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc21_22.1: %i32 = value_of_initializer %int.convert_checked.loc21 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc21_22.2: %i32 = converted @__global_init.%int_1.loc21, %.loc21_22.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %c: %i32 = bind_name c, %.loc21_22.2
+// CHECK:STDOUT:   %impl.elem0.loc24: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc24_22.1: <bound method> = bound_method @__global_init.%int_1.loc24, %impl.elem0.loc24 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc24_22.2: <bound method> = bound_method @__global_init.%int_1.loc24, %specific_fn.loc24 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc24: init %i32 = call %bound_method.loc24_22.2(@__global_init.%int_1.loc24) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc24_22.1: %i32 = value_of_initializer %int.convert_checked.loc24 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc24_22.2: %i32 = converted @__global_init.%int_1.loc24, %.loc24_22.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %c: %i32 = bind_name c, %.loc24_22.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d.patt: %pattern_type.7ce = binding_pattern d [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc27_14: type = splice_block %i32.loc27 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc27: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc27: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc30_14: type = splice_block %i32.loc30 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc30: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc30: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc27: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc27_20.1: <bound method> = bound_method @__global_init.%int_1.loc27, %impl.elem0.loc27 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem0.loc27, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc27_20.2: <bound method> = bound_method @__global_init.%int_1.loc27, %specific_fn.loc27 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc27: init %i32 = call %bound_method.loc27_20.2(@__global_init.%int_1.loc27) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc27_20.1: %i32 = value_of_initializer %int.convert_checked.loc27 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc27_20.2: %i32 = converted @__global_init.%int_1.loc27, %.loc27_20.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %d: %i32 = bind_name d, %.loc27_20.2
+// CHECK:STDOUT:   %impl.elem0.loc30: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc30_20.1: <bound method> = bound_method @__global_init.%int_1.loc30, %impl.elem0.loc30 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc30: <specific function> = specific_function %impl.elem0.loc30, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc30_20.2: <bound method> = bound_method @__global_init.%int_1.loc30, %specific_fn.loc30 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc30: init %i32 = call %bound_method.loc30_20.2(@__global_init.%int_1.loc30) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc30_20.1: %i32 = value_of_initializer %int.convert_checked.loc30 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc30_20.2: %i32 = converted @__global_init.%int_1.loc30, %.loc30_20.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %d: %i32 = bind_name d, %.loc30_20.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %e.patt: %pattern_type.7ce = binding_pattern e [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc33_16: type = splice_block %i32.loc33 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc33: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc33: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc36_16: type = splice_block %i32.loc36 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc36: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc36: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc33: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc33_22.1: <bound method> = bound_method @__global_init.%int_1.loc33, %impl.elem0.loc33 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc33: <specific function> = specific_function %impl.elem0.loc33, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc33_22.2: <bound method> = bound_method @__global_init.%int_1.loc33, %specific_fn.loc33 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc33: init %i32 = call %bound_method.loc33_22.2(@__global_init.%int_1.loc33) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc33_22.1: %i32 = value_of_initializer %int.convert_checked.loc33 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc33_22.2: %i32 = converted @__global_init.%int_1.loc33, %.loc33_22.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %e: %i32 = bind_name e, %.loc33_22.2
+// CHECK:STDOUT:   %impl.elem0.loc36: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc36_22.1: <bound method> = bound_method @__global_init.%int_1.loc36, %impl.elem0.loc36 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc36: <specific function> = specific_function %impl.elem0.loc36, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc36_22.2: <bound method> = bound_method @__global_init.%int_1.loc36, %specific_fn.loc36 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc36: init %i32 = call %bound_method.loc36_22.2(@__global_init.%int_1.loc36) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc36_22.1: %i32 = value_of_initializer %int.convert_checked.loc36 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc36_22.2: %i32 = converted @__global_init.%int_1.loc36, %.loc36_22.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %e: %i32 = bind_name e, %.loc36_22.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %pattern_type.7ce = binding_pattern f [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc46_22: type = splice_block %i32.loc46 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc46: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc46: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc49_22: type = splice_block %i32.loc49 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc49: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc49: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc46: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc46_28.1: <bound method> = bound_method @__global_init.%int_1.loc46, %impl.elem0.loc46 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc46: <specific function> = specific_function %impl.elem0.loc46, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc46_28.2: <bound method> = bound_method @__global_init.%int_1.loc46, %specific_fn.loc46 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc46: init %i32 = call %bound_method.loc46_28.2(@__global_init.%int_1.loc46) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc46_28.1: %i32 = value_of_initializer %int.convert_checked.loc46 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc46_28.2: %i32 = converted @__global_init.%int_1.loc46, %.loc46_28.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %f: %i32 = bind_name f, %.loc46_28.2
+// CHECK:STDOUT:   %impl.elem0.loc49: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc49_28.1: <bound method> = bound_method @__global_init.%int_1.loc49, %impl.elem0.loc49 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc49: <specific function> = specific_function %impl.elem0.loc49, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc49_28.2: <bound method> = bound_method @__global_init.%int_1.loc49, %specific_fn.loc49 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc49: init %i32 = call %bound_method.loc49_28.2(@__global_init.%int_1.loc49) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc49_28.1: %i32 = value_of_initializer %int.convert_checked.loc49 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc49_28.2: %i32 = converted @__global_init.%int_1.loc49, %.loc49_28.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %f: %i32 = bind_name f, %.loc49_28.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %g.patt: %pattern_type.7ce = binding_pattern g [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc59_24: type = splice_block %i32.loc59 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc59: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc59: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc62_24: type = splice_block %i32.loc62 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc62: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc62: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc59: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc59_30.1: <bound method> = bound_method @__global_init.%int_1.loc59, %impl.elem0.loc59 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc59: <specific function> = specific_function %impl.elem0.loc59, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc59_30.2: <bound method> = bound_method @__global_init.%int_1.loc59, %specific_fn.loc59 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc59: init %i32 = call %bound_method.loc59_30.2(@__global_init.%int_1.loc59) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc59_30.1: %i32 = value_of_initializer %int.convert_checked.loc59 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc59_30.2: %i32 = converted @__global_init.%int_1.loc59, %.loc59_30.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %g: %i32 = bind_name g, %.loc59_30.2
+// CHECK:STDOUT:   %impl.elem0.loc62: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc62_30.1: <bound method> = bound_method @__global_init.%int_1.loc62, %impl.elem0.loc62 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc62: <specific function> = specific_function %impl.elem0.loc62, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc62_30.2: <bound method> = bound_method @__global_init.%int_1.loc62, %specific_fn.loc62 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc62: init %i32 = call %bound_method.loc62_30.2(@__global_init.%int_1.loc62) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc62_30.1: %i32 = value_of_initializer %int.convert_checked.loc62 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc62_30.2: %i32 = converted @__global_init.%int_1.loc62, %.loc62_30.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %g: %i32 = bind_name g, %.loc62_30.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %h.patt: %pattern_type.7ce = binding_pattern h [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc72_26: type = splice_block %i32.loc72 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc72: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc72: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc75_26: type = splice_block %i32.loc75 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc75: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc75: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc72: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc72_32.1: <bound method> = bound_method @__global_init.%int_1.loc72, %impl.elem0.loc72 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc72: <specific function> = specific_function %impl.elem0.loc72, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc72_32.2: <bound method> = bound_method @__global_init.%int_1.loc72, %specific_fn.loc72 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc72: init %i32 = call %bound_method.loc72_32.2(@__global_init.%int_1.loc72) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc72_32.1: %i32 = value_of_initializer %int.convert_checked.loc72 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc72_32.2: %i32 = converted @__global_init.%int_1.loc72, %.loc72_32.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %h: %i32 = bind_name h, %.loc72_32.2
+// CHECK:STDOUT:   %impl.elem0.loc75: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc75_32.1: <bound method> = bound_method @__global_init.%int_1.loc75, %impl.elem0.loc75 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc75: <specific function> = specific_function %impl.elem0.loc75, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc75_32.2: <bound method> = bound_method @__global_init.%int_1.loc75, %specific_fn.loc75 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc75: init %i32 = call %bound_method.loc75_32.2(@__global_init.%int_1.loc75) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc75_32.1: %i32 = value_of_initializer %int.convert_checked.loc75 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc75_32.2: %i32 = converted @__global_init.%int_1.loc75, %.loc75_32.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %h: %i32 = bind_name h, %.loc75_32.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %i.patt: %pattern_type.7ce = binding_pattern i [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc85_28: type = splice_block %i32.loc85 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc85: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc85: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc88_28: type = splice_block %i32.loc88 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc88: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc88: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc85: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc85_34.1: <bound method> = bound_method @__global_init.%int_1.loc85, %impl.elem0.loc85 [concrete = constants.%Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc85: <specific function> = specific_function %impl.elem0.loc85, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc85_34.2: <bound method> = bound_method @__global_init.%int_1.loc85, %specific_fn.loc85 [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked.loc85: init %i32 = call %bound_method.loc85_34.2(@__global_init.%int_1.loc85) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc85_34.1: %i32 = value_of_initializer %int.convert_checked.loc85 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc85_34.2: %i32 = converted @__global_init.%int_1.loc85, %.loc85_34.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %i: %i32 = bind_name i, %.loc85_34.2
+// CHECK:STDOUT:   %impl.elem0.loc88: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc88_34.1: <bound method> = bound_method @__global_init.%int_1.loc88, %impl.elem0.loc88 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc88: <specific function> = specific_function %impl.elem0.loc88, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc88_34.2: <bound method> = bound_method @__global_init.%int_1.loc88, %specific_fn.loc88 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked.loc88: init %i32 = call %bound_method.loc88_34.2(@__global_init.%int_1.loc88) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc88_34.1: %i32 = value_of_initializer %int.convert_checked.loc88 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc88_34.2: %i32 = converted @__global_init.%int_1.loc88, %.loc88_34.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %i: %i32 = bind_name i, %.loc88_34.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc27: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc33: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc46: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc59: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc72: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_1.loc85: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc24: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc30: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc36: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc49: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc62: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc75: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_1.loc88: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_use_in_init.carbon
+++ b/toolchain/check/testdata/let/fail_use_in_init.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/fail_use_in_init.carbon
@@ -52,7 +55,7 @@ fn F() {
 // CHECK:STDOUT:     %a.patt: %pattern_type.7ce = binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc16: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:   %.loc19: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/let/generic.carbon
+++ b/toolchain/check/testdata/let/generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/generic.carbon
@@ -61,9 +64,9 @@ fn F() {
 // CHECK:STDOUT:     %p.var_patt: %pattern_type.afe = var_pattern %p.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p.var: ref %ptr = var %p.var_patt
-// CHECK:STDOUT:   %.loc13: type = splice_block %ptr [symbolic = constants.%ptr] {
-// CHECK:STDOUT:     %T.ref.loc13: type = name_ref T, %T [symbolic = constants.%T]
-// CHECK:STDOUT:     %ptr: type = ptr_type %T.ref.loc13 [symbolic = constants.%ptr]
+// CHECK:STDOUT:   %.loc16: type = splice_block %ptr [symbolic = constants.%ptr] {
+// CHECK:STDOUT:     %T.ref.loc16: type = name_ref T, %T [symbolic = constants.%T]
+// CHECK:STDOUT:     %ptr: type = ptr_type %T.ref.loc16 [symbolic = constants.%ptr]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p: ref %ptr = bind_name p, %p.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -72,11 +75,11 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %T = var %a.var_patt
 // CHECK:STDOUT:   %p.ref: ref %ptr = name_ref p, %p
-// CHECK:STDOUT:   %.loc14_15: %ptr = bind_value %p.ref
-// CHECK:STDOUT:   %.loc14_14.1: ref %T = deref %.loc14_15
-// CHECK:STDOUT:   %.loc14_14.2: %T = bind_value %.loc14_14.1
-// CHECK:STDOUT:   assign %a.var, %.loc14_14.2
-// CHECK:STDOUT:   %T.ref.loc14: type = name_ref T, %T [symbolic = constants.%T]
+// CHECK:STDOUT:   %.loc17_15: %ptr = bind_value %p.ref
+// CHECK:STDOUT:   %.loc17_14.1: ref %T = deref %.loc17_15
+// CHECK:STDOUT:   %.loc17_14.2: %T = bind_value %.loc17_14.1
+// CHECK:STDOUT:   assign %a.var, %.loc17_14.2
+// CHECK:STDOUT:   %T.ref.loc17: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %a: ref %T = bind_name a, %a.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/generic_import.carbon

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/global.carbon
@@ -64,18 +67,18 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %n.patt: %pattern_type.7ce = binding_pattern n [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc11_8: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:   %.loc14_8: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc11_14.1: <bound method> = bound_method @__global_init.%int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc14_14.1: <bound method> = bound_method @__global_init.%int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc11_14.2: <bound method> = bound_method @__global_init.%int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc11_14.2(@__global_init.%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc11_14.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc11_14.2: %i32 = converted @__global_init.%int_1, %.loc11_14.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %n: %i32 = bind_name n, %.loc11_14.2
+// CHECK:STDOUT:   %bound_method.loc14_14.2: <bound method> = bound_method @__global_init.%int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc14_14.2(@__global_init.%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc14_14.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc14_14.2: %i32 = converted @__global_init.%int_1, %.loc14_14.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %n: %i32 = bind_name n, %.loc14_14.2
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]

--- a/toolchain/check/testdata/let/local.carbon
+++ b/toolchain/check/testdata/let/local.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/local.carbon
@@ -46,12 +49,12 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11_17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11_17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14_17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14_17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %a.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %i32.loc11_9 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc11_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc14: type = splice_block %i32.loc14_9 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc14_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %i32 = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
@@ -65,9 +68,9 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:     %b.patt: %pattern_type.7ce = binding_pattern b [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.ref: %i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc12: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b: %i32 = bind_name b, %a.ref
 // CHECK:STDOUT:   %b.ref: %i32 = name_ref b, %b

--- a/toolchain/check/testdata/let/no_prelude/import.carbon
+++ b/toolchain/check/testdata/let/no_prelude/import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/no_prelude/import.carbon

--- a/toolchain/check/testdata/let/no_prelude/import_access.carbon
+++ b/toolchain/check/testdata/let/no_prelude/import_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/no_prelude/import_access.carbon

--- a/toolchain/check/testdata/let/shadowed_decl.carbon
+++ b/toolchain/check/testdata/let/shadowed_decl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/shadowed_decl.carbon
@@ -63,19 +66,19 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %a.patt.loc11: %pattern_type.7ce = binding_pattern a [concrete]
-// CHECK:STDOUT:     %a.param_patt: %pattern_type.7ce = value_param_pattern %a.patt.loc11, call_param0 [concrete]
+// CHECK:STDOUT:     %a.patt.loc14: %pattern_type.7ce = binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.param_patt: %pattern_type.7ce = value_param_pattern %a.patt.loc14, call_param0 [concrete]
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11_17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11_17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14_17: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14_17: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %a.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %i32.loc11_9 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc11_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc14: type = splice_block %i32.loc14_9 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc14_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %a.loc11: %i32 = bind_name a, %a.param
+// CHECK:STDOUT:     %a.loc14: %i32 = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param1
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -84,22 +87,22 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: fn @F(%a.param: %i32) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %a.patt.loc12: %pattern_type.7ce = binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.patt.loc15: %pattern_type.7ce = binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc15_10: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_16.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc15_16.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_16.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_16.2(%int_1) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_16.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_16.2: %i32 = converted %int_1, %.loc12_16.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %a.loc12: %i32 = bind_name a, %.loc12_16.2
-// CHECK:STDOUT:   %a.ref: %i32 = name_ref a, %a.loc12
+// CHECK:STDOUT:   %bound_method.loc15_16.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_16.2(%int_1) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_16.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_16.2: %i32 = converted %int_1, %.loc15_16.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %a.loc15: %i32 = bind_name a, %.loc15_16.2
+// CHECK:STDOUT:   %a.ref: %i32 = name_ref a, %a.loc15
 // CHECK:STDOUT:   return %a.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.