### PR TITLE
Manually update `gh` to fix PR labeling for now

### DIFF
--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          # TODO: Renable `disable-sudo` and `block` when the `Update gh` step
-          # can be removed.
+          # TODO: Re-enable `disable-sudo` and `block` when the `Update gh`
+          # step can be removed.
           # disable-sudo: true
           # egress-policy: block
           egress-policy: audit

--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -20,7 +20,7 @@ jobs:
           # TODO: This can be removed once https://github.com/cli/cli/releases/tag/v2.74.1
           # makes its way to the ubuntu images on GitHub workers.
           sudo apt update
-          sudo apt install gh
+          sudo apt install -y gh
 
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -14,6 +14,14 @@ jobs:
   set_labels:
     runs-on: ubuntu-latest
     steps:
+      - name: Update gh
+        run: |
+          # Update `gh` to get the fix for https://github.com/cli/cli/issues/11055
+          # TODO: This can be removed once https://github.com/cli/cli/releases/tag/v2.74.1
+          # makes its way to the ubuntu images on GitHub workers.
+          sudo apt update
+          sudo apt install gh
+
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:

--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -14,6 +14,18 @@ jobs:
   set_labels:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          # TODO: Renable `disable-sudo` and `block` when the `Update gh` step
+          # can be removed.
+          # disable-sudo: true
+          # egress-policy: block
+          egress-policy: audit
+          # prettier-ignore
+          allowed-endpoints: >
+            api.github.com:443
+
       - name: Update gh
         run: |
           # Update `gh` to get the fix for https://github.com/cli/cli/issues/11055
@@ -21,15 +33,6 @@ jobs:
           # makes its way to the ubuntu images on GitHub workers.
           sudo apt update
           sudo apt install -y gh
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-          # prettier-ignore
-          allowed-endpoints: >
-            api.github.com:443
 
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2


### PR DESCRIPTION
Issue https://github.com/cli/cli/issues/11055 suggests updating the `gh` tool explicitly until the update gets applied to the github worker images.