### PR TITLE
Revert "Add FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION to fuzzer mode and enable DCHECKs under fuzzing (#5489)"

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -661,20 +661,12 @@ def _impl(ctx):
 
     fuzzer = feature(
         name = "fuzzer",
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions + all_link_actions,
-                flag_groups = [flag_group(flags = [
-                    "-fsanitize=fuzzer-no-link",
-                ])],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [flag_group(flags = [
-                    "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION",
-                ])],
-            ),
-        ],
+        flag_sets = [flag_set(
+            actions = all_compile_actions + all_link_actions,
+            flag_groups = [flag_group(flags = [
+                "-fsanitize=fuzzer-no-link",
+            ])],
+        )],
     )
 
     # Clang HARDENED_MODE has 4 possible values:

--- a/common/check.h
+++ b/common/check.h
@@ -24,11 +24,8 @@ namespace Carbon {
   CARBON_INTERNAL_CHECK_CONDITION(condition) \
   ? (void)0 : CARBON_INTERNAL_CHECK(condition __VA_OPT__(, ) __VA_ARGS__)
 
-// DCHECK calls CHECK in debug or fuzzing mode, and does nothing otherwise.
-//
-// Note FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION is a standard define coming
-// from LibFuzzer: https://llvm.org/docs/LibFuzzer.html
-#if !defined(NDEBUG) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+// DCHECK calls CHECK in debug mode, and does nothing otherwise.
+#ifndef NDEBUG
 #define CARBON_DCHECK(condition, ...) \
   CARBON_CHECK(condition __VA_OPT__(, ) __VA_ARGS__)
 #else

--- a/common/raw_hashtable_metadata_group.h
+++ b/common/raw_hashtable_metadata_group.h
@@ -480,12 +480,11 @@ class MetadataGroup : public Printable<MetadataGroup> {
   friend class BenchmarkSimdMetadataGroup;
 
   // All SIMD variants that we have an implementation for should be enabled for
-  // debugging and fuzzing. This lets us maintain a SIMD implementation even if
-  // it is not used due to performance reasons, and easily re-enable it if the
-  // performance changes.
+  // debugging. This lets us maintain a SIMD implementation even if it is not
+  // used due to performance reasons, and easily re-enable it if the performance
+  // changes.
   static constexpr bool DebugSimd =
-#if (!defined(NDEBUG) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)) && \
-    (CARBON_NEON_SIMD_SUPPORT || CARBON_X86_SIMD_SUPPORT)
+#if !defined(NDEBUG) && (CARBON_NEON_SIMD_SUPPORT || CARBON_X86_SIMD_SUPPORT)
       true;
 #else
       false;


### PR DESCRIPTION
This reverts commit 1889ee3904d24ede61b626854e3168819d6eb785.

We have identified that this is causing ODR violations, because the `fuzzer` feature is being added `cc_fuzz_test` targets, and thus any includes they make, but not to the rest of the build. Any include that is seen from both places has ODR violations if it branches on FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION.

We need to apply fuzzer globally when building fuzz targets somehow, or not set different defines in fuzzer.
