### PR TITLE
Rework the `IsSuccess` matcher to be fully polymorphic

### DIFF
--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -19,6 +19,7 @@ using ::Carbon::Testing::IsError;
 using ::Carbon::Testing::IsSuccess;
 using ::testing::_;
 using ::testing::Eq;
+using ::testing::VariantWith;
 
 TEST(ErrorTest, Error) {
   Error err("test");
@@ -156,6 +157,17 @@ TYPED_TEST(ErrorOrTest, UnprintableValue) {
 
   TestErrorOr error = this->MakeError();
   EXPECT_THAT(error, IsError(this->ErrorStr()));
+}
+
+// Note that this is more of a test of `IsSuccess` than `ErrorOr` itself.
+TYPED_TEST(ErrorOrTest, NestedMatching) {
+  using TestErrorOr = ErrorOr<std::variant<int, float>, TypeParam>;
+
+  TestErrorOr i(42);
+  EXPECT_THAT(i, IsSuccess(VariantWith<int>(Eq(42))));
+
+  TestErrorOr f(0.42F);
+  EXPECT_THAT(f, IsSuccess(VariantWith<float>(Eq(0.42F))));
 }
 
 TYPED_TEST(ErrorOrTest, ReturnIfErrorNoError) {


### PR DESCRIPTION
Previously, this matcher mostly worked, but the `DescribeTo` functions wouldn't compile when another polymorphic matcher was nested to match the value.

The updated code uses the same polymorphic matcher design as used by `Not` and others in Google Test itself.

I've added a test that uses `VariantWith` to nest matchers more deeply with `IsSuccess`. This test doesn't compile prior to this change.