### PR TITLE
Move and deduplicate testing access when a Carbon class extends a C++ record to `access.carbon`

### DIFF
--- a/toolchain/check/testdata/interop/cpp/class/access.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/access.carbon
@@ -32,6 +32,22 @@ fn F(s: Cpp.S) {
   //@dump-sem-ir-end
 }
 
+// --- import_non_function_member_public_extend.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "non_function_member_public.h";
+
+class Derived {
+  extend base: Cpp.S;
+}
+
+fn F(d: Derived) {
+  //@dump-sem-ir-begin
+  let x: i32 = d.x;
+  //@dump-sem-ir-end
+}
+
 // ============================================================================
 // Protected non-function member
 // ============================================================================
@@ -61,6 +77,28 @@ fn F(c: Cpp.C) {
   let x: i32 = c.x;
 }
 
+// --- fail_import_non_function_member_protected_extend.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "non_function_member_protected.h";
+
+class Derived {
+  extend base: Cpp.C;
+}
+
+fn F(d: Derived) {
+  // CHECK:STDERR: fail_import_non_function_member_protected_extend.carbon:[[@LINE+8]]:16: error: cannot access protected member `x` of type `Derived` [ClassInvalidMemberAccess]
+  // CHECK:STDERR:   let x: i32 = d.x;
+  // CHECK:STDERR:                ^~~
+  // CHECK:STDERR: fail_import_non_function_member_protected_extend.carbon:[[@LINE-10]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: ./non_function_member_protected.h:2:7: note: declared here [ClassMemberDeclaration]
+  // CHECK:STDERR: class C {
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR:
+  let x: i32 = d.x;
+}
+
 // ============================================================================
 // Private non-function member
 // ============================================================================
@@ -87,6 +125,28 @@ fn F(c: Cpp.C) {
   // CHECK:STDERR:       ^
   // CHECK:STDERR:
   let x: i32 = c.x;
+}
+
+// --- fail_import_non_function_member_private_extend.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "non_function_member_private.h";
+
+class Derived {
+  extend base: Cpp.C;
+}
+
+fn F(d: Derived) {
+  // CHECK:STDERR: fail_import_non_function_member_private_extend.carbon:[[@LINE+8]]:16: error: cannot access private member `x` of type `Cpp.C` [ClassInvalidMemberAccess]
+  // CHECK:STDERR:   let x: i32 = d.x;
+  // CHECK:STDERR:                ^~~
+  // CHECK:STDERR: fail_import_non_function_member_private_extend.carbon:[[@LINE-10]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: ./non_function_member_private.h:2:7: note: declared here [ClassMemberDeclaration]
+  // CHECK:STDERR: class C {
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR:
+  let x: i32 = d.x;
 }
 
 // ============================================================================
