### PR TITLE
Add range flag settings to patterns files

### DIFF
--- a/toolchain/check/testdata/patterns/min_prelude/underscore.carbon
+++ b/toolchain/check/testdata/patterns/min_prelude/underscore.carbon
@@ -5,6 +5,8 @@
 // This is mostly checking against crashes for compile time bindings in
 // difficult contexts.
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 // INCLUDE-FILE: toolchain/testing/min_prelude/convert.carbon
 //
 // AUTOUPDATE


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.