### PR TITLE
Follow-up fixes to filesystem code

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -261,7 +261,12 @@ sh_test(
     name = "filesystem_benchmark_test",
     size = "small",
     srcs = [":filesystem_benchmark"],
-    args = ["--benchmark_min_time=1x"],
+    args = [
+        "--benchmark_min_time=1x",
+        # Restrict the sizes to 4-digit ones or smaller to keep test times low.
+        # The `$$` is repeated for Bazel escaping of `$`.
+        "--benchmark_filter=^[^/]+(/[0-9]{1,4}(/[0-9]+)?)?/real_time$$",
+    ],
 )
 
 cc_library(

--- a/common/filesystem_benchmark.cpp
+++ b/common/filesystem_benchmark.cpp
@@ -71,7 +71,7 @@ struct BenchContext {
   std::array<std::filesystem::path, NumFiles> file_paths;
   std::array<std::filesystem::path, NumFiles> missing_paths;
 
-  BenchContext() : tmpdir(std::move(*MakeTmpDir())) {
+  BenchContext() : tmpdir(*MakeTmpDir()) {
     for (int i : llvm::seq(NumFiles)) {
       file_paths[i] = llvm::formatv("file_{0}", i).str();
       auto result = tmpdir.WriteFileFromString(file_paths[i], Text);

--- a/common/filesystem_test.cpp
+++ b/common/filesystem_test.cpp
@@ -45,11 +45,11 @@ TEST_F(FilesystemTest, CreateOpenCloseAndUnlink) {
   auto unlink_result = dir_.Unlink("test");
   ASSERT_FALSE(unlink_result.ok());
   EXPECT_TRUE(unlink_result.error().no_entity());
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 32))
   EXPECT_THAT(unlink_result, IsError(HasSubstr("ENOENT")));
-#elif defined(__APPLE__) || defined(_POSIX_SOURCE)
-  EXPECT_THAT(unlink_result, IsError(HasSubstr("No such file")));
 #endif
+  EXPECT_THAT(unlink_result, IsError(HasSubstr("No such file")));
 
   auto f = dir_.OpenWriteOnly("test", CreationOptions::CreateNew);
   ASSERT_THAT(f, IsSuccess(_));
@@ -59,11 +59,11 @@ TEST_F(FilesystemTest, CreateOpenCloseAndUnlink) {
   f = dir_.OpenWriteOnly("test", CreationOptions::CreateNew);
   ASSERT_FALSE(f.ok());
   EXPECT_TRUE(f.error().already_exists());
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 32))
   EXPECT_THAT(f, IsError(HasSubstr("EEXIST")));
-#elif defined(__APPLE__) || defined(_POSIX_SOURCE)
-  EXPECT_THAT(f, IsError(HasSubstr("File exists")));
 #endif
+  EXPECT_THAT(f, IsError(HasSubstr("File exists")));
 
   f = dir_.OpenWriteOnly("test");
   ASSERT_THAT(f, IsSuccess(_));
@@ -81,11 +81,11 @@ TEST_F(FilesystemTest, CreateOpenCloseAndUnlink) {
   f = dir_.OpenWriteOnly("test");
   EXPECT_FALSE(f.ok());
   EXPECT_TRUE(f.error().no_entity());
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 32))
   EXPECT_THAT(f, IsError(HasSubstr("ENOENT")));
-#elif defined(__APPLE__) || defined(_POSIX_SOURCE)
-  EXPECT_THAT(f, IsError(HasSubstr("No such file")));
 #endif
+  EXPECT_THAT(f, IsError(HasSubstr("No such file")));
 
   f = dir_.OpenWriteOnly("test", CreationOptions::OpenAlways);
   ASSERT_THAT(f, IsSuccess(_));


### PR DESCRIPTION
Tidies up extraneous move, unnecessary function style type cast, and simplifies the temporary directory string construction. These were noticed during another PR review.

Also corrects support for older glibc versions, including the GNU-specific quirks of `strerror_r`. Restricts the fancier formatting with the name of the error number to when a recent glibc is available.

Lastly, filters the benchmarks in the benchmark test down to smaller ones to avoid test timeout flakiness.