### PR TITLE
Replace `isStruct() || isClass()` with `!isUnion()`

### DIFF
--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -529,7 +529,7 @@ static auto MapBuiltinType(Context& context, const clang::BuiltinType& type)
 static auto MapRecordType(Context& context, SemIR::LocId loc_id,
                           const clang::RecordType& type) -> TypeExpr {
   auto* record_decl = clang::dyn_cast<clang::CXXRecordDecl>(type.getDecl());
-  if (record_decl && (record_decl->isStruct() || record_decl->isClass())) {
+  if (record_decl && !record_decl->isUnion()) {
     auto& clang_decls = context.sem_ir().clang_decls();
     SemIR::InstId record_inst_id = SemIR::InstId::None;
     if (auto record_clang_decl_id = clang_decls.Lookup(


### PR DESCRIPTION
Follow up of https://github.com/carbon-language/carbon-lang/pull/5709/files#r2162385549

Part of https://github.com/carbon-language/carbon-lang/issues/5533.