### PR TITLE
Run clangd-tidy for the merge queue

### DIFF
--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -8,8 +8,7 @@ on:
   push:
     branches: [trunk, action-test]
   pull_request:
-  # TODO: Don't run in merge_group until we're ready to replace clang-tidy.
-  # merge_group:
+  merge_group:
 
 permissions:
   contents: read # For actions/checkout.


### PR DESCRIPTION
Necessary for switching off clang-tidy, just forgot about this (temporarily switched back enforcement).