### PR TITLE
Add support for a custom error type in `ErrorOr`

### DIFF
--- a/common/error.h
+++ b/common/error.h
@@ -89,6 +89,7 @@ template <typename ErrorT>
 class [[nodiscard]] ErrorBase : public Printable<ErrorT> {
  public:
   ErrorBase(const ErrorBase&) = delete;
+  auto operator=(const ErrorBase&) -> ErrorBase& = delete;
 
   auto ToString() const -> std::string {
     RawStringOstream os;
@@ -97,9 +98,7 @@ class [[nodiscard]] ErrorBase : public Printable<ErrorT> {
   }
   auto ToError() const -> Error { return Error(this->ToString()); }
 
- private:
-  friend ErrorT;
-
+ protected:
   ErrorBase() = default;
   ErrorBase(ErrorBase&&) noexcept = default;
   auto operator=(ErrorBase&&) noexcept -> ErrorBase& = default;
@@ -114,14 +113,12 @@ class [[nodiscard]] ErrorBase : public Printable<ErrorT> {
 //
 // This is nodiscard to enforce error handling prior to destruction.
 template <typename T, typename ErrorT = Error>
+  requires(!std::is_reference_v<ErrorT> &&
+           (std::same_as<ErrorT, Error> ||
+            std::derived_from<ErrorT, ErrorBase<ErrorT>>))
 class [[nodiscard]] ErrorOr {
  public:
   using ValueT = std::remove_reference_t<T>;
-  static_assert(!std::is_reference_v<ErrorT>,
-                "Error type must be a value type.");
-  static_assert(std::same_as<ErrorT, Error> ||
-                    std::derived_from<ErrorT, ErrorBase<ErrorT>>,
-                "Error type must be `Error` or be derived from `ErrorBase`.");
 
   // Constructs with an error; the error must not be Error::Success().
   // Implicit for easy construction on returns.

--- a/common/error.h
+++ b/common/error.h
@@ -88,14 +88,14 @@ class [[nodiscard]] Error : public Printable<Error> {
 template <typename ErrorT>
 class [[nodiscard]] ErrorBase : public Printable<ErrorT> {
  public:
-  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility): Deleted.
   ErrorBase(const ErrorBase&) = delete;
 
   auto ToString() const -> std::string {
-    return Dump();
+    RawStringOstream os;
+    static_cast<const ErrorT*>(this)->Print(os);
+    return os.TakeStr();
   }
-
-  explicit operator Error() { return Error(this->ToString()); }
+  auto ToError() const -> Error { return Error(this->ToString()); }
 
  private:
   friend ErrorT;
@@ -128,8 +128,17 @@ class [[nodiscard]] ErrorOr {
   // NOLINTNEXTLINE(google-explicit-constructor)
   ErrorOr(ErrorT err) : val_(std::move(err)) {}
 
-  // Constructs with any convertible error, necessary for return statements that
-  // are already converting to the `ErrorOr` wrapper.
+  // Constructs from a custom error type derived from `ErrorBase` into an
+  // `ErrorOr` for `Error` to facilitate returning errors transparently.
+  template <typename OtherErrorT>
+    requires(std::same_as<ErrorT, Error> &&
+             std::derived_from<OtherErrorT, ErrorBase<OtherErrorT>>)
+  // Implicit for easy construction on returns.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  ErrorOr(OtherErrorT other_err) : val_(other_err.ToError()) {}
+
+  // Constructs with any convertible error type, necessary for return statements
+  // that are already converting to the `ErrorOr` wrapper.
   //
   // This supports *explicitly* conversions, not just implicit, which is
   // important to make common patterns of returning and adjusting the error

--- a/common/error.h
+++ b/common/error.h
@@ -92,9 +92,7 @@ class [[nodiscard]] ErrorBase : public Printable<ErrorT> {
   ErrorBase(const ErrorBase&) = delete;
 
   auto ToString() const -> std::string {
-    RawStringOstream s;
-    static_cast<const ErrorT*>(this)->Print(s);
-    return s.TakeStr();
+    return Dump();
   }
 
   explicit operator Error() { return Error(this->ToString()); }

--- a/common/error.h
+++ b/common/error.h
@@ -5,9 +5,11 @@
 #ifndef CARBON_COMMON_ERROR_H_
 #define CARBON_COMMON_ERROR_H_
 
+#include <concepts>
 #include <functional>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <variant>
 
 #include "common/check.h"
@@ -71,19 +73,76 @@ class [[nodiscard]] Error : public Printable<Error> {
   std::string message_;
 };
 
-// Holds a value of type `T`, or an Error explaining why the value is
+// A common base class that custom error types should derive from.
+//
+// This combines the ability to be printed with the ability to convert the error
+// to a string and in turn to a non-customized `Error` type by rendering into a
+// string.
+//
+// The goal is that custom error types can be used for errors that are common
+// and/or would have cost to fully render the error message to a string. A
+// custom type can then be used to allow custom, light-weight handling of errors
+// when appropriate. But to avoid these custom types being excessively viral, we
+// ensure they can be converted to normal `Error` types when needed by rendering
+// fully to a string.
+template <typename ErrorT>
+class [[nodiscard]] ErrorBase : public Printable<ErrorT> {
+ public:
+  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility): Deleted.
+  ErrorBase(const ErrorBase&) = delete;
+
+  auto ToString() const -> std::string {
+    RawStringOstream s;
+    static_cast<const ErrorT*>(this)->Print(s);
+    return s.TakeStr();
+  }
+
+  explicit operator Error() { return Error(this->ToString()); }
+
+ private:
+  friend ErrorT;
+
+  ErrorBase() = default;
+  ErrorBase(ErrorBase&&) noexcept = default;
+  auto operator=(ErrorBase&&) noexcept -> ErrorBase& = default;
+};
+
+// Holds a value of type `T`, or an `ErrorT` type explaining why the value is
 // unavailable.
 //
+// The `ErrorT` type defaults to `Error` but can be customized where desired
+// with a type that derives from `ErrorBase` above. See the documentation for
+// `ErrorBase` to understand the expected contract of custom error types.
+//
 // This is nodiscard to enforce error handling prior to destruction.
-template <typename T>
+template <typename T, typename ErrorT = Error>
 class [[nodiscard]] ErrorOr {
  public:
   using ValueT = std::remove_reference_t<T>;
+  static_assert(!std::is_reference_v<ErrorT>,
+                "Error type must be a value type.");
+  static_assert(std::same_as<ErrorT, Error> ||
+                    std::derived_from<ErrorT, ErrorBase<ErrorT>>,
+                "Error type must be `Error` or be derived from `ErrorBase`.");
 
   // Constructs with an error; the error must not be Error::Success().
   // Implicit for easy construction on returns.
   // NOLINTNEXTLINE(google-explicit-constructor)
-  ErrorOr(Error err) : val_(std::move(err)) {}
+  ErrorOr(ErrorT err) : val_(std::move(err)) {}
+
+  // Constructs with any convertible error, necessary for return statements that
+  // are already converting to the `ErrorOr` wrapper.
+  //
+  // This supports *explicitly* conversions, not just implicit, which is
+  // important to make common patterns of returning and adjusting the error
+  // type without each error type conversion needing to be implicit.
+  template <typename OtherErrorT>
+    requires(std::constructible_from<ErrorT, OtherErrorT> &&
+             std::derived_from<OtherErrorT, ErrorBase<OtherErrorT>>)
+  // Implicit for easy construction on returns.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  ErrorOr(OtherErrorT other_err)
+      : val_(std::in_place_type<ErrorT>, std::move(other_err)) {}
 
   // Constructs with a reference.
   // Implicit for easy construction on returns.
@@ -104,13 +163,13 @@ class [[nodiscard]] ErrorOr {
 
   // Returns the contained error.
   // REQUIRES: `ok()` is false.
-  auto error() const& -> const Error& {
+  auto error() const& -> const ErrorT& {
     CARBON_CHECK(!ok());
-    return std::get<Error>(val_);
+    return std::get<ErrorT>(val_);
   }
-  auto error() && -> Error {
+  auto error() && -> ErrorT {
     CARBON_CHECK(!ok());
-    return std::get<Error>(std::move(val_));
+    return std::get<ErrorT>(std::move(val_));
   }
 
   // Returns the contained value.
@@ -140,7 +199,7 @@ class [[nodiscard]] ErrorOr {
                                      std::reference_wrapper<ValueT>, T>;
 
   // Either an error message or a value.
-  std::variant<Error, StoredT> val_;
+  std::variant<ErrorT, StoredT> val_;
 };
 
 // A helper class for accumulating error message and converting to

--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -53,9 +53,6 @@ class CustomError : public ErrorBase<CustomError> {
 template <typename ErrorT>
 class ErrorOrTest : public ::testing::Test {
  public:
-  template <typename T>
-  using TestErrorOrTemp = ErrorOr<T, ErrorT>;
-
   auto ErrorStr() -> std::string {
     if constexpr (std::same_as<ErrorT, Error>) {
       return "test error";
@@ -81,25 +78,24 @@ using ErrorOrTestParams = ::testing::Types<Error, CustomError>;
 TYPED_TEST_SUITE(ErrorOrTest, ErrorOrTestParams);
 
 TYPED_TEST(ErrorOrTest, ErrorOr) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   TestErrorOr err(this->MakeError());
 
   EXPECT_THAT(err, IsError(this->ErrorStr()));
 }
 
 TYPED_TEST(ErrorOrTest, ErrorOrValue) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   EXPECT_TRUE(TestErrorOr(0).ok());
 }
 
-template <typename Fixture>
-auto IndirectErrorOrTest(Fixture& fixture) ->
-    typename Fixture::template TestErrorOrTemp<int> {
+template <typename ErrorT, typename Fixture>
+auto IndirectErrorOrTest(Fixture& fixture) -> ErrorOr<int, ErrorT> {
   return fixture.MakeError();
 }
 
 TYPED_TEST(ErrorOrTest, IndirectErrorOr) {
-  EXPECT_FALSE(IndirectErrorOrTest(*this).ok());
+  EXPECT_FALSE(IndirectErrorOrTest<TypeParam>(*this).ok());
 }
 
 struct Val {
@@ -107,30 +103,29 @@ struct Val {
 };
 
 TYPED_TEST(ErrorOrTest, ErrorOrArrowOp) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Val>;
+  using TestErrorOr = ErrorOr<Val, TypeParam>;
   TestErrorOr err({1});
   EXPECT_EQ(err->val, 1);
 }
 
 TYPED_TEST(ErrorOrTest, ErrorOrReference) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Val&>;
+  using TestErrorOr = ErrorOr<Val&, TypeParam>;
   Val val = {1};
   TestErrorOr maybe_val(val);
   EXPECT_EQ(maybe_val->val, 1);
 }
 
-template <typename Fixture>
-auto IndirectErrorOrSuccessTest() ->
-    typename Fixture::template TestErrorOrTemp<Success> {
+template <typename ErrorT>
+auto IndirectErrorOrSuccessTest() -> ErrorOr<Success, ErrorT> {
   return Success();
 }
 
 TYPED_TEST(ErrorOrTest, IndirectErrorOrSuccess) {
-  EXPECT_TRUE(IndirectErrorOrSuccessTest<TestFixture>().ok());
+  EXPECT_TRUE(IndirectErrorOrSuccessTest<TypeParam>().ok());
 }
 
 TYPED_TEST(ErrorOrTest, ReturnIfErrorNoError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Success>;
+  using TestErrorOr = ErrorOr<Success, TypeParam>;
   auto result = []() -> TestErrorOr {
     CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
     CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
@@ -140,7 +135,7 @@ TYPED_TEST(ErrorOrTest, ReturnIfErrorNoError) {
 }
 
 TYPED_TEST(ErrorOrTest, ReturnIfErrorHasError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Success>;
+  using TestErrorOr = ErrorOr<Success, TypeParam>;
   auto result = [this]() -> TestErrorOr {
     CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
     CARBON_RETURN_IF_ERROR(TestErrorOr(this->MakeError()));
@@ -150,7 +145,7 @@ TYPED_TEST(ErrorOrTest, ReturnIfErrorHasError) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnNoError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   auto result = []() -> TestErrorOr {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, TestErrorOr(2));
@@ -162,7 +157,7 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnNoError) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnHasDirectError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   auto result = [this]() -> TestErrorOr {
     CARBON_RETURN_IF_ERROR(TestErrorOr(this->MakeError()));
     return 0;
@@ -171,7 +166,7 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnHasDirectError) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnHasErrorInExpected) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   auto result = [this]() -> TestErrorOr {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(this->MakeError()));
     return a;
@@ -189,12 +184,11 @@ class AnotherCustomError : public ErrorBase<AnotherCustomError> {
 };
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnNoErrorAcrossErrorTypes) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   auto result = []() -> ErrorOr<int> {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
-      CARBON_ASSIGN_OR_RETURN(
-          int inner, (ErrorOr<int, AnotherCustomError>(2)));
+      CARBON_ASSIGN_OR_RETURN(int inner, (ErrorOr<int, AnotherCustomError>(2)));
       return inner;
     }());
     int c = 0;
@@ -205,13 +199,12 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnNoErrorAcrossErrorTypes) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnErrorAcrossErrorTypes) {
-  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
+  using TestErrorOr = ErrorOr<int, TypeParam>;
   auto result = []() -> ErrorOr<int> {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
-      CARBON_ASSIGN_OR_RETURN(int inner,
-                              (ErrorOr<int, AnotherCustomError>(
-                                  AnotherCustomError()));
+      CARBON_ASSIGN_OR_RETURN(
+          int inner, (ErrorOr<int, AnotherCustomError>(AnotherCustomError())));
       return inner;
     }());
     int c = 0;

--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -54,7 +54,7 @@ template <typename ErrorT>
 class ErrorOrTest : public ::testing::Test {
  public:
   template <typename T>
-  using TestErrorOr = ErrorOr<T, ErrorT>;
+  using TestErrorOrTemp = ErrorOr<T, ErrorT>;
 
   auto ErrorStr() -> std::string {
     if constexpr (std::same_as<ErrorT, Error>) {
@@ -81,20 +81,20 @@ using ErrorOrTestParams = ::testing::Types<Error, CustomError>;
 TYPED_TEST_SUITE(ErrorOrTest, ErrorOrTestParams);
 
 TYPED_TEST(ErrorOrTest, ErrorOr) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   TestErrorOr err(this->MakeError());
 
   EXPECT_THAT(err, IsError(this->ErrorStr()));
 }
 
 TYPED_TEST(ErrorOrTest, ErrorOrValue) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   EXPECT_TRUE(TestErrorOr(0).ok());
 }
 
 template <typename Fixture>
 auto IndirectErrorOrTest(Fixture& fixture) ->
-    typename Fixture::template TestErrorOr<int> {
+    typename Fixture::template TestErrorOrTemp<int> {
   return fixture.MakeError();
 }
 
@@ -107,13 +107,13 @@ struct Val {
 };
 
 TYPED_TEST(ErrorOrTest, ErrorOrArrowOp) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<Val>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Val>;
   TestErrorOr err({1});
   EXPECT_EQ(err->val, 1);
 }
 
 TYPED_TEST(ErrorOrTest, ErrorOrReference) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<Val&>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Val&>;
   Val val = {1};
   TestErrorOr maybe_val(val);
   EXPECT_EQ(maybe_val->val, 1);
@@ -121,7 +121,7 @@ TYPED_TEST(ErrorOrTest, ErrorOrReference) {
 
 template <typename Fixture>
 auto IndirectErrorOrSuccessTest() ->
-    typename Fixture::template TestErrorOr<Success> {
+    typename Fixture::template TestErrorOrTemp<Success> {
   return Success();
 }
 
@@ -130,7 +130,7 @@ TYPED_TEST(ErrorOrTest, IndirectErrorOrSuccess) {
 }
 
 TYPED_TEST(ErrorOrTest, ReturnIfErrorNoError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<Success>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Success>;
   auto result = []() -> TestErrorOr {
     CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
     CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
@@ -140,7 +140,7 @@ TYPED_TEST(ErrorOrTest, ReturnIfErrorNoError) {
 }
 
 TYPED_TEST(ErrorOrTest, ReturnIfErrorHasError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<Success>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<Success>;
   auto result = [this]() -> TestErrorOr {
     CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
     CARBON_RETURN_IF_ERROR(TestErrorOr(this->MakeError()));
@@ -150,7 +150,7 @@ TYPED_TEST(ErrorOrTest, ReturnIfErrorHasError) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnNoError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   auto result = []() -> TestErrorOr {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, TestErrorOr(2));
@@ -162,7 +162,7 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnNoError) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnHasDirectError) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   auto result = [this]() -> TestErrorOr {
     CARBON_RETURN_IF_ERROR(TestErrorOr(this->MakeError()));
     return 0;
@@ -171,7 +171,7 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnHasDirectError) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnHasErrorInExpected) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   auto result = [this]() -> TestErrorOr {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(this->MakeError()));
     return a;
@@ -189,11 +189,12 @@ class AnotherCustomError : public ErrorBase<AnotherCustomError> {
 };
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnNoErrorAcrossErrorTypes) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   auto result = []() -> ErrorOr<int> {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
-      CARBON_ASSIGN_OR_RETURN(int inner, (ErrorOr<int, AnotherCustomError>)(2));
+      CARBON_ASSIGN_OR_RETURN(
+          int inner, (static_cast<ErrorOr<int, AnotherCustomError>>(2)));
       return inner;
     }());
     int c = 0;
@@ -204,12 +205,13 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnNoErrorAcrossErrorTypes) {
 }
 
 TYPED_TEST(ErrorOrTest, AssignOrReturnErrorAcrossErrorTypes) {
-  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  using TestErrorOr = typename TestFixture::template TestErrorOrTemp<int>;
   auto result = []() -> ErrorOr<int> {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
-      CARBON_ASSIGN_OR_RETURN(
-          int inner, (ErrorOr<int, AnotherCustomError>)(AnotherCustomError()));
+      CARBON_ASSIGN_OR_RETURN(int inner,
+                              (static_cast<ErrorOr<int, AnotherCustomError>>(
+                                  AnotherCustomError())));
       return inner;
     }());
     int c = 0;

--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <concepts>
+
 #include "common/error_test_helpers.h"
 #include "common/raw_string_ostream.h"
 
@@ -29,84 +31,6 @@ auto IndirectError() -> Error { return Error("test"); }
 
 TEST(ErrorTest, IndirectError) { EXPECT_EQ(IndirectError().message(), "test"); }
 
-TEST(ErrorTest, ErrorOr) {
-  ErrorOr<int> err(Error("test"));
-
-  EXPECT_THAT(err, IsError("test"));
-}
-
-TEST(ErrorTest, ErrorOrValue) { EXPECT_TRUE(ErrorOr<int>(0).ok()); }
-
-auto IndirectErrorOrTest() -> ErrorOr<int> { return Error("test"); }
-
-TEST(ErrorTest, IndirectErrorOr) { EXPECT_FALSE(IndirectErrorOrTest().ok()); }
-
-struct Val {
-  int val;
-};
-
-TEST(ErrorTest, ErrorOrArrowOp) {
-  ErrorOr<Val> err({1});
-  EXPECT_EQ(err->val, 1);
-}
-
-TEST(ErrorTest, ErrorOrReference) {
-  Val val = {1};
-  ErrorOr<Val&> maybe_val(val);
-  EXPECT_EQ(maybe_val->val, 1);
-}
-
-auto IndirectErrorOrSuccessTest() -> ErrorOr<Success> { return Success(); }
-
-TEST(ErrorTest, IndirectErrorOrSuccess) {
-  EXPECT_TRUE(IndirectErrorOrSuccessTest().ok());
-}
-
-TEST(ErrorTest, ReturnIfErrorNoError) {
-  auto result = []() -> ErrorOr<Success> {
-    CARBON_RETURN_IF_ERROR(ErrorOr<Success>(Success()));
-    CARBON_RETURN_IF_ERROR(ErrorOr<Success>(Success()));
-    return Success();
-  }();
-  EXPECT_TRUE(result.ok());
-}
-
-TEST(ErrorTest, ReturnIfErrorHasError) {
-  auto result = []() -> ErrorOr<Success> {
-    CARBON_RETURN_IF_ERROR(ErrorOr<Success>(Success()));
-    CARBON_RETURN_IF_ERROR(ErrorOr<Success>(Error("error")));
-    return Success();
-  }();
-  EXPECT_THAT(result, IsError("error"));
-}
-
-TEST(ErrorTest, AssignOrReturnNoError) {
-  auto result = []() -> ErrorOr<int> {
-    CARBON_ASSIGN_OR_RETURN(int a, ErrorOr<int>(1));
-    CARBON_ASSIGN_OR_RETURN(const int b, ErrorOr<int>(2));
-    int c = 0;
-    CARBON_ASSIGN_OR_RETURN(c, ErrorOr<int>(3));
-    return a + b + c;
-  }();
-  EXPECT_THAT(result, IsSuccess(Eq(6)));
-}
-
-TEST(ErrorTest, AssignOrReturnHasDirectError) {
-  auto result = []() -> ErrorOr<int> {
-    CARBON_RETURN_IF_ERROR(ErrorOr<int>(Error("error")));
-    return 0;
-  }();
-  EXPECT_THAT(result, IsError("error"));
-}
-
-TEST(ErrorTest, AssignOrReturnHasErrorInExpected) {
-  auto result = []() -> ErrorOr<int> {
-    CARBON_ASSIGN_OR_RETURN(int a, ErrorOr<int>(Error("error")));
-    return a;
-  }();
-  EXPECT_THAT(result, IsError("error"));
-}
-
 TEST(ErrorTest, ErrorBuilderOperatorImplicitCast) {
   ErrorOr<int> result = ErrorBuilder() << "msg";
   EXPECT_THAT(result, IsError("msg"));
@@ -117,6 +41,189 @@ TEST(ErrorTest, StreamError) {
   RawStringOstream result_stream;
   result_stream << result;
   EXPECT_EQ(result_stream.TakeStr(), "TestFunc: msg");
+}
+
+class CustomError : public ErrorBase<CustomError> {
+ public:
+  auto Print(llvm::raw_ostream& os) const -> void {
+    os << "Custom test error!";
+  }
+};
+
+template <typename ErrorT>
+struct ErrorOrTest : ::testing::Test {
+  template <typename T>
+  using TestErrorOr = ErrorOr<T, ErrorT>;
+
+  auto ErrorStr() -> std::string {
+    if constexpr (std::same_as<ErrorT, Error>) {
+      return "test error";
+    } else if constexpr (std::same_as<ErrorT, CustomError>) {
+      return CustomError().ToString();
+    } else {
+      static_assert(false, "Unsupported custom error type!");
+    }
+  }
+
+  auto MakeError() -> ErrorT {
+    if constexpr (std::same_as<ErrorT, Error>) {
+      return Error("test error");
+    } else if constexpr (std::same_as<ErrorT, CustomError>) {
+      return CustomError();
+    } else {
+      static_assert(false, "Unsupported custom error type!");
+    }
+  }
+};
+
+using ErrorOrTestParams = ::testing::Types<Error, CustomError>;
+TYPED_TEST_SUITE(ErrorOrTest, ErrorOrTestParams);
+
+TYPED_TEST(ErrorOrTest, ErrorOr) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  TestErrorOr err(this->MakeError());
+
+  EXPECT_THAT(err, IsError(this->ErrorStr()));
+}
+
+TYPED_TEST(ErrorOrTest, ErrorOrValue) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  EXPECT_TRUE(TestErrorOr(0).ok());
+}
+
+template <typename Fixture>
+auto IndirectErrorOrTest(Fixture& fixture) ->
+    typename Fixture::template TestErrorOr<int> {
+  return fixture.MakeError();
+}
+
+TYPED_TEST(ErrorOrTest, IndirectErrorOr) {
+  EXPECT_FALSE(IndirectErrorOrTest(*this).ok());
+}
+
+struct Val {
+  int val;
+};
+
+TYPED_TEST(ErrorOrTest, ErrorOrArrowOp) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<Val>;
+  TestErrorOr err({1});
+  EXPECT_EQ(err->val, 1);
+}
+
+TYPED_TEST(ErrorOrTest, ErrorOrReference) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<Val&>;
+  Val val = {1};
+  TestErrorOr maybe_val(val);
+  EXPECT_EQ(maybe_val->val, 1);
+}
+
+template <typename Fixture>
+auto IndirectErrorOrSuccessTest() ->
+    typename Fixture::template TestErrorOr<Success> {
+  return Success();
+}
+
+TYPED_TEST(ErrorOrTest, IndirectErrorOrSuccess) {
+  EXPECT_TRUE(IndirectErrorOrSuccessTest<TestFixture>().ok());
+}
+
+TYPED_TEST(ErrorOrTest, ReturnIfErrorNoError) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<Success>;
+  auto result = []() -> TestErrorOr {
+    CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
+    CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
+    return Success();
+  }();
+  EXPECT_TRUE(result.ok());
+}
+
+TYPED_TEST(ErrorOrTest, ReturnIfErrorHasError) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<Success>;
+  auto result = [this]() -> TestErrorOr {
+    CARBON_RETURN_IF_ERROR(TestErrorOr(Success()));
+    CARBON_RETURN_IF_ERROR(TestErrorOr(this->MakeError()));
+    return Success();
+  }();
+  EXPECT_THAT(result, IsError(this->ErrorStr()));
+}
+
+TYPED_TEST(ErrorOrTest, AssignOrReturnNoError) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  auto result = []() -> TestErrorOr {
+    CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
+    CARBON_ASSIGN_OR_RETURN(const int b, TestErrorOr(2));
+    int c = 0;
+    CARBON_ASSIGN_OR_RETURN(c, TestErrorOr(3));
+    return a + b + c;
+  }();
+  EXPECT_THAT(result, IsSuccess(Eq(6)));
+}
+
+TYPED_TEST(ErrorOrTest, AssignOrReturnHasDirectError) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  auto result = [this]() -> TestErrorOr {
+    CARBON_RETURN_IF_ERROR(TestErrorOr(this->MakeError()));
+    return 0;
+  }();
+  EXPECT_THAT(result, IsError(this->ErrorStr()));
+}
+
+TYPED_TEST(ErrorOrTest, AssignOrReturnHasErrorInExpected) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  auto result = [this]() -> TestErrorOr {
+    CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(this->MakeError()));
+    return a;
+  }();
+  EXPECT_THAT(result, IsError(this->ErrorStr()));
+}
+
+class AnotherCustomError : public ErrorBase<AnotherCustomError> {
+ public:
+  auto Print(llvm::raw_ostream& os) const -> void {
+    os << "Another custom test error!";
+  }
+
+  explicit operator CustomError() { return CustomError(); }
+};
+
+TYPED_TEST(ErrorOrTest, AssignOrReturnNoErrorAcrossErrorTypes) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  auto result = []() -> ErrorOr<int> {
+    CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
+    CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
+      CARBON_ASSIGN_OR_RETURN(int inner, (ErrorOr<int, AnotherCustomError>)(2));
+      return inner;
+    }());
+    int c = 0;
+    CARBON_ASSIGN_OR_RETURN(c, TestErrorOr(3));
+    return a + b + c;
+  }();
+  EXPECT_THAT(result, IsSuccess(Eq(6)));
+}
+
+TYPED_TEST(ErrorOrTest, AssignOrReturnErrorAcrossErrorTypes) {
+  using TestErrorOr = typename TestFixture::template TestErrorOr<int>;
+  auto result = []() -> ErrorOr<int> {
+    CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
+    CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
+      CARBON_ASSIGN_OR_RETURN(
+          int inner, (ErrorOr<int, AnotherCustomError>)(AnotherCustomError()));
+      return inner;
+    }());
+    int c = 0;
+    CARBON_ASSIGN_OR_RETURN(c, TestErrorOr(3));
+    return a + b + c;
+  }();
+
+  // When directly using the `Error` type, the explicit custom type above has
+  // its message preserved. When testing against `CustomError`, that one
+  // overrides the message.
+  if constexpr (std::same_as<TypeParam, Error>) {
+    EXPECT_THAT(result, IsError("Another custom test error!"));
+  } else {
+    EXPECT_THAT(result, IsError("Custom test error!"));
+  }
 }
 
 }  // namespace

