### PR TITLE
Add a flag to dump the C++ AST

### DIFF
--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -201,6 +201,9 @@ auto FileTestAutoupdater::BuildCheckLines(llvm::StringRef output,
     }
 
     do_extra_check_replacements_(check_line);
+    if (check_line.empty()) {
+      continue;
+    }
 
     if (default_file_re_) {
       absl::string_view filename;

--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -393,6 +393,9 @@ auto FileTestAutoupdater::Run(bool dry_run) -> bool {
   if (!dry_run) {
     std::ofstream out(file_test_path_);
     out << new_content;
+  } else {
+    // TODO: Remove.
+    llvm::errs() << "Autoupdate new content:\n" << new_content;
   }
   return true;
 }

--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -393,9 +393,6 @@ auto FileTestAutoupdater::Run(bool dry_run) -> bool {
   if (!dry_run) {
     std::ofstream out(file_test_path_);
     out << new_content;
-  } else {
-    // TODO: Remove.
-    llvm::errs() << "Autoupdate new content:\n" << new_content;
   }
   return true;
 }

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -246,15 +246,23 @@ auto FileTestCase::TestBody() -> void {
   }
   if (test_file.check_subset) {
     EXPECT_THAT(SplitOutput(test_file.actual_stdout),
-                IsSupersetOf(test_file.expected_stdout));
+                IsSupersetOf(test_file.expected_stdout))
+        << "Full Actual text:\n"
+        << test_file.actual_stdout;
     EXPECT_THAT(SplitOutput(test_file.actual_stderr),
-                IsSupersetOf(test_file.expected_stderr));
+                IsSupersetOf(test_file.expected_stderr))
+        << "Full Actual text:\n"
+        << test_file.actual_stderr;
 
   } else {
     EXPECT_THAT(SplitOutput(test_file.actual_stdout),
-                ElementsAreArray(test_file.expected_stdout));
+                ElementsAreArray(test_file.expected_stdout))
+        << "Full Actual text:\n"
+        << test_file.actual_stdout;
     EXPECT_THAT(SplitOutput(test_file.actual_stderr),
-                ElementsAreArray(test_file.expected_stderr));
+                ElementsAreArray(test_file.expected_stderr))
+        << "Full Actual text:\n"
+        << test_file.actual_stderr;
   }
 
   if (HasFailure()) {

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -247,21 +247,21 @@ auto FileTestCase::TestBody() -> void {
   if (test_file.check_subset) {
     EXPECT_THAT(SplitOutput(test_file.actual_stdout),
                 IsSupersetOf(test_file.expected_stdout))
-        << "Full Actual text:\n"
+        << "Actual text:\n"
         << test_file.actual_stdout;
     EXPECT_THAT(SplitOutput(test_file.actual_stderr),
                 IsSupersetOf(test_file.expected_stderr))
-        << "Full Actual text:\n"
+        << "Actual text:\n"
         << test_file.actual_stderr;
 
   } else {
     EXPECT_THAT(SplitOutput(test_file.actual_stdout),
                 ElementsAreArray(test_file.expected_stdout))
-        << "Full Actual text:\n"
+        << "Actual text:\n"
         << test_file.actual_stdout;
     EXPECT_THAT(SplitOutput(test_file.actual_stderr),
                 ElementsAreArray(test_file.expected_stderr))
-        << "Full Actual text:\n"
+        << "Actual text:\n"
         << test_file.actual_stderr;
   }
 

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -196,7 +196,6 @@ cc_library(
         "//common:map",
         "//common:ostream",
         "//common:pretty_stack_trace_function",
-        "//common:raw_string_ostream",
         "//common:vlog",
         "//toolchain/base:fixed_size_value_store",
         "//toolchain/base:kind_switch",

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -196,6 +196,7 @@ cc_library(
         "//common:map",
         "//common:ostream",
         "//common:pretty_stack_trace_function",
+        "//common:raw_string_ostream",
         "//common:vlog",
         "//toolchain/base:fixed_size_value_store",
         "//toolchain/base:kind_switch",

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -4,11 +4,13 @@
 
 #include "toolchain/check/check.h"
 
+#include <regex>
 #include <string>
 #include <utility>
 
 #include "common/check.h"
 #include "common/map.h"
+#include "common/raw_string_ostream.h"
 #include "toolchain/check/check_unit.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/diagnostic_emitter.h"
@@ -392,6 +394,27 @@ static auto MaybeDumpSemIR(
   }
 }
 
+// Handles options for dumping C++ AST.
+static auto MaybeDumpCppAST(llvm::ArrayRef<Unit> units,
+                            const CheckParseTreesOptions& options) -> void {
+  if (!options.dump_cpp_ast_stream) {
+    return;
+  }
+
+  for (const Unit& unit : units) {
+    if (!unit.cpp_ast || !*unit.cpp_ast) {
+      continue;
+    }
+
+    RawStringOstream ast_string;
+    (*unit.cpp_ast)->getASTContext().getTranslationUnitDecl()->dump(ast_string);
+
+    std::regex id_regex(R"( 0x[a-f0-9]+ )");
+    *options.dump_cpp_ast_stream
+        << std::regex_replace(ast_string.TakeStr(), id_regex, " <ID> ");
+  }
+}
+
 auto CheckParseTrees(
     llvm::MutableArrayRef<Unit> units,
     const Parse::GetTreeAndSubtreesStore& tree_and_subtrees_getters,
@@ -509,6 +532,7 @@ auto CheckParseTrees(
   }
 
   MaybeDumpSemIR(units, tree_and_subtrees_getters, options);
+  MaybeDumpCppAST(units, options);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -405,13 +405,8 @@ static auto MaybeDumpCppAST(llvm::ArrayRef<Unit> units,
     if (!unit.cpp_ast || !*unit.cpp_ast) {
       continue;
     }
-
-    RawStringOstream ast_string;
-    (*unit.cpp_ast)->getASTContext().getTranslationUnitDecl()->dump(ast_string);
-
-    std::regex id_regex(R"( 0x[a-f0-9]+ )");
-    *options.dump_cpp_ast_stream
-        << std::regex_replace(ast_string.TakeStr(), id_regex, " <ID> ");
+    clang::ASTContext& ast_context = (*unit.cpp_ast)->getASTContext();
+    ast_context.getTranslationUnitDecl()->dump(*options.dump_cpp_ast_stream);
   }
 }
 

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -4,13 +4,11 @@
 
 #include "toolchain/check/check.h"
 
-#include <regex>
 #include <string>
 #include <utility>
 
 #include "common/check.h"
 #include "common/map.h"
-#include "common/raw_string_ostream.h"
 #include "toolchain/check/check_unit.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/diagnostic_emitter.h"

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -60,6 +60,9 @@ struct CheckParseTreesOptions {
   // If set, SemIR will be dumped to this.
   llvm::raw_ostream* dump_stream = nullptr;
 
+  // If set, C++ AST will be dumped to this.
+  llvm::raw_ostream* dump_cpp_ast_stream = nullptr;
+
   // When dumping textual SemIR (or printing it to for verbose output), whether
   // to use ranges.
   enum class DumpSemIRRanges : int8_t {

--- a/toolchain/check/cpp_thunk.cpp
+++ b/toolchain/check/cpp_thunk.cpp
@@ -201,11 +201,13 @@ static auto CreateThunkFunctionDecl(
       callee_function_decl.getReturnType(), thunk_param_types,
       callee_function_type->getExtProtoInfo());
 
+  clang::DeclContext* decl_context = ast_context.getTranslationUnitDecl();
   // TODO: Thunks should not have external linkage, consider using `SC_Static`.
   clang::FunctionDecl* thunk_function_decl = clang::FunctionDecl::Create(
-      ast_context, ast_context.getTranslationUnitDecl(), clang_loc, clang_loc,
+      ast_context, decl_context, clang_loc, clang_loc,
       clang::DeclarationName(&identifier_info), thunk_function_type,
       /*TInfo=*/nullptr, clang::SC_Extern);
+  decl_context->addDecl(thunk_function_decl);
 
   thunk_function_decl->setParams(BuildThunkParameters(
       ast_context, callee_function_decl, thunk_function_decl));

--- a/toolchain/check/testdata/interop/cpp/function/full_semir.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/full_semir.carbon
@@ -26,7 +26,6 @@ library "[[@TEST_NAME]]";
 import Cpp library "short_param.h";
 
 fn F() {
-  // TODO: Find a way to test the full C++ thunk AST.
   Cpp.foo(1 as i16);
 }
 
@@ -168,21 +167,21 @@ fn F() {
 // CHECK:STDOUT:   %int_16: Core.IntLiteral = int_value 16 [concrete = constants.%int_16]
 // CHECK:STDOUT:   %i16: type = class_type @Int, @Int(constants.%int_16) [concrete = constants.%i16]
 // CHECK:STDOUT:   %impl.elem0: %.91d = impl_witness_access constants.%As.impl_witness.0ef, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.489]
-// CHECK:STDOUT:   %bound_method.loc8_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %bound_method.loc7_13.1: <bound method> = bound_method %int_1, %impl.elem0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Core.IntLiteral.as.As.impl.Convert(constants.%int_16) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc8_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call: init %i16 = call %bound_method.loc8_13.2(%int_1) [concrete = constants.%int_1.f90]
-// CHECK:STDOUT:   %.loc8_13.1: %i16 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call [concrete = constants.%int_1.f90]
-// CHECK:STDOUT:   %.loc8_13.2: %i16 = converted %int_1, %.loc8_13.1 [concrete = constants.%int_1.f90]
-// CHECK:STDOUT:   %.loc8_19.1: ref %i16 = temporary_storage
-// CHECK:STDOUT:   %.loc8_19.2: init %i16 = initialize_from %.loc8_13.2 to %.loc8_19.1 [concrete = constants.%int_1.f90]
-// CHECK:STDOUT:   %addr.loc8_19.1: %ptr.251 = addr_of %.loc8_19.1
-// CHECK:STDOUT:   %foo__carbon_thunk.call: init %empty_tuple.type = call imports.%foo__carbon_thunk.decl(%addr.loc8_19.1)
-// CHECK:STDOUT:   %T.as.Destroy.impl.Op.bound: <bound method> = bound_method %.loc8_19.1, constants.%T.as.Destroy.impl.Op.507
+// CHECK:STDOUT:   %bound_method.loc7_13.2: <bound method> = bound_method %int_1, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call: init %i16 = call %bound_method.loc7_13.2(%int_1) [concrete = constants.%int_1.f90]
+// CHECK:STDOUT:   %.loc7_13.1: %i16 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call [concrete = constants.%int_1.f90]
+// CHECK:STDOUT:   %.loc7_13.2: %i16 = converted %int_1, %.loc7_13.1 [concrete = constants.%int_1.f90]
+// CHECK:STDOUT:   %.loc7_19.1: ref %i16 = temporary_storage
+// CHECK:STDOUT:   %.loc7_19.2: init %i16 = initialize_from %.loc7_13.2 to %.loc7_19.1 [concrete = constants.%int_1.f90]
+// CHECK:STDOUT:   %addr.loc7_19.1: %ptr.251 = addr_of %.loc7_19.1
+// CHECK:STDOUT:   %foo__carbon_thunk.call: init %empty_tuple.type = call imports.%foo__carbon_thunk.decl(%addr.loc7_19.1)
+// CHECK:STDOUT:   %T.as.Destroy.impl.Op.bound: <bound method> = bound_method %.loc7_19.1, constants.%T.as.Destroy.impl.Op.507
 // CHECK:STDOUT:   %T.as.Destroy.impl.Op.specific_fn: <specific function> = specific_function constants.%T.as.Destroy.impl.Op.507, @T.as.Destroy.impl.Op(constants.%i16) [concrete = constants.%T.as.Destroy.impl.Op.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc8_19: <bound method> = bound_method %.loc8_19.1, %T.as.Destroy.impl.Op.specific_fn
-// CHECK:STDOUT:   %addr.loc8_19.2: %ptr.251 = addr_of %.loc8_19.1
-// CHECK:STDOUT:   %T.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method.loc8_19(%addr.loc8_19.2)
+// CHECK:STDOUT:   %bound_method.loc7_19: <bound method> = bound_method %.loc7_19.1, %T.as.Destroy.impl.Op.specific_fn
+// CHECK:STDOUT:   %addr.loc7_19.2: %ptr.251 = addr_of %.loc7_19.1
+// CHECK:STDOUT:   %T.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method.loc7_19(%addr.loc7_19.2)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
@@ -12,20 +12,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
 // CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
 // CHECK:STDOUT: | `-PointerType {{0x[a-f0-9]+}} 'char *'
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
-// CHECK:STDOUT: {{.*}}
 
 // --- thunk_required.h
 

--- a/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
@@ -4,6 +4,7 @@
 //
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
 // EXTRA-ARGS: --dump-cpp-ast
+// SET-CHECK-SUBSET
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -11,20 +12,20 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
 // CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __int128_t '__int128'
-// CHECK:STDOUT: | `-BuiltinType {{0x[a-f0-9]+}} '__int128'
-// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __uint128_t 'unsigned __int128'
-// CHECK:STDOUT: | `-BuiltinType {{0x[a-f0-9]+}} 'unsigned __int128'
-// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __NSConstantString '__NSConstantString_tag'
-// CHECK:STDOUT: | `-RecordType {{0x[a-f0-9]+}} '__NSConstantString_tag'
-// CHECK:STDOUT: |   `-CXXRecord {{0x[a-f0-9]+}} '__NSConstantString_tag'
-// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __builtin_ms_va_list 'char *'
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
 // CHECK:STDOUT: | `-PointerType {{0x[a-f0-9]+}} 'char *'
-// CHECK:STDOUT: |   `-BuiltinType {{0x[a-f0-9]+}} 'char'
-// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __builtin_va_list '__va_list_tag[1]'
-// CHECK:STDOUT: | `-ConstantArrayType {{0x[a-f0-9]+}} '__va_list_tag[1]' 1 {{}}
-// CHECK:STDOUT: |   `-RecordType {{0x[a-f0-9]+}} '__va_list_tag'
-// CHECK:STDOUT: |     `-CXXRecord {{0x[a-f0-9]+}} '__va_list_tag'
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
+// CHECK:STDOUT: {{.*}}
 
 // --- thunk_required.h
 

--- a/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
@@ -10,39 +10,39 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
-// CHECK:STDOUT: TranslationUnitDecl <ID> <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __int128_t '__int128'
-// CHECK:STDOUT: | `-BuiltinType <ID> '__int128'
-// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __uint128_t 'unsigned __int128'
-// CHECK:STDOUT: | `-BuiltinType <ID> 'unsigned __int128'
-// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __NSConstantString '__NSConstantString_tag'
-// CHECK:STDOUT: | `-RecordType <ID> '__NSConstantString_tag'
-// CHECK:STDOUT: |   `-CXXRecord <ID> '__NSConstantString_tag'
-// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __builtin_ms_va_list 'char *'
-// CHECK:STDOUT: | `-PointerType <ID> 'char *'
-// CHECK:STDOUT: |   `-BuiltinType <ID> 'char'
-// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __builtin_va_list '__va_list_tag[1]'
-// CHECK:STDOUT: | `-ConstantArrayType <ID> '__va_list_tag[1]' 1 {{}}
-// CHECK:STDOUT: |   `-RecordType <ID> '__va_list_tag'
-// CHECK:STDOUT: |     `-CXXRecord <ID> '__va_list_tag'
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __int128_t '__int128'
+// CHECK:STDOUT: | `-BuiltinType {{0x[a-f0-9]+}} '__int128'
+// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __uint128_t 'unsigned __int128'
+// CHECK:STDOUT: | `-BuiltinType {{0x[a-f0-9]+}} 'unsigned __int128'
+// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __NSConstantString '__NSConstantString_tag'
+// CHECK:STDOUT: | `-RecordType {{0x[a-f0-9]+}} '__NSConstantString_tag'
+// CHECK:STDOUT: |   `-CXXRecord {{0x[a-f0-9]+}} '__NSConstantString_tag'
+// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __builtin_ms_va_list 'char *'
+// CHECK:STDOUT: | `-PointerType {{0x[a-f0-9]+}} 'char *'
+// CHECK:STDOUT: |   `-BuiltinType {{0x[a-f0-9]+}} 'char'
+// CHECK:STDOUT: |-TypedefDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit __builtin_va_list '__va_list_tag[1]'
+// CHECK:STDOUT: | `-ConstantArrayType {{0x[a-f0-9]+}} '__va_list_tag[1]' 1 {{}}
+// CHECK:STDOUT: |   `-RecordType {{0x[a-f0-9]+}} '__va_list_tag'
+// CHECK:STDOUT: |     `-CXXRecord {{0x[a-f0-9]+}} '__va_list_tag'
 
 // --- thunk_required.h
 
 auto foo(short a) -> void;
-// CHECK:STDOUT: |-FunctionDecl <ID> <./thunk_required.h:[[@LINE-1]]:1, col:22> col:6 used foo 'auto (short) -> void'
-// CHECK:STDOUT: | `-ParmVarDecl <ID> <col:10, col:16> col:16 a 'short'
-// CHECK:STDOUT: `-FunctionDecl <ID> <col:6> col:6 foo__carbon_thunk 'auto (short * _Nonnull) -> void' extern
-// CHECK:STDOUT:   |-ParmVarDecl <ID> <col:6> col:6 used a 'short * _Nonnull':'short *'
-// CHECK:STDOUT:   |-ReturnStmt <ID> <col:6>
-// CHECK:STDOUT:   | `-CallExpr <ID> <col:6> 'void'
-// CHECK:STDOUT:   |   |-ImplicitCastExpr <ID> <col:6> 'auto (*)(short) -> void' <FunctionToPointerDecay>
-// CHECK:STDOUT:   |   | `-DeclRefExpr <ID> <col:6> 'auto (short) -> void' Function <ID> 'foo' 'auto (short) -> void'
-// CHECK:STDOUT:   |   `-ImplicitCastExpr <ID> <col:6> 'short' <LValueToRValue>
-// CHECK:STDOUT:   |     `-UnaryOperator <ID> <col:6> 'short' lvalue prefix '*' cannot overflow
-// CHECK:STDOUT:   |       `-ImplicitCastExpr <ID> <col:6> 'short * _Nonnull':'short *' <LValueToRValue>
-// CHECK:STDOUT:   |         `-DeclRefExpr <ID> <col:6> 'short * _Nonnull':'short *' lvalue ParmVar <ID> 'a' 'short * _Nonnull':'short *'
-// CHECK:STDOUT:   |-AlwaysInlineAttr <ID> <<invalid sloc>> Implicit always_inline
-// CHECK:STDOUT:   `-AsmLabelAttr <ID> <col:6> Implicit "_Z3foos.carbon_thunk"
+// CHECK:STDOUT: |-FunctionDecl {{0x[a-f0-9]+}} <./thunk_required.h:[[@LINE-1]]:1, col:22> col:6 used foo 'auto (short) -> void'
+// CHECK:STDOUT: | `-ParmVarDecl {{0x[a-f0-9]+}} <col:10, col:16> col:16 a 'short'
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <col:6> col:6 foo__carbon_thunk 'auto (short * _Nonnull) -> void' extern
+// CHECK:STDOUT:   |-ParmVarDecl {{0x[a-f0-9]+}} <col:6> col:6 used a 'short * _Nonnull':'short *'
+// CHECK:STDOUT:   |-ReturnStmt {{0x[a-f0-9]+}} <col:6>
+// CHECK:STDOUT:   | `-CallExpr {{0x[a-f0-9]+}} <col:6> 'void'
+// CHECK:STDOUT:   |   |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:6> 'auto (*)(short) -> void' <FunctionToPointerDecay>
+// CHECK:STDOUT:   |   | `-DeclRefExpr {{0x[a-f0-9]+}} <col:6> 'auto (short) -> void' Function {{0x[a-f0-9]+}} 'foo' 'auto (short) -> void'
+// CHECK:STDOUT:   |   `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:6> 'short' <LValueToRValue>
+// CHECK:STDOUT:   |     `-UnaryOperator {{0x[a-f0-9]+}} <col:6> 'short' lvalue prefix '*' cannot overflow
+// CHECK:STDOUT:   |       `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:6> 'short * _Nonnull':'short *' <LValueToRValue>
+// CHECK:STDOUT:   |         `-DeclRefExpr {{0x[a-f0-9]+}} <col:6> 'short * _Nonnull':'short *' lvalue ParmVar {{0x[a-f0-9]+}} 'a' 'short * _Nonnull':'short *'
+// CHECK:STDOUT:   |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
+// CHECK:STDOUT:   `-AsmLabelAttr {{0x[a-f0-9]+}} <col:6> Implicit "_Z3foos.carbon_thunk"
 
 // --- import_thunk_required.carbon
 

--- a/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
@@ -12,7 +12,6 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
 // CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: | `-PointerType {{0x[a-f0-9]+}} 'char *'
 
 // --- thunk_required.h
 

--- a/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
@@ -1,0 +1,55 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+// EXTRA-ARGS: --dump-cpp-ast
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+// CHECK:STDOUT: TranslationUnitDecl <ID> <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __int128_t '__int128'
+// CHECK:STDOUT: | `-BuiltinType <ID> '__int128'
+// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __uint128_t 'unsigned __int128'
+// CHECK:STDOUT: | `-BuiltinType <ID> 'unsigned __int128'
+// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __NSConstantString '__NSConstantString_tag'
+// CHECK:STDOUT: | `-RecordType <ID> '__NSConstantString_tag'
+// CHECK:STDOUT: |   `-CXXRecord <ID> '__NSConstantString_tag'
+// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __builtin_ms_va_list 'char *'
+// CHECK:STDOUT: | `-PointerType <ID> 'char *'
+// CHECK:STDOUT: |   `-BuiltinType <ID> 'char'
+// CHECK:STDOUT: |-TypedefDecl <ID> <<invalid sloc>> <invalid sloc> implicit __builtin_va_list '__va_list_tag[1]'
+// CHECK:STDOUT: | `-ConstantArrayType <ID> '__va_list_tag[1]' 1 {{}}
+// CHECK:STDOUT: |   `-RecordType <ID> '__va_list_tag'
+// CHECK:STDOUT: |     `-CXXRecord <ID> '__va_list_tag'
+
+// --- thunk_required.h
+
+auto foo(short a) -> void;
+// CHECK:STDOUT: |-FunctionDecl <ID> <./thunk_required.h:[[@LINE-1]]:1, col:22> col:6 used foo 'auto (short) -> void'
+// CHECK:STDOUT: | `-ParmVarDecl <ID> <col:10, col:16> col:16 a 'short'
+// CHECK:STDOUT: `-FunctionDecl <ID> <col:6> col:6 foo__carbon_thunk 'auto (short * _Nonnull) -> void' extern
+// CHECK:STDOUT:   |-ParmVarDecl <ID> <col:6> col:6 used a 'short * _Nonnull':'short *'
+// CHECK:STDOUT:   |-ReturnStmt <ID> <col:6>
+// CHECK:STDOUT:   | `-CallExpr <ID> <col:6> 'void'
+// CHECK:STDOUT:   |   |-ImplicitCastExpr <ID> <col:6> 'auto (*)(short) -> void' <FunctionToPointerDecay>
+// CHECK:STDOUT:   |   | `-DeclRefExpr <ID> <col:6> 'auto (short) -> void' Function <ID> 'foo' 'auto (short) -> void'
+// CHECK:STDOUT:   |   `-ImplicitCastExpr <ID> <col:6> 'short' <LValueToRValue>
+// CHECK:STDOUT:   |     `-UnaryOperator <ID> <col:6> 'short' lvalue prefix '*' cannot overflow
+// CHECK:STDOUT:   |       `-ImplicitCastExpr <ID> <col:6> 'short * _Nonnull':'short *' <LValueToRValue>
+// CHECK:STDOUT:   |         `-DeclRefExpr <ID> <col:6> 'short * _Nonnull':'short *' lvalue ParmVar <ID> 'a' 'short * _Nonnull':'short *'
+// CHECK:STDOUT:   |-AlwaysInlineAttr <ID> <<invalid sloc>> Implicit always_inline
+// CHECK:STDOUT:   `-AsmLabelAttr <ID> <col:6> Implicit "_Z3foos.carbon_thunk"
+
+// --- import_thunk_required.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "thunk_required.h";
+
+fn F() {
+  Cpp.foo(1 as i16);
+}

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -208,6 +208,14 @@ Dump the full SemIR to stdout when built.
 )""",
       },
       [&](auto& arg_b) { arg_b.Set(&dump_sem_ir); });
+  b.AddFlag(
+      {
+          .name = "dump-cpp-ast",
+          .help = R"""(
+Dump the full C++ AST to stdout when built.
+)""",
+      },
+      [&](auto& arg_b) { arg_b.Set(&dump_cpp_ast); });
 
   b.AddOneOfOption(
       {
@@ -396,6 +404,11 @@ auto CompileSubcommand::ValidateOptions(
     case Phase::Parse:
       if (options_.dump_sem_ir) {
         emitter.Emit(CompilePhaseFlagConflict, "SemIR",
+                     PhaseToString(options_.phase));
+        return false;
+      }
+      if (options_.dump_cpp_ast) {
+        emitter.Emit(CompilePhaseFlagConflict, "C++ AST",
                      PhaseToString(options_.phase));
         return false;
       }
@@ -1015,10 +1028,14 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   options.gen_implicit_type_impls = options_.gen_implicit_type_impls;
   options.vlog_stream = driver_env.vlog_stream;
   options.fuzzing = driver_env.fuzzing;
-  if (options.vlog_stream || options_.dump_sem_ir || options_.dump_raw_sem_ir) {
+  if (options.vlog_stream || options_.dump_sem_ir || options_.dump_cpp_ast ||
+      options_.dump_raw_sem_ir) {
     options.include_in_dumps = &cache.include_in_dumps();
     if (options_.dump_sem_ir) {
       options.dump_stream = driver_env.output_stream;
+    }
+    if (options_.dump_cpp_ast) {
+      options.dump_cpp_ast_stream = driver_env.output_stream;
     }
     if (options.vlog_stream || options_.dump_sem_ir) {
       options.dump_sem_ir_ranges = options_.dump_sem_ir_ranges;

--- a/toolchain/driver/compile_subcommand.h
+++ b/toolchain/driver/compile_subcommand.h
@@ -52,6 +52,7 @@ struct CompileOptions {
   bool dump_parse_tree = false;
   bool dump_raw_sem_ir = false;
   bool dump_sem_ir = false;
+  bool dump_cpp_ast = false;
   bool dump_llvm_ir = false;
   bool dump_asm = false;
   bool dump_mem_usage = false;

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -263,6 +263,31 @@ auto ToolchainFileTest::GetLineNumberReplacements(
   return replacements;
 }
 
+// For Clang AST dump lines, we remove references to builtins because they're
+// inconsistent between systems and replace the ids since they're inconsistent
+// between runs.
+static auto DoClangASTCheckReplacements(std::string& check_line) -> void {
+  static constexpr llvm::StringRef ClangDeclIdRegex = "0x[a-f0-9]+";
+  static const RE2 is_clang_ast_line_re(
+      R"(^// CHECK:STDOUT: (TranslationUnitDecl|[ |]*`?\-))");
+  if (!RE2::PartialMatch(check_line, is_clang_ast_line_re)) {
+    return;
+  }
+
+  // Filter out references to builtins.
+  static const RE2 is_builtin_referring_re(R"(`-BuiltinType |[ ']__[a-zA-Z])");
+  if (RE2::PartialMatch(check_line, is_builtin_referring_re)) {
+    check_line = "// CHECK:STDOUT: {{.*}}";
+    return;
+  }
+
+  // Replace the ids.
+  static const RE2 clang_decl_id_re(llvm::formatv(" {0} ", ClangDeclIdRegex));
+  static const std::string& clang_decl_id_replacement =
+      *new std::string(llvm::formatv(" {{{{{0}}} ", ClangDeclIdRegex));
+  RE2::GlobalReplace(&check_line, clang_decl_id_re, clang_decl_id_replacement);
+}
+
 auto ToolchainFileTest::DoExtraCheckReplacements(std::string& check_line) const
     -> void {
   if (component_ == "driver") {
@@ -287,19 +312,7 @@ auto ToolchainFileTest::DoExtraCheckReplacements(std::string& check_line) const
     absl::StrReplaceAll({{data_->installation.core_package(), "{{.*}}"}},
                         &check_line);
     if (component_ == "check") {
-      // For Clang AST dump lines, we replace the ids since they're inconsistent
-      // between runs.
-      static constexpr llvm::StringRef ClangDeclIdRegex = "0x[a-f0-9]+";
-      static const RE2 is_clang_ast_line_re(
-          R"(^// CHECK:STDOUT: (TranslationUnitDecl|[ |]*`?\-))");
-      if (RE2::PartialMatch(check_line, is_clang_ast_line_re)) {
-        static const RE2 clang_decl_id_re(
-            llvm::formatv(" {0} ", ClangDeclIdRegex));
-        static const std::string& clang_decl_id_replacement =
-            *new std::string(llvm::formatv(" {{{{{0}}} ", ClangDeclIdRegex));
-        RE2::GlobalReplace(&check_line, clang_decl_id_re,
-                           clang_decl_id_replacement);
-      }
+      DoClangASTCheckReplacements(check_line);
     }
   } else {
     FileTestBase::DoExtraCheckReplacements(check_line);

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -289,11 +289,15 @@ auto ToolchainFileTest::DoExtraCheckReplacements(std::string& check_line) const
     if (component_ == "check") {
       // For Clang AST dump lines, we replace the ids since they're inconsistent
       // between runs.
-      static RE2 is_clang_ast_line_re(
+      static constexpr llvm::StringRef ClangDeclIdRegex = "0x[a-f0-9]+";
+      static const RE2 is_clang_ast_line_re(
           R"(^// CHECK:STDOUT: (TranslationUnitDecl|[ |]*`?\-))");
       if (RE2::PartialMatch(check_line, is_clang_ast_line_re)) {
-        static RE2 clang_decl_id_re(R"( 0x[a-f0-9]+ )");
-        RE2::GlobalReplace(&check_line, clang_decl_id_re, " {{0x[a-f0-9]+}} ");
+        static const RE2 clang_decl_id_re(
+            llvm::formatv(" {0} ", ClangDeclIdRegex));
+        RE2::GlobalReplace(
+            &check_line, clang_decl_id_re,
+            llvm::formatv(" {{{{{0}}} ", ClangDeclIdRegex).str());
       }
     }
   } else {

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -293,7 +293,7 @@ auto ToolchainFileTest::DoExtraCheckReplacements(std::string& check_line) const
           R"(^// CHECK:STDOUT: (TranslationUnitDecl|[ |]*`?\-))");
       if (RE2::PartialMatch(check_line, is_clang_ast_line_re)) {
         static RE2 clang_decl_id_re(R"( 0x[a-f0-9]+ )");
-        RE2::GlobalReplace(&check_line, clang_decl_id_re, " <ID> ");
+        RE2::GlobalReplace(&check_line, clang_decl_id_re, " {{0x[a-f0-9]+}} ");
       }
     }
   } else {

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -286,6 +286,16 @@ auto ToolchainFileTest::DoExtraCheckReplacements(std::string& check_line) const
     // package to the VFS with a fixed name.
     absl::StrReplaceAll({{data_->installation.core_package(), "{{.*}}"}},
                         &check_line);
+    if (component_ == "check") {
+      // For Clang AST dump lines, we replace the ids since they're inconsistent
+      // between runs.
+      static RE2 is_clang_ast_line_re(
+          R"(^// CHECK:STDOUT: (TranslationUnitDecl|[ |]*`?\-))");
+      if (RE2::PartialMatch(check_line, is_clang_ast_line_re)) {
+        static RE2 clang_decl_id_re(R"( 0x[a-f0-9]+ )");
+        RE2::GlobalReplace(&check_line, clang_decl_id_re, " <ID> ");
+      }
+    }
   } else {
     FileTestBase::DoExtraCheckReplacements(check_line);
   }

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -277,7 +277,7 @@ static auto DoClangASTCheckReplacements(std::string& check_line) -> void {
   // Filter out references to builtins.
   static const RE2 is_builtin_referring_re(R"(`-BuiltinType |[ ']__[a-zA-Z])");
   if (RE2::PartialMatch(check_line, is_builtin_referring_re)) {
-    check_line = "// CHECK:STDOUT: {{.*}}";
+    check_line.clear();
     return;
   }
 

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -275,7 +275,8 @@ static auto DoClangASTCheckReplacements(std::string& check_line) -> void {
   }
 
   // Filter out references to builtins.
-  static const RE2 is_builtin_referring_re(R"(`-BuiltinType |[ ']__[a-zA-Z])");
+  static const RE2 is_builtin_referring_re(
+      R"(`-BuiltinType |[ ']__[a-zA-Z]|\| `\-PointerType 0x[a-f0-9]+ 'char \*'$)");
   if (RE2::PartialMatch(check_line, is_builtin_referring_re)) {
     check_line.clear();
     return;

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -295,9 +295,10 @@ auto ToolchainFileTest::DoExtraCheckReplacements(std::string& check_line) const
       if (RE2::PartialMatch(check_line, is_clang_ast_line_re)) {
         static const RE2 clang_decl_id_re(
             llvm::formatv(" {0} ", ClangDeclIdRegex));
-        RE2::GlobalReplace(
-            &check_line, clang_decl_id_re,
-            llvm::formatv(" {{{{{0}}} ", ClangDeclIdRegex).str());
+        static const std::string& clang_decl_id_replacement =
+            *new std::string(llvm::formatv(" {{{{{0}}} ", ClangDeclIdRegex));
+        RE2::GlobalReplace(&check_line, clang_decl_id_re,
+                           clang_decl_id_replacement);
       }
     }
   } else {


### PR DESCRIPTION
Use it to dump the AST that includes a generated C++ thunk.
Based on #5917.

Also added printing of the full actual text when check fails to make debugging easier.
Changed line replacement to allow removing complete lines.

Part of #5514.