### PR TITLE
Add filenames to stack traces

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -81,6 +81,9 @@ auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {
   // spaces then add a couple to indent past the Context label.
   constexpr int Indent = 10;
 
+  output.indent(Indent);
+  output << "filename: " << tokens().source().filename() << "\n";
+
   node_stack_.PrintForStackDump(Indent, output);
   inst_block_stack_.PrintForStackDump(Indent, output);
   pattern_block_stack_.PrintForStackDump(Indent, output);

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -845,6 +845,8 @@ auto CompilationUnit::GetParseTreeAndSubtrees()
 auto CompilationUnit::LogCall(llvm::StringLiteral logging_label,
                               llvm::StringLiteral timing_label,
                               llvm::function_ref<auto()->void> fn) -> void {
+  PrettyStackTraceFunction trace_file(
+      [&](llvm::raw_ostream& out) { out << "filename: " << input_filename_; });
   CARBON_VLOG("*** {0}: {1} ***\n", logging_label, input_filename_);
   Timings::ScopedTiming timing(timings_ ? &*timings_ : nullptr, timing_label);
   fn();

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -845,8 +845,9 @@ auto CompilationUnit::GetParseTreeAndSubtrees()
 auto CompilationUnit::LogCall(llvm::StringLiteral logging_label,
                               llvm::StringLiteral timing_label,
                               llvm::function_ref<auto()->void> fn) -> void {
-  PrettyStackTraceFunction trace_file(
-      [&](llvm::raw_ostream& out) { out << "filename: " << input_filename_; });
+  PrettyStackTraceFunction trace_file([&](llvm::raw_ostream& out) {
+    out << "filename: " << input_filename_ << "\n";
+  });
   CARBON_VLOG("*** {0}: {1} ***\n", logging_label, input_filename_);
   Timings::ScopedTiming timing(timings_ ? &*timings_ : nullptr, timing_label);
   fn();


### PR DESCRIPTION
To make it easier to identify crashing files when testing multiple.

```
(elided)
3.	Check::Context
          filename: duplicate_name_same_line.carbon
          NodeStack:
(elided)
```