### PR TITLE
Update LLVM to head on 2025-08-01

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -103,20 +103,20 @@ bazel_dep(name = "zstd", version = "1.5.7", repo_name = "llvm_zstd")
 
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
-# HEAD as of 2025-05-28.
-llvm_project_version = "7b074fc9362a4a6a5f172dd8936a22fb25eff96b"
+# HEAD as of 2025-08-01.
+llvm_project_version = "6d4a0935c850ec3ddfc70c4ba97b98adc35c676e"
 
 # Load a repository for the raw llvm-project, pre-overlay.
 http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
+    integrity = "sha256-Adc3ltfGFMgJ/kZLS+sc+14nXoBee5he+QyX/iLwEVQ=",
     patch_args = ["-p1"],
     patches = [
         "@carbon//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",
         "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
         "@carbon//bazel/llvm_project:0003_Comment_out_unloaded_proto_library_dependencies.patch",
     ],
-    sha256 = "07f80f32e81ac5dc19c5e49830f6d4a2e6208adb7d875ac3d1e8d043a602d9e4",
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],
 )

--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -46,6 +46,9 @@ for dep in deps:
             "clang",
             "clang-tools-extra/clangd",
             "libunwind",
+            # While this is in a `third_party` directory, its code is documented
+            # as part of LLVM and for use in compiler-rt.
+            "third-party/siphash",
         ):
             sys.exit(
                 "ERROR: unexpected dependency into the LLVM project: %s" % dep

--- a/toolchain/lower/testdata/interop/cpp/thunk.carbon
+++ b/toolchain/lower/testdata/interop/cpp/thunk.carbon
@@ -392,7 +392,7 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
 // CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
 // CHECK:STDOUT:   call void @_ZN1YC1ERKS_(ptr nonnull align 4 dereferenceable(12) %agg.tmp, ptr nonnull align 4 dereferenceable(12) %1)
-// CHECK:STDOUT:   call void @_Z11pass_struct1Y(ptr %agg.tmp)
+// CHECK:STDOUT:   call void @_Z11pass_struct1Y(ptr dead_on_return %agg.tmp)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
This pulls in updated LLVM IR features in our thunk test, and needs us to adapt the dependency tests, but otherwise seems to work easily.