### PR TITLE
Shortcut out of resolve rewrites after finding a cycle

### DIFF
--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -409,6 +409,7 @@ class SubstImplWitnessAccessCallbacks : public SubstInstCallbacks {
         } else {
           rhs_inst_id = search_constraint.rhs_id;
         }
+        break;
       }
     }
 
@@ -461,7 +462,14 @@ auto ResolveFacetTypeRewriteConstraints(
                                                     &constraint));
       if (subst_inst_id != constraint.rhs_id) {
         constraint.rhs_id = subst_inst_id;
-        if (constraint.rhs_id != SemIR::ErrorInst::InstId) {
+        if (constraint.rhs_id == SemIR::ErrorInst::InstId) {
+          // An error anywhere in the FacetType will turn the whole FacetType
+          // into an error. The ErrorInst says we have already diagnosed a cycle
+          // so we can stop applying rewrites. We don't return, so that we can
+          // also diagnose conflicting rewrites.
+          applied_rewrite = false;
+          break;
+        } else {
           // If the RHS is replaced with a non-error value, we need to do
           // another pass so that the new RHS value can continue to propagate.
           applied_rewrite = true;

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -316,6 +316,12 @@ auto SubstInst(Context& context, SemIR::InstId inst_id,
     }
 
     if (callbacks.Subst(item.inst_id)) {
+      // If any instruction is an ErrorInst, combining it into another
+      // instruction will also produce an ErrorInst, so shortcut out here to
+      // save wasted work.
+      if (item.inst_id == SemIR::ErrorInst::InstId) {
+        return SemIR::ErrorInst::InstId;
+      }
       index = item.next_index;
       continue;
     }

--- a/toolchain/check/testdata/facet/facet_assoc_const.carbon
+++ b/toolchain/check/testdata/facet/facet_assoc_const.carbon
@@ -247,15 +247,12 @@ library "[[@TEST_NAME]]";
 interface M { let X:! type; let Y:! type; let Z:! type; }
 
 // This fails because it resolves to `.X = .X` which is cyclical.
-// The value of .X and .Y becomes <error> but .Z is still valid.
 //
-//@dump-sem-ir-begin
 // CHECK:STDERR: fail_cycle.carbon:[[@LINE+4]]:10: error: found cycle in facet type constraint for `.(M.X)` [FacetTypeConstraintCycle]
 // CHECK:STDERR: fn F(T:! M where .X = .Y and .Y = .X and .Z = ()) {}
 // CHECK:STDERR:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F(T:! M where .X = .Y and .Y = .X and .Z = ()) {}
-//@dump-sem-ir-end
 
 // --- fail_cycle_between_interfaces.carbon
 library "[[@TEST_NAME]]";
@@ -320,6 +317,21 @@ class C(T:! type, U:! type);
 // CHECK:STDERR:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F(T:! I where .X1 = C(.X2, .X3) and .X2 = C(.X3, .X1));
+
+// --- fail_cycle_and_conflict.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; let Y:! type; }
+
+// CHECK:STDERR: fail_cycle_and_conflict.carbon:[[@LINE+8]]:10: error: found cycle in facet type constraint for `.(M.X)` [FacetTypeConstraintCycle]
+// CHECK:STDERR: fn F(T:! M where .X = .X and .Y = () and .Y = {}) {}
+// CHECK:STDERR:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_cycle_and_conflict.carbon:[[@LINE+4]]:10: error: associated constant `.(M.Y)` given two different values `()` and `{}` [AssociatedConstantWithDifferentValues]
+// CHECK:STDERR: fn F(T:! M where .X = .X and .Y = () and .Y = {}) {}
+// CHECK:STDERR:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(T:! M where .X = .X and .Y = () and .Y = {}) {}
 
 // --- non-type.carbon
 library "[[@TEST_NAME]]";
@@ -425,81 +437,3 @@ interface Z {
 fn F(A:! Z where .T = .V.U and .V = .Self and .U = ()) -> A.T {
   return ();
 }
-
-// CHECK:STDOUT: --- fail_cycle.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %M.type: type = facet_type <@M> [concrete]
-// CHECK:STDOUT:   %M.assoc_type: type = assoc_entity_type @M [concrete]
-// CHECK:STDOUT:   %assoc0: %M.assoc_type = assoc_entity element0, @M.%X [concrete]
-// CHECK:STDOUT:   %assoc1: %M.assoc_type = assoc_entity element1, @M.%Y [concrete]
-// CHECK:STDOUT:   %assoc2: %M.assoc_type = assoc_entity element2, @M.%Z [concrete]
-// CHECK:STDOUT:   %.Self: %M.type = bind_symbolic_name .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %M.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @M [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %M.lookup_impl_witness, element0 [symbolic_self]
-// CHECK:STDOUT:   %impl.elem1: type = impl_witness_access %M.lookup_impl_witness, element1 [symbolic_self]
-// CHECK:STDOUT:   %impl.elem2: type = impl_witness_access %M.lookup_impl_witness, element2 [symbolic_self]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
-// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: imports {
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %T.patt: <error> = symbolic_binding_pattern T, 0 [concrete]
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc13_12.1: type = splice_block %.loc13_12.2 [concrete = <error>] {
-// CHECK:STDOUT:       %M.ref: type = name_ref M, file.%M.decl [concrete = constants.%M.type]
-// CHECK:STDOUT:       <elided>
-// CHECK:STDOUT:       %.Self.ref.loc13_18: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %X.ref.loc13_18: %M.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:       %.Self.as_type.loc13_18: type = facet_access_type %.Self.ref.loc13_18 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc13_18: type = converted %.Self.ref.loc13_18, %.Self.as_type.loc13_18 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %impl.elem0.loc13_18: type = impl_witness_access constants.%M.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:       %.Self.ref.loc13_23: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %Y.ref.loc13_23: %M.assoc_type = name_ref Y, @Y.%assoc1 [concrete = constants.%assoc1]
-// CHECK:STDOUT:       %.Self.as_type.loc13_23: type = facet_access_type %.Self.ref.loc13_23 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc13_23: type = converted %.Self.ref.loc13_23, %.Self.as_type.loc13_23 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %impl.elem1.loc13_23: type = impl_witness_access constants.%M.lookup_impl_witness, element1 [symbolic_self = constants.%impl.elem1]
-// CHECK:STDOUT:       %.Self.ref.loc13_30: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %Y.ref.loc13_30: %M.assoc_type = name_ref Y, @Y.%assoc1 [concrete = constants.%assoc1]
-// CHECK:STDOUT:       %.Self.as_type.loc13_30: type = facet_access_type %.Self.ref.loc13_30 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc13_30: type = converted %.Self.ref.loc13_30, %.Self.as_type.loc13_30 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %impl.elem1.loc13_30: type = impl_witness_access constants.%M.lookup_impl_witness, element1 [symbolic_self = constants.%impl.elem1]
-// CHECK:STDOUT:       %.Self.ref.loc13_35: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %X.ref.loc13_35: %M.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:       %.Self.as_type.loc13_35: type = facet_access_type %.Self.ref.loc13_35 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc13_35: type = converted %.Self.ref.loc13_35, %.Self.as_type.loc13_35 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %impl.elem0.loc13_35: type = impl_witness_access constants.%M.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:       %.Self.ref.loc13_42: %M.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %Z.ref: %M.assoc_type = name_ref Z, @Z.%assoc2 [concrete = constants.%assoc2]
-// CHECK:STDOUT:       %.Self.as_type.loc13_42: type = facet_access_type %.Self.ref.loc13_42 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc13_42: type = converted %.Self.ref.loc13_42, %.Self.as_type.loc13_42 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %impl.elem2: type = impl_witness_access constants.%M.lookup_impl_witness, element2 [symbolic_self = constants.%impl.elem2]
-// CHECK:STDOUT:       %.loc13_48.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:       %.loc13_48.2: type = converted %.loc13_48.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.loc13_12.2: type = where_expr %.Self [concrete = <error>] {
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc13_18, %impl.elem1.loc13_23
-// CHECK:STDOUT:         requirement_rewrite %impl.elem1.loc13_30, %impl.elem0.loc13_35
-// CHECK:STDOUT:         requirement_rewrite %impl.elem2, %.loc13_48.2
-// CHECK:STDOUT:       }
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T: <error> = bind_symbolic_name T, 0 [concrete = <error>]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T: <error>) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:
-// CHECK:STDOUT:   fn() {
-// CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     return
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(<error>) {}
-// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/impl_assoc_const.carbon
@@ -273,6 +273,21 @@ interface J {
 // CHECK:STDERR:
 impl () as I where .Self impls J and .X1 = .(J.X3) and .X2 = .X1 and .(J.X3) = .X2 {}
 
+// --- fail_cycle_and_conflict.carbon
+library "[[@TEST_NAME]]";
+
+interface M { let X:! type; let Y:! type; }
+
+// CHECK:STDERR: fail_cycle_and_conflict.carbon:[[@LINE+8]]:12: error: found cycle in facet type constraint for `.(M.X)` [FacetTypeConstraintCycle]
+// CHECK:STDERR: impl () as M where .X = .X and .Y = () and .Y = {} {}
+// CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_cycle_and_conflict.carbon:[[@LINE+4]]:12: error: associated constant `.(M.Y)` given two different values `()` and `{}` [AssociatedConstantWithDifferentValues]
+// CHECK:STDERR: impl () as M where .X = .X and .Y = () and .Y = {} {}
+// CHECK:STDERR:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl () as M where .X = .X and .Y = () and .Y = {} {}
+
 // --- non-type.carbon
 library "[[@TEST_NAME]]";
 


### PR DESCRIPTION
When resolving a facet type's rewrite constraints, if we find a cycle, we can stop replacing the RHS of constraints. Continuing would only be important if we want to propagate the error through the whole cycle, but once there's an error in a rewrite constraint, the FacetType will also resolve to an error, so there's no benefit to propagating the error more.

Ensure that we still diagnose a conflicting rewrite in the facet type after diagnosing a cycle, in the case that both issues are present in the same facet type.

Together with https://github.com/carbon-language/carbon-lang/pull/5692 this takes our pathological exponential example[1] from running for minutes to running in 17ms, which will still need to be improved by eliminating exponential behaviour. But this avoids wasted work nonetheless.

[1] https://github.com/carbon-language/carbon-lang/pull/5673#discussion_r2152859014