### PR TITLE
Replace `EXTRA-ARGS: --no-prelude-import` with `INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon`

### DIFF
--- a/toolchain/check/testdata/interop/cpp/function/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --no-prelude-import
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:


### PR DESCRIPTION
Follow up https://github.com/carbon-language/carbon-lang/pull/5538 to be consistent with the practice introduced in https://github.com/carbon-language/carbon-lang/pull/5694.