### PR TITLE
Add range flag settings to pointer files

### DIFF
--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -66,8 +69,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param0
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -82,23 +85,23 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %n.var: ref %i32 = var %n.var_patt
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_3.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc15_3.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_3.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_3.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc12_3: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   assign %n.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %bound_method.loc15_3.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_3.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc15_3: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   assign %n.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_10: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n: ref %i32 = bind_name n, %n.var
 // CHECK:STDOUT:   %n.ref: ref %i32 = name_ref n, %n
-// CHECK:STDOUT:   %addr.loc13_13: %ptr.235 = addr_of %n.ref
-// CHECK:STDOUT:   %.loc13_12: ref %i32 = deref %addr.loc13_13
-// CHECK:STDOUT:   %addr.loc13_11: %ptr.235 = addr_of %.loc13_12
-// CHECK:STDOUT:   %.loc13_10.1: ref %i32 = deref %addr.loc13_11
-// CHECK:STDOUT:   %.loc13_10.2: %i32 = bind_value %.loc13_10.1
-// CHECK:STDOUT:   return %.loc13_10.2
+// CHECK:STDOUT:   %addr.loc16_13: %ptr.235 = addr_of %n.ref
+// CHECK:STDOUT:   %.loc16_12: ref %i32 = deref %addr.loc16_13
+// CHECK:STDOUT:   %addr.loc16_11: %ptr.235 = addr_of %.loc16_12
+// CHECK:STDOUT:   %.loc16_10.1: ref %i32 = deref %addr.loc16_11
+// CHECK:STDOUT:   %.loc16_10.2: %i32 = bind_value %.loc16_10.1
+// CHECK:STDOUT:   return %.loc16_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -95,34 +98,34 @@ fn F() {
 // CHECK:STDOUT:     %s.var_patt: %pattern_type.851 = var_pattern %s.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %s.var: ref %struct_type.a.b.501 = var %s.var_patt
-// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc12: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc12_46.1: %struct_type.a.b.cfd = struct_literal (%int_1.loc12, %int_2.loc12)
-// CHECK:STDOUT:   %impl.elem0.loc12_46.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_46.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_46.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc12_46.1: <specific function> = specific_function %impl.elem0.loc12_46.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_46.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_46.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc12_46.1: init %i32 = call %bound_method.loc12_46.2(%int_1.loc12) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_46.2: init %i32 = converted %int_1.loc12, %int.convert_checked.loc12_46.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc12_46.3: ref %i32 = struct_access %s.var, element0
-// CHECK:STDOUT:   %.loc12_46.4: init %i32 = initialize_from %.loc12_46.2 to %.loc12_46.3 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc12_46.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_46.3: <bound method> = bound_method %int_2.loc12, %impl.elem0.loc12_46.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc12_46.2: <specific function> = specific_function %impl.elem0.loc12_46.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_46.4: <bound method> = bound_method %int_2.loc12, %specific_fn.loc12_46.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc12_46.2: init %i32 = call %bound_method.loc12_46.4(%int_2.loc12) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_46.5: init %i32 = converted %int_2.loc12, %int.convert_checked.loc12_46.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_46.6: ref %i32 = struct_access %s.var, element1
-// CHECK:STDOUT:   %.loc12_46.7: init %i32 = initialize_from %.loc12_46.5 to %.loc12_46.6 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc12_46.8: init %struct_type.a.b.501 = struct_init (%.loc12_46.4, %.loc12_46.7) to %s.var [concrete = constants.%struct]
-// CHECK:STDOUT:   %.loc12_3: init %struct_type.a.b.501 = converted %.loc12_46.1, %.loc12_46.8 [concrete = constants.%struct]
-// CHECK:STDOUT:   assign %s.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_27: type = splice_block %struct_type.a.b.loc12 [concrete = constants.%struct_type.a.b.501] {
-// CHECK:STDOUT:     %int_32.loc12_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc12_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %struct_type.a.b.loc12: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc15: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc15_46.1: %struct_type.a.b.cfd = struct_literal (%int_1.loc15, %int_2.loc15)
+// CHECK:STDOUT:   %impl.elem0.loc15_46.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_46.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_46.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc15_46.1: <specific function> = specific_function %impl.elem0.loc15_46.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_46.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_46.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc15_46.1: init %i32 = call %bound_method.loc15_46.2(%int_1.loc15) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_46.2: init %i32 = converted %int_1.loc15, %int.convert_checked.loc15_46.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc15_46.3: ref %i32 = struct_access %s.var, element0
+// CHECK:STDOUT:   %.loc15_46.4: init %i32 = initialize_from %.loc15_46.2 to %.loc15_46.3 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc15_46.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc15_46.3: <bound method> = bound_method %int_2.loc15, %impl.elem0.loc15_46.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc15_46.2: <specific function> = specific_function %impl.elem0.loc15_46.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_46.4: <bound method> = bound_method %int_2.loc15, %specific_fn.loc15_46.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc15_46.2: init %i32 = call %bound_method.loc15_46.4(%int_2.loc15) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_46.5: init %i32 = converted %int_2.loc15, %int.convert_checked.loc15_46.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_46.6: ref %i32 = struct_access %s.var, element1
+// CHECK:STDOUT:   %.loc15_46.7: init %i32 = initialize_from %.loc15_46.5 to %.loc15_46.6 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc15_46.8: init %struct_type.a.b.501 = struct_init (%.loc15_46.4, %.loc15_46.7) to %s.var [concrete = constants.%struct]
+// CHECK:STDOUT:   %.loc15_3: init %struct_type.a.b.501 = converted %.loc15_46.1, %.loc15_46.8 [concrete = constants.%struct]
+// CHECK:STDOUT:   assign %s.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_27: type = splice_block %struct_type.a.b.loc15 [concrete = constants.%struct_type.a.b.501] {
+// CHECK:STDOUT:     %int_32.loc15_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc15_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %struct_type.a.b.loc15: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %s: ref %struct_type.a.b.501 = bind_name s, %s.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -130,16 +133,16 @@ fn F() {
 // CHECK:STDOUT:     %p.var_patt: %pattern_type.8dd = var_pattern %p.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p.var: ref %ptr.3ee = var %p.var_patt
