### PR TITLE
Properly dump SemIR for inline C++ imports

### DIFF
--- a/toolchain/check/testdata/interop/cpp/inline.carbon
+++ b/toolchain/check/testdata/interop/cpp/inline.carbon
@@ -14,12 +14,14 @@
 
 library "[[@TEST_NAME]]";
 
+//@dump-sem-ir-begin
 import Cpp inline '''
 
 // A C++ function.
 inline void func() {}
 
 ''';
+//@dump-sem-ir-end
 
 fn Run() {
   //@dump-sem-ir-begin
@@ -31,12 +33,14 @@ fn Run() {
 
 library "[[@TEST_NAME]]";
 
+//@dump-sem-ir-begin
 import Cpp inline '''c++
 
 // A C++ function.
 inline void another_func() {}
 
 ''';
+//@dump-sem-ir-end
 
 fn Run() {
   //@dump-sem-ir-begin
@@ -58,6 +62,12 @@ fn Run() {
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %func.decl: %func.type = fn_decl @func [concrete = constants.%func] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %Cpp.import_cpp = import_cpp {
+// CHECK:STDOUT:     import Cpp inline
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -82,6 +92,12 @@ fn Run() {
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %another_func.decl: %another_func.type = fn_decl @another_func [concrete = constants.%another_func] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %Cpp.import_cpp = import_cpp {
+// CHECK:STDOUT:     import Cpp inline
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1210,10 +1210,16 @@ auto Formatter::FormatImportCppDeclRhs() -> void {
   OpenBrace();
   for (ImportCpp import_cpp : sem_ir_->import_cpps().values()) {
     Indent();
-    out_ << "import Cpp \""
-         << FormatEscaped(
-                sem_ir_->string_literal_values().Get(import_cpp.library_id))
-         << "\"\n";
+    out_ << "import Cpp ";
+    if (import_cpp.library_id.has_value()) {
+      out_ << "\""
+           << FormatEscaped(
+                  sem_ir_->string_literal_values().Get(import_cpp.library_id))
+           << "\"";
+    } else {
+      out_ << "inline";
+    }
+    out_ << "\n";
   }
   CloseBrace();
 }


### PR DESCRIPTION
Dumping SemIR crashed on inline C++ imports and this outputs `import Cpp inline` instead.
Followup of #5904.