### PR TITLE
Disable the modernize headers `clang-tidy` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks:
   - '-misc-const-correctness'
   - '-misc-include-cleaner'
   - '-misc-use-anonymous-namespace'
+  - '-modernize-deprecated-headers'
   - '-modernize-return-braced-init-list'
   - '-modernize-use-default-member-init'
   - '-modernize-use-integer-sign-comparison'

--- a/common/filesystem.cpp
+++ b/common/filesystem.cpp
@@ -5,7 +5,7 @@
 #include "common/filesystem.h"
 
 #include <fcntl.h>
-#include <time.h>  // NOLINT(modernize-deprecated-headers)
+#include <time.h>
 #include <unistd.h>
 
 #include <chrono>


### PR DESCRIPTION
Our style guide suggests using `<stdint.h>` and not the `std::` qualifiers, and this is consistent with other headers like `<time.h>`. The `clang-tidy` check enforces the reverse pattern, so disable it to allow us to continue following our style pattern.