### PR TITLE
Update pre-commit clang-format version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,8 @@ repos:
       - id: prettier
         name: prettier
         language: node
+        # TODO: Not upgrading to/past 3.4.0 due to list indent changes that may
+        # get fixed. See: https://github.com/prettier/prettier/issues/16929
         additional_dependencies: ['prettier@3.3.3']
         types_or: [html, javascript, json, markdown, yaml]
         entry: npx prettier@3.3.3 --write --log-level=warn
@@ -88,7 +90,7 @@ repos:
         types_or: [c++, def]
         language: python
         args: ['-i']
-        additional_dependencies: ['clang-format==20.1.4']
+        additional_dependencies: ['clang-format==20.1.8']
 
   - repo: local
     hooks:

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -529,8 +529,7 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
 // and continuing the dispatch.
 #define CARBON_DISPATCH_LEX_TOKEN(LexMethod)                                 \
   static auto Dispatch##LexMethod(Lexer& lexer, llvm::StringRef source_text, \
-                                  ssize_t position)                          \
-      ->void {                                                               \
+                                  ssize_t position) -> void {                \
     Lexer::LexResult result = lexer.LexMethod(source_text, position);        \
     CARBON_CHECK(result, "Failed to form a token!");                         \
     [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
@@ -543,17 +542,16 @@ CARBON_DISPATCH_LEX_TOKEN(LexNumericLiteral)
 CARBON_DISPATCH_LEX_TOKEN(LexStringLiteral)
 
 // A set of custom dispatch functions that pre-select the symbol token to lex.
-#define CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexMethod)                        \
-  static auto Dispatch##LexMethod##SymbolToken(                            \
-      Lexer& lexer, llvm::StringRef source_text, ssize_t position)         \
-      ->void {                                                             \
-    Lexer::LexResult result = lexer.LexMethod##SymbolToken(                \
-        source_text,                                                       \
-        OneCharTokenKindTable[static_cast<unsigned char>(                  \
-            source_text[position])],                                       \
-        position);                                                         \
-    CARBON_CHECK(result, "Failed to form a token!");                       \
-    [[clang::musttail]] return DispatchNext(lexer, source_text, position); \
+#define CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexMethod)                          \
+  static auto Dispatch##LexMethod##SymbolToken(                              \
+      Lexer& lexer, llvm::StringRef source_text, ssize_t position) -> void { \
+    Lexer::LexResult result = lexer.LexMethod##SymbolToken(                  \
+        source_text,                                                         \
+        OneCharTokenKindTable[static_cast<unsigned char>(                    \
+            source_text[position])],                                         \
+        position);                                                           \
+    CARBON_CHECK(result, "Failed to form a token!");                         \
+    [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
   }
 CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexOneChar)
 CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexOpening)
@@ -563,8 +561,7 @@ CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexClosing)
 // whitespace and comments.
 #define CARBON_DISPATCH_LEX_NON_TOKEN(LexMethod)                             \
   static auto Dispatch##LexMethod(Lexer& lexer, llvm::StringRef source_text, \
-                                  ssize_t position)                          \
-      ->void {                                                               \
+                                  ssize_t position) -> void {                \
     lexer.LexMethod(source_text, position);                                  \
     [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
   }

--- a/toolchain/parse/handle.h
+++ b/toolchain/parse/handle.h
@@ -10,7 +10,7 @@
 namespace Carbon::Parse {
 
 // Declare handlers for each parse state.
-#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context)->void;
+#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context) -> void;
 #include "toolchain/parse/state.def"
 
 }  // namespace Carbon::Parse


### PR DESCRIPTION
Versus #5823, this is manually updated (still verified with `pre-commit run -a`).

I also looked at updating prettier; adding a note why I'm not doing that.