### PR TITLE
Don't keep insts in eval block from failed deduce

### DIFF
--- a/common/array_stack.h
+++ b/common/array_stack.h
@@ -41,6 +41,10 @@ class ArrayStack {
     values_.truncate(region);
   }
 
+  // Pops the top array from the stack, merging its contents into the next
+  // array.
+  auto PopAndMergeArray() -> void { (void)array_offsets_.pop_back_val(); }
+
   // Returns the top array from the stack.
   auto PeekArray() const -> llvm::ArrayRef<ValueT> {
     CARBON_CHECK(!array_offsets_.empty());

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -523,9 +523,8 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
     // `DeductionInconsistent` diagnostic. If we defer that check until after
     // all conversions are done (after the code below) then we won't diagnose
     // that incorrectly.
-    auto arg_type_id = context().insts().Get(deduced_arg_id).type_id();
     auto binding_type_id = context().insts().Get(binding_id).type_id();
-    if (arg_type_id.is_concrete() && binding_type_id.is_symbolic()) {
+    if (binding_type_id.is_symbolic()) {
       auto param_type_const_id = SubstConstant(
           context(), binding_type_id.AsConstantId(), substitutions_);
       CARBON_CHECK(param_type_const_id.has_value());

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -525,6 +525,14 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
     // that incorrectly.
     auto binding_type_id = context().insts().Get(binding_id).type_id();
     if (binding_type_id.is_symbolic()) {
+      // SubstConstant() creates new instructions from the substitutions, but if
+      // conversion fails we will not use those instructions. Avoid marking them
+      // as dependent instructions when convert fails so they will not be
+      // evaluated when the enclosing generic has a specific applied. This is
+      // particularly important for LookupImplWitness, which may be created in
+      // the process but will fail when being re-evaluated.
+      auto commit = context().generic_region_stack().BeginCommit();
+
       auto param_type_const_id = SubstConstant(
           context(), binding_type_id.AsConstantId(), substitutions_);
       CARBON_CHECK(param_type_const_id.has_value());
@@ -542,6 +550,11 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
                                            binding_type_id)
                     : TryConvertToValueOfType(context(), loc_id_,
                                               deduced_arg_id, binding_type_id);
+      if (converted_arg_id == SemIR::ErrorInst::InstId) {
+        std::move(commit).Discard();
+        return false;
+      }
+
       // Replace the deduced arg with its value converted to the parameter
       // type. The conversion of the argument type must produce a constant value
       // to be used in deduction.

--- a/toolchain/check/generic_region_stack.cpp
+++ b/toolchain/check/generic_region_stack.cpp
@@ -7,6 +7,7 @@
 namespace Carbon::Check {
 
 auto GenericRegionStack::Push(PendingGeneric generic) -> void {
+  CARBON_CHECK(!ongoing_commit_, "New GenericRegion pushed during Commit");
   pending_generic_ids_.push_back(generic);
   pending_eval_block_stack_.PushArray();
   dependent_inst_stack_.PushArray();
@@ -14,6 +15,7 @@ auto GenericRegionStack::Push(PendingGeneric generic) -> void {
 }
 
 auto GenericRegionStack::Pop() -> void {
+  CARBON_CHECK(!ongoing_commit_, "GenericRegion popped during Commit");
   pending_generic_ids_.pop_back();
   pending_eval_block_stack_.PopArray();
   dependent_inst_stack_.PopArray();

--- a/toolchain/check/generic_region_stack.h
+++ b/toolchain/check/generic_region_stack.h
@@ -60,6 +60,60 @@ class GenericRegionStack {
     pending_generic_ids_.back().generic_id = generic_id;
   }
 
+  // While held alive, instructions added as dependents or to the eval block are
+  // treated as part of a single commit. If `Discard` is called, then those
+  // instructions will all be dropped from the GenericRegionStack. Otherwise,
+  // they will be kept.
+  class [[nodiscard]] Commit {
+    friend GenericRegionStack;
+
+   public:
+    ~Commit() { std::move(*this).Keep(); }
+
+    auto Discard() && -> void {
+      if (stack_) {
+        stack_->dependent_inst_stack_.PopArray();
+        stack_->pending_eval_block_stack_.PopArray();
+        stack_->ongoing_commit_ = false;
+        stack_ = nullptr;
+      }
+    }
+
+    auto Keep() && -> void {
+      if (stack_) {
+        stack_->dependent_inst_stack_.PopAndMergeArray();
+        stack_->pending_eval_block_stack_.PopAndMergeArray();
+        stack_->ongoing_commit_ = false;
+        stack_ = nullptr;
+      }
+    }
+
+   private:
+    explicit Commit(GenericRegionStack* stack) : stack_(stack) {
+      if (stack_) {
+        stack_->dependent_inst_stack_.PushArray();
+        stack_->pending_eval_block_stack_.PushArray();
+        stack_->ongoing_commit_ = true;
+      }
+    }
+
+    // After move, ensure only one Commit will do cleanup.
+    Commit(Commit&& rhs) noexcept
+        : stack_(std::exchange(rhs.stack_, nullptr)) {}
+    auto operator=(Commit&& rhs) noexcept -> Commit& {
+      stack_ = std::exchange(rhs.stack_, nullptr);
+      return *this;
+    }
+
+    GenericRegionStack* stack_;
+  };
+
+  // Begin a commit, where instructions may be created but thrown away. At the
+  // end of the commit, the caller may choose to keep all instructions added as
+  // dependent or to the eval block, or to discard them all. If they are
+  // discarded, they must not be referenced afterward.
+  auto BeginCommit() -> Commit { return Commit(Empty() ? nullptr : this); }
+
   // Adds an instruction to the list of instructions whose type or value depends
   // on something in the current pending generic.
   auto AddDependentInst(SemIR::InstId inst_id) -> void {
@@ -119,6 +173,8 @@ class GenericRegionStack {
   // blocks for each enclosing generic. We reserve this to a suitable size in
   // the constructor.
   llvm::SmallVector<ConstantsInGenericMap, 0> constants_in_generic_stack_;
+
+  bool ongoing_commit_ = false;
 };
 
 }  // namespace Carbon::Check

--- a/toolchain/check/testdata/deduce/min_prelude/symbolic_facets.carbon
+++ b/toolchain/check/testdata/deduce/min_prelude/symbolic_facets.carbon
@@ -1,0 +1,82 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// EXTRA-ARGS: --dump-sem-ir-ranges=only
+// INCLUDE-FILE: toolchain/testing/min_prelude/facet_types.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/deduce/min_prelude/symbolic_facets.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/deduce/min_prelude/symbolic_facets.carbon
+
+// By placing each interface inside a generic class, a facet type refering to
+// the interface becomes symbolic. Normally they would be concrete. This can
+// affect decisions in deduce which unwraps symbolic values, but still needs to
+// ensure they convert correctly.
+
+// --- fail_missing_interface.carbon
+library "[[@TEST_NAME]]";
+
+class C(CC:! type) {
+  interface A {}
+  fn F(T:! A) {}
+}
+
+class D(DD:! type) {
+  interface B {}
+  fn G(T:! B) {
+    // T only implements D(DD).B, so should not convert to a facet value
+    // implementing C(()).A.
+    //
+    // CHECK:STDERR: fail_missing_interface.carbon:[[@LINE+7]]:5: error: cannot convert type `T` that implements `B` into type implementing `A` [ConversionFailureFacetToFacet]
+    // CHECK:STDERR:     C(()).F(T);
+    // CHECK:STDERR:     ^~~~~~~~~~
+    // CHECK:STDERR: fail_missing_interface.carbon:[[@LINE-12]]:3: note: while deducing parameters of generic declared here [DeductionGenericHere]
+    // CHECK:STDERR:   fn F(T:! A) {}
+    // CHECK:STDERR:   ^~~~~~~~~~~~~
+    // CHECK:STDERR:
+    C(()).F(T);
+  }
+}
+
+// --- fail_interface_wrong_generic_param.carbon
+library "[[@TEST_NAME]]";
+
+class C(CC:! type) {
+  interface A {}
+  fn F(T:! A) {}
+}
+
+class D(DD:! type) {
+  interface B {}
+  fn G(T:! B & C({}).A) {
+    // T implements C({}).A and D(DD).B, so should not convert to a facet value
+    // implementing C(()).A.
+    //
+    // CHECK:STDERR: fail_interface_wrong_generic_param.carbon:[[@LINE+7]]:5: error: cannot convert type `T` that implements `A & B` into type implementing `A` [ConversionFailureFacetToFacet]
+    // CHECK:STDERR:     C(()).F(T);
+    // CHECK:STDERR:     ^~~~~~~~~~
+    // CHECK:STDERR: fail_interface_wrong_generic_param.carbon:[[@LINE-12]]:3: note: while deducing parameters of generic declared here [DeductionGenericHere]
+    // CHECK:STDERR:   fn F(T:! A) {}
+    // CHECK:STDERR:   ^~~~~~~~~~~~~
+    // CHECK:STDERR:
+    C(()).F(T);
+  }
+}
+
+// --- compatible_deduce.carbon
+library "[[@TEST_NAME]]";
+
+class C(CC:! type) {
+  interface A {}
+  fn F(T:! A) {}
+}
+
+class D(DD:! type) {
+  interface B {}
+  fn G(T:! B & C(()).A) {
+    C(()).F(T);
+  }
+}

--- a/toolchain/check/testdata/deduce/min_prelude/symbolic_facets.carbon
+++ b/toolchain/check/testdata/deduce/min_prelude/symbolic_facets.carbon
@@ -66,7 +66,11 @@ class D(DD:! type) {
   }
 }
 
-// --- compatible_deduce.carbon
+fn H(T:! C({}).A & D({}).B) {
+  D({}).G(T);
+}
+
+// --- fail_interface_wrong_generic_param_using_generic_arg.carbon
 library "[[@TEST_NAME]]";
 
 class C(CC:! type) {
@@ -76,7 +80,98 @@ class C(CC:! type) {
 
 class D(DD:! type) {
   interface B {}
-  fn G(T:! B & C(()).A) {
+  fn G(T:! B & C({}).A) {
+    // T implements C({}).A and D(DD).B, so should not convert to a facet value
+    // implementing C(()).A.
+    //
+    // CHECK:STDERR: fail_interface_wrong_generic_param_using_generic_arg.carbon:[[@LINE+7]]:5: error: cannot convert type `T` that implements `A & B` into type implementing `A` [ConversionFailureFacetToFacet]
+    // CHECK:STDERR:     C(DD).F(T);
+    // CHECK:STDERR:     ^~~~~~~~~~
+    // CHECK:STDERR: fail_interface_wrong_generic_param_using_generic_arg.carbon:[[@LINE-12]]:3: note: while deducing parameters of generic declared here [DeductionGenericHere]
+    // CHECK:STDERR:   fn F(T:! A) {}
+    // CHECK:STDERR:   ^~~~~~~~~~~~~
+    // CHECK:STDERR:
+    C(DD).F(T);
+  }
+}
+
+fn H(T:! C({}).A & D({}).B) {
+  D({}).G(T);
+}
+
+// --- fail_interface_wrong_generic_param_with_rewrite.carbon
+library "[[@TEST_NAME]]";
+
+class C(CC:! type) {
+  interface A { let X:! type; }
+  fn F(T:! A where .X = CC) {}
+}
+
+class D(DD:! type) {
+  interface B {}
+  fn G(T:! B & C({}).A where .X = {}) {
+    // T implements C({}).A and D(DD).B, so should not convert to a facet value
+    // implementing C(()).A.
+    //
+    // CHECK:STDERR: fail_interface_wrong_generic_param_with_rewrite.carbon:[[@LINE+7]]:5: error: cannot convert type `T` that implements `A & B where .(A.X) = {}` into type implementing `A where .(A.X) = ()` [ConversionFailureFacetToFacet]
+    // CHECK:STDERR:     C(()).F(T);
+    // CHECK:STDERR:     ^~~~~~~~~~
+    // CHECK:STDERR: fail_interface_wrong_generic_param_with_rewrite.carbon:[[@LINE-12]]:3: note: while deducing parameters of generic declared here [DeductionGenericHere]
+    // CHECK:STDERR:   fn F(T:! A where .X = CC) {}
+    // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
     C(()).F(T);
   }
+}
+
+fn H(T:! C({}).A & D({}).B where .X = {}) {
+  D({}).G(T);
+}
+
+// --- fail_interface_wrong_generic_param_using_generic_arg_with_rewrite.carbon
+library "[[@TEST_NAME]]";
+
+class C(CC:! type) {
+  interface A { let X:! type; }
+  fn F(T:! A where .X = CC) {}
+}
+
+class D(DD:! type) {
+  interface B {}
+  fn G(T:! B & C({}).A where .X = {}) {
+    // T implements C({}).A and D(DD).B, so should not convert to a facet value
+    // implementing C(()).A.
+    //
+    // CHECK:STDERR: fail_interface_wrong_generic_param_using_generic_arg_with_rewrite.carbon:[[@LINE+7]]:5: error: cannot convert type `T` that implements `A & B where .(A.X) = {}` into type implementing `A where .(A.X) = DD` [ConversionFailureFacetToFacet]
+    // CHECK:STDERR:     C(DD).F(T);
+    // CHECK:STDERR:     ^~~~~~~~~~
+    // CHECK:STDERR: fail_interface_wrong_generic_param_using_generic_arg_with_rewrite.carbon:[[@LINE-12]]:3: note: while deducing parameters of generic declared here [DeductionGenericHere]
+    // CHECK:STDERR:   fn F(T:! A where .X = CC) {}
+    // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
+    C(DD).F(T);
+  }
+}
+
+fn H(T:! C({}).A & D({}).B where .X = {}) {
+  D({}).G(T);
+}
+
+// --- compatible_deduce.carbon
+library "[[@TEST_NAME]]";
+
+class C(CC:! type) {
+  interface A { let X:! type; }
+  fn F(T:! A where .X = CC) {}
+}
+
+class D(DD:! type) {
+  interface B {}
+  fn G(T:! B & C(()).A where .X = ()) {
+    C(()).F(T);
+  }
+}
+
+fn H(T:! C(()).A & D({}).B where .X = ()) {
+  D({}).G(T);
 }


### PR DESCRIPTION
Deduction does `SubstConstant()` to apply enclosing specifics, and deduced arguments, to the arguments. This process creates new instructions with the applied substitutions, which may include `LookupImplWitness`. If the conversion fails, those instructions will not be used, but they have been added to the enclosing generic when there is one. This leaves behind a `LookupImplWitness` instruction with a runtime constant value as a dependent instruction and in the eval block. When the generic's eval block is re-evaluated later, the `LookupImplWitness` instruction fails to produce a constant value (again), which violates its contract and we crash.

To avoid this, we scope the SubstConstant and Convert steps in deduce with a "commit" for the generic stack. If the conversion fails, we drop all instructions created by SubstConstant and Convert from the enclosing generic context. Such instructions must not be referred to again, but they will not be as they are not stored anywhere or returned if Convert failed.

This fixes the crash demonstrated in https://carbon.godbolt.org/z/1EjMroT6e