### PR TITLE
Fix clangd-tidy to avoid blocking merges while testing

### DIFF
--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -52,11 +52,6 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
-          base:
-            ${{ github.event_name == 'pull_request' &&
-            github.event.pull_request.base.sha || (github.event_name ==
-            'merge_group' && github.event.merge_group.base_sha ||
-            github.event.push.before ) }}
           filters: |
             has_cpp:
               - added|modified: '{**/*.cpp,**/*.h}'

--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -8,7 +8,8 @@ on:
   push:
     branches: [trunk, action-test]
   pull_request:
-  merge_group:
+  # TODO: Don't run in merge_group until we're ready to replace clang-tidy.
+  # merge_group:
 
 permissions:
   contents: read # For actions/checkout.
@@ -58,7 +59,7 @@ jobs:
             github.event.push.before ) }}
           filters: |
             has_cpp:
-              - '{**/*.cpp,**/*.h}'
+              - added|modified: '{**/*.cpp,**/*.h}'
           list-files: 'shell'
 
       - uses: ./.github/actions/build-setup-common

--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clang-tidy:
+  clangd-tidy:
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
What I'm trying to fix is visible at:

- PR: https://github.com/carbon-language/carbon-lang/pull/5779
- clangd-tidy run on merge: https://github.com/carbon-language/carbon-lang/actions/runs/16155546033/job/45597095935
- Merge attempt: https://github.com/carbon-language/carbon-lang/pull/5779#event-18534768919

That PR deletes block_value_store, so excluding deleted files here (`added|modified`). But also, I think this is blocking merge just because it's set for merge_group. Or it may be because of the clang-tidy job name overlap -- I'm just going to address both.

Also trying to remove the base commit; I think dorny/paths-filter should actually be calculating this reasonably well, and it was holdover from where we set the commit explicitly elsewhere. There's a warning about it being ignored in pull_request, visible [here](https://github.com/carbon-language/carbon-lang/actions/runs/16155814211/job/45597903684).