### PR TITLE
Stop round tripping through an InstId to get the ConstantId of a TypeId

### DIFF
--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -319,7 +319,7 @@ static auto LookupMemberNameInScope(Context& context, SemIR::LocId loc_id,
         // Witness that `T` implements the `assoc_interface`.
         auto lookup_result = LookupImplWitness(
             context, loc_id,
-            context.constant_values().Get(base_as_type.inst_id),
+            context.types().GetConstantId(base_as_type.type_id),
             EvalOrAddInst(
                 context, loc_id,
                 FacetTypeFromInterface(context, assoc_interface.interface_id,


### PR DESCRIPTION
TypeId and ConstantId are easily interchangeable, and there's no need to go through InstId, which is more complicated.