### PR TITLE
Add a comment on EntityName's CarbonHashtableEq about its requirements

### DIFF
--- a/toolchain/sem_ir/entity_name.h
+++ b/toolchain/sem_ir/entity_name.h
@@ -47,7 +47,7 @@ struct EntityName : public Printable<EntityName> {
   // The parent scope.
   NameScopeId parent_scope_id;
 
-  // TODO: The following fields are only meaningful for a symbolic binding.
+  // TODO: The following two fields are only meaningful for a symbolic binding.
   // Consider splitting them off into a separate type so that we don't store
   // them for other kinds of `EntityName`.
 

--- a/toolchain/sem_ir/entity_name.h
+++ b/toolchain/sem_ir/entity_name.h
@@ -21,6 +21,9 @@ struct EntityName : public Printable<EntityName> {
 
   friend auto CarbonHashtableEq(const EntityName& lhs, const EntityName& rhs)
       -> bool {
+    // This requires that there are no padding bits in the type. This is upheld
+    // since it holds values all of the same size: each is 32 bits, with one
+    // split into 31 and 1 bits.
     return std::memcmp(&lhs, &rhs, sizeof(EntityName)) == 0;
   }
 
@@ -44,7 +47,7 @@ struct EntityName : public Printable<EntityName> {
   // The parent scope.
   NameScopeId parent_scope_id;
 
-  // TODO: The following two fields are only meaningful for a symbolic binding.
+  // TODO: The following fields are only meaningful for a symbolic binding.
   // Consider splitting them off into a separate type so that we don't store
   // them for other kinds of `EntityName`.
 


### PR DESCRIPTION
The entity name structure will grow at least one more field for symbolic bindings (see [open discussion](https://docs.google.com/document/d/1Yt-i5AmF76LSvD4TrWRIAE_92kii6j5yFiW-S7ahzlg/edit?tab=t.0)), so we can just refer to the "following" fields to include them all.