### PR TITLE
Add range flag settings to operators files

### DIFF
--- a/toolchain/check/testdata/operators/builtin/and.carbon
+++ b/toolchain/check/testdata/operators/builtin/and.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/and.carbon
@@ -73,8 +76,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc11_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc11_11.2: type = converted %bool.make_type, %.loc11_11.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc14_11.2: type = converted %bool.make_type, %.loc14_11.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -83,8 +86,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc12_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc12_11.2: type = converted %bool.make_type, %.loc12_11.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc15_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc15_11.2: type = converted %bool.make_type, %.loc15_11.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -93,8 +96,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc14_13.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc14_13.2: type = converted %bool.make_type, %.loc14_13.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc17_13.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc17_13.2: type = converted %bool.make_type, %.loc17_13.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -104,10 +107,10 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.831 = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc25_23.1: type = splice_block %.loc25_23.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc25: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc25_23.2: type = value_of_initializer %bool.make_type.loc25 [concrete = bool]
-// CHECK:STDOUT:       %.loc25_23.3: type = converted %bool.make_type.loc25, %.loc25_23.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc28_23.1: type = splice_block %.loc28_23.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc28: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc28_23.2: type = value_of_initializer %bool.make_type.loc28 [concrete = bool]
+// CHECK:STDOUT:       %.loc28_23.3: type = converted %bool.make_type.loc28, %.loc28_23.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: bool = bind_name x, %x.param
 // CHECK:STDOUT:   }
@@ -129,21 +132,21 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.call: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc15_14.1: bool = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc15_14.2: bool = converted %F.call, %.loc15_14.1
+// CHECK:STDOUT:   %.loc18_14.1: bool = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc18_14.2: bool = converted %F.call, %.loc18_14.1
 // CHECK:STDOUT:   %false: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc15_14.2 br !and.rhs else br !and.result(%false)
+// CHECK:STDOUT:   if %.loc18_14.2 br !and.rhs else br !and.result(%false)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%G.decl [concrete = constants.%G]
 // CHECK:STDOUT:   %G.call: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc15_14.3: bool = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc15_14.4: bool = converted %G.call, %.loc15_14.3
-// CHECK:STDOUT:   br !and.result(%.loc15_14.4)
+// CHECK:STDOUT:   %.loc18_14.3: bool = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc18_14.4: bool = converted %G.call, %.loc18_14.3
+// CHECK:STDOUT:   br !and.result(%.loc18_14.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
-// CHECK:STDOUT:   %.loc15_14.5: bool = block_arg !and.result
-// CHECK:STDOUT:   return %.loc15_14.5
+// CHECK:STDOUT:   %.loc18_14.5: bool = block_arg !and.result
+// CHECK:STDOUT:   return %.loc18_14.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Constant() {
@@ -153,162 +156,162 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.831 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref bool = var %a.var_patt
-// CHECK:STDOUT:   %true.loc19_47: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   assign %a.var, %true.loc19_47
-// CHECK:STDOUT:   br !.loc19_13
+// CHECK:STDOUT:   %true.loc22_47: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   assign %a.var, %true.loc22_47
+// CHECK:STDOUT:   br !.loc22_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc19_13:
-// CHECK:STDOUT:   %true.loc19_13: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %false.loc19: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %true.loc19_13 br !and.rhs.loc19 else br !and.result.loc19(%false.loc19)
+// CHECK:STDOUT: !.loc22_13:
+// CHECK:STDOUT:   %true.loc22_13: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %false.loc22: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   if %true.loc22_13 br !and.rhs.loc22 else br !and.result.loc22(%false.loc22)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.rhs.loc19:
-// CHECK:STDOUT:   %true.loc19_22: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   br !and.result.loc19(%true.loc19_22)
+// CHECK:STDOUT: !and.rhs.loc22:
+// CHECK:STDOUT:   %true.loc22_22: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   br !and.result.loc22(%true.loc22_22)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.result.loc19:
-// CHECK:STDOUT:   %.loc19_18: bool = block_arg !and.result.loc19 [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc19_18 br !if.expr.then.loc19 else br !if.expr.else.loc19
+// CHECK:STDOUT: !and.result.loc22:
+// CHECK:STDOUT:   %.loc22_18: bool = block_arg !and.result.loc22 [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc22_18 br !if.expr.then.loc22 else br !if.expr.else.loc22
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc19:
-// CHECK:STDOUT:   %bool.make_type.loc19: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc19_32.1: type = value_of_initializer %bool.make_type.loc19 [concrete = bool]
-// CHECK:STDOUT:   %.loc19_32.2: type = converted %bool.make_type.loc19, %.loc19_32.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc19(%.loc19_32.2)
+// CHECK:STDOUT: !if.expr.then.loc22:
+// CHECK:STDOUT:   %bool.make_type.loc22: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc22_32.1: type = value_of_initializer %bool.make_type.loc22 [concrete = bool]
+// CHECK:STDOUT:   %.loc22_32.2: type = converted %bool.make_type.loc22, %.loc22_32.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_32.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc19:
-// CHECK:STDOUT:   %.loc19_43: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc19_37: type = converted %.loc19_43, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc19(%.loc19_37)
+// CHECK:STDOUT: !if.expr.else.loc22:
+// CHECK:STDOUT:   %.loc22_43: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_37: type = converted %.loc22_43, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_37)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc19:
-// CHECK:STDOUT:   %.loc19_10: type = block_arg !if.expr.result.loc19 [concrete = bool]
-// CHECK:STDOUT:   br !.loc19_7
+// CHECK:STDOUT: !if.expr.result.loc22:
+// CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result.loc22 [concrete = bool]
+// CHECK:STDOUT:   br !.loc22_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc19_7:
+// CHECK:STDOUT: !.loc22_7:
 // CHECK:STDOUT:   %a: ref bool = bind_name a, %a.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.cb1 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.var_patt: %pattern_type.cb1 = var_pattern %b.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b.var: ref %empty_tuple.type = var %b.var_patt
-// CHECK:STDOUT:   %.loc20_49.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc20_49.2: init %empty_tuple.type = tuple_init () to %b.var [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc20_3: init %empty_tuple.type = converted %.loc20_49.1, %.loc20_49.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   assign %b.var, %.loc20_3
-// CHECK:STDOUT:   br !.loc20_13
+// CHECK:STDOUT:   %.loc23_49.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc23_49.2: init %empty_tuple.type = tuple_init () to %b.var [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc23_3: init %empty_tuple.type = converted %.loc23_49.1, %.loc23_49.2 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   assign %b.var, %.loc23_3
+// CHECK:STDOUT:   br !.loc23_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc20_13:
-// CHECK:STDOUT:   %true.loc20: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %false.loc20_18: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %true.loc20 br !and.rhs.loc20 else br !and.result.loc20(%false.loc20_18)
+// CHECK:STDOUT: !.loc23_13:
+// CHECK:STDOUT:   %true.loc23: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %false.loc23_18: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   if %true.loc23 br !and.rhs.loc23 else br !and.result.loc23(%false.loc23_18)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.rhs.loc20:
-// CHECK:STDOUT:   %false.loc20_22: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   br !and.result.loc20(%false.loc20_22)
+// CHECK:STDOUT: !and.rhs.loc23:
+// CHECK:STDOUT:   %false.loc23_22: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   br !and.result.loc23(%false.loc23_22)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.result.loc20:
-// CHECK:STDOUT:   %.loc20_18: bool = block_arg !and.result.loc20 [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc20_18 br !if.expr.then.loc20 else br !if.expr.else.loc20
+// CHECK:STDOUT: !and.result.loc23:
+// CHECK:STDOUT:   %.loc23_18: bool = block_arg !and.result.loc23 [concrete = constants.%false]
+// CHECK:STDOUT:   if %.loc23_18 br !if.expr.then.loc23 else br !if.expr.else.loc23
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc20:
-// CHECK:STDOUT:   %bool.make_type.loc20: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc20_33.1: type = value_of_initializer %bool.make_type.loc20 [concrete = bool]
-// CHECK:STDOUT:   %.loc20_33.2: type = converted %bool.make_type.loc20, %.loc20_33.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc20(%.loc20_33.2)
+// CHECK:STDOUT: !if.expr.then.loc23:
+// CHECK:STDOUT:   %bool.make_type.loc23: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc23_33.1: type = value_of_initializer %bool.make_type.loc23 [concrete = bool]
+// CHECK:STDOUT:   %.loc23_33.2: type = converted %bool.make_type.loc23, %.loc23_33.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc23(%.loc23_33.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc20:
-// CHECK:STDOUT:   %.loc20_44: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc20_38: type = converted %.loc20_44, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc20(%.loc20_38)
+// CHECK:STDOUT: !if.expr.else.loc23:
+// CHECK:STDOUT:   %.loc23_44: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc23_38: type = converted %.loc23_44, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc23(%.loc23_38)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc20:
-// CHECK:STDOUT:   %.loc20_10: type = block_arg !if.expr.result.loc20 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !.loc20_7
+// CHECK:STDOUT: !if.expr.result.loc23:
+// CHECK:STDOUT:   %.loc23_10: type = block_arg !if.expr.result.loc23 [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !.loc23_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc20_7:
+// CHECK:STDOUT: !.loc23_7:
 // CHECK:STDOUT:   %b: ref %empty_tuple.type = bind_name b, %b.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.cb1 = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.var_patt: %pattern_type.cb1 = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref %empty_tuple.type = var %c.var_patt
-// CHECK:STDOUT:   %.loc21_49.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc21_49.2: init %empty_tuple.type = tuple_init () to %c.var [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc21_3: init %empty_tuple.type = converted %.loc21_49.1, %.loc21_49.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   assign %c.var, %.loc21_3
-// CHECK:STDOUT:   br !.loc21_13
+// CHECK:STDOUT:   %.loc24_49.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc24_49.2: init %empty_tuple.type = tuple_init () to %c.var [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc24_3: init %empty_tuple.type = converted %.loc24_49.1, %.loc24_49.2 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   assign %c.var, %.loc24_3
+// CHECK:STDOUT:   br !.loc24_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc21_13:
-// CHECK:STDOUT:   %false.loc21_13: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %false.loc21_19: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %false.loc21_13 br !and.rhs.loc21 else br !and.result.loc21(%false.loc21_19)
+// CHECK:STDOUT: !.loc24_13:
+// CHECK:STDOUT:   %false.loc24_13: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   %false.loc24_19: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   if %false.loc24_13 br !and.rhs.loc24 else br !and.result.loc24(%false.loc24_19)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.rhs.loc21:
-// CHECK:STDOUT:   %true.loc21: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   br !and.result.loc21(%true.loc21)
+// CHECK:STDOUT: !and.rhs.loc24:
+// CHECK:STDOUT:   %true.loc24: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   br !and.result.loc24(%true.loc24)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.result.loc21:
-// CHECK:STDOUT:   %.loc21_19: bool = block_arg !and.result.loc21 [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc21_19 br !if.expr.then.loc21 else br !if.expr.else.loc21
+// CHECK:STDOUT: !and.result.loc24:
+// CHECK:STDOUT:   %.loc24_19: bool = block_arg !and.result.loc24 [concrete = constants.%false]
+// CHECK:STDOUT:   if %.loc24_19 br !if.expr.then.loc24 else br !if.expr.else.loc24
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc21:
-// CHECK:STDOUT:   %bool.make_type.loc21: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc21_33.1: type = value_of_initializer %bool.make_type.loc21 [concrete = bool]
-// CHECK:STDOUT:   %.loc21_33.2: type = converted %bool.make_type.loc21, %.loc21_33.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc21(%.loc21_33.2)
+// CHECK:STDOUT: !if.expr.then.loc24:
+// CHECK:STDOUT:   %bool.make_type.loc24: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc24_33.1: type = value_of_initializer %bool.make_type.loc24 [concrete = bool]
+// CHECK:STDOUT:   %.loc24_33.2: type = converted %bool.make_type.loc24, %.loc24_33.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc24(%.loc24_33.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc21:
-// CHECK:STDOUT:   %.loc21_44: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc21_38: type = converted %.loc21_44, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc21(%.loc21_38)
+// CHECK:STDOUT: !if.expr.else.loc24:
+// CHECK:STDOUT:   %.loc24_44: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc24_38: type = converted %.loc24_44, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc24(%.loc24_38)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc21:
-// CHECK:STDOUT:   %.loc21_10: type = block_arg !if.expr.result.loc21 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !.loc21_7
+// CHECK:STDOUT: !if.expr.result.loc24:
+// CHECK:STDOUT:   %.loc24_10: type = block_arg !if.expr.result.loc24 [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !.loc24_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc21_7:
+// CHECK:STDOUT: !.loc24_7:
 // CHECK:STDOUT:   %c: ref %empty_tuple.type = bind_name c, %c.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d.patt: %pattern_type.cb1 = binding_pattern d [concrete]
 // CHECK:STDOUT:     %d.var_patt: %pattern_type.cb1 = var_pattern %d.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %d.var: ref %empty_tuple.type = var %d.var_patt
-// CHECK:STDOUT:   %.loc22_50.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_50.2: init %empty_tuple.type = tuple_init () to %d.var [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc22_3: init %empty_tuple.type = converted %.loc22_50.1, %.loc22_50.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   assign %d.var, %.loc22_3
-// CHECK:STDOUT:   br !.loc22_13
+// CHECK:STDOUT:   %.loc25_50.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc25_50.2: init %empty_tuple.type = tuple_init () to %d.var [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc25_3: init %empty_tuple.type = converted %.loc25_50.1, %.loc25_50.2 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   assign %d.var, %.loc25_3
+// CHECK:STDOUT:   br !.loc25_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc22_13:
-// CHECK:STDOUT:   %false.loc22_13: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %false.loc22_19: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %false.loc22_13 br !and.rhs.loc22 else br !and.result.loc22(%false.loc22_19)
+// CHECK:STDOUT: !.loc25_13:
+// CHECK:STDOUT:   %false.loc25_13: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   %false.loc25_19: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   if %false.loc25_13 br !and.rhs.loc25 else br !and.result.loc25(%false.loc25_19)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.rhs.loc22:
-// CHECK:STDOUT:   %false.loc22_23: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   br !and.result.loc22(%false.loc22_23)
+// CHECK:STDOUT: !and.rhs.loc25:
+// CHECK:STDOUT:   %false.loc25_23: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   br !and.result.loc25(%false.loc25_23)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !and.result.loc22:
-// CHECK:STDOUT:   %.loc22_19: bool = block_arg !and.result.loc22 [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc22_19 br !if.expr.then.loc22 else br !if.expr.else.loc22
+// CHECK:STDOUT: !and.result.loc25:
+// CHECK:STDOUT:   %.loc25_19: bool = block_arg !and.result.loc25 [concrete = constants.%false]
+// CHECK:STDOUT:   if %.loc25_19 br !if.expr.then.loc25 else br !if.expr.else.loc25
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc22:
-// CHECK:STDOUT:   %bool.make_type.loc22: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc22_34.1: type = value_of_initializer %bool.make_type.loc22 [concrete = bool]
-// CHECK:STDOUT:   %.loc22_34.2: type = converted %bool.make_type.loc22, %.loc22_34.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_34.2)
+// CHECK:STDOUT: !if.expr.then.loc25:
+// CHECK:STDOUT:   %bool.make_type.loc25: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc25_34.1: type = value_of_initializer %bool.make_type.loc25 [concrete = bool]
+// CHECK:STDOUT:   %.loc25_34.2: type = converted %bool.make_type.loc25, %.loc25_34.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc25(%.loc25_34.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc22:
-// CHECK:STDOUT:   %.loc22_45: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_39: type = converted %.loc22_45, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_39)
+// CHECK:STDOUT: !if.expr.else.loc25:
+// CHECK:STDOUT:   %.loc25_45: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc25_39: type = converted %.loc25_45, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc25(%.loc25_39)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc22:
-// CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result.loc22 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !.loc22_7
+// CHECK:STDOUT: !if.expr.result.loc25:
+// CHECK:STDOUT:   %.loc25_10: type = block_arg !if.expr.result.loc25 [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !.loc25_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc22_7:
+// CHECK:STDOUT: !.loc25_7:
 // CHECK:STDOUT:   %d: ref %empty_tuple.type = bind_name d, %d.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -320,41 +323,41 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.cb1 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %empty_tuple.type = var %a.var_patt
-// CHECK:STDOUT:   %.loc26_46.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc26_46.2: init %empty_tuple.type = tuple_init () to %a.var [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc26_3: init %empty_tuple.type = converted %.loc26_46.1, %.loc26_46.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   assign %a.var, %.loc26_3
-// CHECK:STDOUT:   br !.loc26_13
+// CHECK:STDOUT:   %.loc29_46.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc29_46.2: init %empty_tuple.type = tuple_init () to %a.var [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc29_3: init %empty_tuple.type = converted %.loc29_46.1, %.loc29_46.2 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   assign %a.var, %.loc29_3
+// CHECK:STDOUT:   br !.loc29_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc26_13:
-// CHECK:STDOUT:   %false.loc26_13: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %false.loc26_19: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %false.loc26_13 br !and.rhs else br !and.result(%false.loc26_19)
+// CHECK:STDOUT: !.loc29_13:
+// CHECK:STDOUT:   %false.loc29_13: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   %false.loc29_19: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   if %false.loc29_13 br !and.rhs else br !and.result(%false.loc29_19)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
 // CHECK:STDOUT:   %x.ref: bool = name_ref x, %x
 // CHECK:STDOUT:   br !and.result(%x.ref)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
