### PR TITLE
Improve building of generated sources for ClangD

### DIFF
--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -68,7 +68,7 @@ def _build_generated_files(
     subprocess.check_call(
         [bazel, "build", "--keep_going", "--remote_download_outputs=toplevel"]
         + generated_file_labels
-        # We also need the Bazel C++ runfiles that aren't "generated", but not
+        # We also need the Bazel C++ runfiles that aren't "generated", but are not
         # linked into place until built.
         + ["@bazel_tools//tools/cpp/runfiles:runfiles"]
     )
@@ -83,11 +83,12 @@ def _get_config_for_entry(entry: Dict[str, Any]) -> str:
     if not arguments or len(arguments) < 2 or arguments[-2] != "-o":
         return "unknown"
     obj_file = arguments[-1]
+    assert obj_file is str
 
     # The configuration is the name of the subdirectory of `bazel-out`.
     if not obj_file.startswith("bazel-out/"):
         return "unknown"
-    return str(obj_file.split("/")[1])
+    return obj_file.split("/")[1]
 
 
 def _filter_compilation_database(file_path: str) -> None:
@@ -99,11 +100,9 @@ def _filter_compilation_database(file_path: str) -> None:
         with open(file_path, "r") as f:
             commands = json.load(f)
     except FileNotFoundError:
-        print(f"Error: The file '{file_path}' was not found.")
-        sys.exit(1)
+        sys.exit(f"Error: The file '{file_path}' was not found.")
     except json.JSONDecodeError:
-        print(f"Error: The file '{file_path}' is not a valid JSON file.")
-        sys.exit(1)
+        sys.exit(f"Error: The file '{file_path}' is not a valid JSON file.")
 
     # We want to skip compiles that were in the "exec" configuration for tools.
     # Because we generate compile commands for every target, these will already
@@ -113,7 +112,7 @@ def _filter_compilation_database(file_path: str) -> None:
     # Detecting this based on the `-exec-` string in the configuration name of
     # the directory is a bit of a hack, but there doesn't appear to be any way
     # to filter these out using Bazel when creating the compilation database, or
-    # a way to easily ask Bazel to compute what this string would be for th exec
+    # a way to easily ask Bazel to compute what this string would be for the exec
     # configuration.
     filtered_commands = [
         entry
@@ -122,12 +121,11 @@ def _filter_compilation_database(file_path: str) -> None:
     ]
 
     with open(file_path, "w") as f:
-        # Use indent=4 for a human-readable, pretty-printed output file
+        # Use indent=4 for a human-readable, pretty-printed output file.
         json.dump(filtered_commands, f, indent=4)
     print(
-        "Filtered out "
-        f"{len(commands) - len(filtered_commands)} "
-        "duplicate entries..."
+        f"Filtered out {len(commands) - len(filtered_commands)} duplicate "
+        "entries..."
     )
 
 

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -26,8 +26,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import argparse
 import subprocess
 import sys
-import json
-from typing import Any, Dict
 
 import scripts_utils
 
@@ -68,64 +66,9 @@ def _build_generated_files(
     subprocess.check_call(
         [bazel, "build", "--keep_going", "--remote_download_outputs=toplevel"]
         + generated_file_labels
-        # We also need the Bazel C++ runfiles that aren't "generated", but are not
-        # linked into place until built.
+        # We also need the Bazel C++ runfiles that aren't "generated", but are
+        # not linked into place until built.
         + ["@bazel_tools//tools/cpp/runfiles:runfiles"]
-    )
-
-
-def _get_config_for_entry(entry: Dict[str, Any]) -> str:
-    """Returns the configuration for a compile command entry."""
-    arguments = entry.get("arguments")
-
-    # Only handle files where the object file argument is easily found as
-    # the last argument, which matches the expected structure from Bazel.
-    if not arguments or len(arguments) < 2 or arguments[-2] != "-o":
-        return "unknown"
-    obj_file = arguments[-1]
-    assert obj_file is str
-
-    # The configuration is the name of the subdirectory of `bazel-out`.
-    if not obj_file.startswith("bazel-out/"):
-        return "unknown"
-    return obj_file.split("/")[1]
-
-
-def _filter_compilation_database(file_path: str) -> None:
-    """Filters out duplicate exec-configuration entries from the compilation
-    database.
-    """
-    print("Filtering out duplicate exec-configuration entries...")
-    try:
-        with open(file_path, "r") as f:
-            commands = json.load(f)
-    except FileNotFoundError:
-        sys.exit(f"Error: The file '{file_path}' was not found.")
-    except json.JSONDecodeError:
-        sys.exit(f"Error: The file '{file_path}' is not a valid JSON file.")
-
-    # We want to skip compiles that were in the "exec" configuration for tools.
-    # Because we generate compile commands for every target, these will already
-    # be covered there and this creates a smaller and more minimal compilation
-    # database.
-    #
-    # Detecting this based on the `-exec-` string in the configuration name of
-    # the directory is a bit of a hack, but there doesn't appear to be any way
-    # to filter these out using Bazel when creating the compilation database, or
-    # a way to easily ask Bazel to compute what this string would be for the exec
-    # configuration.
-    filtered_commands = [
-        entry
-        for entry in commands
-        if "-exec-" not in _get_config_for_entry(entry)
-    ]
-
-    with open(file_path, "w") as f:
-        # Use indent=4 for a human-readable, pretty-printed output file.
-        json.dump(filtered_commands, f, indent=4)
-    print(
-        f"Filtered out {len(commands) - len(filtered_commands)} duplicate "
-        "entries..."
     )
 
 
@@ -155,9 +98,15 @@ def main() -> None:
         "Generating compile_commands.json (may take a few minutes)...",
         flush=True,
     )
-    subprocess.run([bazel, "run", "@hedron_compile_commands//:refresh_all"])
-
-    _filter_compilation_database("compile_commands.json")
+    subprocess.run(
+        [
+            bazel,
+            "run",
+            "@hedron_compile_commands//:refresh_all",
+            "--",
+            "--notool_deps",
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -26,6 +26,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import argparse
 import subprocess
 import sys
+import json
+from typing import Any, Dict
 
 import scripts_utils
 
@@ -39,8 +41,8 @@ def _build_generated_files(
     # files but aren't classified as "generated file".
     kinds_query = (
         "filter("
-        ' ".*\\.(h|cpp|cc|c|cxx|def|inc)$",'
-        ' kind("(generated file|generate_llvm_tools_def|manifest_as_cpp)",'
+        ' ".*\\.(h|hpp|hxx|cpp|cc|c|cxx|def|inc|s|S)$",'
+        ' kind("(.*generate.*|manifest_as_cpp)",'
         # tree_sitter is excluded here because it causes the query to failure on
         # `@platforms`.
         "      deps(//... except //utils/tree_sitter/...))"
@@ -66,6 +68,66 @@ def _build_generated_files(
     subprocess.check_call(
         [bazel, "build", "--keep_going", "--remote_download_outputs=toplevel"]
         + generated_file_labels
+        # We also need the Bazel C++ runfiles that aren't "generated", but not
+        # linked into place until built.
+        + ["@bazel_tools//tools/cpp/runfiles:runfiles"]
+    )
+
+
+def _get_config_for_entry(entry: Dict[str, Any]) -> str:
+    """Returns the configuration for a compile command entry."""
+    arguments = entry.get("arguments")
+
+    # Only handle files where the object file argument is easily found as
+    # the last argument, which matches the expected structure from Bazel.
+    if not arguments or len(arguments) < 2 or arguments[-2] != "-o":
+        return "unknown"
+    obj_file = arguments[-1]
+
+    # The configuration is the name of the subdirectory of `bazel-out`.
+    if not obj_file.startswith("bazel-out/"):
+        return "unknown"
+    return str(obj_file.split("/")[1])
+
+
+def _filter_compilation_database(file_path: str) -> None:
+    """Filters out duplicate exec-configuration entries from the compilation
+    database.
+    """
+    print("Filtering out duplicate exec-configuration entries...")
+    try:
+        with open(file_path, "r") as f:
+            commands = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: The file '{file_path}' was not found.")
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"Error: The file '{file_path}' is not a valid JSON file.")
+        sys.exit(1)
+
+    # We want to skip compiles that were in the "exec" configuration for tools.
+    # Because we generate compile commands for every target, these will already
+    # be covered there and this creates a smaller and more minimal compilation
+    # database.
+    #
+    # Detecting this based on the `-exec-` string in the configuration name of
+    # the directory is a bit of a hack, but there doesn't appear to be any way
+    # to filter these out using Bazel when creating the compilation database, or
+    # a way to easily ask Bazel to compute what this string would be for th exec
+    # configuration.
+    filtered_commands = [
+        entry
+        for entry in commands
+        if "-exec-" not in _get_config_for_entry(entry)
+    ]
+
+    with open(file_path, "w") as f:
+        # Use indent=4 for a human-readable, pretty-printed output file
+        json.dump(filtered_commands, f, indent=4)
+    print(
+        "Filtered out "
+        f"{len(commands) - len(filtered_commands)} "
+        "duplicate entries..."
     )
 
 
@@ -96,6 +158,8 @@ def main() -> None:
         flush=True,
     )
     subprocess.run([bazel, "run", "@hedron_compile_commands//:refresh_all"])
+
+    _filter_compilation_database("compile_commands.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We have grown more generation rules, so try to use a regex instead of listing all of them.

Also, manually add the runfiles C++ library that isn't "generated", but is symlinked into the source tree only when built.