### PR TITLE
Add pre-commit check for invalid build graph state

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -229,6 +229,19 @@ repos:
               .*/testdata/.*\.golden
           )$
       - id: check-links
+  - repo: local
+    hooks:
+      - id: check-build-graph
+        name: Check build graph
+        entry: scripts/check_build_graph.py
+        language: python
+        files: |
+          (?x)^(
+            .*BUILD.*|
+            .*MODULE.bazel.*|
+            .*WORKSPACE.*|
+            .*\.bzl
+          )$
 
 # This excludes third-party code, and patches to third-party code.
 exclude: |

--- a/scripts/check_build_graph.py
+++ b/scripts/check_build_graph.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+"""Verify that the bazel build graph is in a valid state, for pre-commit."""
+
+__copyright__ = """
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+import subprocess
+import sys
+
+import scripts_utils
+
+
+def main() -> int:
+    scripts_utils.chdir_repo_root()
+    bazel = scripts_utils.locate_bazel()
+    sys.exit(subprocess.run([bazel, "build", "--nobuild", "//..."]).returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_build_graph.py
+++ b/scripts/check_build_graph.py
@@ -9,15 +9,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """
 
 import subprocess
-import sys
 
 import scripts_utils
 
 
-def main() -> int:
+def main() -> None:
     scripts_utils.chdir_repo_root()
     bazel = scripts_utils.locate_bazel()
-    sys.exit(subprocess.run([bazel, "build", "--nobuild", "//..."]).returncode)
+    subprocess.check_call([bazel, "build", "--nobuild", "//..."])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This can catch things like dependency cycles introduced by `fix-cc-deps`.