### PR TITLE
Include the Name when dumping an instruction with a name

### DIFF
--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -258,6 +258,7 @@ cc_library(
     deps = [
         ":file",
         ":stringify",
+        ":typed_insts",
         "//common:ostream",
         "//common:raw_string_ostream",
     ],

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -9,7 +9,9 @@
 #include <string>
 
 #include "common/raw_string_ostream.h"
+#include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/stringify.h"
+#include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::SemIR {
 
@@ -214,6 +216,14 @@ LLVM_DUMP_METHOD auto Dump(const File& file, InstId inst_id) -> std::string {
   }
 
   Inst inst = file.insts().Get(inst_id);
+
+  if (inst.arg0_and_kind().kind() == IdKind::For<SemIR::EntityNameId>) {
+    auto entity_name_id = SemIR::EntityNameId(inst.arg0());
+    out << "\n  - name:"
+        << DumpNameIfValid(file,
+                           file.entity_names().Get(entity_name_id).name_id);
+  }
+
   if (inst.type_id().has_value()) {
     out << "\n  - type: " << Dump(file, inst.type_id());
   }


### PR DESCRIPTION
If the first argument is an EntityNameId, then dump the name from within it. In particular this affects dumping BindName and BindSymbolicName.

```
(lldb) dump context non_canonical_query_self_inst_id
inst96: {kind: BindSymbolicName, arg0: entity_name4, arg1: inst<none>, type: type(symbolic_constant35)}
  - name: `T`
  - type: type(symbolic_constant35): I(.Self) where .Self.(I(.Self).X) = (); {kind: FacetType, arg0: facet_type4, type: type(TypeType)}
  - value: symbolic_constant36
  - loc: LocId(<none>)
```