### PR TITLE
Split a cross-file `Lower::Context` out of `Lower::FileContext`.

### DIFF
--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -713,8 +713,8 @@ auto CompilationUnit::RunLower() -> void {
       subtrees = cache_->tree_and_subtrees_getters();
     }
     module_ = Lower::LowerToLLVM(*llvm_context_, driver_env_->fs, subtrees,
-                                 input_filename_, *sem_ir_, sem_ir_->cpp_ast(),
-                                 &inst_namer, vlog_stream_);
+                                 input_filename_, *sem_ir_, &inst_namer,
+                                 vlog_stream_);
   });
   if (vlog_stream_) {
     CARBON_VLOG("*** llvm::Module ***\n");

--- a/toolchain/lower/BUILD
+++ b/toolchain/lower/BUILD
@@ -30,6 +30,7 @@ cc_library(
     srcs = [
         "constant.cpp",
         "constant.h",
+        "context.cpp",
         "file_context.cpp",
         "function_context.cpp",
         "mangler.cpp",
@@ -40,6 +41,7 @@ cc_library(
         "handle*.cpp",
     ]),
     hdrs = [
+        "context.h",
         "file_context.h",
         "function_context.h",
     ],

--- a/toolchain/lower/context.cpp
+++ b/toolchain/lower/context.cpp
@@ -31,17 +31,17 @@ Context::Context(llvm::LLVMContext& llvm_context,
 
 auto Context::GetFileContext(const SemIR::File* file,
                              const SemIR::InstNamer* inst_namer)
-    -> FileContext* {
+    -> FileContext& {
   auto insert_result = file_contexts_.Insert(file->check_ir_id(), [&] {
     auto file_context =
         std::make_unique<FileContext>(*this, *file, inst_namer, vlog_stream_);
     file_context->PrepareToLower();
     return file_context;
   });
-  return insert_result.value().get();
+  return *insert_result.value();
 }
 
-auto Context::Finalize() -> std::unique_ptr<llvm::Module> {
+auto Context::Finalize() && -> std::unique_ptr<llvm::Module> {
   file_contexts_.ForEach(
       [](auto, auto& file_context) { file_context->Finalize(); });
   return std::move(llvm_module_);

--- a/toolchain/lower/context.cpp
+++ b/toolchain/lower/context.cpp
@@ -1,0 +1,88 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/lower/context.h"
+
+#include "common/check.h"
+#include "common/vlog.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+#include "toolchain/lower/file_context.h"
+#include "toolchain/sem_ir/inst_namer.h"
+
+namespace Carbon::Lower {
+
+Context::Context(llvm::LLVMContext& llvm_context,
+                 llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+                 std::optional<llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>>
+                     tree_and_subtrees_getters_for_debug_info,
+                 llvm::StringRef module_name, llvm::raw_ostream* vlog_stream)
+    : llvm_context_(&llvm_context),
+      llvm_module_(std::make_unique<llvm::Module>(module_name, llvm_context)),
+      file_system_(std::move(fs)),
+      di_builder_(*llvm_module_),
+      di_compile_unit_(
+          tree_and_subtrees_getters_for_debug_info
+              ? BuildDICompileUnit(module_name, *llvm_module_, di_builder_)
+              : nullptr),
+      tree_and_subtrees_getters_for_debug_info_(
+          tree_and_subtrees_getters_for_debug_info),
+      vlog_stream_(vlog_stream) {}
+
+auto Context::GetFileContext(const SemIR::File* file,
+                             const SemIR::InstNamer* inst_namer)
+    -> FileContext* {
+  auto insert_result = file_contexts_.Insert(file->check_ir_id(), [&] {
+    auto file_context =
+        std::make_unique<FileContext>(*this, *file, inst_namer, vlog_stream_);
+    file_context->PrepareToLower();
+    return file_context;
+  });
+  return insert_result.value().get();
+}
+
+auto Context::Finalize() -> std::unique_ptr<llvm::Module> {
+  file_contexts_.ForEach(
+      [](auto, auto& file_context) { file_context->Finalize(); });
+  return std::move(llvm_module_);
+}
+
+auto Context::BuildDICompileUnit(llvm::StringRef module_name,
+                                 llvm::Module& llvm_module,
+                                 llvm::DIBuilder& di_builder)
+    -> llvm::DICompileUnit* {
+  llvm_module.addModuleFlag(llvm::Module::Max, "Dwarf Version", 5);
+  llvm_module.addModuleFlag(llvm::Module::Warning, "Debug Info Version",
+                            llvm::DEBUG_METADATA_VERSION);
+  // TODO: Include directory path in the compile_unit_file.
+  llvm::DIFile* compile_unit_file = di_builder.createFile(module_name, "");
+  // TODO: Introduce a new language code for Carbon. C works well for now since
+  // it's something debuggers will already know/have support for at least.
+  // Probably have to bump to C++ at some point for virtual functions,
+  // templates, etc.
+  return di_builder.createCompileUnit(llvm::dwarf::DW_LANG_C, compile_unit_file,
+                                      "carbon",
+                                      /*isOptimized=*/false, /*Flags=*/"",
+                                      /*RV=*/0);
+}
+
+auto Context::GetLocForDI(SemIR::AbsoluteNodeId abs_node_id) -> LocForDI {
+  const auto& tree_and_subtrees =
+      (*tree_and_subtrees_getters_for_debug_info_)[abs_node_id.check_ir_id()
+                                                       .index]();
+  const auto& tokens = tree_and_subtrees.tree().tokens();
+
+  if (abs_node_id.node_id().has_value()) {
+    auto token =
+        tree_and_subtrees.GetSubtreeTokenRange(abs_node_id.node_id()).begin;
+    return {.filename = tokens.source().filename(),
+            .line_number = tokens.GetLineNumber(token),
+            .column_number = tokens.GetColumnNumber(token)};
+  } else {
+    return {.filename = tokens.source().filename(),
+            .line_number = 0,
+            .column_number = 0};
+  }
+}
+
+}  // namespace Carbon::Lower

--- a/toolchain/lower/context.h
+++ b/toolchain/lower/context.h
@@ -46,11 +46,11 @@ class Context {
   // TODO: Consider building an InstNamer if we're not given one.
   auto GetFileContext(const SemIR::File* file,
                       const SemIR::InstNamer* inst_namer = nullptr)
-      -> FileContext*;
+      -> FileContext&;
 
   // Finishes lowering and takes ownership of the LLVM module. The context
   // cannot be used further after calling this.
-  auto Finalize() -> std::unique_ptr<llvm::Module>;
+  auto Finalize() && -> std::unique_ptr<llvm::Module>;
 
   // Returns location information for use with DebugInfo.
   auto GetLocForDI(SemIR::AbsoluteNodeId abs_node_id) -> LocForDI;

--- a/toolchain/lower/context.h
+++ b/toolchain/lower/context.h
@@ -1,0 +1,133 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_LOWER_CONTEXT_H_
+#define CARBON_TOOLCHAIN_LOWER_CONTEXT_H_
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "toolchain/parse/tree_and_subtrees.h"
+#include "toolchain/sem_ir/absolute_node_id.h"
+#include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst_namer.h"
+
+namespace Carbon::Lower {
+
+class FileContext;
+
+// Context for lowering to an LLVM module.
+class Context {
+ public:
+  // Location information for use with DebugInfo. The line_number and
+  // column_number are >= 0, with 0 as unknown, so that they can be passed
+  // directly to DebugInfo.
+  struct LocForDI {
+    llvm::StringRef filename;
+    int32_t line_number;
+    int32_t column_number;
+  };
+
+  explicit Context(llvm::LLVMContext& llvm_context,
+                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+                   std::optional<llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>>
+                       tree_and_subtrees_getters_for_debug_info,
+                   llvm::StringRef module_name, llvm::raw_ostream* vlog_stream);
+
+  // Gets or creates the `FileContext` for a given SemIR file. If an
+  // `inst_namer` is specified the first time this is called for a file, it will
+  // be used for that file. Otherwise, no instruction namer will be used.
+  // TODO: Consider building an InstNamer if we're not given one.
+  auto GetFileContext(const SemIR::File* file,
+                      const SemIR::InstNamer* inst_namer = nullptr)
+      -> FileContext*;
+
+  // Finishes lowering and takes ownership of the LLVM module. The context
+  // cannot be used further after calling this.
+  auto Finalize() -> std::unique_ptr<llvm::Module>;
+
+  // Returns location information for use with DebugInfo.
+  auto GetLocForDI(SemIR::AbsoluteNodeId abs_node_id) -> LocForDI;
+
+  // Returns a lowered value to use for a value of type `type`.
+  auto GetTypeAsValue() -> llvm::Constant* {
+    return llvm::ConstantStruct::get(GetTypeType());
+  }
+
+  // Returns a lowered value to use for a value of int literal type.
+  auto GetIntLiteralAsValue() -> llvm::Constant* {
+    // TODO: Consider adding a named struct type for integer literals.
+    return llvm::ConstantStruct::get(llvm::StructType::get(llvm_context()));
+  }
+
+  // Returns the empty LLVM struct type used to represent the type `type`.
+  auto GetTypeType() -> llvm::StructType* {
+    if (!type_type_) {
+      // `type` is lowered to an empty LLVM StructType.
+      type_type_ = llvm::StructType::create(*llvm_context_, {}, "type");
+    }
+    return type_type_;
+  }
+
+  auto llvm_context() -> llvm::LLVMContext& { return *llvm_context_; }
+  auto llvm_module() -> llvm::Module& { return *llvm_module_; }
+  auto file_system() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>& {
+    return file_system_;
+  }
+  auto di_builder() -> llvm::DIBuilder& { return di_builder_; }
+  auto di_compile_unit() -> llvm::DICompileUnit* { return di_compile_unit_; }
+
+  auto printf_int_format_string() -> llvm::Value* {
+    return printf_int_format_string_;
+  }
+  auto SetPrintfIntFormatString(llvm::Value* printf_int_format_string) {
+    CARBON_CHECK(!printf_int_format_string_,
+                 "PrintInt formatting string already generated");
+    printf_int_format_string_ = printf_int_format_string;
+  }
+
+ private:
+  // Create the DICompileUnit metadata for this compilation.
+  auto BuildDICompileUnit(llvm::StringRef module_name,
+                          llvm::Module& llvm_module,
+                          llvm::DIBuilder& di_builder) -> llvm::DICompileUnit*;
+
+  // State for building the LLVM IR.
+  llvm::LLVMContext* llvm_context_;
+  std::unique_ptr<llvm::Module> llvm_module_;
+
+  // The filesystem for source code.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> file_system_;
+
+  // State for building the LLVM IR debug info metadata.
+  llvm::DIBuilder di_builder_;
+
+  // The DICompileUnit, if any - null implies debug info is not being emitted.
+  llvm::DICompileUnit* di_compile_unit_;
+
+  // The trees are only provided when debug info should be emitted.
+  std::optional<llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>>
+      tree_and_subtrees_getters_for_debug_info_;
+
+  // The optional vlog stream.
+  llvm::raw_ostream* vlog_stream_;
+
+  // The `FileContext`s for each IR that is involved in this lowering action.
+  Map<SemIR::CheckIRId, std::unique_ptr<FileContext>> file_contexts_;
+
+  // Lowered version of the builtin type `type`.
+  llvm::StructType* type_type_ = nullptr;
+
+  // Global format string for `printf.int.format` used by the PrintInt builtin.
+  llvm::Value* printf_int_format_string_ = nullptr;
+};
+
+}  // namespace Carbon::Lower
+
+#endif  // CARBON_TOOLCHAIN_LOWER_CONTEXT_H_

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -23,8 +23,8 @@ auto LowerToLLVM(llvm::LLVMContext& llvm_context,
   Context context(llvm_context, std::move(fs),
                   tree_and_subtrees_getters_for_debug_info, module_name,
                   vlog_stream);
-  context.GetFileContext(&sem_ir, inst_namer)->LowerDefinitions();
-  return context.Finalize();
+  context.GetFileContext(&sem_ir, inst_namer).LowerDefinitions();
+  return std::move(context).Finalize();
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 
+#include "toolchain/lower/context.h"
 #include "toolchain/lower/file_context.h"
 
 namespace Carbon::Lower {
@@ -16,13 +17,14 @@ auto LowerToLLVM(llvm::LLVMContext& llvm_context,
                  std::optional<llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>>
                      tree_and_subtrees_getters_for_debug_info,
                  llvm::StringRef module_name, const SemIR::File& sem_ir,
-                 clang::ASTUnit* cpp_ast, const SemIR::InstNamer* inst_namer,
+                 const SemIR::InstNamer* inst_namer,
                  llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module> {
-  FileContext context(llvm_context, std::move(fs),
-                      tree_and_subtrees_getters_for_debug_info, module_name,
-                      sem_ir, cpp_ast, inst_namer, vlog_stream);
-  return context.Run();
+  Context context(llvm_context, std::move(fs),
+                  tree_and_subtrees_getters_for_debug_info, module_name,
+                  vlog_stream);
+  context.GetFileContext(&sem_ir, inst_namer)->LowerDefinitions();
+  return context.Finalize();
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/lower.h
+++ b/toolchain/lower/lower.h
@@ -20,7 +20,7 @@ auto LowerToLLVM(llvm::LLVMContext& llvm_context,
                  std::optional<llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>>
                      tree_and_subtrees_getters_for_debug_info,
                  llvm::StringRef module_name, const SemIR::File& sem_ir,
-                 clang::ASTUnit* cpp_ast, const SemIR::InstNamer* inst_namer,
+                 const SemIR::InstNamer* inst_namer,
                  llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module>;
 

--- a/toolchain/lower/mangler.h
+++ b/toolchain/lower/mangler.h
@@ -24,10 +24,13 @@ class Mangler {
   // specified `FileContext`.
   explicit Mangler(FileContext& file_context)
       : file_context_(file_context),
-        cpp_mangle_context_(
-            file_context.cpp_ast()
-                ? file_context.cpp_ast()->getASTContext().createMangleContext()
-                : nullptr) {}
+        cpp_mangle_context_(file_context.cpp_ast()
+                                // Clang's createMangleContext is not
+                                // const-correct, but doesn't modify the AST.
+                                ? const_cast<clang::ASTContext&>(
+                                      file_context.cpp_ast()->getASTContext())
+                                      .createMangleContext()
+                                : nullptr) {}
 
   // Produce a deterministically unique mangled name for the function specified
   // by `function_id` and `specific_id`.


### PR DESCRIPTION
In preparation for lowering information from multiple `SemIR::File`s into a single `llvm::Module`. The primary purpose of this is to support lowering a local specific for an imported generic function, where the instructions for the generic function are in a different file than the instructions for the specific. See #5475 for a draft PR implementing that functionality on top of this.

The per-`llvm::Module` state now lives in `Lower::Context`, and `Lower::FileContext` tracks only the per-`SemIR::File` information. `Lower::Context` should not mention any `SemIR` IDs that are file-specific. For now, the C++ lowering and the specific coalescing logic are kept per-file for simplicity.