-// CHECK:STDOUT:   %.loc26_19: bool = block_arg !and.result [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc26_19 br !if.expr.then else br !if.expr.else
+// CHECK:STDOUT:   %.loc29_19: bool = block_arg !and.result [concrete = constants.%false]
+// CHECK:STDOUT:   if %.loc29_19 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %bool.make_type.loc26: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc26_30.1: type = value_of_initializer %bool.make_type.loc26 [concrete = bool]
-// CHECK:STDOUT:   %.loc26_30.2: type = converted %bool.make_type.loc26, %.loc26_30.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result(%.loc26_30.2)
+// CHECK:STDOUT:   %bool.make_type.loc29: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc29_30.1: type = value_of_initializer %bool.make_type.loc29 [concrete = bool]
+// CHECK:STDOUT:   %.loc29_30.2: type = converted %bool.make_type.loc29, %.loc29_30.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result(%.loc29_30.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %.loc26_41: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc26_35: type = converted %.loc26_41, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result(%.loc26_35)
+// CHECK:STDOUT:   %.loc29_41: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc29_35: type = converted %.loc29_41, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result(%.loc29_35)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc26_10: type = block_arg !if.expr.result [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !.loc26_7
+// CHECK:STDOUT:   %.loc29_10: type = block_arg !if.expr.result [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !.loc29_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc26_7:
+// CHECK:STDOUT: !.loc29_7:
 // CHECK:STDOUT:   %a: ref %empty_tuple.type = bind_name a, %a.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/assignment.carbon
+++ b/toolchain/check/testdata/operators/builtin/assignment.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/assignment.carbon
@@ -126,189 +129,189 @@ fn Main() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %i32 = var %a.var_patt
 // CHECK:STDOUT:   %int_12: Core.IntLiteral = int_value 12 [concrete = constants.%int_12.6a3]
-// CHECK:STDOUT:   %impl.elem0.loc12: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_3.1: <bound method> = bound_method %int_12, %impl.elem0.loc12 [concrete = constants.%Convert.bound.221]
-// CHECK:STDOUT:   %specific_fn.loc12: <specific function> = specific_function %impl.elem0.loc12, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_3.2: <bound method> = bound_method %int_12, %specific_fn.loc12 [concrete = constants.%bound_method.dae]
-// CHECK:STDOUT:   %int.convert_checked.loc12: init %i32 = call %bound_method.loc12_3.2(%int_12) [concrete = constants.%int_12.1e1]
-// CHECK:STDOUT:   %.loc12_3: init %i32 = converted %int_12, %int.convert_checked.loc12 [concrete = constants.%int_12.1e1]
-// CHECK:STDOUT:   assign %a.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %impl.elem0.loc15: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_3.1: <bound method> = bound_method %int_12, %impl.elem0.loc15 [concrete = constants.%Convert.bound.221]
+// CHECK:STDOUT:   %specific_fn.loc15: <specific function> = specific_function %impl.elem0.loc15, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_3.2: <bound method> = bound_method %int_12, %specific_fn.loc15 [concrete = constants.%bound_method.dae]
+// CHECK:STDOUT:   %int.convert_checked.loc15: init %i32 = call %bound_method.loc15_3.2(%int_12) [concrete = constants.%int_12.1e1]
+// CHECK:STDOUT:   %.loc15_3: init %i32 = converted %int_12, %int.convert_checked.loc15 [concrete = constants.%int_12.1e1]
+// CHECK:STDOUT:   assign %a.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_10: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %a.ref.loc13: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc16: ref %i32 = name_ref a, %a
 // CHECK:STDOUT:   %int_9: Core.IntLiteral = int_value 9 [concrete = constants.%int_9.988]
-// CHECK:STDOUT:   %impl.elem0.loc13: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc13_5.1: <bound method> = bound_method %int_9, %impl.elem0.loc13 [concrete = constants.%Convert.bound.9e2]
-// CHECK:STDOUT:   %specific_fn.loc13: <specific function> = specific_function %impl.elem0.loc13, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc13_5.2: <bound method> = bound_method %int_9, %specific_fn.loc13 [concrete = constants.%bound_method.cd3]
-// CHECK:STDOUT:   %int.convert_checked.loc13: init %i32 = call %bound_method.loc13_5.2(%int_9) [concrete = constants.%int_9.f88]
-// CHECK:STDOUT:   %.loc13: init %i32 = converted %int_9, %int.convert_checked.loc13 [concrete = constants.%int_9.f88]
-// CHECK:STDOUT:   assign %a.ref.loc13, %.loc13
+// CHECK:STDOUT:   %impl.elem0.loc16: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc16_5.1: <bound method> = bound_method %int_9, %impl.elem0.loc16 [concrete = constants.%Convert.bound.9e2]
+// CHECK:STDOUT:   %specific_fn.loc16: <specific function> = specific_function %impl.elem0.loc16, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc16_5.2: <bound method> = bound_method %int_9, %specific_fn.loc16 [concrete = constants.%bound_method.cd3]
+// CHECK:STDOUT:   %int.convert_checked.loc16: init %i32 = call %bound_method.loc16_5.2(%int_9) [concrete = constants.%int_9.f88]
+// CHECK:STDOUT:   %.loc16: init %i32 = converted %int_9, %int.convert_checked.loc16 [concrete = constants.%int_9.f88]
+// CHECK:STDOUT:   assign %a.ref.loc16, %.loc16
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.511 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.var_patt: %pattern_type.511 = var_pattern %b.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b.var: ref %tuple.type.d07 = var %b.var_patt
-// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc15: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc15_28.1: %tuple.type.f94 = tuple_literal (%int_1.loc15, %int_2.loc15)
-// CHECK:STDOUT:   %impl.elem0.loc15_28.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc15_28.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_28.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc15_28.1: <specific function> = specific_function %impl.elem0.loc15_28.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc15_28.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_28.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc15_28.1: init %i32 = call %bound_method.loc15_28.2(%int_1.loc15) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc15_28.2: init %i32 = converted %int_1.loc15, %int.convert_checked.loc15_28.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %tuple.elem0.loc15: ref %i32 = tuple_access %b.var, element0
-// CHECK:STDOUT:   %.loc15_28.3: init %i32 = initialize_from %.loc15_28.2 to %tuple.elem0.loc15 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc15_28.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc15_28.3: <bound method> = bound_method %int_2.loc15, %impl.elem0.loc15_28.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc15_28.2: <specific function> = specific_function %impl.elem0.loc15_28.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc15_28.4: <bound method> = bound_method %int_2.loc15, %specific_fn.loc15_28.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc15_28.2: init %i32 = call %bound_method.loc15_28.4(%int_2.loc15) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc15_28.4: init %i32 = converted %int_2.loc15, %int.convert_checked.loc15_28.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %tuple.elem1.loc15: ref %i32 = tuple_access %b.var, element1
-// CHECK:STDOUT:   %.loc15_28.5: init %i32 = initialize_from %.loc15_28.4 to %tuple.elem1.loc15 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc15_28.6: init %tuple.type.d07 = tuple_init (%.loc15_28.3, %.loc15_28.5) to %b.var [concrete = constants.%tuple]
-// CHECK:STDOUT:   %.loc15_3: init %tuple.type.d07 = converted %.loc15_28.1, %.loc15_28.6 [concrete = constants.%tuple]
-// CHECK:STDOUT:   assign %b.var, %.loc15_3
-// CHECK:STDOUT:   %.loc15_19.1: type = splice_block %.loc15_19.3 [concrete = constants.%tuple.type.d07] {
-// CHECK:STDOUT:     %int_32.loc15_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc15_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc15_19.2: %tuple.type.24b = tuple_literal (%i32.loc15_11, %i32.loc15_16)
-// CHECK:STDOUT:     %.loc15_19.3: type = converted %.loc15_19.2, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc18: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc18_28.1: %tuple.type.f94 = tuple_literal (%int_1.loc18, %int_2.loc18)
+// CHECK:STDOUT:   %impl.elem0.loc18_28.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc18_28.1: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_28.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc18_28.1: <specific function> = specific_function %impl.elem0.loc18_28.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc18_28.2: <bound method> = bound_method %int_1.loc18, %specific_fn.loc18_28.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc18_28.1: init %i32 = call %bound_method.loc18_28.2(%int_1.loc18) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc18_28.2: init %i32 = converted %int_1.loc18, %int.convert_checked.loc18_28.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %tuple.elem0.loc18: ref %i32 = tuple_access %b.var, element0
+// CHECK:STDOUT:   %.loc18_28.3: init %i32 = initialize_from %.loc18_28.2 to %tuple.elem0.loc18 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc18_28.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc18_28.3: <bound method> = bound_method %int_2.loc18, %impl.elem0.loc18_28.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc18_28.2: <specific function> = specific_function %impl.elem0.loc18_28.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc18_28.4: <bound method> = bound_method %int_2.loc18, %specific_fn.loc18_28.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc18_28.2: init %i32 = call %bound_method.loc18_28.4(%int_2.loc18) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc18_28.4: init %i32 = converted %int_2.loc18, %int.convert_checked.loc18_28.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %tuple.elem1.loc18: ref %i32 = tuple_access %b.var, element1
+// CHECK:STDOUT:   %.loc18_28.5: init %i32 = initialize_from %.loc18_28.4 to %tuple.elem1.loc18 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc18_28.6: init %tuple.type.d07 = tuple_init (%.loc18_28.3, %.loc18_28.5) to %b.var [concrete = constants.%tuple]
+// CHECK:STDOUT:   %.loc18_3: init %tuple.type.d07 = converted %.loc18_28.1, %.loc18_28.6 [concrete = constants.%tuple]
+// CHECK:STDOUT:   assign %b.var, %.loc18_3
+// CHECK:STDOUT:   %.loc18_19.1: type = splice_block %.loc18_19.3 [concrete = constants.%tuple.type.d07] {
+// CHECK:STDOUT:     %int_32.loc18_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc18_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc18_19.2: %tuple.type.24b = tuple_literal (%i32.loc18_11, %i32.loc18_16)
+// CHECK:STDOUT:     %.loc18_19.3: type = converted %.loc18_19.2, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b: ref %tuple.type.d07 = bind_name b, %b.var
-// CHECK:STDOUT:   %b.ref.loc16: ref %tuple.type.d07 = name_ref b, %b
+// CHECK:STDOUT:   %b.ref.loc19: ref %tuple.type.d07 = name_ref b, %b
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
-// CHECK:STDOUT:   %tuple.elem0.loc16: ref %i32 = tuple_access %b.ref.loc16, element0
-// CHECK:STDOUT:   %int_3.loc16: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %impl.elem0.loc16: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc16_7.1: <bound method> = bound_method %int_3.loc16, %impl.elem0.loc16 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc16: <specific function> = specific_function %impl.elem0.loc16, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc16_7.2: <bound method> = bound_method %int_3.loc16, %specific_fn.loc16 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc16: init %i32 = call %bound_method.loc16_7.2(%int_3.loc16) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc16: init %i32 = converted %int_3.loc16, %int.convert_checked.loc16 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   assign %tuple.elem0.loc16, %.loc16
-// CHECK:STDOUT:   %b.ref.loc17: ref %tuple.type.d07 = name_ref b, %b
-// CHECK:STDOUT:   %int_1.loc17: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %tuple.elem1.loc17: ref %i32 = tuple_access %b.ref.loc17, element1
-// CHECK:STDOUT:   %int_4.loc17: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
-// CHECK:STDOUT:   %impl.elem0.loc17: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc17_7.1: <bound method> = bound_method %int_4.loc17, %impl.elem0.loc17 [concrete = constants.%Convert.bound.ac3]
-// CHECK:STDOUT:   %specific_fn.loc17: <specific function> = specific_function %impl.elem0.loc17, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc17_7.2: <bound method> = bound_method %int_4.loc17, %specific_fn.loc17 [concrete = constants.%bound_method.1da]
-// CHECK:STDOUT:   %int.convert_checked.loc17: init %i32 = call %bound_method.loc17_7.2(%int_4.loc17) [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc17: init %i32 = converted %int_4.loc17, %int.convert_checked.loc17 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   assign %tuple.elem1.loc17, %.loc17
+// CHECK:STDOUT:   %tuple.elem0.loc19: ref %i32 = tuple_access %b.ref.loc19, element0
+// CHECK:STDOUT:   %int_3.loc19: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %impl.elem0.loc19: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc19_7.1: <bound method> = bound_method %int_3.loc19, %impl.elem0.loc19 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem0.loc19, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc19_7.2: <bound method> = bound_method %int_3.loc19, %specific_fn.loc19 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc19: init %i32 = call %bound_method.loc19_7.2(%int_3.loc19) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc19: init %i32 = converted %int_3.loc19, %int.convert_checked.loc19 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   assign %tuple.elem0.loc19, %.loc19
+// CHECK:STDOUT:   %b.ref.loc20: ref %tuple.type.d07 = name_ref b, %b
+// CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %tuple.elem1.loc20: ref %i32 = tuple_access %b.ref.loc20, element1
+// CHECK:STDOUT:   %int_4.loc20: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
+// CHECK:STDOUT:   %impl.elem0.loc20: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc20_7.1: <bound method> = bound_method %int_4.loc20, %impl.elem0.loc20 [concrete = constants.%Convert.bound.ac3]
+// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem0.loc20, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc20_7.2: <bound method> = bound_method %int_4.loc20, %specific_fn.loc20 [concrete = constants.%bound_method.1da]
+// CHECK:STDOUT:   %int.convert_checked.loc20: init %i32 = call %bound_method.loc20_7.2(%int_4.loc20) [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc20: init %i32 = converted %int_4.loc20, %int.convert_checked.loc20 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   assign %tuple.elem1.loc20, %.loc20
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.851 = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.var_patt: %pattern_type.851 = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref %struct_type.a.b.501 = var %c.var_patt
-// CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc19: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc19_46.1: %struct_type.a.b.cfd = struct_literal (%int_1.loc19, %int_2.loc19)
-// CHECK:STDOUT:   %impl.elem0.loc19_46.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc19_46.1: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_46.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc19_46.1: <specific function> = specific_function %impl.elem0.loc19_46.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc19_46.2: <bound method> = bound_method %int_1.loc19, %specific_fn.loc19_46.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc19_46.1: init %i32 = call %bound_method.loc19_46.2(%int_1.loc19) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc19_46.2: init %i32 = converted %int_1.loc19, %int.convert_checked.loc19_46.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc19_46.3: ref %i32 = struct_access %c.var, element0
-// CHECK:STDOUT:   %.loc19_46.4: init %i32 = initialize_from %.loc19_46.2 to %.loc19_46.3 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc19_46.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc19_46.3: <bound method> = bound_method %int_2.loc19, %impl.elem0.loc19_46.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc19_46.2: <specific function> = specific_function %impl.elem0.loc19_46.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc19_46.4: <bound method> = bound_method %int_2.loc19, %specific_fn.loc19_46.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc19_46.2: init %i32 = call %bound_method.loc19_46.4(%int_2.loc19) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc19_46.5: init %i32 = converted %int_2.loc19, %int.convert_checked.loc19_46.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc19_46.6: ref %i32 = struct_access %c.var, element1
-// CHECK:STDOUT:   %.loc19_46.7: init %i32 = initialize_from %.loc19_46.5 to %.loc19_46.6 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc19_46.8: init %struct_type.a.b.501 = struct_init (%.loc19_46.4, %.loc19_46.7) to %c.var [concrete = constants.%struct]
-// CHECK:STDOUT:   %.loc19_3: init %struct_type.a.b.501 = converted %.loc19_46.1, %.loc19_46.8 [concrete = constants.%struct]
-// CHECK:STDOUT:   assign %c.var, %.loc19_3
-// CHECK:STDOUT:   %.loc19_27: type = splice_block %struct_type.a.b [concrete = constants.%struct_type.a.b.501] {
-// CHECK:STDOUT:     %int_32.loc19_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc19_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc19_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc19_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %int_1.loc22: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc22: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc22_46.1: %struct_type.a.b.cfd = struct_literal (%int_1.loc22, %int_2.loc22)
+// CHECK:STDOUT:   %impl.elem0.loc22_46.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc22_46.1: <bound method> = bound_method %int_1.loc22, %impl.elem0.loc22_46.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc22_46.1: <specific function> = specific_function %impl.elem0.loc22_46.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc22_46.2: <bound method> = bound_method %int_1.loc22, %specific_fn.loc22_46.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc22_46.1: init %i32 = call %bound_method.loc22_46.2(%int_1.loc22) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc22_46.2: init %i32 = converted %int_1.loc22, %int.convert_checked.loc22_46.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc22_46.3: ref %i32 = struct_access %c.var, element0
+// CHECK:STDOUT:   %.loc22_46.4: init %i32 = initialize_from %.loc22_46.2 to %.loc22_46.3 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc22_46.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc22_46.3: <bound method> = bound_method %int_2.loc22, %impl.elem0.loc22_46.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc22_46.2: <specific function> = specific_function %impl.elem0.loc22_46.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc22_46.4: <bound method> = bound_method %int_2.loc22, %specific_fn.loc22_46.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc22_46.2: init %i32 = call %bound_method.loc22_46.4(%int_2.loc22) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc22_46.5: init %i32 = converted %int_2.loc22, %int.convert_checked.loc22_46.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc22_46.6: ref %i32 = struct_access %c.var, element1
+// CHECK:STDOUT:   %.loc22_46.7: init %i32 = initialize_from %.loc22_46.5 to %.loc22_46.6 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc22_46.8: init %struct_type.a.b.501 = struct_init (%.loc22_46.4, %.loc22_46.7) to %c.var [concrete = constants.%struct]
+// CHECK:STDOUT:   %.loc22_3: init %struct_type.a.b.501 = converted %.loc22_46.1, %.loc22_46.8 [concrete = constants.%struct]
+// CHECK:STDOUT:   assign %c.var, %.loc22_3
+// CHECK:STDOUT:   %.loc22_27: type = splice_block %struct_type.a.b [concrete = constants.%struct_type.a.b.501] {
+// CHECK:STDOUT:     %int_32.loc22_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc22_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc22_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc22_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %struct_type.a.b: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c: ref %struct_type.a.b.501 = bind_name c, %c.var
-// CHECK:STDOUT:   %c.ref.loc20: ref %struct_type.a.b.501 = name_ref c, %c
-// CHECK:STDOUT:   %.loc20_4: ref %i32 = struct_access %c.ref.loc20, element0
-// CHECK:STDOUT:   %int_3.loc20: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %impl.elem0.loc20: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc20_7.1: <bound method> = bound_method %int_3.loc20, %impl.elem0.loc20 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem0.loc20, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc20_7.2: <bound method> = bound_method %int_3.loc20, %specific_fn.loc20 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc20: init %i32 = call %bound_method.loc20_7.2(%int_3.loc20) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc20_7: init %i32 = converted %int_3.loc20, %int.convert_checked.loc20 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   assign %.loc20_4, %.loc20_7
-// CHECK:STDOUT:   %c.ref.loc21: ref %struct_type.a.b.501 = name_ref c, %c
-// CHECK:STDOUT:   %.loc21_4: ref %i32 = struct_access %c.ref.loc21, element1
-// CHECK:STDOUT:   %int_4.loc21: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
-// CHECK:STDOUT:   %impl.elem0.loc21: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc21_7.1: <bound method> = bound_method %int_4.loc21, %impl.elem0.loc21 [concrete = constants.%Convert.bound.ac3]
-// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem0.loc21, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc21_7.2: <bound method> = bound_method %int_4.loc21, %specific_fn.loc21 [concrete = constants.%bound_method.1da]
-// CHECK:STDOUT:   %int.convert_checked.loc21: init %i32 = call %bound_method.loc21_7.2(%int_4.loc21) [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   %.loc21_7: init %i32 = converted %int_4.loc21, %int.convert_checked.loc21 [concrete = constants.%int_4.940]
-// CHECK:STDOUT:   assign %.loc21_4, %.loc21_7
+// CHECK:STDOUT:   %c.ref.loc23: ref %struct_type.a.b.501 = name_ref c, %c
+// CHECK:STDOUT:   %.loc23_4: ref %i32 = struct_access %c.ref.loc23, element0
+// CHECK:STDOUT:   %int_3.loc23: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %impl.elem0.loc23: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc23_7.1: <bound method> = bound_method %int_3.loc23, %impl.elem0.loc23 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc23: <specific function> = specific_function %impl.elem0.loc23, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc23_7.2: <bound method> = bound_method %int_3.loc23, %specific_fn.loc23 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc23: init %i32 = call %bound_method.loc23_7.2(%int_3.loc23) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc23_7: init %i32 = converted %int_3.loc23, %int.convert_checked.loc23 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   assign %.loc23_4, %.loc23_7
+// CHECK:STDOUT:   %c.ref.loc24: ref %struct_type.a.b.501 = name_ref c, %c
+// CHECK:STDOUT:   %.loc24_4: ref %i32 = struct_access %c.ref.loc24, element1
+// CHECK:STDOUT:   %int_4.loc24: Core.IntLiteral = int_value 4 [concrete = constants.%int_4.0c1]
+// CHECK:STDOUT:   %impl.elem0.loc24: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc24_7.1: <bound method> = bound_method %int_4.loc24, %impl.elem0.loc24 [concrete = constants.%Convert.bound.ac3]
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc24_7.2: <bound method> = bound_method %int_4.loc24, %specific_fn.loc24 [concrete = constants.%bound_method.1da]
+// CHECK:STDOUT:   %int.convert_checked.loc24: init %i32 = call %bound_method.loc24_7.2(%int_4.loc24) [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   %.loc24_7: init %i32 = converted %int_4.loc24, %int.convert_checked.loc24 [concrete = constants.%int_4.940]
+// CHECK:STDOUT:   assign %.loc24_4, %.loc24_7
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %p.patt: %pattern_type.fe8 = binding_pattern p [concrete]
 // CHECK:STDOUT:     %p.var_patt: %pattern_type.fe8 = var_pattern %p.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p.var: ref %ptr.235 = var %p.var_patt
