### PR TITLE
Revert "Manually update `gh` to fix PR labeling for now (#5665)"

### DIFF
--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -17,22 +17,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
-          # TODO: Re-enable `disable-sudo` and `block` when the `Update gh`
-          # step can be removed.
-          # disable-sudo: true
-          # egress-policy: block
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
           # prettier-ignore
           allowed-endpoints: >
             api.github.com:443
-
-      - name: Update gh
-        run: |
-          # Update `gh` to get the fix for https://github.com/cli/cli/issues/11055
-          # TODO: This can be removed once https://github.com/cli/cli/releases/tag/v2.74.1
-          # makes its way to the ubuntu images on GitHub workers.
-          sudo apt update
-          sudo apt install -y gh
 
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2


### PR DESCRIPTION
This reverts commit f967bf0b8573d41a52f92ebbfe058cc938c627c2.

The apt repo does not have 2.74.1 yet.
