### PR TITLE
Use enumerated values in formatter

### DIFF
--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -76,32 +76,33 @@ auto Formatter::Format() -> void {
       sem_ir_->inst_blocks().GetOrEmpty(sem_ir_->top_inst_block_id()),
       /*use_tentative_output_scopes=*/false);
 
-  for (auto [id, _] : sem_ir_->interfaces().enumerate()) {
-    FormatInterface(id);
+  for (const auto& [id, interface] : sem_ir_->interfaces().enumerate()) {
+    FormatInterface(id, interface);
   }
 
-  for (auto [id, _] : sem_ir_->associated_constants().enumerate()) {
-    FormatAssociatedConstant(id);
+  for (const auto& [id, assoc_const] :
+       sem_ir_->associated_constants().enumerate()) {
+    FormatAssociatedConstant(id, assoc_const);
   }
 
-  for (auto [id, _] : sem_ir_->impls().enumerate()) {
-    FormatImpl(id);
+  for (const auto& [id, impl] : sem_ir_->impls().enumerate()) {
+    FormatImpl(id, impl);
   }
 
-  for (auto [id, _] : sem_ir_->classes().enumerate()) {
-    FormatClass(id);
+  for (const auto& [id, class_info] : sem_ir_->classes().enumerate()) {
+    FormatClass(id, class_info);
   }
 
-  for (auto [id, _] : sem_ir_->vtables().enumerate()) {
-    FormatVtable(id);
+  for (const auto& [id, vtable] : sem_ir_->vtables().enumerate()) {
+    FormatVtable(id, vtable);
   }
 
-  for (auto [id, _] : sem_ir_->functions().enumerate()) {
-    FormatFunction(id);
+  for (const auto& [id, function] : sem_ir_->functions().enumerate()) {
+    FormatFunction(id, function);
   }
 
-  for (auto [id, _] : sem_ir_->specifics().enumerate()) {
-    FormatSpecific(id);
+  for (const auto& [id, specific] : sem_ir_->specifics().enumerate()) {
+    FormatSpecific(id, specific);
   }
 
   out_ << "\n";
@@ -330,8 +331,7 @@ auto Formatter::FormatTopLevelScopeIfUsed(InstNamer::ScopeId scope_id,
   indent_ -= 2;
 }
 
-auto Formatter::FormatClass(ClassId id) -> void {
-  const Class& class_info = sem_ir_->classes().Get(id);
+auto Formatter::FormatClass(ClassId id, const Class& class_info) -> void {
   if (!ShouldFormatEntity(class_info)) {
     return;
   }
@@ -365,8 +365,7 @@ auto Formatter::FormatClass(ClassId id) -> void {
   FormatEntityEnd(class_info.generic_id);
 }
 
-auto Formatter::FormatVtable(VtableId id) -> void {
-  const Vtable& vtable_info = sem_ir_->vtables().Get(id);
+auto Formatter::FormatVtable(VtableId id, const Vtable& vtable_info) -> void {
   out_ << '\n';
   Indent();
   out_ << "vtable ";
@@ -383,8 +382,8 @@ auto Formatter::FormatVtable(VtableId id) -> void {
   out_ << '\n';
 }
 
-auto Formatter::FormatInterface(InterfaceId id) -> void {
-  const Interface& interface_info = sem_ir_->interfaces().Get(id);
+auto Formatter::FormatInterface(InterfaceId id, const Interface& interface_info)
+    -> void {
   if (!ShouldFormatEntity(interface_info)) {
     return;
   }
@@ -418,9 +417,9 @@ auto Formatter::FormatInterface(InterfaceId id) -> void {
   FormatEntityEnd(interface_info.generic_id);
 }
 
-auto Formatter::FormatAssociatedConstant(AssociatedConstantId id) -> void {
-  const AssociatedConstant& assoc_const =
-      sem_ir_->associated_constants().Get(id);
+auto Formatter::FormatAssociatedConstant(AssociatedConstantId id,
+                                         const AssociatedConstant& assoc_const)
+    -> void {
   if (!ShouldFormatEntity(assoc_const.decl_id)) {
     return;
   }
@@ -443,8 +442,7 @@ auto Formatter::FormatAssociatedConstant(AssociatedConstantId id) -> void {
   FormatEntityEnd(assoc_const.generic_id);
 }
 
-auto Formatter::FormatImpl(ImplId id) -> void {
-  const Impl& impl_info = sem_ir_->impls().Get(id);
+auto Formatter::FormatImpl(ImplId id, const Impl& impl_info) -> void {
   if (!ShouldFormatEntity(impl_info)) {
     return;
   }
@@ -485,8 +483,7 @@ auto Formatter::FormatImpl(ImplId id) -> void {
   FormatEntityEnd(impl_info.generic_id);
 }
 
-auto Formatter::FormatFunction(FunctionId id) -> void {
-  const Function& fn = sem_ir_->functions().Get(id);
+auto Formatter::FormatFunction(FunctionId id, const Function& fn) -> void {
   if (!ShouldFormatEntity(fn)) {
     return;
   }
@@ -581,8 +578,8 @@ auto Formatter::FormatSpecificRegion(const Generic& generic,
   }
 }
 
-auto Formatter::FormatSpecific(SpecificId id) -> void {
-  const auto& specific = sem_ir_->specifics().Get(id);
+auto Formatter::FormatSpecific(SpecificId id, const Specific& specific)
+    -> void {
   const auto& generic = sem_ir_->generics().Get(specific.generic_id);
   if (!ShouldFormatEntity(generic.decl_id)) {
     // Omit specifics if we also omitted the generic.

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -150,22 +150,23 @@ class Formatter {
                                  bool use_tentative_output_scopes) -> void;
 
   // Formats a full class.
-  auto FormatClass(ClassId id) -> void;
+  auto FormatClass(ClassId id, const Class& class_info) -> void;
 
   // Formats a full vtable.
-  auto FormatVtable(VtableId id) -> void;
+  auto FormatVtable(VtableId id, const Vtable& vtable_info) -> void;
 
   // Formats a full interface.
-  auto FormatInterface(InterfaceId id) -> void;
+  auto FormatInterface(InterfaceId id, const Interface& interface_info) -> void;
 
   // Formats an associated constant entity.
-  auto FormatAssociatedConstant(AssociatedConstantId id) -> void;
+  auto FormatAssociatedConstant(AssociatedConstantId id,
+                                const AssociatedConstant& assoc_const) -> void;
 
   // Formats a full impl.
-  auto FormatImpl(ImplId id) -> void;
+  auto FormatImpl(ImplId id, const Impl& impl) -> void;
 
   // Formats a full function.
-  auto FormatFunction(FunctionId id) -> void;
+  auto FormatFunction(FunctionId id, const Function& fn) -> void;
 
   // Helper for FormatSpecific to print regions.
   auto FormatSpecificRegion(const Generic& generic, const Specific& specific,
@@ -173,7 +174,7 @@ class Formatter {
                             llvm::StringRef region_name) -> void;
 
   // Formats a full specific.
-  auto FormatSpecific(SpecificId id) -> void;
+  auto FormatSpecific(SpecificId id, const Specific& specific) -> void;
 
   // Handles generic-specific setup for FormatEntityStart.
   auto FormatGenericStart(llvm::StringRef entity_kind, GenericId generic_id)


### PR DESCRIPTION
Noticed this was essentially just fetching then discarding the values, which felt odd to me. I was considering adding an `ids()` function, but this would leave only 3 spots that'd use it, and the absence seems like it'll nudge code towards using the value of `enumerate()` when reasonable.