--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -194,7 +194,7 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnNoErrorAcrossErrorTypes) {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
       CARBON_ASSIGN_OR_RETURN(
-          int inner, (static_cast<ErrorOr<int, AnotherCustomError>>(2)));
+          int inner, (ErrorOr<int, AnotherCustomError>(2)));
       return inner;
     }());
     int c = 0;
@@ -210,8 +210,8 @@ TYPED_TEST(ErrorOrTest, AssignOrReturnErrorAcrossErrorTypes) {
     CARBON_ASSIGN_OR_RETURN(int a, TestErrorOr(1));
     CARBON_ASSIGN_OR_RETURN(const int b, []() -> TestErrorOr {
       CARBON_ASSIGN_OR_RETURN(int inner,
-                              (static_cast<ErrorOr<int, AnotherCustomError>>(
-                                  AnotherCustomError())));
+                              (ErrorOr<int, AnotherCustomError>(
+                                  AnotherCustomError()));
       return inner;
     }());
     int c = 0;

--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -51,7 +51,8 @@ class CustomError : public ErrorBase<CustomError> {
 };
 
 template <typename ErrorT>
-struct ErrorOrTest : ::testing::Test {
+class ErrorOrTest : public ::testing::Test {
+ public:
   template <typename T>
   using TestErrorOr = ErrorOr<T, ErrorT>;
 


### PR DESCRIPTION
This doesn't split apart the current error type into one that tracks location and one that doesn't, although that might be easier to do once we have this.

Instead, this is primarily intended to support custom error types that lazily materialize the error message in case that can be avoided by completely handling the error. For example, many file system operations are *expected* to produce errors even in the hot path and we don't want to render `ENOENT` (for example) to a pretty string and instead will directly query the error to understand and handle it in code.

The type parameter ordering isn't the most obvious, but helpfully allows us to default the error type in a useful way.