### PR TITLE
Add test name to all file_test errors

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -434,7 +434,10 @@ static auto RunSingleTest(FileTestInfo& test, bool single_threaded,
 
   if (!test.test_result->ok()) {
     std::unique_lock<std::mutex> lock(output_mutex);
-    llvm::errs() << "\n" << test.test_result->error().message() << "\n";
+    if (!single_threaded) {
+      llvm::errs() << "\n" << test.test_name << ": ";
+    }
+    llvm::errs() << test.test_result->error().message() << "\n";
     return true;
   }
 

--- a/testing/file_test/test_file.cpp
+++ b/testing/file_test/test_file.cpp
@@ -833,8 +833,7 @@ auto ProcessTestFile(llvm::StringRef test_name, bool running_autoupdate)
       test_file.file_splits, include_files));
 
   if (!found_autoupdate) {
-    return ErrorBuilder() << "Missing AUTOUPDATE/NOAUTOUPDATE setting: "
-                          << test_name;
+    return ErrorBuilder() << "Missing AUTOUPDATE/NOAUTOUPDATE setting";
   }
 
   constexpr llvm::StringLiteral AutoupdateSplit = "AUTOUPDATE-SPLIT";


### PR DESCRIPTION
Common case is going to be like:

```
Running tests with 64 thread(s)

Autoupdate can't discard non-CHECK lines inside conflicts:

......................!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!..!!!!!!!!!!!!!!!!!!!!.
```

->

```
Running tests with 64 thread(s)

toolchain/check/testdata/as/unsafe_as.carbon: Autoupdate can't discard non-CHECK lines inside conflicts:

......................!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!..!!!!!!!!!!!!!!!!!!!!.
```

(i.e., the conflict line was blank)

One error had the test name, I'm dropping it here, meaning:

```
................................................................................
Missing AUTOUPDATE/NOAUTOUPDATE setting: toolchain/codegen/testdata/assembly/basic.carbon
................................................................................
```

->

```
................................................................................
toolchain/codegen/testdata/assembly/basic.carbon: Missing AUTOUPDATE/NOAUTOUPDATE setting
................................................................................
```

For single-threaded runs, at the top there's already:

```
  } else if (single_threaded) {
    std::unique_lock<std::mutex> lock(output_mutex);
    llvm::errs() << "\nTEST: " << test.test_name << ' ';
  }
```