-// CHECK:STDOUT:   %a.ref.loc23: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %addr.loc23: %ptr.235 = addr_of %a.ref.loc23
-// CHECK:STDOUT:   assign %p.var, %addr.loc23
-// CHECK:STDOUT:   %.loc23: type = splice_block %ptr [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr: type = ptr_type %i32.loc23 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %a.ref.loc26: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %addr.loc26: %ptr.235 = addr_of %a.ref.loc26
+// CHECK:STDOUT:   assign %p.var, %addr.loc26
+// CHECK:STDOUT:   %.loc26: type = splice_block %ptr [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc26: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc26: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr: type = ptr_type %i32.loc26 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p: ref %ptr.235 = bind_name p, %p.var
-// CHECK:STDOUT:   %p.ref.loc24: ref %ptr.235 = name_ref p, %p
-// CHECK:STDOUT:   %.loc24_4: %ptr.235 = bind_value %p.ref.loc24
-// CHECK:STDOUT:   %.loc24_3: ref %i32 = deref %.loc24_4
+// CHECK:STDOUT:   %p.ref.loc27: ref %ptr.235 = name_ref p, %p
+// CHECK:STDOUT:   %.loc27_4: %ptr.235 = bind_value %p.ref.loc27
+// CHECK:STDOUT:   %.loc27_3: ref %i32 = deref %.loc27_4
 // CHECK:STDOUT:   %int_5: Core.IntLiteral = int_value 5 [concrete = constants.%int_5.64b]
-// CHECK:STDOUT:   %impl.elem0.loc24: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc24_6.1: <bound method> = bound_method %int_5, %impl.elem0.loc24 [concrete = constants.%Convert.bound.4e6]
-// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc24_6.2: <bound method> = bound_method %int_5, %specific_fn.loc24 [concrete = constants.%bound_method.a25]
-// CHECK:STDOUT:   %int.convert_checked.loc24: init %i32 = call %bound_method.loc24_6.2(%int_5) [concrete = constants.%int_5.0f6]
-// CHECK:STDOUT:   %.loc24_6: init %i32 = converted %int_5, %int.convert_checked.loc24 [concrete = constants.%int_5.0f6]
-// CHECK:STDOUT:   assign %.loc24_3, %.loc24_6
+// CHECK:STDOUT:   %impl.elem0.loc27: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc27_6.1: <bound method> = bound_method %int_5, %impl.elem0.loc27 [concrete = constants.%Convert.bound.4e6]
+// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem0.loc27, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc27_6.2: <bound method> = bound_method %int_5, %specific_fn.loc27 [concrete = constants.%bound_method.a25]
+// CHECK:STDOUT:   %int.convert_checked.loc27: init %i32 = call %bound_method.loc27_6.2(%int_5) [concrete = constants.%int_5.0f6]
+// CHECK:STDOUT:   %.loc27_6: init %i32 = converted %int_5, %int.convert_checked.loc27 [concrete = constants.%int_5.0f6]
+// CHECK:STDOUT:   assign %.loc27_3, %.loc27_6
 // CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
 // CHECK:STDOUT:   if %true br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %p.ref.loc26: ref %ptr.235 = name_ref p, %p
-// CHECK:STDOUT:   %.loc26_18: %ptr.235 = bind_value %p.ref.loc26
-// CHECK:STDOUT:   br !if.expr.result(%.loc26_18)
+// CHECK:STDOUT:   %p.ref.loc29: ref %ptr.235 = name_ref p, %p
+// CHECK:STDOUT:   %.loc29_18: %ptr.235 = bind_value %p.ref.loc29
+// CHECK:STDOUT:   br !if.expr.result(%.loc29_18)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %a.ref.loc26: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %addr.loc26: %ptr.235 = addr_of %a.ref.loc26
-// CHECK:STDOUT:   br !if.expr.result(%addr.loc26)
+// CHECK:STDOUT:   %a.ref.loc29: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %addr.loc29: %ptr.235 = addr_of %a.ref.loc29
+// CHECK:STDOUT:   br !if.expr.result(%addr.loc29)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc26_5: %ptr.235 = block_arg !if.expr.result
-// CHECK:STDOUT:   %.loc26_3: ref %i32 = deref %.loc26_5
+// CHECK:STDOUT:   %.loc29_5: %ptr.235 = block_arg !if.expr.result
+// CHECK:STDOUT:   %.loc29_3: ref %i32 = deref %.loc29_5
 // CHECK:STDOUT:   %int_10: Core.IntLiteral = int_value 10 [concrete = constants.%int_10.64f]
-// CHECK:STDOUT:   %impl.elem0.loc26: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc26_29.1: <bound method> = bound_method %int_10, %impl.elem0.loc26 [concrete = constants.%Convert.bound.491]
-// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem0.loc26, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc26_29.2: <bound method> = bound_method %int_10, %specific_fn.loc26 [concrete = constants.%bound_method.5ba]
-// CHECK:STDOUT:   %int.convert_checked.loc26: init %i32 = call %bound_method.loc26_29.2(%int_10) [concrete = constants.%int_10.265]
-// CHECK:STDOUT:   %.loc26_29: init %i32 = converted %int_10, %int.convert_checked.loc26 [concrete = constants.%int_10.265]
-// CHECK:STDOUT:   assign %.loc26_3, %.loc26_29
+// CHECK:STDOUT:   %impl.elem0.loc29: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc29_29.1: <bound method> = bound_method %int_10, %impl.elem0.loc29 [concrete = constants.%Convert.bound.491]
+// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem0.loc29, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc29_29.2: <bound method> = bound_method %int_10, %specific_fn.loc29 [concrete = constants.%bound_method.5ba]
+// CHECK:STDOUT:   %int.convert_checked.loc29: init %i32 = call %bound_method.loc29_29.2(%int_10) [concrete = constants.%int_10.265]
+// CHECK:STDOUT:   %.loc29_29: init %i32 = converted %int_10, %int.convert_checked.loc29 [concrete = constants.%int_10.265]
+// CHECK:STDOUT:   assign %.loc29_3, %.loc29_29
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/bit_and.carbon
+++ b/toolchain/check/testdata/operators/builtin/bit_and.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon

--- a/toolchain/check/testdata/operators/builtin/fail_and_or_partial_constant.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_and_or_partial_constant.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_and_or_partial_constant.carbon

--- a/toolchain/check/testdata/operators/builtin/fail_assignment_to_error.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_assignment_to_error.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_assignment_to_error.carbon
@@ -50,12 +53,12 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %undeclared.ref: <error> = name_ref undeclared, <error> [concrete = <error>]
-// CHECK:STDOUT:   %int_42.loc16: Core.IntLiteral = int_value 42 [concrete = constants.%int_42]
+// CHECK:STDOUT:   %int_42.loc19: Core.IntLiteral = int_value 42 [concrete = constants.%int_42]
 // CHECK:STDOUT:   assign %undeclared.ref, <error>
 // CHECK:STDOUT:   %also_undeclared.ref: <error> = name_ref also_undeclared, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc21: ref <error> = deref <error> [concrete = <error>]
