### PR TITLE
Fix a use of an imported InstId used where a local InstId is required

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1351,7 +1351,7 @@ static auto MakeAssociatedConstant(
       .name_id = GetLocalNameId(context, import_assoc_const.name_id),
       .parent_scope_id = SemIR::NameScopeId::None,
       .decl_id = assoc_const_decl_id,
-      .generic_id = MakeIncompleteGeneric(context, import_assoc_const.decl_id,
+      .generic_id = MakeIncompleteGeneric(context, assoc_const_decl_id,
                                           import_assoc_const.generic_id),
       .default_value_id =
           import_assoc_const.default_value_id.has_value()

--- a/toolchain/check/testdata/for/actual.carbon
+++ b/toolchain/check/testdata/for/actual.carbon
@@ -70,7 +70,6 @@ fn Read() {
 // CHECK:STDOUT:   %IntRange.Make.type.51f: type = fn_type @IntRange.Make, @IntRange(%N.c80) [symbolic]
 // CHECK:STDOUT:   %IntRange.Make.2ec: %IntRange.Make.type.51f = struct_value () [symbolic]
 // CHECK:STDOUT:   %Iterate.type: type = facet_type <@Iterate> [concrete]
-// CHECK:STDOUT:   %Self.a96: %Iterate.type = bind_symbolic_name Self, 0 [symbolic]
 // CHECK:STDOUT:   %.Self.ef1: %Iterate.type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %Iterate.assoc_type: type = assoc_entity_type @Iterate [concrete]
 // CHECK:STDOUT:   %assoc1.02e: %Iterate.assoc_type = assoc_entity element1, imports.%Core.import_ref.9e6 [concrete]
@@ -128,7 +127,6 @@ fn Read() {
 // CHECK:STDOUT:   %assoc0.8dc: %OrderedWith.assoc_type.d92 = assoc_entity element0, imports.%Core.import_ref.13d [symbolic]
 // CHECK:STDOUT:   %require_complete.0f5: <witness> = require_complete_type %ptr.784 [symbolic]
 // CHECK:STDOUT:   %Inc.type: type = facet_type <@Inc> [concrete]
-// CHECK:STDOUT:   %Iterate.facet.7f1: %Iterate.type = facet_value %.Self.as_type.935, (%Iterate.lookup_impl_witness.65a) [symbolic_self]
 // CHECK:STDOUT:   %assoc0.724: %Iterate.assoc_type = assoc_entity element0, imports.%Core.import_ref.4f9 [concrete]
 // CHECK:STDOUT:   %Iterate_where.type.fce: type = facet_type <@Iterate where %impl.elem1.164 = %Int.49d0e6.1 and %impl.elem0.19f = %Int.49d0e6.1> [symbolic]
 // CHECK:STDOUT:   %require_complete.d96: <witness> = require_complete_type %Iterate_where.type.fce [symbolic]
@@ -765,14 +763,6 @@ fn Read() {
 // CHECK:STDOUT:   %IntRange => constants.%IntRange.349
 // CHECK:STDOUT:   %pattern_type.loc5_49 => constants.%pattern_type.dcd
 // CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @CursorType(constants.%Self.a96) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @CursorType(constants.%Iterate.facet.7f1) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @ElementType(constants.%Self.a96) {}
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @ElementType(constants.%Iterate.facet.7f1) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @IntRange.as.Iterate.impl(constants.%N.c80) {
 // CHECK:STDOUT:   %N => constants.%N.c80


### PR DESCRIPTION
Found by WIP validation for this type of issue ongoing in #5997

I'm not entirely sure how the one test update falls out of this change -
but it is from the same test that I originally reduced the problem from,
which is reassuring.

The reduced test case I investigated the issue with was this:
`a.carbon`:
```
library "lib";
interface I1(Other:! type) {
   let Result:! type;
}
```
`b.carbon`:
```
import library "lib";
class T1 { }
impl T1 as I1(Self) where .Result = Self { }
```
The SemIR dump diff looked like this:
```
89c89
<   %Main.import_ref.b6f = import_ref Main//lib, inst28 [no loc], unloaded
---
>   %Main.import_ref.b6f = import_ref Main//lib, inst27 [no loc], unloaded
96c96
<   %Main.import_ref.f7b: @I1.%I1.type (%I1.type.e87) = import_ref Main//lib, inst28 [no loc], loaded [symbolic = @I1.%Self (constants.%Self.c47)]
---
>   %Main.import_ref.f7b: @I1.%I1.type (%I1.type.e87) = import_ref Main//lib, inst27 [no loc], loaded [symbolic = @I1.%Self (constants.%Self.c47)]
```
Which is a difference, but given the `inst28`/`inst27` don't appear
anywhere else than these two lines, it doesn't give a terribly
meaningful diff/story about what changed - but perhaps it's
sufficient...

Not sure if this test ^ is sufficiently more interesting than the diff
update already in this patch. If so, happy to add the above as a new
test case.

Open to ideas.
