### PR TITLE
Use `linkonce_odr` linkage for specific functions.

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -372,11 +372,13 @@ auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id,
 
   auto function_type_info = BuildFunctionTypeInfo(function, specific_id);
 
+  auto linkage = specific_id.has_value() ? llvm::Function::LinkOnceODRLinkage
+                                         : llvm::Function::ExternalLinkage;
+
   Mangler m(*this);
   std::string mangled_name = m.Mangle(function_id, specific_id);
 
-  auto* llvm_function = llvm::Function::Create(function_type_info.type,
-                                               llvm::Function::ExternalLinkage,
+  auto* llvm_function = llvm::Function::Create(function_type_info.type, linkage,
                                                mangled_name, llvm_module());
 
   CARBON_CHECK(llvm_function->getName() == mangled_name,

--- a/toolchain/lower/testdata/function/generic/call.carbon
+++ b/toolchain/lower/testdata/function/generic/call.carbon
@@ -65,27 +65,27 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.15b1f98bd9cc0c5b(ptr %x) !dbg !19 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.15b1f98bd9cc0c5b(ptr %x) !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.2cc450fc05045897(ptr %x) !dbg !21 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.2cc450fc05045897(ptr %x) !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !23 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !25 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.66be507887ceee78(double %x) !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !27 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !27 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !28
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -85,12 +85,12 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !22 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !22 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !24 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !25
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !26
@@ -120,12 +120,12 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %x, !dbg !44
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(double %x) !dbg !45 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.66be507887ceee78(double %x) !dbg !45 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !46
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !47 {
+// CHECK:STDOUT: define linkonce_odr double @_CG.Main.66be507887ceee78(double %x) !dbg !47 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !48
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !49
@@ -155,37 +155,37 @@ fn M() {
 // CHECK:STDOUT:   ret double %x, !dbg !67
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !68 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !68 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %x, !dbg !69
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !70 {
+// CHECK:STDOUT: define linkonce_odr %type @_CH.Main.5754c7a55c7cbe4a(%type %x) !dbg !70 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret %type %x, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CH.Main.66be507887ceee78(double %x) !dbg !72 {
+// CHECK:STDOUT: define linkonce_odr double @_CH.Main.66be507887ceee78(double %x) !dbg !72 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret double %x, !dbg !73
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.e8193710fd35b608(ptr %x) !dbg !74 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CH.Main.e8193710fd35b608(ptr %x) !dbg !74 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !75
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.04bf2edaaa84aa22(ptr %x) !dbg !76 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CH.Main.04bf2edaaa84aa22(ptr %x) !dbg !76 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !77
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CH.Main.bda010de15e6a5ad(ptr %x) !dbg !78 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CH.Main.bda010de15e6a5ad(ptr %x) !dbg !78 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CH.Main.15b1f98bd9cc0c5b(ptr sret({}) %return, ptr %x) !dbg !80 {
+// CHECK:STDOUT: define linkonce_odr void @_CH.Main.15b1f98bd9cc0c5b(ptr sret({}) %return, ptr %x) !dbg !80 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !81
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -54,19 +54,19 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !15 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !15 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !17 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %H.call = call i32 @_CH.Main.b88d1103f417c6d4(i32 %x), !dbg !18
 // CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !19
 // CHECK:STDOUT:   ret i32 %x, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !21 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.b88d1103f417c6d4(i32 %x) !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !22
 // CHECK:STDOUT:   ret i32 %x, !dbg !23

--- a/toolchain/lower/testdata/function/generic/call_dedup_ptr.carbon
+++ b/toolchain/lower/testdata/function/generic/call_dedup_ptr.carbon
@@ -47,17 +47,17 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !17 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !19 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !21 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !22
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call_deref_ptr.carbon
+++ b/toolchain/lower/testdata/function/generic/call_deref_ptr.carbon
@@ -60,45 +60,45 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.b88d1103f417c6d4(ptr %x) !dbg !14 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(ptr %x) !dbg !14 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %A.call = call %type @_CA.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !15
 // CHECK:STDOUT:   call void @_CB.Main.b88d1103f417c6d4(ptr %x), !dbg !16
 // CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CF.Main.66be507887ceee78(ptr %x) !dbg !18 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.66be507887ceee78(ptr %x) !dbg !18 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %A.call = call %type @_CA.Main.5754c7a55c7cbe4a(%type zeroinitializer), !dbg !19
 // CHECK:STDOUT:   call void @_CB.Main.66be507887ceee78(ptr %x), !dbg !20
 // CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CA.Main.5754c7a55c7cbe4a(%type %x) !dbg !22 {
+// CHECK:STDOUT: define linkonce_odr %type @_CA.Main.5754c7a55c7cbe4a(%type %x) !dbg !22 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret %type %x, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.b88d1103f417c6d4(ptr %x) !dbg !24 {
+// CHECK:STDOUT: define linkonce_odr void @_CB.Main.b88d1103f417c6d4(ptr %x) !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc25_5.2 = load i32, ptr %x, align 4, !dbg !25
 // CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %.loc25_5.2), !dbg !26
 // CHECK:STDOUT:   ret void, !dbg !27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.66be507887ceee78(ptr %x) !dbg !28 {
+// CHECK:STDOUT: define linkonce_odr void @_CB.Main.66be507887ceee78(ptr %x) !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc25_5.2 = load double, ptr %x, align 8, !dbg !29
 // CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %.loc25_5.2), !dbg !30
 // CHECK:STDOUT:   ret void, !dbg !31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x) !dbg !32 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CD.Main.b88d1103f417c6d4(i32 %x) !dbg !32 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %x, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x) !dbg !34 {
+// CHECK:STDOUT: define linkonce_odr double @_CD.Main.66be507887ceee78(double %x) !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret double %x, !dbg !35
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call_different_associated_const.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_associated_const.carbon
@@ -46,14 +46,14 @@ fn H() {
 // CHECK:STDOUT:   ret void, !dbg !9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CG.Main.47c020a542e13d96() !dbg !10 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.47c020a542e13d96() !dbg !10 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca i1, align 1, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 1, ptr %x.var), !dbg !11
 // CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CG.Main.a10ac7cbfa858009() !dbg !13 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.a10ac7cbfa858009() !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca i32, align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 4, ptr %x.var), !dbg !14

--- a/toolchain/lower/testdata/function/generic/call_different_impls.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_impls.carbon
@@ -57,13 +57,13 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CG.Main.2c436a64dfc3fd29() !dbg !16 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.2c436a64dfc3fd29() !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_CF.X.Main:I.Main"(), !dbg !17
 // CHECK:STDOUT:   ret void, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CG.Main.c124d41ebc08c32b() !dbg !19 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.c124d41ebc08c32b() !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_CF.Y.Main:I.Main"(), !dbg !20
 // CHECK:STDOUT:   ret void, !dbg !21

--- a/toolchain/lower/testdata/function/generic/call_impl_function.carbon
+++ b/toolchain/lower/testdata/function/generic/call_impl_function.carbon
@@ -69,7 +69,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CCallGenericMethod.Main.b330a91dfda257ee(i32 %x) !dbg !15 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CCallGenericMethod.Main.b330a91dfda257ee(i32 %x) !dbg !15 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc35_15 = call i32 @"_CF.ImplsSomeInterface.Main:SomeInterface.Main"(i32 %x), !dbg !16
 // CHECK:STDOUT:   ret i32 %.loc35_15, !dbg !17

--- a/toolchain/lower/testdata/function/generic/call_method.carbon
+++ b/toolchain/lower/testdata/function/generic/call_method.carbon
@@ -44,7 +44,7 @@ fn CallF() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !12 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CF.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %x, !dbg !13
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
@@ -66,7 +66,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !21
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !22
@@ -80,7 +80,7 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %F.call, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !27 {
+// CHECK:STDOUT: define linkonce_odr double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !27 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !28
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !29
@@ -94,7 +94,7 @@ fn M() {
 // CHECK:STDOUT:   ret double %F.call, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !34 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !35
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !36
@@ -108,7 +108,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %F.call, !dbg !40
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !41 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !41 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !42
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !43

--- a/toolchain/lower/testdata/function/generic/call_recursive_diamond.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_diamond.carbon
@@ -85,7 +85,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !21
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !22
@@ -107,7 +107,7 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %C.call, !dbg !29
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !30 {
+// CHECK:STDOUT: define linkonce_odr double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !31
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !32
@@ -129,7 +129,7 @@ fn M() {
 // CHECK:STDOUT:   ret double %C.call, !dbg !39
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !40 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !40 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !41
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !42
@@ -151,7 +151,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %C.call, !dbg !49
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !50 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !50 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !51
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc20, label %if.else.loc20, !dbg !52
@@ -173,56 +173,56 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %C.call, !dbg !59
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !60 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !60 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !61
 // CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !62
 // CHECK:STDOUT:   ret i32 %D.call, !dbg !63
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !64 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !64 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !65
 // CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !66
 // CHECK:STDOUT:   ret i32 %D.call, !dbg !67
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !68 {
+// CHECK:STDOUT: define linkonce_odr double @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !68 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !69
 // CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !70
 // CHECK:STDOUT:   ret double %D.call, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !72 {
+// CHECK:STDOUT: define linkonce_odr double @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !72 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !73
 // CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !74
 // CHECK:STDOUT:   ret double %D.call, !dbg !75
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !76 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !76 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !77
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !78
 // CHECK:STDOUT:   ret ptr %D.call, !dbg !79
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !80 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !80 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !81
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !82
 // CHECK:STDOUT:   ret ptr %D.call, !dbg !83
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !84 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !84 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 1), !dbg !85
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !86
 // CHECK:STDOUT:   ret ptr %D.call, !dbg !87
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !88 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !88 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %print.int = call i32 (ptr, ...) @printf(ptr @printf.int.format, i32 2), !dbg !89
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !90
@@ -231,28 +231,28 @@ fn M() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !92 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !92 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !93
 // CHECK:STDOUT:   %A.call = call i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !94
 // CHECK:STDOUT:   ret i32 %A.call, !dbg !95
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !96 {
+// CHECK:STDOUT: define linkonce_odr double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !96 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !97
 // CHECK:STDOUT:   %A.call = call double @_CA.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !98
 // CHECK:STDOUT:   ret double %A.call, !dbg !99
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !100 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !100 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !101
 // CHECK:STDOUT:   %A.call = call ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !102
 // CHECK:STDOUT:   ret ptr %A.call, !dbg !103
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !104 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !104 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !105
 // CHECK:STDOUT:   %A.call = call ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !106

--- a/toolchain/lower/testdata/function/generic/call_recursive_impl.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_impl.carbon
@@ -65,7 +65,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.2c436a64dfc3fd29(i32 %count) !dbg !16 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.2c436a64dfc3fd29(i32 %count) !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_CF.X.Main:I.Main"(), !dbg !17
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !18
@@ -80,7 +80,7 @@ fn Run() {
 // CHECK:STDOUT:   ret i32 %G.call, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.c124d41ebc08c32b(i32 %count) !dbg !24 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.c124d41ebc08c32b(i32 %count) !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_CF.Y.Main:I.Main"(), !dbg !25
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 0, !dbg !26

--- a/toolchain/lower/testdata/function/generic/call_recursive_mutual.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_mutual.carbon
@@ -68,7 +68,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !21
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !22
@@ -82,7 +82,7 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %G.call, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !27 {
+// CHECK:STDOUT: define linkonce_odr double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !27 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !28
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !29
@@ -96,7 +96,7 @@ fn M() {
 // CHECK:STDOUT:   ret double %G.call, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !34 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !35
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !36
@@ -110,7 +110,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !40
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !41 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !41 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !42
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !43
@@ -124,7 +124,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !47
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !48 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !48 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !49
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !50
@@ -138,7 +138,7 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %F.call, !dbg !54
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !55 {
+// CHECK:STDOUT: define linkonce_odr double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !55 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !56
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !57
@@ -152,7 +152,7 @@ fn M() {
 // CHECK:STDOUT:   ret double %F.call, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !62 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !62 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !63
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !64
@@ -166,7 +166,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %F.call, !dbg !68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !69 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !69 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 3, !dbg !70
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then, label %if.else, !dbg !71

--- a/toolchain/lower/testdata/function/generic/call_recursive_sccs_deep.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_sccs_deep.carbon
@@ -112,41 +112,41 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CA.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !21
 // CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !22
 // CHECK:STDOUT:   ret i32 %D.call, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !24 {
+// CHECK:STDOUT: define linkonce_odr double @_CA.Main.66be507887ceee78(double %x, i32 %count) !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CB.Main.66be507887ceee78(double %x, i32 %count), !dbg !25
 // CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %count), !dbg !26
 // CHECK:STDOUT:   ret double %D.call, !dbg !27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !28 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CA.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !29
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !30
 // CHECK:STDOUT:   ret ptr %D.call, !dbg !31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !32 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CA.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !32 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !33
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !34
 // CHECK:STDOUT:   ret ptr %D.call, !dbg !35
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !36 {
+// CHECK:STDOUT: define linkonce_odr void @_CB.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !36 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !37
 // CHECK:STDOUT:   ret void, !dbg !38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !39 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !39 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !40
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !41
@@ -168,13 +168,13 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %F.call, !dbg !48
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !49 {
+// CHECK:STDOUT: define linkonce_odr void @_CB.Main.66be507887ceee78(double %x, i32 %count) !dbg !49 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CC.Main.66be507887ceee78(double %x, i32 %count), !dbg !50
 // CHECK:STDOUT:   ret void, !dbg !51
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !52 {
+// CHECK:STDOUT: define linkonce_odr double @_CD.Main.66be507887ceee78(double %x, i32 %count) !dbg !52 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !53
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !54
@@ -196,13 +196,13 @@ fn M() {
 // CHECK:STDOUT:   ret double %F.call, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !62 {
+// CHECK:STDOUT: define linkonce_odr void @_CB.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !62 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !63
 // CHECK:STDOUT:   ret void, !dbg !64
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !65 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !65 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !66
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !67
@@ -224,13 +224,13 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %F.call, !dbg !74
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !75 {
+// CHECK:STDOUT: define linkonce_odr void @_CB.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !75 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !76
 // CHECK:STDOUT:   ret void, !dbg !77
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !78 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !78 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.greater = icmp sgt i32 %count, 4, !dbg !79
 // CHECK:STDOUT:   br i1 %int.greater, label %if.then.loc46, label %if.else.loc46, !dbg !80
@@ -252,7 +252,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %F.call, !dbg !87
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !88 {
+// CHECK:STDOUT: define linkonce_odr void @_CC.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !88 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !89
 // CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !90
@@ -267,19 +267,19 @@ fn M() {
 // CHECK:STDOUT:   ret void, !dbg !95
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CE.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !96 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CE.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !96 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !97
 // CHECK:STDOUT:   ret i32 %G.call, !dbg !98
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !99 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !99 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count), !dbg !100
 // CHECK:STDOUT:   ret i32 %G.call, !dbg !101
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !102 {
+// CHECK:STDOUT: define linkonce_odr void @_CC.Main.66be507887ceee78(double %x, i32 %count) !dbg !102 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !103
 // CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !104
@@ -294,19 +294,19 @@ fn M() {
 // CHECK:STDOUT:   ret void, !dbg !109
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CE.Main.66be507887ceee78(double %x, i32 %count) !dbg !110 {
+// CHECK:STDOUT: define linkonce_odr double @_CE.Main.66be507887ceee78(double %x, i32 %count) !dbg !110 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %count), !dbg !111
 // CHECK:STDOUT:   ret double %G.call, !dbg !112
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !113 {
+// CHECK:STDOUT: define linkonce_odr double @_CF.Main.66be507887ceee78(double %x, i32 %count) !dbg !113 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x, i32 %count), !dbg !114
 // CHECK:STDOUT:   ret double %G.call, !dbg !115
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !116 {
+// CHECK:STDOUT: define linkonce_odr void @_CC.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !116 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !117
 // CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !118
@@ -321,19 +321,19 @@ fn M() {
 // CHECK:STDOUT:   ret void, !dbg !123
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CE.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !124 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CE.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !124 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !125
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !126
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !127 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !127 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count), !dbg !128
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !129
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !130 {
+// CHECK:STDOUT: define linkonce_odr void @_CC.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !130 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.less_eq = icmp sle i32 %count, 2, !dbg !131
 // CHECK:STDOUT:   br i1 %int.less_eq, label %if.then, label %if.else, !dbg !132
@@ -348,13 +348,13 @@ fn M() {
 // CHECK:STDOUT:   ret void, !dbg !137
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CE.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !138 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CE.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !138 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !139
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !140
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !141 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !141 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count), !dbg !142
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !143
@@ -362,28 +362,28 @@ fn M() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !144 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.b88d1103f417c6d4(i32 %x, i32 %count) !dbg !144 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !145
 // CHECK:STDOUT:   %D.call = call i32 @_CD.Main.b88d1103f417c6d4(i32 %x, i32 %int.sadd), !dbg !146
 // CHECK:STDOUT:   ret i32 %D.call, !dbg !147
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !148 {
+// CHECK:STDOUT: define linkonce_odr double @_CG.Main.66be507887ceee78(double %x, i32 %count) !dbg !148 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !149
 // CHECK:STDOUT:   %D.call = call double @_CD.Main.66be507887ceee78(double %x, i32 %int.sadd), !dbg !150
 // CHECK:STDOUT:   ret double %D.call, !dbg !151
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !152 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.e8193710fd35b608(ptr %x, i32 %count) !dbg !152 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !153
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.e8193710fd35b608(ptr %x, i32 %int.sadd), !dbg !154
 // CHECK:STDOUT:   ret ptr %D.call, !dbg !155
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !156 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.04bf2edaaa84aa22(ptr %x, i32 %count) !dbg !156 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %int.sadd = add i32 %count, 1, !dbg !157
 // CHECK:STDOUT:   %D.call = call ptr @_CD.Main.04bf2edaaa84aa22(ptr %x, i32 %int.sadd), !dbg !158

--- a/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
+++ b/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
@@ -80,43 +80,43 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !25 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.e8193710fd35b608(ptr %x) !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.e8193710fd35b608(ptr %x), !dbg !26
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !28 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.04bf2edaaa84aa22(ptr %x) !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.04bf2edaaa84aa22(ptr %x), !dbg !29
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !30
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !31 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CF.Main.bda010de15e6a5ad(ptr %x) !dbg !31 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call ptr @_CG.Main.bda010de15e6a5ad(ptr %x), !dbg !32
 // CHECK:STDOUT:   ret ptr %G.call, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !34 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.b88d1103f417c6d4(i32 %x) !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call i32 @_CG.Main.b88d1103f417c6d4(i32 %x), !dbg !35
 // CHECK:STDOUT:   ret i32 %G.call, !dbg !36
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CF.Main.66be507887ceee78(double %x) !dbg !37 {
+// CHECK:STDOUT: define linkonce_odr double @_CF.Main.66be507887ceee78(double %x) !dbg !37 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call double @_CG.Main.66be507887ceee78(double %x), !dbg !38
 // CHECK:STDOUT:   ret double %G.call, !dbg !39
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !40 {
+// CHECK:STDOUT: define linkonce_odr %type @_CF.Main.5754c7a55c7cbe4a(%type %x) !dbg !40 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %G.call = call %type @_CG.Main.5754c7a55c7cbe4a(%type %x), !dbg !41
 // CHECK:STDOUT:   ret %type %G.call, !dbg !42
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.e8193710fd35b608(ptr %x) !dbg !43 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.e8193710fd35b608(ptr %x) !dbg !43 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !44
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !44
@@ -124,7 +124,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !46
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.04bf2edaaa84aa22(ptr %x) !dbg !47 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.04bf2edaaa84aa22(ptr %x) !dbg !47 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !48
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !48
@@ -132,7 +132,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !50
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CG.Main.bda010de15e6a5ad(ptr %x) !dbg !51 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.bda010de15e6a5ad(ptr %x) !dbg !51 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !52
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !52
@@ -140,7 +140,7 @@ fn M() {
 // CHECK:STDOUT:   ret ptr %Cfn.call, !dbg !54
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !55 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.b88d1103f417c6d4(i32 %x) !dbg !55 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !56
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !56
@@ -148,7 +148,7 @@ fn M() {
 // CHECK:STDOUT:   ret i32 %Cfn.call, !dbg !58
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CG.Main.66be507887ceee78(double %x) !dbg !59 {
+// CHECK:STDOUT: define linkonce_odr double @_CG.Main.66be507887ceee78(double %x) !dbg !59 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !60
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !60
@@ -156,7 +156,7 @@ fn M() {
 // CHECK:STDOUT:   ret double %Cfn.call, !dbg !62
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !63 {
+// CHECK:STDOUT: define linkonce_odr %type @_CG.Main.5754c7a55c7cbe4a(%type %x) !dbg !63 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !64
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(i64 0, ptr %c.var), !dbg !64
@@ -164,32 +164,32 @@ fn M() {
 // CHECK:STDOUT:   ret %type %Cfn.call, !dbg !66
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CCfn.C.Main.e8193710fd35b608(ptr %self, ptr %x) !dbg !67 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CCfn.C.Main.e8193710fd35b608(ptr %self, ptr %x) !dbg !67 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CCfn.C.Main.04bf2edaaa84aa22(ptr %self, ptr %x) !dbg !69 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CCfn.C.Main.04bf2edaaa84aa22(ptr %self, ptr %x) !dbg !69 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !70
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @_CCfn.C.Main.bda010de15e6a5ad(ptr %self, ptr %x) !dbg !71 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CCfn.C.Main.bda010de15e6a5ad(ptr %self, ptr %x) !dbg !71 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret ptr %x, !dbg !72
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @_CCfn.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !73 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CCfn.C.Main.b88d1103f417c6d4(ptr %self, i32 %x) !dbg !73 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %x, !dbg !74
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define double @_CCfn.C.Main.66be507887ceee78(ptr %self, double %x) !dbg !75 {
+// CHECK:STDOUT: define linkonce_odr double @_CCfn.C.Main.66be507887ceee78(ptr %self, double %x) !dbg !75 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret double %x, !dbg !76
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define %type @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %self, %type %x) !dbg !77 {
+// CHECK:STDOUT: define linkonce_odr %type @_CCfn.C.Main.5754c7a55c7cbe4a(ptr %self, %type %x) !dbg !77 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret %type %x, !dbg !78
 // CHECK:STDOUT: }


### PR DESCRIPTION
The same specific function will (eventually) be emitted as part of lowering multiple different source files, so don't give them unique external linkage.