### PR TITLE
Add an optional bazel feature to use mold linker for building the toolchain on Linux

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -671,7 +671,6 @@ def _impl(ctx):
                 flag_groups = ([
                     flag_group(
                         flags = [
-                            "-fuse-ld=lld",
                             "-stdlib=libc++",
                             "-unwindlib=libunwind",
                             # Force the C++ standard library and runtime
@@ -724,6 +723,35 @@ def _impl(ctx):
                         expand_if_available = "force_pic",
                     ),
                 ],
+            ),
+        ],
+    )
+
+    linux_lld_feature = feature(
+        name = "linux_lld",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([flag_group(flags = [
+                    "-fuse-ld=lld",
+                ])]),
+                with_features = [
+                    with_feature_set(not_features = ["linux_mold"]),
+                ],
+            ),
+        ],
+    )
+
+    linux_mold_feature = feature(
+        name = "linux_mold",
+        enabled = False,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([flag_group(flags = [
+                    "-fuse-ld=mold",
+                ])]),
             ),
         ],
     )
@@ -1149,6 +1177,8 @@ def _impl(ctx):
     if ctx.attr.target_os == "linux":
         features.append(sanitizer_static_lib_flags)
         features.append(linux_flags_feature)
+        features.append(linux_lld_feature)
+        features.append(linux_mold_feature)
         sysroot = None
     elif ctx.attr.target_os == "windows":
         # TODO: Need to figure out if we need to add windows specific features

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -24,6 +24,7 @@ contributions.
     -   [Optional tools](#optional-tools)
         -   [Using LLDB with VS Code](#using-lldb-with-vs-code)
         -   [Using GDB with VS Code](#using-gdb-with-vs-code)
+        -   [Using mold linker](#using-mold-linker)
     -   [Manually building Clang and LLVM (not recommended)](#manually-building-clang-and-llvm-not-recommended)
 -   [Troubleshooting build issues](#troubleshooting-build-issues)
     -   [`bazel clean`](#bazel-clean)
@@ -272,6 +273,20 @@ A typical debug session looks like:
    Code.
 3. Go to the "Run and debug" panel in VS Code.
 4. Select and run the `file_test (gdb)` configuration.
+
+#### Using mold linker
+
+The [mold](https://github.com/rui314/mold) linker is a drop-in replacement for
+unix linkers. By default we use `lld` to link in the toolchain build, but you
+can choose to use `mold` on Linux. You can expect `mold` to reduce linking times
+by about 1/2 (for example, linking debug `file_test` from 21s to 12s).
+
+To use mold, install it and ensure `mold` is in your path, then add this to your
+`user.bazelrc` in the root of the Carbon git repository:
+
+```
+build --features=linux_mold
+```
 
 ### Manually building Clang and LLVM (not recommended)
 


### PR DESCRIPTION
The [`mold`](https://github.com/rui314/mold) linker is linking debug `file_test` about 2x faster than `lld` on my workstation, in 12s instead of 21s. This makes a pretty big impact on my edit-test-debug cycle.

The feature is called `linux_mold` and can be enabled in `user.bazelrc` if desired. We leave `lld` as the default linker.