### PR TITLE
Migrate away from llvm::ArrayRef(std::nullopt_t)

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -710,7 +710,7 @@ auto FileContext::BuildDISubprogram(const SemIR::Function& function,
       /*File=*/context().di_builder().createFile(loc.filename, ""),
       /*LineNo=*/loc.line_number,
       context().di_builder().createSubroutineType(
-          context().di_builder().getOrCreateTypeArray(std::nullopt)),
+          context().di_builder().getOrCreateTypeArray({})),
       /*ScopeLine=*/0, llvm::DINode::FlagZero,
       llvm::DISubprogram::SPFlagDefinition);
 }


### PR DESCRIPTION
The upstream LLVM has deprecated ArrayRef(std::nullopt_t).  This CL
migrates away from that.
