### PR TITLE
Rename the workflow step that sets labels to a more appropriate name

### DIFF
--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write # For gh to edit labels.
 
 jobs:
-  assign_reviewer:
+  set_labels:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Currently it's called `assign_reviewers` as it was copied from the workflow that does said task. But this workflow is setting labels, so call it `set_labels`.