### PR TITLE
Add an int min_prelude

### DIFF
--- a/toolchain/testing/min_prelude/int.carbon
+++ b/toolchain/testing/min_prelude/int.carbon
@@ -1,0 +1,52 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// A minimal prelude for testing using `Int` or `i32`; required for arrays.
+package Core library "prelude";
+
+interface As(Dest:! type) {
+  fn Convert[self: Self]() -> Dest;
+}
+
+interface ImplicitAs(Dest:! type) {
+  // TODO: extend As(Dest);
+  fn Convert[self: Self]() -> Dest;
+}
+
+fn IntLiteral() -> type = "int_literal.make_type";
+
+private fn MakeInt(size: IntLiteral()) -> type = "int.make_type_signed";
+
+class Int(N:! IntLiteral()) {
+  adapt MakeInt(N);
+}
+
+// Conversions.
+
+impl forall [To:! IntLiteral()] IntLiteral() as ImplicitAs(Int(To)) {
+  fn Convert[self: Self]() -> Int(To) = "int.convert_checked";
+}
+
+impl forall [From:! IntLiteral()] Int(From) as ImplicitAs(IntLiteral()) {
+  fn Convert[self: Self]() -> IntLiteral() = "int.convert_checked";
+}
+
+// TODO: Remove these once ImplicitAs extends As.
+impl forall [To:! IntLiteral()] IntLiteral() as As(Int(To)) {
+  fn Convert[self: Self]() -> Int(To) = "int.convert_checked";
+}
+
+impl forall [From:! IntLiteral()] Int(From) as As(IntLiteral()) {
+  fn Convert[self: Self]() -> IntLiteral() = "int.convert_checked";
+}
+
+// Support testing negative values.
+
+interface Negate {
+  fn Op[self: Self]() -> Self;
+}
+
+impl IntLiteral() as Negate {
+  fn Op[self: Self]() -> Self = "int.snegate";
+}


### PR DESCRIPTION
The general intent here is to support basic use of `i32` and similar integer types in min_prelude tests, without all the various arithmetic support.

This is in support of #5547 and #5549. However, I was originally asking for this to be reviewed as part of #5546 rather than either of those PRs, and I've retracted #5546 due to [the discussion on Discord about test change complexity](https://discord.com/channels/655572317891461132/655578254970716160/1377406366200758293). So, to try to still get this in (and then merge the already-approved #5547 and #5549), splitting out this file.

Note this is actually the form of the prelude in #5549, which was adding negate -- it felt better to me to add that together as long as I'm splitting it out.