### PR TITLE
Add a fixed-size ValueStore

### DIFF
--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -85,6 +85,18 @@ cc_library(
 )
 
 cc_library(
+    name = "fixed_size_value_store",
+    hdrs = ["fixed_size_value_store.h"],
+    deps = [
+        ":mem_usage",
+        ":value_store",
+        "//common:check",
+        "//common:move_only",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "value_store",
     hdrs = [
         "value_store.h",

--- a/toolchain/base/fixed_size_value_store.h
+++ b/toolchain/base/fixed_size_value_store.h
@@ -1,0 +1,74 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_BASE_FIXED_SIZE_VALUE_STORE_H_
+#define CARBON_TOOLCHAIN_BASE_FIXED_SIZE_VALUE_STORE_H_
+
+#include "common/check.h"
+#include "common/move_only.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "toolchain/base/mem_usage.h"
+#include "toolchain/base/value_store.h"
+
+namespace Carbon {
+
+// A value store with a predetermined size.
+template <typename IdT, typename ValueT>
+class FixedSizeValueStore : public MoveOnly<FixedSizeValueStore<IdT, ValueT>> {
+ public:
+  using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
+  using RefType = ValueStoreTypes<IdT, ValueT>::RefType;
+  using ConstRefType = ValueStoreTypes<IdT, ValueT>::ConstRefType;
+
+  // Makes a ValueStore of the specified size, but without initializing values.
+  // Entries must be set before reading.
+  static auto MakeForOverwrite(size_t size) -> FixedSizeValueStore {
+    FixedSizeValueStore store;
+    store.values_.resize_for_overwrite(size);
+    return store;
+  }
+
+  // Makes a ValueStore of the specified size, initialized to a default.
+  explicit FixedSizeValueStore(size_t size, ValueT default_value) {
+    values_.resize(size, default_value);
+  }
+
+  // Sets the value for an ID.
+  auto Set(IdT id, ValueType value) -> void {
+    CARBON_DCHECK(id.index >= 0, "{0}", id);
+    values_[id.index] = value;
+  }
+
+  // Returns a mutable value for an ID.
+  auto Get(IdT id) -> RefType {
+    CARBON_DCHECK(id.index >= 0, "{0}", id);
+    return values_[id.index];
+  }
+
+  // Returns the value for an ID.
+  auto Get(IdT id) const -> ConstRefType {
+    CARBON_DCHECK(id.index >= 0, "{0}", id);
+    return values_[id.index];
+  }
+
+  // Collects memory usage of the values.
+  auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
+      -> void {
+    mem_usage.Collect(label.str(), values_);
+  }
+
+  auto size() const -> size_t { return values_.size(); }
+
+ private:
+  // Allow default construction for `MakeForOverwrite`.
+  FixedSizeValueStore() = default;
+
+  // Storage for the `ValueT` objects, indexed by the id.
+  llvm::SmallVector<ValueT, 0> values_;
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_TOOLCHAIN_BASE_FIXED_SIZE_VALUE_STORE_H_

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -156,6 +156,7 @@ cc_library(
         "//common:find",
         "//common:ostream",
         "//common:struct_reflection",
+        "//toolchain/base:fixed_size_value_store",
         "//toolchain/base:value_store",
         "//toolchain/lex:token_index",
         "//toolchain/lex:tokenized_buffer",

--- a/toolchain/parse/tree_and_subtrees.h
+++ b/toolchain/parse/tree_and_subtrees.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_PARSE_TREE_AND_SUBTREES_H_
 
 #include "llvm/ADT/SmallVector.h"
+#include "toolchain/base/fixed_size_value_store.h"
 #include "toolchain/lex/token_index.h"
 #include "toolchain/parse/tree.h"
 
@@ -184,7 +185,8 @@ class TreeAndSubtrees {
   // first child of its parent, this will be an offset to the node's parent's
   // next sibling, or if it the parent is also a first child, the grandparent's
   // next sibling, and so on.
-  llvm::SmallVector<int32_t> subtree_sizes_;
+  using SubtreeSizeStore = FixedSizeValueStore<NodeId, int32_t>;
+  SubtreeSizeStore subtree_sizes_;
 };
 
 // A standard signature for a callback to support lazy construction.
@@ -218,7 +220,7 @@ class TreeAndSubtrees::SiblingIterator
 
   using iterator_facade_base::operator++;
   auto operator++() -> SiblingIterator& {
-    node_.index -= tree_->subtree_sizes_[node_.index];
+    node_.index -= tree_->subtree_sizes_.Get(node_);
     return *this;
   }
 

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -184,6 +184,7 @@ cc_library(
         ":typed_insts",
         "//common:concepts",
         "//common:ostream",
+        "//toolchain/base:fixed_size_value_store",
         "//toolchain/base:kind_switch",
         "//toolchain/base:shared_value_stores",
         "//toolchain/lex:tokenized_buffer",

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -9,6 +9,7 @@
 
 #include "common/concepts.h"
 #include "llvm/Support/raw_ostream.h"
+#include "toolchain/base/fixed_size_value_store.h"
 #include "toolchain/parse/tree_and_subtrees.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/inst_namer.h"
@@ -375,13 +376,13 @@ class Formatter {
   llvm::StringRef pending_imported_from_;
 
   // Indexes of chunks of output that should be included when an instruction is
-  // referenced, indexed by the instruction's index. This is resized in advance
-  // to the correct size.
-  llvm::SmallVector<size_t, 0> tentative_inst_chunks_;
+  // referenced, indexed by the instruction's index.
+  FixedSizeValueStore<InstId, size_t> tentative_inst_chunks_;
 
   // Maps nodes to their parents. Only set when dump ranges are in use, because
   // the parents aren't used otherwise.
-  llvm::SmallVector<Parse::NodeId> node_parents_;
+  using NodeParentStore = FixedSizeValueStore<Parse::NodeId, Parse::NodeId>;
+  std::optional<NodeParentStore> node_parents_;
 };
 
 template <typename IdT>


### PR DESCRIPTION
Trying to build a type around the common idiom we have for types based on an Id range. The primary advantage of this is it makes clear the `Id` association, and drops the `.index` use.

Lowering was motivating me because it has a few of these, and check probably has more (e.g. `tree_and_subtrees_getters`), but I'm just changing a handful of examples to show the concept and see if there's agreement.

I wanted to inherit from ValueStoreTypes, but name lookup didn't seem to find the types without `using` statements, at which point there didn't seem to be much reason to use inheritance.