### PR TITLE
Use `typename` on templates for consistency.

### DIFF
--- a/common/map_test.cpp
+++ b/common/map_test.cpp
@@ -17,7 +17,7 @@
 // Workaround for std::pair comparison deficiency in libc++ 16.
 #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 170000
 namespace std {
-template <class T, class U, class V, class W>
+template <typename T, typename U, typename V, typename W>
   requires(convertible_to<V, T> && convertible_to<W, U>)
 inline auto operator==(
     pair<std::reference_wrapper<T>, std::reference_wrapper<U>> lhs,

--- a/toolchain/base/kind_switch.h
+++ b/toolchain/base/kind_switch.h
@@ -78,12 +78,12 @@ concept IsStdVariant = IsStdVariantValue<std::decay_t<T>>;
 
 // Used to provide a reason in the compiler error from `ValidCaseType`, which
 // will state that "T does not satisfy TypeFoundInVariant".
-template <class T>
+template <typename T>
 concept TypeFoundInVariant = false;
 
 // Used to cause a compler error, which will state that "ValidCaseType was not
 // satisfied" for T and std::variant<...>.
-template <class T, class StdVariant>
+template <typename T, typename StdVariant>
   requires TypeFoundInVariant<T>
 struct ValidCaseType;
 

--- a/toolchain/check/diagnostic_helpers.h
+++ b/toolchain/check/diagnostic_helpers.h
@@ -26,7 +26,7 @@ class LocIdForDiagnostics {
     return LocIdForDiagnostics(SemIR::LocId(node_id), true);
   }
 
-  template <class LocT>
+  template <typename LocT>
     requires std::constructible_from<SemIR::LocId, LocT>
   // NOLINTNEXTLINE(google-explicit-constructor)
   LocIdForDiagnostics(LocT loc_id)

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -65,7 +65,7 @@ constexpr TypeInstId TypeInstId::None = TypeInstId::UnsafeMake(InstId::None);
 // Unlike TypeInstId, this type can *not* be an operand in instructions, since
 // being a template prevents it from being used in non-generic contexts such as
 // switches.
-template <class T>
+template <typename T>
 struct KnownInstId : public InstId {
   static const KnownInstId None;
 
@@ -81,7 +81,7 @@ struct KnownInstId : public InstId {
       : InstId(id) {}
 };
 
-template <class T>
+template <typename T>
 constexpr KnownInstId<T> KnownInstId<T>::None =
     KnownInstId<T>::UnsafeMake(InstId::None);
 

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -522,7 +522,7 @@ class InstStore {
     return TryGetAs<InstT>(inst_id);
   }
 
-  template <class InstT>
+  template <typename InstT>
   struct GetAsWithIdResult {
     KnownInstId<InstT> inst_id;
     InstT inst;

--- a/toolchain/sem_ir/type_iterator.h
+++ b/toolchain/sem_ir/type_iterator.h
@@ -198,7 +198,7 @@ class TypeIterator::Step {
                    ClassStart, StructStart, TupleStart, InterfaceStart,
                    IntStart, ArrayStart, PointerStart, End, Done, Error>;
 
-  template <class T>
+  template <typename T>
   auto Is() const -> bool {
     return std::holds_alternative<T>(any);
   }
@@ -208,7 +208,7 @@ class TypeIterator::Step {
   // This is a template to allow implicit conversion directly from step values
   // that can go inside `Any` to `Step` (without having to make the `Any`
   // explicitly first).
-  template <class T>
+  template <typename T>
     requires std::constructible_from<Any, T>
   // NOLINTNEXTLINE(google-explicit-constructor)
   Step(T any) : any(any) {}


### PR DESCRIPTION
They're essentially equivalent, we just typically write `typename`; even in the examples here, most have other templates in the same file that use `typename`.