### PR TITLE
Fix handling of enums in overload resolution.

### DIFF
--- a/toolchain/check/cpp_type_mapping.cpp
+++ b/toolchain/check/cpp_type_mapping.cpp
@@ -127,6 +127,11 @@ static auto TryMapClassType(Context& context, SemIR::TypeId type_id)
 // Maps a non-wrapper (no const or pointer) Carbon type to a C++ type.
 static auto MapNonWrapperType(Context& context, SemIR::InstId inst_id,
                               SemIR::TypeId type_id) -> clang::QualType {
+  // It's important to check for a class type first, because an enum imported
+  // from C++ is both a Carbon class type and has an object representation that
+  // is a builtin type, and we want to map back to the enum.
+  // TODO: The order won't matter once TryMapBuiltinType stops looking through
+  // adapters.
   clang::QualType mapped_type = TryMapClassType(context, type_id);
   if (mapped_type.isNull()) {
     mapped_type = TryMapBuiltinType(context, inst_id, type_id);

--- a/toolchain/check/cpp_type_mapping.cpp
+++ b/toolchain/check/cpp_type_mapping.cpp
@@ -127,9 +127,9 @@ static auto TryMapClassType(Context& context, SemIR::TypeId type_id)
 // Maps a non-wrapper (no const or pointer) Carbon type to a C++ type.
 static auto MapNonWrapperType(Context& context, SemIR::InstId inst_id,
                               SemIR::TypeId type_id) -> clang::QualType {
-  clang::QualType mapped_type = TryMapBuiltinType(context, inst_id, type_id);
+  clang::QualType mapped_type = TryMapClassType(context, type_id);
   if (mapped_type.isNull()) {
-    mapped_type = TryMapClassType(context, type_id);
+    mapped_type = TryMapBuiltinType(context, inst_id, type_id);
   }
   return mapped_type;
 }

--- a/toolchain/lower/testdata/interop/cpp/enum.carbon
+++ b/toolchain/lower/testdata/interop/cpp/enum.carbon
@@ -10,8 +10,6 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/interop/cpp/enum.carbon
 
-// TODO: Tests marked as `fail_todo_5891_` to fixed as a follow-up of https://github.com/carbon-language/carbon-lang/pull/5891.
-
 // --- enum_member.h
 
 struct C {
@@ -24,7 +22,7 @@ struct C {
   static void F(E);
 };
 
-// --- fail_todo_5891_pass_as_arg.carbon
+// --- pass_as_arg.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -32,49 +30,15 @@ import Cpp library "enum_member.h";
 
 fn Pass() {
   Cpp.C.F(Cpp.C.a);
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+7]]:3: error: no matching function for call to `F` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.b);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.b);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
+  Cpp.C.F(Cpp.C.a);
   Cpp.C.F(Cpp.C.b);
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+7]]:3: error: no matching function for call to `F` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.c);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.c);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(Cpp.C.c);
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+7]]:3: error: no matching function for call to `F` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.a);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.a);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(Cpp.C.E.a);
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+7]]:3: error: no matching function for call to `F` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.b);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.b);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(Cpp.C.E.b);
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+7]]:3: error: no matching function for call to `F` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.c);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_5891_pass_as_arg.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.c);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(Cpp.C.E.c);
 }
 
-// --- fail_todo_5891_convert.carbon
+// --- convert.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -91,13 +55,6 @@ fn ConvertEnumToI16(e: Cpp.C.E) {
 }
 
 fn ConvertI16ToEnum(n: i16) {
-  // CHECK:STDERR: fail_todo_5891_convert.carbon:[[@LINE+7]]:3: error: no matching function for call to `F` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.C.F(n as Cpp.C.E);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_5891_convert.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.C.F(n as Cpp.C.E);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(n as Cpp.C.E);
 }
 
