### PR TITLE
Allow repeated includes, particularly for min_prelude

### DIFF
--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -49,6 +49,7 @@ cc_library(
         "//common:init_llvm",
         "//common:ostream",
         "//common:raw_string_ostream",
+        "//common:set",
         "//testing/base:file_helpers",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",

--- a/testing/file_test/testdata/include_repeated.carbon
+++ b/testing/file_test/testdata/include_repeated.carbon
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: testing/file_test/testdata/include_files/no_split.carbon
+// INCLUDE-FILE: testing/file_test/testdata/include_files/no_split.carbon
+// INCLUDE-FILE: testing/file_test/testdata/include_files/no_split.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //testing/file_test:file_test_base_test --test_arg=--file_tests=testing/file_test/testdata/include_repeated.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_repeated.carbon
+
+// CHECK:STDOUT: 3 args: `default_args`, `include_repeated.carbon`, `include_files/no_split.carbon`
+// CHECK:STDOUT: include_files/no_split.carbon:5: no split

--- a/toolchain/testing/testdata/min_prelude/int.carbon
+++ b/toolchain/testing/testdata/min_prelude/int.carbon
@@ -2,12 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// TODO: This should move to the place where it's imported, but it ends up
-// included more than once and that fails to build.
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/as.carbon
-// TODO: This should move to the place where it's imported, but it ends up
-// included more than once and that fails to build.
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int_literal.carbon
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int.carbon
 // EXTRA-ARGS: --custom-core --exclude-dump-file-prefix=min_prelude/
 

--- a/toolchain/testing/testdata/min_prelude/parts/float.carbon
+++ b/toolchain/testing/testdata/min_prelude/parts/float.carbon
@@ -1,6 +1,8 @@
 // Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int_literal.carbon
 
 // --- min_prelude/parts/float.carbon
 

--- a/toolchain/testing/testdata/min_prelude/parts/int.carbon
+++ b/toolchain/testing/testdata/min_prelude/parts/int.carbon
@@ -1,6 +1,9 @@
 // Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/as.carbon
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int_literal.carbon
 
 // --- min_prelude/parts/int.carbon
 

--- a/toolchain/testing/testdata/min_prelude/parts/iterate.carbon
+++ b/toolchain/testing/testdata/min_prelude/parts/iterate.carbon
@@ -1,6 +1,8 @@
 // Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/optional.carbon
 
 // --- min_prelude/parts/iterate.carbon
 

--- a/toolchain/testing/testdata/min_prelude/parts/optional.carbon
+++ b/toolchain/testing/testdata/min_prelude/parts/optional.carbon
@@ -1,6 +1,8 @@
 // Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/bool.carbon
 
 // --- min_prelude/parts/optional.carbon
 

--- a/toolchain/testing/testdata/min_prelude/parts/uint.carbon
+++ b/toolchain/testing/testdata/min_prelude/parts/uint.carbon
@@ -1,6 +1,9 @@
 // Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/as.carbon
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int_literal.carbon
 
 // --- min_prelude/parts/uint.carbon
 

--- a/toolchain/testing/testdata/min_prelude/primitives.carbon
+++ b/toolchain/testing/testdata/min_prelude/primitives.carbon
@@ -2,14 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// TODO: This should move to the place where it's imported, but it ends up
-// included more than once and that fails to build.
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/as.carbon
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/bool.carbon
-// TODO: This should move to the place where it's imported, but it ends up
-// included more than once and that fails to build.
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/float.carbon
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int_literal.carbon
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int.carbon
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/uint.carbon
 // EXTRA-ARGS: --custom-core --exclude-dump-file-prefix=min_prelude/

--- a/toolchain/testing/testdata/min_prelude/uint.carbon
+++ b/toolchain/testing/testdata/min_prelude/uint.carbon
@@ -2,12 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// TODO: This should move to the place where it's imported, but it ends up
-// included more than once and that fails to build.
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/as.carbon
-// TODO: This should move to the place where it's imported, but it ends up
-// included more than once and that fails to build.
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int_literal.carbon
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/int.carbon
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/parts/uint.carbon
 // EXTRA-ARGS: --custom-core --exclude-dump-file-prefix=min_prelude/


### PR DESCRIPTION
Make min_prelude parts include what they use, and remove the inclusions which were for indirect uses from the main min_prelude files.