### PR TITLE
Include generate_llvm_tools_def in the list of file generators

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -12,7 +12,6 @@
 #include <utility>
 
 #include "common/check.h"
-
 #include "common/ostream.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "common/check.h"
+
 #include "common/ostream.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"


### PR DESCRIPTION
Trying to fix the error at:
https://github.com/carbon-language/carbon-lang/actions/runs/16349808015/job/46193321961?pr=5811

Also make it a little easier to debug which files are being built, I've done this a few times now.