-// CHECK:STDOUT:   %int_42.loc21: Core.IntLiteral = int_value 42 [concrete = constants.%int_42]
-// CHECK:STDOUT:   assign %.loc21, <error>
+// CHECK:STDOUT:   %.loc24: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %int_42.loc24: Core.IntLiteral = int_value 42 [concrete = constants.%int_42]
+// CHECK:STDOUT:   assign %.loc24, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
@@ -151,172 +154,172 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc18: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   assign %int_1.loc18, %int_2.loc18
+// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc21: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   assign %int_1.loc21, %int_2.loc21
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.ref()
-// CHECK:STDOUT:   %int_1.loc23: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %impl.elem0.loc23: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc23_7.1: <bound method> = bound_method %int_1.loc23, %impl.elem0.loc23 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc23: <specific function> = specific_function %impl.elem0.loc23, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc23_7.2: <bound method> = bound_method %int_1.loc23, %specific_fn.loc23 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc23: init %i32 = call %bound_method.loc23_7.2(%int_1.loc23) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc23: init %i32 = converted %int_1.loc23, %int.convert_checked.loc23 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   assign %F.call, %.loc23
-// CHECK:STDOUT:   %int_1.loc28: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc28: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc28_8.1: %tuple.type.f94 = tuple_literal (%int_1.loc28, %int_2.loc28)
-// CHECK:STDOUT:   %int_3.loc28: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %int_4.loc28: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
-// CHECK:STDOUT:   %.loc28_17.1: %tuple.type.f94 = tuple_literal (%int_3.loc28, %int_4.loc28)
-// CHECK:STDOUT:   %tuple.elem0.loc28: Core.IntLiteral = tuple_access %.loc28_8.1, element0
-// CHECK:STDOUT:   %.loc28_17.2: init Core.IntLiteral = initialize_from %int_3.loc28 to %tuple.elem0.loc28 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %tuple.elem1.loc28: Core.IntLiteral = tuple_access %.loc28_8.1, element1
-// CHECK:STDOUT:   %.loc28_17.3: init Core.IntLiteral = initialize_from %int_4.loc28 to %tuple.elem1.loc28 [concrete = constants.%int_4]
-// CHECK:STDOUT:   %.loc28_17.4: init %tuple.type.f94 = tuple_init (%.loc28_17.2, %.loc28_17.3) to %.loc28_8.1 [concrete = constants.%tuple.302]
-// CHECK:STDOUT:   %.loc28_10: init %tuple.type.f94 = converted %.loc28_17.1, %.loc28_17.4 [concrete = constants.%tuple.302]
-// CHECK:STDOUT:   assign %.loc28_8.1, %.loc28_10
-// CHECK:STDOUT:   %tuple.loc28: %tuple.type.f94 = tuple_value (%int_1.loc28, %int_2.loc28) [concrete = constants.%tuple.ad8]
-// CHECK:STDOUT:   %.loc28_8.2: %tuple.type.f94 = converted %.loc28_8.1, %tuple.loc28 [concrete = constants.%tuple.ad8]
+// CHECK:STDOUT:   %int_1.loc26: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc26: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc26_7.1: <bound method> = bound_method %int_1.loc26, %impl.elem0.loc26 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem0.loc26, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc26_7.2: <bound method> = bound_method %int_1.loc26, %specific_fn.loc26 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc26: init %i32 = call %bound_method.loc26_7.2(%int_1.loc26) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc26: init %i32 = converted %int_1.loc26, %int.convert_checked.loc26 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   assign %F.call, %.loc26
+// CHECK:STDOUT:   %int_1.loc31: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc31: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc31_8.1: %tuple.type.f94 = tuple_literal (%int_1.loc31, %int_2.loc31)
+// CHECK:STDOUT:   %int_3.loc31: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %int_4.loc31: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
+// CHECK:STDOUT:   %.loc31_17.1: %tuple.type.f94 = tuple_literal (%int_3.loc31, %int_4.loc31)
+// CHECK:STDOUT:   %tuple.elem0.loc31: Core.IntLiteral = tuple_access %.loc31_8.1, element0
+// CHECK:STDOUT:   %.loc31_17.2: init Core.IntLiteral = initialize_from %int_3.loc31 to %tuple.elem0.loc31 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %tuple.elem1.loc31: Core.IntLiteral = tuple_access %.loc31_8.1, element1
+// CHECK:STDOUT:   %.loc31_17.3: init Core.IntLiteral = initialize_from %int_4.loc31 to %tuple.elem1.loc31 [concrete = constants.%int_4]
+// CHECK:STDOUT:   %.loc31_17.4: init %tuple.type.f94 = tuple_init (%.loc31_17.2, %.loc31_17.3) to %.loc31_8.1 [concrete = constants.%tuple.302]
+// CHECK:STDOUT:   %.loc31_10: init %tuple.type.f94 = converted %.loc31_17.1, %.loc31_17.4 [concrete = constants.%tuple.302]
+// CHECK:STDOUT:   assign %.loc31_8.1, %.loc31_10
+// CHECK:STDOUT:   %tuple.loc31: %tuple.type.f94 = tuple_value (%int_1.loc31, %int_2.loc31) [concrete = constants.%tuple.ad8]
+// CHECK:STDOUT:   %.loc31_8.2: %tuple.type.f94 = converted %.loc31_8.1, %tuple.loc31 [concrete = constants.%tuple.ad8]
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %n.patt: %pattern_type.7ce = binding_pattern n [concrete]
 // CHECK:STDOUT:     %n.var_patt: %pattern_type.7ce = var_pattern %n.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n.var: ref %i32 = var %n.var_patt
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
-// CHECK:STDOUT:   %impl.elem0.loc29: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc29_3.1: <bound method> = bound_method %int_0, %impl.elem0.loc29 [concrete = constants.%Convert.bound.d04]
-// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem0.loc29, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc29_3.2: <bound method> = bound_method %int_0, %specific_fn.loc29 [concrete = constants.%bound_method.b6e]
-// CHECK:STDOUT:   %int.convert_checked.loc29: init %i32 = call %bound_method.loc29_3.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc29_3: init %i32 = converted %int_0, %int.convert_checked.loc29 [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   assign %n.var, %.loc29_3
-// CHECK:STDOUT:   %.loc29_10: type = splice_block %i32.loc29 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc29: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc29: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %impl.elem0.loc32: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc32_3.1: <bound method> = bound_method %int_0, %impl.elem0.loc32 [concrete = constants.%Convert.bound.d04]
+// CHECK:STDOUT:   %specific_fn.loc32: <specific function> = specific_function %impl.elem0.loc32, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc32_3.2: <bound method> = bound_method %int_0, %specific_fn.loc32 [concrete = constants.%bound_method.b6e]
+// CHECK:STDOUT:   %int.convert_checked.loc32: init %i32 = call %bound_method.loc32_3.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc32_3: init %i32 = converted %int_0, %int.convert_checked.loc32 [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   assign %n.var, %.loc32_3
+// CHECK:STDOUT:   %.loc32_10: type = splice_block %i32.loc32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n: ref %i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %n.ref.loc34_4: ref %i32 = name_ref n, %n
-// CHECK:STDOUT:   %n.ref.loc34_7: ref %i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc34_8.1: %tuple.type.d07 = tuple_literal (%n.ref.loc34_4, %n.ref.loc34_7)
-// CHECK:STDOUT:   %int_1.loc34: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc34: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc34_17.1: %tuple.type.f94 = tuple_literal (%int_1.loc34, %int_2.loc34)
-// CHECK:STDOUT:   %impl.elem0.loc34_17.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc34_17.1: <bound method> = bound_method %int_1.loc34, %impl.elem0.loc34_17.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc34_17.1: <specific function> = specific_function %impl.elem0.loc34_17.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc34_17.2: <bound method> = bound_method %int_1.loc34, %specific_fn.loc34_17.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc34_17.1: init %i32 = call %bound_method.loc34_17.2(%int_1.loc34) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc34_17.2: init %i32 = converted %int_1.loc34, %int.convert_checked.loc34_17.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %tuple.elem0.loc34: %i32 = tuple_access %.loc34_8.1, element0
-// CHECK:STDOUT:   %.loc34_17.3: init %i32 = initialize_from %.loc34_17.2 to %tuple.elem0.loc34 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc34_17.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc34_17.3: <bound method> = bound_method %int_2.loc34, %impl.elem0.loc34_17.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc34_17.2: <specific function> = specific_function %impl.elem0.loc34_17.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc34_17.4: <bound method> = bound_method %int_2.loc34, %specific_fn.loc34_17.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc34_17.2: init %i32 = call %bound_method.loc34_17.4(%int_2.loc34) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc34_17.4: init %i32 = converted %int_2.loc34, %int.convert_checked.loc34_17.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %tuple.elem1.loc34: %i32 = tuple_access %.loc34_8.1, element1
-// CHECK:STDOUT:   %.loc34_17.5: init %i32 = initialize_from %.loc34_17.4 to %tuple.elem1.loc34 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc34_17.6: init %tuple.type.d07 = tuple_init (%.loc34_17.3, %.loc34_17.5) to %.loc34_8.1 [concrete = constants.%tuple.21c]
-// CHECK:STDOUT:   %.loc34_10: init %tuple.type.d07 = converted %.loc34_17.1, %.loc34_17.6 [concrete = constants.%tuple.21c]
-// CHECK:STDOUT:   assign %.loc34_8.1, %.loc34_10
-// CHECK:STDOUT:   %.loc34_4: %i32 = bind_value %n.ref.loc34_4
-// CHECK:STDOUT:   %.loc34_7: %i32 = bind_value %n.ref.loc34_7
-// CHECK:STDOUT:   %tuple.loc34: %tuple.type.d07 = tuple_value (%.loc34_4, %.loc34_7)
-// CHECK:STDOUT:   %.loc34_8.2: %tuple.type.d07 = converted %.loc34_8.1, %tuple.loc34
-// CHECK:STDOUT:   %int_32.loc39_3: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc39_3: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %int_32.loc39_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc39_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %ptr: type = ptr_type %i32.loc39_9 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:   assign %i32.loc39_3, %ptr
-// CHECK:STDOUT:   %int_1.loc44: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc44: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc44_18.1: %struct_type.x.y = struct_literal (%int_1.loc44, %int_2.loc44)
-// CHECK:STDOUT:   %int_3.loc44: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %int_4.loc44: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
-// CHECK:STDOUT:   %.loc44_37.1: %struct_type.x.y = struct_literal (%int_3.loc44, %int_4.loc44)
-// CHECK:STDOUT:   %.loc44_37.2: Core.IntLiteral = struct_access %.loc44_18.1, element0
-// CHECK:STDOUT:   %.loc44_37.3: init Core.IntLiteral = initialize_from %int_3.loc44 to %.loc44_37.2 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %.loc44_37.4: Core.IntLiteral = struct_access %.loc44_18.1, element1
-// CHECK:STDOUT:   %.loc44_37.5: init Core.IntLiteral = initialize_from %int_4.loc44 to %.loc44_37.4 [concrete = constants.%int_4]
-// CHECK:STDOUT:   %.loc44_37.6: init %struct_type.x.y = struct_init (%.loc44_37.3, %.loc44_37.5) to %.loc44_18.1 [concrete = constants.%struct.a0d]
-// CHECK:STDOUT:   %.loc44_20: init %struct_type.x.y = converted %.loc44_37.1, %.loc44_37.6 [concrete = constants.%struct.a0d]
-// CHECK:STDOUT:   assign %.loc44_18.1, %.loc44_20
-// CHECK:STDOUT:   %struct: %struct_type.x.y = struct_value (%int_1.loc44, %int_2.loc44) [concrete = constants.%struct.004]
-// CHECK:STDOUT:   %.loc44_18.2: %struct_type.x.y = converted %.loc44_18.1, %struct [concrete = constants.%struct.004]
-// CHECK:STDOUT:   %true.loc49: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %true.loc49 br !if.expr.then.loc49 else br !if.expr.else.loc49
+// CHECK:STDOUT:   %n.ref.loc37_4: ref %i32 = name_ref n, %n
+// CHECK:STDOUT:   %n.ref.loc37_7: ref %i32 = name_ref n, %n
+// CHECK:STDOUT:   %.loc37_8.1: %tuple.type.d07 = tuple_literal (%n.ref.loc37_4, %n.ref.loc37_7)
+// CHECK:STDOUT:   %int_1.loc37: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc37: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc37_17.1: %tuple.type.f94 = tuple_literal (%int_1.loc37, %int_2.loc37)
+// CHECK:STDOUT:   %impl.elem0.loc37_17.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc37_17.1: <bound method> = bound_method %int_1.loc37, %impl.elem0.loc37_17.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc37_17.1: <specific function> = specific_function %impl.elem0.loc37_17.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc37_17.2: <bound method> = bound_method %int_1.loc37, %specific_fn.loc37_17.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc37_17.1: init %i32 = call %bound_method.loc37_17.2(%int_1.loc37) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc37_17.2: init %i32 = converted %int_1.loc37, %int.convert_checked.loc37_17.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %tuple.elem0.loc37: %i32 = tuple_access %.loc37_8.1, element0
+// CHECK:STDOUT:   %.loc37_17.3: init %i32 = initialize_from %.loc37_17.2 to %tuple.elem0.loc37 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc37_17.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc37_17.3: <bound method> = bound_method %int_2.loc37, %impl.elem0.loc37_17.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc37_17.2: <specific function> = specific_function %impl.elem0.loc37_17.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc37_17.4: <bound method> = bound_method %int_2.loc37, %specific_fn.loc37_17.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc37_17.2: init %i32 = call %bound_method.loc37_17.4(%int_2.loc37) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc37_17.4: init %i32 = converted %int_2.loc37, %int.convert_checked.loc37_17.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %tuple.elem1.loc37: %i32 = tuple_access %.loc37_8.1, element1
+// CHECK:STDOUT:   %.loc37_17.5: init %i32 = initialize_from %.loc37_17.4 to %tuple.elem1.loc37 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc37_17.6: init %tuple.type.d07 = tuple_init (%.loc37_17.3, %.loc37_17.5) to %.loc37_8.1 [concrete = constants.%tuple.21c]
+// CHECK:STDOUT:   %.loc37_10: init %tuple.type.d07 = converted %.loc37_17.1, %.loc37_17.6 [concrete = constants.%tuple.21c]
+// CHECK:STDOUT:   assign %.loc37_8.1, %.loc37_10
+// CHECK:STDOUT:   %.loc37_4: %i32 = bind_value %n.ref.loc37_4
+// CHECK:STDOUT:   %.loc37_7: %i32 = bind_value %n.ref.loc37_7
+// CHECK:STDOUT:   %tuple.loc37: %tuple.type.d07 = tuple_value (%.loc37_4, %.loc37_7)
+// CHECK:STDOUT:   %.loc37_8.2: %tuple.type.d07 = converted %.loc37_8.1, %tuple.loc37
+// CHECK:STDOUT:   %int_32.loc42_3: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc42_3: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %int_32.loc42_9: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc42_9: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %ptr: type = ptr_type %i32.loc42_9 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   assign %i32.loc42_3, %ptr
+// CHECK:STDOUT:   %int_1.loc47: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc47: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc47_18.1: %struct_type.x.y = struct_literal (%int_1.loc47, %int_2.loc47)
+// CHECK:STDOUT:   %int_3.loc47: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %int_4.loc47: Core.IntLiteral = int_value 4 [concrete = constants.%int_4]
+// CHECK:STDOUT:   %.loc47_37.1: %struct_type.x.y = struct_literal (%int_3.loc47, %int_4.loc47)
+// CHECK:STDOUT:   %.loc47_37.2: Core.IntLiteral = struct_access %.loc47_18.1, element0
+// CHECK:STDOUT:   %.loc47_37.3: init Core.IntLiteral = initialize_from %int_3.loc47 to %.loc47_37.2 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %.loc47_37.4: Core.IntLiteral = struct_access %.loc47_18.1, element1
+// CHECK:STDOUT:   %.loc47_37.5: init Core.IntLiteral = initialize_from %int_4.loc47 to %.loc47_37.4 [concrete = constants.%int_4]
+// CHECK:STDOUT:   %.loc47_37.6: init %struct_type.x.y = struct_init (%.loc47_37.3, %.loc47_37.5) to %.loc47_18.1 [concrete = constants.%struct.a0d]
+// CHECK:STDOUT:   %.loc47_20: init %struct_type.x.y = converted %.loc47_37.1, %.loc47_37.6 [concrete = constants.%struct.a0d]
+// CHECK:STDOUT:   assign %.loc47_18.1, %.loc47_20
+// CHECK:STDOUT:   %struct: %struct_type.x.y = struct_value (%int_1.loc47, %int_2.loc47) [concrete = constants.%struct.004]
+// CHECK:STDOUT:   %.loc47_18.2: %struct_type.x.y = converted %.loc47_18.1, %struct [concrete = constants.%struct.004]
+// CHECK:STDOUT:   %true.loc52: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %true.loc52 br !if.expr.then.loc52 else br !if.expr.else.loc52
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc49:
-// CHECK:STDOUT:   %int_1.loc49: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_32.loc49: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc49: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %impl.elem0.loc49_12: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc49_12.1: <bound method> = bound_method %int_1.loc49, %impl.elem0.loc49_12 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc49_12: <specific function> = specific_function %impl.elem0.loc49_12, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc49_12.2: <bound method> = bound_method %int_1.loc49, %specific_fn.loc49_12 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc49_12: init %i32 = call %bound_method.loc49_12.2(%int_1.loc49) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc49_12.1: %i32 = value_of_initializer %int.convert_checked.loc49_12 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc49_12.2: %i32 = converted %int_1.loc49, %.loc49_12.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   br !if.expr.result.loc49(%.loc49_12.2)
+// CHECK:STDOUT: !if.expr.then.loc52:
+// CHECK:STDOUT:   %int_1.loc52: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_32.loc52: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc52: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %impl.elem0.loc52_12: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc52_12.1: <bound method> = bound_method %int_1.loc52, %impl.elem0.loc52_12 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc52_12: <specific function> = specific_function %impl.elem0.loc52_12, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc52_12.2: <bound method> = bound_method %int_1.loc52, %specific_fn.loc52_12 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc52_12: init %i32 = call %bound_method.loc52_12.2(%int_1.loc52) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc52_12.1: %i32 = value_of_initializer %int.convert_checked.loc52_12 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc52_12.2: %i32 = converted %int_1.loc52, %.loc52_12.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   br !if.expr.result.loc52(%.loc52_12.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc49:
-// CHECK:STDOUT:   %int_2.loc49: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %impl.elem0.loc49_19: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc49_19.1: <bound method> = bound_method %int_2.loc49, %impl.elem0.loc49_19 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc49_19: <specific function> = specific_function %impl.elem0.loc49_19, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc49_19.2: <bound method> = bound_method %int_2.loc49, %specific_fn.loc49_19 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc49_19: init %i32 = call %bound_method.loc49_19.2(%int_2.loc49) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc49_19.1: %i32 = value_of_initializer %int.convert_checked.loc49_19 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc49_19.2: %i32 = converted %int_2.loc49, %.loc49_19.1 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   br !if.expr.result.loc49(%.loc49_19.2)
+// CHECK:STDOUT: !if.expr.else.loc52:
+// CHECK:STDOUT:   %int_2.loc52: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %impl.elem0.loc52_19: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc52_19.1: <bound method> = bound_method %int_2.loc52, %impl.elem0.loc52_19 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc52_19: <specific function> = specific_function %impl.elem0.loc52_19, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc52_19.2: <bound method> = bound_method %int_2.loc52, %specific_fn.loc52_19 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc52_19: init %i32 = call %bound_method.loc52_19.2(%int_2.loc52) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc52_19.1: %i32 = value_of_initializer %int.convert_checked.loc52_19 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc52_19.2: %i32 = converted %int_2.loc52, %.loc52_19.1 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   br !if.expr.result.loc52(%.loc52_19.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc49:
-// CHECK:STDOUT:   %.loc49_4: %i32 = block_arg !if.expr.result.loc49 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %int_3.loc49: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
-// CHECK:STDOUT:   %impl.elem0.loc49_27: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc49_27.1: <bound method> = bound_method %int_3.loc49, %impl.elem0.loc49_27 [concrete = constants.%Convert.bound.b30]
-// CHECK:STDOUT:   %specific_fn.loc49_27: <specific function> = specific_function %impl.elem0.loc49_27, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc49_27.2: <bound method> = bound_method %int_3.loc49, %specific_fn.loc49_27 [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked.loc49_27: init %i32 = call %bound_method.loc49_27.2(%int_3.loc49) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc49_27: init %i32 = converted %int_3.loc49, %int.convert_checked.loc49_27 [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   assign %.loc49_4, %.loc49_27
+// CHECK:STDOUT: !if.expr.result.loc52:
+// CHECK:STDOUT:   %.loc52_4: %i32 = block_arg !if.expr.result.loc52 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %int_3.loc52: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
+// CHECK:STDOUT:   %impl.elem0.loc52_27: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc52_27.1: <bound method> = bound_method %int_3.loc52, %impl.elem0.loc52_27 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %specific_fn.loc52_27: <specific function> = specific_function %impl.elem0.loc52_27, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc52_27.2: <bound method> = bound_method %int_3.loc52, %specific_fn.loc52_27 [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked.loc52_27: init %i32 = call %bound_method.loc52_27.2(%int_3.loc52) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc52_27: init %i32 = converted %int_3.loc52, %int.convert_checked.loc52_27 [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   assign %.loc52_4, %.loc52_27
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %pattern_type.7ce = binding_pattern a [concrete]
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.7ce = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %i32 = var %a.var_patt
-// CHECK:STDOUT:   %.loc52: type = splice_block %i32.loc52 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc52: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc52: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc55: type = splice_block %i32.loc55 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc55: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc55: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %true.loc57: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %true.loc57 br !if.expr.then.loc57 else br !if.expr.else.loc57
+// CHECK:STDOUT:   %true.loc60: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %true.loc60 br !if.expr.then.loc60 else br !if.expr.else.loc60
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc57:
-// CHECK:STDOUT:   %a.ref.loc57_17: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc57_17: %i32 = bind_value %a.ref.loc57_17
-// CHECK:STDOUT:   br !if.expr.result.loc57(%.loc57_17)
+// CHECK:STDOUT: !if.expr.then.loc60:
+// CHECK:STDOUT:   %a.ref.loc60_17: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %.loc60_17: %i32 = bind_value %a.ref.loc60_17
+// CHECK:STDOUT:   br !if.expr.result.loc60(%.loc60_17)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc57:
-// CHECK:STDOUT:   %a.ref.loc57_24: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc57_24: %i32 = bind_value %a.ref.loc57_24
-// CHECK:STDOUT:   br !if.expr.result.loc57(%.loc57_24)
+// CHECK:STDOUT: !if.expr.else.loc60:
+// CHECK:STDOUT:   %a.ref.loc60_24: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %.loc60_24: %i32 = bind_value %a.ref.loc60_24
+// CHECK:STDOUT:   br !if.expr.result.loc60(%.loc60_24)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc57:
-// CHECK:STDOUT:   %.loc57_4: %i32 = block_arg !if.expr.result.loc57
+// CHECK:STDOUT: !if.expr.result.loc60:
+// CHECK:STDOUT:   %.loc60_4: %i32 = block_arg !if.expr.result.loc60
 // CHECK:STDOUT:   %int_10: Core.IntLiteral = int_value 10 [concrete = constants.%int_10.64f]