-// CHECK:STDOUT:   %s.ref.loc14: ref %struct_type.a.b.501 = name_ref s, %s
-// CHECK:STDOUT:   %addr.loc14: %ptr.3ee = addr_of %s.ref.loc14
-// CHECK:STDOUT:   assign %p.var, %addr.loc14
-// CHECK:STDOUT:   %.loc14: type = splice_block %ptr.loc14 [concrete = constants.%ptr.3ee] {
-// CHECK:STDOUT:     %int_32.loc14_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc14_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc14_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %struct_type.a.b.loc14: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
-// CHECK:STDOUT:     %ptr.loc14: type = ptr_type %struct_type.a.b.loc14 [concrete = constants.%ptr.3ee]
+// CHECK:STDOUT:   %s.ref.loc17: ref %struct_type.a.b.501 = name_ref s, %s
+// CHECK:STDOUT:   %addr.loc17: %ptr.3ee = addr_of %s.ref.loc17
+// CHECK:STDOUT:   assign %p.var, %addr.loc17
+// CHECK:STDOUT:   %.loc17: type = splice_block %ptr.loc17 [concrete = constants.%ptr.3ee] {
+// CHECK:STDOUT:     %int_32.loc17_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc17_24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc17_24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %struct_type.a.b.loc17: type = struct_type {.a: %i32, .b: %i32} [concrete = constants.%struct_type.a.b.501]
+// CHECK:STDOUT:     %ptr.loc17: type = ptr_type %struct_type.a.b.loc17 [concrete = constants.%ptr.3ee]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p: ref %ptr.3ee = bind_name p, %p.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -147,14 +150,14 @@ fn F() {
 // CHECK:STDOUT:     %q.var_patt: %pattern_type.fe8 = var_pattern %q.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %q.var: ref %ptr.235 = var %q.var_patt
-// CHECK:STDOUT:   %s.ref.loc15: ref %struct_type.a.b.501 = name_ref s, %s
-// CHECK:STDOUT:   %.loc15_19: ref %i32 = struct_access %s.ref.loc15, element0
-// CHECK:STDOUT:   %addr.loc15: %ptr.235 = addr_of %.loc15_19
-// CHECK:STDOUT:   assign %q.var, %addr.loc15
-// CHECK:STDOUT:   %.loc15_13: type = splice_block %ptr.loc15 [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc15: type = ptr_type %i32.loc15 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %s.ref.loc18: ref %struct_type.a.b.501 = name_ref s, %s
+// CHECK:STDOUT:   %.loc18_19: ref %i32 = struct_access %s.ref.loc18, element0
+// CHECK:STDOUT:   %addr.loc18: %ptr.235 = addr_of %.loc18_19
+// CHECK:STDOUT:   assign %q.var, %addr.loc18
+// CHECK:STDOUT:   %.loc18_13: type = splice_block %ptr.loc18 [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr.loc18: type = ptr_type %i32.loc18 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %q: ref %ptr.235 = bind_name q, %q.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -162,14 +165,14 @@ fn F() {
 // CHECK:STDOUT:     %r.var_patt: %pattern_type.fe8 = var_pattern %r.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %r.var: ref %ptr.235 = var %r.var_patt
-// CHECK:STDOUT:   %s.ref.loc16: ref %struct_type.a.b.501 = name_ref s, %s
-// CHECK:STDOUT:   %.loc16_19: ref %i32 = struct_access %s.ref.loc16, element1
-// CHECK:STDOUT:   %addr.loc16: %ptr.235 = addr_of %.loc16_19
-// CHECK:STDOUT:   assign %r.var, %addr.loc16
-// CHECK:STDOUT:   %.loc16_13: type = splice_block %ptr.loc16 [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc16: type = ptr_type %i32.loc16 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %s.ref.loc19: ref %struct_type.a.b.501 = name_ref s, %s
+// CHECK:STDOUT:   %.loc19_19: ref %i32 = struct_access %s.ref.loc19, element1
+// CHECK:STDOUT:   %addr.loc19: %ptr.235 = addr_of %.loc19_19
+// CHECK:STDOUT:   assign %r.var, %addr.loc19
+// CHECK:STDOUT:   %.loc19_13: type = splice_block %ptr.loc19 [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr.loc19: type = ptr_type %i32.loc19 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %r: ref %ptr.235 = bind_name r, %r.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -177,35 +180,35 @@ fn F() {
 // CHECK:STDOUT:     %t.var_patt: %pattern_type.511 = var_pattern %t.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t.var: ref %tuple.type.d07 = var %t.var_patt
-// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %int_2.loc18: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
-// CHECK:STDOUT:   %.loc18_28.1: %tuple.type.f94 = tuple_literal (%int_1.loc18, %int_2.loc18)
-// CHECK:STDOUT:   %impl.elem0.loc18_28.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc18_28.1: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_28.1 [concrete = constants.%Convert.bound.ab5]
-// CHECK:STDOUT:   %specific_fn.loc18_28.1: <specific function> = specific_function %impl.elem0.loc18_28.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc18_28.2: <bound method> = bound_method %int_1.loc18, %specific_fn.loc18_28.1 [concrete = constants.%bound_method.9a1]
-// CHECK:STDOUT:   %int.convert_checked.loc18_28.1: init %i32 = call %bound_method.loc18_28.2(%int_1.loc18) [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %.loc18_28.2: init %i32 = converted %int_1.loc18, %int.convert_checked.loc18_28.1 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %tuple.elem0.loc18: ref %i32 = tuple_access %t.var, element0
-// CHECK:STDOUT:   %.loc18_28.3: init %i32 = initialize_from %.loc18_28.2 to %tuple.elem0.loc18 [concrete = constants.%int_1.5d2]
-// CHECK:STDOUT:   %impl.elem0.loc18_28.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc18_28.3: <bound method> = bound_method %int_2.loc18, %impl.elem0.loc18_28.2 [concrete = constants.%Convert.bound.ef9]
-// CHECK:STDOUT:   %specific_fn.loc18_28.2: <specific function> = specific_function %impl.elem0.loc18_28.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc18_28.4: <bound method> = bound_method %int_2.loc18, %specific_fn.loc18_28.2 [concrete = constants.%bound_method.b92]
-// CHECK:STDOUT:   %int.convert_checked.loc18_28.2: init %i32 = call %bound_method.loc18_28.4(%int_2.loc18) [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc18_28.4: init %i32 = converted %int_2.loc18, %int.convert_checked.loc18_28.2 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %tuple.elem1.loc18: ref %i32 = tuple_access %t.var, element1
-// CHECK:STDOUT:   %.loc18_28.5: init %i32 = initialize_from %.loc18_28.4 to %tuple.elem1.loc18 [concrete = constants.%int_2.ef8]
-// CHECK:STDOUT:   %.loc18_28.6: init %tuple.type.d07 = tuple_init (%.loc18_28.3, %.loc18_28.5) to %t.var [concrete = constants.%tuple]
-// CHECK:STDOUT:   %.loc18_3: init %tuple.type.d07 = converted %.loc18_28.1, %.loc18_28.6 [concrete = constants.%tuple]
-// CHECK:STDOUT:   assign %t.var, %.loc18_3
-// CHECK:STDOUT:   %.loc18_19.1: type = splice_block %.loc18_19.3 [concrete = constants.%tuple.type.d07] {
-// CHECK:STDOUT:     %int_32.loc18_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc18_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %int_32.loc18_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc18_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc18_19.2: %tuple.type.24b = tuple_literal (%i32.loc18_11, %i32.loc18_16)
-// CHECK:STDOUT:     %.loc18_19.3: type = converted %.loc18_19.2, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
+// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_2.loc21: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
+// CHECK:STDOUT:   %.loc21_28.1: %tuple.type.f94 = tuple_literal (%int_1.loc21, %int_2.loc21)
+// CHECK:STDOUT:   %impl.elem0.loc21_28.1: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc21_28.1: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21_28.1 [concrete = constants.%Convert.bound.ab5]
+// CHECK:STDOUT:   %specific_fn.loc21_28.1: <specific function> = specific_function %impl.elem0.loc21_28.1, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc21_28.2: <bound method> = bound_method %int_1.loc21, %specific_fn.loc21_28.1 [concrete = constants.%bound_method.9a1]
+// CHECK:STDOUT:   %int.convert_checked.loc21_28.1: init %i32 = call %bound_method.loc21_28.2(%int_1.loc21) [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %.loc21_28.2: init %i32 = converted %int_1.loc21, %int.convert_checked.loc21_28.1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %tuple.elem0.loc21: ref %i32 = tuple_access %t.var, element0
+// CHECK:STDOUT:   %.loc21_28.3: init %i32 = initialize_from %.loc21_28.2 to %tuple.elem0.loc21 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %impl.elem0.loc21_28.2: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
+// CHECK:STDOUT:   %bound_method.loc21_28.3: <bound method> = bound_method %int_2.loc21, %impl.elem0.loc21_28.2 [concrete = constants.%Convert.bound.ef9]
+// CHECK:STDOUT:   %specific_fn.loc21_28.2: <specific function> = specific_function %impl.elem0.loc21_28.2, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc21_28.4: <bound method> = bound_method %int_2.loc21, %specific_fn.loc21_28.2 [concrete = constants.%bound_method.b92]
+// CHECK:STDOUT:   %int.convert_checked.loc21_28.2: init %i32 = call %bound_method.loc21_28.4(%int_2.loc21) [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc21_28.4: init %i32 = converted %int_2.loc21, %int.convert_checked.loc21_28.2 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %tuple.elem1.loc21: ref %i32 = tuple_access %t.var, element1
+// CHECK:STDOUT:   %.loc21_28.5: init %i32 = initialize_from %.loc21_28.4 to %tuple.elem1.loc21 [concrete = constants.%int_2.ef8]
+// CHECK:STDOUT:   %.loc21_28.6: init %tuple.type.d07 = tuple_init (%.loc21_28.3, %.loc21_28.5) to %t.var [concrete = constants.%tuple]
+// CHECK:STDOUT:   %.loc21_3: init %tuple.type.d07 = converted %.loc21_28.1, %.loc21_28.6 [concrete = constants.%tuple]
+// CHECK:STDOUT:   assign %t.var, %.loc21_3
+// CHECK:STDOUT:   %.loc21_19.1: type = splice_block %.loc21_19.3 [concrete = constants.%tuple.type.d07] {
+// CHECK:STDOUT:     %int_32.loc21_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc21_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc21_16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc21_16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc21_19.2: %tuple.type.24b = tuple_literal (%i32.loc21_11, %i32.loc21_16)
+// CHECK:STDOUT:     %.loc21_19.3: type = converted %.loc21_19.2, constants.%tuple.type.d07 [concrete = constants.%tuple.type.d07]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t: ref %tuple.type.d07 = bind_name t, %t.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -213,15 +216,15 @@ fn F() {
 // CHECK:STDOUT:     %t0.var_patt: %pattern_type.fe8 = var_pattern %t0.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t0.var: ref %ptr.235 = var %t0.var_patt
