### PR TITLE
Give ScopeStack::LookupOrAddName a callback to call if the name doesn't exist

### DIFF
--- a/toolchain/check/facet_type.cpp
+++ b/toolchain/check/facet_type.cpp
@@ -616,23 +616,23 @@ auto ResolveFacetTypeRewriteConstraints(
 
 auto MakePeriodSelfFacetValue(Context& context, SemIR::TypeId self_type_id)
     -> SemIR::InstId {
-  auto entity_name_id = context.entity_names().AddCanonical({
-      .name_id = SemIR::NameId::PeriodSelf,
-      .parent_scope_id = context.scope_stack().PeekNameScopeId(),
-  });
-  auto inst_id = AddInst(
-      context, SemIR::LocIdAndInst::NoLoc<SemIR::BindSymbolicName>({
-                   .type_id = self_type_id,
-                   .entity_name_id = entity_name_id,
-                   // `None` because there is no equivalent non-symbolic value.
-                   .value_id = SemIR::InstId::None,
-               }));
-  // TODO: LookupOrAddName should (optionally?) take a callback to run and
-  // construct the `inst_id` only if it's not found by lookup.
-  auto existing =
-      context.scope_stack().LookupOrAddName(SemIR::NameId::PeriodSelf, inst_id);
-  // Shouldn't have any names in newly created scope.
-  CARBON_CHECK(!existing.has_value());
+  auto [added, inst_id] =
+      context.scope_stack().LookupOrAddNameWith(SemIR::NameId::PeriodSelf, [&] {
+        auto entity_name_id = context.entity_names().AddCanonical({
+            .name_id = SemIR::NameId::PeriodSelf,
+            .parent_scope_id = context.scope_stack().PeekNameScopeId(),
+        });
+        return AddInst(
+            context,
+            SemIR::LocIdAndInst::NoLoc<SemIR::BindSymbolicName>({
+                .type_id = self_type_id,
+                .entity_name_id = entity_name_id,
+                // `None` because there is no equivalent non-symbolic value.
+                .value_id = SemIR::InstId::None,
+            }));
+      });
+  // Should always have a fresh scope to add `.Self` into.
+  CARBON_CHECK(added);
   return inst_id;
 }
 

--- a/toolchain/check/facet_type.h
+++ b/toolchain/check/facet_type.h
@@ -100,6 +100,9 @@ auto ResolveFacetTypeRewriteConstraints(
 //
 // The `self_type_id` is either a facet type (as `FacetType`) or `type` (as
 // `TypeType`).
+//
+// It is required that `.Self` is not already a name in scope, which usually
+// means making a fresh scope with `ScopeStack::PushForSameRegion()` first.
 auto MakePeriodSelfFacetValue(Context& context, SemIR::TypeId self_type_id)
     -> SemIR::InstId;
 

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -20,13 +20,13 @@ namespace Carbon::Check {
 
 auto AddNameToLookup(Context& context, SemIR::NameId name_id,
                      SemIR::InstId target_id, ScopeIndex scope_index) -> void {
-  if (auto existing = context.scope_stack().LookupOrAddName(name_id, target_id,
-                                                            scope_index);
-      existing.has_value()) {
+  auto [added, inst_id] = context.scope_stack().LookupOrAddNameWith(
+      name_id, [=] { return target_id; }, scope_index);
+  if (!added) {
     // TODO: Add coverage to this use case and use the location of the name
     // instead of the target.
     DiagnoseDuplicateName(context, name_id, SemIR::LocId(target_id),
-                          SemIR::LocId(existing));
+                          SemIR::LocId(inst_id));
   }
 }
 

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -442,18 +442,18 @@ auto MatchContext::DoEmitPatternMatch(
     Context& context, SemIR::ReturnSlotPattern return_slot_pattern,
     SemIR::InstId pattern_inst_id, WorkItem entry) -> void {
   CARBON_CHECK(kind_ == MatchKind::Callee);
-  auto type_id =
-      ExtractScrutineeType(context.sem_ir(), return_slot_pattern.type_id);
-  auto return_slot_id = AddInst<SemIR::ReturnSlot>(
-      context, SemIR::LocId(pattern_inst_id),
-      {.type_id = type_id,
-       .type_inst_id = context.types().GetInstId(type_id),
-       .storage_id = entry.scrutinee_id});
-  bool already_in_lookup =
-      context.scope_stack()
-          .LookupOrAddName(SemIR::NameId::ReturnSlot, return_slot_id)
-          .has_value();
-  CARBON_CHECK(!already_in_lookup);
+  auto [added, _] =
+      context.scope_stack().LookupOrAddNameWith(SemIR::NameId::ReturnSlot, [&] {
+        auto type_id =
+            ExtractScrutineeType(context.sem_ir(), return_slot_pattern.type_id);
+        auto return_slot_id = AddInst<SemIR::ReturnSlot>(
+            context, SemIR::LocId(pattern_inst_id),
+            {.type_id = type_id,
+             .type_inst_id = context.types().GetInstId(type_id),
+             .storage_id = entry.scrutinee_id});
+        return return_slot_id;
+      });
+  CARBON_CHECK(added);
 }
 
 auto MatchContext::DoEmitPatternMatch(Context& context,

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -195,8 +195,10 @@ auto ScopeStack::LookupInLexicalScopes(SemIR::NameId name_id)
       llvm::ArrayRef(first_non_lexical_scope, non_lexical_scope_stack_.end())};
 }
 
-auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
-                                 ScopeIndex scope_index) -> SemIR::InstId {
+auto ScopeStack::LookupOrAddNameWith(
+    SemIR::NameId name_id,
+    llvm::function_ref<auto()->SemIR::InstId> make_target_inst_id,
+    ScopeIndex scope_index) -> std::pair<bool, SemIR::InstId> {
   // Find the corresponding scope depth.
   //
   // TODO: Consider passing in the depth rather than performing a scan for it.
@@ -222,7 +224,7 @@ auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
   auto& lexical_results = lexical_lookup_.Get(name_id);
   if (!lexical_results.empty() &&
       lexical_results.back().scope_index >= scope_index) {
-    return lexical_results.back().inst_id;
+    return {false, lexical_results.back().inst_id};
   }
 
   // Add the name into the scope.
@@ -231,8 +233,10 @@ auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
   ++scope_stack_[scope_depth].num_names;
 
   // Add a corresponding lexical lookup result.
-  lexical_results.push_back({.inst_id = target_id, .scope_index = scope_index});
-  return SemIR::InstId::None;
+  auto target_inst_id = make_target_inst_id();
+  lexical_results.push_back(
+      {.inst_id = target_inst_id, .scope_index = scope_index});
+  return {true, target_inst_id};
 }
 
 auto ScopeStack::SetReturnedVarOrGetExisting(SemIR::InstId inst_id)

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -5,6 +5,9 @@
 #ifndef CARBON_TOOLCHAIN_CHECK_SCOPE_STACK_H_
 #define CARBON_TOOLCHAIN_CHECK_SCOPE_STACK_H_
 
+#include <concepts>
+#include <type_traits>
+
 #include "common/array_stack.h"
 #include "common/move_only.h"
 #include "common/set.h"
@@ -145,12 +148,15 @@ class ScopeStack {
       -> std::pair<SemIR::InstId, llvm::ArrayRef<NonLexicalScope>>;
 
   // Looks up the name `name_id` in the current scope, or in `scope_index` if
-  // specified. Returns the existing instruction if the name is already declared
-  // in that scope or any unfinished scope within it, and otherwise adds the
-  // name with the value `target_id` and returns `None`.
-  auto LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
-                       ScopeIndex scope_index = ScopeIndex::None)
-      -> SemIR::InstId;
+  // specified. Returns `false` with the existing instruction if the name is
+  // already declared in that scope or any unfinished scope within it, and
+  // otherwise calls `make_target_inst_id` to generate an `InstId`, adds the
+  // name with that `InstId` and returns `true` along with it.
+  auto LookupOrAddNameWith(
+      SemIR::NameId name_id,
+      llvm::function_ref<auto()->SemIR::InstId> make_target_inst_id,
+      ScopeIndex scope_index = ScopeIndex::None)
+      -> std::pair<bool /*added*/, SemIR::InstId>;
 
   // Prepares to add a compile-time binding in the current scope, and returns
   // its index. The added binding must then be pushed using


### PR DESCRIPTION
Rather than requiring the caller to construct the `inst_id` speculatively, allow the caller to lazily construct it if the name does not yet exist. Since it will be constructed in a lambda, include it in the return value unconditionally, and return a bool indicating if the name and inst id were newly added or not.

All callers of LookupOrAddName that construct the InstId locally have CHECKs that show they expect to to always construct it anyways, so this doesn't change any SemIR results.