### PR TITLE
Add range flag settings to where_expr files

### DIFF
--- a/toolchain/check/testdata/where_expr/constraints.carbon
+++ b/toolchain/check/testdata/where_expr/constraints.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/where_expr/constraints.carbon

--- a/toolchain/check/testdata/where_expr/designator.carbon
+++ b/toolchain/check/testdata/where_expr/designator.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/where_expr/designator.carbon

--- a/toolchain/check/testdata/where_expr/dot_self_index.carbon
+++ b/toolchain/check/testdata/where_expr/dot_self_index.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/where_expr/dot_self_index.carbon
@@ -98,7 +101,7 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:   %Empty.decl: %Empty.type.d5a = interface_decl @Empty [concrete = constants.%Empty.generic] {
 // CHECK:STDOUT:     %W.patt: %pattern_type.98f = symbolic_binding_pattern W, 0 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %W.loc11_17.1: type = bind_symbolic_name W, 0 [symbolic = %W.loc11_17.2 (constants.%W)]
+// CHECK:STDOUT:     %W.loc14_17.1: type = bind_symbolic_name W, 0 [symbolic = %W.loc14_17.2 (constants.%W)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %H.decl: %H.type = fn_decl @H [concrete = constants.%H] {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
@@ -106,49 +109,49 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:     %U.param_patt: @H.%pattern_type (%pattern_type.668) = value_param_pattern %U.patt, call_param0 [concrete]
 // CHECK:STDOUT:     %V.patt: %pattern_type.98f = symbolic_binding_pattern V, 1 [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.loc18_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc18_6.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc21_6.1: type = bind_symbolic_name T, 0 [symbolic = %T.loc21_6.2 (constants.%T)]
 // CHECK:STDOUT:     %U.param: @H.%Empty_where.type (%Empty_where.type.b73) = value_param call_param0
-// CHECK:STDOUT:     %.loc18_28.1: type = splice_block %.loc18_28.2 [symbolic = %Empty_where.type (constants.%Empty_where.type.b73)] {
+// CHECK:STDOUT:     %.loc21_28.1: type = splice_block %.loc21_28.2 [symbolic = %Empty_where.type (constants.%Empty_where.type.b73)] {
 // CHECK:STDOUT:       %Empty.ref: %Empty.type.d5a = name_ref Empty, file.%Empty.decl [concrete = constants.%Empty.generic]
-// CHECK:STDOUT:       %T.ref.loc18_25: type = name_ref T, %T.loc18_6.1 [symbolic = %T.loc18_6.2 (constants.%T)]
-// CHECK:STDOUT:       %Empty.type.loc18_26.1: type = facet_type <@Empty, @Empty(constants.%T)> [symbolic = %Empty.type.loc18_26.2 (constants.%Empty.type.3e5fde.2)]
-// CHECK:STDOUT:       %.Self.1: @H.%Empty.type.loc18_26.2 (%Empty.type.3e5fde.2) = bind_symbolic_name .Self [symbolic = %.Self.2 (constants.%.Self.c95)]
-// CHECK:STDOUT:       %.Self.ref: @H.%Empty.type.loc18_26.2 (%Empty.type.3e5fde.2) = name_ref .Self, %.Self.1 [symbolic = %.Self.2 (constants.%.Self.c95)]
-// CHECK:STDOUT:       %.loc18_34.1: @H.%Empty.assoc_type (%Empty.assoc_type.3cf698.2) = specific_constant @A.%assoc0, @Empty(constants.%T) [symbolic = %assoc0 (constants.%assoc0.3715ce.2)]
-// CHECK:STDOUT:       %A.ref: @H.%Empty.assoc_type (%Empty.assoc_type.3cf698.2) = name_ref A, %.loc18_34.1 [symbolic = %assoc0 (constants.%assoc0.3715ce.2)]
-// CHECK:STDOUT:       %.Self.as_type.loc18_34.1: type = facet_access_type %.Self.ref [symbolic = %.Self.as_type.loc18_34.2 (constants.%.Self.as_type.a75)]
-// CHECK:STDOUT:       %.loc18_34.2: type = converted %.Self.ref, %.Self.as_type.loc18_34.1 [symbolic = %.Self.as_type.loc18_34.2 (constants.%.Self.as_type.a75)]
-// CHECK:STDOUT:       %impl.elem0.loc18_34.1: type = impl_witness_access constants.%Empty.lookup_impl_witness.b1d, element0 [symbolic = %impl.elem0.loc18_34.2 (constants.%impl.elem0.c6e)]
-// CHECK:STDOUT:       %T.ref.loc18_39: type = name_ref T, %T.loc18_6.1 [symbolic = %T.loc18_6.2 (constants.%T)]
-// CHECK:STDOUT:       %ptr.loc18_40.1: type = ptr_type %T.ref.loc18_39 [symbolic = %ptr.loc18_40.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:       %.loc18_28.2: type = where_expr %.Self.1 [symbolic = %Empty_where.type (constants.%Empty_where.type.b73)] {
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc18_34.1, %ptr.loc18_40.1
+// CHECK:STDOUT:       %T.ref.loc21_25: type = name_ref T, %T.loc21_6.1 [symbolic = %T.loc21_6.2 (constants.%T)]
+// CHECK:STDOUT:       %Empty.type.loc21_26.1: type = facet_type <@Empty, @Empty(constants.%T)> [symbolic = %Empty.type.loc21_26.2 (constants.%Empty.type.3e5fde.2)]
+// CHECK:STDOUT:       %.Self.1: @H.%Empty.type.loc21_26.2 (%Empty.type.3e5fde.2) = bind_symbolic_name .Self [symbolic = %.Self.2 (constants.%.Self.c95)]
+// CHECK:STDOUT:       %.Self.ref: @H.%Empty.type.loc21_26.2 (%Empty.type.3e5fde.2) = name_ref .Self, %.Self.1 [symbolic = %.Self.2 (constants.%.Self.c95)]
+// CHECK:STDOUT:       %.loc21_34.1: @H.%Empty.assoc_type (%Empty.assoc_type.3cf698.2) = specific_constant @A.%assoc0, @Empty(constants.%T) [symbolic = %assoc0 (constants.%assoc0.3715ce.2)]
+// CHECK:STDOUT:       %A.ref: @H.%Empty.assoc_type (%Empty.assoc_type.3cf698.2) = name_ref A, %.loc21_34.1 [symbolic = %assoc0 (constants.%assoc0.3715ce.2)]
+// CHECK:STDOUT:       %.Self.as_type.loc21_34.1: type = facet_access_type %.Self.ref [symbolic = %.Self.as_type.loc21_34.2 (constants.%.Self.as_type.a75)]
+// CHECK:STDOUT:       %.loc21_34.2: type = converted %.Self.ref, %.Self.as_type.loc21_34.1 [symbolic = %.Self.as_type.loc21_34.2 (constants.%.Self.as_type.a75)]
+// CHECK:STDOUT:       %impl.elem0.loc21_34.1: type = impl_witness_access constants.%Empty.lookup_impl_witness.b1d, element0 [symbolic = %impl.elem0.loc21_34.2 (constants.%impl.elem0.c6e)]
+// CHECK:STDOUT:       %T.ref.loc21_39: type = name_ref T, %T.loc21_6.1 [symbolic = %T.loc21_6.2 (constants.%T)]
+// CHECK:STDOUT:       %ptr.loc21_40.1: type = ptr_type %T.ref.loc21_39 [symbolic = %ptr.loc21_40.2 (constants.%ptr.79f)]
+// CHECK:STDOUT:       %.loc21_28.2: type = where_expr %.Self.1 [symbolic = %Empty_where.type (constants.%Empty_where.type.b73)] {
+// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc21_34.1, %ptr.loc21_40.1
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %U: @H.%Empty_where.type (%Empty_where.type.b73) = bind_name U, %U.param
-// CHECK:STDOUT:     %V.loc18_43.1: type = bind_symbolic_name V, 1 [symbolic = %V.loc18_43.2 (constants.%V)]
+// CHECK:STDOUT:     %V.loc21_43.1: type = bind_symbolic_name V, 1 [symbolic = %V.loc21_43.2 (constants.%V)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
 // CHECK:STDOUT:     %U.patt: %pattern_type.012 = binding_pattern U [concrete]
 // CHECK:STDOUT:     %U.param_patt: %pattern_type.012 = value_param_pattern %U.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.param: %Empty_where.type.fc2 = value_param call_param0
-// CHECK:STDOUT:     %.loc20_20.1: type = splice_block %.loc20_20.2 [concrete = constants.%Empty_where.type.fc2] {
+// CHECK:STDOUT:     %.loc23_20.1: type = splice_block %.loc23_20.2 [concrete = constants.%Empty_where.type.fc2] {
 // CHECK:STDOUT:       %Empty.ref: %Empty.type.d5a = name_ref Empty, file.%Empty.decl [concrete = constants.%Empty.generic]
-// CHECK:STDOUT:       %int_32.loc20_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc20_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %int_32.loc23_15: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc23_15: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:       %Empty.type: type = facet_type <@Empty, @Empty(constants.%i32)> [concrete = constants.%Empty.type.f0b]
 // CHECK:STDOUT:       %.Self: %Empty.type.f0b = bind_symbolic_name .Self [symbolic_self = constants.%.Self.e6e]
 // CHECK:STDOUT:       %.Self.ref: %Empty.type.f0b = name_ref .Self, %.Self [symbolic_self = constants.%.Self.e6e]
-// CHECK:STDOUT:       %.loc20_26.1: %Empty.assoc_type.7c7 = specific_constant @A.%assoc0, @Empty(constants.%i32) [concrete = constants.%assoc0.758]
-// CHECK:STDOUT:       %A.ref: %Empty.assoc_type.7c7 = name_ref A, %.loc20_26.1 [concrete = constants.%assoc0.758]
+// CHECK:STDOUT:       %.loc23_26.1: %Empty.assoc_type.7c7 = specific_constant @A.%assoc0, @Empty(constants.%i32) [concrete = constants.%assoc0.758]
+// CHECK:STDOUT:       %A.ref: %Empty.assoc_type.7c7 = name_ref A, %.loc23_26.1 [concrete = constants.%assoc0.758]
 // CHECK:STDOUT:       %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type.920]
-// CHECK:STDOUT:       %.loc20_26.2: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type.920]
+// CHECK:STDOUT:       %.loc23_26.2: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type.920]
 // CHECK:STDOUT:       %impl.elem0: type = impl_witness_access constants.%Empty.lookup_impl_witness.4e3, element0 [symbolic_self = constants.%impl.elem0.64a]
-// CHECK:STDOUT:       %int_32.loc20_31: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:       %i32.loc20_31: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %ptr: type = ptr_type %i32.loc20_31 [concrete = constants.%ptr.235]
-// CHECK:STDOUT:       %.loc20_20.2: type = where_expr %.Self [concrete = constants.%Empty_where.type.fc2] {
+// CHECK:STDOUT:       %int_32.loc23_31: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:       %i32.loc23_31: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:       %ptr: type = ptr_type %i32.loc23_31 [concrete = constants.%ptr.235]
+// CHECK:STDOUT:       %.loc23_20.2: type = where_expr %.Self [concrete = constants.%Empty_where.type.fc2] {
 // CHECK:STDOUT:         requirement_rewrite %impl.elem0, %ptr
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
@@ -156,13 +159,13 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic interface @Empty(%W.loc11_17.1: type) {
-// CHECK:STDOUT:   %W.loc11_17.2: type = bind_symbolic_name W, 0 [symbolic = %W.loc11_17.2 (constants.%W)]
+// CHECK:STDOUT: generic interface @Empty(%W.loc14_17.1: type) {
+// CHECK:STDOUT:   %W.loc14_17.2: type = bind_symbolic_name W, 0 [symbolic = %W.loc14_17.2 (constants.%W)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Empty.type: type = facet_type <@Empty, @Empty(%W.loc11_17.2)> [symbolic = %Empty.type (constants.%Empty.type.3e5fde.1)]
+// CHECK:STDOUT:   %Empty.type: type = facet_type <@Empty, @Empty(%W.loc14_17.2)> [symbolic = %Empty.type (constants.%Empty.type.3e5fde.1)]
 // CHECK:STDOUT:   %Self.2: @Empty.%Empty.type (%Empty.type.3e5fde.1) = bind_symbolic_name Self, 1 [symbolic = %Self.2 (constants.%Self.8c5170.1)]
-// CHECK:STDOUT:   %Empty.assoc_type: type = assoc_entity_type @Empty, @Empty(%W.loc11_17.2) [symbolic = %Empty.assoc_type (constants.%Empty.assoc_type.3cf698.1)]
+// CHECK:STDOUT:   %Empty.assoc_type: type = assoc_entity_type @Empty, @Empty(%W.loc14_17.2) [symbolic = %Empty.assoc_type (constants.%Empty.assoc_type.3cf698.1)]
 // CHECK:STDOUT:   %assoc0: @Empty.%Empty.assoc_type (%Empty.assoc_type.3cf698.1) = assoc_entity element0, %A [symbolic = %assoc0 (constants.%assoc0.3715ce.1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
@@ -178,27 +181,27 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic assoc_const @A(@Empty.%W.loc11_17.1: type, @Empty.%Self.1: @Empty.%Empty.type (%Empty.type.3e5fde.1)) {
+// CHECK:STDOUT: generic assoc_const @A(@Empty.%W.loc14_17.1: type, @Empty.%Self.1: @Empty.%Empty.type (%Empty.type.3e5fde.1)) {
 // CHECK:STDOUT:   assoc_const A:! type;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @H(%T.loc18_6.1: type, %V.loc18_43.1: type) {
-// CHECK:STDOUT:   %T.loc18_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc18_6.2 (constants.%T)]
-// CHECK:STDOUT:   %Empty.type.loc18_26.2: type = facet_type <@Empty, @Empty(%T.loc18_6.2)> [symbolic = %Empty.type.loc18_26.2 (constants.%Empty.type.3e5fde.2)]
-// CHECK:STDOUT:   %.Self.2: @H.%Empty.type.loc18_26.2 (%Empty.type.3e5fde.2) = bind_symbolic_name .Self [symbolic = %.Self.2 (constants.%.Self.c95)]
-// CHECK:STDOUT:   %require_complete.loc18_34: <witness> = require_complete_type %Empty.type.loc18_26.2 [symbolic = %require_complete.loc18_34 (constants.%require_complete.22f)]
-// CHECK:STDOUT:   %Empty.assoc_type: type = assoc_entity_type @Empty, @Empty(%T.loc18_6.2) [symbolic = %Empty.assoc_type (constants.%Empty.assoc_type.3cf698.2)]
+// CHECK:STDOUT: generic fn @H(%T.loc21_6.1: type, %V.loc21_43.1: type) {
+// CHECK:STDOUT:   %T.loc21_6.2: type = bind_symbolic_name T, 0 [symbolic = %T.loc21_6.2 (constants.%T)]
+// CHECK:STDOUT:   %Empty.type.loc21_26.2: type = facet_type <@Empty, @Empty(%T.loc21_6.2)> [symbolic = %Empty.type.loc21_26.2 (constants.%Empty.type.3e5fde.2)]
+// CHECK:STDOUT:   %.Self.2: @H.%Empty.type.loc21_26.2 (%Empty.type.3e5fde.2) = bind_symbolic_name .Self [symbolic = %.Self.2 (constants.%.Self.c95)]
+// CHECK:STDOUT:   %require_complete.loc21_34: <witness> = require_complete_type %Empty.type.loc21_26.2 [symbolic = %require_complete.loc21_34 (constants.%require_complete.22f)]
+// CHECK:STDOUT:   %Empty.assoc_type: type = assoc_entity_type @Empty, @Empty(%T.loc21_6.2) [symbolic = %Empty.assoc_type (constants.%Empty.assoc_type.3cf698.2)]
 // CHECK:STDOUT:   %assoc0: @H.%Empty.assoc_type (%Empty.assoc_type.3cf698.2) = assoc_entity element0, @Empty.%A [symbolic = %assoc0 (constants.%assoc0.3715ce.2)]
-// CHECK:STDOUT:   %.Self.as_type.loc18_34.2: type = facet_access_type %.Self.2 [symbolic = %.Self.as_type.loc18_34.2 (constants.%.Self.as_type.a75)]
-// CHECK:STDOUT:   %Empty.lookup_impl_witness: <witness> = lookup_impl_witness %.Self.2, @Empty, @Empty(%T.loc18_6.2) [symbolic = %Empty.lookup_impl_witness (constants.%Empty.lookup_impl_witness.b1d)]
-// CHECK:STDOUT:   %impl.elem0.loc18_34.2: type = impl_witness_access %Empty.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc18_34.2 (constants.%impl.elem0.c6e)]
-// CHECK:STDOUT:   %ptr.loc18_40.2: type = ptr_type %T.loc18_6.2 [symbolic = %ptr.loc18_40.2 (constants.%ptr.79f)]
-// CHECK:STDOUT:   %Empty_where.type: type = facet_type <@Empty, @Empty(%T.loc18_6.2) where %impl.elem0.loc18_34.2 = %ptr.loc18_40.2> [symbolic = %Empty_where.type (constants.%Empty_where.type.b73)]
+// CHECK:STDOUT:   %.Self.as_type.loc21_34.2: type = facet_access_type %.Self.2 [symbolic = %.Self.as_type.loc21_34.2 (constants.%.Self.as_type.a75)]
+// CHECK:STDOUT:   %Empty.lookup_impl_witness: <witness> = lookup_impl_witness %.Self.2, @Empty, @Empty(%T.loc21_6.2) [symbolic = %Empty.lookup_impl_witness (constants.%Empty.lookup_impl_witness.b1d)]
+// CHECK:STDOUT:   %impl.elem0.loc21_34.2: type = impl_witness_access %Empty.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc21_34.2 (constants.%impl.elem0.c6e)]
+// CHECK:STDOUT:   %ptr.loc21_40.2: type = ptr_type %T.loc21_6.2 [symbolic = %ptr.loc21_40.2 (constants.%ptr.79f)]
+// CHECK:STDOUT:   %Empty_where.type: type = facet_type <@Empty, @Empty(%T.loc21_6.2) where %impl.elem0.loc21_34.2 = %ptr.loc21_40.2> [symbolic = %Empty_where.type (constants.%Empty_where.type.b73)]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %Empty_where.type [symbolic = %pattern_type (constants.%pattern_type.668)]
-// CHECK:STDOUT:   %V.loc18_43.2: type = bind_symbolic_name V, 1 [symbolic = %V.loc18_43.2 (constants.%V)]
+// CHECK:STDOUT:   %V.loc21_43.2: type = bind_symbolic_name V, 1 [symbolic = %V.loc21_43.2 (constants.%V)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc18_17: <witness> = require_complete_type %Empty_where.type [symbolic = %require_complete.loc18_17 (constants.%require_complete.af8)]
+// CHECK:STDOUT:   %require_complete.loc21_17: <witness> = require_complete_type %Empty_where.type [symbolic = %require_complete.loc21_17 (constants.%require_complete.af8)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%U.param: @H.%Empty_where.type (%Empty_where.type.b73)) {
 // CHECK:STDOUT:   !entry:
@@ -209,25 +212,25 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT: fn @G(%U.param: %Empty_where.type.fc2) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %H.ref: %H.type = name_ref H, file.%H.decl [concrete = constants.%H]
-// CHECK:STDOUT:   %int_32.loc21: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
-// CHECK:STDOUT:   %i32.loc21: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   %int_32.loc24: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:   %i32.loc24: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   %U.ref: %Empty_where.type.fc2 = name_ref U, %U
 // CHECK:STDOUT:   %bool.make_type: init type = call constants.%Bool() [concrete = bool]
-// CHECK:STDOUT:   %.loc21_17.1: type = value_of_initializer %bool.make_type [concrete = bool]
-// CHECK:STDOUT:   %.loc21_17.2: type = converted %bool.make_type, %.loc21_17.1 [concrete = bool]
+// CHECK:STDOUT:   %.loc24_17.1: type = value_of_initializer %bool.make_type [concrete = bool]
+// CHECK:STDOUT:   %.loc24_17.2: type = converted %bool.make_type, %.loc24_17.1 [concrete = bool]
 // CHECK:STDOUT:   %H.specific_fn: <specific function> = specific_function %H.ref, @H(constants.%i32, bool) [concrete = constants.%H.specific_fn]
 // CHECK:STDOUT:   %H.call: init %empty_tuple.type = call %H.specific_fn(%U.ref)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Empty(constants.%W) {
-// CHECK:STDOUT:   %W.loc11_17.2 => constants.%W
+// CHECK:STDOUT:   %W.loc14_17.2 => constants.%W
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @A(constants.%W, constants.%Self.8c5170.1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Empty(constants.%T) {
-// CHECK:STDOUT:   %W.loc11_17.2 => constants.%T
+// CHECK:STDOUT:   %W.loc14_17.2 => constants.%T
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Empty.type => constants.%Empty.type.3e5fde.2
@@ -239,23 +242,23 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT: specific @A(constants.%T, constants.%Empty.facet.e74) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%T, constants.%V) {
-// CHECK:STDOUT:   %T.loc18_6.2 => constants.%T
-// CHECK:STDOUT:   %Empty.type.loc18_26.2 => constants.%Empty.type.3e5fde.2
+// CHECK:STDOUT:   %T.loc21_6.2 => constants.%T
+// CHECK:STDOUT:   %Empty.type.loc21_26.2 => constants.%Empty.type.3e5fde.2
 // CHECK:STDOUT:   %.Self.2 => constants.%.Self.c95
-// CHECK:STDOUT:   %require_complete.loc18_34 => constants.%require_complete.22f
+// CHECK:STDOUT:   %require_complete.loc21_34 => constants.%require_complete.22f
 // CHECK:STDOUT:   %Empty.assoc_type => constants.%Empty.assoc_type.3cf698.2
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.3715ce.2
-// CHECK:STDOUT:   %.Self.as_type.loc18_34.2 => constants.%.Self.as_type.a75
+// CHECK:STDOUT:   %.Self.as_type.loc21_34.2 => constants.%.Self.as_type.a75
 // CHECK:STDOUT:   %Empty.lookup_impl_witness => constants.%Empty.lookup_impl_witness.b1d
-// CHECK:STDOUT:   %impl.elem0.loc18_34.2 => constants.%impl.elem0.c6e
-// CHECK:STDOUT:   %ptr.loc18_40.2 => constants.%ptr.79f
+// CHECK:STDOUT:   %impl.elem0.loc21_34.2 => constants.%impl.elem0.c6e
+// CHECK:STDOUT:   %ptr.loc21_40.2 => constants.%ptr.79f
 // CHECK:STDOUT:   %Empty_where.type => constants.%Empty_where.type.b73
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.668
-// CHECK:STDOUT:   %V.loc18_43.2 => constants.%V
+// CHECK:STDOUT:   %V.loc21_43.2 => constants.%V
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Empty(constants.%i32) {
-// CHECK:STDOUT:   %W.loc11_17.2 => constants.%i32
+// CHECK:STDOUT:   %W.loc14_17.2 => constants.%i32
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Empty.type => constants.%Empty.type.f0b
@@ -267,21 +270,21 @@ fn G(U: Empty(i32) where .A = i32*) {
 // CHECK:STDOUT: specific @A(constants.%i32, constants.%Empty.facet.112) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @H(constants.%i32, bool) {
-// CHECK:STDOUT:   %T.loc18_6.2 => constants.%i32
-// CHECK:STDOUT:   %Empty.type.loc18_26.2 => constants.%Empty.type.f0b
+// CHECK:STDOUT:   %T.loc21_6.2 => constants.%i32
+// CHECK:STDOUT:   %Empty.type.loc21_26.2 => constants.%Empty.type.f0b
 // CHECK:STDOUT:   %.Self.2 => constants.%.Self.e6e
-// CHECK:STDOUT:   %require_complete.loc18_34 => constants.%complete_type.091
+// CHECK:STDOUT:   %require_complete.loc21_34 => constants.%complete_type.091
 // CHECK:STDOUT:   %Empty.assoc_type => constants.%Empty.assoc_type.7c7
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.758
-// CHECK:STDOUT:   %.Self.as_type.loc18_34.2 => constants.%.Self.as_type.920
+// CHECK:STDOUT:   %.Self.as_type.loc21_34.2 => constants.%.Self.as_type.920
 // CHECK:STDOUT:   %Empty.lookup_impl_witness => constants.%Empty.lookup_impl_witness.4e3
-// CHECK:STDOUT:   %impl.elem0.loc18_34.2 => constants.%impl.elem0.64a
-// CHECK:STDOUT:   %ptr.loc18_40.2 => constants.%ptr.235
+// CHECK:STDOUT:   %impl.elem0.loc21_34.2 => constants.%impl.elem0.64a
+// CHECK:STDOUT:   %ptr.loc21_40.2 => constants.%ptr.235
 // CHECK:STDOUT:   %Empty_where.type => constants.%Empty_where.type.fc2
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.012
-// CHECK:STDOUT:   %V.loc18_43.2 => bool
+// CHECK:STDOUT:   %V.loc21_43.2 => bool
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete.loc18_17 => constants.%complete_type.a3f
+// CHECK:STDOUT:   %require_complete.loc21_17 => constants.%complete_type.a3f
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/where_expr/equal_rewrite.carbon
+++ b/toolchain/check/testdata/where_expr/equal_rewrite.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/where_expr/equal_rewrite.carbon

--- a/toolchain/check/testdata/where_expr/fail_not_facet.carbon
+++ b/toolchain/check/testdata/where_expr/fail_not_facet.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/where_expr/fail_not_facet.carbon

--- a/toolchain/check/testdata/where_expr/min_prelude/dot_self_impls.carbon
+++ b/toolchain/check/testdata/where_expr/min_prelude/dot_self_impls.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
-// EXTRA-ARGS: --no-dump-sem-ir
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/where_expr/non_generic.carbon
+++ b/toolchain/check/testdata/where_expr/non_generic.carbon
@@ -2,6 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/where_expr/non_generic.carbon
@@ -57,17 +60,17 @@ fn NotGenericF(U: I where .T == i32) {}
 // CHECK:STDOUT:     %U.param_patt: %pattern_type.f03 = value_param_pattern %U.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %U.param: %I_where.type = value_param call_param0
-// CHECK:STDOUT:     %.loc14_21.1: type = splice_block %.loc14_21.2 [concrete = constants.%I_where.type] {
+// CHECK:STDOUT:     %.loc17_21.1: type = splice_block %.loc17_21.2 [concrete = constants.%I_where.type] {
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:       %.Self: %I.type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:       %.Self.ref: %I.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:       %T.ref: %I.assoc_type = name_ref T, @T.%assoc0 [concrete = constants.%assoc0]
 // CHECK:STDOUT:       %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc14_27: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
+// CHECK:STDOUT:       %.loc17_27: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
 // CHECK:STDOUT:       %impl.elem0: type = impl_witness_access constants.%I.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:       %.loc14_21.2: type = where_expr %.Self [concrete = constants.%I_where.type] {
+// CHECK:STDOUT:       %.loc17_21.2: type = where_expr %.Self [concrete = constants.%I_where.type] {
 // CHECK:STDOUT:         requirement_equivalent %impl.elem0, %i32
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }


### PR DESCRIPTION
Where `--no-dump-sem-ir` is used, change to `--dump-sem-ir-ranges=only`. Otherwise, add `--dump-sem-ir-ranges=if-present` with a TODO to change to `only`.

Note, SemIR is affected just because the extra comments change line numbers in files where splits aren't in use.