### PR TITLE
Abandon SubstInst when encountering ErrorInst

### DIFF
--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -316,6 +316,12 @@ auto SubstInst(Context& context, SemIR::InstId inst_id,
     }
 
     if (callbacks.Subst(item.inst_id)) {
+      // If any instruction is an ErrorInst, combining it into another
+      // instruction will also produce an ErrorInst, so shortcut out here to
+      // save wasted work.
+      if (item.inst_id == SemIR::ErrorInst::InstId) {
+        return SemIR::ErrorInst::InstId;
+      }
       index = item.next_index;
       continue;
     }


### PR DESCRIPTION
`SubstInst()` replaces individual instructions, and then rebuilds them into instructions that contain those instructions. If any instruction is an `ErrorInst`, the final result will also be an `ErrorInst`. In pathological cases, it's possible to generate large types, [such as](https://github.com/carbon-language/carbon-lang/issues/5672) tuples of tuples of tuples of tuples of `something`. If that `something` is `ErrorInst`, we can save a lot of work by avoiding building the surrounding types, and evaluating them all to `ErrorInst`.