-// CHECK:STDOUT:   %t.ref.loc19: ref %tuple.type.d07 = name_ref t, %t
+// CHECK:STDOUT:   %t.ref.loc22: ref %tuple.type.d07 = name_ref t, %t
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
-// CHECK:STDOUT:   %tuple.elem0.loc19: ref %i32 = tuple_access %t.ref.loc19, element0
-// CHECK:STDOUT:   %addr.loc19: %ptr.235 = addr_of %tuple.elem0.loc19
-// CHECK:STDOUT:   assign %t0.var, %addr.loc19
-// CHECK:STDOUT:   %.loc19: type = splice_block %ptr.loc19 [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc19: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc19: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc19: type = ptr_type %i32.loc19 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %tuple.elem0.loc22: ref %i32 = tuple_access %t.ref.loc22, element0
+// CHECK:STDOUT:   %addr.loc22: %ptr.235 = addr_of %tuple.elem0.loc22
+// CHECK:STDOUT:   assign %t0.var, %addr.loc22
+// CHECK:STDOUT:   %.loc22: type = splice_block %ptr.loc22 [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr.loc22: type = ptr_type %i32.loc22 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t0: ref %ptr.235 = bind_name t0, %t0.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -229,15 +232,15 @@ fn F() {
 // CHECK:STDOUT:     %t1.var_patt: %pattern_type.fe8 = var_pattern %t1.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t1.var: ref %ptr.235 = var %t1.var_patt
