### PR TITLE
Switch compile functions to use options structs

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -204,6 +204,7 @@ cc_library(
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:typed_insts",
         "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:TargetParser",
     ],
 )
 

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -204,7 +204,6 @@ cc_library(
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:typed_insts",
         "@llvm-project//llvm:Support",
-        "@llvm-project//llvm:TargetParser",
     ],
 )
 

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -322,18 +322,14 @@ static auto BuildApiMapAndDiagnosePackaging(
   return api_map;
 }
 
-auto CheckParseTrees(
-    llvm::MutableArrayRef<Unit> units,
-    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
-    bool prelude_import, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-    llvm::StringRef target, llvm::raw_ostream* vlog_stream, bool fuzzing)
-    -> void {
+auto CheckParseTrees(CheckParseTreesParams params) -> void {
   // UnitAndImports is big due to its SmallVectors, so we default to 0 on the
   // stack.
   llvm::SmallVector<UnitAndImports, 0> unit_infos(
-      llvm::map_range(units, [&](Unit& unit) {
+      llvm::map_range(params.units, [&](Unit& unit) {
         return UnitAndImports(
-            &unit, tree_and_subtrees_getters[unit.sem_ir->check_ir_id().index]);
+            &unit,
+            params.tree_and_subtrees_getters[unit.sem_ir->check_ir_id().index]);
       }));
 
   Map<ImportKey, UnitAndImports*> api_map =
@@ -341,21 +337,21 @@ auto CheckParseTrees(
 
   // Mark down imports for all files.
   llvm::SmallVector<UnitAndImports*> ready_to_check;
-  ready_to_check.reserve(units.size());
+  ready_to_check.reserve(params.units.size());
   for (auto& unit_info : unit_infos) {
     const auto& packaging = unit_info.parse_tree().packaging_decl();
     if (packaging && packaging->is_impl) {
       // An `impl` has an implicit import of its `api`.
       auto implicit_names = packaging->names;
       implicit_names.package_id = PackageNameId::None;
-      TrackImport(api_map, nullptr, unit_info, implicit_names, fuzzing);
+      TrackImport(api_map, nullptr, unit_info, implicit_names, params.fuzzing);
     }
 
     Map<ImportKey, Parse::NodeId> explicit_import_map;
 
     // Add the prelude import. It's added to explicit_import_map so that it can
     // conflict with an explicit import of the prelude.
-    if (prelude_import &&
+    if (params.prelude_import &&
         !(packaging && packaging->names.package_id == PackageNameId::Core)) {
       auto prelude_id =
           unit_info.unit->value_stores->string_literal_values().Add("prelude");
@@ -363,11 +359,12 @@ auto CheckParseTrees(
                   {.node_id = Parse::NoneNodeId(),
                    .package_id = PackageNameId::Core,
                    .library_id = prelude_id},
-                  fuzzing);
+                  params.fuzzing);
     }
 
     for (const auto& import : unit_info.parse_tree().imports()) {
-      TrackImport(api_map, &explicit_import_map, unit_info, import, fuzzing);
+      TrackImport(api_map, &explicit_import_map, unit_info, import,
+                  params.fuzzing);
     }
 
     // If there were no imports, mark the file as ready to check for below.
@@ -381,7 +378,8 @@ auto CheckParseTrees(
   for (int check_index = 0;
        check_index < static_cast<int>(ready_to_check.size()); ++check_index) {
     auto* unit_info = ready_to_check[check_index];
-    CheckUnit(unit_info, tree_and_subtrees_getters, fs, target, vlog_stream)
+    CheckUnit(unit_info, params.tree_and_subtrees_getters, params.fs,
+              params.target, params.vlog_stream)
         .Run();
     for (auto* incoming_import : unit_info->incoming_imports) {
       --incoming_import->imports_remaining;
@@ -429,8 +427,8 @@ auto CheckParseTrees(
     // incomplete imports.
     for (auto& unit_info : unit_infos) {
       if (unit_info.imports_remaining > 0) {
-        CheckUnit(&unit_info, tree_and_subtrees_getters, fs, target,
-                  vlog_stream)
+        CheckUnit(&unit_info, params.tree_and_subtrees_getters, params.fs,
+                  params.target, params.vlog_stream)
             .Run();
       }
     }

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -9,7 +9,6 @@
 
 #include "common/check.h"
 #include "common/map.h"
-#include "llvm/TargetParser/Host.h"
 #include "toolchain/check/check_unit.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/diagnostic_emitter.h"
@@ -326,7 +325,7 @@ static auto BuildApiMapAndDiagnosePackaging(
 auto CheckParseTrees(
     llvm::MutableArrayRef<Unit> units,
     llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs, llvm::StringRef target,
     const CheckParseTreesOptions& options) -> void {
   // UnitAndImports is big due to its SmallVectors, so we default to 0 on the
   // stack.
@@ -376,10 +375,6 @@ auto CheckParseTrees(
       ready_to_check.push_back(&unit_info);
     }
   }
-
-  std::string target = !options.target.empty()
-                           ? options.target.str()
-                           : llvm::sys::getDefaultTargetTriple();
 
   // Check everything with no dependencies. Earlier entries with dependencies
   // will be checked as soon as all their dependencies have been checked.

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -9,6 +9,7 @@
 
 #include "common/check.h"
 #include "common/map.h"
+#include "llvm/TargetParser/Host.h"
 #include "toolchain/check/check_unit.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/diagnostic_emitter.h"
@@ -322,14 +323,17 @@ static auto BuildApiMapAndDiagnosePackaging(
   return api_map;
 }
 
-auto CheckParseTrees(CheckParseTreesParams params) -> void {
+auto CheckParseTrees(
+    llvm::MutableArrayRef<Unit> units,
+    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    const CheckParseTreesOptions& options) -> void {
   // UnitAndImports is big due to its SmallVectors, so we default to 0 on the
   // stack.
   llvm::SmallVector<UnitAndImports, 0> unit_infos(
-      llvm::map_range(params.units, [&](Unit& unit) {
+      llvm::map_range(units, [&](Unit& unit) {
         return UnitAndImports(
-            &unit,
-            params.tree_and_subtrees_getters[unit.sem_ir->check_ir_id().index]);
+            &unit, tree_and_subtrees_getters[unit.sem_ir->check_ir_id().index]);
       }));
 
   Map<ImportKey, UnitAndImports*> api_map =
@@ -337,21 +341,21 @@ auto CheckParseTrees(CheckParseTreesParams params) -> void {
 
   // Mark down imports for all files.
   llvm::SmallVector<UnitAndImports*> ready_to_check;
-  ready_to_check.reserve(params.units.size());
+  ready_to_check.reserve(units.size());
   for (auto& unit_info : unit_infos) {
     const auto& packaging = unit_info.parse_tree().packaging_decl();
     if (packaging && packaging->is_impl) {
       // An `impl` has an implicit import of its `api`.
       auto implicit_names = packaging->names;
       implicit_names.package_id = PackageNameId::None;
-      TrackImport(api_map, nullptr, unit_info, implicit_names, params.fuzzing);
+      TrackImport(api_map, nullptr, unit_info, implicit_names, options.fuzzing);
     }
 
     Map<ImportKey, Parse::NodeId> explicit_import_map;
 
     // Add the prelude import. It's added to explicit_import_map so that it can
     // conflict with an explicit import of the prelude.
-    if (params.prelude_import &&
+    if (options.prelude_import &&
         !(packaging && packaging->names.package_id == PackageNameId::Core)) {
       auto prelude_id =
           unit_info.unit->value_stores->string_literal_values().Add("prelude");
@@ -359,12 +363,12 @@ auto CheckParseTrees(CheckParseTreesParams params) -> void {
                   {.node_id = Parse::NoneNodeId(),
                    .package_id = PackageNameId::Core,
                    .library_id = prelude_id},
-                  params.fuzzing);
+                  options.fuzzing);
     }
 
     for (const auto& import : unit_info.parse_tree().imports()) {
       TrackImport(api_map, &explicit_import_map, unit_info, import,
-                  params.fuzzing);
+                  options.fuzzing);
     }
 
     // If there were no imports, mark the file as ready to check for below.
@@ -373,13 +377,17 @@ auto CheckParseTrees(CheckParseTreesParams params) -> void {
     }
   }
 
+  std::string target = !options.target.empty()
+                           ? options.target.str()
+                           : llvm::sys::getDefaultTargetTriple();
+
   // Check everything with no dependencies. Earlier entries with dependencies
   // will be checked as soon as all their dependencies have been checked.
   for (int check_index = 0;
        check_index < static_cast<int>(ready_to_check.size()); ++check_index) {
     auto* unit_info = ready_to_check[check_index];
-    CheckUnit(unit_info, params.tree_and_subtrees_getters, params.fs,
-              params.target, params.vlog_stream)
+    CheckUnit(unit_info, tree_and_subtrees_getters, fs, target,
+              options.vlog_stream)
         .Run();
     for (auto* incoming_import : unit_info->incoming_imports) {
       --incoming_import->imports_remaining;
@@ -427,8 +435,8 @@ auto CheckParseTrees(CheckParseTreesParams params) -> void {
     // incomplete imports.
     for (auto& unit_info : unit_infos) {
       if (unit_info.imports_remaining > 0) {
-        CheckUnit(&unit_info, params.tree_and_subtrees_getters, params.fs,
-                  params.target, params.vlog_stream)
+        CheckUnit(&unit_info, tree_and_subtrees_getters, fs, target,
+                  options.vlog_stream)
             .Run();
       }
     }

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -31,14 +31,19 @@ struct Unit {
   std::unique_ptr<clang::ASTUnit>* cpp_ast;
 };
 
+struct CheckParseTreesParams {
+  llvm::MutableArrayRef<Unit> units;
+  llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters;
+  bool prelude_import = false;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
+  llvm::StringRef target;
+  llvm::raw_ostream* vlog_stream = nullptr;
+  bool fuzzing = false;
+};
+
 // Checks a group of parse trees. This will use imports to decide the order of
 // checking.
-auto CheckParseTrees(
-    llvm::MutableArrayRef<Unit> units,
-    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
-    bool prelude_import, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-    llvm::StringRef target, llvm::raw_ostream* vlog_stream, bool fuzzing)
-    -> void;
+auto CheckParseTrees(CheckParseTreesParams params) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -38,9 +38,6 @@ struct CheckParseTreesOptions {
   // Whether to import the prelude.
   bool prelude_import = false;
 
-  // The LLVM target information. Uses LLVM's default if unset.
-  llvm::StringRef target = "";
-
   // If set, enables verbose output.
   llvm::raw_ostream* vlog_stream = nullptr;
 
@@ -54,7 +51,7 @@ struct CheckParseTreesOptions {
 auto CheckParseTrees(
     llvm::MutableArrayRef<Unit> units,
     llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs, llvm::StringRef target,
     const CheckParseTreesOptions& options) -> void;
 
 }  // namespace Carbon::Check

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -34,10 +34,20 @@ struct Unit {
 struct CheckParseTreesParams {
   llvm::MutableArrayRef<Unit> units;
   llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters;
+
+  // Whether to import the prelude.
   bool prelude_import = false;
+
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
+
+  // The LLVM target information.
   llvm::StringRef target;
+
+  // Optionally provided to enable VLOG output.
   llvm::raw_ostream* vlog_stream = nullptr;
+
+  // Whether fuzzing is being run. Used to disable features we don't want to
+  // fuzz.
   bool fuzzing = false;
 };
 

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -31,19 +31,17 @@ struct Unit {
   std::unique_ptr<clang::ASTUnit>* cpp_ast;
 };
 
-struct CheckParseTreesParams {
-  llvm::MutableArrayRef<Unit> units;
-  llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters;
+struct CheckParseTreesOptions {
+  // Options must be set individually, not through initialization.
+  explicit CheckParseTreesOptions() = default;
 
   // Whether to import the prelude.
   bool prelude_import = false;
 
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
-
   // The LLVM target information.
-  llvm::StringRef target;
+  llvm::StringRef target = "";
 
-  // Optionally provided to enable VLOG output.
+  // If set, enables verbose output.
   llvm::raw_ostream* vlog_stream = nullptr;
 
   // Whether fuzzing is being run. Used to disable features we don't want to
@@ -53,7 +51,11 @@ struct CheckParseTreesParams {
 
 // Checks a group of parse trees. This will use imports to decide the order of
 // checking.
-auto CheckParseTrees(CheckParseTreesParams params) -> void;
+auto CheckParseTrees(
+    llvm::MutableArrayRef<Unit> units,
+    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    const CheckParseTreesOptions& options) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -38,7 +38,7 @@ struct CheckParseTreesOptions {
   // Whether to import the prelude.
   bool prelude_import = false;
 
-  // The LLVM target information.
+  // The LLVM target information. Uses LLVM's default if unset.
   llvm::StringRef target = "";
 
   // If set, enables verbose output.

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -608,9 +608,9 @@ auto CompilationUnit::RunLex() -> void {
 
   LogCall("Lex::Lex", "lex", [&] {
     tokens_ = Lex::Lex({
-        .value_stores = value_stores_,
-        .source = *source_,
-        .consumer = *consumer_,
+        .value_stores = &value_stores_,
+        .source = &*source_,
+        .consumer = consumer_,
     });
   });
   if (options_->dump_tokens && IncludeInDumps()) {
@@ -630,8 +630,8 @@ auto CompilationUnit::RunLex() -> void {
 auto CompilationUnit::RunParse() -> void {
   LogCall("Parse::Parse", "parse", [&] {
     parse_tree_ = Parse::Parse({
-        .tokens = *tokens_,
-        .consumer = *consumer_,
+        .tokens = &*tokens_,
+        .consumer = consumer_,
         .vlog_stream = vlog_stream_,
     });
   });
@@ -730,14 +730,14 @@ auto CompilationUnit::RunLower() -> void {
     // producing textual LLVM IR.
     SemIR::InstNamer inst_namer(&*sem_ir_);
     module_ = Lower::LowerToLLVM({
-        .llvm_context = *llvm_context_,
+        .llvm_context = llvm_context_.get(),
         .fs = driver_env_->fs,
         .llvm_verifier_stream =
             options_->run_llvm_verifier ? driver_env_->error_stream : nullptr,
         .want_debug_info = options_->include_debug_info,
         .tree_and_subtrees_getters = cache_->tree_and_subtrees_getters(),
         .module_name = input_filename_,
-        .sem_ir = *sem_ir_,
+        .sem_ir = &*sem_ir_,
         .inst_namer = &inst_namer,
         .vlog_stream = vlog_stream_,
     });

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -983,11 +983,11 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   CARBON_VLOG_TO(driver_env.vlog_stream, "*** Check::CheckParseTrees ***\n");
   Check::CheckParseTreesOptions options;
   options.prelude_import = options_.prelude_import;
-  options.target = options_.codegen_options.target;
   options.vlog_stream = driver_env.vlog_stream;
   options.fuzzing = driver_env.fuzzing;
   Check::CheckParseTrees(check_units, cache.tree_and_subtrees_getters(),
-                         driver_env.fs, options);
+                         driver_env.fs, options_.codegen_options.target,
+                         options);
   CARBON_VLOG_TO(driver_env.vlog_stream,
                  "*** Check::CheckParseTrees done ***\n");
   for (auto& unit : units) {

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -606,8 +606,13 @@ auto CompilationUnit::RunLex() -> void {
 
   CARBON_VLOG("*** SourceBuffer ***\n```\n{0}\n```\n", source_->text());
 
-  LogCall("Lex::Lex", "lex",
-          [&] { tokens_ = Lex::Lex(value_stores_, *source_, *consumer_); });
+  LogCall("Lex::Lex", "lex", [&] {
+    tokens_ = Lex::Lex({
+        .value_stores = value_stores_,
+        .source = *source_,
+        .consumer = *consumer_,
+    });
+  });
   if (options_->dump_tokens && IncludeInDumps()) {
     consumer_->Flush();
     tokens_->Print(*driver_env_->output_stream,
@@ -624,7 +629,11 @@ auto CompilationUnit::RunLex() -> void {
 
 auto CompilationUnit::RunParse() -> void {
   LogCall("Parse::Parse", "parse", [&] {
-    parse_tree_ = Parse::Parse(*tokens_, *consumer_, vlog_stream_);
+    parse_tree_ = Parse::Parse({
+        .tokens = *tokens_,
+        .consumer = *consumer_,
+        .vlog_stream = vlog_stream_,
+    });
   });
   if (options_->dump_parse_tree && IncludeInDumps()) {
     consumer_->Flush();
@@ -720,13 +729,18 @@ auto CompilationUnit::RunLower() -> void {
     // TODO: Consider disabling instruction naming by default if we're not
     // producing textual LLVM IR.
     SemIR::InstNamer inst_namer(&*sem_ir_);
-    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> subtrees =
-        cache_->tree_and_subtrees_getters();
-    module_ = Lower::LowerToLLVM(
-        *llvm_context_, driver_env_->fs,
-        options_->run_llvm_verifier ? driver_env_->error_stream : nullptr,
-        options_->include_debug_info, subtrees, input_filename_, *sem_ir_,
-        &inst_namer, vlog_stream_);
+    module_ = Lower::LowerToLLVM({
+        .llvm_context = *llvm_context_,
+        .fs = driver_env_->fs,
+        .llvm_verifier_stream =
+            options_->run_llvm_verifier ? driver_env_->error_stream : nullptr,
+        .want_debug_info = options_->include_debug_info,
+        .tree_and_subtrees_getters = cache_->tree_and_subtrees_getters(),
+        .module_name = input_filename_,
+        .sem_ir = *sem_ir_,
+        .inst_namer = &inst_namer,
+        .vlog_stream = vlog_stream_,
+    });
   });
   if (vlog_stream_) {
     CARBON_VLOG("*** llvm::Module ***\n");
@@ -977,10 +991,15 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Execute the actual checking.
   CARBON_VLOG_TO(driver_env.vlog_stream, "*** Check::CheckParseTrees ***\n");
-  Check::CheckParseTrees(check_units, cache.tree_and_subtrees_getters(),
-                         options_.prelude_import, driver_env.fs,
-                         options_.codegen_options.target,
-                         driver_env.vlog_stream, driver_env.fuzzing);
+  Check::CheckParseTrees({
+      .units = check_units,
+      .tree_and_subtrees_getters = cache.tree_and_subtrees_getters(),
+      .prelude_import = options_.prelude_import,
+      .fs = driver_env.fs,
+      .target = options_.codegen_options.target,
+      .vlog_stream = driver_env.vlog_stream,
+      .fuzzing = driver_env.fuzzing,
+  });
   CARBON_VLOG_TO(driver_env.vlog_stream,
                  "*** Check::CheckParseTrees done ***\n");
   for (auto& unit : units) {

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -607,11 +607,9 @@ auto CompilationUnit::RunLex() -> void {
   CARBON_VLOG("*** SourceBuffer ***\n```\n{0}\n```\n", source_->text());
 
   LogCall("Lex::Lex", "lex", [&] {
-    tokens_ = Lex::Lex({
-        .value_stores = &value_stores_,
-        .source = &*source_,
-        .consumer = consumer_,
-    });
+    Lex::LexOptions options;
+    options.consumer = consumer_;
+    tokens_ = Lex::Lex(value_stores_, *source_, options);
   });
   if (options_->dump_tokens && IncludeInDumps()) {
     consumer_->Flush();
@@ -629,11 +627,10 @@ auto CompilationUnit::RunLex() -> void {
 
 auto CompilationUnit::RunParse() -> void {
   LogCall("Parse::Parse", "parse", [&] {
-    parse_tree_ = Parse::Parse({
-        .tokens = &*tokens_,
-        .consumer = consumer_,
-        .vlog_stream = vlog_stream_,
-    });
+    Parse::ParseOptions options;
+    options.consumer = consumer_;
+    options.vlog_stream = vlog_stream_;
+    parse_tree_ = Parse::Parse(*tokens_, options);
   });
   if (options_->dump_parse_tree && IncludeInDumps()) {
     consumer_->Flush();
@@ -726,21 +723,14 @@ auto CompilationUnit::PostCheck() -> void {
 auto CompilationUnit::RunLower() -> void {
   LogCall("Lower::LowerToLLVM", "lower", [&] {
     llvm_context_ = std::make_unique<llvm::LLVMContext>();
-    // TODO: Consider disabling instruction naming by default if we're not
-    // producing textual LLVM IR.
-    SemIR::InstNamer inst_namer(&*sem_ir_);
-    module_ = Lower::LowerToLLVM({
-        .llvm_context = llvm_context_.get(),
-        .fs = driver_env_->fs,
-        .llvm_verifier_stream =
-            options_->run_llvm_verifier ? driver_env_->error_stream : nullptr,
-        .want_debug_info = options_->include_debug_info,
-        .tree_and_subtrees_getters = cache_->tree_and_subtrees_getters(),
-        .module_name = input_filename_,
-        .sem_ir = &*sem_ir_,
-        .inst_namer = &inst_namer,
-        .vlog_stream = vlog_stream_,
-    });
+    Lower::LowerToLLVMOptions options;
+    options.llvm_verifier_stream =
+        options_->run_llvm_verifier ? driver_env_->error_stream : nullptr;
+    options.want_debug_info = options_->include_debug_info;
+    options.vlog_stream = vlog_stream_;
+    module_ = Lower::LowerToLLVM(*llvm_context_, driver_env_->fs,
+                                 cache_->tree_and_subtrees_getters(), *sem_ir_,
+                                 options);
   });
   if (vlog_stream_) {
     CARBON_VLOG("*** llvm::Module ***\n");
@@ -991,15 +981,13 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Execute the actual checking.
   CARBON_VLOG_TO(driver_env.vlog_stream, "*** Check::CheckParseTrees ***\n");
-  Check::CheckParseTrees({
-      .units = check_units,
-      .tree_and_subtrees_getters = cache.tree_and_subtrees_getters(),
-      .prelude_import = options_.prelude_import,
-      .fs = driver_env.fs,
-      .target = options_.codegen_options.target,
-      .vlog_stream = driver_env.vlog_stream,
-      .fuzzing = driver_env.fuzzing,
-  });
+  Check::CheckParseTreesOptions options;
+  options.prelude_import = options_.prelude_import;
+  options.target = options_.codegen_options.target;
+  options.vlog_stream = driver_env.vlog_stream;
+  options.fuzzing = driver_env.fuzzing;
+  Check::CheckParseTrees(check_units, cache.tree_and_subtrees_getters(),
+                         driver_env.fs, options);
   CARBON_VLOG_TO(driver_env.vlog_stream,
                  "*** Check::CheckParseTrees done ***\n");
   for (auto& unit : units) {

--- a/toolchain/driver/format_subcommand.cpp
+++ b/toolchain/driver/format_subcommand.cpp
@@ -82,7 +82,11 @@ auto FormatSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
       continue;
     }
     SharedValueStores value_stores;
-    auto tokens = Lex::Lex(value_stores, *source, driver_env.consumer);
+    auto tokens = Lex::Lex({
+        .value_stores = value_stores,
+        .source = *source,
+        .consumer = driver_env.consumer,
+    });
 
     RawStringOstream buffer;
     if (Format::Format(tokens, buffer)) {

--- a/toolchain/driver/format_subcommand.cpp
+++ b/toolchain/driver/format_subcommand.cpp
@@ -82,11 +82,9 @@ auto FormatSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
       continue;
     }
     SharedValueStores value_stores;
-    auto tokens = Lex::Lex({
-        .value_stores = &value_stores,
-        .source = &*source,
-        .consumer = &driver_env.consumer,
-    });
+    Lex::LexOptions lex_options;
+    lex_options.consumer = &driver_env.consumer;
+    auto tokens = Lex::Lex(value_stores, *source, lex_options);
 
     RawStringOstream buffer;
     if (Format::Format(tokens, buffer)) {

--- a/toolchain/driver/format_subcommand.cpp
+++ b/toolchain/driver/format_subcommand.cpp
@@ -83,9 +83,9 @@ auto FormatSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
     }
     SharedValueStores value_stores;
     auto tokens = Lex::Lex({
-        .value_stores = value_stores,
-        .source = *source,
-        .consumer = driver_env.consumer,
+        .value_stores = &value_stores,
+        .source = &*source,
+        .consumer = &driver_env.consumer,
     });
 
     RawStringOstream buffer;

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -163,9 +163,9 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
   // TODO: Include the prelude.
   Check::CheckParseTreesOptions check_options;
   check_options.vlog_stream = context.vlog_stream();
-  Check::CheckParseTrees(units,
-                         llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>(getter),
-                         fs, check_options);
+  Check::CheckParseTrees(
+      units, llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>(getter), fs,
+      llvm::sys::getDefaultTargetTriple(), check_options);
 
   // Note we need to publish diagnostics even when empty.
   // TODO: Consider caching previously published diagnostics and only publishing

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -131,16 +131,16 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
   }
   source_ = std::make_unique<SourceBuffer>(std::move(*source));
   value_stores_ = std::make_unique<SharedValueStores>();
-  tokens_ = std::make_unique<Lex::TokenizedBuffer>(Lex::Lex({
-      .value_stores = value_stores_.get(),
-      .source = source_.get(),
-      .consumer = &consumer,
-  }));
-  tree_ = std::make_unique<Parse::Tree>(Parse::Parse({
-      .tokens = tokens_.get(),
-      .consumer = &consumer,
-      .vlog_stream = context.vlog_stream(),
-  }));
+
+  Lex::LexOptions lex_options;
+  lex_options.consumer = &consumer;
+  tokens_ = std::make_unique<Lex::TokenizedBuffer>(
+      Lex::Lex(*value_stores_, *source_, lex_options));
+
+  Parse::ParseOptions parse_options;
+  parse_options.consumer = &consumer;
+  parse_options.vlog_stream = context.vlog_stream();
+  tree_ = std::make_unique<Parse::Tree>(Parse::Parse(*tokens_, parse_options));
   tree_and_subtrees_ =
       std::make_unique<Parse::TreeAndSubtrees>(*tokens_, *tree_);
 
@@ -159,15 +159,13 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
   };
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> fs =
       new llvm::vfs::InMemoryFileSystem;
+
   // TODO: Include the prelude.
-  Check::CheckParseTrees({
-      .units = units,
-      .tree_and_subtrees_getters =
-          llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>(getter),
-      .fs = fs,
-      .target = llvm::sys::getDefaultTargetTriple(),
-      .vlog_stream = context.vlog_stream(),
-  });
+  Check::CheckParseTreesOptions check_options;
+  check_options.vlog_stream = context.vlog_stream();
+  Check::CheckParseTrees(units,
+                         llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>(getter),
+                         fs, check_options);
 
   // Note we need to publish diagnostics even when empty.
   // TODO: Consider caching previously published diagnostics and only publishing

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -131,10 +131,16 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
   }
   source_ = std::make_unique<SourceBuffer>(std::move(*source));
   value_stores_ = std::make_unique<SharedValueStores>();
-  tokens_ = std::make_unique<Lex::TokenizedBuffer>(
-      Lex::Lex(*value_stores_, *source_, consumer));
-  tree_ = std::make_unique<Parse::Tree>(
-      Parse::Parse(*tokens_, consumer, context.vlog_stream()));
+  tokens_ = std::make_unique<Lex::TokenizedBuffer>(Lex::Lex({
+      .value_stores = *value_stores_,
+      .source = *source_,
+      .consumer = consumer,
+  }));
+  tree_ = std::make_unique<Parse::Tree>(Parse::Parse({
+      .tokens = *tokens_,
+      .consumer = consumer,
+      .vlog_stream = context.vlog_stream(),
+  }));
   tree_and_subtrees_ =
       std::make_unique<Parse::TreeAndSubtrees>(*tokens_, *tree_);
 
@@ -154,10 +160,14 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> fs =
       new llvm::vfs::InMemoryFileSystem;
   // TODO: Include the prelude.
-  Check::CheckParseTrees(
-      units, llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>(getter),
-      /*prelude_import=*/false, fs, llvm::sys::getDefaultTargetTriple(),
-      context.vlog_stream(), /*fuzzing=*/false);
+  Check::CheckParseTrees({
+      .units = units,
+      .tree_and_subtrees_getters =
+          llvm::ArrayRef<Parse::GetTreeAndSubtreesFn>(getter),
+      .fs = fs,
+      .target = llvm::sys::getDefaultTargetTriple(),
+      .vlog_stream = context.vlog_stream(),
+  });
 
   // Note we need to publish diagnostics even when empty.
   // TODO: Consider caching previously published diagnostics and only publishing

--- a/toolchain/language_server/context.cpp
+++ b/toolchain/language_server/context.cpp
@@ -132,13 +132,13 @@ auto Context::File::SetText(Context& context, std::optional<int64_t> version,
   source_ = std::make_unique<SourceBuffer>(std::move(*source));
   value_stores_ = std::make_unique<SharedValueStores>();
   tokens_ = std::make_unique<Lex::TokenizedBuffer>(Lex::Lex({
-      .value_stores = *value_stores_,
-      .source = *source_,
-      .consumer = consumer,
+      .value_stores = value_stores_.get(),
+      .source = source_.get(),
+      .consumer = &consumer,
   }));
   tree_ = std::make_unique<Parse::Tree>(Parse::Parse({
-      .tokens = *tokens_,
-      .consumer = consumer,
+      .tokens = tokens_.get(),
+      .consumer = &consumer,
       .vlog_stream = context.vlog_stream(),
   }));
   tree_and_subtrees_ =

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1694,7 +1694,7 @@ auto Lexer::DiagnoseAndFixMismatchedBrackets() -> void {
 }
 
 auto Lex(LexParams params) -> TokenizedBuffer {
-  return Lexer(params.value_stores, params.source, params.consumer).Lex();
+  return Lexer(*params.value_stores, *params.source, *params.consumer).Lex();
 }
 
 }  // namespace Carbon::Lex

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1693,8 +1693,11 @@ auto Lexer::DiagnoseAndFixMismatchedBrackets() -> void {
   fixes.FixTokenCrossReferences();
 }
 
-auto Lex(LexParams params) -> TokenizedBuffer {
-  return Lexer(*params.value_stores, *params.source, *params.consumer).Lex();
+auto Lex(SharedValueStores& value_stores, SourceBuffer& source,
+         LexOptions options) -> TokenizedBuffer {
+  auto* consumer =
+      options.consumer ? options.consumer : &Diagnostics::ConsoleConsumer();
+  return Lexer(value_stores, source, *consumer).Lex();
 }
 
 }  // namespace Carbon::Lex

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1693,9 +1693,8 @@ auto Lexer::DiagnoseAndFixMismatchedBrackets() -> void {
   fixes.FixTokenCrossReferences();
 }
 
-auto Lex(SharedValueStores& value_stores, SourceBuffer& source,
-         Diagnostics::Consumer& consumer) -> TokenizedBuffer {
-  return Lexer(value_stores, source, consumer).Lex();
+auto Lex(LexParams params) -> TokenizedBuffer {
+  return Lexer(params.value_stores, params.source, params.consumer).Lex();
 }
 
 }  // namespace Carbon::Lex

--- a/toolchain/lex/lex.h
+++ b/toolchain/lex/lex.h
@@ -13,9 +13,14 @@
 namespace Carbon::Lex {
 
 struct LexParams {
-  SharedValueStores& value_stores;
-  SourceBuffer& source;
-  Diagnostics::Consumer& consumer;
+  // Must be non-null.
+  SharedValueStores* value_stores;
+
+  // Must be non-null.
+  SourceBuffer* source;
+
+  // Must be non-null.
+  Diagnostics::Consumer* consumer;
 };
 
 // Lexes a buffer of source code into a tokenized buffer.

--- a/toolchain/lex/lex.h
+++ b/toolchain/lex/lex.h
@@ -12,13 +12,17 @@
 
 namespace Carbon::Lex {
 
+struct LexParams {
+  SharedValueStores& value_stores;
+  SourceBuffer& source;
+  Diagnostics::Consumer& consumer;
+};
+
 // Lexes a buffer of source code into a tokenized buffer.
 //
 // The provided source buffer must outlive any returned `TokenizedBuffer`
 // which will refer into the source.
-auto Lex(SharedValueStores& value_stores,
-         SourceBuffer& source [[clang::lifetimebound]],
-         Diagnostics::Consumer& consumer) -> TokenizedBuffer;
+auto Lex(LexParams params) -> TokenizedBuffer;
 
 }  // namespace Carbon::Lex
 

--- a/toolchain/lex/lex.h
+++ b/toolchain/lex/lex.h
@@ -12,22 +12,21 @@
 
 namespace Carbon::Lex {
 
-struct LexParams {
-  // Must be non-null.
-  SharedValueStores* value_stores;
+struct LexOptions {
+  // Options must be set individually, not through initialization.
+  explicit LexOptions() = default;
 
-  // Must be non-null.
-  SourceBuffer* source;
-
-  // Must be non-null.
-  Diagnostics::Consumer* consumer;
+  // If set, a consumer for diagnostics. Otherwise, diagnostics go to stderr.
+  Diagnostics::Consumer* consumer = nullptr;
 };
 
 // Lexes a buffer of source code into a tokenized buffer.
 //
 // The provided source buffer must outlive any returned `TokenizedBuffer`
 // which will refer into the source.
-auto Lex(LexParams params) -> TokenizedBuffer;
+auto Lex(SharedValueStores& value_stores,
+         SourceBuffer& source [[clang::lifetimebound]], LexOptions options)
+    -> TokenizedBuffer;
 
 }  // namespace Carbon::Lex
 

--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -218,9 +218,9 @@ class LexerBenchHelper {
   auto Lex() -> TokenizedBuffer {
     Diagnostics::Consumer& consumer = Diagnostics::NullConsumer();
     return Lex::Lex({
-        .value_stores = value_stores_,
-        .source = source_,
-        .consumer = consumer,
+        .value_stores = &value_stores_,
+        .source = &source_,
+        .consumer = &consumer,
     });
   }
 
@@ -228,9 +228,9 @@ class LexerBenchHelper {
     RawStringOstream result;
     Diagnostics::StreamConsumer consumer(&result);
     auto buffer = Lex::Lex({
-        .value_stores = value_stores_,
-        .source = source_,
-        .consumer = consumer,
+        .value_stores = &value_stores_,
+        .source = &source_,
+        .consumer = &consumer,
     });
     consumer.Flush();
     CARBON_CHECK(buffer.has_errors(),

--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -217,13 +217,21 @@ class LexerBenchHelper {
 
   auto Lex() -> TokenizedBuffer {
     Diagnostics::Consumer& consumer = Diagnostics::NullConsumer();
-    return Lex::Lex(value_stores_, source_, consumer);
+    return Lex::Lex({
+        .value_stores = value_stores_,
+        .source = source_,
+        .consumer = consumer,
+    });
   }
 
   auto DiagnoseErrors() -> std::string {
     RawStringOstream result;
     Diagnostics::StreamConsumer consumer(&result);
-    auto buffer = Lex::Lex(value_stores_, source_, consumer);
+    auto buffer = Lex::Lex({
+        .value_stores = value_stores_,
+        .source = source_,
+        .consumer = consumer,
+    });
     consumer.Flush();
     CARBON_CHECK(buffer.has_errors(),
                  "Asked to diagnose errors but none found!");

--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -217,21 +217,17 @@ class LexerBenchHelper {
 
   auto Lex() -> TokenizedBuffer {
     Diagnostics::Consumer& consumer = Diagnostics::NullConsumer();
-    return Lex::Lex({
-        .value_stores = &value_stores_,
-        .source = &source_,
-        .consumer = &consumer,
-    });
+    Lex::LexOptions options;
+    options.consumer = &consumer;
+    return Lex::Lex(value_stores_, source_, options);
   }
 
   auto DiagnoseErrors() -> std::string {
     RawStringOstream result;
     Diagnostics::StreamConsumer consumer(&result);
-    auto buffer = Lex::Lex({
-        .value_stores = &value_stores_,
-        .source = &source_,
-        .consumer = &consumer,
-    });
+    Lex::LexOptions options;
+    options.consumer = &consumer;
+    auto buffer = Lex::Lex(value_stores_, source_, options);
     consumer.Flush();
     CARBON_CHECK(buffer.has_errors(),
                  "Asked to diagnose errors but none found!");

--- a/toolchain/lex/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lex/tokenized_buffer_fuzzer.cpp
@@ -36,9 +36,9 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
 
   SharedValueStores value_stores;
   auto buffer = Lex::Lex({
-      .value_stores = value_stores,
-      .source = *source,
-      .consumer = Diagnostics::NullConsumer(),
+      .value_stores = &value_stores,
+      .source = &*source,
+      .consumer = &Diagnostics::NullConsumer(),
   });
   if (buffer.has_errors()) {
     return 0;

--- a/toolchain/lex/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lex/tokenized_buffer_fuzzer.cpp
@@ -35,7 +35,11 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
       SourceBuffer::MakeFromFile(fs, TestFileName, Diagnostics::NullConsumer());
 
   SharedValueStores value_stores;
-  auto buffer = Lex::Lex(value_stores, *source, Diagnostics::NullConsumer());
+  auto buffer = Lex::Lex({
+      .value_stores = value_stores,
+      .source = *source,
+      .consumer = Diagnostics::NullConsumer(),
+  });
   if (buffer.has_errors()) {
     return 0;
   }

--- a/toolchain/lex/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lex/tokenized_buffer_fuzzer.cpp
@@ -35,11 +35,9 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
       SourceBuffer::MakeFromFile(fs, TestFileName, Diagnostics::NullConsumer());
 
   SharedValueStores value_stores;
-  auto buffer = Lex::Lex({
-      .value_stores = &value_stores,
-      .source = &*source,
-      .consumer = &Diagnostics::NullConsumer(),
-  });
+  Lex::LexOptions options;
+  options.consumer = &Diagnostics::NullConsumer();
+  auto buffer = Lex::Lex(value_stores, *source, options);
   if (buffer.has_errors()) {
     return 0;
   }

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -12,7 +12,6 @@
 
 namespace Carbon::Lower {
 
-// TODO: Remove module_name argument.
 auto LowerToLLVM(
     llvm::LLVMContext& llvm_context,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -12,18 +12,12 @@
 
 namespace Carbon::Lower {
 
-auto LowerToLLVM(
-    llvm::LLVMContext& llvm_context,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-    llvm::raw_ostream* llvm_verifier_stream, bool want_debug_info,
-    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
-    llvm::StringRef module_name, const SemIR::File& sem_ir,
-    const SemIR::InstNamer* inst_namer, llvm::raw_ostream* vlog_stream)
-    -> std::unique_ptr<llvm::Module> {
-  Context context(llvm_context, std::move(fs), want_debug_info,
-                  tree_and_subtrees_getters, module_name, vlog_stream);
-  context.GetFileContext(&sem_ir, inst_namer).LowerDefinitions();
-  return std::move(context).Finalize(llvm_verifier_stream);
+auto LowerToLLVM(LowerToLLVMParams params) -> std::unique_ptr<llvm::Module> {
+  Context context(params.llvm_context, std::move(params.fs),
+                  params.want_debug_info, params.tree_and_subtrees_getters,
+                  params.module_name, params.vlog_stream);
+  context.GetFileContext(&params.sem_ir, params.inst_namer).LowerDefinitions();
+  return std::move(context).Finalize(params.llvm_verifier_stream);
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -13,10 +13,10 @@
 namespace Carbon::Lower {
 
 auto LowerToLLVM(LowerToLLVMParams params) -> std::unique_ptr<llvm::Module> {
-  Context context(params.llvm_context, std::move(params.fs),
+  Context context(*params.llvm_context, std::move(params.fs),
                   params.want_debug_info, params.tree_and_subtrees_getters,
                   params.module_name, params.vlog_stream);
-  context.GetFileContext(&params.sem_ir, params.inst_namer).LowerDefinitions();
+  context.GetFileContext(params.sem_ir, params.inst_namer).LowerDefinitions();
   return std::move(context).Finalize(params.llvm_verifier_stream);
 }
 

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -12,12 +12,23 @@
 
 namespace Carbon::Lower {
 
-auto LowerToLLVM(LowerToLLVMParams params) -> std::unique_ptr<llvm::Module> {
-  Context context(*params.llvm_context, std::move(params.fs),
-                  params.want_debug_info, params.tree_and_subtrees_getters,
-                  params.module_name, params.vlog_stream);
-  context.GetFileContext(params.sem_ir, params.inst_namer).LowerDefinitions();
-  return std::move(context).Finalize(params.llvm_verifier_stream);
+// TODO: Remove module_name argument.
+auto LowerToLLVM(
+    llvm::LLVMContext& llvm_context,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
+    const SemIR::File& sem_ir, const LowerToLLVMOptions& options)
+    -> std::unique_ptr<llvm::Module> {
+  Context context(llvm_context, std::move(fs), options.want_debug_info,
+                  tree_and_subtrees_getters, sem_ir.filename(),
+                  options.vlog_stream);
+
+  // TODO: Consider disabling instruction naming by default if we're not
+  // producing textual LLVM IR.
+  SemIR::InstNamer inst_namer(&sem_ir);
+  context.GetFileContext(&sem_ir, &inst_namer).LowerDefinitions();
+
+  return std::move(context).Finalize(options.llvm_verifier_stream);
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/lower.h
+++ b/toolchain/lower/lower.h
@@ -14,31 +14,27 @@
 
 namespace Carbon::Lower {
 
-struct LowerToLLVMParams {
-  // Must be non-null.
-  llvm::LLVMContext* llvm_context;
+struct LowerToLLVMOptions {
+  // Options must be set individually, not through initialization.
+  explicit LowerToLLVMOptions() = default;
 
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
+  // If set, enables LLVM IR verification.
+  llvm::raw_ostream* llvm_verifier_stream = nullptr;
 
-  // Optionally provided to enable verification.
-  llvm::raw_ostream* llvm_verifier_stream;
+  // Whether to include debug info in lowered output.
+  bool want_debug_info = false;
 
-  bool want_debug_info;
-  llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters;
-  llvm::StringRef module_name;
-
-  // Must be non-null.
-  const SemIR::File* sem_ir;
-
-  // Must be non-null.
-  const SemIR::InstNamer* inst_namer;
-
-  // Optionally provided to enable VLOG output.
+  // If set, enables verbose output.
   llvm::raw_ostream* vlog_stream = nullptr;
 };
 
 // Lowers SemIR to LLVM IR.
-auto LowerToLLVM(LowerToLLVMParams params) -> std::unique_ptr<llvm::Module>;
+auto LowerToLLVM(
+    llvm::LLVMContext& llvm_context,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
+    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
+    const SemIR::File& sem_ir, const LowerToLLVMOptions& options)
+    -> std::unique_ptr<llvm::Module>;
 
 }  // namespace Carbon::Lower
 

--- a/toolchain/lower/lower.h
+++ b/toolchain/lower/lower.h
@@ -15,17 +15,25 @@
 namespace Carbon::Lower {
 
 struct LowerToLLVMParams {
-  llvm::LLVMContext& llvm_context;
+  // Must be non-null.
+  llvm::LLVMContext* llvm_context;
+
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
 
-  // Should be non-null when verification is desired.
+  // Optionally provided to enable verification.
   llvm::raw_ostream* llvm_verifier_stream;
 
   bool want_debug_info;
   llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters;
   llvm::StringRef module_name;
-  const SemIR::File& sem_ir;
+
+  // Must be non-null.
+  const SemIR::File* sem_ir;
+
+  // Must be non-null.
   const SemIR::InstNamer* inst_namer;
+
+  // Optionally provided to enable VLOG output.
   llvm::raw_ostream* vlog_stream = nullptr;
 };
 

--- a/toolchain/lower/lower.h
+++ b/toolchain/lower/lower.h
@@ -14,18 +14,23 @@
 
 namespace Carbon::Lower {
 
+struct LowerToLLVMParams {
+  llvm::LLVMContext& llvm_context;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
+
+  // Should be non-null when verification is desired.
+  llvm::raw_ostream* llvm_verifier_stream;
+
+  bool want_debug_info;
+  llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters;
+  llvm::StringRef module_name;
+  const SemIR::File& sem_ir;
+  const SemIR::InstNamer* inst_namer;
+  llvm::raw_ostream* vlog_stream = nullptr;
+};
+
 // Lowers SemIR to LLVM IR.
-//
-// `llvm_verifier_stream` should be non-null when verification is desired.
-// TODO: Switch to a struct for parameters.
-auto LowerToLLVM(
-    llvm::LLVMContext& llvm_context,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
-    llvm::raw_ostream* llvm_verifier_stream, bool want_debug_info,
-    llvm::ArrayRef<Parse::GetTreeAndSubtreesFn> tree_and_subtrees_getters,
-    llvm::StringRef module_name, const SemIR::File& sem_ir,
-    const SemIR::InstNamer* inst_namer, llvm::raw_ostream* vlog_stream)
-    -> std::unique_ptr<llvm::Module>;
+auto LowerToLLVM(LowerToLLVMParams params) -> std::unique_ptr<llvm::Module>;
 
 }  // namespace Carbon::Lower
 

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -17,10 +17,13 @@ auto HandleInvalid(Context& context) -> void {
                context.PopState());
 }
 
-auto Parse(ParseParams params) -> Tree {
+auto Parse(Lex::TokenizedBuffer& tokens, ParseOptions options) -> Tree {
+  auto* consumer =
+      options.consumer ? options.consumer : &Diagnostics::ConsoleConsumer();
+
   // Delegate to the parser.
-  Tree tree(*params.tokens);
-  Context context(&tree, params.tokens, params.consumer, params.vlog_stream);
+  Tree tree(tokens);
+  Context context(&tree, &tokens, consumer, options.vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -43,7 +46,7 @@ auto Parse(ParseParams params) -> Tree {
 
   // Mark the tree as potentially having errors if there were errors coming in
   // from the tokenized buffer or we diagnosed new errors.
-  tree.set_has_errors(params.tokens->has_errors() || context.has_errors());
+  tree.set_has_errors(tokens.has_errors() || context.has_errors());
 
   if (auto verify = tree.Verify(); !verify.ok()) {
     // TODO: This is temporarily printing to stderr directly during development.

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -17,11 +17,10 @@ auto HandleInvalid(Context& context) -> void {
                context.PopState());
 }
 
-auto Parse(Lex::TokenizedBuffer& tokens, Diagnostics::Consumer& consumer,
-           llvm::raw_ostream* vlog_stream) -> Tree {
+auto Parse(ParseParams params) -> Tree {
   // Delegate to the parser.
-  Tree tree(tokens);
-  Context context(&tree, &tokens, &consumer, vlog_stream);
+  Tree tree(params.tokens);
+  Context context(&tree, &params.tokens, &params.consumer, params.vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -44,7 +43,7 @@ auto Parse(Lex::TokenizedBuffer& tokens, Diagnostics::Consumer& consumer,
 
   // Mark the tree as potentially having errors if there were errors coming in
   // from the tokenized buffer or we diagnosed new errors.
-  tree.set_has_errors(tokens.has_errors() || context.has_errors());
+  tree.set_has_errors(params.tokens.has_errors() || context.has_errors());
 
   if (auto verify = tree.Verify(); !verify.ok()) {
     // TODO: This is temporarily printing to stderr directly during development.

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -19,8 +19,8 @@ auto HandleInvalid(Context& context) -> void {
 
 auto Parse(ParseParams params) -> Tree {
   // Delegate to the parser.
-  Tree tree(params.tokens);
-  Context context(&tree, &params.tokens, &params.consumer, params.vlog_stream);
+  Tree tree(*params.tokens);
+  Context context(&tree, params.tokens, params.consumer, params.vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -43,7 +43,7 @@ auto Parse(ParseParams params) -> Tree {
 
   // Mark the tree as potentially having errors if there were errors coming in
   // from the tokenized buffer or we diagnosed new errors.
-  tree.set_has_errors(params.tokens.has_errors() || context.has_errors());
+  tree.set_has_errors(params.tokens->has_errors() || context.has_errors());
 
   if (auto verify = tree.Verify(); !verify.ok()) {
     // TODO: This is temporarily printing to stderr directly during development.

--- a/toolchain/parse/parse.h
+++ b/toolchain/parse/parse.h
@@ -12,21 +12,21 @@
 
 namespace Carbon::Parse {
 
-struct ParseParams {
-  // Must be non-null.
-  Lex::TokenizedBuffer* tokens;
+struct ParseOptions {
+  // Options must be set individually, not through initialization.
+  explicit ParseOptions() = default;
 
-  // Must be non-null.
-  Diagnostics::Consumer* consumer;
+  // If set, a consumer for diagnostics. Otherwise, diagnostics go to stderr.
+  Diagnostics::Consumer* consumer = nullptr;
 
-  // Optionally provided to enable VLOG output.
+  // If set, enables verbose output.
   llvm::raw_ostream* vlog_stream = nullptr;
 };
 
 // Parses the token buffer into a `Tree`.
 //
 // This is the factory function which is used to build parse trees.
-auto Parse(ParseParams params) -> Tree;
+auto Parse(Lex::TokenizedBuffer& tokens, ParseOptions options) -> Tree;
 
 }  // namespace Carbon::Parse
 

--- a/toolchain/parse/parse.h
+++ b/toolchain/parse/parse.h
@@ -12,11 +12,16 @@
 
 namespace Carbon::Parse {
 
+struct ParseParams {
+  Lex::TokenizedBuffer& tokens;
+  Diagnostics::Consumer& consumer;
+  llvm::raw_ostream* vlog_stream = nullptr;
+};
+
 // Parses the token buffer into a `Tree`.
 //
 // This is the factory function which is used to build parse trees.
-auto Parse(Lex::TokenizedBuffer& tokens, Diagnostics::Consumer& consumer,
-           llvm::raw_ostream* vlog_stream) -> Tree;
+auto Parse(ParseParams params) -> Tree;
 
 }  // namespace Carbon::Parse
 

--- a/toolchain/parse/parse.h
+++ b/toolchain/parse/parse.h
@@ -13,8 +13,13 @@
 namespace Carbon::Parse {
 
 struct ParseParams {
-  Lex::TokenizedBuffer& tokens;
-  Diagnostics::Consumer& consumer;
+  // Must be non-null.
+  Lex::TokenizedBuffer* tokens;
+
+  // Must be non-null.
+  Diagnostics::Consumer* consumer;
+
+  // Optionally provided to enable VLOG output.
   llvm::raw_ostream* vlog_stream = nullptr;
 };
 

--- a/toolchain/parse/parse_fuzzer.cpp
+++ b/toolchain/parse/parse_fuzzer.cpp
@@ -33,14 +33,21 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
 
   // Lex the input.
   SharedValueStores value_stores;
-  auto tokens = Lex::Lex(value_stores, *source, Diagnostics::NullConsumer());
+  auto tokens = Lex::Lex({
+      .value_stores = value_stores,
+      .source = *source,
+      .consumer = Diagnostics::NullConsumer(),
+  });
   if (tokens.has_errors()) {
     return 0;
   }
 
   // Now parse it into a tree. Note that parsing will (when asserts are enabled)
   // walk the entire tree to verify it so we don't have to do that here.
-  Parse::Parse(tokens, Diagnostics::NullConsumer(), /*vlog_stream=*/nullptr);
+  Parse::Parse({
+      .tokens = tokens,
+      .consumer = Diagnostics::NullConsumer(),
+  });
   return 0;
 }
 

--- a/toolchain/parse/parse_fuzzer.cpp
+++ b/toolchain/parse/parse_fuzzer.cpp
@@ -34,9 +34,9 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   // Lex the input.
   SharedValueStores value_stores;
   auto tokens = Lex::Lex({
-      .value_stores = value_stores,
-      .source = *source,
-      .consumer = Diagnostics::NullConsumer(),
+      .value_stores = &value_stores,
+      .source = &*source,
+      .consumer = &Diagnostics::NullConsumer(),
   });
   if (tokens.has_errors()) {
     return 0;
@@ -45,8 +45,8 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
   // Now parse it into a tree. Note that parsing will (when asserts are enabled)
   // walk the entire tree to verify it so we don't have to do that here.
   Parse::Parse({
-      .tokens = tokens,
-      .consumer = Diagnostics::NullConsumer(),
+      .tokens = &tokens,
+      .consumer = &Diagnostics::NullConsumer(),
   });
   return 0;
 }

--- a/toolchain/parse/parse_fuzzer.cpp
+++ b/toolchain/parse/parse_fuzzer.cpp
@@ -33,21 +33,18 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size) {
 
   // Lex the input.
   SharedValueStores value_stores;
-  auto tokens = Lex::Lex({
-      .value_stores = &value_stores,
-      .source = &*source,
-      .consumer = &Diagnostics::NullConsumer(),
-  });
+  Lex::LexOptions lex_options;
+  lex_options.consumer = &Diagnostics::NullConsumer();
+  auto tokens = Lex::Lex(value_stores, *source, lex_options);
   if (tokens.has_errors()) {
     return 0;
   }
 
   // Now parse it into a tree. Note that parsing will (when asserts are enabled)
   // walk the entire tree to verify it so we don't have to do that here.
-  Parse::Parse({
-      .tokens = &tokens,
-      .consumer = &Diagnostics::NullConsumer(),
-  });
+  Parse::ParseOptions parse_options;
+  parse_options.consumer = &Diagnostics::NullConsumer();
+  Parse::Parse(tokens, parse_options);
   return 0;
 }
 

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -170,10 +170,9 @@ TEST_F(TreeTest, HighRecursion) {
   Lex::TokenizedBuffer& tokens = compile_helper_.GetTokenizedBuffer(code);
   ASSERT_FALSE(tokens.has_errors());
   Testing::MockDiagnosticConsumer consumer;
-  Tree tree = Parse({
-      .tokens = &tokens,
-      .consumer = &consumer,
-  });
+  Parse::ParseOptions options;
+  options.consumer = &consumer;
+  Tree tree = Parse(tokens, options);
   EXPECT_FALSE(tree.has_errors());
 }
 

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -170,7 +170,10 @@ TEST_F(TreeTest, HighRecursion) {
   Lex::TokenizedBuffer& tokens = compile_helper_.GetTokenizedBuffer(code);
   ASSERT_FALSE(tokens.has_errors());
   Testing::MockDiagnosticConsumer consumer;
-  Tree tree = Parse({.tokens = tokens, .consumer = consumer});
+  Tree tree = Parse({
+      .tokens = &tokens,
+      .consumer = &consumer,
+  });
   EXPECT_FALSE(tree.has_errors());
 }
 

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -170,7 +170,7 @@ TEST_F(TreeTest, HighRecursion) {
   Lex::TokenizedBuffer& tokens = compile_helper_.GetTokenizedBuffer(code);
   ASSERT_FALSE(tokens.has_errors());
   Testing::MockDiagnosticConsumer consumer;
-  Tree tree = Parse(tokens, consumer, /*vlog_stream=*/nullptr);
+  Tree tree = Parse({.tokens = tokens, .consumer = consumer});
   EXPECT_FALSE(tree.has_errors());
 }
 

--- a/toolchain/testing/compile_helper.cpp
+++ b/toolchain/testing/compile_helper.cpp
@@ -15,8 +15,11 @@ auto CompileHelper::GetTokenizedBuffer(llvm::StringRef text,
   auto& source = GetSourceBuffer(text);
 
   value_store_storage_.emplace_front();
-  token_storage_.push_front(Lex::Lex(value_store_storage_.front(), source,
-                                     consumer ? *consumer : consumer_));
+  token_storage_.push_front(Lex::Lex({
+      .value_stores = value_store_storage_.front(),
+      .source = source,
+      .consumer = consumer ? *consumer : consumer_,
+  }));
   return token_storage_.front();
 }
 
@@ -29,8 +32,10 @@ auto CompileHelper::GetTokenizedBufferWithSharedValueStore(
 
 auto CompileHelper::GetTree(llvm::StringRef text) -> Parse::Tree& {
   auto& tokens = GetTokenizedBuffer(text);
-  tree_storage_.push_front(Parse::Parse(tokens, consumer_,
-                                        /*vlog_stream=*/nullptr));
+  tree_storage_.push_front(Parse::Parse({
+      .tokens = tokens,
+      .consumer = consumer_,
+  }));
   return tree_storage_.front();
 }
 

--- a/toolchain/testing/compile_helper.cpp
+++ b/toolchain/testing/compile_helper.cpp
@@ -15,11 +15,10 @@ auto CompileHelper::GetTokenizedBuffer(llvm::StringRef text,
   auto& source = GetSourceBuffer(text);
 
   value_store_storage_.emplace_front();
-  token_storage_.push_front(Lex::Lex({
-      .value_stores = &value_store_storage_.front(),
-      .source = &source,
-      .consumer = consumer ? consumer : &consumer_,
-  }));
+  Lex::LexOptions options;
+  options.consumer = consumer ? consumer : &consumer_;
+  token_storage_.push_front(
+      Lex::Lex(value_store_storage_.front(), source, options));
   return token_storage_.front();
 }
 
@@ -32,10 +31,9 @@ auto CompileHelper::GetTokenizedBufferWithSharedValueStore(
 
 auto CompileHelper::GetTree(llvm::StringRef text) -> Parse::Tree& {
   auto& tokens = GetTokenizedBuffer(text);
-  tree_storage_.push_front(Parse::Parse({
-      .tokens = &tokens,
-      .consumer = &consumer_,
-  }));
+  Parse::ParseOptions options;
+  options.consumer = &consumer_;
+  tree_storage_.push_front(Parse::Parse(tokens, options));
   return tree_storage_.front();
 }
 

--- a/toolchain/testing/compile_helper.cpp
+++ b/toolchain/testing/compile_helper.cpp
@@ -16,9 +16,9 @@ auto CompileHelper::GetTokenizedBuffer(llvm::StringRef text,
 
   value_store_storage_.emplace_front();
   token_storage_.push_front(Lex::Lex({
-      .value_stores = value_store_storage_.front(),
-      .source = source,
-      .consumer = consumer ? *consumer : consumer_,
+      .value_stores = &value_store_storage_.front(),
+      .source = &source,
+      .consumer = consumer ? consumer : &consumer_,
   }));
   return token_storage_.front();
 }
@@ -33,8 +33,8 @@ auto CompileHelper::GetTokenizedBufferWithSharedValueStore(
 auto CompileHelper::GetTree(llvm::StringRef text) -> Parse::Tree& {
   auto& tokens = GetTokenizedBuffer(text);
   tree_storage_.push_front(Parse::Parse({
-      .tokens = tokens,
-      .consumer = consumer_,
+      .tokens = &tokens,
+      .consumer = &consumer_,
   }));
   return tree_storage_.front();
 }


### PR DESCRIPTION
I've been mulling this mainly for the parameter complexity of check/lower, but doing lex/parse for symmetry.

I'm motivated by the plan to move dumping for all of them into the respective functions, because of discussion about llvm-verifier. That basically would add another bool parameter (or more) to each of these. My instinct is we're going to probably accrue a little more over time, so I'm suggesting this as maybe adding the boundary a little simpler and/or easier to read.

Note it may make sense to refactor a little further, e.g. maybe Lower::Context could receive the full set of options and pick out what it wants, but I figured creating the struct itself would be a decent start.

I'm trying to put things into options when we can produce a reasonable default if the user doesn't assign a value. I'm using an explicit constructor so that values can be added without affecting every caller.

A different factoring would be to pass in everything through the param struct, but that just felt weird when I was trying it out.

Removing `inst_namer` and `module_name` from `LowerToLLVM` params -- both of these can be inferred from `sem_ir`, and I'm not seeing a particular reason to maintain them at the call site.