### PR TITLE
C++ interop: Don't crash when looking up names inside an incomplete C++ class/struct/union

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2144,6 +2144,15 @@ auto ImportNameFromCpp(Context& context, SemIR::LocId loc_id,
         builder.Note(loc_id, InCppNameLookup, name_id);
       });
 
+  if (auto class_decl = context.insts().TryGetAs<SemIR::ClassDecl>(
+          context.name_scopes().Get(scope_id).inst_id());
+      class_decl.has_value()) {
+    if (!context.types().IsComplete(
+            context.classes().Get(class_decl->class_id).self_type_id)) {
+      return SemIR::ScopeLookupResult::MakeError();
+    }
+  }
+
   auto lookup = ClangLookupName(context, scope_id, name_id);
   if (!lookup) {
     SemIR::InstId builtin_inst_id =

--- a/toolchain/check/testdata/interop/cpp/class/constructor.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/constructor.carbon
@@ -203,6 +203,32 @@ fn F() {
   //@dump-sem-ir-end
 }
 
+// ============================================================================
+// Trying to call a constructor of an incomplete class
+// ============================================================================
+
+// --- incomplete.h
+
+class C;
+
+// --- fail_import_incomplete.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "incomplete.h";
+
+fn F() {
+   // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE+8]]:4: error: member access into incomplete class `Cpp.C` [QualifiedExprInIncompleteClassScope]
+   // CHECK:STDERR:    Cpp.C.C();
+   // CHECK:STDERR:    ^~~~~~~
+   // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
+   // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+   // CHECK:STDERR: class C;
+   // CHECK:STDERR:       ^
+   // CHECK:STDERR:
+   Cpp.C.C();
+}
+
 // CHECK:STDOUT: --- import_default.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/interop/cpp/function/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/class.carbon
@@ -342,6 +342,32 @@ fn F() {
 }
 
 // ============================================================================
+// Incomplete class
+// ============================================================================
+
+// --- incomplete.h
+
+class Incomplete;
+
+// --- fail_import_incomplete.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "incomplete.h";
+
+fn F() {
+  // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE+8]]:3: error: member access into incomplete class `Cpp.Incomplete` [QualifiedExprInIncompleteClassScope]
+  // CHECK:STDERR:   Cpp.Incomplete.foo();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: class Incomplete;
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR:
+  Cpp.Incomplete.foo();
+}
+
+// ============================================================================
 // Pointer to forward-declared class as parameter type
 // ============================================================================
 

--- a/toolchain/check/testdata/interop/cpp/function/struct.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/struct.carbon
@@ -340,6 +340,32 @@ fn F() {
 }
 
 // ============================================================================
+// Incomplete struct
+// ============================================================================
+
+// --- incomplete.h
+
+struct Incomplete;
+
+// --- fail_import_incomplete.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "incomplete.h";
+
+fn F() {
+  // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE+8]]:3: error: member access into incomplete class `Cpp.Incomplete` [QualifiedExprInIncompleteClassScope]
+  // CHECK:STDERR:   Cpp.Incomplete.foo();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: ./incomplete.h:2:8: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: struct Incomplete;
+  // CHECK:STDERR:        ^
+  // CHECK:STDERR:
+  Cpp.Incomplete.foo();
+}
+
+// ============================================================================
 // Pointer to forward-declared struct as parameter type
 // ============================================================================
 

--- a/toolchain/check/testdata/interop/cpp/function/union.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/union.carbon
@@ -303,6 +303,32 @@ fn F() {
 }
 
 // ============================================================================
+// Incomplete union
+// ============================================================================
+
+// --- incomplete.h
+
+union Incomplete;
+
+// --- fail_import_incomplete.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "incomplete.h";
+
+fn F() {
+  // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE+8]]:3: error: member access into incomplete class `Cpp.Incomplete` [QualifiedExprInIncompleteClassScope]
+  // CHECK:STDERR:   Cpp.Incomplete.foo();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: union Incomplete;
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR:
+  Cpp.Incomplete.foo();
+}
+
+// ============================================================================
 // Pointer to forward-declared union as parameter type
 // ============================================================================
 


### PR DESCRIPTION
Only do the lookup when the class is complete.

Before this change we crash in `Sema::LookupQualifiedName()` on `Declaration context must already be complete!`.