### PR TITLE
Support C++ pointers as function parameters and return values

### DIFF
--- a/toolchain/check/import_cpp.cpp
+++ b/toolchain/check/import_cpp.cpp
@@ -568,6 +568,21 @@ static auto MapType(Context& context, SemIR::LocId loc_id, clang::QualType type)
     return MapRecordType(context, loc_id, *record_type);
   }
 
+  if (const auto* pointer_type = clang::dyn_cast<clang::PointerType>(type)) {
+    clang::QualType pointee_type = pointer_type->getPointeeType();
+    auto [pointee_type_inst_id, pointee_type_id] = 
+        MapType(context, loc_id, pointee_type);
+    
+    if (pointee_type_id == SemIR::ErrorInst::TypeId) {
+      return {.inst_id = SemIR::ErrorInst::TypeInstId,
+              .type_id = SemIR::ErrorInst::TypeId};
+    }
+    
+    auto pointer_type_id = GetPointerType(context, pointee_type_inst_id);
+    return {.inst_id = context.types().GetInstId(pointer_type_id),
+            .type_id = pointer_type_id};
+  }
+
   return {.inst_id = SemIR::ErrorInst::TypeInstId,
           .type_id = SemIR::ErrorInst::TypeId};
 }

--- a/toolchain/check/testdata/interop/cpp/function/pointer.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/pointer.carbon
@@ -1,0 +1,143 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/primitives.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/function/pointer.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/function/pointer.carbon
+
+// ============================================================================
+// Basic pointer parameter
+// ============================================================================
+
+// --- int_ptr_param.h
+
+auto take_int_ptr(int* p) -> void;
+
+// --- import_int_ptr_param.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "int_ptr_param.h";
+
+fn TestIntPtrParam() {
+  //@dump-sem-ir-begin
+  var x: i32 = 42;
+  Cpp.take_int_ptr(&x);
+  //@dump-sem-ir-end
+}
+
+// ============================================================================
+// Basic pointer return type
+// ============================================================================
+
+// --- int_ptr_return.h
+
+auto get_int_ptr() -> int*;
+
+// --- import_int_ptr_return.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "int_ptr_return.h";
+
+fn TestIntPtrReturn() {
+  //@dump-sem-ir-begin
+  var ptr: i32* = Cpp.get_int_ptr();
+  //@dump-sem-ir-end
+}
+
+// ============================================================================
+// Pointer to pointer (nested)
+// ============================================================================
+
+// --- int_ptr_ptr.h
+
+auto take_int_ptr_ptr(int** pp) -> void;
+
+// --- import_int_ptr_ptr.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "int_ptr_ptr.h";
+
+fn TestIntPtrPtr() {
+  //@dump-sem-ir-begin
+  var x: i32 = 42;
+  var ptr: i32* = &x;
+  Cpp.take_int_ptr_ptr(&ptr);
+  //@dump-sem-ir-end
+}
+
+// ============================================================================
+// Pointer to struct
+// ============================================================================
+
+// --- struct_ptr.h
+
+struct Point {
+  int x;
+  int y;
+};
+
+auto take_point_ptr(Point* p) -> void;
+
+// --- import_struct_ptr.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "struct_ptr.h";
+
+fn TestStructPtr() {
+  //@dump-sem-ir-begin
+  var p: Cpp.Point = {.x = 10, .y = 20};
+  Cpp.take_point_ptr(&p);
+  //@dump-sem-ir-end
+}
+
+// ============================================================================
+// Function with mixed pointer and non-pointer parameters
+// ============================================================================
+
+// --- mixed_params.h
+
+auto mixed_function(int value, int* ptr, short another_value) -> void;
+
+// --- import_mixed_params.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "mixed_params.h";
+
+fn TestMixedParams() {
+  //@dump-sem-ir-begin
+  var x: i32 = 42;
+  var y: i16 = 10;
+  Cpp.mixed_function(5, &x, y);
+  //@dump-sem-ir-end
+}
+
+// ============================================================================
+// Pointer to const (should work the same as regular pointer for now)
+// ============================================================================
+
+// --- const_ptr.h
+
+auto take_const_int_ptr(const int* p) -> void;
+
+// --- import_const_ptr.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "const_ptr.h";
+
+fn TestConstPtr() {
+  //@dump-sem-ir-begin
+  var x: i32 = 42;
+  Cpp.take_const_int_ptr(&x);
+  //@dump-sem-ir-end
+} 


### PR DESCRIPTION
add pointer type mapping to MapType function in import_cpp.cpp, Handle clang::pointerType with recursive pointee type resolution, support for basic pointers, nested pointers, and pointers to structs, add test coverage for various pointer scenarios

Resolves #5772

Implement C++ pointer support in Carbon's interop system by extending MapType function to handle `clang::PointerType`.

Added:
basic pointer parameters: `void foo(int* p)`
basic pointer return types: `int* get_ptr()`
nested pointers: `void foo(int** pp)`
pointers to structs: `void foo(Point* p)`
mixed parameters: `void foo(int value, int* ptr, short other)`
const pointers: `void foo(const int* p)`

extended `MapType` function in `toolchain/check/import_cpp.cpp`
added recursive type mapping for pointee types using existing `GetPointerType`

added test file `toolchain/check/testdata/interop/cpp/function/pointer.carbon`

This provides the "general pointer support foundation" that complements @bricknerb's draft PR #5773 which focuses on `_Nonnull` pointer annotations. My implementation handles the broader case im assuming #5772 requests, while his work can enhance nullability handling.

This resolves the core issue where C++ functions with pointer parameters/returns were unsupported.

Fixes #5772 