-// CHECK:STDOUT:   %t.ref.loc20: ref %tuple.type.d07 = name_ref t, %t
-// CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:   %tuple.elem1.loc20: ref %i32 = tuple_access %t.ref.loc20, element1
-// CHECK:STDOUT:   %addr.loc20: %ptr.235 = addr_of %tuple.elem1.loc20
-// CHECK:STDOUT:   assign %t1.var, %addr.loc20
-// CHECK:STDOUT:   %.loc20: type = splice_block %ptr.loc20 [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc20: type = ptr_type %i32.loc20 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %t.ref.loc23: ref %tuple.type.d07 = name_ref t, %t
+// CHECK:STDOUT:   %int_1.loc23: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %tuple.elem1.loc23: ref %i32 = tuple_access %t.ref.loc23, element1
+// CHECK:STDOUT:   %addr.loc23: %ptr.235 = addr_of %tuple.elem1.loc23
+// CHECK:STDOUT:   assign %t1.var, %addr.loc23
+// CHECK:STDOUT:   %.loc23: type = splice_block %ptr.loc23 [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr.loc23: type = ptr_type %i32.loc23 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t1: ref %ptr.235 = bind_name t1, %t1.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/pointer/arrow.carbon
+++ b/toolchain/check/testdata/pointer/arrow.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/arrow.carbon
@@ -60,11 +63,11 @@ fn Foo(ptr: C*) {
 // CHECK:STDOUT:     %ptr.param_patt: %pattern_type.44a = value_param_pattern %ptr.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %ptr.param: %ptr.019 = value_param call_param0
-// CHECK:STDOUT:     %.loc16: type = splice_block %ptr.loc16_14 [concrete = constants.%ptr.019] {
+// CHECK:STDOUT:     %.loc19: type = splice_block %ptr.loc19_14 [concrete = constants.%ptr.019] {
 // CHECK:STDOUT:       %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:       %ptr.loc16_14: type = ptr_type %C.ref [concrete = constants.%ptr.019]
+// CHECK:STDOUT:       %ptr.loc19_14: type = ptr_type %C.ref [concrete = constants.%ptr.019]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %ptr.loc16_8: %ptr.019 = bind_name ptr, %ptr.param
+// CHECK:STDOUT:     %ptr.loc19_8: %ptr.019 = bind_name ptr, %ptr.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -79,7 +82,7 @@ fn Foo(ptr: C*) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %ptr: type = ptr_type %C.ref [concrete = constants.%ptr.019]
-// CHECK:STDOUT:   %.loc13: %C.elem = field_decl field, element0 [concrete]
+// CHECK:STDOUT:   %.loc16: %C.elem = field_decl field, element0 [concrete]
 // CHECK:STDOUT:   %struct_type.field: type = struct_type {.field: %ptr.019} [concrete = constants.%struct_type.field]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.field [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
@@ -88,41 +91,41 @@ fn Foo(ptr: C*) {
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .Member = %Member.decl
 // CHECK:STDOUT:   .C = <poisoned>
-// CHECK:STDOUT:   .field = %.loc13
+// CHECK:STDOUT:   .field = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Member(%self.param: %C);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%ptr.param: %ptr.019) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %ptr.ref.loc17: %ptr.019 = name_ref ptr, %ptr.loc16_8
-// CHECK:STDOUT:   %.loc17_4.1: ref %C = deref %ptr.ref.loc17
-// CHECK:STDOUT:   %Member.ref.loc17: %Member.type = name_ref Member, @C.%Member.decl [concrete = constants.%Member]
-// CHECK:STDOUT:   %Member.bound.loc17: <bound method> = bound_method %.loc17_4.1, %Member.ref.loc17
-// CHECK:STDOUT:   %.loc17_4.2: %C = bind_value %.loc17_4.1
-// CHECK:STDOUT:   %Member.call.loc17: init %empty_tuple.type = call %Member.bound.loc17(%.loc17_4.2)
-// CHECK:STDOUT:   %ptr.ref.loc18: %ptr.019 = name_ref ptr, %ptr.loc16_8
-// CHECK:STDOUT:   %.loc18_6.1: ref %C = deref %ptr.ref.loc18
-// CHECK:STDOUT:   %Member.ref.loc18: %Member.type = name_ref Member, @C.%Member.decl [concrete = constants.%Member]
-// CHECK:STDOUT:   %Member.bound.loc18: <bound method> = bound_method %.loc18_6.1, %Member.ref.loc18
-// CHECK:STDOUT:   %.loc18_6.2: %C = bind_value %.loc18_6.1
-// CHECK:STDOUT:   %Member.call.loc18: init %empty_tuple.type = call %Member.bound.loc18(%.loc18_6.2)
-// CHECK:STDOUT:   %ptr.ref.loc20: %ptr.019 = name_ref ptr, %ptr.loc16_8
-// CHECK:STDOUT:   %.loc20_4: ref %C = deref %ptr.ref.loc20
-// CHECK:STDOUT:   %field.ref.loc20: %C.elem = name_ref field, @C.%.loc13 [concrete = @C.%.loc13]
-// CHECK:STDOUT:   %.loc20_9: ref %ptr.019 = class_element_access %.loc20_4, element0
-// CHECK:STDOUT:   %ptr.ref.loc21: %ptr.019 = name_ref ptr, %ptr.loc16_8
+// CHECK:STDOUT:   %ptr.ref.loc20: %ptr.019 = name_ref ptr, %ptr.loc19_8
+// CHECK:STDOUT:   %.loc20_4.1: ref %C = deref %ptr.ref.loc20
+// CHECK:STDOUT:   %Member.ref.loc20: %Member.type = name_ref Member, @C.%Member.decl [concrete = constants.%Member]
+// CHECK:STDOUT:   %Member.bound.loc20: <bound method> = bound_method %.loc20_4.1, %Member.ref.loc20
+// CHECK:STDOUT:   %.loc20_4.2: %C = bind_value %.loc20_4.1
+// CHECK:STDOUT:   %Member.call.loc20: init %empty_tuple.type = call %Member.bound.loc20(%.loc20_4.2)
+// CHECK:STDOUT:   %ptr.ref.loc21: %ptr.019 = name_ref ptr, %ptr.loc19_8
 // CHECK:STDOUT:   %.loc21_6.1: ref %C = deref %ptr.ref.loc21
-// CHECK:STDOUT:   %field.ref.loc21: %C.elem = name_ref field, @C.%.loc13 [concrete = @C.%.loc13]
-// CHECK:STDOUT:   %.loc21_6.2: ref %ptr.019 = class_element_access %.loc21_6.1, element0
-// CHECK:STDOUT:   %ptr.ref.loc23: %ptr.019 = name_ref ptr, %ptr.loc16_8
-// CHECK:STDOUT:   %.loc23_6.1: ref %C = deref %ptr.ref.loc23
-// CHECK:STDOUT:   %field.ref.loc23_6: %C.elem = name_ref field, @C.%.loc13 [concrete = @C.%.loc13]
-// CHECK:STDOUT:   %.loc23_6.2: ref %ptr.019 = class_element_access %.loc23_6.1, element0
-// CHECK:STDOUT:   %.loc23_6.3: %ptr.019 = bind_value %.loc23_6.2
-// CHECK:STDOUT:   %.loc23_13.1: ref %C = deref %.loc23_6.3
-// CHECK:STDOUT:   %field.ref.loc23_13: %C.elem = name_ref field, @C.%.loc13 [concrete = @C.%.loc13]
-// CHECK:STDOUT:   %.loc23_13.2: ref %ptr.019 = class_element_access %.loc23_13.1, element0
+// CHECK:STDOUT:   %Member.ref.loc21: %Member.type = name_ref Member, @C.%Member.decl [concrete = constants.%Member]
+// CHECK:STDOUT:   %Member.bound.loc21: <bound method> = bound_method %.loc21_6.1, %Member.ref.loc21
+// CHECK:STDOUT:   %.loc21_6.2: %C = bind_value %.loc21_6.1
+// CHECK:STDOUT:   %Member.call.loc21: init %empty_tuple.type = call %Member.bound.loc21(%.loc21_6.2)
+// CHECK:STDOUT:   %ptr.ref.loc23: %ptr.019 = name_ref ptr, %ptr.loc19_8
+// CHECK:STDOUT:   %.loc23_4: ref %C = deref %ptr.ref.loc23
+// CHECK:STDOUT:   %field.ref.loc23: %C.elem = name_ref field, @C.%.loc16 [concrete = @C.%.loc16]
+// CHECK:STDOUT:   %.loc23_9: ref %ptr.019 = class_element_access %.loc23_4, element0
+// CHECK:STDOUT:   %ptr.ref.loc24: %ptr.019 = name_ref ptr, %ptr.loc19_8
+// CHECK:STDOUT:   %.loc24_6.1: ref %C = deref %ptr.ref.loc24
+// CHECK:STDOUT:   %field.ref.loc24: %C.elem = name_ref field, @C.%.loc16 [concrete = @C.%.loc16]
+// CHECK:STDOUT:   %.loc24_6.2: ref %ptr.019 = class_element_access %.loc24_6.1, element0
+// CHECK:STDOUT:   %ptr.ref.loc26: %ptr.019 = name_ref ptr, %ptr.loc19_8
+// CHECK:STDOUT:   %.loc26_6.1: ref %C = deref %ptr.ref.loc26
+// CHECK:STDOUT:   %field.ref.loc26_6: %C.elem = name_ref field, @C.%.loc16 [concrete = @C.%.loc16]
+// CHECK:STDOUT:   %.loc26_6.2: ref %ptr.019 = class_element_access %.loc26_6.1, element0
+// CHECK:STDOUT:   %.loc26_6.3: %ptr.019 = bind_value %.loc26_6.2
+// CHECK:STDOUT:   %.loc26_13.1: ref %C = deref %.loc26_6.3
+// CHECK:STDOUT:   %field.ref.loc26_13: %C.elem = name_ref field, @C.%.loc16 [concrete = @C.%.loc16]
+// CHECK:STDOUT:   %.loc26_13.2: ref %ptr.019 = class_element_access %.loc26_13.1, element0
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/basic.carbon
+++ b/toolchain/check/testdata/pointer/basic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/basic.carbon
@@ -69,8 +72,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %int_32.loc14: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param0
 // CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -85,15 +88,15 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %n.var: ref %i32 = var %n.var_patt
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
 // CHECK:STDOUT:   %impl.elem0: %.9c3 = impl_witness_access constants.%ImplicitAs.impl_witness.c75, element0 [concrete = constants.%Convert.956]
-// CHECK:STDOUT:   %bound_method.loc12_3.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc15_3.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Convert.2(constants.%int_32) [concrete = constants.%Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc12_3.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc12_3.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   %.loc12_3: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:   assign %n.var, %.loc12_3
-// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32.loc12 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc12: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %bound_method.loc15_3.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %int.convert_checked: init %i32 = call %bound_method.loc15_3.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   %.loc15_3: init %i32 = converted %int_0, %int.convert_checked [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:   assign %n.var, %.loc15_3
+// CHECK:STDOUT:   %.loc15_10: type = splice_block %i32.loc15 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n: ref %i32 = bind_name n, %n.var
 // CHECK:STDOUT:   name_binding_decl {
@@ -104,16 +107,16 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %n.ref: ref %i32 = name_ref n, %n
 // CHECK:STDOUT:   %addr: %ptr.235 = addr_of %n.ref
 // CHECK:STDOUT:   assign %p.var, %addr
-// CHECK:STDOUT:   %.loc13: type = splice_block %ptr [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc13: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc13: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr: type = ptr_type %i32.loc13 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %.loc16: type = splice_block %ptr [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc16: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc16: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr: type = ptr_type %i32.loc16 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p: ref %ptr.235 = bind_name p, %p.var
 // CHECK:STDOUT:   %p.ref: ref %ptr.235 = name_ref p, %p
-// CHECK:STDOUT:   %.loc15_11: %ptr.235 = bind_value %p.ref
-// CHECK:STDOUT:   %.loc15_10.1: ref %i32 = deref %.loc15_11
-// CHECK:STDOUT:   %.loc15_10.2: %i32 = bind_value %.loc15_10.1
-// CHECK:STDOUT:   return %.loc15_10.2
+// CHECK:STDOUT:   %.loc18_11: %ptr.235 = bind_value %p.ref
+// CHECK:STDOUT:   %.loc18_10.1: ref %i32 = deref %.loc18_11
+// CHECK:STDOUT:   %.loc18_10.2: %i32 = bind_value %.loc18_10.1
+// CHECK:STDOUT:   return %.loc18_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -51,11 +54,11 @@ fn Test() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %undeclared.ref.loc16: <error> = name_ref undeclared, <error> [concrete = <error>]
-// CHECK:STDOUT:   %addr.loc16: <error> = addr_of %undeclared.ref.loc16 [concrete = <error>]
-// CHECK:STDOUT:   %undeclared.ref.loc25: <error> = name_ref undeclared, <error> [concrete = <error>]
-// CHECK:STDOUT:   %addr.loc25_5: <error> = addr_of %undeclared.ref.loc25 [concrete = <error>]
-// CHECK:STDOUT:   %addr.loc25_3: <error> = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %undeclared.ref.loc19: <error> = name_ref undeclared, <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc19: <error> = addr_of %undeclared.ref.loc19 [concrete = <error>]
+// CHECK:STDOUT:   %undeclared.ref.loc28: <error> = name_ref undeclared, <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc28_5: <error> = addr_of %undeclared.ref.loc28 [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc28_3: <error> = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -201,9 +204,9 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:     %param.param_patt: %pattern_type.7ce = value_param_pattern %param.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %param.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc95: type = splice_block %i32.loc95 [concrete = constants.%i32] {
-// CHECK:STDOUT:       %int_32.loc95: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc95: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc98: type = splice_block %i32.loc98 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %int_32.loc98: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc98: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %param: %i32 = bind_name param, %param.param
 // CHECK:STDOUT:   }
@@ -216,45 +219,45 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT: fn @AddressOfLiteral() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
-// CHECK:STDOUT:   %addr.loc20: %ptr.1d1 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc23: %ptr.1d1 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %addr.loc25: %ptr.bb2 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc28: %ptr.bb2 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   %float: f64 = float_literal 1 [concrete = constants.%float]
-// CHECK:STDOUT:   %addr.loc30: %ptr.ef1 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc33: %ptr.ef1 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   %str: String = string_literal "Hello" [concrete = constants.%str]
-// CHECK:STDOUT:   %addr.loc35: %ptr.a45 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc38: %ptr.a45 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2]
-// CHECK:STDOUT:   %.loc40: %tuple.type = tuple_literal (%int_1, %int_2)
-// CHECK:STDOUT:   %addr.loc40: %ptr.b50 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc43: %tuple.type = tuple_literal (%int_1, %int_2)
+// CHECK:STDOUT:   %addr.loc43: %ptr.b50 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   %int_5: Core.IntLiteral = int_value 5 [concrete = constants.%int_5]
-// CHECK:STDOUT:   %.loc45: %struct_type.a.a6c = struct_literal (%int_5)
-// CHECK:STDOUT:   %addr.loc45: %ptr.4e0 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc48: %struct_type.a.a6c = struct_literal (%int_5)
+// CHECK:STDOUT:   %addr.loc48: %ptr.4e0 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfOperator() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %true.loc53: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %false.loc53_10: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   if %true.loc53 br !and.rhs else br !and.result(%false.loc53_10)
+// CHECK:STDOUT:   %true.loc56: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %false.loc56_10: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   if %true.loc56 br !and.rhs else br !and.result(%false.loc56_10)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %false.loc53_14: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   br !and.result(%false.loc53_14)
+// CHECK:STDOUT:   %false.loc56_14: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:   br !and.result(%false.loc56_14)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
-// CHECK:STDOUT:   %.loc53: bool = block_arg !and.result [concrete = constants.%false]
-// CHECK:STDOUT:   %addr.loc53: %ptr.bb2 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc56: bool = block_arg !and.result [concrete = constants.%false]
+// CHECK:STDOUT:   %addr.loc56: %ptr.bb2 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   %H.ref: %H.type = name_ref H, file.%H.decl [concrete = constants.%H]
 // CHECK:STDOUT:   %H.call: init %struct_type.a.ba9 = call %H.ref()
-// CHECK:STDOUT:   %.loc58_6.1: ref %struct_type.a.ba9 = temporary_storage
-// CHECK:STDOUT:   %.loc58_6.2: ref %struct_type.a.ba9 = temporary %.loc58_6.1, %H.call
-// CHECK:STDOUT:   %.loc58_7: ref %i32 = struct_access %.loc58_6.2, element0
-// CHECK:STDOUT:   %addr.loc58: %ptr.235 = addr_of <error> [concrete = <error>]
-// CHECK:STDOUT:   %true.loc63: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %.loc63: bool = not %true.loc63 [concrete = constants.%false]
-// CHECK:STDOUT:   %addr.loc63: %ptr.bb2 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc61_6.1: ref %struct_type.a.ba9 = temporary_storage
+// CHECK:STDOUT:   %.loc61_6.2: ref %struct_type.a.ba9 = temporary %.loc61_6.1, %H.call
+// CHECK:STDOUT:   %.loc61_7: ref %i32 = struct_access %.loc61_6.2, element0
+// CHECK:STDOUT:   %addr.loc61: %ptr.235 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %true.loc66: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:   %.loc66: bool = not %true.loc66 [concrete = constants.%false]
+// CHECK:STDOUT:   %addr.loc66: %ptr.bb2 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -268,14 +271,14 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfType() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %int_32.loc79: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc79: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %addr.loc79: %ptr.db7 = addr_of <error> [concrete = <error>]
-// CHECK:STDOUT:   %int_32.loc84: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc84: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %const: type = const_type %i32.loc84 [concrete = constants.%const]
+// CHECK:STDOUT:   %int_32.loc82: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc82: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %addr.loc82: %ptr.db7 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %int_32.loc87: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc87: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %const: type = const_type %i32.loc87 [concrete = constants.%const]
 // CHECK:STDOUT:   %ptr: type = ptr_type %const [concrete = constants.%ptr.36b]
-// CHECK:STDOUT:   %addr.loc84: %ptr.db7 = addr_of <error> [concrete = <error>]
+// CHECK:STDOUT:   %addr.loc87: %ptr.db7 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -283,11 +286,11 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2]
-// CHECK:STDOUT:   %.loc92_10.1: %tuple.type = tuple_literal (%int_1, %int_2)
+// CHECK:STDOUT:   %.loc95_10.1: %tuple.type = tuple_literal (%int_1, %int_2)
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0]
 // CHECK:STDOUT:   %tuple: %tuple.type = tuple_value (%int_1, %int_2) [concrete = constants.%tuple]
-// CHECK:STDOUT:   %.loc92_10.2: %tuple.type = converted %.loc92_10.1, %tuple [concrete = constants.%tuple]
-// CHECK:STDOUT:   %tuple.elem0: Core.IntLiteral = tuple_access %.loc92_10.2, element0 [concrete = constants.%int_1]
+// CHECK:STDOUT:   %.loc95_10.2: %tuple.type = converted %.loc95_10.1, %tuple [concrete = constants.%tuple]
+// CHECK:STDOUT:   %tuple.elem0: Core.IntLiteral = tuple_access %.loc95_10.2, element0 [concrete = constants.%int_1]
 // CHECK:STDOUT:   %addr: %ptr.1d1 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -302,10 +305,10 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:   %param.ref: %i32 = name_ref param, %param
 // CHECK:STDOUT:   %addr: %ptr.235 = addr_of <error> [concrete = <error>]
 // CHECK:STDOUT:   assign %param_addr.var, %addr
-// CHECK:STDOUT:   %.loc100: type = splice_block %ptr [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:     %int_32.loc100: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc100: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr: type = ptr_type %i32.loc100 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:   %.loc103: type = splice_block %ptr [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:     %int_32.loc103: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc103: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr: type = ptr_type %i32.loc103 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %param_addr: ref %ptr.235 = bind_name param_addr, %param_addr.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/pointer/fail_deref_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_error.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_deref_error.carbon
@@ -49,27 +52,27 @@ let n2: i32 = undeclared->foo;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %n.patt: %pattern_type.7ce = binding_pattern n [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc15: type = splice_block %i32.loc15 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc18: type = splice_block %i32.loc18 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n: %i32 = bind_name n, <error>
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %n2.patt: %pattern_type.7ce = binding_pattern n2 [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc20: type = splice_block %i32.loc20 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %int_32.loc20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %.loc23: type = splice_block %i32.loc23 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %n2: %i32 = bind_name n2, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %undeclared.ref.loc15: <error> = name_ref undeclared, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc15: ref <error> = deref <error> [concrete = <error>]
-// CHECK:STDOUT:   %undeclared.ref.loc20: <error> = name_ref undeclared, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc20: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %undeclared.ref.loc18: <error> = name_ref undeclared, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc18: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %undeclared.ref.loc23: <error> = name_ref undeclared, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc23: ref <error> = deref <error> [concrete = <error>]
 // CHECK:STDOUT:   %foo.ref: <error> = name_ref foo, <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_deref_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_function.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_deref_function.carbon
@@ -46,10 +49,10 @@ fn A() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref.loc16: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc16: ref <error> = deref <error> [concrete = <error>]
-// CHECK:STDOUT:   %A.ref.loc21: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
-// CHECK:STDOUT:   %.loc21: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %A.ref.loc19: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:   %.loc19: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %A.ref.loc24: %A.type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:   %.loc24: ref <error> = deref <error> [concrete = <error>]
 // CHECK:STDOUT:   %foo.ref: <error> = name_ref foo, <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_deref_namespace.carbon
@@ -50,10 +53,10 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref.loc18: <namespace> = name_ref A, file.%A [concrete = file.%A]
-// CHECK:STDOUT:   %.loc18: ref <error> = deref <error> [concrete = <error>]
-// CHECK:STDOUT:   %A.ref.loc23: <namespace> = name_ref A, file.%A [concrete = file.%A]
-// CHECK:STDOUT:   %.loc23: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %A.ref.loc21: <namespace> = name_ref A, file.%A [concrete = file.%A]
+// CHECK:STDOUT:   %.loc21: ref <error> = deref <error> [concrete = <error>]
+// CHECK:STDOUT:   %A.ref.loc26: <namespace> = name_ref A, file.%A [concrete = file.%A]
+// CHECK:STDOUT:   %.loc26: ref <error> = deref <error> [concrete = <error>]
 // CHECK:STDOUT:   %foo.ref: <error> = name_ref foo, <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -77,7 +80,7 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:     %n.param_patt: %pattern_type.7ce = value_param_pattern %n.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %n.param: %i32 = value_param call_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.loc14: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }
@@ -87,29 +90,29 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Deref(%n.param: %i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %n.ref.loc16: %i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc16: ref <error> = deref %n.ref.loc16 [concrete = <error>]
-// CHECK:STDOUT:   %n.ref.loc21: %i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc21: ref <error> = deref %n.ref.loc21 [concrete = <error>]
-// CHECK:STDOUT:   %foo.ref.loc21: <error> = name_ref foo, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc26_5.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %empty_tuple.loc26: %empty_tuple.type = tuple_value () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc26_5.2: %empty_tuple.type = converted %.loc26_5.1, %empty_tuple.loc26 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc26_3: ref <error> = deref %.loc26_5.2 [concrete = <error>]
-// CHECK:STDOUT:   %.loc31_4.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:   %empty_tuple.loc31: %empty_tuple.type = tuple_value () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc31_4.2: %empty_tuple.type = converted %.loc31_4.1, %empty_tuple.loc31 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:   %.loc31_5: ref <error> = deref %.loc31_4.2 [concrete = <error>]
-// CHECK:STDOUT:   %foo.ref.loc31: <error> = name_ref foo, <error> [concrete = <error>]
-// CHECK:STDOUT:   %.loc36_5.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %empty_struct.loc36: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:   %.loc36_5.2: %empty_struct_type = converted %.loc36_5.1, %empty_struct.loc36 [concrete = constants.%empty_struct]
-// CHECK:STDOUT:   %.loc36_3: ref <error> = deref %.loc36_5.2 [concrete = <error>]
-// CHECK:STDOUT:   %.loc41_4.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %empty_struct.loc41: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:   %.loc41_4.2: %empty_struct_type = converted %.loc41_4.1, %empty_struct.loc41 [concrete = constants.%empty_struct]
-// CHECK:STDOUT:   %.loc41_5: ref <error> = deref %.loc41_4.2 [concrete = <error>]
-// CHECK:STDOUT:   %foo.ref.loc41: <error> = name_ref foo, <error> [concrete = <error>]
+// CHECK:STDOUT:   %n.ref.loc19: %i32 = name_ref n, %n
+// CHECK:STDOUT:   %.loc19: ref <error> = deref %n.ref.loc19 [concrete = <error>]
+// CHECK:STDOUT:   %n.ref.loc24: %i32 = name_ref n, %n
+// CHECK:STDOUT:   %.loc24: ref <error> = deref %n.ref.loc24 [concrete = <error>]
+// CHECK:STDOUT:   %foo.ref.loc24: <error> = name_ref foo, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc29_5.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %empty_tuple.loc29: %empty_tuple.type = tuple_value () [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc29_5.2: %empty_tuple.type = converted %.loc29_5.1, %empty_tuple.loc29 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc29_3: ref <error> = deref %.loc29_5.2 [concrete = <error>]
+// CHECK:STDOUT:   %.loc34_4.1: %empty_tuple.type = tuple_literal ()
+// CHECK:STDOUT:   %empty_tuple.loc34: %empty_tuple.type = tuple_value () [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc34_4.2: %empty_tuple.type = converted %.loc34_4.1, %empty_tuple.loc34 [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc34_5: ref <error> = deref %.loc34_4.2 [concrete = <error>]
+// CHECK:STDOUT:   %foo.ref.loc34: <error> = name_ref foo, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc39_5.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %empty_struct.loc39: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %.loc39_5.2: %empty_struct_type = converted %.loc39_5.1, %empty_struct.loc39 [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %.loc39_3: ref <error> = deref %.loc39_5.2 [concrete = <error>]
+// CHECK:STDOUT:   %.loc44_4.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %empty_struct.loc44: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %.loc44_4.2: %empty_struct_type = converted %.loc44_4.1, %empty_struct.loc44 [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %.loc44_5: ref <error> = deref %.loc44_4.2 [concrete = <error>]
+// CHECK:STDOUT:   %foo.ref.loc44: <error> = name_ref foo, <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_type.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_type.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_deref_type.carbon
@@ -53,9 +56,9 @@ var p2: i32->foo;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p.var: ref <error> = var %p.var_patt [concrete = <error>]
 // CHECK:STDOUT:   %.1: <error> = splice_block <error> [concrete = <error>] {
-// CHECK:STDOUT:     %int_32.loc18: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc18: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc18: ref <error> = deref %i32.loc18 [concrete = <error>]
+// CHECK:STDOUT:     %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc21: ref <error> = deref %i32.loc21 [concrete = <error>]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p: <error> = bind_name p, <error>
 // CHECK:STDOUT:   name_binding_decl {
@@ -64,9 +67,9 @@ var p2: i32->foo;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p2.var: ref <error> = var %p2.var_patt [concrete = <error>]
 // CHECK:STDOUT:   %.2: <error> = splice_block <error> [concrete = <error>] {
-// CHECK:STDOUT:     %int_32.loc23: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc23: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %.loc23: ref <error> = deref %i32.loc23 [concrete = <error>]
+// CHECK:STDOUT:     %int_32.loc26: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc26: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %.loc26: ref <error> = deref %i32.loc26 [concrete = <error>]
 // CHECK:STDOUT:     %foo.ref: <error> = name_ref foo, <error> [concrete = <error>]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %p2: <error> = bind_name p2, <error>

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -56,16 +59,16 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT:     %return.patt: %pattern_type.3c6 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.3c6 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc11_43: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:     %.loc11_44: type = converted %.loc11_43, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %ptr.loc11_44: type = ptr_type %.loc11_44 [concrete = constants.%ptr.c28]
-// CHECK:STDOUT:     %const.loc11_35: type = const_type %ptr.loc11_44 [concrete = constants.%const.987]
+// CHECK:STDOUT:     %.loc14_43: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:     %.loc14_44: type = converted %.loc14_43, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
+// CHECK:STDOUT:     %ptr.loc14_44: type = ptr_type %.loc14_44 [concrete = constants.%ptr.c28]
+// CHECK:STDOUT:     %const.loc14_35: type = const_type %ptr.loc14_44 [concrete = constants.%const.987]
 // CHECK:STDOUT:     %p.param: %ptr.bf9 = value_param call_param0
-// CHECK:STDOUT:     %.loc11_29: type = splice_block %ptr.loc11_29 [concrete = constants.%ptr.bf9] {
-// CHECK:STDOUT:       %.loc11_28: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:       %.loc11_21: type = converted %.loc11_28, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:       %const.loc11_21: type = const_type %.loc11_21 [concrete = constants.%const.c48]
-// CHECK:STDOUT:       %ptr.loc11_29: type = ptr_type %const.loc11_21 [concrete = constants.%ptr.bf9]
+// CHECK:STDOUT:     %.loc14_29: type = splice_block %ptr.loc14_29 [concrete = constants.%ptr.bf9] {
+// CHECK:STDOUT:       %.loc14_28: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:       %.loc14_21: type = converted %.loc14_28, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
+// CHECK:STDOUT:       %const.loc14_21: type = const_type %.loc14_21 [concrete = constants.%const.c48]
+// CHECK:STDOUT:       %ptr.loc14_29: type = ptr_type %const.loc14_21 [concrete = constants.%ptr.bf9]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.bf9 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %const.987 = out_param call_param1
@@ -76,7 +79,7 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT: fn @ConstMismatch(%p.param: %ptr.bf9) -> %const.987 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %ptr.bf9 = name_ref p, %p
-// CHECK:STDOUT:   %.loc19: %const.987 = converted %p.ref, <error> [concrete = <error>]
+// CHECK:STDOUT:   %.loc22: %const.987 = converted %p.ref, <error> [concrete = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/import.carbon
+++ b/toolchain/check/testdata/pointer/import.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/import.carbon

--- a/toolchain/check/testdata/pointer/nested_const.carbon
+++ b/toolchain/check/testdata/pointer/nested_const.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/nested_const.carbon
@@ -52,18 +55,18 @@ fn F(p: const (const (const i32*)*)) -> const i32 {
 // CHECK:STDOUT:     %return.patt: %pattern_type.a65 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.a65 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc12_47: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc12_47: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %const.loc12_41: type = const_type %i32.loc12_47 [concrete = constants.%const.20a]
+// CHECK:STDOUT:     %int_32.loc15_47: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc15_47: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %const.loc15_41: type = const_type %i32.loc15_47 [concrete = constants.%const.20a]
 // CHECK:STDOUT:     %p.param: %const.fa2 = value_param call_param0
-// CHECK:STDOUT:     %.loc12: type = splice_block %const.loc12_9 [concrete = constants.%const.fa2] {
-// CHECK:STDOUT:       %int_32.loc12_29: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc12_29: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %const.loc12_23: type = const_type %i32.loc12_29 [concrete = constants.%const.20a]
-// CHECK:STDOUT:       %ptr.loc12_32: type = ptr_type %const.loc12_23 [concrete = constants.%ptr.36b]
-// CHECK:STDOUT:       %const.loc12_16: type = const_type %ptr.loc12_32 [concrete = constants.%const.58f]
-// CHECK:STDOUT:       %ptr.loc12_34: type = ptr_type %const.loc12_16 [concrete = constants.%ptr.6e8]
-// CHECK:STDOUT:       %const.loc12_9: type = const_type %ptr.loc12_34 [concrete = constants.%const.fa2]
+// CHECK:STDOUT:     %.loc15: type = splice_block %const.loc15_9 [concrete = constants.%const.fa2] {
+// CHECK:STDOUT:       %int_32.loc15_29: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc15_29: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %const.loc15_23: type = const_type %i32.loc15_29 [concrete = constants.%const.20a]
+// CHECK:STDOUT:       %ptr.loc15_32: type = ptr_type %const.loc15_23 [concrete = constants.%ptr.36b]
+// CHECK:STDOUT:       %const.loc15_16: type = const_type %ptr.loc15_32 [concrete = constants.%const.58f]
+// CHECK:STDOUT:       %ptr.loc15_34: type = ptr_type %const.loc15_16 [concrete = constants.%ptr.6e8]
+// CHECK:STDOUT:       %const.loc15_9: type = const_type %ptr.loc15_34 [concrete = constants.%const.fa2]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %const.fa2 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %const.20a = out_param call_param1
@@ -74,10 +77,10 @@ fn F(p: const (const (const i32*)*)) -> const i32 {
 // CHECK:STDOUT: fn @F(%p.param: %const.fa2) -> %const.20a {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: %const.fa2 = name_ref p, %p
-// CHECK:STDOUT:   %.loc13_11.1: ref %const.58f = deref %p.ref
-// CHECK:STDOUT:   %.loc13_11.2: %const.58f = bind_value %.loc13_11.1
-// CHECK:STDOUT:   %.loc13_10.1: ref %const.20a = deref %.loc13_11.2
-// CHECK:STDOUT:   %.loc13_10.2: %const.20a = bind_value %.loc13_10.1
-// CHECK:STDOUT:   return %.loc13_10.2
+// CHECK:STDOUT:   %.loc16_11.1: ref %const.58f = deref %p.ref
+// CHECK:STDOUT:   %.loc16_11.2: %const.58f = bind_value %.loc16_11.1
+// CHECK:STDOUT:   %.loc16_10.1: ref %const.20a = deref %.loc16_11.2
+// CHECK:STDOUT:   %.loc16_10.2: %const.20a = bind_value %.loc16_10.1
+// CHECK:STDOUT:   return %.loc16_10.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/types.carbon
+++ b/toolchain/check/testdata/pointer/types.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/pointer/types.carbon
@@ -56,14 +59,14 @@ fn ConstPtr(p: const i32*) -> (const i32)* {
 // CHECK:STDOUT:     %return.patt: %pattern_type.fe8 = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.fe8 = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc11_20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc11_20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %ptr.loc11_23: type = ptr_type %i32.loc11_20 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:     %int_32.loc14_20: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc14_20: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %ptr.loc14_23: type = ptr_type %i32.loc14_20 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:     %p.param: %ptr.235 = value_param call_param0
-// CHECK:STDOUT:     %.loc11: type = splice_block %ptr.loc11_14 [concrete = constants.%ptr.235] {
-// CHECK:STDOUT:       %int_32.loc11_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc11_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %ptr.loc11_14: type = ptr_type %i32.loc11_11 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:     %.loc14: type = splice_block %ptr.loc14_14 [concrete = constants.%ptr.235] {
+// CHECK:STDOUT:       %int_32.loc14_11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc14_11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %ptr.loc14_14: type = ptr_type %i32.loc14_11 [concrete = constants.%ptr.235]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.235 = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.235 = out_param call_param1
@@ -75,16 +78,16 @@ fn ConstPtr(p: const i32*) -> (const i32)* {
 // CHECK:STDOUT:     %return.patt: %pattern_type.bff = return_slot_pattern [concrete]
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.bff = out_param_pattern %return.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %int_32.loc15_38: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:     %i32.loc15_38: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:     %const.loc15_32: type = const_type %i32.loc15_38 [concrete = constants.%const]
-// CHECK:STDOUT:     %ptr.loc15_42: type = ptr_type %const.loc15_32 [concrete = constants.%ptr.36b]
+// CHECK:STDOUT:     %int_32.loc18_38: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32.loc18_38: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %const.loc18_32: type = const_type %i32.loc18_38 [concrete = constants.%const]
+// CHECK:STDOUT:     %ptr.loc18_42: type = ptr_type %const.loc18_32 [concrete = constants.%ptr.36b]
 // CHECK:STDOUT:     %p.param: %ptr.36b = value_param call_param0
-// CHECK:STDOUT:     %.loc15: type = splice_block %ptr.loc15_25 [concrete = constants.%ptr.36b] {
-// CHECK:STDOUT:       %int_32.loc15_22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc15_22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %const.loc15_16: type = const_type %i32.loc15_22 [concrete = constants.%const]
-// CHECK:STDOUT:       %ptr.loc15_25: type = ptr_type %const.loc15_16 [concrete = constants.%ptr.36b]
+// CHECK:STDOUT:     %.loc18: type = splice_block %ptr.loc18_25 [concrete = constants.%ptr.36b] {
+// CHECK:STDOUT:       %int_32.loc18_22: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc18_22: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %const.loc18_16: type = const_type %i32.loc18_22 [concrete = constants.%const]
+// CHECK:STDOUT:       %ptr.loc18_25: type = ptr_type %const.loc18_16 [concrete = constants.%ptr.36b]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %p: %ptr.36b = bind_name p, %p.param
 // CHECK:STDOUT:     %return.param: ref %ptr.36b = out_param call_param1


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.