### PR TITLE
Change BlockValueStore to take ElementT as a parameter

### DIFF
--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -578,7 +578,7 @@ struct NameScopeId : public IdBase<NameScopeId> {
 
 constexpr NameScopeId NameScopeId::Package = NameScopeId(0);
 
-// The ID of an `Inst` block.
+// The ID of an `InstId` block.
 struct InstBlockId : public IdBase<InstBlockId> {
   static constexpr llvm::StringLiteral Label = "inst_block";
 

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -20,7 +20,6 @@ namespace Carbon::SemIR {
 class File;
 struct FacetTypeInfo;
 struct SpecificInterface;
-struct StructTypeField;
 
 // The ID of an `Inst`.
 struct InstId : public IdBase<InstId> {
@@ -582,9 +581,6 @@ constexpr NameScopeId NameScopeId::Package = NameScopeId(0);
 // The ID of an instruction block.
 struct InstBlockId : public IdBase<InstBlockId> {
   static constexpr llvm::StringLiteral Label = "inst_block";
-  // Types for BlockValueStore<InstBlockId>.
-  using ElementType = InstId;
-  using ValueType = llvm::MutableArrayRef<ElementType>;
 
   // The canonical empty block, reused to avoid allocating empty vectors. Always
   // the 0-index block.
@@ -717,9 +713,6 @@ struct ExprRegionId : public IdBase<ExprRegionId> {
 // The ID of a struct type field block.
 struct StructTypeFieldsId : public IdBase<StructTypeFieldsId> {
   static constexpr llvm::StringLiteral Label = "struct_type_fields";
-  // Types for BlockValueStore<StructTypeFieldsId>.
-  using ElementType = StructTypeField;
-  using ValueType = llvm::MutableArrayRef<StructTypeField>;
 
   // The canonical empty block, reused to avoid allocating empty vectors. Always
   // the 0-index block.

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -578,7 +578,7 @@ struct NameScopeId : public IdBase<NameScopeId> {
 
 constexpr NameScopeId NameScopeId::Package = NameScopeId(0);
 
-// The ID of an instruction block.
+// The ID of an `Inst` block.
 struct InstBlockId : public IdBase<InstBlockId> {
   static constexpr llvm::StringLiteral Label = "inst_block";
 
@@ -710,7 +710,7 @@ struct ExprRegionId : public IdBase<ExprRegionId> {
   using IdBase::IdBase;
 };
 
-// The ID of a struct type field block.
+// The ID of a `StructTypeField` block.
 struct StructTypeFieldsId : public IdBase<StructTypeFieldsId> {
   static constexpr llvm::StringLiteral Label = "struct_type_fields";
 

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -619,9 +619,9 @@ class InstStore {
 };
 
 // Adapts BlockValueStore for instruction blocks.
-class InstBlockStore : public BlockValueStore<InstBlockId> {
+class InstBlockStore : public BlockValueStore<InstBlockId, InstId> {
  public:
-  using BaseType = BlockValueStore<InstBlockId>;
+  using BaseType = BlockValueStore<InstBlockId, InstId>;
 
   explicit InstBlockStore(llvm::BumpPtrAllocator& allocator)
       : BaseType(allocator) {
@@ -642,7 +642,7 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
   // Reserves and returns a block ID. The contents of the block should be
   // specified by calling ReplacePlaceholder.
   auto AddPlaceholder() -> InstBlockId {
-    return values().Add(llvm::MutableArrayRef<ElementType>());
+    return values().Add(llvm::MutableArrayRef<InstId>());
   }
 
   // Sets the contents of a placeholder block to the given content.

--- a/toolchain/sem_ir/struct_type_field.h
+++ b/toolchain/sem_ir/struct_type_field.h
@@ -24,7 +24,8 @@ struct StructTypeField : Printable<StructTypeField> {
   TypeInstId type_inst_id;
 };
 
-using StructTypeFieldsStore = BlockValueStore<StructTypeFieldsId>;
+using StructTypeFieldsStore =
+    BlockValueStore<StructTypeFieldsId, StructTypeField>;
 
 // See common/hashing.h. Supports canonicalization of fields.
 inline auto CarbonHashValue(const StructTypeField& value, uint64_t seed)


### PR DESCRIPTION
Also modify CopyOnWriteBlock to just pull block type information from the return type of the function it receives, rather than taking some as a parameter.

I chose the `RefType`/`ConstRefType` names based on other similar `ValueStore` uses which I think are equivalent.