### PR TITLE
Fix repeated newlines in expression mermaid

### DIFF
--- a/docs/design/expressions/README.md
+++ b/docs/design/expressions/README.md
@@ -64,11 +64,11 @@ graph BT
 
     top((" "))
 
-    suffixOps{"x.y<br>
-               x.(...)<br>
-               x->y<br>
-               x->(...)<br>
-               x(...)<br>
+    suffixOps{"x.y
+               x.(...)
+               x->y
+               x->(...)
+               x(...)
                x[y]"}
     click suffixOps "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/README.md#suffix-operators"
 
@@ -78,8 +78,8 @@ graph BT
     pointerType{"T*"}
     click pointer-type "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/type_operators.md"
 
-    pointer{"*x<br>
-             &x<br>"}
+    pointer{"*x
+             &x"}
     click pointer "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/pointer.md"
 
     negation["-x"]
@@ -88,7 +88,8 @@ graph BT
     complement["^x"]
     click complement "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/bitwise.md"
 
-    incDec["++x;<br>--x;"]
+    incDec["++x;
+            --x;"]
     click incDec "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/assignment.md"
 
     unary((" "))
@@ -96,11 +97,11 @@ graph BT
     as["x as T"]
     click as "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/implicit_conversions.md"
 
-    multiplication>"x * y<br>
+    multiplication>"x * y
                     x / y"]
     click multiplication "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/arithmetic.md"
 
-    addition>"x + y<br>
+    addition>"x + y
               x - y"]
     click addition "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/arithmetic.md"
 
@@ -114,7 +115,7 @@ graph BT
     click bitwise_or "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/bitwise.md"
     click bitwise_xor "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/bitwise.md"
 
-    shift["x << y<br>
+    shift["x << y
            x >> y"]
     click shift "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/bitwise.md"
 
@@ -122,11 +123,11 @@ graph BT
 
     where["T where R"]
 
-    comparison["x == y<br>
-                x != y<br>
-                x < y<br>
-                x <= y<br>
-                x > y<br>
+    comparison["x == y
+                x != y
+                x < y
+                x <= y
+                x > y
                 x >= y"]
     click comparison "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/expressions/comparison_operators.md"
 
@@ -148,7 +149,8 @@ graph BT
 
     insideParens["(...)"]
 
-    assignment["x = y;<br>x $= y;"]
+    assignment["x = y;
+                x $= y;"]
     click assignment "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/assignment.md"
 
     expressionStatement["x;"]


### PR DESCRIPTION
A newline adds a br. The br tag is redundant, unless you really want two newlines. Might stem from a mistake in #1089 

We have a couple spots using br to keep text on a single line; changing those for consistency.

Before:

![Screenshot 2025-06-30 at 1 01 51 PM](https://github.com/user-attachments/assets/29c16b0f-1180-4e91-a2f8-3889db4dd311)

After:

![Screenshot 2025-06-30 at 1 01 18 PM](https://github.com/user-attachments/assets/1b69356e-92b7-4db5-8e0d-9e838035a9f5)
