### PR TITLE
Remove IdT from ValueStoreTypes

### DIFF
--- a/toolchain/base/canonical_value_store.h
+++ b/toolchain/base/canonical_value_store.h
@@ -26,9 +26,9 @@ template <typename IdT, typename KeyT, typename ValueT = KeyT>
 class CanonicalValueStore {
  public:
   using KeyType = std::remove_cvref_t<KeyT>;
-  using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
-  using RefType = ValueStoreTypes<IdT, ValueT>::RefType;
-  using ConstRefType = ValueStoreTypes<IdT, ValueT>::ConstRefType;
+  using ValueType = ValueStoreTypes<ValueT>::ValueType;
+  using RefType = ValueStoreTypes<ValueT>::RefType;
+  using ConstRefType = ValueStoreTypes<ValueT>::ConstRefType;
 
   // Stores a canonical copy of the value and returns an ID to reference it.
   auto Add(ValueType value) -> IdT;

--- a/toolchain/base/fixed_size_value_store.h
+++ b/toolchain/base/fixed_size_value_store.h
@@ -19,9 +19,9 @@ template <typename IdT, typename ValueT>
 class FixedSizeValueStore {
  public:
   using IdType = IdT;
-  using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
-  using RefType = ValueStoreTypes<IdT, ValueT>::RefType;
-  using ConstRefType = ValueStoreTypes<IdT, ValueT>::ConstRefType;
+  using ValueType = ValueStoreTypes<ValueT>::ValueType;
+  using RefType = ValueStoreTypes<ValueT>::RefType;
+  using ConstRefType = ValueStoreTypes<ValueT>::ConstRefType;
 
   // Makes a ValueStore of the specified size, but without initializing values.
   // Entries must be set before reading.

--- a/toolchain/base/relational_value_store.h
+++ b/toolchain/base/relational_value_store.h
@@ -33,8 +33,8 @@ namespace Carbon {
 template <typename RelatedIdT, typename IdT, typename ValueT>
 class RelationalValueStore {
  public:
-  using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
-  using ConstRefType = ValueStoreTypes<IdT, ValueT>::ConstRefType;
+  using ValueType = ValueStoreTypes<ValueT>::ValueType;
+  using ConstRefType = ValueStoreTypes<ValueT>::ConstRefType;
 
   // Given the related ID and a value, stores the value and returns a mapped ID
   // to reference it in the store.

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -40,9 +40,9 @@ class ValueStore
                               Internal::ValueStoreNotPrintable> {
  public:
   using IdType = IdT;
-  using ValueType = ValueStoreTypes<IdT, ValueT>::ValueType;
-  using RefType = ValueStoreTypes<IdT, ValueT>::RefType;
-  using ConstRefType = ValueStoreTypes<IdT, ValueT>::ConstRefType;
+  using ValueType = ValueStoreTypes<ValueT>::ValueType;
+  using RefType = ValueStoreTypes<ValueT>::RefType;
+  using ConstRefType = ValueStoreTypes<ValueT>::ConstRefType;
 
   // A range over references to the values in a ValueStore, returned from
   // `ValueStore::values()`. Hides the complex type name of the iterator

--- a/toolchain/base/value_store_types.h
+++ b/toolchain/base/value_store_types.h
@@ -13,7 +13,7 @@
 namespace Carbon {
 
 // Common calculation for ValueStore types.
-template <typename IdT, typename ValueT = IdT::ValueType>
+template <typename ValueT>
 class ValueStoreTypes {
  public:
   using ValueType = std::remove_cvref_t<ValueT>;


### PR DESCRIPTION
`IdT` is no longer needed because `ValueT` is always supplied.