### PR TITLE
Allow dumping with a Parse::Context

### DIFF
--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -121,6 +121,7 @@ cc_library(
     srcs = ["dump.cpp"],
     hdrs = ["dump.h"],
     deps = [
+        ":context",
         ":tree",
         "//common:ostream",
         "//common:raw_string_ostream",

--- a/toolchain/parse/dump.cpp
+++ b/toolchain/parse/dump.cpp
@@ -10,6 +10,7 @@
 
 #include "common/raw_string_ostream.h"
 #include "toolchain/lex/dump.h"
+#include "toolchain/parse/context.h"
 
 namespace Carbon::Parse {
 
@@ -31,6 +32,16 @@ LLVM_DUMP_METHOD auto Dump(const Tree& tree, NodeId node_id) -> std::string {
   out << "NodeId(kind: " << kind
       << ", token: " << Lex::Dump(tree.tokens(), token) << ")";
   return out.TakeStr();
+}
+
+static LLVM_DUMP_METHOD auto Dump(const Context& context, Lex::TokenIndex token)
+    -> std::string {
+  return Dump(context.tree(), token);
+}
+
+static LLVM_DUMP_METHOD auto Dump(const Context& context, NodeId node_id)
+    -> std::string {
+  return Dump(context.tree(), node_id);
 }
 
 }  // namespace Carbon::Parse


### PR DESCRIPTION
Don't make the debugging user have to get the `.tree()` off of the context (which takes a bit of work to find).