### PR TITLE
Add a flag to control generation of standard type impls

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -448,7 +448,7 @@ auto CheckParseTrees(
        check_index < static_cast<int>(ready_to_check.size()); ++check_index) {
     auto* unit_info = ready_to_check[check_index];
     CheckUnit(unit_info, &tree_and_subtrees_getters, fs, clang_invocation,
-              options.desugar_type_impls, options.vlog_stream)
+              options.implicit_type_impls, options.vlog_stream)
         .Run();
     for (auto* incoming_import : unit_info->incoming_imports) {
       --incoming_import->imports_remaining;
@@ -497,7 +497,7 @@ auto CheckParseTrees(
     for (auto& unit_info : unit_infos) {
       if (unit_info.imports_remaining > 0) {
         CheckUnit(&unit_info, &tree_and_subtrees_getters, fs, clang_invocation,
-                  options.desugar_type_impls, options.vlog_stream)
+                  options.implicit_type_impls, options.vlog_stream)
             .Run();
       }
     }

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -448,7 +448,7 @@ auto CheckParseTrees(
        check_index < static_cast<int>(ready_to_check.size()); ++check_index) {
     auto* unit_info = ready_to_check[check_index];
     CheckUnit(unit_info, &tree_and_subtrees_getters, fs, clang_invocation,
-              options.vlog_stream)
+              options.desugar_type_impls, options.vlog_stream)
         .Run();
     for (auto* incoming_import : unit_info->incoming_imports) {
       --incoming_import->imports_remaining;
@@ -497,7 +497,7 @@ auto CheckParseTrees(
     for (auto& unit_info : unit_infos) {
       if (unit_info.imports_remaining > 0) {
         CheckUnit(&unit_info, &tree_and_subtrees_getters, fs, clang_invocation,
-                  options.vlog_stream)
+                  options.desugar_type_impls, options.vlog_stream)
             .Run();
       }
     }

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -40,6 +40,11 @@ struct CheckParseTreesOptions {
   // Whether to import the prelude.
   bool prelude_import = false;
 
+  // Whether to desugar standard impls for types, such as `Core.Destroy`. This
+  // only controls generation of the `impl`; code which expects the `impl` is
+  // expected to fail.
+  bool desugar_type_impls = true;
+
   // If set, enables verbose output.
   llvm::raw_ostream* vlog_stream = nullptr;
 

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -40,10 +40,10 @@ struct CheckParseTreesOptions {
   // Whether to import the prelude.
   bool prelude_import = false;
 
-  // Whether to desugar standard impls for types, such as `Core.Destroy`. This
+  // Whether to generate standard impls for types, such as `Core.Destroy`. This
   // only controls generation of the `impl`; code which expects the `impl` is
   // expected to fail.
-  bool desugar_type_impls = true;
+  bool implicit_type_impls = true;
 
   // If set, enables verbose output.
   llvm::raw_ostream* vlog_stream = nullptr;

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -59,7 +59,7 @@ CheckUnit::CheckUnit(
     const Parse::GetTreeAndSubtreesStore* tree_and_subtrees_getters,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
     std::shared_ptr<clang::CompilerInvocation> clang_invocation,
-    llvm::raw_ostream* vlog_stream)
+    bool desugar_type_impls, llvm::raw_ostream* vlog_stream)
     : unit_and_imports_(unit_and_imports),
       tree_and_subtrees_getter_(tree_and_subtrees_getters->Get(
           unit_and_imports->unit->sem_ir->check_ir_id())),
@@ -68,9 +68,10 @@ CheckUnit::CheckUnit(
       clang_invocation_(std::move(clang_invocation)),
       emitter_(&unit_and_imports_->err_tracker, tree_and_subtrees_getters,
                unit_and_imports_->unit->sem_ir),
-      context_(
-          &emitter_, tree_and_subtrees_getter_, unit_and_imports_->unit->sem_ir,
-          GetImportedIRCount(unit_and_imports), total_ir_count_, vlog_stream) {}
+      context_(&emitter_, tree_and_subtrees_getter_,
+               unit_and_imports_->unit->sem_ir,
+               GetImportedIRCount(unit_and_imports), total_ir_count_,
+               desugar_type_impls, vlog_stream) {}
 
 auto CheckUnit::Run() -> void {
   Timings::ScopedTiming timing(unit_and_imports_->unit->timings, "check");

--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -59,7 +59,7 @@ CheckUnit::CheckUnit(
     const Parse::GetTreeAndSubtreesStore* tree_and_subtrees_getters,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
     std::shared_ptr<clang::CompilerInvocation> clang_invocation,
-    bool desugar_type_impls, llvm::raw_ostream* vlog_stream)
+    bool implicit_type_impls, llvm::raw_ostream* vlog_stream)
     : unit_and_imports_(unit_and_imports),
       tree_and_subtrees_getter_(tree_and_subtrees_getters->Get(
           unit_and_imports->unit->sem_ir->check_ir_id())),
@@ -71,7 +71,7 @@ CheckUnit::CheckUnit(
       context_(&emitter_, tree_and_subtrees_getter_,
                unit_and_imports_->unit->sem_ir,
                GetImportedIRCount(unit_and_imports), total_ir_count_,
-               desugar_type_impls, vlog_stream) {}
+               implicit_type_impls, vlog_stream) {}
 
 auto CheckUnit::Run() -> void {
   Timings::ScopedTiming timing(unit_and_imports_->unit->timings, "check");

--- a/toolchain/check/check_unit.h
+++ b/toolchain/check/check_unit.h
@@ -128,7 +128,7 @@ class CheckUnit {
       const Parse::GetTreeAndSubtreesStore* tree_and_subtrees_getters,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
       std::shared_ptr<clang::CompilerInvocation> clang_invocation,
-      bool desugar_type_impls, llvm::raw_ostream* vlog_stream);
+      bool implicit_type_impls, llvm::raw_ostream* vlog_stream);
 
   // Produces and checks the IR for the provided unit.
   auto Run() -> void;

--- a/toolchain/check/check_unit.h
+++ b/toolchain/check/check_unit.h
@@ -128,7 +128,7 @@ class CheckUnit {
       const Parse::GetTreeAndSubtreesStore* tree_and_subtrees_getters,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
       std::shared_ptr<clang::CompilerInvocation> clang_invocation,
-      llvm::raw_ostream* vlog_stream);
+      bool desugar_type_impls, llvm::raw_ostream* vlog_stream);
 
   // Produces and checks the IR for the provided unit.
   auto Run() -> void;

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -16,10 +16,11 @@ namespace Carbon::Check {
 Context::Context(DiagnosticEmitterBase* emitter,
                  Parse::GetTreeAndSubtreesFn tree_and_subtrees_getter,
                  SemIR::File* sem_ir, int imported_ir_count, int total_ir_count,
-                 llvm::raw_ostream* vlog_stream)
+                 bool desugar_type_impls, llvm::raw_ostream* vlog_stream)
     : emitter_(emitter),
       tree_and_subtrees_getter_(tree_and_subtrees_getter),
       sem_ir_(sem_ir),
+      desugar_type_impls_(desugar_type_impls),
       vlog_stream_(vlog_stream),
       node_stack_(sem_ir->parse_tree(), vlog_stream),
       inst_block_stack_("inst_block_stack_", *sem_ir, vlog_stream),

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -16,11 +16,11 @@ namespace Carbon::Check {
 Context::Context(DiagnosticEmitterBase* emitter,
                  Parse::GetTreeAndSubtreesFn tree_and_subtrees_getter,
                  SemIR::File* sem_ir, int imported_ir_count, int total_ir_count,
-                 bool desugar_type_impls, llvm::raw_ostream* vlog_stream)
+                 bool implicit_type_impls, llvm::raw_ostream* vlog_stream)
     : emitter_(emitter),
       tree_and_subtrees_getter_(tree_and_subtrees_getter),
       sem_ir_(sem_ir),
-      desugar_type_impls_(desugar_type_impls),
+      implicit_type_impls_(implicit_type_impls),
       vlog_stream_(vlog_stream),
       node_stack_(sem_ir->parse_tree(), vlog_stream),
       inst_block_stack_("inst_block_stack_", *sem_ir, vlog_stream),

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -58,7 +58,7 @@ class Context {
   explicit Context(DiagnosticEmitterBase* emitter,
                    Parse::GetTreeAndSubtreesFn tree_and_subtrees_getter,
                    SemIR::File* sem_ir, int imported_ir_count,
-                   int total_ir_count, bool desugar_type_impls,
+                   int total_ir_count, bool implicit_type_impls,
                    llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
@@ -93,7 +93,7 @@ class Context {
     return parse_tree().tokens();
   }
 
-  auto desugar_type_impls() -> bool { return desugar_type_impls_; }
+  auto implicit_type_impls() -> bool { return implicit_type_impls_; }
 
   auto vlog_stream() -> llvm::raw_ostream* { return vlog_stream_; }
 
@@ -304,9 +304,9 @@ class Context {
   // The SemIR::File being added to.
   SemIR::File* sem_ir_;
 
-  // Whether to desugar standard impls for types, such as `Core.Destroy`; see
+  // Whether to generate standard impls for types, such as `Core.Destroy`; see
   // `CheckParseTreesOptions`.
-  bool desugar_type_impls_;
+  bool implicit_type_impls_;
 
   // Whether to print verbose output.
   llvm::raw_ostream* vlog_stream_;

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -58,7 +58,8 @@ class Context {
   explicit Context(DiagnosticEmitterBase* emitter,
                    Parse::GetTreeAndSubtreesFn tree_and_subtrees_getter,
                    SemIR::File* sem_ir, int imported_ir_count,
-                   int total_ir_count, llvm::raw_ostream* vlog_stream);
+                   int total_ir_count, bool desugar_type_impls,
+                   llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
   auto TODO(SemIR::LocId loc_id, std::string label) -> bool;
@@ -91,6 +92,8 @@ class Context {
   auto tokens() const -> const Lex::TokenizedBuffer& {
     return parse_tree().tokens();
   }
+
+  auto desugar_type_impls() -> bool { return desugar_type_impls_; }
 
   auto vlog_stream() -> llvm::raw_ostream* { return vlog_stream_; }
 
@@ -300,6 +303,10 @@ class Context {
 
   // The SemIR::File being added to.
   SemIR::File* sem_ir_;
+
+  // Whether to desugar standard impls for types, such as `Core.Destroy`; see
+  // `CheckParseTreesOptions`.
+  bool desugar_type_impls_;
 
   // Whether to print verbose output.
   llvm::raw_ostream* vlog_stream_;

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -284,16 +284,16 @@ Whether to use the implicit prelude import. Enabled by default.
       });
   b.AddFlag(
       {
-          .name = "desugar-type-impls",
+          .name = "implicit-type-impls",
           .help = R"""(
-Whether to desugar standard impls for types, such as `Core.Destroy`. This only
+Whether to generate standard impls for types, such as `Core.Destroy`. This only
 controls generation of the `impl`; code which expects the `impl` is expected to
 fail. Enabled by default.
 )""",
       },
       [&](auto& arg_b) {
         arg_b.Default(true);
-        arg_b.Set(&desugar_type_impls);
+        arg_b.Set(&implicit_type_impls);
       });
   b.AddFlag(
       {
@@ -1012,7 +1012,7 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   CARBON_VLOG_TO(driver_env.vlog_stream, "*** Check::CheckParseTrees ***\n");
   Check::CheckParseTreesOptions options;
   options.prelude_import = options_.prelude_import;
-  options.desugar_type_impls = options_.desugar_type_impls;
+  options.implicit_type_impls = options_.implicit_type_impls;
   options.vlog_stream = driver_env.vlog_stream;
   options.fuzzing = driver_env.fuzzing;
   if (options.vlog_stream || options_.dump_sem_ir || options_.dump_raw_sem_ir) {

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -284,6 +284,19 @@ Whether to use the implicit prelude import. Enabled by default.
       });
   b.AddFlag(
       {
+          .name = "desugar-type-impls",
+          .help = R"""(
+Whether to desugar standard impls for types, such as `Core.Destroy`. This only
+controls generation of the `impl`; code which expects the `impl` is expected to
+fail. Enabled by default.
+)""",
+      },
+      [&](auto& arg_b) {
+        arg_b.Default(true);
+        arg_b.Set(&desugar_type_impls);
+      });
+  b.AddFlag(
+      {
           .name = "custom-core",
           .value_name = "CUSTOM_CORE",
           .help = R"""(
@@ -999,6 +1012,7 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   CARBON_VLOG_TO(driver_env.vlog_stream, "*** Check::CheckParseTrees ***\n");
   Check::CheckParseTreesOptions options;
   options.prelude_import = options_.prelude_import;
+  options.desugar_type_impls = options_.desugar_type_impls;
   options.vlog_stream = driver_env.vlog_stream;
   options.fuzzing = driver_env.fuzzing;
   if (options.vlog_stream || options_.dump_sem_ir || options_.dump_raw_sem_ir) {

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -60,6 +60,7 @@ struct CompileOptions {
   bool preorder_parse_tree = false;
   bool builtin_sem_ir = false;
   bool prelude_import = false;
+  bool desugar_type_impls = false;
   bool include_debug_info = true;
   bool run_llvm_verifier = true;
 

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -60,7 +60,7 @@ struct CompileOptions {
   bool preorder_parse_tree = false;
   bool builtin_sem_ir = false;
   bool prelude_import = false;
-  bool desugar_type_impls = false;
+  bool implicit_type_impls = false;
   bool include_debug_info = true;
   bool run_llvm_verifier = true;
 


### PR DESCRIPTION
This wires up a flag to control whether impls are generated, separate from use of the flag.

Starting with destruction, every type will have an implicit `impl as Core.Destroy`. This is expected to be mirrored into copy and move. That creates a challenge where it's hard to write tests of types that don't depend on interfaces and impls, making all tests more complex.

For contrast, it should remain relatively straightforward to write a test that defines type without invoking destroy/copy/move, and so won't determine whether these interfaces were added.

Note, a contrary argument to this might be that we're going to start doing everything as interfaces (even `var x: ()` might require `impl () as Core.ImplicitAs(type)`), and so maybe this won't work out long-term. But, I still lean slightly for seeing if it's useful.