### PR TITLE
Avoid deducing errors as argument instructions after subst

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -543,6 +543,12 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
                                            binding_type_id)
                     : TryConvertToValueOfType(context(), loc_id_,
                                               deduced_arg_id, binding_type_id);
+      // The conversion of the argument to the parameter type can fail after
+      // applying the enclosing specific, in which case deduction fails.
+      if (converted_arg_id == SemIR::ErrorInst::InstId) {
+        return false;
+      }
+
       // Replace the deduced arg with its value converted to the parameter
       // type. The conversion of the argument type must produce a constant value
       // to be used in deduction.

--- a/toolchain/check/testdata/facet/fail_convert_class_type_to_generic_facet_value.carbon
+++ b/toolchain/check/testdata/facet/fail_convert_class_type_to_generic_facet_value.carbon
@@ -43,7 +43,6 @@ fn G() {
 // CHECK:STDOUT:   %Scalar: type = bind_symbolic_name Scalar, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %Generic.type.c21: type = generic_interface_type @Generic [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %Generic.generic: %Generic.type.c21 = struct_value () [concrete]
 // CHECK:STDOUT:   %Generic.type.91ccba.1: type = facet_type <@Generic, @Generic(%Scalar)> [symbolic]
 // CHECK:STDOUT:   %Self.dee: %Generic.type.91ccba.1 = bind_symbolic_name Self, 1 [symbolic]
@@ -74,8 +73,6 @@ fn G() {
 // CHECK:STDOUT:   %CallGenericMethod: %CallGenericMethod.type = struct_value () [concrete]
 // CHECK:STDOUT:   %G.type: type = fn_type @G [concrete]
 // CHECK:STDOUT:   %G: %G.type = struct_value () [concrete]
-// CHECK:STDOUT:   %Generic.type.c3b: type = facet_type <@Generic, @Generic(%WrongGenericParam)> [concrete]
-// CHECK:STDOUT:   %pattern_type.7ae: type = pattern_type %Generic.type.c3b [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -213,8 +210,6 @@ fn G() {
 // CHECK:STDOUT:   %CallGenericMethod.ref: %CallGenericMethod.type = name_ref CallGenericMethod, file.%CallGenericMethod.decl [concrete = constants.%CallGenericMethod]
 // CHECK:STDOUT:   %WrongGenericParam.ref: type = name_ref WrongGenericParam, file.%WrongGenericParam.decl [concrete = constants.%WrongGenericParam]
 // CHECK:STDOUT:   %ImplsGeneric.ref: type = name_ref ImplsGeneric, file.%ImplsGeneric.decl [concrete = constants.%ImplsGeneric]
-// CHECK:STDOUT:   %CallGenericMethod.specific_fn: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%WrongGenericParam, <error>) [concrete = <error>]
-// CHECK:STDOUT:   %CallGenericMethod.call: init %empty_tuple.type = call %CallGenericMethod.specific_fn() [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -251,12 +246,5 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Generic(constants.%WrongGenericParam) {
 // CHECK:STDOUT:   %Scalar.loc15_19.2 => constants.%WrongGenericParam
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @CallGenericMethod(constants.%WrongGenericParam, <error>) {
-// CHECK:STDOUT:   %T.loc27_22.2 => constants.%WrongGenericParam
-// CHECK:STDOUT:   %Generic.type.loc27_45.2 => constants.%Generic.type.c3b
-// CHECK:STDOUT:   %U.loc27_32.2 => <error>
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ae
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/generic/dot_self_symbolic_type.carbon
+++ b/toolchain/check/testdata/generic/dot_self_symbolic_type.carbon
@@ -78,7 +78,6 @@ fn H(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %A.type.495: type = generic_interface_type @A [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %A.generic: %A.type.495 = struct_value () [concrete]
 // CHECK:STDOUT:   %CC: type = bind_symbolic_name CC, 0 [symbolic]
 // CHECK:STDOUT:   %C.type: type = generic_class_type @C [concrete]
@@ -88,13 +87,13 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %.Self.fafe34.1: %A.type.75a876.2 = bind_symbolic_name .Self [symbolic]
 // CHECK:STDOUT:   %A.assoc_type.ed3b32.2: type = assoc_entity_type @A, @A(%CC) [symbolic]
 // CHECK:STDOUT:   %assoc0.ce3509.2: %A.assoc_type.ed3b32.2 = assoc_entity element0, @A.%X [symbolic]
-// CHECK:STDOUT:   %require_complete.6daa34.1: <witness> = require_complete_type %A.type.75a876.2 [symbolic]
-// CHECK:STDOUT:   %.Self.as_type.1bbfba.1: type = facet_access_type %.Self.fafe34.1 [symbolic]
+// CHECK:STDOUT:   %require_complete.6da: <witness> = require_complete_type %A.type.75a876.2 [symbolic]
+// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self.fafe34.1 [symbolic]
 // CHECK:STDOUT:   %A.lookup_impl_witness.4e49fb.1: <witness> = lookup_impl_witness %.Self.fafe34.1, @A, @A(%CC) [symbolic]
 // CHECK:STDOUT:   %impl.elem0.452c56.1: type = impl_witness_access %A.lookup_impl_witness.4e49fb.1, element0 [symbolic]
 // CHECK:STDOUT:   %A_where.type.5b404c.1: type = facet_type <@A, @A(%CC) where %impl.elem0.452c56.1 = %CC> [symbolic]
 // CHECK:STDOUT:   %T.dad: %A_where.type.5b404c.1 = bind_symbolic_name T, 1 [symbolic]
-// CHECK:STDOUT:   %pattern_type.2e945c.1: type = pattern_type %A_where.type.5b404c.1 [symbolic]
+// CHECK:STDOUT:   %pattern_type.2e9: type = pattern_type %A_where.type.5b404c.1 [symbolic]
 // CHECK:STDOUT:   %F.type.704ae6.1: type = fn_type @F, @C(%CC) [symbolic]
 // CHECK:STDOUT:   %F.2d247e.1: %F.type.704ae6.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
@@ -112,12 +111,6 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %.Self.fafe34.2: %A.type.75a876.3 = bind_symbolic_name .Self [symbolic]
 // CHECK:STDOUT:   %A.lookup_impl_witness.4e49fb.2: <witness> = lookup_impl_witness %.Self.fafe34.2, @A, @A(%DD) [symbolic]
 // CHECK:STDOUT:   %impl.elem0.452c56.2: type = impl_witness_access %A.lookup_impl_witness.4e49fb.2, element0 [symbolic]
-// CHECK:STDOUT:   %A_where.type.5b404c.2: type = facet_type <@A, @A(%DD) where %impl.elem0.452c56.2 = %DD> [symbolic]
-// CHECK:STDOUT:   %require_complete.6daa34.2: <witness> = require_complete_type %A.type.75a876.3 [symbolic]
-// CHECK:STDOUT:   %A.assoc_type.ed3b32.3: type = assoc_entity_type @A, @A(%DD) [symbolic]
-// CHECK:STDOUT:   %assoc0.ce3509.3: %A.assoc_type.ed3b32.3 = assoc_entity element0, @A.%X [symbolic]
-// CHECK:STDOUT:   %.Self.as_type.1bbfba.2: type = facet_access_type %.Self.fafe34.2 [symbolic]
-// CHECK:STDOUT:   %pattern_type.2e945c.2: type = pattern_type %A_where.type.5b404c.2 [symbolic]
 // CHECK:STDOUT:   %T.8b3: type = bind_symbolic_name T, 0 [symbolic]
 // CHECK:STDOUT:   %G.type.0da: type = fn_type @G, @D(%empty_struct_type) [concrete]
 // CHECK:STDOUT:   %G.54c: %G.type.0da = struct_value () [concrete]
@@ -139,7 +132,7 @@ fn H(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %F.decl: @C.%F.type (%F.type.704ae6.1) = fn_decl @F [symbolic = @C.%F (constants.%F.2d247e.1)] {
-// CHECK:STDOUT:       %T.patt: @F.%pattern_type (%pattern_type.2e945c.1) = symbolic_binding_pattern T, 1 [concrete]
+// CHECK:STDOUT:       %T.patt: @F.%pattern_type (%pattern_type.2e9) = symbolic_binding_pattern T, 1 [concrete]
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %.loc11_18.1: type = splice_block %.loc11_18.2 [symbolic = %A_where.type (constants.%A_where.type.5b404c.1)] {
 // CHECK:STDOUT:         %A.ref: %A.type.495 = name_ref A, file.%A.decl [concrete = constants.%A.generic]
@@ -149,8 +142,8 @@ fn H(T:! type) {
 // CHECK:STDOUT:         %.Self.ref: @F.%A.type.loc11_16.1 (%A.type.75a876.2) = name_ref .Self, %.Self.2 [symbolic = %.Self.1 (constants.%.Self.fafe34.1)]
 // CHECK:STDOUT:         %.loc11_24.1: @F.%A.assoc_type (%A.assoc_type.ed3b32.2) = specific_constant @X.%assoc0, @A(constants.%CC) [symbolic = %assoc0 (constants.%assoc0.ce3509.2)]
 // CHECK:STDOUT:         %X.ref: @F.%A.assoc_type (%A.assoc_type.ed3b32.2) = name_ref X, %.loc11_24.1 [symbolic = %assoc0 (constants.%assoc0.ce3509.2)]
-// CHECK:STDOUT:         %.Self.as_type.loc11_24.2: type = facet_access_type %.Self.ref [symbolic = %.Self.as_type.loc11_24.1 (constants.%.Self.as_type.1bbfba.1)]
-// CHECK:STDOUT:         %.loc11_24.2: type = converted %.Self.ref, %.Self.as_type.loc11_24.2 [symbolic = %.Self.as_type.loc11_24.1 (constants.%.Self.as_type.1bbfba.1)]
+// CHECK:STDOUT:         %.Self.as_type.loc11_24.2: type = facet_access_type %.Self.ref [symbolic = %.Self.as_type.loc11_24.1 (constants.%.Self.as_type)]
+// CHECK:STDOUT:         %.loc11_24.2: type = converted %.Self.ref, %.Self.as_type.loc11_24.2 [symbolic = %.Self.as_type.loc11_24.1 (constants.%.Self.as_type)]
 // CHECK:STDOUT:         %impl.elem0.loc11_24.2: type = impl_witness_access constants.%A.lookup_impl_witness.4e49fb.1, element0 [symbolic = %impl.elem0.loc11_24.1 (constants.%impl.elem0.452c56.1)]
 // CHECK:STDOUT:         %CC.ref.loc11_29: type = name_ref CC, @C.%CC.loc6_9.1 [symbolic = %CC (constants.%CC)]
 // CHECK:STDOUT:         %.loc11_18.2: type = where_expr %.Self.2 [symbolic = %A_where.type (constants.%A_where.type.5b404c.1)] {
@@ -192,15 +185,15 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %CC: type = bind_symbolic_name CC, 0 [symbolic = %CC (constants.%CC)]
 // CHECK:STDOUT:   %A.type.loc11_16.1: type = facet_type <@A, @A(%CC)> [symbolic = %A.type.loc11_16.1 (constants.%A.type.75a876.2)]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %A.type.loc11_16.1 [symbolic = %require_complete (constants.%require_complete.6daa34.1)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %A.type.loc11_16.1 [symbolic = %require_complete (constants.%require_complete.6da)]
 // CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A, @A(%CC) [symbolic = %A.assoc_type (constants.%A.assoc_type.ed3b32.2)]
 // CHECK:STDOUT:   %assoc0: @F.%A.assoc_type (%A.assoc_type.ed3b32.2) = assoc_entity element0, @A.%X [symbolic = %assoc0 (constants.%assoc0.ce3509.2)]
-// CHECK:STDOUT:   %.Self.as_type.loc11_24.1: type = facet_access_type %.Self.1 [symbolic = %.Self.as_type.loc11_24.1 (constants.%.Self.as_type.1bbfba.1)]
+// CHECK:STDOUT:   %.Self.as_type.loc11_24.1: type = facet_access_type %.Self.1 [symbolic = %.Self.as_type.loc11_24.1 (constants.%.Self.as_type)]
 // CHECK:STDOUT:   %A.lookup_impl_witness: <witness> = lookup_impl_witness %.Self.1, @A, @A(%CC) [symbolic = %A.lookup_impl_witness (constants.%A.lookup_impl_witness.4e49fb.1)]
 // CHECK:STDOUT:   %impl.elem0.loc11_24.1: type = impl_witness_access %A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc11_24.1 (constants.%impl.elem0.452c56.1)]
 // CHECK:STDOUT:   %A_where.type: type = facet_type <@A, @A(%CC) where %impl.elem0.loc11_24.1 = %CC> [symbolic = %A_where.type (constants.%A_where.type.5b404c.1)]
 // CHECK:STDOUT:   %T.loc11_8.1: @F.%A_where.type (%A_where.type.5b404c.1) = bind_symbolic_name T, 1 [symbolic = %T.loc11_8.1 (constants.%T.dad)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %A_where.type [symbolic = %pattern_type (constants.%pattern_type.2e945c.1)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %A_where.type [symbolic = %pattern_type (constants.%pattern_type.2e9)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -232,8 +225,6 @@ fn H(T:! type) {
 // CHECK:STDOUT:     %.loc25: @G.%F.type (%F.type.704ae6.2) = specific_constant @C.%F.decl, @C(constants.%DD) [symbolic = %F (constants.%F.2d247e.2)]
 // CHECK:STDOUT:     %F.ref: @G.%F.type (%F.type.704ae6.2) = name_ref F, %.loc25 [symbolic = %F (constants.%F.2d247e.2)]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc16_8.2 [symbolic = %T.loc16_8.1 (constants.%T.336)]
-// CHECK:STDOUT:     %F.specific_fn: <specific function> = specific_function %F.ref, @F(constants.%DD, <error>) [concrete = <error>]
-// CHECK:STDOUT:     %F.call: init %empty_tuple.type = call %F.specific_fn() [concrete = <error>]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -250,15 +241,15 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %CC => constants.%CC
 // CHECK:STDOUT:   %A.type.loc11_16.1 => constants.%A.type.75a876.2
 // CHECK:STDOUT:   %.Self.1 => constants.%.Self.fafe34.1
-// CHECK:STDOUT:   %require_complete => constants.%require_complete.6daa34.1
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.6da
 // CHECK:STDOUT:   %A.assoc_type => constants.%A.assoc_type.ed3b32.2
 // CHECK:STDOUT:   %assoc0 => constants.%assoc0.ce3509.2
-// CHECK:STDOUT:   %.Self.as_type.loc11_24.1 => constants.%.Self.as_type.1bbfba.1
+// CHECK:STDOUT:   %.Self.as_type.loc11_24.1 => constants.%.Self.as_type
 // CHECK:STDOUT:   %A.lookup_impl_witness => constants.%A.lookup_impl_witness.4e49fb.1
 // CHECK:STDOUT:   %impl.elem0.loc11_24.1 => constants.%impl.elem0.452c56.1
 // CHECK:STDOUT:   %A_where.type => constants.%A_where.type.5b404c.1
 // CHECK:STDOUT:   %T.loc11_8.1 => constants.%T.dad
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2e945c.1
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2e9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D(constants.%DD) {
@@ -279,21 +270,6 @@ fn H(T:! type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %F.type => constants.%F.type.704ae6.2
 // CHECK:STDOUT:   %F => constants.%F.2d247e.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(constants.%DD, <error>) {
-// CHECK:STDOUT:   %CC => constants.%DD
-// CHECK:STDOUT:   %A.type.loc11_16.1 => constants.%A.type.75a876.3
-// CHECK:STDOUT:   %.Self.1 => constants.%.Self.fafe34.2
-// CHECK:STDOUT:   %require_complete => constants.%require_complete.6daa34.2
-// CHECK:STDOUT:   %A.assoc_type => constants.%A.assoc_type.ed3b32.3
-// CHECK:STDOUT:   %assoc0 => constants.%assoc0.ce3509.3
-// CHECK:STDOUT:   %.Self.as_type.loc11_24.1 => constants.%.Self.as_type.1bbfba.2
-// CHECK:STDOUT:   %A.lookup_impl_witness => constants.%A.lookup_impl_witness.4e49fb.2
-// CHECK:STDOUT:   %impl.elem0.loc11_24.1 => constants.%impl.elem0.452c56.2
-// CHECK:STDOUT:   %A_where.type => constants.%A_where.type.5b404c.2
-// CHECK:STDOUT:   %T.loc11_8.1 => <error>
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.2e945c.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D(constants.%empty_struct_type) {
@@ -336,18 +312,18 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %A.generic: %A.type.495 = struct_value () [concrete]
 // CHECK:STDOUT:   %A.type.75a876.1: type = facet_type <@A, @A(%AA)> [symbolic]
-// CHECK:STDOUT:   %A.assoc_type.ed3b32.1: type = assoc_entity_type @A, @A(%AA) [symbolic]
-// CHECK:STDOUT:   %assoc0.ce3509.1: %A.assoc_type.ed3b32.1 = assoc_entity element0, @A.%X [symbolic]
+// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A, @A(%AA) [symbolic]
+// CHECK:STDOUT:   %assoc0: %A.assoc_type = assoc_entity element0, @A.%X [symbolic]
 // CHECK:STDOUT:   %B.type.bf2: type = generic_interface_type @B [concrete]
 // CHECK:STDOUT:   %B.generic: %B.type.bf2 = struct_value () [concrete]
 // CHECK:STDOUT:   %.Self.fafe34.1: %A.type.75a876.1 = bind_symbolic_name .Self [symbolic]
-// CHECK:STDOUT:   %require_complete.6daa34.1: <witness> = require_complete_type %A.type.75a876.1 [symbolic]
-// CHECK:STDOUT:   %.Self.as_type.1bbfba.1: type = facet_access_type %.Self.fafe34.1 [symbolic]
+// CHECK:STDOUT:   %require_complete.6da: <witness> = require_complete_type %A.type.75a876.1 [symbolic]
+// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self.fafe34.1 [symbolic]
 // CHECK:STDOUT:   %A.lookup_impl_witness.4e49fb.1: <witness> = lookup_impl_witness %.Self.fafe34.1, @A, @A(%AA) [symbolic]
 // CHECK:STDOUT:   %impl.elem0.452c56.1: type = impl_witness_access %A.lookup_impl_witness.4e49fb.1, element0 [symbolic]
 // CHECK:STDOUT:   %A_where.type.812090.1: type = facet_type <@A, @A(%AA) where %impl.elem0.452c56.1 = %empty_tuple.type> [symbolic]
 // CHECK:STDOUT:   %BB.a66: %A_where.type.812090.1 = bind_symbolic_name BB, 1 [symbolic]
-// CHECK:STDOUT:   %pattern_type.0b2895.1: type = pattern_type %A_where.type.812090.1 [symbolic]
+// CHECK:STDOUT:   %pattern_type.0b2: type = pattern_type %A_where.type.812090.1 [symbolic]
 // CHECK:STDOUT:   %BB.as_type: type = facet_access_type %BB.a66 [symbolic]
 // CHECK:STDOUT:   %ptr.79f131.1: type = ptr_type %AA [symbolic]
 // CHECK:STDOUT:   %B.type.4e3fc4.1: type = facet_type <@B, @B(%ptr.79f131.1)> [symbolic]
@@ -365,13 +341,6 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %.Self.fafe34.2: %A.type.75a876.2 = bind_symbolic_name .Self [symbolic]
 // CHECK:STDOUT:   %A.lookup_impl_witness.4e49fb.2: <witness> = lookup_impl_witness %.Self.fafe34.2, @A, @A(%DD) [symbolic]
 // CHECK:STDOUT:   %impl.elem0.452c56.2: type = impl_witness_access %A.lookup_impl_witness.4e49fb.2, element0 [symbolic]
-// CHECK:STDOUT:   %A_where.type.812090.2: type = facet_type <@A, @A(%DD) where %impl.elem0.452c56.2 = %empty_tuple.type> [symbolic]
-// CHECK:STDOUT:   %require_complete.6daa34.2: <witness> = require_complete_type %A.type.75a876.2 [symbolic]
-// CHECK:STDOUT:   %A.assoc_type.ed3b32.2: type = assoc_entity_type @A, @A(%DD) [symbolic]
-// CHECK:STDOUT:   %assoc0.ce3509.2: %A.assoc_type.ed3b32.2 = assoc_entity element0, @A.%X [symbolic]
-// CHECK:STDOUT:   %.Self.as_type.1bbfba.2: type = facet_access_type %.Self.fafe34.2 [symbolic]
-// CHECK:STDOUT:   %pattern_type.0b2895.2: type = pattern_type %A_where.type.812090.2 [symbolic]
-// CHECK:STDOUT:   %require_complete.13ba89.2: <witness> = require_complete_type %B.type.4e3fc4.2 [symbolic]
 // CHECK:STDOUT:   %B.lookup_impl_witness.8e3: <witness> = lookup_impl_witness %T.336, @B, @B(%ptr.79f131.2) [symbolic]
 // CHECK:STDOUT:   %B.facet.44e: %B.type.4e3fc4.2 = facet_value %T.336, (%B.lookup_impl_witness.8e3) [symbolic]
 // CHECK:STDOUT:   %T.8b3: type = bind_symbolic_name T, 0 [symbolic]
@@ -383,13 +352,6 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %.Self.4e2: %A.type.700 = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %A.lookup_impl_witness.935: <witness> = lookup_impl_witness %.Self.4e2, @A, @A(%empty_struct_type) [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.ab3: type = impl_witness_access %A.lookup_impl_witness.935, element0 [symbolic_self]
-// CHECK:STDOUT:   %A_where.type.cf4: type = facet_type <@A, @A(%empty_struct_type) where %impl.elem0.ab3 = %empty_tuple.type> [concrete]
-// CHECK:STDOUT:   %A.assoc_type.fb9: type = assoc_entity_type @A, @A(%empty_struct_type) [concrete]
-// CHECK:STDOUT:   %assoc0.1e3: %A.assoc_type.fb9 = assoc_entity element0, @A.%X [concrete]
-// CHECK:STDOUT:   %complete_type.393: <witness> = complete_type_witness %A.type.700 [concrete]
-// CHECK:STDOUT:   %.Self.as_type.ac1: type = facet_access_type %.Self.4e2 [symbolic_self]
-// CHECK:STDOUT:   %pattern_type.a26: type = pattern_type %A_where.type.cf4 [concrete]
-// CHECK:STDOUT:   %complete_type.bb7: <witness> = complete_type_witness %B.type.973 [concrete]
 // CHECK:STDOUT:   %B.lookup_impl_witness.c4b: <witness> = lookup_impl_witness %T.8b3, @B, @B(%ptr.c28) [symbolic]
 // CHECK:STDOUT:   %B.facet.8ed: %B.type.973 = facet_value %T.8b3, (%B.lookup_impl_witness.c4b) [symbolic]
 // CHECK:STDOUT: }
@@ -397,7 +359,7 @@ fn H(T:! type) {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   impl_decl @impl.e5b [concrete] {
 // CHECK:STDOUT:     %AA.patt: %pattern_type.98f = symbolic_binding_pattern AA, 0 [concrete]
-// CHECK:STDOUT:     %BB.patt: @impl.e5b.%pattern_type (%pattern_type.0b2895.1) = symbolic_binding_pattern BB, 1 [concrete]
+// CHECK:STDOUT:     %BB.patt: @impl.e5b.%pattern_type (%pattern_type.0b2) = symbolic_binding_pattern BB, 1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %BB.ref: @impl.e5b.%A_where.type (%A_where.type.812090.1) = name_ref BB, %BB.loc9_25.1 [symbolic = %BB.loc9_25.2 (constants.%BB.a66)]
 // CHECK:STDOUT:     %BB.as_type.loc9_51.1: type = facet_access_type %BB.ref [symbolic = %BB.as_type.loc9_51.2 (constants.%BB.as_type)]
@@ -413,10 +375,10 @@ fn H(T:! type) {
 // CHECK:STDOUT:       %A.type.loc9_34.1: type = facet_type <@A, @A(constants.%AA)> [symbolic = %A.type.loc9_34.2 (constants.%A.type.75a876.1)]
 // CHECK:STDOUT:       <elided>
 // CHECK:STDOUT:       %.Self.ref: @impl.e5b.%A.type.loc9_34.2 (%A.type.75a876.1) = name_ref .Self, %.Self.1 [symbolic = %.Self.2 (constants.%.Self.fafe34.1)]
-// CHECK:STDOUT:       %.loc9_42.1: @impl.e5b.%A.assoc_type (%A.assoc_type.ed3b32.1) = specific_constant @X.%assoc0, @A(constants.%AA) [symbolic = %assoc0 (constants.%assoc0.ce3509.1)]
-// CHECK:STDOUT:       %X.ref: @impl.e5b.%A.assoc_type (%A.assoc_type.ed3b32.1) = name_ref X, %.loc9_42.1 [symbolic = %assoc0 (constants.%assoc0.ce3509.1)]
-// CHECK:STDOUT:       %.Self.as_type.loc9_42.1: type = facet_access_type %.Self.ref [symbolic = %.Self.as_type.loc9_42.2 (constants.%.Self.as_type.1bbfba.1)]
-// CHECK:STDOUT:       %.loc9_42.2: type = converted %.Self.ref, %.Self.as_type.loc9_42.1 [symbolic = %.Self.as_type.loc9_42.2 (constants.%.Self.as_type.1bbfba.1)]
+// CHECK:STDOUT:       %.loc9_42.1: @impl.e5b.%A.assoc_type (%A.assoc_type) = specific_constant @X.%assoc0, @A(constants.%AA) [symbolic = %assoc0 (constants.%assoc0)]
+// CHECK:STDOUT:       %X.ref: @impl.e5b.%A.assoc_type (%A.assoc_type) = name_ref X, %.loc9_42.1 [symbolic = %assoc0 (constants.%assoc0)]
+// CHECK:STDOUT:       %.Self.as_type.loc9_42.1: type = facet_access_type %.Self.ref [symbolic = %.Self.as_type.loc9_42.2 (constants.%.Self.as_type)]
+// CHECK:STDOUT:       %.loc9_42.2: type = converted %.Self.ref, %.Self.as_type.loc9_42.1 [symbolic = %.Self.as_type.loc9_42.2 (constants.%.Self.as_type)]
 // CHECK:STDOUT:       %impl.elem0.loc9_42.1: type = impl_witness_access constants.%A.lookup_impl_witness.4e49fb.1, element0 [symbolic = %impl.elem0.loc9_42.2 (constants.%impl.elem0.452c56.1)]
 // CHECK:STDOUT:       %.loc9_48.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:       %.loc9_48.2: type = converted %.loc9_48.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
@@ -434,15 +396,15 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %AA.loc9_14.2: type = bind_symbolic_name AA, 0 [symbolic = %AA.loc9_14.2 (constants.%AA)]
 // CHECK:STDOUT:   %A.type.loc9_34.2: type = facet_type <@A, @A(%AA.loc9_14.2)> [symbolic = %A.type.loc9_34.2 (constants.%A.type.75a876.1)]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %require_complete.loc9_42: <witness> = require_complete_type %A.type.loc9_34.2 [symbolic = %require_complete.loc9_42 (constants.%require_complete.6daa34.1)]
-// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A, @A(%AA.loc9_14.2) [symbolic = %A.assoc_type (constants.%A.assoc_type.ed3b32.1)]
-// CHECK:STDOUT:   %assoc0: @impl.e5b.%A.assoc_type (%A.assoc_type.ed3b32.1) = assoc_entity element0, @A.%X [symbolic = %assoc0 (constants.%assoc0.ce3509.1)]
-// CHECK:STDOUT:   %.Self.as_type.loc9_42.2: type = facet_access_type %.Self.2 [symbolic = %.Self.as_type.loc9_42.2 (constants.%.Self.as_type.1bbfba.1)]
+// CHECK:STDOUT:   %require_complete.loc9_42: <witness> = require_complete_type %A.type.loc9_34.2 [symbolic = %require_complete.loc9_42 (constants.%require_complete.6da)]
+// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A, @A(%AA.loc9_14.2) [symbolic = %A.assoc_type (constants.%A.assoc_type)]
+// CHECK:STDOUT:   %assoc0: @impl.e5b.%A.assoc_type (%A.assoc_type) = assoc_entity element0, @A.%X [symbolic = %assoc0 (constants.%assoc0)]
+// CHECK:STDOUT:   %.Self.as_type.loc9_42.2: type = facet_access_type %.Self.2 [symbolic = %.Self.as_type.loc9_42.2 (constants.%.Self.as_type)]
 // CHECK:STDOUT:   %A.lookup_impl_witness: <witness> = lookup_impl_witness %.Self.2, @A, @A(%AA.loc9_14.2) [symbolic = %A.lookup_impl_witness (constants.%A.lookup_impl_witness.4e49fb.1)]
 // CHECK:STDOUT:   %impl.elem0.loc9_42.2: type = impl_witness_access %A.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc9_42.2 (constants.%impl.elem0.452c56.1)]
 // CHECK:STDOUT:   %A_where.type: type = facet_type <@A, @A(%AA.loc9_14.2) where %impl.elem0.loc9_42.2 = constants.%empty_tuple.type> [symbolic = %A_where.type (constants.%A_where.type.812090.1)]
 // CHECK:STDOUT:   %BB.loc9_25.2: @impl.e5b.%A_where.type (%A_where.type.812090.1) = bind_symbolic_name BB, 1 [symbolic = %BB.loc9_25.2 (constants.%BB.a66)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %A_where.type [symbolic = %pattern_type (constants.%pattern_type.0b2895.1)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %A_where.type [symbolic = %pattern_type (constants.%pattern_type.0b2)]
 // CHECK:STDOUT:   %BB.as_type.loc9_51.2: type = facet_access_type %BB.loc9_25.2 [symbolic = %BB.as_type.loc9_51.2 (constants.%BB.as_type)]
 // CHECK:STDOUT:   %ptr.loc9_61.2: type = ptr_type %AA.loc9_14.2 [symbolic = %ptr.loc9_61.2 (constants.%ptr.79f131.1)]
 // CHECK:STDOUT:   %B.type.loc9_62.2: type = facet_type <@B, @B(%ptr.loc9_61.2)> [symbolic = %B.type.loc9_62.2 (constants.%B.type.4e3fc4.1)]
@@ -506,15 +468,15 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %AA.loc9_14.2 => constants.%AA
 // CHECK:STDOUT:   %A.type.loc9_34.2 => constants.%A.type.75a876.1
 // CHECK:STDOUT:   %.Self.2 => constants.%.Self.fafe34.1
-// CHECK:STDOUT:   %require_complete.loc9_42 => constants.%require_complete.6daa34.1
-// CHECK:STDOUT:   %A.assoc_type => constants.%A.assoc_type.ed3b32.1
-// CHECK:STDOUT:   %assoc0 => constants.%assoc0.ce3509.1
-// CHECK:STDOUT:   %.Self.as_type.loc9_42.2 => constants.%.Self.as_type.1bbfba.1
+// CHECK:STDOUT:   %require_complete.loc9_42 => constants.%require_complete.6da
+// CHECK:STDOUT:   %A.assoc_type => constants.%A.assoc_type
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0
+// CHECK:STDOUT:   %.Self.as_type.loc9_42.2 => constants.%.Self.as_type
 // CHECK:STDOUT:   %A.lookup_impl_witness => constants.%A.lookup_impl_witness.4e49fb.1
 // CHECK:STDOUT:   %impl.elem0.loc9_42.2 => constants.%impl.elem0.452c56.1
 // CHECK:STDOUT:   %A_where.type => constants.%A_where.type.812090.1
 // CHECK:STDOUT:   %BB.loc9_25.2 => constants.%BB.a66
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.0b2895.1
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.0b2
 // CHECK:STDOUT:   %BB.as_type.loc9_51.2 => constants.%BB.as_type
 // CHECK:STDOUT:   %ptr.loc9_61.2 => constants.%ptr.79f131.1
 // CHECK:STDOUT:   %B.type.loc9_62.2 => constants.%B.type.4e3fc4.1
@@ -532,26 +494,6 @@ fn H(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%DD, constants.%T.336) {
 // CHECK:STDOUT:   %T.loc15_8.1 => constants.%T.336
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl.e5b(constants.%DD, <error>) {
-// CHECK:STDOUT:   %AA.loc9_14.2 => constants.%DD
-// CHECK:STDOUT:   %A.type.loc9_34.2 => constants.%A.type.75a876.2
-// CHECK:STDOUT:   %.Self.2 => constants.%.Self.fafe34.2
-// CHECK:STDOUT:   %require_complete.loc9_42 => constants.%require_complete.6daa34.2
-// CHECK:STDOUT:   %A.assoc_type => constants.%A.assoc_type.ed3b32.2
-// CHECK:STDOUT:   %assoc0 => constants.%assoc0.ce3509.2
-// CHECK:STDOUT:   %.Self.as_type.loc9_42.2 => constants.%.Self.as_type.1bbfba.2
-// CHECK:STDOUT:   %A.lookup_impl_witness => constants.%A.lookup_impl_witness.4e49fb.2
-// CHECK:STDOUT:   %impl.elem0.loc9_42.2 => constants.%impl.elem0.452c56.2
-// CHECK:STDOUT:   %A_where.type => constants.%A_where.type.812090.2
-// CHECK:STDOUT:   %BB.loc9_25.2 => <error>
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.0b2895.2
-// CHECK:STDOUT:   %BB.as_type.loc9_51.2 => <error>
-// CHECK:STDOUT:   %ptr.loc9_61.2 => constants.%ptr.79f131.2
-// CHECK:STDOUT:   %B.type.loc9_62.2 => constants.%B.type.4e3fc4.2
-// CHECK:STDOUT:   %require_complete.loc9_62 => constants.%require_complete.13ba89.2
-// CHECK:STDOUT:   %B.impl_witness => <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D(constants.%empty_struct_type) {
@@ -575,25 +517,5 @@ fn H(T:! type) {
 // CHECK:STDOUT:   %impl.elem0 => constants.%impl.elem0.ab3
 // CHECK:STDOUT:   %B.lookup_impl_witness => constants.%B.lookup_impl_witness.c4b
 // CHECK:STDOUT:   %B.facet.loc21_7.2 => constants.%B.facet.8ed
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @impl.e5b(constants.%empty_struct_type, <error>) {
-// CHECK:STDOUT:   %AA.loc9_14.2 => constants.%empty_struct_type
-// CHECK:STDOUT:   %A.type.loc9_34.2 => constants.%A.type.700
-// CHECK:STDOUT:   %.Self.2 => constants.%.Self.4e2
-// CHECK:STDOUT:   %require_complete.loc9_42 => constants.%complete_type.393
-// CHECK:STDOUT:   %A.assoc_type => constants.%A.assoc_type.fb9
-// CHECK:STDOUT:   %assoc0 => constants.%assoc0.1e3
-// CHECK:STDOUT:   %.Self.as_type.loc9_42.2 => constants.%.Self.as_type.ac1
-// CHECK:STDOUT:   %A.lookup_impl_witness => constants.%A.lookup_impl_witness.935
-// CHECK:STDOUT:   %impl.elem0.loc9_42.2 => constants.%impl.elem0.ab3
-// CHECK:STDOUT:   %A_where.type => constants.%A_where.type.cf4
-// CHECK:STDOUT:   %BB.loc9_25.2 => <error>
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.a26
-// CHECK:STDOUT:   %BB.as_type.loc9_51.2 => <error>
-// CHECK:STDOUT:   %ptr.loc9_61.2 => constants.%ptr.c28
-// CHECK:STDOUT:   %B.type.loc9_62.2 => constants.%B.type.973
-// CHECK:STDOUT:   %require_complete.loc9_62 => constants.%complete_type.bb7
-// CHECK:STDOUT:   %B.impl_witness => <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
If convert fails after applying a substitution in deduce, fail deduction rather than succeeding deduction with an ErrorInst in the deduced argument.

For example, in `toolchain/check/testdata/facet/fail_convert_class_type_to_generic_facet_value.carbon` the `WrongGenericParam` is deduced for the first argument, then substituted into the second parameter, but the argument can not convert to the parameter after substitution. In this case, deduction fails instead of producig a call with an error in the second argument. The resulting semir drops the call with an error argument:
```
-// CHECK:STDOUT:   %CallGenericMethod.specific_fn: <specific function> = specific_function %CallGenericMethod.ref, @CallGenericMethod(constants.%WrongGenericParam, <error>) [concrete = <error>]
-// CHECK:STDOUT:   %CallGenericMethod.call: init %empty_tuple.type = call %CallGenericMethod.specific_fn() [concrete = <error>]
```