-// CHECK:STDOUT:   %impl.elem0.loc57: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc57_27.1: <bound method> = bound_method %int_10, %impl.elem0.loc57 [concrete = constants.%Convert.bound.491]
-// CHECK:STDOUT:   %specific_fn.loc57: <specific function> = specific_function %impl.elem0.loc57, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc57_27.2: <bound method> = bound_method %int_10, %specific_fn.loc57 [concrete = constants.%bound_method.5ba]
-// CHECK:STDOUT:   %int.convert_checked.loc57: init %i32 = call %bound_method.loc57_27.2(%int_10) [concrete = constants.%int_10.265]
-// CHECK:STDOUT:   %.loc57_27: init %i32 = converted %int_10, %int.convert_checked.loc57 [concrete = constants.%int_10.265]
-// CHECK:STDOUT:   assign %.loc57_4, %.loc57_27
+// CHECK:STDOUT:   %impl.elem0.loc60: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc60_27.1: <bound method> = bound_method %int_10, %impl.elem0.loc60 [concrete = constants.%Convert.bound.491]
+// CHECK:STDOUT:   %specific_fn.loc60: <specific function> = specific_function %impl.elem0.loc60, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc60_27.2: <bound method> = bound_method %int_10, %specific_fn.loc60 [concrete = constants.%bound_method.5ba]
+// CHECK:STDOUT:   %int.convert_checked.loc60: init %i32 = call %bound_method.loc60_27.2(%int_10) [concrete = constants.%int_10.265]
+// CHECK:STDOUT:   %.loc60_27: init %i32 = converted %int_10, %int.convert_checked.loc60 [concrete = constants.%int_10.265]
+// CHECK:STDOUT:   assign %.loc60_4, %.loc60_27
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/fail_redundant_compound_access.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_redundant_compound_access.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_redundant_compound_access.carbon
@@ -95,13 +98,13 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc11_25.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound.d04]
+// CHECK:STDOUT:   %bound_method.loc14_25.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound.d04]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc11_25.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method.b6e]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc11_25.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc11_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc11_25.2: %i32 = converted %int_0, %.loc11_25.1 [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   return %.loc11_25.2
+// CHECK:STDOUT:   %bound_method.loc14_25.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method.b6e]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc14_25.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc14_25.1: %i32 = value_of_initializer %int.convert_checked [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc14_25.2: %i32 = converted %int_0, %.loc14_25.1 [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   return %.loc14_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
@@ -113,27 +116,27 @@ fn Main() {
 // CHECK:STDOUT:   %a.var: ref %i32 = var %a.var_patt
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc14_3.1: <bound method> = bound_method %int_3, %impl.elem0 [concrete = constants.%Convert.bound.b30]
+// CHECK:STDOUT:   %bound_method.loc17_3.1: <bound method> = bound_method %int_3, %impl.elem0 [concrete = constants.%Convert.bound.b30]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc14_3.2: <bound method> = bound_method %int_3, %specific_fn [concrete = constants.%bound_method.047]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc14_3.2(%int_3) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc14_3: init %i32 = converted %int_3, %int.convert_checked [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   assign %a.var, %.loc14_3
-// CHECK:STDOUT:   %.loc14_10: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:   %bound_method.loc17_3.2: <bound method> = bound_method %int_3, %specific_fn [concrete = constants.%bound_method.047]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc17_3.2(%int_3) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc17_3: init %i32 = converted %int_3, %int.convert_checked [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   assign %a.var, %.loc17_3
+// CHECK:STDOUT:   %.loc17_10: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %a.ref.loc19_3: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %a.ref.loc19_7: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %a.ref.loc19_10: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc19: %i32 = bind_value %a.ref.loc19_10
-// CHECK:STDOUT:   assign %a.ref.loc19_3, %.loc19
-// CHECK:STDOUT:   %a.ref.loc24_3: ref %i32 = name_ref a, %a
-// CHECK:STDOUT:   %a.ref.loc24_7: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc22_3: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc22_7: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc22_10: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %.loc22: %i32 = bind_value %a.ref.loc22_10
+// CHECK:STDOUT:   assign %a.ref.loc22_3, %.loc22
+// CHECK:STDOUT:   %a.ref.loc27_3: ref %i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc27_7: ref %i32 = name_ref a, %a
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.call: init %i32 = call %F.ref()
-// CHECK:STDOUT:   assign %a.ref.loc24_3, %F.call
+// CHECK:STDOUT:   assign %a.ref.loc27_3, %F.call
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_type_mismatch.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_type_mismatch.carbon
@@ -60,13 +63,13 @@ fn Main() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %x.var: ref bool = var %x.var_patt
 // CHECK:STDOUT:   %int_12: Core.IntLiteral = int_value 12 [concrete = constants.%int_12]
-// CHECK:STDOUT:   %.loc19_17.1: bool = converted %int_12, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc19_17.2: <error> = not <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc22_17.1: bool = converted %int_12, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc22_17.2: <error> = not <error> [concrete = <error>]
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT:   %.loc19_10.1: type = splice_block %.loc19_10.3 [concrete = bool] {
+// CHECK:STDOUT:   %.loc22_10.1: type = splice_block %.loc22_10.3 [concrete = bool] {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc19_10.2: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc19_10.3: type = converted %bool.make_type, %.loc19_10.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc22_10.2: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc22_10.3: type = converted %bool.make_type, %.loc22_10.2 [concrete = bool]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %x: ref bool = bind_name x, %x.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/operators/builtin/fail_type_mismatch_assignment.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_type_mismatch_assignment.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_type_mismatch_assignment.carbon
@@ -81,20 +84,20 @@ fn Main() {
 // CHECK:STDOUT:   %a.var: ref %i32 = var %a.var_patt
 // CHECK:STDOUT:   %int_3: Core.IntLiteral = int_value 3 [concrete = constants.%int_3.1ba]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_3.1: <bound method> = bound_method %int_3, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc15_3.1: <bound method> = bound_method %int_3, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_3.2: <bound method> = bound_method %int_3, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_3.2(%int_3) [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   %.loc12_3: init %i32 = converted %int_3, %int.convert_checked [concrete = constants.%int_3.822]
-// CHECK:STDOUT:   assign %a.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:   %bound_method.loc15_3.2: <bound method> = bound_method %int_3, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_3.2(%int_3) [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   %.loc15_3: init %i32 = converted %int_3, %int.convert_checked [concrete = constants.%int_3.822]
+// CHECK:STDOUT:   assign %a.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_10: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %a.ref: ref %i32 = name_ref a, %a
 // CHECK:STDOUT:   %float: f64 = float_literal 5.6000000000000005 [concrete = constants.%float]
-// CHECK:STDOUT:   %.loc20: %i32 = converted %float, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc23: %i32 = converted %float, <error> [concrete = <error>]
 // CHECK:STDOUT:   assign %a.ref, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_type_mismatch_once.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_type_mismatch_once.carbon
@@ -64,7 +67,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc21: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %float: f64 = float_literal 3.4000000000000004 [concrete = constants.%float]
 // CHECK:STDOUT:   %int_12: Core.IntLiteral = int_value 12 [concrete = constants.%int_12]
 // CHECK:STDOUT:   %impl.elem0: <error> = impl_witness_access <error>, element0 [concrete = <error>]

--- a/toolchain/check/testdata/operators/builtin/fail_unimplemented_op.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_unimplemented_op.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/fail_unimplemented_op.carbon
@@ -61,7 +64,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc19: %empty_struct_type = struct_literal ()
 // CHECK:STDOUT:   %int_34: Core.IntLiteral = int_value 34 [concrete = constants.%int_34]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/or.carbon
+++ b/toolchain/check/testdata/operators/builtin/or.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/or.carbon
@@ -73,8 +76,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc11_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc11_11.2: type = converted %bool.make_type, %.loc11_11.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc14_11.2: type = converted %bool.make_type, %.loc14_11.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -83,8 +86,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc12_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc12_11.2: type = converted %bool.make_type, %.loc12_11.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc15_11.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc15_11.2: type = converted %bool.make_type, %.loc15_11.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -93,8 +96,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc14_12.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:     %.loc14_12.2: type = converted %bool.make_type, %.loc14_12.1 [concrete = bool]
+// CHECK:STDOUT:     %.loc17_12.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:     %.loc17_12.2: type = converted %bool.make_type, %.loc17_12.1 [concrete = bool]
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param0
 // CHECK:STDOUT:     %return: ref bool = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -104,10 +107,10 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %x.param_patt: %pattern_type.831 = value_param_pattern %x.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %x.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc25_23.1: type = splice_block %.loc25_23.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc25: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc25_23.2: type = value_of_initializer %bool.make_type.loc25 [concrete = bool]
-// CHECK:STDOUT:       %.loc25_23.3: type = converted %bool.make_type.loc25, %.loc25_23.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc28_23.1: type = splice_block %.loc28_23.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc28: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc28_23.2: type = value_of_initializer %bool.make_type.loc28 [concrete = bool]
+// CHECK:STDOUT:       %.loc28_23.3: type = converted %bool.make_type.loc28, %.loc28_23.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %x: bool = bind_name x, %x.param
 // CHECK:STDOUT:   }
@@ -129,22 +132,22 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %F.call: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc15_14.1: bool = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc15_14.2: bool = converted %F.call, %.loc15_14.1
-// CHECK:STDOUT:   %.loc15_14.3: bool = not %.loc15_14.2
+// CHECK:STDOUT:   %.loc18_14.1: bool = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc18_14.2: bool = converted %F.call, %.loc18_14.1
+// CHECK:STDOUT:   %.loc18_14.3: bool = not %.loc18_14.2
 // CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc15_14.3 br !or.rhs else br !or.result(%true)
+// CHECK:STDOUT:   if %.loc18_14.3 br !or.rhs else br !or.result(%true)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
 // CHECK:STDOUT:   %G.ref: %G.type = name_ref G, file.%G.decl [concrete = constants.%G]
 // CHECK:STDOUT:   %G.call: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc15_14.4: bool = value_of_initializer %G.call
-// CHECK:STDOUT:   %.loc15_14.5: bool = converted %G.call, %.loc15_14.4
-// CHECK:STDOUT:   br !or.result(%.loc15_14.5)
+// CHECK:STDOUT:   %.loc18_14.4: bool = value_of_initializer %G.call
+// CHECK:STDOUT:   %.loc18_14.5: bool = converted %G.call, %.loc18_14.4
+// CHECK:STDOUT:   br !or.result(%.loc18_14.5)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.result:
-// CHECK:STDOUT:   %.loc15_14.6: bool = block_arg !or.result
-// CHECK:STDOUT:   return %.loc15_14.6
+// CHECK:STDOUT:   %.loc18_14.6: bool = block_arg !or.result
+// CHECK:STDOUT:   return %.loc18_14.6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Constant() {
@@ -154,162 +157,162 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.831 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref bool = var %a.var_patt
-// CHECK:STDOUT:   %true.loc19_46: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   assign %a.var, %true.loc19_46
-// CHECK:STDOUT:   br !.loc19_13
+// CHECK:STDOUT:   %true.loc22_46: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   assign %a.var, %true.loc22_46
+// CHECK:STDOUT:   br !.loc22_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc19_13:
-// CHECK:STDOUT:   %true.loc19_13: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %.loc19_18.1: bool = not %true.loc19_13 [concrete = constants.%false]
-// CHECK:STDOUT:   %true.loc19_18: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc19_18.1 br !or.rhs.loc19 else br !or.result.loc19(%true.loc19_18)
+// CHECK:STDOUT: !.loc22_13:
+// CHECK:STDOUT:   %true.loc22_13: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %.loc22_18.1: bool = not %true.loc22_13 [concrete = constants.%false]
+// CHECK:STDOUT:   %true.loc22_18: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc22_18.1 br !or.rhs.loc22 else br !or.result.loc22(%true.loc22_18)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.rhs.loc19:
-// CHECK:STDOUT:   %true.loc19_21: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   br !or.result.loc19(%true.loc19_21)
+// CHECK:STDOUT: !or.rhs.loc22:
+// CHECK:STDOUT:   %true.loc22_21: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   br !or.result.loc22(%true.loc22_21)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.result.loc19:
-// CHECK:STDOUT:   %.loc19_18.2: bool = block_arg !or.result.loc19 [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc19_18.2 br !if.expr.then.loc19 else br !if.expr.else.loc19
+// CHECK:STDOUT: !or.result.loc22:
+// CHECK:STDOUT:   %.loc22_18.2: bool = block_arg !or.result.loc22 [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc22_18.2 br !if.expr.then.loc22 else br !if.expr.else.loc22
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc19:
-// CHECK:STDOUT:   %bool.make_type.loc19: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc19_31.1: type = value_of_initializer %bool.make_type.loc19 [concrete = bool]
-// CHECK:STDOUT:   %.loc19_31.2: type = converted %bool.make_type.loc19, %.loc19_31.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc19(%.loc19_31.2)
+// CHECK:STDOUT: !if.expr.then.loc22:
+// CHECK:STDOUT:   %bool.make_type.loc22: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc22_31.1: type = value_of_initializer %bool.make_type.loc22 [concrete = bool]
+// CHECK:STDOUT:   %.loc22_31.2: type = converted %bool.make_type.loc22, %.loc22_31.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_31.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc19:
-// CHECK:STDOUT:   %.loc19_42: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc19_36: type = converted %.loc19_42, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc19(%.loc19_36)
+// CHECK:STDOUT: !if.expr.else.loc22:
+// CHECK:STDOUT:   %.loc22_42: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_36: type = converted %.loc22_42, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_36)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc19:
-// CHECK:STDOUT:   %.loc19_10: type = block_arg !if.expr.result.loc19 [concrete = bool]
-// CHECK:STDOUT:   br !.loc19_7
+// CHECK:STDOUT: !if.expr.result.loc22:
+// CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result.loc22 [concrete = bool]
+// CHECK:STDOUT:   br !.loc22_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc19_7:
+// CHECK:STDOUT: !.loc22_7:
 // CHECK:STDOUT:   %a: ref bool = bind_name a, %a.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.var_patt: %pattern_type.831 = var_pattern %b.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b.var: ref bool = var %b.var_patt
-// CHECK:STDOUT:   %true.loc20_47: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   assign %b.var, %true.loc20_47
-// CHECK:STDOUT:   br !.loc20_13
+// CHECK:STDOUT:   %true.loc23_47: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   assign %b.var, %true.loc23_47
+// CHECK:STDOUT:   br !.loc23_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc20_13:
-// CHECK:STDOUT:   %true.loc20_13: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %.loc20_18.1: bool = not %true.loc20_13 [concrete = constants.%false]
-// CHECK:STDOUT:   %true.loc20_18: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc20_18.1 br !or.rhs.loc20 else br !or.result.loc20(%true.loc20_18)
+// CHECK:STDOUT: !.loc23_13:
+// CHECK:STDOUT:   %true.loc23_13: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %.loc23_18.1: bool = not %true.loc23_13 [concrete = constants.%false]
+// CHECK:STDOUT:   %true.loc23_18: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc23_18.1 br !or.rhs.loc23 else br !or.result.loc23(%true.loc23_18)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.rhs.loc20:
-// CHECK:STDOUT:   %false.loc20: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   br !or.result.loc20(%false.loc20)
+// CHECK:STDOUT: !or.rhs.loc23:
+// CHECK:STDOUT:   %false.loc23: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   br !or.result.loc23(%false.loc23)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.result.loc20:
-// CHECK:STDOUT:   %.loc20_18.2: bool = block_arg !or.result.loc20 [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc20_18.2 br !if.expr.then.loc20 else br !if.expr.else.loc20
+// CHECK:STDOUT: !or.result.loc23:
+// CHECK:STDOUT:   %.loc23_18.2: bool = block_arg !or.result.loc23 [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc23_18.2 br !if.expr.then.loc23 else br !if.expr.else.loc23
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc20:
-// CHECK:STDOUT:   %bool.make_type.loc20: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc20_32.1: type = value_of_initializer %bool.make_type.loc20 [concrete = bool]
-// CHECK:STDOUT:   %.loc20_32.2: type = converted %bool.make_type.loc20, %.loc20_32.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc20(%.loc20_32.2)
+// CHECK:STDOUT: !if.expr.then.loc23:
+// CHECK:STDOUT:   %bool.make_type.loc23: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc23_32.1: type = value_of_initializer %bool.make_type.loc23 [concrete = bool]
+// CHECK:STDOUT:   %.loc23_32.2: type = converted %bool.make_type.loc23, %.loc23_32.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc23(%.loc23_32.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc20:
-// CHECK:STDOUT:   %.loc20_43: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc20_37: type = converted %.loc20_43, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc20(%.loc20_37)
+// CHECK:STDOUT: !if.expr.else.loc23:
+// CHECK:STDOUT:   %.loc23_43: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc23_37: type = converted %.loc23_43, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc23(%.loc23_37)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc20:
-// CHECK:STDOUT:   %.loc20_10: type = block_arg !if.expr.result.loc20 [concrete = bool]
-// CHECK:STDOUT:   br !.loc20_7
+// CHECK:STDOUT: !if.expr.result.loc23:
+// CHECK:STDOUT:   %.loc23_10: type = block_arg !if.expr.result.loc23 [concrete = bool]
+// CHECK:STDOUT:   br !.loc23_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc20_7:
+// CHECK:STDOUT: !.loc23_7:
 // CHECK:STDOUT:   %b: ref bool = bind_name b, %b.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.831 = binding_pattern c [concrete]
 // CHECK:STDOUT:     %c.var_patt: %pattern_type.831 = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref bool = var %c.var_patt
-// CHECK:STDOUT:   %true.loc21_47: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   assign %c.var, %true.loc21_47
-// CHECK:STDOUT:   br !.loc21_13
+// CHECK:STDOUT:   %true.loc24_47: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   assign %c.var, %true.loc24_47
+// CHECK:STDOUT:   br !.loc24_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc21_13:
-// CHECK:STDOUT:   %false.loc21: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %.loc21_19.1: bool = not %false.loc21 [concrete = constants.%true]
-// CHECK:STDOUT:   %true.loc21_19: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc21_19.1 br !or.rhs.loc21 else br !or.result.loc21(%true.loc21_19)
+// CHECK:STDOUT: !.loc24_13:
+// CHECK:STDOUT:   %false.loc24: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   %.loc24_19.1: bool = not %false.loc24 [concrete = constants.%true]
+// CHECK:STDOUT:   %true.loc24_19: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc24_19.1 br !or.rhs.loc24 else br !or.result.loc24(%true.loc24_19)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.rhs.loc21:
-// CHECK:STDOUT:   %true.loc21_22: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   br !or.result.loc21(%true.loc21_22)
+// CHECK:STDOUT: !or.rhs.loc24:
+// CHECK:STDOUT:   %true.loc24_22: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   br !or.result.loc24(%true.loc24_22)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.result.loc21:
-// CHECK:STDOUT:   %.loc21_19.2: bool = block_arg !or.result.loc21 [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc21_19.2 br !if.expr.then.loc21 else br !if.expr.else.loc21
+// CHECK:STDOUT: !or.result.loc24:
+// CHECK:STDOUT:   %.loc24_19.2: bool = block_arg !or.result.loc24 [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc24_19.2 br !if.expr.then.loc24 else br !if.expr.else.loc24
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc21:
-// CHECK:STDOUT:   %bool.make_type.loc21: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc21_32.1: type = value_of_initializer %bool.make_type.loc21 [concrete = bool]
-// CHECK:STDOUT:   %.loc21_32.2: type = converted %bool.make_type.loc21, %.loc21_32.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc21(%.loc21_32.2)
+// CHECK:STDOUT: !if.expr.then.loc24:
+// CHECK:STDOUT:   %bool.make_type.loc24: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc24_32.1: type = value_of_initializer %bool.make_type.loc24 [concrete = bool]
+// CHECK:STDOUT:   %.loc24_32.2: type = converted %bool.make_type.loc24, %.loc24_32.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc24(%.loc24_32.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc21:
-// CHECK:STDOUT:   %.loc21_43: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc21_37: type = converted %.loc21_43, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc21(%.loc21_37)
+// CHECK:STDOUT: !if.expr.else.loc24:
+// CHECK:STDOUT:   %.loc24_43: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc24_37: type = converted %.loc24_43, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc24(%.loc24_37)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc21:
-// CHECK:STDOUT:   %.loc21_10: type = block_arg !if.expr.result.loc21 [concrete = bool]
-// CHECK:STDOUT:   br !.loc21_7
+// CHECK:STDOUT: !if.expr.result.loc24:
+// CHECK:STDOUT:   %.loc24_10: type = block_arg !if.expr.result.loc24 [concrete = bool]
+// CHECK:STDOUT:   br !.loc24_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc21_7:
+// CHECK:STDOUT: !.loc24_7:
 // CHECK:STDOUT:   %c: ref bool = bind_name c, %c.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d.patt: %pattern_type.cb1 = binding_pattern d [concrete]
 // CHECK:STDOUT:     %d.var_patt: %pattern_type.cb1 = var_pattern %d.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %d.var: ref %empty_tuple.type = var %d.var_patt
-// CHECK:STDOUT:   %.loc22_49.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_49.2: init %empty_tuple.type = tuple_init () to %d.var [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc22_3: init %empty_tuple.type = converted %.loc22_49.1, %.loc22_49.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   assign %d.var, %.loc22_3
-// CHECK:STDOUT:   br !.loc22_13
+// CHECK:STDOUT:   %.loc25_49.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc25_49.2: init %empty_tuple.type = tuple_init () to %d.var [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc25_3: init %empty_tuple.type = converted %.loc25_49.1, %.loc25_49.2 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   assign %d.var, %.loc25_3
+// CHECK:STDOUT:   br !.loc25_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc22_13:
-// CHECK:STDOUT:   %false.loc22_13: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %.loc22_19.1: bool = not %false.loc22_13 [concrete = constants.%true]
-// CHECK:STDOUT:   %true.loc22: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc22_19.1 br !or.rhs.loc22 else br !or.result.loc22(%true.loc22)
+// CHECK:STDOUT: !.loc25_13:
+// CHECK:STDOUT:   %false.loc25_13: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   %.loc25_19.1: bool = not %false.loc25_13 [concrete = constants.%true]
+// CHECK:STDOUT:   %true.loc25: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc25_19.1 br !or.rhs.loc25 else br !or.result.loc25(%true.loc25)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.rhs.loc22:
-// CHECK:STDOUT:   %false.loc22_22: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   br !or.result.loc22(%false.loc22_22)
+// CHECK:STDOUT: !or.rhs.loc25:
+// CHECK:STDOUT:   %false.loc25_22: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   br !or.result.loc25(%false.loc25_22)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !or.result.loc22:
-// CHECK:STDOUT:   %.loc22_19.2: bool = block_arg !or.result.loc22 [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc22_19.2 br !if.expr.then.loc22 else br !if.expr.else.loc22
+// CHECK:STDOUT: !or.result.loc25:
+// CHECK:STDOUT:   %.loc25_19.2: bool = block_arg !or.result.loc25 [concrete = constants.%false]
+// CHECK:STDOUT:   if %.loc25_19.2 br !if.expr.then.loc25 else br !if.expr.else.loc25
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc22:
-// CHECK:STDOUT:   %bool.make_type.loc22: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc22_33.1: type = value_of_initializer %bool.make_type.loc22 [concrete = bool]
-// CHECK:STDOUT:   %.loc22_33.2: type = converted %bool.make_type.loc22, %.loc22_33.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_33.2)
+// CHECK:STDOUT: !if.expr.then.loc25:
+// CHECK:STDOUT:   %bool.make_type.loc25: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc25_33.1: type = value_of_initializer %bool.make_type.loc25 [concrete = bool]
+// CHECK:STDOUT:   %.loc25_33.2: type = converted %bool.make_type.loc25, %.loc25_33.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc25(%.loc25_33.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc22:
-// CHECK:STDOUT:   %.loc22_44: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_38: type = converted %.loc22_44, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_38)
+// CHECK:STDOUT: !if.expr.else.loc25:
+// CHECK:STDOUT:   %.loc25_44: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc25_38: type = converted %.loc25_44, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc25(%.loc25_38)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc22:
-// CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result.loc22 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !.loc22_7
+// CHECK:STDOUT: !if.expr.result.loc25:
+// CHECK:STDOUT:   %.loc25_10: type = block_arg !if.expr.result.loc25 [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !.loc25_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc22_7:
+// CHECK:STDOUT: !.loc25_7:
 // CHECK:STDOUT:   %d: ref %empty_tuple.type = bind_name d, %d.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -321,40 +324,40 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.831 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref bool = var %a.var_patt
-// CHECK:STDOUT:   %true.loc26_43: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   assign %a.var, %true.loc26_43
-// CHECK:STDOUT:   br !.loc26_13
+// CHECK:STDOUT:   %true.loc29_43: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   assign %a.var, %true.loc29_43
+// CHECK:STDOUT:   br !.loc29_13
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc26_13:
-// CHECK:STDOUT:   %true.loc26_13: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %.loc26_18.1: bool = not %true.loc26_13 [concrete = constants.%false]
-// CHECK:STDOUT:   %true.loc26_18: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc26_18.1 br !or.rhs else br !or.result(%true.loc26_18)
+// CHECK:STDOUT: !.loc29_13:
+// CHECK:STDOUT:   %true.loc29_13: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %.loc29_18.1: bool = not %true.loc29_13 [concrete = constants.%false]
+// CHECK:STDOUT:   %true.loc29_18: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc29_18.1 br !or.rhs else br !or.result(%true.loc29_18)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
 // CHECK:STDOUT:   %x.ref: bool = name_ref x, %x
 // CHECK:STDOUT:   br !or.result(%x.ref)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.result:
-// CHECK:STDOUT:   %.loc26_18.2: bool = block_arg !or.result [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc26_18.2 br !if.expr.then else br !if.expr.else
+// CHECK:STDOUT:   %.loc29_18.2: bool = block_arg !or.result [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc29_18.2 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %bool.make_type.loc26: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc26_28.1: type = value_of_initializer %bool.make_type.loc26 [concrete = bool]
-// CHECK:STDOUT:   %.loc26_28.2: type = converted %bool.make_type.loc26, %.loc26_28.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result(%.loc26_28.2)
+// CHECK:STDOUT:   %bool.make_type.loc29: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc29_28.1: type = value_of_initializer %bool.make_type.loc29 [concrete = bool]
+// CHECK:STDOUT:   %.loc29_28.2: type = converted %bool.make_type.loc29, %.loc29_28.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result(%.loc29_28.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %.loc26_39: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc26_33: type = converted %.loc26_39, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result(%.loc26_33)
+// CHECK:STDOUT:   %.loc29_39: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc29_33: type = converted %.loc29_39, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result(%.loc29_33)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
-// CHECK:STDOUT:   %.loc26_10: type = block_arg !if.expr.result [concrete = bool]
-// CHECK:STDOUT:   br !.loc26_7
+// CHECK:STDOUT:   %.loc29_10: type = block_arg !if.expr.result [concrete = bool]
+// CHECK:STDOUT:   br !.loc29_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc26_7:
+// CHECK:STDOUT: !.loc29_7:
 // CHECK:STDOUT:   %a: ref bool = bind_name a, %a.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/unary_op.carbon
+++ b/toolchain/check/testdata/operators/builtin/unary_op.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/builtin/unary_op.carbon
@@ -61,14 +64,14 @@ fn Constant() {
 // CHECK:STDOUT:     %return.patt: %pattern_type.831 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.831 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %bool.make_type.loc11_20: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc11_20.1: type = value_of_initializer %bool.make_type.loc11_20 [concrete = bool]
-// CHECK:STDOUT:     %.loc11_20.2: type = converted %bool.make_type.loc11_20, %.loc11_20.1 [concrete = bool]
+// CHECK:STDOUT:     %bool.make_type.loc14_20: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc14_20.1: type = value_of_initializer %bool.make_type.loc14_20 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_20.2: type = converted %bool.make_type.loc14_20, %.loc14_20.1 [concrete = bool]
 // CHECK:STDOUT:     %b.param: bool = value_param call_param0
-// CHECK:STDOUT:     %.loc11_11.1: type = splice_block %.loc11_11.3 [concrete = bool] {
-// CHECK:STDOUT:       %bool.make_type.loc11_11: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:       %.loc11_11.2: type = value_of_initializer %bool.make_type.loc11_11 [concrete = bool]
-// CHECK:STDOUT:       %.loc11_11.3: type = converted %bool.make_type.loc11_11, %.loc11_11.2 [concrete = bool]
+// CHECK:STDOUT:     %.loc14_11.1: type = splice_block %.loc14_11.3 [concrete = bool] {
+// CHECK:STDOUT:       %bool.make_type.loc14_11: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:       %.loc14_11.2: type = value_of_initializer %bool.make_type.loc14_11 [concrete = bool]
+// CHECK:STDOUT:       %.loc14_11.3: type = converted %bool.make_type.loc14_11, %.loc14_11.2 [concrete = bool]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %b: bool = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref bool = out_param call_param1
@@ -77,29 +80,29 @@ fn Constant() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %not_true.patt: %pattern_type.831 = binding_pattern not_true [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc15_15.1: type = splice_block %.loc15_15.3 [concrete = bool] {
-// CHECK:STDOUT:     %bool.make_type.loc15: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc15_15.2: type = value_of_initializer %bool.make_type.loc15 [concrete = bool]
-// CHECK:STDOUT:     %.loc15_15.3: type = converted %bool.make_type.loc15, %.loc15_15.2 [concrete = bool]
+// CHECK:STDOUT:   %.loc18_15.1: type = splice_block %.loc18_15.3 [concrete = bool] {
+// CHECK:STDOUT:     %bool.make_type.loc18: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc18_15.2: type = value_of_initializer %bool.make_type.loc18 [concrete = bool]
+// CHECK:STDOUT:     %.loc18_15.3: type = converted %bool.make_type.loc18, %.loc18_15.2 [concrete = bool]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %not_true: bool = bind_name not_true, @__global_init.%.loc15
+// CHECK:STDOUT:   %not_true: bool = bind_name not_true, @__global_init.%.loc18
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %not_false.patt: %pattern_type.831 = binding_pattern not_false [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc16_16.1: type = splice_block %.loc16_16.3 [concrete = bool] {
-// CHECK:STDOUT:     %bool.make_type.loc16: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:     %.loc16_16.2: type = value_of_initializer %bool.make_type.loc16 [concrete = bool]
-// CHECK:STDOUT:     %.loc16_16.3: type = converted %bool.make_type.loc16, %.loc16_16.2 [concrete = bool]
+// CHECK:STDOUT:   %.loc19_16.1: type = splice_block %.loc19_16.3 [concrete = bool] {
+// CHECK:STDOUT:     %bool.make_type.loc19: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:     %.loc19_16.2: type = value_of_initializer %bool.make_type.loc19 [concrete = bool]
+// CHECK:STDOUT:     %.loc19_16.3: type = converted %bool.make_type.loc19, %.loc19_16.2 [concrete = bool]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %not_false: bool = bind_name not_false, @__global_init.%.loc16
+// CHECK:STDOUT:   %not_false: bool = bind_name not_false, @__global_init.%.loc19
 // CHECK:STDOUT:   %Constant.decl: %Constant.type = fn_decl @Constant [concrete = constants.%Constant] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Not(%b.param: bool) -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b
-// CHECK:STDOUT:   %.loc12: bool = not %b.ref
-// CHECK:STDOUT:   return %.loc12
+// CHECK:STDOUT:   %.loc15: bool = not %b.ref
+// CHECK:STDOUT:   return %.loc15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Constant() {
@@ -109,64 +112,64 @@ fn Constant() {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.cb1 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %empty_tuple.type = var %a.var_patt
-// CHECK:STDOUT:   %.loc19_43.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc19_43.2: init %empty_tuple.type = tuple_init () to %a.var [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc19_3: init %empty_tuple.type = converted %.loc19_43.1, %.loc19_43.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   assign %a.var, %.loc19_3
-// CHECK:STDOUT:   br !.loc19_17
+// CHECK:STDOUT:   %.loc22_43.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_43.2: init %empty_tuple.type = tuple_init () to %a.var [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc22_3: init %empty_tuple.type = converted %.loc22_43.1, %.loc22_43.2 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   assign %a.var, %.loc22_3
+// CHECK:STDOUT:   br !.loc22_17
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc19_17:
-// CHECK:STDOUT:   %true.loc19: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %.loc19_13: bool = not %true.loc19 [concrete = constants.%false]
-// CHECK:STDOUT:   if %.loc19_13 br !if.expr.then.loc19 else br !if.expr.else.loc19
+// CHECK:STDOUT: !.loc22_17:
+// CHECK:STDOUT:   %true.loc22: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %.loc22_13: bool = not %true.loc22 [concrete = constants.%false]
+// CHECK:STDOUT:   if %.loc22_13 br !if.expr.then.loc22 else br !if.expr.else.loc22
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc19:
-// CHECK:STDOUT:   %bool.make_type.loc19: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc19_27.1: type = value_of_initializer %bool.make_type.loc19 [concrete = bool]
-// CHECK:STDOUT:   %.loc19_27.2: type = converted %bool.make_type.loc19, %.loc19_27.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc19(%.loc19_27.2)
+// CHECK:STDOUT: !if.expr.then.loc22:
+// CHECK:STDOUT:   %bool.make_type.loc22: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc22_27.1: type = value_of_initializer %bool.make_type.loc22 [concrete = bool]
+// CHECK:STDOUT:   %.loc22_27.2: type = converted %bool.make_type.loc22, %.loc22_27.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_27.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc19:
-// CHECK:STDOUT:   %.loc19_38: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc19_32: type = converted %.loc19_38, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc19(%.loc19_32)
+// CHECK:STDOUT: !if.expr.else.loc22:
+// CHECK:STDOUT:   %.loc22_38: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_32: type = converted %.loc22_38, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc22(%.loc22_32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc19:
-// CHECK:STDOUT:   %.loc19_10: type = block_arg !if.expr.result.loc19 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !.loc19_7
+// CHECK:STDOUT: !if.expr.result.loc22:
+// CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result.loc22 [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !.loc22_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc19_7:
+// CHECK:STDOUT: !.loc22_7:
 // CHECK:STDOUT:   %a: ref %empty_tuple.type = bind_name a, %a.var
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = binding_pattern b [concrete]
 // CHECK:STDOUT:     %b.var_patt: %pattern_type.831 = var_pattern %b.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %b.var: ref bool = var %b.var_patt
-// CHECK:STDOUT:   %true.loc20: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   assign %b.var, %true.loc20
-// CHECK:STDOUT:   br !.loc20_17
+// CHECK:STDOUT:   %true.loc23: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   assign %b.var, %true.loc23
+// CHECK:STDOUT:   br !.loc23_17
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc20_17:
+// CHECK:STDOUT: !.loc23_17:
 // CHECK:STDOUT:   %false: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %.loc20_13: bool = not %false [concrete = constants.%true]
-// CHECK:STDOUT:   if %.loc20_13 br !if.expr.then.loc20 else br !if.expr.else.loc20
+// CHECK:STDOUT:   %.loc23_13: bool = not %false [concrete = constants.%true]
+// CHECK:STDOUT:   if %.loc23_13 br !if.expr.then.loc23 else br !if.expr.else.loc23
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc20:
-// CHECK:STDOUT:   %bool.make_type.loc20: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc20_28.1: type = value_of_initializer %bool.make_type.loc20 [concrete = bool]
-// CHECK:STDOUT:   %.loc20_28.2: type = converted %bool.make_type.loc20, %.loc20_28.1 [concrete = bool]
-// CHECK:STDOUT:   br !if.expr.result.loc20(%.loc20_28.2)
+// CHECK:STDOUT: !if.expr.then.loc23:
+// CHECK:STDOUT:   %bool.make_type.loc23: init type = call constants.%Bool() [concrete = bool]
+// CHECK:STDOUT:   %.loc23_28.1: type = value_of_initializer %bool.make_type.loc23 [concrete = bool]
+// CHECK:STDOUT:   %.loc23_28.2: type = converted %bool.make_type.loc23, %.loc23_28.1 [concrete = bool]
+// CHECK:STDOUT:   br !if.expr.result.loc23(%.loc23_28.2)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc20:
-// CHECK:STDOUT:   %.loc20_39: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %.loc20_33: type = converted %.loc20_39, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:   br !if.expr.result.loc20(%.loc20_33)
+// CHECK:STDOUT: !if.expr.else.loc23:
+// CHECK:STDOUT:   %.loc23_39: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %.loc23_33: type = converted %.loc23_39, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   br !if.expr.result.loc23(%.loc23_33)
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc20:
-// CHECK:STDOUT:   %.loc20_10: type = block_arg !if.expr.result.loc20 [concrete = bool]
-// CHECK:STDOUT:   br !.loc20_7
+// CHECK:STDOUT: !if.expr.result.loc23:
+// CHECK:STDOUT:   %.loc23_10: type = block_arg !if.expr.result.loc23 [concrete = bool]
+// CHECK:STDOUT:   br !.loc23_7
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc20_7:
+// CHECK:STDOUT: !.loc23_7:
 // CHECK:STDOUT:   %b: ref bool = bind_name b, %b.var
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -174,9 +177,9 @@ fn Constant() {
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %.loc15: bool = not %true [concrete = constants.%false]
+// CHECK:STDOUT:   %.loc18: bool = not %true [concrete = constants.%false]
 // CHECK:STDOUT:   %false: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %.loc16: bool = not %false [concrete = constants.%true]
+// CHECK:STDOUT:   %.loc19: bool = not %false [concrete = constants.%true]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/add.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.0b8 = fn_decl @Op.4 [concrete = constants.%Op.d8e] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.de4 = impl_witness_access constants.%Add.impl_witness, element0 [concrete = constants.%Op.c84]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.6d3 = impl_witness_access constants.%AddAssign.impl_witness, element0 [concrete = constants.%Op.d8e]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/binary_op.carbon.tmpl
+++ b/toolchain/check/testdata/operators/overloaded/binary_op.carbon.tmpl
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 
 HEADER

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.969 = fn_decl @Op.4 [concrete = constants.%Op.747] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.670 = impl_witness_access constants.%BitAnd.impl_witness, element0 [concrete = constants.%Op.c43]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.c09 = impl_witness_access constants.%BitAndAssign.impl_witness, element0 [concrete = constants.%Op.747]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -73,9 +76,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc23_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param1
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -89,9 +92,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_23: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_23: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param1
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -114,10 +117,10 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestOp(%a.param: %C) -> %return.param: %C {
@@ -125,8 +128,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %a.ref: %C = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem0: %.669 = impl_witness_access constants.%BitComplement.impl_witness, element0 [concrete = constants.%Op.bf2]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc23: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref) to %.loc23
+// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref) to %.loc26
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.8ba = fn_decl @Op.4 [concrete = constants.%Op.b27] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.421 = impl_witness_access constants.%BitOr.impl_witness, element0 [concrete = constants.%Op.59a]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.8bd = impl_witness_access constants.%BitOrAssign.impl_witness, element0 [concrete = constants.%Op.b27]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.8ab = fn_decl @Op.4 [concrete = constants.%Op.67d] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.f3f = impl_witness_access constants.%BitXor.impl_witness, element0 [concrete = constants.%Op.442]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.100 = impl_witness_access constants.%BitXorAssign.impl_witness, element0 [concrete = constants.%Op.67d]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -77,10 +80,10 @@ fn TestOp() {
 // CHECK:STDOUT:   %Op.decl: %Op.type.9e0 = fn_decl @Op.2 [concrete = constants.%Op.cf9] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc18_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc21_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc18_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc21_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:       %ptr: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
@@ -111,10 +114,10 @@ fn TestOp() {
 // CHECK:STDOUT:     %c.var_patt: %pattern_type.c48 = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref %C = var %c.var_patt
-// CHECK:STDOUT:   %.loc22_15.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc22_15.2: init %C = class_init (), %c.var [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc22_3: init %C = converted %.loc22_15.1, %.loc22_15.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   assign %c.var, %.loc22_3
+// CHECK:STDOUT:   %.loc25_15.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc25_15.2: init %C = class_init (), %c.var [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc25_3: init %C = converted %.loc25_15.1, %.loc25_15.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   assign %c.var, %.loc25_3
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref %C = name_ref c, %c

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/div.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.b04 = fn_decl @Op.4 [concrete = constants.%Op.27c] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.b77 = impl_witness_access constants.%Div.impl_witness, element0 [concrete = constants.%Op.21e]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.20f = impl_witness_access constants.%DivAssign.impl_witness, element0 [concrete = constants.%Op.27c]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/eq.carbon

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -121,10 +124,10 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc33_27: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc36_27: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc33_33: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc36_33: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -133,10 +136,10 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.73a = fn_decl @Op.2 [concrete = constants.%Op.0c9] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc16_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc19_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc16_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc19_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:       %ptr: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
@@ -153,18 +156,18 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.0b8 = fn_decl @Op.4 [concrete = constants.%Op.d8e] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc19_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc22_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc19_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc19_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc19_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc22_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc22_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc22_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc19_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc22_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -192,8 +195,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %a.ref: %C = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem0: %.bc7 = impl_witness_access constants.%Inc.impl_witness, element0 [concrete = constants.%Op.0c9]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc30: ref %C = temporary_storage
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc30
+// CHECK:STDOUT:   %.loc33: ref %C = temporary_storage
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc33
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -204,8 +207,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.6d3 = impl_witness_access constants.%AddAssign.impl_witness, element0 [concrete = constants.%Op.d8e]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc41: ref %C = temporary_storage
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc41
+// CHECK:STDOUT:   %.loc44: ref %C = temporary_storage
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc44
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/fail_error_recovery.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_error_recovery.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/fail_error_recovery.carbon
@@ -79,7 +82,7 @@ fn G(n: i32) {
 // CHECK:STDOUT:     %n.param_patt: %pattern_type.7ce = value_param_pattern %n.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc22: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc25: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -93,9 +96,9 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc15_23: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc18_23: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc15_17: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc18_17: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param1
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -108,12 +111,12 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc23_30: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_30: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc23_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_24: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_24: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -123,7 +126,7 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %b.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc34: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -157,15 +160,15 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.c48 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %C = var %a.var_patt
-// CHECK:STDOUT:   %.loc32_15.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc32_15.2: init %C = class_init (), %a.var [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc32_3: init %C = converted %.loc32_15.1, %.loc32_15.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   assign %a.var, %.loc32_3
-// CHECK:STDOUT:   %C.ref.loc32: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:   %.loc35_15.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc35_15.2: init %C = class_init (), %a.var [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc35_3: init %C = converted %.loc35_15.1, %.loc35_15.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   assign %a.var, %.loc35_3
+// CHECK:STDOUT:   %C.ref.loc35: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %a: ref %C = bind_name a, %a.var
-// CHECK:STDOUT:   %a.ref.loc37: ref %C = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc40: ref %C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
-// CHECK:STDOUT:   %a.ref.loc42: ref %C = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc45: ref %C = name_ref a, %a
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -131,9 +134,9 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc23_24: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_24: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc23_12: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_12: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %D = value_param call_param1
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [concrete = constants.%D]
@@ -160,12 +163,12 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc17_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc20_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc17_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc20_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc17_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc20_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -181,18 +184,18 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.0b8 = fn_decl @Op.4 [concrete = constants.%Op.d8e] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc20_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc20_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc20_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc20_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc20_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -230,9 +233,9 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %b.ref: %D = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.de4 = impl_witness_access constants.%Add.impl_witness, element0 [concrete = constants.%Op.c84]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc23: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %.loc34: %C = converted %b.ref, <error> [concrete = <error>]
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, <error>) to %.loc23
+// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %.loc37: %C = converted %b.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, <error>) to %.loc26
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -243,10 +246,10 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.c48 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %C = var %a.var_patt
-// CHECK:STDOUT:   %.loc38_15.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc38_15.2: init %C = class_init (), %a.var [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc38_3: init %C = converted %.loc38_15.1, %.loc38_15.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   assign %a.var, %.loc38_3
+// CHECK:STDOUT:   %.loc41_15.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc41_15.2: init %C = class_init (), %a.var [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc41_3: init %C = converted %.loc41_15.1, %.loc41_15.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   assign %a.var, %.loc41_3
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %a: ref %C = bind_name a, %a.var
 // CHECK:STDOUT:   %a.ref: ref %C = name_ref a, %a
@@ -254,7 +257,7 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %impl.elem0: %.6d3 = impl_witness_access constants.%AddAssign.impl_witness, element0 [concrete = constants.%Op.d8e]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
 // CHECK:STDOUT:   %addr: %ptr.019 = addr_of %a.ref
-// CHECK:STDOUT:   %.loc49: %C = converted %b.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc52: %C = converted %b.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, <error>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
+++ b/toolchain/check/testdata/operators/overloaded/implicit_as.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/implicit_as.carbon
@@ -50,7 +53,7 @@ fn Test() {
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.ac8: type = facet_type <@ImplicitAs, @ImplicitAs(%X)> [concrete]
 // CHECK:STDOUT:   %Convert.type.665: type = fn_type @Convert.1, @ImplicitAs(%X) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.aa3: <witness> = impl_witness file.%ImplicitAs.impl_witness_table.loc15 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.aa3: <witness> = impl_witness file.%ImplicitAs.impl_witness_table.loc18 [concrete]
 // CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
 // CHECK:STDOUT:   %pattern_type.019: type = pattern_type %X [concrete]
 // CHECK:STDOUT:   %Convert.type.853: type = fn_type @Convert.2 [concrete]
@@ -58,7 +61,7 @@ fn Test() {
 // CHECK:STDOUT:   %ImplicitAs.facet.d80: %ImplicitAs.type.ac8 = facet_value %i32, (%ImplicitAs.impl_witness.aa3) [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.205: type = facet_type <@ImplicitAs, @ImplicitAs(%i32)> [concrete]
 // CHECK:STDOUT:   %Convert.type.1b6: type = fn_type @Convert.1, @ImplicitAs(%i32) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.b30: <witness> = impl_witness file.%ImplicitAs.impl_witness_table.loc19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.b30: <witness> = impl_witness file.%ImplicitAs.impl_witness_table.loc22 [concrete]
 // CHECK:STDOUT:   %Convert.type.8a1: type = fn_type @Convert.3 [concrete]
 // CHECK:STDOUT:   %Convert.c7a: %Convert.type.8a1 = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.facet.bf9: %ImplicitAs.type.205 = facet_value %X, (%ImplicitAs.impl_witness.b30) [concrete]
@@ -110,8 +113,8 @@ fn Test() {
 // CHECK:STDOUT:     %X.ref: type = name_ref X, file.%X.decl [concrete = constants.%X]
 // CHECK:STDOUT:     %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%X)> [concrete = constants.%ImplicitAs.type.ac8]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.loc15 = impl_witness_table (@impl.8f9.%Convert.decl), @impl.8f9 [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.loc15: <witness> = impl_witness %ImplicitAs.impl_witness_table.loc15 [concrete = constants.%ImplicitAs.impl_witness.aa3]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.loc18 = impl_witness_table (@impl.8f9.%Convert.decl), @impl.8f9 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.loc18: <witness> = impl_witness %ImplicitAs.impl_witness_table.loc18 [concrete = constants.%ImplicitAs.impl_witness.aa3]
 // CHECK:STDOUT:   impl_decl @impl.c94 [concrete] {} {
 // CHECK:STDOUT:     %X.ref: type = name_ref X, file.%X.decl [concrete = constants.%X]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
@@ -120,14 +123,14 @@ fn Test() {
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %ImplicitAs.type: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%i32)> [concrete = constants.%ImplicitAs.type.205]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.loc19 = impl_witness_table (@impl.c94.%Convert.decl), @impl.c94 [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.loc19: <witness> = impl_witness %ImplicitAs.impl_witness_table.loc19 [concrete = constants.%ImplicitAs.impl_witness.b30]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.loc22 = impl_witness_table (@impl.c94.%Convert.decl), @impl.c94 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.loc22: <witness> = impl_witness %ImplicitAs.impl_witness_table.loc22 [concrete = constants.%ImplicitAs.impl_witness.b30]
 // CHECK:STDOUT:   %Sink_i32.decl: %Sink_i32.type = fn_decl @Sink_i32 [concrete = constants.%Sink_i32] {
 // CHECK:STDOUT:     %n.patt: %pattern_type.7ce = binding_pattern n [concrete]
 // CHECK:STDOUT:     %n.param_patt: %pattern_type.7ce = value_param_pattern %n.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc25: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc28: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
@@ -146,10 +149,10 @@ fn Test() {
 // CHECK:STDOUT:     %return.patt: @Source.%pattern_type (%pattern_type.7dcd0a.2) = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: @Source.%pattern_type (%pattern_type.7dcd0a.2) = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref.loc27_24: type = name_ref T, %T.loc27_11.1 [symbolic = %T.loc27_11.2 (constants.%T)]
-// CHECK:STDOUT:     %T.loc27_11.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc27_11.2 (constants.%T)]
-// CHECK:STDOUT:     %return.param: ref @Source.%T.loc27_11.2 (%T) = out_param call_param0
-// CHECK:STDOUT:     %return: ref @Source.%T.loc27_11.2 (%T) = return_slot %return.param
+// CHECK:STDOUT:     %T.ref.loc30_24: type = name_ref T, %T.loc30_11.1 [symbolic = %T.loc30_11.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc30_11.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc30_11.2 (constants.%T)]
+// CHECK:STDOUT:     %return.param: ref @Source.%T.loc30_11.2 (%T) = out_param call_param0
+// CHECK:STDOUT:     %return: ref @Source.%T.loc30_11.2 (%T) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Test.decl: %Test.type = fn_decl @Test [concrete = constants.%Test] {} {}
 // CHECK:STDOUT: }
@@ -163,7 +166,7 @@ fn Test() {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %X.ref: type = name_ref X, file.%X.decl [concrete = constants.%X]
 // CHECK:STDOUT:     %self.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc16_20: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc19_20: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
@@ -175,7 +178,7 @@ fn Test() {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .X = <poisoned>
 // CHECK:STDOUT:   .Convert = %Convert.decl
-// CHECK:STDOUT:   witness = file.%ImplicitAs.impl_witness.loc15
+// CHECK:STDOUT:   witness = file.%ImplicitAs.impl_witness.loc18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.c94: %X.ref as %ImplicitAs.type {
@@ -197,125 +200,125 @@ fn Test() {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .X = <poisoned>
 // CHECK:STDOUT:   .Convert = %Convert.decl
-// CHECK:STDOUT:   witness = file.%ImplicitAs.impl_witness.loc19
+// CHECK:STDOUT:   witness = file.%ImplicitAs.impl_witness.loc22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.loc12: %X.elem = field_decl n, element0 [concrete]
+// CHECK:STDOUT:   %.loc15: %X.elem = field_decl n, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.n: type = struct_type {.n: %i32} [concrete = constants.%struct_type.n]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.n [concrete = constants.%complete_type.54b]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%X
-// CHECK:STDOUT:   .n = %.loc12
+// CHECK:STDOUT:   .n = %.loc15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Convert.2(%self.param: %i32) -> %return.param: %X {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: %i32 = name_ref self, %self
-// CHECK:STDOUT:   %.loc16_51.1: %struct_type.n = struct_literal (%self.ref)
-// CHECK:STDOUT:   %.loc16_51.2: ref %i32 = class_element_access %return, element0
-// CHECK:STDOUT:   %.loc16_51.3: init %i32 = initialize_from %self.ref to %.loc16_51.2
-// CHECK:STDOUT:   %.loc16_51.4: init %X = class_init (%.loc16_51.3), %return
-// CHECK:STDOUT:   %.loc16_52: init %X = converted %.loc16_51.1, %.loc16_51.4
-// CHECK:STDOUT:   return %.loc16_52 to %return
+// CHECK:STDOUT:   %.loc19_51.1: %struct_type.n = struct_literal (%self.ref)
+// CHECK:STDOUT:   %.loc19_51.2: ref %i32 = class_element_access %return, element0
+// CHECK:STDOUT:   %.loc19_51.3: init %i32 = initialize_from %self.ref to %.loc19_51.2
+// CHECK:STDOUT:   %.loc19_51.4: init %X = class_init (%.loc19_51.3), %return
+// CHECK:STDOUT:   %.loc19_52: init %X = converted %.loc19_51.1, %.loc19_51.4
+// CHECK:STDOUT:   return %.loc19_52 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Convert.3(%self.param: %X) -> %i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: %X = name_ref self, %self
-// CHECK:STDOUT:   %n.ref: %X.elem = name_ref n, @X.%.loc12 [concrete = @X.%.loc12]
-// CHECK:STDOUT:   %.loc20_45.1: ref %i32 = class_element_access %self.ref, element0
-// CHECK:STDOUT:   %.loc20_45.2: %i32 = bind_value %.loc20_45.1
-// CHECK:STDOUT:   return %.loc20_45.2
+// CHECK:STDOUT:   %n.ref: %X.elem = name_ref n, @X.%.loc15 [concrete = @X.%.loc15]
+// CHECK:STDOUT:   %.loc23_45.1: ref %i32 = class_element_access %self.ref, element0
+// CHECK:STDOUT:   %.loc23_45.2: %i32 = bind_value %.loc23_45.1
+// CHECK:STDOUT:   return %.loc23_45.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Sink_i32(%n.param: %i32);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Sink_X(%x.param: %X);
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @Source(%T.loc27_11.1: type) {
-// CHECK:STDOUT:   %T.loc27_11.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc27_11.2 (constants.%T)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc27_11.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.2)]
+// CHECK:STDOUT: generic fn @Source(%T.loc30_11.1: type) {
+// CHECK:STDOUT:   %T.loc30_11.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc30_11.2 (constants.%T)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.loc30_11.2 [symbolic = %pattern_type (constants.%pattern_type.7dcd0a.2)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc27_11.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
-// CHECK:STDOUT:   %Source.specific_fn.loc27_35.2: <specific function> = specific_function constants.%Source, @Source(%T.loc27_11.2) [symbolic = %Source.specific_fn.loc27_35.2 (constants.%Source.specific_fn.ff0)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.loc30_11.2 [symbolic = %require_complete (constants.%require_complete.4ae)]
+// CHECK:STDOUT:   %Source.specific_fn.loc30_35.2: <specific function> = specific_function constants.%Source, @Source(%T.loc30_11.2) [symbolic = %Source.specific_fn.loc30_35.2 (constants.%Source.specific_fn.ff0)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn() -> @Source.%T.loc27_11.2 (%T) {
+// CHECK:STDOUT:   fn() -> @Source.%T.loc30_11.2 (%T) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %Source.ref: %Source.type = name_ref Source, file.%Source.decl [concrete = constants.%Source]
-// CHECK:STDOUT:     %T.ref.loc27_42: type = name_ref T, %T.loc27_11.1 [symbolic = %T.loc27_11.2 (constants.%T)]
-// CHECK:STDOUT:     %Source.specific_fn.loc27_35.1: <specific function> = specific_function %Source.ref, @Source(constants.%T) [symbolic = %Source.specific_fn.loc27_35.2 (constants.%Source.specific_fn.ff0)]
-// CHECK:STDOUT:     %Source.call: init @Source.%T.loc27_11.2 (%T) = call %Source.specific_fn.loc27_35.1()
-// CHECK:STDOUT:     %.loc27_44.1: @Source.%T.loc27_11.2 (%T) = value_of_initializer %Source.call
-// CHECK:STDOUT:     %.loc27_44.2: @Source.%T.loc27_11.2 (%T) = converted %Source.call, %.loc27_44.1
-// CHECK:STDOUT:     return %.loc27_44.2
+// CHECK:STDOUT:     %T.ref.loc30_42: type = name_ref T, %T.loc30_11.1 [symbolic = %T.loc30_11.2 (constants.%T)]
+// CHECK:STDOUT:     %Source.specific_fn.loc30_35.1: <specific function> = specific_function %Source.ref, @Source(constants.%T) [symbolic = %Source.specific_fn.loc30_35.2 (constants.%Source.specific_fn.ff0)]
+// CHECK:STDOUT:     %Source.call: init @Source.%T.loc30_11.2 (%T) = call %Source.specific_fn.loc30_35.1()
+// CHECK:STDOUT:     %.loc30_44.1: @Source.%T.loc30_11.2 (%T) = value_of_initializer %Source.call
+// CHECK:STDOUT:     %.loc30_44.2: @Source.%T.loc30_11.2 (%T) = converted %Source.call, %.loc30_44.1
+// CHECK:STDOUT:     return %.loc30_44.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Sink_i32.ref: %Sink_i32.type = name_ref Sink_i32, file.%Sink_i32.decl [concrete = constants.%Sink_i32]
-// CHECK:STDOUT:   %Source.ref.loc30: %Source.type = name_ref Source, file.%Source.decl [concrete = constants.%Source]
+// CHECK:STDOUT:   %Source.ref.loc33: %Source.type = name_ref Source, file.%Source.decl [concrete = constants.%Source]
 // CHECK:STDOUT:   %X.ref: type = name_ref X, file.%X.decl [concrete = constants.%X]
-// CHECK:STDOUT:   %Source.specific_fn.loc30: <specific function> = specific_function %Source.ref.loc30, @Source(constants.%X) [concrete = constants.%Source.specific_fn.363]
-// CHECK:STDOUT:   %.loc30_20.1: ref %X = temporary_storage
-// CHECK:STDOUT:   %Source.call.loc30: init %X = call %Source.specific_fn.loc30() to %.loc30_20.1
-// CHECK:STDOUT:   %impl.elem0.loc30: %.2ea = impl_witness_access constants.%ImplicitAs.impl_witness.b30, element0 [concrete = constants.%Convert.c7a]
-// CHECK:STDOUT:   %bound_method.loc30: <bound method> = bound_method %Source.call.loc30, %impl.elem0.loc30
-// CHECK:STDOUT:   %.loc30_20.2: ref %X = temporary %.loc30_20.1, %Source.call.loc30
-// CHECK:STDOUT:   %.loc30_20.3: %X = bind_value %.loc30_20.2
-// CHECK:STDOUT:   %Convert.call.loc30: init %i32 = call %bound_method.loc30(%.loc30_20.3)
-// CHECK:STDOUT:   %.loc30_20.4: %i32 = value_of_initializer %Convert.call.loc30
-// CHECK:STDOUT:   %.loc30_20.5: %i32 = converted %Source.call.loc30, %.loc30_20.4
-// CHECK:STDOUT:   %Sink_i32.call: init %empty_tuple.type = call %Sink_i32.ref(%.loc30_20.5)
+// CHECK:STDOUT:   %Source.specific_fn.loc33: <specific function> = specific_function %Source.ref.loc33, @Source(constants.%X) [concrete = constants.%Source.specific_fn.363]
+// CHECK:STDOUT:   %.loc33_20.1: ref %X = temporary_storage
+// CHECK:STDOUT:   %Source.call.loc33: init %X = call %Source.specific_fn.loc33() to %.loc33_20.1
+// CHECK:STDOUT:   %impl.elem0.loc33: %.2ea = impl_witness_access constants.%ImplicitAs.impl_witness.b30, element0 [concrete = constants.%Convert.c7a]
+// CHECK:STDOUT:   %bound_method.loc33: <bound method> = bound_method %Source.call.loc33, %impl.elem0.loc33
+// CHECK:STDOUT:   %.loc33_20.2: ref %X = temporary %.loc33_20.1, %Source.call.loc33
+// CHECK:STDOUT:   %.loc33_20.3: %X = bind_value %.loc33_20.2
+// CHECK:STDOUT:   %Convert.call.loc33: init %i32 = call %bound_method.loc33(%.loc33_20.3)
+// CHECK:STDOUT:   %.loc33_20.4: %i32 = value_of_initializer %Convert.call.loc33
+// CHECK:STDOUT:   %.loc33_20.5: %i32 = converted %Source.call.loc33, %.loc33_20.4
+// CHECK:STDOUT:   %Sink_i32.call: init %empty_tuple.type = call %Sink_i32.ref(%.loc33_20.5)
 // CHECK:STDOUT:   %Sink_X.ref: %Sink_X.type = name_ref Sink_X, file.%Sink_X.decl [concrete = constants.%Sink_X]
-// CHECK:STDOUT:   %Source.ref.loc31: %Source.type = name_ref Source, file.%Source.decl [concrete = constants.%Source]
+// CHECK:STDOUT:   %Source.ref.loc34: %Source.type = name_ref Source, file.%Source.decl [concrete = constants.%Source]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %Source.specific_fn.loc31: <specific function> = specific_function %Source.ref.loc31, @Source(constants.%i32) [concrete = constants.%Source.specific_fn.cc7]
-// CHECK:STDOUT:   %Source.call.loc31: init %i32 = call %Source.specific_fn.loc31()
-// CHECK:STDOUT:   %impl.elem0.loc31: %.9b4 = impl_witness_access constants.%ImplicitAs.impl_witness.aa3, element0 [concrete = constants.%Convert.08a]
-// CHECK:STDOUT:   %bound_method.loc31: <bound method> = bound_method %Source.call.loc31, %impl.elem0.loc31
-// CHECK:STDOUT:   %.loc31_20.1: ref %X = temporary_storage
-// CHECK:STDOUT:   %.loc31_20.2: %i32 = value_of_initializer %Source.call.loc31
-// CHECK:STDOUT:   %.loc31_20.3: %i32 = converted %Source.call.loc31, %.loc31_20.2
-// CHECK:STDOUT:   %Convert.call.loc31: init %X = call %bound_method.loc31(%.loc31_20.3) to %.loc31_20.1
-// CHECK:STDOUT:   %.loc31_20.4: init %X = converted %Source.call.loc31, %Convert.call.loc31
-// CHECK:STDOUT:   %.loc31_20.5: ref %X = temporary %.loc31_20.1, %.loc31_20.4
-// CHECK:STDOUT:   %.loc31_20.6: %X = bind_value %.loc31_20.5
-// CHECK:STDOUT:   %Sink_X.call: init %empty_tuple.type = call %Sink_X.ref(%.loc31_20.6)
+// CHECK:STDOUT:   %Source.specific_fn.loc34: <specific function> = specific_function %Source.ref.loc34, @Source(constants.%i32) [concrete = constants.%Source.specific_fn.cc7]
+// CHECK:STDOUT:   %Source.call.loc34: init %i32 = call %Source.specific_fn.loc34()
+// CHECK:STDOUT:   %impl.elem0.loc34: %.9b4 = impl_witness_access constants.%ImplicitAs.impl_witness.aa3, element0 [concrete = constants.%Convert.08a]
+// CHECK:STDOUT:   %bound_method.loc34: <bound method> = bound_method %Source.call.loc34, %impl.elem0.loc34
+// CHECK:STDOUT:   %.loc34_20.1: ref %X = temporary_storage
+// CHECK:STDOUT:   %.loc34_20.2: %i32 = value_of_initializer %Source.call.loc34
+// CHECK:STDOUT:   %.loc34_20.3: %i32 = converted %Source.call.loc34, %.loc34_20.2
+// CHECK:STDOUT:   %Convert.call.loc34: init %X = call %bound_method.loc34(%.loc34_20.3) to %.loc34_20.1
+// CHECK:STDOUT:   %.loc34_20.4: init %X = converted %Source.call.loc34, %Convert.call.loc34
+// CHECK:STDOUT:   %.loc34_20.5: ref %X = temporary %.loc34_20.1, %.loc34_20.4
+// CHECK:STDOUT:   %.loc34_20.6: %X = bind_value %.loc34_20.5
+// CHECK:STDOUT:   %Sink_X.call: init %empty_tuple.type = call %Sink_X.ref(%.loc34_20.6)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Source(constants.%T) {
-// CHECK:STDOUT:   %T.loc27_11.2 => constants.%T
+// CHECK:STDOUT:   %T.loc30_11.2 => constants.%T
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7dcd0a.2
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.4ae
-// CHECK:STDOUT:   %Source.specific_fn.loc27_35.2 => constants.%Source.specific_fn.ff0
+// CHECK:STDOUT:   %Source.specific_fn.loc30_35.2 => constants.%Source.specific_fn.ff0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Source(constants.%X) {
-// CHECK:STDOUT:   %T.loc27_11.2 => constants.%X
+// CHECK:STDOUT:   %T.loc30_11.2 => constants.%X
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.019
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.54b
-// CHECK:STDOUT:   %Source.specific_fn.loc27_35.2 => constants.%Source.specific_fn.363
+// CHECK:STDOUT:   %Source.specific_fn.loc30_35.2 => constants.%Source.specific_fn.363
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Source(constants.%i32) {
-// CHECK:STDOUT:   %T.loc27_11.2 => constants.%i32
+// CHECK:STDOUT:   %T.loc30_11.2 => constants.%i32
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
-// CHECK:STDOUT:   %Source.specific_fn.loc27_35.2 => constants.%Source.specific_fn.cc7
+// CHECK:STDOUT:   %Source.specific_fn.loc30_35.2 => constants.%Source.specific_fn.cc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -77,10 +80,10 @@ fn TestOp() {
 // CHECK:STDOUT:   %Op.decl: %Op.type.73a = fn_decl @Op.2 [concrete = constants.%Op.0c9] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc18_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc21_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc18_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc21_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:       %ptr: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
@@ -111,10 +114,10 @@ fn TestOp() {
 // CHECK:STDOUT:     %c.var_patt: %pattern_type.c48 = var_pattern %c.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %c.var: ref %C = var %c.var_patt
-// CHECK:STDOUT:   %.loc22_15.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc22_15.2: init %C = class_init (), %c.var [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc22_3: init %C = converted %.loc22_15.1, %.loc22_15.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   assign %c.var, %.loc22_3
+// CHECK:STDOUT:   %.loc25_15.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc25_15.2: init %C = class_init (), %c.var [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc25_3: init %C = converted %.loc25_15.1, %.loc25_15.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   assign %c.var, %.loc25_3
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %c: ref %C = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref %C = name_ref c, %c

--- a/toolchain/check/testdata/operators/overloaded/index.carbon
+++ b/toolchain/check/testdata/operators/overloaded/index.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/index.carbon

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.386 = fn_decl @Op.4 [concrete = constants.%Op.8fc] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.8a4 = impl_witness_access constants.%LeftShift.impl_witness, element0 [concrete = constants.%Op.df9]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.ac9 = impl_witness_access constants.%LeftShiftAssign.impl_witness, element0 [concrete = constants.%Op.8fc]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.fa2 = fn_decl @Op.4 [concrete = constants.%Op.d6c] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.0c1 = impl_witness_access constants.%Mod.impl_witness, element0 [concrete = constants.%Op.777]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.1f2 = impl_witness_access constants.%ModAssign.impl_witness, element0 [concrete = constants.%Op.d6c]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.c02 = fn_decl @Op.4 [concrete = constants.%Op.a8c] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.ccd = impl_witness_access constants.%Mul.impl_witness, element0 [concrete = constants.%Op.550]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.de8 = impl_witness_access constants.%MulAssign.impl_witness, element0 [concrete = constants.%Op.a8c]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -73,9 +76,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc23_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param1
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -89,9 +92,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_23: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_23: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param1
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -114,10 +117,10 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestOp(%a.param: %C) -> %return.param: %C {
@@ -125,8 +128,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %a.ref: %C = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem0: %.365 = impl_witness_access constants.%Negate.impl_witness, element0 [concrete = constants.%Op.64c]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc23: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref) to %.loc23
+// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref) to %.loc26
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
+++ b/toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/no_prelude/index.carbon

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/ordered.carbon

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.aab = fn_decl @Op.4 [concrete = constants.%Op.7b2] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.17b = impl_witness_access constants.%RightShift.impl_witness, element0 [concrete = constants.%Op.79a]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.285 = impl_witness_access constants.%RightShiftAssign.impl_witness, element0 [concrete = constants.%Op.7b2]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -105,12 +108,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc26_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_26: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc26_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_14: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %a: %C = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc29_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -122,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.param_patt: %pattern_type.c48 = value_param_pattern %b.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc30: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc30_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc30_18 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc33: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc33_18: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc33_18 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.019 = bind_name a, %a.param
 // CHECK:STDOUT:     %b.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc30_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc33_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %b: %C = bind_name b, %b.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -142,12 +145,12 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.c48 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.c48 = out_param_pattern %return.patt, call_param2 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %C.ref.loc18_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self.param: %C = value_param call_param0
-// CHECK:STDOUT:     %C.ref.loc18_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_15: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %self: %C = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc18_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:     %return.param: ref %C = out_param call_param2
 // CHECK:STDOUT:     %return: ref %C = return_slot %return.param
@@ -163,18 +166,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op.decl: %Op.type.966 = fn_decl @Op.4 [concrete = constants.%Op.a55] {
 // CHECK:STDOUT:     %self.patt: %pattern_type.44a = binding_pattern self [concrete]
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.44a = value_param_pattern %self.patt, call_param0 [concrete]
-// CHECK:STDOUT:     %.loc23_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
+// CHECK:STDOUT:     %.loc26_9: %pattern_type.f6d = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     %other.patt: %pattern_type.c48 = binding_pattern other [concrete]
 // CHECK:STDOUT:     %other.param_patt: %pattern_type.c48 = value_param_pattern %other.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %self.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc23_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
-// CHECK:STDOUT:       %C.ref.loc23_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc23_20 [concrete = constants.%ptr.019]
+// CHECK:STDOUT:     %.loc26_21: type = splice_block %ptr [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:       %C.ref.loc26_20: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:       %ptr: type = ptr_type %C.ref.loc26_20 [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: %ptr.019 = bind_name self, %self.param
 // CHECK:STDOUT:     %other.param: %C = value_param call_param1
-// CHECK:STDOUT:     %C.ref.loc23_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc26_31: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %other: %C = bind_name other, %other.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -195,10 +198,10 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2(%self.param: %C, %other.param: %C) -> %return.param: %C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19_13.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
-// CHECK:STDOUT:   %.loc19_14: init %C = converted %.loc19_13.1, %.loc19_13.2 [concrete = constants.%C.val]
-// CHECK:STDOUT:   return %.loc19_14 to %return
+// CHECK:STDOUT:   %.loc22_13.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc22_13.2: init %C = class_init (), %return [concrete = constants.%C.val]
+// CHECK:STDOUT:   %.loc22_14: init %C = converted %.loc22_13.1, %.loc22_13.2 [concrete = constants.%C.val]
+// CHECK:STDOUT:   return %.loc22_14 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.4(%self.param: %ptr.019, %other.param: %C) {
@@ -212,19 +215,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.ee4 = impl_witness_access constants.%Sub.impl_witness, element0 [concrete = constants.%Op.151]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %a.ref, %impl.elem0
-// CHECK:STDOUT:   %.loc26: ref %C = splice_block %return {}
-// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc26
+// CHECK:STDOUT:   %.loc29: ref %C = splice_block %return {}
+// CHECK:STDOUT:   %Op.call: init %C = call %bound_method(%a.ref, %b.ref) to %.loc29
 // CHECK:STDOUT:   return %Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%a.param: %ptr.019, %b.param: %C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: %ptr.019 = name_ref a, %a
-// CHECK:STDOUT:   %.loc31: ref %C = deref %a.ref
+// CHECK:STDOUT:   %.loc34: ref %C = deref %a.ref
 // CHECK:STDOUT:   %b.ref: %C = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem0: %.dac = impl_witness_access constants.%SubAssign.impl_witness, element0 [concrete = constants.%Op.a55]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc31, %impl.elem0
-// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc31
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc34, %impl.elem0
+// CHECK:STDOUT:   %addr: %ptr.019 = addr_of %.loc34
 // CHECK:STDOUT:   %Op.call: init %empty_tuple.type = call %bound_method(%addr, %b.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/unary_op.carbon.tmpl
+++ b/toolchain/check/testdata/operators/overloaded/unary_op.carbon.tmpl
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 
 HEADER

--- a/toolchain/check/testdata/operators/overloaded/unary_stmt.carbon.tmpl
+++ b/toolchain/check/testdata/operators/overloaded/unary_stmt.carbon.tmpl
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 
 HEADER


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.