### PR TITLE
Set deduce_through to false for FacetType, since we don't deduce through it

### DIFF
--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -113,11 +113,6 @@ class DeductionWorklist {
       case SemIR::IdKind::None:
       case SemIR::IdKind::For<SemIR::ClassId>:
       case SemIR::IdKind::For<SemIR::IntKind>:
-      // Decided on 2025-04-02 not to do deduction through facet types, because
-      // types can implement a generic interface multiple times with different
-      // arguments. See:
-      // https://docs.google.com/document/d/1Iut5f2TQBrtBNIduF4vJYOKfw7MbS8xH_J01_Q4e6Rk/edit?pli=1&resourcekey=0-mc_vh5UzrzXfU4kO-3tOjA&tab=t.0#heading=h.95phmuvxog9n
-      case SemIR::IdKind::For<SemIR::FacetTypeId>:
         break;
       case CARBON_KIND(SemIR::InstId inst_id): {
         Add(inst_id, SemIR::InstId(arg));

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -648,11 +648,14 @@ struct FacetAccessType {
 
 // A facet type value.
 struct FacetType {
+  // Decided on 2025-04-02 not to do deduction through facet types, because
+  // types can implement a generic interface multiple times with different
+  // arguments. See:
+  // https://docs.google.com/document/d/1Iut5f2TQBrtBNIduF4vJYOKfw7MbS8xH_J01_Q4e6Rk/edit?pli=1&resourcekey=0-mc_vh5UzrzXfU4kO-3tOjA&tab=t.0#heading=h.95phmuvxog9n
   static constexpr auto Kind = InstKind::FacetType.Define<Parse::NodeId>(
       {.ir_name = "facet_type",
        .is_type = InstIsType::Always,
-       .constant_kind = InstConstantKind::Always,
-       .deduce_through = true});
+       .constant_kind = InstConstantKind::Always});
 
   TypeId type_id;
   // TODO: Rename this to facet_type_info_id.

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -648,10 +648,6 @@ struct FacetAccessType {
 
 // A facet type value.
 struct FacetType {
-  // Decided on 2025-04-02 not to do deduction through facet types, because
-  // types can implement a generic interface multiple times with different
-  // arguments. See:
-  // https://docs.google.com/document/d/1Iut5f2TQBrtBNIduF4vJYOKfw7MbS8xH_J01_Q4e6Rk/edit?pli=1&resourcekey=0-mc_vh5UzrzXfU4kO-3tOjA&tab=t.0#heading=h.95phmuvxog9n
   static constexpr auto Kind = InstKind::FacetType.Define<Parse::NodeId>(
       {.ir_name = "facet_type",
        .is_type = InstIsType::Always,


### PR DESCRIPTION
We decided on 2025-04-02 not to do deduction through facet types, because types can implement a generic interface multiple times with different arguments. See: https://docs.google.com/document/d/1Iut5f2TQBrtBNIduF4vJYOKfw7MbS8xH_J01_Q4e6Rk/edit?pli=1&resourcekey=0-mc_vh5UzrzXfU4kO-3tOjA&tab=t.0#heading=h.95phmuvxog9n

Then we no longer need the case handling `FacetTypeId` in deduce.cpp. We move the comment over to the definition of the `FacetType::Kind`.

The deduce case was for `FacetTypeId`, not `FacetType`, but `FacetType` is the only instruction which holds such an Id.