### PR TITLE
Introduce the `none.carbon` min-prelude

### DIFF
--- a/toolchain/check/testdata/alias/basics.carbon
+++ b/toolchain/check/testdata/alias/basics.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/alias/in_namespace.carbon
+++ b/toolchain/check/testdata/alias/in_namespace.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/alias/preserve_in_type_printing.carbon
+++ b/toolchain/check/testdata/alias/preserve_in_type_printing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/basics/dump_sem_ir_ranges_only.carbon
+++ b/toolchain/check/testdata/basics/dump_sem_ir_ranges_only.carbon
@@ -5,7 +5,7 @@
 // This tests `--dump-sem-ir-range=only` behavior, which is set implicitly by
 // file_test.
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/basics/duplicate_name_same_line.carbon
+++ b/toolchain/check/testdata/basics/duplicate_name_same_line.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/basics/name_lookup.carbon
+++ b/toolchain/check/testdata/basics/name_lookup.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/basics/raw_sem_ir/builtins.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/builtins.carbon
@@ -2,7 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import --dump-raw-sem-ir --builtin-sem-ir
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+// EXTRA-ARGS: --dump-raw-sem-ir --builtin-sem-ir
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/basics/raw_sem_ir/multifile.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/multifile.carbon
@@ -2,7 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import --dump-raw-sem-ir --no-dump-sem-ir
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+// EXTRA-ARGS: --dump-raw-sem-ir --no-dump-sem-ir
 //
 // Check that raw IR dumping works as expected.
 //

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
@@ -2,7 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import --dump-raw-sem-ir --no-dump-sem-ir
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+// EXTRA-ARGS: --dump-raw-sem-ir --no-dump-sem-ir
 //
 // Check that raw IR dumping works as expected.
 //

--- a/toolchain/check/testdata/builtins/no_op.carbon
+++ b/toolchain/check/testdata/builtins/no_op.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/class/name_poisoning.carbon
+++ b/toolchain/check/testdata/class/name_poisoning.carbon
@@ -2,8 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/convert.carbon
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/const/import.carbon
+++ b/toolchain/check/testdata/const/import.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/function/declaration/name_poisoning.carbon
+++ b/toolchain/check/testdata/function/declaration/name_poisoning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/generic/dot_self_symbolic_type.carbon
+++ b/toolchain/check/testdata/generic/dot_self_symbolic_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/global/basics.carbon
+++ b/toolchain/check/testdata/global/basics.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/impl_assoc_const.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/impl_self_as.carbon
+++ b/toolchain/check/testdata/impl/impl_self_as.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/impl_where_redecl.carbon
+++ b/toolchain/check/testdata/impl/impl_where_redecl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/import_impl_with_no_interface.carbon
+++ b/toolchain/check/testdata/impl/import_impl_with_no_interface.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/impl/name_poisoning.carbon
+++ b/toolchain/check/testdata/impl/name_poisoning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interface/fail_assoc_const_not_constant.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_not_constant.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interface/name_poisoning.carbon
+++ b/toolchain/check/testdata/interface/name_poisoning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/bad_import.carbon
+++ b/toolchain/check/testdata/interop/cpp/bad_import.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/cpp_diagnostics.carbon
+++ b/toolchain/check/testdata/interop/cpp/cpp_diagnostics.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/cpp_namespace.carbon
+++ b/toolchain/check/testdata/interop/cpp/cpp_namespace.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/file_not_found.carbon
+++ b/toolchain/check/testdata/interop/cpp/file_not_found.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/function/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/function/inline.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/inline.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/function/struct.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/struct.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/include.carbon
+++ b/toolchain/check/testdata/interop/cpp/include.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/multiple_imports.carbon
+++ b/toolchain/check/testdata/interop/cpp/multiple_imports.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/namespace.carbon
+++ b/toolchain/check/testdata/interop/cpp/namespace.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/union.carbon
+++ b/toolchain/check/testdata/interop/cpp/union.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/interop/cpp/unsupported_decl_type.carbon
+++ b/toolchain/check/testdata/interop/cpp/unsupported_decl_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/packages/core_name_poisoning.carbon
+++ b/toolchain/check/testdata/packages/core_name_poisoning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/packages/fail_modifiers.carbon
+++ b/toolchain/check/testdata/packages/fail_modifiers.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/tuple/basics.carbon
+++ b/toolchain/check/testdata/tuple/basics.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/check/testdata/var/fail_in_interface.carbon
+++ b/toolchain/check/testdata/var/fail_in_interface.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/lower/testdata/builtins/bool.carbon
+++ b/toolchain/lower/testdata/builtins/bool.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/lower/testdata/builtins/no_op.carbon
+++ b/toolchain/lower/testdata/builtins/no_op.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/lower/testdata/builtins/types.carbon
+++ b/toolchain/lower/testdata/builtins/types.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/testing/testdata/min_prelude/none.carbon
+++ b/toolchain/testing/testdata/min_prelude/none.carbon
@@ -1,0 +1,10 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// EXTRA-ARGS: --no-prelude-import --exclude-dump-file-prefix=min_prelude/
+
+// --- min_prelude/none.carbon
+
+// A minimal prelude that avoids importing any prelude library at all.
+package Core library "prelude";

--- a/toolchain/testing/testdata/min_prelude/none.carbon
+++ b/toolchain/testing/testdata/min_prelude/none.carbon
@@ -7,4 +7,4 @@
 // --- min_prelude/none.carbon
 
 // A minimal prelude that avoids importing any prelude library at all.
-package Core library "prelude";
+package MinPreludeNone;


### PR DESCRIPTION
The none.carbon min-prelude is not just an empty prelude, it also prevents any prelude from being imported at all. So no import machinery runs before the test, only the `package` statement from the prelude would run.

Use the none.carbon min-prelude in a few tests that were specifying `--no-prelude-import` to give it a trial run.