### PR TITLE
Remove unused vlog_stream_ member.

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -65,7 +65,6 @@ CheckUnit::CheckUnit(
       total_ir_count_(tree_and_subtrees_getters.size()),
       fs_(std::move(fs)),
       target_(target),
-      vlog_stream_(vlog_stream),
       emitter_(&unit_and_imports_->err_tracker, tree_and_subtrees_getters,
                unit_and_imports_->unit->sem_ir),
       context_(

--- a/toolchain/check/check_unit.h
+++ b/toolchain/check/check_unit.h
@@ -187,7 +187,6 @@ class CheckUnit {
   int total_ir_count_;
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs_;
   llvm::StringRef target_;
-  llvm::raw_ostream* vlog_stream_;
 
   DiagnosticEmitter emitter_;
   Context context_;


### PR DESCRIPTION
This resolves an unused-private-member warning with recent versions of Clang.
