### PR TITLE
Replacing lowering vectors with FixedSizeValueStore

### DIFF
--- a/toolchain/base/fixed_size_value_store.h
+++ b/toolchain/base/fixed_size_value_store.h
@@ -11,6 +11,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/base/mem_usage.h"
 #include "toolchain/base/value_store.h"
+#include "toolchain/base/value_store_chunk.h"
 
 namespace Carbon {
 
@@ -18,21 +19,47 @@ namespace Carbon {
 template <typename IdT, typename ValueT>
 class FixedSizeValueStore : public MoveOnly<FixedSizeValueStore<IdT, ValueT>> {
  public:
+  using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
   using RefType = ValueStoreTypes<IdT, ValueT>::RefType;
   using ConstRefType = ValueStoreTypes<IdT, ValueT>::ConstRefType;
 
   // Makes a ValueStore of the specified size, but without initializing values.
   // Entries must be set before reading.
-  static auto MakeForOverwrite(size_t size) -> FixedSizeValueStore {
+  static auto MakeForOverwriteWithExplicitSize(size_t size)
+      -> FixedSizeValueStore {
     FixedSizeValueStore store;
     store.values_.resize_for_overwrite(size);
     return store;
   }
 
+  // Makes a ValueStore of the same size as a source `ValueStoreT`, but without
+  // initializing values. Entries must be set before reading.
+  template <typename ValueStoreT>
+    requires std::same_as<IdT, typename ValueStoreT::IdType>
+  static auto MakeForOverwrite(const ValueStoreT& size_source)
+      -> FixedSizeValueStore {
+    FixedSizeValueStore store;
+    store.values_.resize_for_overwrite(size_source.size());
+    return store;
+  }
+
   // Makes a ValueStore of the specified size, initialized to a default.
-  explicit FixedSizeValueStore(size_t size, ValueT default_value) {
-    values_.resize(size, default_value);
+  static auto MakeWithExplicitSize(size_t size, ValueT default_value)
+      -> FixedSizeValueStore {
+    FixedSizeValueStore store;
+    store.values_.resize(size, default_value);
+    return store;
+  }
+
+  // Makes a ValueStore of the same size as a source `ValueStoreT`. This is
+  // the safest constructor to use, since it ensures everything's initialized to
+  // a default, and verifies a matching `IdT` for the size.
+  template <typename ValueStoreT>
+    requires std::same_as<IdT, typename ValueStoreT::IdType>
+  explicit FixedSizeValueStore(const ValueStoreT& size_source,
+                               ValueT default_value) {
+    values_.resize(size_source.size(), default_value);
   }
 
   // Sets the value for an ID.
@@ -60,9 +87,12 @@ class FixedSizeValueStore : public MoveOnly<FixedSizeValueStore<IdT, ValueT>> {
   }
 
   auto size() const -> size_t { return values_.size(); }
+  auto values() -> auto {
+    return llvm::make_range(values_.begin(), values_.end());
+  }
 
  private:
-  // Allow default construction for `MakeForOverwrite`.
+  // Allow default construction for `Make` functions.
   FixedSizeValueStore() = default;
 
   // Storage for the `ValueT` objects, indexed by the id.

--- a/toolchain/base/fixed_size_value_store.h
+++ b/toolchain/base/fixed_size_value_store.h
@@ -17,7 +17,7 @@ namespace Carbon {
 
 // A value store with a predetermined size.
 template <typename IdT, typename ValueT>
-class FixedSizeValueStore : public MoveOnly<FixedSizeValueStore<IdT, ValueT>> {
+class FixedSizeValueStore {
  public:
   using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
@@ -61,6 +61,11 @@ class FixedSizeValueStore : public MoveOnly<FixedSizeValueStore<IdT, ValueT>> {
                                ValueT default_value) {
     values_.resize(size_source.size(), default_value);
   }
+
+  // Move-only.
+  FixedSizeValueStore(FixedSizeValueStore&&) noexcept = default;
+  auto operator=(FixedSizeValueStore&&) noexcept
+      -> FixedSizeValueStore& = default;
 
   // Sets the value for an ID.
   auto Set(IdT id, ValueType value) -> void {

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -65,6 +65,7 @@ class ValueStore
                             typename IdT::ValueType>,
           Yaml::Printable<ValueStore<IdT>>, Internal::ValueStoreNotPrintable> {
  public:
+  using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT>::ValueType;
   using RefType = ValueStoreTypes<IdT>::RefType;
   using ConstRefType = ValueStoreTypes<IdT>::ConstRefType;
@@ -221,6 +222,7 @@ class ValueStoreRange {
 template <typename IdT>
 class CanonicalValueStore {
  public:
+  using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT>::ValueType;
   using RefType = ValueStoreTypes<IdT>::RefType;
   using ConstRefType = ValueStoreTypes<IdT>::ConstRefType;
@@ -323,6 +325,7 @@ auto CanonicalValueStore<IdT>::Reserve(size_t size) -> void {
 template <typename RelatedIdT, typename IdT>
 class RelationalValueStore {
  public:
+  using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT>::ValueType;
   using ConstRefType = ValueStoreTypes<IdT>::ConstRefType;
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -222,7 +222,6 @@ class ValueStoreRange {
 template <typename IdT>
 class CanonicalValueStore {
  public:
-  using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT>::ValueType;
   using RefType = ValueStoreTypes<IdT>::RefType;
   using ConstRefType = ValueStoreTypes<IdT>::ConstRefType;
@@ -325,7 +324,6 @@ auto CanonicalValueStore<IdT>::Reserve(size_t size) -> void {
 template <typename RelatedIdT, typename IdT>
 class RelationalValueStore {
  public:
-  using IdType = IdT;
   using ValueType = ValueStoreTypes<IdT>::ValueType;
   using ConstRefType = ValueStoreTypes<IdT>::ConstRefType;
 

--- a/toolchain/lower/BUILD
+++ b/toolchain/lower/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "//common:map",
         "//common:raw_string_ostream",
         "//common:vlog",
+        "//toolchain/base:fixed_size_value_store",
         "//toolchain/base:kind_switch",
         "//toolchain/parse:tree",
         "//toolchain/sem_ir:absolute_node_id",

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -18,7 +18,7 @@ namespace Carbon::Lower {
 class ConstantContext {
  public:
   explicit ConstantContext(FileContext& file_context,
-                           FileContext::LoweredConstantStore* constants)
+                           const FileContext::LoweredConstantStore* constants)
       : file_context_(&file_context), constants_(constants) {}
 
   // Gets the lowered constant value for an instruction, which must have a
@@ -90,7 +90,7 @@ class ConstantContext {
 
  private:
   FileContext* file_context_;
-  FileContext::LoweredConstantStore* constants_;
+  const FileContext::LoweredConstantStore* constants_;
   int32_t last_lowered_constant_index_ = -1;
 };
 

--- a/toolchain/lower/constant.cpp
+++ b/toolchain/lower/constant.cpp
@@ -18,7 +18,7 @@ namespace Carbon::Lower {
 class ConstantContext {
  public:
   explicit ConstantContext(FileContext& file_context,
-                           llvm::MutableArrayRef<llvm::Constant*> constants)
+                           FileContext::LoweredConstantStore* constants)
       : file_context_(&file_context), constants_(constants) {}
 
   // Gets the lowered constant value for an instruction, which must have a
@@ -40,8 +40,7 @@ class ConstantContext {
       // This constant hasn't been lowered.
       return nullptr;
     }
-    CARBON_CHECK(inst_id.index >= 0);
-    return constants_[inst_id.index];
+    return constants_->Get(inst_id);
   }
 
   // Returns a constant for the case of a value that should never be used.
@@ -91,7 +90,7 @@ class ConstantContext {
 
  private:
   FileContext* file_context_;
-  llvm::MutableArrayRef<llvm::Constant*> constants_;
+  FileContext::LoweredConstantStore* constants_;
   int32_t last_lowered_constant_index_ = -1;
 };
 
@@ -283,8 +282,8 @@ static auto MaybeEmitAsConstant(ConstantContext& context, InstT inst)
 }
 
 auto LowerConstants(FileContext& file_context,
-                    llvm::MutableArrayRef<llvm::Constant*> constants) -> void {
-  ConstantContext context(file_context, constants);
+                    FileContext::LoweredConstantStore& constants) -> void {
+  ConstantContext context(file_context, &constants);
   // Lower each constant in InstId order. This guarantees we lower the
   // dependencies of a constant before we lower the constant itself.
   for (auto [inst_id, const_id] :
@@ -317,7 +316,7 @@ auto LowerConstants(FileContext& file_context,
 #include "toolchain/sem_ir/inst_kind.def"
     }
 
-    constants[inst_id.index] = value;
+    constants.Set(inst_id, value);
     context.SetLastLoweredConstantIndex(inst_id.index);
   }
 }

--- a/toolchain/lower/constant.h
+++ b/toolchain/lower/constant.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_LOWER_CONSTANT_H_
 
 #include "llvm/ADT/ArrayRef.h"
+#include "toolchain/base/fixed_size_value_store.h"
 #include "toolchain/lower/file_context.h"
 
 namespace Carbon::Lower {
@@ -15,7 +16,7 @@ namespace Carbon::Lower {
 // concrete constant instructions are populated with corresponding constant
 // values.
 auto LowerConstants(FileContext& file_context,
-                    llvm::MutableArrayRef<llvm::Constant*> constants) -> void;
+                    FileContext::LoweredConstantStore& constants) -> void;
 
 }  // namespace Carbon::Lower
 

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -20,6 +20,9 @@ namespace Carbon::Lower {
 // Context and shared functionality for lowering within a SemIR file.
 class FileContext {
  public:
+  using LoweredConstantStore =
+      FixedSizeValueStore<SemIR::InstId, llvm::Constant*>;
+
   // Describes a specific function's body fingerprint.
   struct SpecificFunctionFingerprint {
     // Fingerprint with all specific-dependent instructions, except specific
@@ -72,9 +75,9 @@ class FileContext {
     CARBON_CHECK(type_id.has_value(), "Should not be called with `None`");
     CARBON_CHECK(type_id.is_concrete(), "Lowering symbolic type {0}: {1}",
                  type_id, sem_ir().types().GetAsInst(type_id));
-    CARBON_CHECK(types_[type_id.index], "Missing type {0}: {1}", type_id,
+    CARBON_CHECK(types_.Get(type_id), "Missing type {0}: {1}", type_id,
                  sem_ir().types().GetAsInst(type_id));
-    return types_[type_id.index];
+    return types_.Get(type_id);
   }
 
   // Returns location information for use with DebugInfo.
@@ -145,8 +148,8 @@ class FileContext {
   // Gets the location in which a callable's function is stored.
   auto GetFunctionAddr(SemIR::FunctionId function_id,
                        SemIR::SpecificId specific_id) -> llvm::Function** {
-    return specific_id.has_value() ? &specific_functions_[specific_id.index]
-                                   : &functions_[function_id.index];
+    return specific_id.has_value() ? &specific_functions_.Get(specific_id)
+                                   : &functions_.Get(function_id);
   }
 
   // Notes that a C++ function has been referenced for the first time, so we
@@ -195,7 +198,7 @@ class FileContext {
   // by one while lowering their definitions.
   auto AddLoweredSpecificForGeneric(SemIR::GenericId generic_id,
                                     SemIR::SpecificId specific_id) {
-    lowered_specifics_[generic_id.index].push_back(specific_id);
+    lowered_specifics_.Get(generic_id).push_back(specific_id);
   }
 
   // Initializes and returns a SpecificFunctionFingerprint* instance for a
@@ -206,7 +209,7 @@ class FileContext {
     if (!specific_id.has_value()) {
       return nullptr;
     }
-    return &lowered_specific_fingerprint_[specific_id.index];
+    return &lowered_specific_fingerprint_.Get(specific_id);
   }
 
   // Entry point for coalescing equivalent specifics. Two function definitions,
@@ -282,44 +285,37 @@ class FileContext {
 
   // Maps callables to lowered functions. SemIR treats callables as the
   // canonical form of a function, so lowering needs to do the same.
-  // Vector indexes correspond to `FunctionId` indexes. We resize this directly
-  // to the correct size.
-  llvm::SmallVector<llvm::Function*, 0> functions_;
+  using LoweredFunctionStore =
+      FixedSizeValueStore<SemIR::FunctionId, llvm::Function*>;
+  LoweredFunctionStore functions_;
 
-  // Maps specific callables to lowered functions. Vector indexes correspond to
-  // `SpecificId` indexes. We resize this directly to the correct size.
-  llvm::SmallVector<llvm::Function*, 0> specific_functions_;
+  // Maps specific callables to lowered functions.
+  FixedSizeValueStore<SemIR::SpecificId, llvm::Function*> specific_functions_;
 
   // Provides lowered versions of types.
-  // Vector indexes correspond to `TypeId` indexes for non-symbolic types. We
-  // resize this directly to the (often large) correct size.
-  llvm::SmallVector<llvm::Type*, 0> types_;
+  using LoweredTypeStore = FixedSizeValueStore<SemIR::TypeId, llvm::Type*>;
+  LoweredTypeStore types_;
 
   // Maps constants to their lowered values.
-  // Vector indexes correspond to `InstId` indexes for constant instructions. We
-  // resize this directly to the (often large) correct size.
-  llvm::SmallVector<llvm::Constant*, 0> constants_;
+  LoweredConstantStore constants_;
 
   // Maps global variables to their lowered variant.
   Map<SemIR::InstId, llvm::GlobalVariable*> global_variables_;
 
   // For a generic function, keep track of the specifics for which LLVM
   // function declarations were created. Those can be retrieved then from
-  // `specific_functions_`. We resize this to the correct size. Vector indexes
-  // correspond to `GenericId` indexes.
-  llvm::SmallVector<llvm::SmallVector<SemIR::SpecificId>, 0> lowered_specifics_;
+  // `specific_functions_`.
+  FixedSizeValueStore<SemIR::GenericId, llvm::SmallVector<SemIR::SpecificId>>
+      lowered_specifics_;
 
   // For specifics that exist in lowered_specifics, a hash of their function
-  // type information: return and parameter types. We resize this to the
-  // correct size. Vector indexes correspond to `SpecificId` indexes.
+  // type information: return and parameter types.
   // TODO: Hashing all members of `FunctionTypeInfo` may not be necessary.
-  llvm::SmallVector<llvm::BLAKE3Result<32>, 0>
+  FixedSizeValueStore<SemIR::SpecificId, llvm::BLAKE3Result<32>>
       lowered_specifics_type_fingerprint_;
 
   // This is initialized and populated while lowering a specific.
-  // We resize this to the correct size. Vector indexes correspond to
-  // `SpecificId` indexes.
-  llvm::SmallVector<SpecificFunctionFingerprint, 0>
+  FixedSizeValueStore<SemIR::SpecificId, SpecificFunctionFingerprint>
       lowered_specific_fingerprint_;
 
   // Equivalent specifics that have been found. For each specific, this points
@@ -327,10 +323,10 @@ class FileContext {
   // define the canonical specific as the one with the lowest
   // `SpecificId.index`.
   //
-  // We resize this to the correct size and initialize to `SpecificId::None`,
-  // which defines that there is no other equivalent specific to this
-  // `SpecificId`. Vector indexes correspond to `SpecificId` indexes.
-  llvm::SmallVector<SemIR::SpecificId, 0> equivalent_specifics_;
+  // Entries are initialized to `SpecificId::None`, which defines that there is
+  // no other equivalent specific to this `SpecificId`.
+  FixedSizeValueStore<SemIR::SpecificId, SemIR::SpecificId>
+      equivalent_specifics_;
 
   // Non-equivalent specifics found.
   // TODO: Revisit this due to its quadratic space growth.

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -292,11 +292,12 @@ class FileContext {
   // Maps specific callables to lowered functions.
   FixedSizeValueStore<SemIR::SpecificId, llvm::Function*> specific_functions_;
 
-  // Provides lowered versions of types.
+  // Provides lowered versions of types. Entries are non-symbolic types.
   using LoweredTypeStore = FixedSizeValueStore<SemIR::TypeId, llvm::Type*>;
   LoweredTypeStore types_;
 
-  // Maps constants to their lowered values.
+  // Maps constants to their lowered values. Indexes are the `InstId` for
+  // constant instructions.
   LoweredConstantStore constants_;
 
   // Maps global variables to their lowered variant.

--- a/toolchain/parse/tree_and_subtrees.cpp
+++ b/toolchain/parse/tree_and_subtrees.cpp
@@ -16,7 +16,8 @@ TreeAndSubtrees::TreeAndSubtrees(const Lex::TokenizedBuffer& tokens,
                                  const Tree& tree)
     : tokens_(&tokens),
       tree_(&tree),
-      subtree_sizes_(SubtreeSizeStore::MakeForOverwrite(tree_->size())) {
+      subtree_sizes_(
+          SubtreeSizeStore::MakeForOverwriteWithExplicitSize(tree_->size())) {
   // A stack of nodes which haven't yet been used as children.
   llvm::SmallVector<NodeId> size_stack;
   for (auto n : tree.postorder()) {

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -44,7 +44,7 @@ Formatter::Formatter(const File* sem_ir,
       use_dump_sem_ir_ranges_(use_dump_sem_ir_ranges),
       // Create a placeholder visible chunk and assign it to all instructions
       // that don't have a chunk of their own.
-      tentative_inst_chunks_(sem_ir_->insts().size(), AddChunkNoFlush(true)) {
+      tentative_inst_chunks_(sem_ir_->insts(), AddChunkNoFlush(true)) {
   if (use_dump_sem_ir_ranges_) {
     ComputeNodeParents();
   }
@@ -103,8 +103,8 @@ auto Formatter::Format() -> void {
 
 auto Formatter::ComputeNodeParents() -> void {
   CARBON_CHECK(!node_parents_);
-  node_parents_ =
-      NodeParentStore(sem_ir_->parse_tree().size(), Parse::NodeId::None);
+  node_parents_ = NodeParentStore::MakeWithExplicitSize(
+      sem_ir_->parse_tree().size(), Parse::NodeId::None);
   for (auto n : sem_ir_->parse_tree().postorder()) {
     for (auto child : get_tree_and_subtrees_().children(n)) {
       node_parents_->Set(child, n);

--- a/toolchain/sem_ir/generic.h
+++ b/toolchain/sem_ir/generic.h
@@ -104,6 +104,8 @@ struct Specific : Printable<Specific> {
 // their associated generic argument list.
 class SpecificStore : public Yaml::Printable<SpecificStore> {
  public:
+  using IdType = SpecificId;
+
   // Adds a new specific, or gets the existing specific for a specified generic
   // and argument list. Returns the ID of the specific. The argument IDs must be
   // for instructions in the constant block, and must be a canonical instruction

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -389,6 +389,8 @@ struct LocIdAndInst {
 // Provides a ValueStore wrapper for an API specific to instructions.
 class InstStore {
  public:
+  using IdType = InstId;
+
   explicit InstStore(File* file) : file_(file) {}
 
   // Adds an instruction to the instruction list, returning an ID to reference


### PR DESCRIPTION
Changes the vectors on `Lower::FileContext` to be `FixedSizeValueStore` where possible, which we have several at this point.

This changes `FixedSizeValueStore` to prefer inferring the size from a `ValueStore<IdT>`, which should make adding incorrect sizes harder. Note I wasn't sure that adding a `size()` to `TypeStore` that returned `insts().size()` would be good because it doesn't directly work that way; `ConstantValueStore` would've also required more work since it doesn't have access to that right now.