@@ -111,7 +68,7 @@ enum Bits {
 
 void Take(Bits b);
 
-// --- fail_todo_use_5891_bitmask.carbon
+// --- use_bitmask.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -122,12 +79,191 @@ import Cpp library "bitmask.h";
 fn BitOr(a: Cpp.Bits, b: Cpp.Bits) -> Cpp.Bits = "int.or";
 
 fn Call() {
-  // CHECK:STDERR: fail_todo_use_5891_bitmask.carbon:[[@LINE+7]]:3: error: no matching function for call to `Take` [CppOverloadingNoViableFunctionFound]
-  // CHECK:STDERR:   Cpp.Take(BitOr(Cpp.A, Cpp.C));
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_use_5891_bitmask.carbon:[[@LINE+4]]:3: note: in call to Cpp function here [InCallToCppFunction]
-  // CHECK:STDERR:   Cpp.Take(BitOr(Cpp.A, Cpp.C));
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.Take(BitOr(Cpp.A, Cpp.C));
 }
+
+// CHECK:STDOUT: ; ModuleID = 'pass_as_arg.carbon'
+// CHECK:STDOUT: source_filename = "pass_as_arg.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CPass.Main() !dbg !7 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc7_16.1.temp = alloca i16, align 2, !dbg !10
+// CHECK:STDOUT:   %.loc8_16.1.temp = alloca i16, align 2, !dbg !11
+// CHECK:STDOUT:   %.loc9_16.1.temp = alloca i16, align 2, !dbg !12
+// CHECK:STDOUT:   %.loc10_16.1.temp = alloca i16, align 2, !dbg !13
+// CHECK:STDOUT:   %.loc11_18.1.temp = alloca i16, align 2, !dbg !14
+// CHECK:STDOUT:   %.loc12_18.1.temp = alloca i16, align 2, !dbg !15
+// CHECK:STDOUT:   %.loc13_18.1.temp = alloca i16, align 2, !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_16.1.temp), !dbg !10
+// CHECK:STDOUT:   store i16 0, ptr %.loc7_16.1.temp, align 2, !dbg !10
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc7_16.1.temp), !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc8_16.1.temp), !dbg !11
+// CHECK:STDOUT:   store i16 0, ptr %.loc8_16.1.temp, align 2, !dbg !11
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc8_16.1.temp), !dbg !18
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_16.1.temp), !dbg !12
+// CHECK:STDOUT:   store i16 7, ptr %.loc9_16.1.temp, align 2, !dbg !12
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc9_16.1.temp), !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc10_16.1.temp), !dbg !13
+// CHECK:STDOUT:   store i16 8, ptr %.loc10_16.1.temp, align 2, !dbg !13
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc10_16.1.temp), !dbg !20
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc11_18.1.temp), !dbg !14
+// CHECK:STDOUT:   store i16 0, ptr %.loc11_18.1.temp, align 2, !dbg !14
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc11_18.1.temp), !dbg !21
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_18.1.temp), !dbg !15
+// CHECK:STDOUT:   store i16 7, ptr %.loc12_18.1.temp, align 2, !dbg !15
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc12_18.1.temp), !dbg !22
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc13_18.1.temp), !dbg !16
+// CHECK:STDOUT:   store i16 8, ptr %.loc13_18.1.temp, align 2, !dbg !16
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc13_18.1.temp), !dbg !23
+// CHECK:STDOUT:   ret void, !dbg !24
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_ZN1C1FENS_1EE(i16)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_ZN1C1FENS_1EE.carbon_thunk(ptr %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
+// CHECK:STDOUT:   %2 = load i16, ptr %1, align 2
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE(i16 signext %2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 6, 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 1, !"wchar_size", i32 4}
+// CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 0}
+// CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "pass_as_arg.carbon", directory: "")
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Pass", linkageName: "_CPass.Main", scope: null, file: !6, line: 6, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
+// CHECK:STDOUT: !9 = !{}
+// CHECK:STDOUT: !10 = !DILocation(line: 7, column: 11, scope: !7)
+// CHECK:STDOUT: !11 = !DILocation(line: 8, column: 11, scope: !7)
+// CHECK:STDOUT: !12 = !DILocation(line: 9, column: 11, scope: !7)
+// CHECK:STDOUT: !13 = !DILocation(line: 10, column: 11, scope: !7)
+// CHECK:STDOUT: !14 = !DILocation(line: 11, column: 11, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 12, column: 11, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 13, column: 11, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 7, column: 3, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 8, column: 3, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 9, column: 3, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 10, column: 3, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 11, column: 3, scope: !7)
+// CHECK:STDOUT: !22 = !DILocation(line: 12, column: 3, scope: !7)
+// CHECK:STDOUT: !23 = !DILocation(line: 13, column: 3, scope: !7)
+// CHECK:STDOUT: !24 = !DILocation(line: 6, column: 1, scope: !7)
+// CHECK:STDOUT: ; ModuleID = 'convert.carbon'
+// CHECK:STDOUT: source_filename = "convert.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CTakeI16.Main(i16)
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CPassEnum.Main() !dbg !7 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CTakeI16.Main(i16 7), !dbg !10
+// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CConvertEnumToI16.Main(i16 %e) !dbg !12 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CTakeI16.Main(i16 %e), !dbg !13
+// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CConvertI16ToEnum.Main(i16 %n) !dbg !15 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc17_13.3.temp = alloca i16, align 2, !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_13.3.temp), !dbg !16
+// CHECK:STDOUT:   store i16 %n, ptr %.loc17_13.3.temp, align 2, !dbg !16
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk(ptr %.loc17_13.3.temp), !dbg !17
+// CHECK:STDOUT:   ret void, !dbg !18
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_ZN1C1FENS_1EE(i16)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_ZN1C1FENS_1EE.carbon_thunk(ptr %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
+// CHECK:STDOUT:   %2 = load i16, ptr %1, align 2
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE(i16 signext %2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 1, !"wchar_size", i32 4}
+// CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 0}
+// CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "convert.carbon", directory: "")
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "PassEnum", linkageName: "_CPassEnum.Main", scope: null, file: !6, line: 8, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
+// CHECK:STDOUT: !9 = !{}
+// CHECK:STDOUT: !10 = !DILocation(line: 9, column: 3, scope: !7)
+// CHECK:STDOUT: !11 = !DILocation(line: 8, column: 1, scope: !7)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "ConvertEnumToI16", linkageName: "_CConvertEnumToI16.Main", scope: null, file: !6, line: 12, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !13 = !DILocation(line: 13, column: 3, scope: !12)
+// CHECK:STDOUT: !14 = !DILocation(line: 12, column: 1, scope: !12)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "ConvertI16ToEnum", linkageName: "_CConvertI16ToEnum.Main", scope: null, file: !6, line: 16, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 11, scope: !15)
+// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 3, scope: !15)
+// CHECK:STDOUT: !18 = !DILocation(line: 16, column: 1, scope: !15)
+// CHECK:STDOUT: ; ModuleID = 'use_bitmask.carbon'
+// CHECK:STDOUT: source_filename = "use_bitmask.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CCall.Main() !dbg !7 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_Z4Take4Bits(i32 5), !dbg !10
+// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z4Take4Bits(i32)
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 1, !"wchar_size", i32 4}
+// CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 0}
+// CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "use_bitmask.carbon", directory: "")
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "Call", linkageName: "_CCall.Main", scope: null, file: !6, line: 10, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
+// CHECK:STDOUT: !9 = !{}
+// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 3, scope: !7)
+// CHECK:STDOUT: !11 = !DILocation(line: 10, column: 1, scope: !7)


### PR DESCRIPTION
When mapping Carbon types to C++ types, check first for the Carbon type being imported from C++ before checking whether it's an adapter for a builtin. Enums imported from C++ will be both, and it's important we map them back to the enum type rather than to their underlying (integer) type.

Fixes #6061