### PR TITLE
Fix the hardening mode defines, also use debug

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -653,7 +653,7 @@ def _impl(ctx):
         )],
     )
 
-    # Clang HARDENED_MODE has 4 possible values:
+    # Clang HARDENING_MODE has 4 possible values:
     # https://libcxx.llvm.org/Hardening.html#notes-for-users
     libcpp_debug_flags = [
         "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG",

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -654,12 +654,12 @@ def _impl(ctx):
     )
 
     # Clang HARDENED_MODE has 4 possible values:
-    # https://releases.llvm.org/18.1.0/projects/libcxx/docs/Hardening.html#hardening-modes
+    # https://libcxx.llvm.org/Hardening.html#notes-for-users
     libcpp_debug_flags = [
-        "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
+        "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG",
     ]
     libcpp_release_flags = [
-        "-D_LIBCPP_ENABLE_HARDENED_MODE=_LIBCPP_HARDENING_MODE_FAST",
+        "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST",
     ]
 
     linux_flags_feature = feature(


### PR DESCRIPTION
This is based on #5664 because it's fixing an issue which `DEBUG` would catch. That's also why I'm switching to `DEBUG` from `EXTENSIVE`; I think we should be okay with the performance cost in `file_test`, which is probably our main concern.

Note digging into this also got me to notice that the flags weren't actually enabled; this is fixing the define names.