### PR TITLE
Don't unnecessarily create output files in a driver test.

### DIFF
--- a/toolchain/driver/testdata/compile/clang_args_warning.carbon
+++ b/toolchain/driver/testdata/compile/clang_args_warning.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: --include-diagnostic-kind compile --clang-arg=-L/usr/lib foo.carbon
+// ARGS: --include-diagnostic-kind compile --clang-arg=-L/usr/lib foo.carbon --phase=lex
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:

--- a/toolchain/driver/testdata/compile/fail_clang_args.carbon
+++ b/toolchain/driver/testdata/compile/fail_clang_args.carbon
@@ -11,7 +11,7 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/compile/fail_clang_args.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/fail_clang_args.carbon
-// CHECK:STDERR: clang version {{.*}}
+// CHECK:STDERR: {{.*}}clang version {{.*}}
 // CHECK:STDERR: InstalledDir: {{.*}}/toolchain/install/prefix_root/lib/carbon/../../lib/carbon/llvm/bin
 // CHECK:STDERR:  "{{.*}}/toolchain/install/prefix_root/lib/carbon/../../lib/carbon/llvm/bin/clang" "-cc1" {{.*}}"-triple" "x86-pc-linux-gnu" {{.*}}"-fsyntax-only" {{.*}} "-resource-dir" {{.*}} "-Wall" "-Wextra" "-Wuninitialized" "-Wno-all" {{.*}}
 


### PR DESCRIPTION
Make another driver test a little more permissive.