### PR TITLE
Fearlessly hold references into ValueStore again

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -602,8 +602,8 @@ auto DeduceGenericCallArguments(
   return deduction.MakeSpecific();
 }
 
-auto DeduceImplArguments(Context& context, SemIR::LocId loc_id, DeduceImpl impl,
-                         SemIR::ConstantId self_id,
+auto DeduceImplArguments(Context& context, SemIR::LocId loc_id,
+                         const SemIR::Impl& impl, SemIR::ConstantId self_id,
                          SemIR::SpecificId constraint_specific_id)
     -> SemIR::SpecificId {
   DeductionContext deduction(&context, loc_id, impl.generic_id,
@@ -613,7 +613,7 @@ auto DeduceImplArguments(Context& context, SemIR::LocId loc_id, DeduceImpl impl,
 
   // Prepare to perform deduction of the type and interface.
   deduction.Add(impl.self_id, context.constant_values().GetInstId(self_id));
-  deduction.Add(impl.specific_id, constraint_specific_id);
+  deduction.Add(impl.interface.specific_id, constraint_specific_id);
 
   if (!deduction.Deduce() || !deduction.CheckDeductionIsComplete()) {
     return SemIR::SpecificId::None;

--- a/toolchain/check/deduce.h
+++ b/toolchain/check/deduce.h
@@ -18,21 +18,10 @@ auto DeduceGenericCallArguments(
     SemIR::InstBlockId param_patterns_id, SemIR::InstId self_id,
     llvm::ArrayRef<SemIR::InstId> arg_ids) -> SemIR::SpecificId;
 
-// Data from the `Impl` that is used by deduce.
-//
-// We don't use a reference to an `Impl` as deduction can invalidate the
-// reference by causing impl declarations to be imported from `Core` during
-// conversion.
-struct DeduceImpl {
-  SemIR::InstId self_id;
-  SemIR::GenericId generic_id;
-  SemIR::SpecificId specific_id;
-};
-
 // Deduces the impl arguments to use in a use of a parameterized impl. Returns
 // `None` if deduction fails.
-auto DeduceImplArguments(Context& context, SemIR::LocId loc_id, DeduceImpl impl,
-                         SemIR::ConstantId self_id,
+auto DeduceImplArguments(Context& context, SemIR::LocId loc_id,
+                         const SemIR::Impl& impl, SemIR::ConstantId self_id,
                          SemIR::SpecificId constraint_specific_id)
     -> SemIR::SpecificId;
 

--- a/toolchain/check/handle_choice.cpp
+++ b/toolchain/check/handle_choice.cpp
@@ -286,17 +286,14 @@ auto HandleParseNode(Context& context, Parse::ChoiceDefinitionId node_id)
   auto& class_info = context.classes().Get(class_id);
   class_info.complete_type_witness_id = choice_witness_id;
 
-  auto self_type_id = class_info.self_type_id;
-  auto name_scope_id = class_info.scope_id;
-
   auto self_struct_type_id = GetStructType(
       context, context.struct_type_fields().AddCanonical(struct_type_fields));
 
   for (auto [i, deferred_binding] :
        llvm::enumerate(context.choice_deferred_bindings())) {
     MakeLetBinding(context,
-                   ChoiceInfo{.self_type_id = self_type_id,
-                              .name_scope_id = name_scope_id,
+                   ChoiceInfo{.self_type_id = class_info.self_type_id,
+                              .name_scope_id = class_info.scope_id,
                               .self_struct_type_id = self_struct_type_id,
                               .discriminant_type_id = discriminant_type_id,
                               .num_alternative_bits = num_alternative_bits},

--- a/toolchain/check/handle_choice.cpp
+++ b/toolchain/check/handle_choice.cpp
@@ -283,12 +283,11 @@ auto HandleParseNode(Context& context, Parse::ChoiceDefinitionId node_id)
           .type_id = GetSingletonType(context, SemIR::WitnessType::TypeInstId),
           .object_repr_type_inst_id =
               context.types().GetInstId(GetStructType(context, fields_id))});
-  // Note: avoid storing a reference to the returned Class, since it may be
-  // invalidated by other type constructions.
-  context.classes().Get(class_id).complete_type_witness_id = choice_witness_id;
+  auto& class_info = context.classes().Get(class_id);
+  class_info.complete_type_witness_id = choice_witness_id;
 
-  auto self_type_id = context.classes().Get(class_id).self_type_id;
-  auto name_scope_id = context.classes().Get(class_id).scope_id;
+  auto self_type_id = class_info.self_type_id;
+  auto name_scope_id = class_info.scope_id;
 
   auto self_struct_type_id = GetStructType(
       context, context.struct_type_fields().AddCanonical(struct_type_fields));
@@ -310,7 +309,7 @@ auto HandleParseNode(Context& context, Parse::ChoiceDefinitionId node_id)
   context.scope_stack().Pop();
   context.decl_name_stack().PopScope();
 
-  FinishGenericDefinition(context, context.classes().Get(class_id).generic_id);
+  FinishGenericDefinition(context, class_info.generic_id);
 
   context.choice_deferred_bindings().clear();
   return true;

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -164,9 +164,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
 // Adds functions to the witness that the specified impl implements the given
 // interface.
 auto FinishImplWitness(Context& context, SemIR::ImplId impl_id) -> void {
-  // Make a copy of the impl. We're going to reference it a lot, and `impl`s
-  // could get invalidated by some of the things we do.
-  const auto impl = context.impls().Get(impl_id);
+  const auto& impl = context.impls().Get(impl_id);
 
   CARBON_CHECK(impl.is_being_defined());
   CARBON_CHECK(impl.witness_id.has_value());

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -192,9 +192,7 @@ auto LookupNameInExactScope(Context& context, SemIR::LocId loc_id,
     if (imported_inst_id.has_value()) {
       SemIR::ScopeLookupResult result = SemIR::ScopeLookupResult::MakeFound(
           imported_inst_id, SemIR::AccessKind::Public);
-      // `ImportNameFromCpp()` can invalidate `scope`, so we do a scope lookup.
-      context.name_scopes().Get(scope_id).AddRequired(
-          {.name_id = name_id, .result = result});
+      scope.AddRequired({.name_id = name_id, .result = result});
       return result;
     }
   }

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -159,7 +159,6 @@ auto BuildReturnWithExpr(Context& context, SemIR::LocId loc_id,
   } else if (return_info.has_return_slot()) {
     return_slot_id = GetCurrentReturnSlot(context);
     CARBON_CHECK(return_slot_id.has_value());
-    // Note that this can import a function and invalidate `function`.
     expr_id = Initialize(context, loc_id, return_slot_id, expr_id);
   } else {
     expr_id =

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -161,18 +161,16 @@ static auto CloneFunctionDecl(Context& context, SemIR::LocId loc_id,
     -> std::pair<SemIR::FunctionId, SemIR::InstId> {
   StartGenericDecl(context);
 
-  // Clone the signature. Note that we re-get the function after each of these,
-  // because they might trigger imports that invalidate the function.
+  const auto& signature = context.functions().Get(signature_id);
+
+  // Clone the signature.
   context.pattern_block_stack().Push();
   auto implicit_param_patterns_id = ClonePatternBlock(
-      context, signature_specific_id,
-      context.functions().Get(signature_id).implicit_param_patterns_id);
-  auto param_patterns_id = ClonePatternBlock(
-      context, signature_specific_id,
-      context.functions().Get(signature_id).param_patterns_id);
-  auto return_slot_pattern_id = ClonePattern(
-      context, signature_specific_id,
-      context.functions().Get(signature_id).return_slot_pattern_id);
+      context, signature_specific_id, signature.implicit_param_patterns_id);
+  auto param_patterns_id = ClonePatternBlock(context, signature_specific_id,
+                                             signature.param_patterns_id);
+  auto return_slot_pattern_id = ClonePattern(context, signature_specific_id,
+                                             signature.return_slot_pattern_id);
   auto self_param_id = FindSelfPattern(context, implicit_param_patterns_id);
   auto pattern_block_id = context.pattern_block_stack().Pop();
 
@@ -191,7 +189,6 @@ static auto CloneFunctionDecl(Context& context, SemIR::LocId loc_id,
   auto generic_id = BuildGenericDecl(context, decl_id);
 
   // Create the `Function` object.
-  auto& signature = context.functions().Get(signature_id);
   auto& callee = context.functions().Get(callee_id);
   function_decl.function_id = context.functions().Add(SemIR::Function{
       {.name_id = signature.name_id,

--- a/toolchain/sem_ir/name_scope.h
+++ b/toolchain/sem_ir/name_scope.h
@@ -151,9 +151,6 @@ class NameScope : public Printable<NameScope> {
   auto entries() const -> llvm::ArrayRef<Entry> { return names_; }
 
   // Get a specific Name entry based on an EntryId that return from a lookup.
-  //
-  // The Entry could become invalidated if the scope object is invalidated or if
-  // a name is added.
   auto GetEntry(EntryId entry_id) const -> const Entry& {
     return names_[entry_id.index];
   }
@@ -257,9 +254,6 @@ class NameScope : public Printable<NameScope> {
 
  private:
   // Names in the scope, including poisoned names.
-  //
-  // Entries could become invalidated if the scope object is invalidated or if a
-  // name is added.
   //
   // We store both an insertion-ordered vector for iterating
   // and a map from `NameId` to the index of that vector for name lookup.


### PR DESCRIPTION
Undo changes that were meant to prevent use of a reference into `ValueStore` after being invalidated. After #5576, the `ValueStore` makes such references stable, so there's no need to worry about invalidation.