@@ -329,6 +389,39 @@ fn F() {
 // CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %x: %i32 = bind_name x, %.loc8_17.2
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- import_non_function_member_public_extend.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [concrete]
+// CHECK:STDOUT:   %S: type = class_type @S [concrete]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %S.elem: type = unbound_element_type %S, %i32 [concrete]
+// CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%d.param: %Derived) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %x.patt: %pattern_type.7ce = binding_pattern x [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %d.ref: %Derived = name_ref d, %d
+// CHECK:STDOUT:   %x.ref: %S.elem = name_ref x, @S.%.1 [concrete = @S.%.1]
+// CHECK:STDOUT:   %.loc12_17.1: ref %S = class_element_access %d.ref, element0
+// CHECK:STDOUT:   %.loc12_17.2: ref %S = converted %d.ref, %.loc12_17.1
+// CHECK:STDOUT:   %.loc12_17.3: ref %i32 = class_element_access %.loc12_17.2, element0
+// CHECK:STDOUT:   %.loc12_10: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc12_17.4: %i32 = bind_value %.loc12_17.3
+// CHECK:STDOUT:   %x: %i32 = bind_name x, %.loc12_17.4
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/class/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/class.carbon
@@ -212,36 +212,6 @@ fn MyF() {
 //@dump-sem-ir-end
 
 // ============================================================================
-// To inherit private
-// ============================================================================
-
-// --- to_inherit_private.h
-
-class Bar {
- private:
-  static auto foo() -> void;
-};
-
-// --- fail_to_inherit_private.carbon
-
-library "[[@TEST_NAME]]";
-
-import Cpp library "to_inherit_private.h";
-
-class Derived {
-  extend base: Cpp.Bar;
-}
-
-fn MyF() {
-  // CHECK:STDERR: fail_to_inherit_private.carbon:[[@LINE+5]]:3: error: cannot access private member `foo` of type `Cpp.Bar` [ClassInvalidMemberAccess]
-  // CHECK:STDERR:   Derived.foo();
-  // CHECK:STDERR:   ^~~~~~~~~~~
-  // CHECK:STDERR: fail_to_inherit_private.carbon: note: declared here [ClassMemberDeclaration]
-  // CHECK:STDERR:
-  Derived.foo();
-}
-
-// ============================================================================
 // Template
 // ============================================================================
 

--- a/toolchain/check/testdata/interop/cpp/class/struct.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/struct.carbon
@@ -200,60 +200,6 @@ fn MyF(bar: Cpp.Bar*) {
 //@dump-sem-ir-end
 
 // ============================================================================
-// To inherit public
-// ============================================================================
-
-// --- to_inherit_public.h
-
-struct Bar { static auto foo() -> void; };
-
-// --- import_to_inherit_public.carbon
-
-library "[[@TEST_NAME]]";
-
-import Cpp library "to_inherit_public.h";
-
-//@dump-sem-ir-begin
-class Derived {
-  extend base: Cpp.Bar;
-}
-
-fn MyF() {
-  Derived.foo();
-}
-//@dump-sem-ir-end
-
-// ============================================================================
-// To inherit private
-// ============================================================================
-
-// --- to_inherit_private.h
-
-struct Bar {
- private:
-  static auto foo() -> void;
-};
-
-// --- fail_to_inherit_private.carbon
-
-library "[[@TEST_NAME]]";
-
-import Cpp library "to_inherit_private.h";
-
-class Derived {
-  extend base: Cpp.Bar;
-}
-
-fn MyF() {
-  // CHECK:STDERR: fail_to_inherit_private.carbon:[[@LINE+5]]:3: error: cannot access private member `foo` of type `Cpp.Bar` [ClassInvalidMemberAccess]
-  // CHECK:STDERR:   Derived.foo();
-  // CHECK:STDERR:   ^~~~~~~~~~~
-  // CHECK:STDERR: fail_to_inherit_private.carbon: note: declared here [ClassMemberDeclaration]
-  // CHECK:STDERR:
-  Derived.foo();
-}
-
-// ============================================================================
 // Template
 // ============================================================================
 
@@ -574,59 +520,6 @@ fn MyF(bar: Cpp.Bar*);
 // CHECK:STDOUT:   %bar.ref: %ptr.f68 = name_ref bar, %bar
 // CHECK:STDOUT:   %.loc15: ref %Bar = deref %bar.ref
 // CHECK:STDOUT:   %f.ref: <error> = name_ref f, <error> [concrete = <error>]
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- import_to_inherit_public.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %Derived: type = class_type @Derived [concrete]
-// CHECK:STDOUT:   %Bar: type = class_type @Bar [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %Derived.elem: type = unbound_element_type %Derived, %Bar [concrete]
-// CHECK:STDOUT:   %struct_type.base.36d: type = struct_type {.base: %Bar} [concrete]
-// CHECK:STDOUT:   %complete_type.fff: <witness> = complete_type_witness %struct_type.base.36d [concrete]
-// CHECK:STDOUT:   %MyF.type: type = fn_type @MyF [concrete]
-// CHECK:STDOUT:   %MyF: %MyF.type = struct_value () [concrete]
-// CHECK:STDOUT:   %Bar.foo.type: type = fn_type @Bar.foo [concrete]
-// CHECK:STDOUT:   %Bar.foo: %Bar.foo.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .Bar = %Bar.decl
-// CHECK:STDOUT:     import Cpp//...
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Bar.decl: type = class_decl @Bar [concrete = constants.%Bar] {} {}
-// CHECK:STDOUT:   %Bar.foo.decl: %Bar.foo.type = fn_decl @Bar.foo [concrete = constants.%Bar.foo] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   %Derived.decl: type = class_decl @Derived [concrete = constants.%Derived] {} {}
-// CHECK:STDOUT:   %MyF.decl: %MyF.type = fn_decl @MyF [concrete = constants.%MyF] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %Bar.ref: type = name_ref Bar, imports.%Bar.decl [concrete = constants.%Bar]
-// CHECK:STDOUT:   %.loc8: %Derived.elem = base_decl %Bar.ref, element0 [concrete]
-// CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %Bar} [concrete = constants.%struct_type.base.36d]
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %struct_type.base [concrete = constants.%complete_type.fff]
-// CHECK:STDOUT:   complete_type_witness = %complete_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = constants.%Derived
-// CHECK:STDOUT:   .Cpp = <poisoned>
-// CHECK:STDOUT:   .base = %.loc8
-// CHECK:STDOUT:   .foo = <poisoned>
-// CHECK:STDOUT:   extend %Bar.ref
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @MyF() {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Derived.ref: type = name_ref Derived, file.%Derived.decl [concrete = constants.%Derived]
-// CHECK:STDOUT:   %foo.ref: %Bar.foo.type = name_ref foo, imports.%Bar.foo.decl [concrete = constants.%Bar.foo]
-// CHECK:STDOUT:   %Bar.foo.call: init %empty_tuple.type = call %foo.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Followup of #5858.
Part of #5859.