### PR TITLE
Tweak the name for the function that diagnoses when fuzzing external libraries

### DIFF
--- a/toolchain/driver/clang_subcommand.cpp
+++ b/toolchain/driver/clang_subcommand.cpp
@@ -52,7 +52,7 @@ auto ClangSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Don't run Clang when fuzzing, it is known to not be reliable under fuzzing
   // due to many unfixed issues.
-  if (!DisableFuzzingExternalLibraries(driver_env, "clang")) {
+  if (TestAndDiagnoseIfFuzzingExternalLibraries(driver_env, "clang")) {
     return {.success = false};
   }
 

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -923,7 +923,7 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
     if (driver_env.fuzzing && !options_.clang_args.empty()) {
       // Parsing specific Clang arguments can reach deep into
       // external libraries that aren't fuzz clean.
-      DisableFuzzingExternalLibraries(driver_env, "compile");
+      TestAndDiagnoseIfFuzzingExternalLibraries(driver_env, "compile");
       return {.success = false};
     }
     for (auto str : options_.clang_args) {

--- a/toolchain/driver/driver_subcommand.cpp
+++ b/toolchain/driver/driver_subcommand.cpp
@@ -10,12 +10,11 @@
 
 namespace Carbon {
 
-auto DriverSubcommand::DisableFuzzingExternalLibraries(DriverEnv& driver_env,
-                                                       llvm::StringRef name)
-    -> bool {
+auto DriverSubcommand::TestAndDiagnoseIfFuzzingExternalLibraries(
+    DriverEnv& driver_env, llvm::StringRef name) -> bool {
   // Only need to do anything when fuzzing.
   if (!driver_env.fuzzing) {
-    return true;
+    return false;
   }
 
   CARBON_DIAGNOSTIC(
@@ -23,7 +22,7 @@ auto DriverSubcommand::DisableFuzzingExternalLibraries(DriverEnv& driver_env,
       "preventing fuzzing of `{0}` subcommand due to external library",
       std::string);
   driver_env.emitter.Emit(ToolFuzzingDisallowed, name.str());
-  return false;
+  return true;
 }
 
 }  // namespace Carbon

--- a/toolchain/driver/driver_subcommand.h
+++ b/toolchain/driver/driver_subcommand.h
@@ -61,13 +61,13 @@ class DriverSubcommand {
   virtual auto Run(DriverEnv& driver_env) -> DriverResult = 0;
 
  protected:
-  // Diagnoses and returns false if currently fuzzing.
+  // Tests if fuzzing and if so diagnose and returns true.
   //
-  // This should be used in subcommands to check and diagnose rather than
+  // This should be used in subcommands to diagnose and exit early rather than
   // entering them during fuzzing when they use external libraries that we can't
   // keep fuzz-clean.
-  auto DisableFuzzingExternalLibraries(DriverEnv& driver_env,
-                                       llvm::StringRef name) -> bool;
+  auto TestAndDiagnoseIfFuzzingExternalLibraries(DriverEnv& driver_env,
+                                                 llvm::StringRef name) -> bool;
 
  private:
   // Subcommand information.

--- a/toolchain/driver/lld_subcommand.cpp
+++ b/toolchain/driver/lld_subcommand.cpp
@@ -95,7 +95,7 @@ auto LldSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Don't run LLD when fuzzing, as we're not currently in a good position to
   // debug and fix fuzzer-found bugs within LLD.
-  if (!DisableFuzzingExternalLibraries(driver_env, "lld")) {
+  if (TestAndDiagnoseIfFuzzingExternalLibraries(driver_env, "lld")) {
     return {.success = false};
   }
 

--- a/toolchain/driver/llvm_subcommand.cpp
+++ b/toolchain/driver/llvm_subcommand.cpp
@@ -63,7 +63,7 @@ auto LLVMSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   LLVMRunner runner(driver_env.installation, driver_env.vlog_stream);
 
   // Don't run arbitrary LLVM tools and libraries when fuzzing.
-  if (!DisableFuzzingExternalLibraries(driver_env, "llvm")) {
+  if (TestAndDiagnoseIfFuzzingExternalLibraries(driver_env, "llvm")) {
     return {.success = false};
   }
 


### PR DESCRIPTION
The old function name caused some confusion during the review of #5338, sending this to see if it provides a less surprising function name and boolean result. Happy to try other names / approaches as well.