### PR TITLE
Remove prebuilt_binary from file_test rules

### DIFF
--- a/testing/file_test/rules.bzl
+++ b/testing/file_test/rules.bzl
@@ -8,9 +8,8 @@ file_test uses the tests_as_input_file rule to transform test dependencies into
 a file which can be accessed as a list. This avoids long argument parsing.
 """
 
-load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bazel/cc_rules:defs.bzl", "cc_test")
-load("//bazel/manifest:defs.bzl", "manifest", "manifest_as_cpp")
+load("//bazel/manifest:defs.bzl", "manifest_as_cpp")
 
 def file_test(
         name,
@@ -19,7 +18,6 @@ def file_test(
         deps = [],
         data = [],
         args = [],
-        prebuilt_binary = None,
         **kwargs):
     """Generates tests using the file_test base.
 
@@ -34,45 +32,22 @@ def file_test(
       deps: Passed to cc_test.
       data: Passed to cc_test.
       args: Passed to cc_test.
-      prebuilt_binary: If set, specifies a prebuilt test binary to use instead
-                       of building a new one.
       **kwargs: Passed to cc_test.
     """
 
     # Ensure tests are always a filegroup for tests_as_input_file_rule.
-    if prebuilt_binary:
-        # TODO: The prebuilt_binary support is only used by explorer. We should
-        # remove this once explorer is removed, and think about better factoring
-        # approaches if we need it later for toolchain.
-        tests_file = "{0}.tests".format(name)
-        manifest(
-            name = tests_file,
-            srcs = tests,
-            testonly = 1,
-        )
-        args = ["--explorer_test_targets_file=$(rootpath :{0})".format(tests_file)] + args
-
-        sh_test(
-            name = name,
-            srcs = srcs + [prebuilt_binary],
-            deps = deps,
-            data = [":" + tests_file] + tests + data,
-            args = args,
-            **kwargs
-        )
-    else:
-        manifest_cpp = "{0}_autogen_manifest.cpp".format(name)
-        manifest_as_cpp(
-            name = manifest_cpp,
-            var_name = "CarbonFileTestManifest",
-            srcs = tests,
-            testonly = 1,
-        )
-        cc_test(
-            name = name,
-            srcs = srcs + [":" + manifest_cpp],
-            deps = deps + ["//testing/file_test:manifest_impl"],
-            data = tests + data,
-            args = args,
-            **kwargs
-        )
+    manifest_cpp = "{0}_autogen_manifest.cpp".format(name)
+    manifest_as_cpp(
+        name = manifest_cpp,
+        var_name = "CarbonFileTestManifest",
+        srcs = tests,
+        testonly = 1,
+    )
+    cc_test(
+        name = name,
+        srcs = srcs + [":" + manifest_cpp],
+        deps = deps + ["//testing/file_test:manifest_impl"],
+        data = tests + data,
+        args = args,
+        **kwargs
+    )


### PR DESCRIPTION
Since explorer was removed, this is no longer in use.