### PR TITLE
Print captured stdout/stderr on test crashes

### DIFF
--- a/common/pretty_stack_trace_function.h
+++ b/common/pretty_stack_trace_function.h
@@ -11,6 +11,8 @@
 
 namespace Carbon {
 
+// Calls `fn` as part of LLVM's pretty stack trace support. Implementations
+// should typically have a terminating `\n`.
 class PrettyStackTraceFunction : public llvm::PrettyStackTraceEntry {
  public:
   explicit PrettyStackTraceFunction(

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -48,6 +48,7 @@ cc_library(
         "//common:find",
         "//common:init_llvm",
         "//common:ostream",
+        "//common:pretty_stack_trace_function",
         "//common:raw_string_ostream",
         "//testing/base:file_helpers",
         "@abseil-cpp//absl/flags:flag",


### PR DESCRIPTION
Related to #5733, but as a general fix, this will hopefully make it a little easier to debug test/autoupdate crashes.