### PR TITLE
Print test names when running with --threads=1

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -405,6 +405,7 @@ static auto RunSingleTest(FileTestInfo& test, bool single_threaded,
     }
 
     if (single_threaded) {
+      llvm::errs() << "\nTEST: " << test.test_name << ' ';
       RunSingleTestHelper(test, *test_instance);
     } else {
       // Use a crash recovery context to try to get a stack trace when

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -386,6 +386,9 @@ static auto RunSingleTest(FileTestInfo& test, bool single_threaded,
   if (absl::GetFlag(FLAGS_dump_output)) {
     std::unique_lock<std::mutex> lock(output_mutex);
     llvm::errs() << "\n--- Dumping: " << test.test_name << "\n\n";
+  } else if (single_threaded) {
+    std::unique_lock<std::mutex> lock(output_mutex);
+    llvm::errs() << "\nTEST: " << test.test_name << ' ';
   }
 
   // Load expected output.
@@ -405,7 +408,6 @@ static auto RunSingleTest(FileTestInfo& test, bool single_threaded,
     }
 
     if (single_threaded) {
-      llvm::errs() << "\nTEST: " << test.test_name << ' ';
       RunSingleTestHelper(test, *test_instance);
     } else {
       // Use a crash recovery context to try to get a stack trace when


### PR DESCRIPTION
When tests crash by stack overflow (and maybe other ways), they don't print a stack trace so you don't have any way to know which file it was. By running with --threads=1 you can figure this out, if we print out the name of each test before we run it.

This prints each test name on its own line, then allows the autoupdate sigil to be added to the end of that line:
```
TEST: toolchain/check/testdata/alias/basics.carbon .
TEST: toolchain/check/testdata/alias/builtins.carbon !
TEST: toolchain/check/testdata/alias/export_name.carbon .
TEST: toolchain/check/testdata/alias/import.carbon .
...
```