### PR TITLE
In `test_clang_cpp`, if `CalledProcessError` is raised, log the stderr for easier debugging

### DIFF
--- a/toolchain/install/llvm_symlinks_test.py
+++ b/toolchain/install/llvm_symlinks_test.py
@@ -15,6 +15,10 @@ import sys
 import unittest
 
 
+def log(s: str) -> None:
+    print(s, file=sys.stderr)
+
+
 class LLVMSymlinksTest(unittest.TestCase):
     def setUp(self) -> None:
         # The install root is adjacent to the test script
@@ -86,13 +90,16 @@ class LLVMSymlinksTest(unittest.TestCase):
         # the test file and writing to stdout. We define a macro that we'll
         # check is expanded.
         bin = self.install_root / "lib/carbon/llvm/bin/clang-cpp"
-        run = subprocess.run(
-            [bin, "-D", "TEST=SUCCESS", text_file, "-"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-
+        try:
+            run = subprocess.run(
+                [bin, "-D", "TEST=SUCCESS", text_file, "-"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as err:
+            log(err.stderr)
+            raise
         self.assertEqual(run.stderr, "")
         self.assertRegex(run.stdout, r"(^|\n)SUCCESS\n")
 

--- a/toolchain/install/llvm_symlinks_test.py
+++ b/toolchain/install/llvm_symlinks_test.py
@@ -15,10 +15,6 @@ import sys
 import unittest
 
 
-def log(s: str) -> None:
-    print(s, file=sys.stderr)
-
-
 class LLVMSymlinksTest(unittest.TestCase):
     def setUp(self) -> None:
         # The install root is adjacent to the test script
@@ -98,7 +94,7 @@ class LLVMSymlinksTest(unittest.TestCase):
                 text=True,
             )
         except subprocess.CalledProcessError as err:
-            log(err.stderr)
+            print(err.stderr, file=sys.stderr)
             raise
         self.assertEqual(run.stderr, "")
         self.assertRegex(run.stdout, r"(^|\n)SUCCESS\n")


### PR DESCRIPTION
Found this is very useful for debugging since otherwise it's hard to tell what happened in the process.
Based on similar logic in `scripts/target_determinator.py`.