### PR TITLE
Fix language-server crash with cpp_ast

### DIFF
--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -15,7 +15,8 @@
 
 namespace Carbon::Check {
 
-// Checking information that's tracked per file.
+// Checking information that's tracked per file. All members are caller-owned.
+// Other than `timings`, members must be non-null.
 struct Unit {
   Diagnostics::Consumer* consumer;
   SharedValueStores* value_stores;
@@ -25,8 +26,9 @@ struct Unit {
   // The unit's SemIR, provided as empty and filled in by CheckParseTrees.
   SemIR::File* sem_ir;
 
-  // The Clang AST owned by `CompileSubcommand`.
-  std::unique_ptr<clang::ASTUnit>* cpp_ast = nullptr;
+  // Storage for the unit's Clang AST. The unique_ptr should start empty, and
+  // can be assigned as part of checking.
+  std::unique_ptr<clang::ASTUnit>* cpp_ast;
 };
 
 // Checks a group of parse trees. This will use imports to decide the order of

--- a/toolchain/diagnostics/coverage_test.cpp
+++ b/toolchain/diagnostics/coverage_test.cpp
@@ -21,28 +21,29 @@ constexpr Kind Kinds[] = {
 
 constexpr Kind UntestedKinds[] = {
     // These exist only for unit tests.
-    Kind::TestDiagnostic,
-    Kind::TestDiagnosticNote,
+    Kind::TestDiagnostic, Kind::TestDiagnosticNote,
 
     // Diagnosing erroneous install conditions, but test environments are
     // typically correct.
-    Kind::CompilePreludeManifestError,
-    Kind::DriverInstallInvalid,
+    Kind::CompilePreludeManifestError, Kind::DriverInstallInvalid,
 
     // These diagnose filesystem issues that are hard to unit test.
-    Kind::ErrorReadingFile,
-    Kind::ErrorStattingFile,
-    Kind::FileTooLarge,
+    Kind::ErrorReadingFile, Kind::ErrorStattingFile, Kind::FileTooLarge,
 
     // These aren't feasible to test with a normal testcase, but are tested in
     // lex/tokenized_buffer_test.cpp.
-    Kind::TooManyTokens,
-    Kind::UnsupportedCrLineEnding,
+    Kind::TooManyTokens, Kind::UnsupportedCrLineEnding,
     Kind::UnsupportedLfCrLineEnding,
 
     // This is a little long but is tested in lex/numeric_literal_test.cpp.
     Kind::TooManyDigits,
 
+    // TODO: This currently has coverage, but mainly due to incorrect behavior
+    // in C++ diagnostics. See
+    // language_server/testdata/text_document/open_with_cpp_nonexistent.carbon.
+    // Leaving this TODO here until it's more precisely tested, because the C++
+    // diagnostics should be fixed (removing coverage); see below TODO.
+    //
     // TODO: This can only fire if the first message in a diagnostic is rooted
     // in a file other than the file being compiled. The language server
     // currently only supports compiling one file at a time. Do one of:
@@ -50,7 +51,7 @@ constexpr Kind UntestedKinds[] = {
     //   in the current file.
     // - Require all diagnostics produced by compiling have their first location
     //   be in the file being compiled, never an import.
-    Kind::LanguageServerDiagnosticInWrongFile,
+    // Kind::LanguageServerDiagnosticInWrongFile,
 };
 
 // Looks for diagnostic kinds that aren't covered by a file_test.

--- a/toolchain/diagnostics/coverage_test.cpp
+++ b/toolchain/diagnostics/coverage_test.cpp
@@ -19,39 +19,43 @@ constexpr Kind Kinds[] = {
 #include "toolchain/diagnostics/diagnostic_kind.def"
 };
 
+// TODO: LanguageServerDiagnosticInWrongFile currently has coverage, but
+// mainly due to incorrect behavior in C++ diagnostics. See
+// language_server/testdata/text_document/open_with_cpp_nonexistent.carbon.
+// Leaving this TODO here until it's more precisely tested, because the C++
+// diagnostics should be fixed (removing coverage); see below TODO.
+//
+// TODO: This can only fire if the first message in a diagnostic is rooted
+// in a file other than the file being compiled. The language server
+// currently only supports compiling one file at a time. Do one of:
+// - When imports are supported, find a diagnostic whose first message isn't
+//   in the current file.
+// - Require all diagnostics produced by compiling have their first location
+//   be in the file being compiled, never an import.
+// Kind::LanguageServerDiagnosticInWrongFile,
 constexpr Kind UntestedKinds[] = {
     // These exist only for unit tests.
-    Kind::TestDiagnostic, Kind::TestDiagnosticNote,
+    Kind::TestDiagnostic,
+    Kind::TestDiagnosticNote,
 
     // Diagnosing erroneous install conditions, but test environments are
     // typically correct.
-    Kind::CompilePreludeManifestError, Kind::DriverInstallInvalid,
+    Kind::CompilePreludeManifestError,
+    Kind::DriverInstallInvalid,
 
     // These diagnose filesystem issues that are hard to unit test.
-    Kind::ErrorReadingFile, Kind::ErrorStattingFile, Kind::FileTooLarge,
+    Kind::ErrorReadingFile,
+    Kind::ErrorStattingFile,
+    Kind::FileTooLarge,
 
     // These aren't feasible to test with a normal testcase, but are tested in
     // lex/tokenized_buffer_test.cpp.
-    Kind::TooManyTokens, Kind::UnsupportedCrLineEnding,
+    Kind::TooManyTokens,
+    Kind::UnsupportedCrLineEnding,
     Kind::UnsupportedLfCrLineEnding,
 
     // This is a little long but is tested in lex/numeric_literal_test.cpp.
     Kind::TooManyDigits,
-
-    // TODO: This currently has coverage, but mainly due to incorrect behavior
-    // in C++ diagnostics. See
-    // language_server/testdata/text_document/open_with_cpp_nonexistent.carbon.
-    // Leaving this TODO here until it's more precisely tested, because the C++
-    // diagnostics should be fixed (removing coverage); see below TODO.
-    //
-    // TODO: This can only fire if the first message in a diagnostic is rooted
-    // in a file other than the file being compiled. The language server
-    // currently only supports compiling one file at a time. Do one of:
-    // - When imports are supported, find a diagnostic whose first message isn't
-    //   in the current file.
-    // - Require all diagnostics produced by compiling have their first location
-    //   be in the file being compiled, never an import.
-    // Kind::LanguageServerDiagnosticInWrongFile,
 };
 
 // Looks for diagnostic kinds that aren't covered by a file_test.

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -140,14 +140,17 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
 
   SemIR::File sem_ir(tree_.get(), SemIR::CheckIRId(0), tree_->packaging_decl(),
                      *value_stores_, uri_.file().str());
-  auto getter = [this]() -> const Parse::TreeAndSubtrees& {
-    return *tree_and_subtrees_;
-  };
+  std::unique_ptr<clang::ASTUnit> cpp_ast;
   // TODO: Support cross-file checking when multiple files have edits.
   llvm::SmallVector<Check::Unit> units = {{{.consumer = &consumer,
                                             .value_stores = value_stores_.get(),
                                             .timings = nullptr,
-                                            .sem_ir = &sem_ir}}};
+                                            .sem_ir = &sem_ir,
+                                            .cpp_ast = &cpp_ast}}};
+
+  auto getter = [this]() -> const Parse::TreeAndSubtrees& {
+    return *tree_and_subtrees_;
+  };
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> fs =
       new llvm::vfs::InMemoryFileSystem;
   // TODO: Include the prelude.

--- a/toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
+++ b/toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
@@ -2,6 +2,11 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// TODO: At present, this has a
+// "dropping diagnostic in /test.carbon.generated.cpp_imports.h". That should be
+// fixed to assign back to this file, but that may come from other fixes to C++
+// diagnostic output.
+//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/language_server/testdata/text_document/open_with_cpp.carbon

--- a/toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
+++ b/toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
@@ -9,9 +9,9 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/language_server/testdata/text_document/open_with_cpp.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/language_server/testdata/text_document/open_with_cpp.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
 
 // --- STDIN
 [[@LSP-CALL:initialize]]

--- a/toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
+++ b/toolchain/language_server/testdata/text_document/open_with_cpp_nonexistent.carbon
@@ -1,0 +1,71 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/language_server/testdata/text_document/open_with_cpp.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/language_server/testdata/text_document/open_with_cpp.carbon
+
+// --- STDIN
+[[@LSP-CALL:initialize]]
+[[@LSP-NOTIFY:textDocument/didOpen:
+  "textDocument": {"uri": "file:/test.carbon", "languageId": "carbon",
+                   "text": "import Cpp library \"nonexistent.h\";"}
+]]
+[[@LSP-NOTIFY:textDocument/didClose:
+  "textDocument": {"uri": "file:/test.carbon"}
+]]
+[[@LSP-CALL:shutdown]]
+[[@LSP-NOTIFY:exit]]
+
+// --- AUTOUPDATE-SPLIT
+
+// CHECK:STDERR: /test.carbon: warning: dropping diagnostic in /test.carbon.generated.cpp_imports.h:
+// CHECK:STDERR: /test.carbon.generated.cpp_imports.h:1: error: C++:
+// CHECK:STDERR: /test.carbon.generated.cpp_imports.h:1:10: fatal error: 'nonexistent.h' file not found
+// CHECK:STDERR:     1 | #include "nonexistent.h"
+// CHECK:STDERR:       |          ^~~~~~~~~~~~~~~
+// CHECK:STDERR:
+// CHECK:STDERR: /test.carbon:1:1: note: in `Cpp` import
+// CHECK:STDERR: import Cpp library "nonexistent.h";
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:  [LanguageServerDiagnosticInWrongFile]
+// CHECK:STDERR:
+// CHECK:STDOUT: Content-Length: 146{{\r}}
+// CHECK:STDOUT: {{\r}}
+// CHECK:STDOUT: {
+// CHECK:STDOUT:   "id": 1,
+// CHECK:STDOUT:   "jsonrpc": "2.0",
+// CHECK:STDOUT:   "result": {
+// CHECK:STDOUT:     "capabilities": {
+// CHECK:STDOUT:       "documentSymbolProvider": true,
+// CHECK:STDOUT:       "textDocumentSync": 2
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }Content-Length: 144{{\r}}
+// CHECK:STDOUT: {{\r}}
+// CHECK:STDOUT: {
+// CHECK:STDOUT:   "jsonrpc": "2.0",
+// CHECK:STDOUT:   "method": "textDocument/publishDiagnostics",
+// CHECK:STDOUT:   "params": {
+// CHECK:STDOUT:     "diagnostics": [],
+// CHECK:STDOUT:     "uri": "file:///test.carbon"
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }Content-Length: 144{{\r}}
+// CHECK:STDOUT: {{\r}}
+// CHECK:STDOUT: {
+// CHECK:STDOUT:   "jsonrpc": "2.0",
+// CHECK:STDOUT:   "method": "textDocument/publishDiagnostics",
+// CHECK:STDOUT:   "params": {
+// CHECK:STDOUT:     "diagnostics": [],
+// CHECK:STDOUT:     "uri": "file:///test.carbon"
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }Content-Length: 51{{\r}}
+// CHECK:STDOUT: {{\r}}
+// CHECK:STDOUT: {
+// CHECK:STDOUT:   "id": 2,
+// CHECK:STDOUT:   "jsonrpc": "2.0",
+// CHECK:STDOUT:   "result": null
+// CHECK:STDOUT: }


### PR DESCRIPTION
Removes the nullptr default for safety.

Note, I think cpp support doesn't allow things like `<version>` or inline code yet, and language-server support doesn't allow non-hermetic files, so the best I can test is an error.