### PR TITLE
Change CodeGen to use a diagnostic consumer

### DIFF
--- a/toolchain/codegen/BUILD
+++ b/toolchain/codegen/BUILD
@@ -17,6 +17,8 @@ cc_library(
     hdrs = ["codegen.h"],
     deps = [
         "//common:check",
+        "//toolchain/diagnostics:diagnostic_emitter",
+        "//toolchain/diagnostics:file_diagnostics",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:MC",
         "@llvm-project//llvm:Support",

--- a/toolchain/diagnostics/coverage_test.cpp
+++ b/toolchain/diagnostics/coverage_test.cpp
@@ -43,6 +43,9 @@ constexpr Kind UntestedKinds[] = {
     // This is a little long but is tested in lex/numeric_literal_test.cpp.
     Kind::TooManyDigits,
 
+    // Producing an emit failure may be infeasible.
+    Kind::CodeGenUnableToEmit,
+
     // TODO: This can only fire if the first message in a diagnostic is rooted
     // in a file other than the file being compiled. The language server
     // currently only supports compiling one file at a time. Do one of:

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -500,6 +500,12 @@ CARBON_DIAGNOSTIC_KIND(GenericMissingExplicitParameters)
 CARBON_DIAGNOSTIC_KIND(TuplePatternSizeDoesntMatchLiteral)
 
 // ============================================================================
+// CodeGen diagnostics
+// ============================================================================
+
+CARBON_DIAGNOSTIC_KIND(CodeGenUnableToEmit)
+
+// ============================================================================
 // Language server diagnostics
 // ============================================================================
 

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -741,8 +741,7 @@ auto CompilationUnit::PostCompile() -> void {
 
 auto CompilationUnit::RunCodeGenHelper() -> bool {
   std::optional<CodeGen> codegen =
-      CodeGen::Make(module_.get(), options_->codegen_options.target,
-                    driver_env_->error_stream);
+      CodeGen::Make(module_.get(), options_->codegen_options.target, consumer_);
   if (!codegen) {
     return false;
   }


### PR DESCRIPTION
We've been trying to have errors/warnings all go through the diagnostics consumers instead of straight to stderr.