### PR TITLE
Avoid `readability-function-size` clang-tidy checks on `Stringify()`

### DIFF
--- a/toolchain/sem_ir/stringify.cpp
+++ b/toolchain/sem_ir/stringify.cpp
@@ -669,6 +669,7 @@ class Stringifier {
 
 }  // namespace
 
+// NOLINTNEXTLINE(readability-function-size)
 static auto Stringify(const File& sem_ir, StepStack& step_stack)
     -> std::string {
   RawStringOstream out;


### PR DESCRIPTION
This currently triggers due to preprocessing.