### PR TITLE
Flip the dump-sem-ir-ranges default in file_test

### DIFF
--- a/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // The default behavior should be `--dump-sem-ir-ranges=if-present`, although
-// tests set it to `only`. This explicitly tests the default of the toolchain, not of file_test.
+// tests set it to `only`. This explicitly tests the default of the toolchain,
+// not of file_test.
 // ARGS: compile --phase=check --no-prelude-import --dump-sem-ir %s
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
@@ -2,7 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// The default behavior should be `--dump-sem-ir-ranges=if-present`.
+// The default behavior should be `--dump-sem-ir-ranges=if-present`, although
+// tests set it to `only`. This explicitly tests the default.
+// ARGS: compile --phase=check --no-prelude-import --dump-sem-ir %s
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // The default behavior should be `--dump-sem-ir-ranges=if-present`, although
-// tests set it to `only`. This explicitly tests the default.
+// tests set it to `only`. This explicitly tests the default of the toolchain, not of file_test.
 // ARGS: compile --phase=check --no-prelude-import --dump-sem-ir %s
 //
 // AUTOUPDATE

--- a/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges_only.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/dump_sem_ir_ranges_only.carbon
@@ -2,7 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --dump-sem-ir-ranges=only
+// This tests `--dump-sem-ir-range=only` behavior, which is set implicitly by
+// file_test.
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
+++ b/toolchain/check/testdata/packages/implicit_imports_prelude.carbon
@@ -4,6 +4,9 @@
 //
 // This is just checking an implicit import behavior with the prelude present.
 //
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/packages/implicit_imports_prelude.carbon

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -192,7 +192,7 @@ auto ToolchainFileTest::GetDefaultArgs() const
   } else if (component_ == "parse") {
     args.push_back("--dump-parse-tree");
   } else if (component_ == "check") {
-    args.push_back("--dump-sem-ir");
+    args.insert(args.end(), {"--dump-sem-ir", "--dump-sem-ir-ranges=only"});
   } else if (component_ == "lower") {
     args.insert(args.end(), {"--dump-llvm-ir", "--target=x86_64-linux-gnu"});
   } else {


### PR DESCRIPTION
This doesn't remove no-longer-needed flags; I'll do that in a separate PR after this is merged.