### PR TITLE
Avoid python stack traces when hitting ^C in autoupdate

### DIFF
--- a/scripts/run_bazel.py
+++ b/scripts/run_bazel.py
@@ -14,6 +14,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
 import subprocess
+import sys
 import time
 
 import scripts_utils
@@ -82,4 +83,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -96,4 +96,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)


### PR DESCRIPTION
Currently hitting ^C prints out two stack traces, requiring scrolling up though multiple screens of scrollback to get back to the autoupdate results. This primarily shows up when hitting ^C while it's symbolizing a C++ stack trace.