### PR TITLE
Customize `ClangDecl` store hashing and equality instead of customizing `ClangDecl` hashing and equality

### DIFF
--- a/common/hashtable_key_context.h
+++ b/common/hashtable_key_context.h
@@ -109,9 +109,15 @@ struct DefaultKeyContext {
 //
 // Derived types should publicly inherit from this mixin and define overloads of
 // the `TranslateKey` method as indicated below in its comment.
-template <typename DerivedT>
+template <typename DerivedT, typename InputKeyContextT = DefaultKeyContext>
 class TranslatingKeyContext {
+ protected:
+  using BaseKeyContextT = InputKeyContextT;
+
  public:
+  explicit TranslatingKeyContext(
+      BaseKeyContextT base_key_context = BaseKeyContextT())
+      : base_key_context_(base_key_context) {}
   // Derived types should provide one or more overloads that hide this function
   // and perform translation for the key types which need it.
   //
@@ -141,6 +147,9 @@ class TranslatingKeyContext {
 
   template <typename AnyKeyT, typename TableKeyT>
   auto KeyEq(const AnyKeyT& lhs_key, const TableKeyT& rhs_key) const -> bool;
+
+ private:
+  BaseKeyContextT base_key_context_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -197,36 +206,36 @@ auto DefaultKeyContext::KeyEq(const AnyKeyT& lhs_key,
   return HashtableEq(lhs_key, rhs_key);
 }
 
-template <typename DerivedT>
+template <typename DerivedT, typename InputKeyContextT>
 template <typename AnyKeyT>
-auto TranslatingKeyContext<DerivedT>::HashKey(const AnyKeyT& key,
-                                              uint64_t seed) const -> HashCode {
+auto TranslatingKeyContext<DerivedT, InputKeyContextT>::HashKey(
+    const AnyKeyT& key, uint64_t seed) const -> HashCode {
   const DerivedT& self = *static_cast<const DerivedT*>(this);
   if constexpr (requires { self.TranslateKey(key); }) {
-    return HashValue(self.TranslateKey(key), seed);
+    return base_key_context_.HashKey(self.TranslateKey(key), seed);
   } else {
-    return HashValue(key, seed);
+    return base_key_context_.HashKey(key, seed);
   }
 }
 
-template <typename DerivedT>
+template <typename DerivedT, typename InputKeyContextT>
 template <typename AnyKeyT, typename TableKeyT>
-auto TranslatingKeyContext<DerivedT>::KeyEq(const AnyKeyT& lhs_key,
-                                            const TableKeyT& rhs_key) const
-    -> bool {
+auto TranslatingKeyContext<DerivedT, InputKeyContextT>::KeyEq(
+    const AnyKeyT& lhs_key, const TableKeyT& rhs_key) const -> bool {
   const DerivedT& self = *static_cast<const DerivedT*>(this);
   // Because we don't want to make no-op calls and potentially struggle with
   // temporary lifetimes at runtime we have to fully expand the 4 states.
   constexpr bool TranslateLhs = requires { self.TranslateKey(lhs_key); };
   constexpr bool TranslateRhs = requires { self.TranslateKey(rhs_key); };
   if constexpr (TranslateLhs && TranslateRhs) {
-    return HashtableEq(self.TranslateKey(lhs_key), self.TranslateKey(rhs_key));
+    return base_key_context_.KeyEq(self.TranslateKey(lhs_key),
+                                   self.TranslateKey(rhs_key));
   } else if constexpr (TranslateLhs) {
-    return HashtableEq(self.TranslateKey(lhs_key), rhs_key);
+    return base_key_context_.KeyEq(self.TranslateKey(lhs_key), rhs_key);
   } else if constexpr (TranslateRhs) {
-    return HashtableEq(lhs_key, self.TranslateKey(rhs_key));
+    return base_key_context_.KeyEq(lhs_key, self.TranslateKey(rhs_key));
   } else {
-    return HashtableEq(lhs_key, rhs_key);
+    return base_key_context_.KeyEq(lhs_key, rhs_key);
   }
 }
 

--- a/common/hashtable_key_context_test.cpp
+++ b/common/hashtable_key_context_test.cpp
@@ -171,6 +171,8 @@ TEST(HashtableKeyContextTest, DefaultKeyContext) {
 
 struct TestTranslatingKeyContext
     : TranslatingKeyContext<TestTranslatingKeyContext> {
+  explicit TestTranslatingKeyContext(llvm::ArrayRef<llvm::APInt> input_array)
+      : array(input_array) {}
   auto TranslateKey(int index) const -> const llvm::APInt& {
     return array[index];
   }
@@ -187,7 +189,7 @@ TEST(HashtableKeyContextTest, TranslatingKeyContext) {
   llvm::SmallVector<llvm::APInt> values = {one_64,  two_64, one_128,
                                            two_128, one_64, one_64};
 
-  TestTranslatingKeyContext context = {.array = values};
+  TestTranslatingKeyContext context(values);
 
   uint64_t seed = 1234;
   EXPECT_THAT(context.HashKey(0, seed), Eq(HashValue(one_64, seed)));

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -222,25 +222,27 @@ class ValueStoreRange {
 // to later retrieve the value.
 //
 // IdT::ValueType must represent the type being indexed.
-template <typename IdT>
+template <typename IdT, typename InputKeyContextT = DefaultKeyContext>
 class CanonicalValueStore {
  public:
+  using KeyContextT = InputKeyContextT;
   using ValueType = ValueStoreTypes<IdT>::ValueType;
   using RefType = ValueStoreTypes<IdT>::RefType;
   using ConstRefType = ValueStoreTypes<IdT>::ConstRefType;
 
   // Stores a canonical copy of the value and returns an ID to reference it.
-  auto Add(ValueType value) -> IdT;
+  auto Add(ValueType value, KeyContextT key_context = KeyContextT()) -> IdT;
 
   // Returns the value for an ID.
   auto Get(IdT id) const -> ConstRefType { return values_.Get(id); }
 
   // Looks up the canonical ID for a value, or returns `None` if not in the
   // store.
-  auto Lookup(ValueType value) const -> IdT;
+  auto Lookup(ValueType value, KeyContextT key_context = KeyContextT()) const
+      -> IdT;
 
   // Reserves space.
-  auto Reserve(size_t size) -> void;
+  auto Reserve(size_t size, KeyContextT key_context = KeyContextT()) -> void;
 
   // These are to support printable structures, and are not guaranteed.
   auto OutputYaml() const -> Yaml::OutputMapping {
@@ -253,10 +255,11 @@ class CanonicalValueStore {
   auto size() const -> size_t { return values_.size(); }
 
   // Collects memory usage of the values and deduplication set.
-  auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
-      -> void {
+  auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label,
+                       KeyContextT key_context = KeyContextT()) const -> void {
     mem_usage.Collect(MemUsage::ConcatLabel(label, "values_"), values_);
-    auto bytes = set_.ComputeMetrics(KeyContext(&values_)).storage_bytes;
+    auto bytes =
+        set_.ComputeMetrics(KeyContext(&values_, key_context)).storage_bytes;
     mem_usage.Add(MemUsage::ConcatLabel(label, "set_"), bytes, bytes);
   }
 
@@ -267,11 +270,13 @@ class CanonicalValueStore {
   Set<IdT, /*SmallSize=*/0, KeyContext> set_;
 };
 
-template <typename IdT>
-class CanonicalValueStore<IdT>::KeyContext
-    : public TranslatingKeyContext<KeyContext> {
+template <typename IdT, typename InputKeyContextT>
+class CanonicalValueStore<IdT, InputKeyContextT>::KeyContext
+    : public TranslatingKeyContext<KeyContext, InputKeyContextT> {
  public:
-  explicit KeyContext(const ValueStore<IdT>* values) : values_(values) {}
+  explicit KeyContext(const ValueStore<IdT>* values, KeyContextT key_context)
+      : TranslatingKeyContext<KeyContext, InputKeyContextT>(key_context),
+        values_(values) {}
 
   // Note that it is safe to return a `const` reference here as the underlying
   // object's lifetime is provided by the `ValueStore`.
@@ -283,26 +288,31 @@ class CanonicalValueStore<IdT>::KeyContext
   const ValueStore<IdT>* values_;
 };
 
-template <typename IdT>
-auto CanonicalValueStore<IdT>::Add(ValueType value) -> IdT {
+template <typename IdT, typename InputKeyContextT>
+auto CanonicalValueStore<IdT, InputKeyContextT>::Add(ValueType value,
+                                                     KeyContextT key_context)
+    -> IdT {
   auto make_key = [&] { return IdT(values_.Add(std::move(value))); };
-  return set_.Insert(value, make_key, KeyContext(&values_)).key();
+  return set_.Insert(value, make_key, KeyContext(&values_, key_context)).key();
 }
 
-template <typename IdT>
-auto CanonicalValueStore<IdT>::Lookup(ValueType value) const -> IdT {
-  if (auto result = set_.Lookup(value, KeyContext(&values_))) {
+template <typename IdT, typename InputKeyContextT>
+auto CanonicalValueStore<IdT, InputKeyContextT>::Lookup(
+    ValueType value, KeyContextT key_context) const -> IdT {
+  if (auto result = set_.Lookup(value, KeyContext(&values_, key_context))) {
     return result.key();
   }
   return IdT::None;
 }
 
-template <typename IdT>
-auto CanonicalValueStore<IdT>::Reserve(size_t size) -> void {
+template <typename IdT, typename InputKeyContextT>
+auto CanonicalValueStore<IdT, InputKeyContextT>::Reserve(
+    size_t size, KeyContextT key_context) -> void {
   // Compute the resulting new insert count using the size of values -- the
   // set doesn't have a fast to compute current size.
   if (size > values_.size()) {
-    set_.GrowForInsertCount(size - values_.size(), KeyContext(&values_));
+    set_.GrowForInsertCount(size - values_.size(),
+                            KeyContext(&values_, key_context));
   }
   values_.Reserve(size);
 }

--- a/toolchain/sem_ir/clang_decl.h
+++ b/toolchain/sem_ir/clang_decl.h
@@ -28,17 +28,6 @@ namespace Carbon::SemIR {
 struct ClangDecl : public Printable<ClangDecl> {
   auto Print(llvm::raw_ostream& out) const -> void;
 
-  friend auto CarbonHashtableEq(const ClangDecl& lhs, const ClangDecl& rhs)
-      -> bool {
-    return HashtableEq(lhs.decl, rhs.decl);
-  }
-
-  // Hashing for ClangDecl. See common/hashing.h.
-  friend auto CarbonHashValue(const ClangDecl& value, uint64_t seed)
-      -> HashCode {
-    return HashValue(value.decl, seed);
-  }
-
   // The Clang declaration pointing to the Clang AST.
   // TODO: Ensure we can easily serialize/deserialize this. Consider
   // `clang::LazyDeclPtr`.

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -203,10 +203,22 @@ class File : public Printable<File> {
   // pointer in the constructor and remove this function. This is part of
   // https://github.com/carbon-language/carbon-lang/issues/4666
   auto set_cpp_ast(clang::ASTUnit* cpp_ast) -> void { cpp_ast_ = cpp_ast; }
-  auto clang_decls() -> CanonicalValueStore<ClangDeclId>& {
+
+  struct ClangDeclStoreKeyContext {
+    auto HashKey(const ClangDecl& key, uint64_t seed) const -> HashCode {
+      return HashValue(key.decl, seed);
+    }
+    auto KeyEq(const ClangDecl& lhs_key, const ClangDecl& rhs_key) const
+        -> bool {
+      return HashtableEq(lhs_key.decl, rhs_key.decl);
+    }
+  };
+  auto clang_decls()
+      -> CanonicalValueStore<ClangDeclId, ClangDeclStoreKeyContext>& {
     return clang_decls_;
   }
-  auto clang_decls() const -> const CanonicalValueStore<ClangDeclId>& {
+  auto clang_decls() const
+      -> const CanonicalValueStore<ClangDeclId, ClangDeclStoreKeyContext>& {
     return clang_decls_;
   }
   auto names() const -> NameStoreWrapper {
@@ -338,7 +350,7 @@ class File : public Printable<File> {
   // Clang AST declarations pointing to the AST and their mapped Carbon
   // instructions. When calling `Lookup()`, `inst_id` is ignored. `Add()` will
   // not add multiple entries with the same `decl` and different `inst_id`.
-  CanonicalValueStore<ClangDeclId> clang_decls_;
+  CanonicalValueStore<ClangDeclId, ClangDeclStoreKeyContext> clang_decls_;
 
   // All instructions. The first entries will always be the singleton
   // instructions.


### PR DESCRIPTION
This keeps the principal of hashing and equality of a type includes all its values.

Done by:
* Extending `CanonicalValueStore` to allow a custom Key Context.
* Extending `TranslatingKeyContext` to contain a base Key Context (instead of always using the default hashing and equality).

This is a draft.

TODO:
* Create a `ClangDeclStore` (possibly in a separate PR), to make its API clearer to use.
* Add and update documentation.
* Add tests.