### PR TITLE
Remove redundant SemIR:: uses in SemIR

### DIFF
--- a/toolchain/sem_ir/constant.cpp
+++ b/toolchain/sem_ir/constant.cpp
@@ -36,10 +36,9 @@ auto ConstantStore::GetOrAdd(Inst inst, ConstantDependence dependence)
   return result.value();
 }
 
-auto GetInstWithConstantValue(const SemIR::File& file,
-                              SemIR::ConstantId const_id) -> SemIR::InstId {
+auto GetInstWithConstantValue(const File& file, ConstantId const_id) -> InstId {
   if (!const_id.has_value() || !const_id.is_constant()) {
-    return SemIR::InstId::None;
+    return InstId::None;
   }
 
   // For concrete constants, the corresponding instruction has the desired

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -251,8 +251,7 @@ class ConstantValueStore {
 // the eval block that computes the constant value in each specific.
 //
 // Returns InstId::None if the ConstantId is None or NotConstant.
-auto GetInstWithConstantValue(const SemIR::File& file,
-                              SemIR::ConstantId const_id) -> SemIR::InstId;
+auto GetInstWithConstantValue(const File& file, ConstantId const_id) -> InstId;
 
 // Provides storage for instructions representing deduplicated global constants.
 class ConstantStore {

--- a/toolchain/sem_ir/diagnostic_loc_converter.cpp
+++ b/toolchain/sem_ir/diagnostic_loc_converter.cpp
@@ -107,8 +107,8 @@ class ClangImportCollector : public clang::DiagnosticRenderer {
 auto DiagnosticLocConverter::ConvertWithImports(LocId loc_id,
                                                 bool token_only) const
     -> LocAndImports {
-  llvm::SmallVector<SemIR::AbsoluteNodeId> absolute_node_ids =
-      SemIR::GetAbsoluteNodeId(sem_ir_, loc_id);
+  llvm::SmallVector<AbsoluteNodeId> absolute_node_ids =
+      GetAbsoluteNodeId(sem_ir_, loc_id);
   auto final_node_id = absolute_node_ids.pop_back_val();
 
   // Convert the final location.
@@ -125,7 +125,7 @@ auto DiagnosticLocConverter::ConvertWithImports(LocId loc_id,
   }
 
   // Convert the C++ import locations.
-  if (final_node_id.check_ir_id() == SemIR::CheckIRId::Cpp) {
+  if (final_node_id.check_ir_id() == CheckIRId::Cpp) {
     const clang::ASTUnit* ast = sem_ir_->clang_ast_unit();
     // Collect the location backtrace that Clang would use for an error here.
     ClangImportCollector(ast->getLangOpts(),
@@ -143,15 +143,15 @@ auto DiagnosticLocConverter::ConvertWithImports(LocId loc_id,
 
 auto DiagnosticLocConverter::Convert(LocId loc_id, bool token_only) const
     -> Diagnostics::ConvertedLoc {
-  llvm::SmallVector<SemIR::AbsoluteNodeId> absolute_node_ids =
-      SemIR::GetAbsoluteNodeId(sem_ir_, loc_id);
+  llvm::SmallVector<AbsoluteNodeId> absolute_node_ids =
+      GetAbsoluteNodeId(sem_ir_, loc_id);
   return ConvertImpl(absolute_node_ids.back(), token_only);
 }
 
-auto DiagnosticLocConverter::ConvertImpl(SemIR::AbsoluteNodeId absolute_node_id,
+auto DiagnosticLocConverter::ConvertImpl(AbsoluteNodeId absolute_node_id,
                                          bool token_only) const
     -> Diagnostics::ConvertedLoc {
-  if (absolute_node_id.check_ir_id() == SemIR::CheckIRId::Cpp) {
+  if (absolute_node_id.check_ir_id() == CheckIRId::Cpp) {
     return ConvertImpl(absolute_node_id.clang_source_loc_id());
   }
 
@@ -159,11 +159,11 @@ auto DiagnosticLocConverter::ConvertImpl(SemIR::AbsoluteNodeId absolute_node_id,
                      token_only);
 }
 
-auto DiagnosticLocConverter::ConvertImpl(SemIR::CheckIRId check_ir_id,
+auto DiagnosticLocConverter::ConvertImpl(CheckIRId check_ir_id,
                                          Parse::NodeId node_id,
                                          bool token_only) const
     -> Diagnostics::ConvertedLoc {
-  CARBON_CHECK(check_ir_id != SemIR::CheckIRId::Cpp);
+  CARBON_CHECK(check_ir_id != CheckIRId::Cpp);
   const auto& tree_and_subtrees =
       tree_and_subtrees_getters_->Get(check_ir_id)();
   return tree_and_subtrees.NodeToDiagnosticLoc(node_id, token_only);

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -217,8 +217,8 @@ LLVM_DUMP_METHOD auto Dump(const File& file, InstId inst_id) -> std::string {
 
   Inst inst = file.insts().Get(inst_id);
 
-  if (inst.arg0_and_kind().kind() == IdKind::For<SemIR::EntityNameId>) {
-    auto entity_name_id = SemIR::EntityNameId(inst.arg0());
+  if (inst.arg0_and_kind().kind() == IdKind::For<EntityNameId>) {
+    auto entity_name_id = EntityNameId(inst.arg0());
     out << "\n  - name:"
         << DumpNameIfValid(file,
                            file.entity_names().Get(entity_name_id).name_id);

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -37,7 +37,7 @@ namespace Carbon::SemIR {
 Formatter::Formatter(
     const File* sem_ir, int total_ir_count,
     Parse::GetTreeAndSubtreesFn get_tree_and_subtrees,
-    const FixedSizeValueStore<SemIR::CheckIRId, bool>* include_ir_in_dumps,
+    const FixedSizeValueStore<CheckIRId, bool>* include_ir_in_dumps,
     bool use_dump_sem_ir_ranges)
     : sem_ir_(sem_ir),
       inst_namer_(sem_ir_, total_ir_count),
@@ -943,23 +943,23 @@ auto Formatter::FormatInstArgAndKind(Inst::ArgAndKind arg_and_kind) -> void {
 
 auto Formatter::FormatInstRhs(Inst inst) -> void {
   CARBON_KIND_SWITCH(inst) {
-    case SemIR::InstKind::ArrayInit:
-    case SemIR::InstKind::StructInit:
-    case SemIR::InstKind::TupleInit: {
+    case InstKind::ArrayInit:
+    case InstKind::StructInit:
+    case InstKind::TupleInit: {
       auto init = inst.As<AnyAggregateInit>();
       FormatArgs(init.elements_id);
       FormatReturnSlotArg(init.dest_id);
       return;
     }
 
-    case SemIR::InstKind::ImportRefLoaded:
-    case SemIR::InstKind::ImportRefUnloaded:
+    case InstKind::ImportRefLoaded:
+    case InstKind::ImportRefUnloaded:
       FormatImportRefRhs(inst.As<AnyImportRef>());
       return;
 
-    case SemIR::InstKind::OutParam:
-    case SemIR::InstKind::RefParam:
-    case SemIR::InstKind::ValueParam: {
+    case InstKind::OutParam:
+    case InstKind::RefParam:
+    case InstKind::ValueParam: {
       auto param = inst.As<AnyParam>();
       FormatArgs(param.index);
       // Omit pretty_name because it's an implementation detail of

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -23,7 +23,7 @@ class Formatter {
   explicit Formatter(
       const File* sem_ir, int total_ir_count,
       Parse::GetTreeAndSubtreesFn get_tree_and_subtrees,
-      const FixedSizeValueStore<SemIR::CheckIRId, bool>* include_ir_in_dumps,
+      const FixedSizeValueStore<CheckIRId, bool>* include_ir_in_dumps,
       bool use_dump_sem_ir_ranges);
 
   // Prints the SemIR into an internal buffer. Must only be called once.
@@ -337,7 +337,7 @@ class Formatter {
   Parse::GetTreeAndSubtreesFn get_tree_and_subtrees_;
 
   // For each CheckIRId, whether entities from it should be formatted.
-  const FixedSizeValueStore<SemIR::CheckIRId, bool>* include_ir_in_dumps_;
+  const FixedSizeValueStore<CheckIRId, bool>* include_ir_in_dumps_;
 
   // Whether to use ranges when dumping, or to dump the full SemIR.
   bool use_dump_sem_ir_ranges_;

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -80,10 +80,10 @@ auto DecomposeVirtualFunction(const File& sem_ir, InstId fn_decl_id,
   auto fn_decl_const_id =
       GetConstantValueInSpecific(sem_ir, base_class_specific_id, fn_decl_id);
   fn_decl_id = sem_ir.constant_values().GetInstId(fn_decl_const_id);
-  auto specific_id = SemIR::SpecificId::None;
+  auto specific_id = SpecificId::None;
   auto callee_id = fn_decl_id;
   if (auto specific_function =
-          sem_ir.insts().TryGetAs<SemIR::SpecificFunction>(fn_decl_id)) {
+          sem_ir.insts().TryGetAs<SpecificFunction>(fn_decl_id)) {
     specific_id = specific_function->specific_id;
     callee_id = specific_function->callee_id;
   }

--- a/toolchain/sem_ir/import_ir.cpp
+++ b/toolchain/sem_ir/import_ir.cpp
@@ -25,7 +25,7 @@ auto ImportIRInst::Print(llvm::raw_ostream& out) const -> void {
   out << "}";
 }
 
-auto GetCanonicalFileAndInstId(const File* sem_ir, SemIR::InstId inst_id)
+auto GetCanonicalFileAndInstId(const File* sem_ir, InstId inst_id)
     -> std::pair<const File*, InstId> {
   while (true) {
     // Step through an imported instruction to the instruction it was imported
@@ -43,8 +43,7 @@ auto GetCanonicalFileAndInstId(const File* sem_ir, SemIR::InstId inst_id)
     }
 
     // Step through export declarations to their exported value.
-    if (auto export_decl =
-            sem_ir->insts().TryGetAs<SemIR::ExportDecl>(inst_id)) {
+    if (auto export_decl = sem_ir->insts().TryGetAs<ExportDecl>(inst_id)) {
       inst_id = export_decl->value_id;
       continue;
     }

--- a/toolchain/sem_ir/import_ir.h
+++ b/toolchain/sem_ir/import_ir.h
@@ -78,7 +78,7 @@ using ImportIRInstStore = ValueStore<ImportIRInstId, ImportIRInst>;
 // Returns the canonical `File` and `InstId` for an entity, tracing imported
 // instructions. Note the returned `File` might not be directly imported by the
 // input `sem_ir`.
-auto GetCanonicalFileAndInstId(const File* sem_ir, SemIR::InstId inst_id)
+auto GetCanonicalFileAndInstId(const File* sem_ir, InstId inst_id)
     -> std::pair<const File*, InstId>;
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -70,7 +70,7 @@ class InstNamer::NamingContext {
     AddInstName((inst_namer_->MaybePushEntity(id) + suffix).str());
   }
 
-  auto sem_ir() -> const SemIR::File& { return *inst_namer_->sem_ir_; }
+  auto sem_ir() -> const File& { return *inst_namer_->sem_ir_; }
 
   InstNamer* inst_namer_;
   ScopeId scope_id_;

--- a/toolchain/sem_ir/pattern.cpp
+++ b/toolchain/sem_ir/pattern.cpp
@@ -42,7 +42,7 @@ static auto GetBoundEntityName(const File& sem_ir, Inst inst)
     return {sem_ir.entity_names().Get(binding_pattern->entity_name_id).name_id,
             binding_pattern->entity_name_id};
   }
-  return {SemIR::NameId::None, SemIR::EntityNameId::None};
+  return {NameId::None, EntityNameId::None};
 }
 
 auto IsSelfPattern(const File& sem_ir, InstId pattern_id) -> bool {
@@ -56,7 +56,7 @@ auto GetFirstBindingNameFromPatternId(const File& sem_ir, InstId pattern_id)
   llvm::SmallVector<InstId> work_list = {pattern_id};
   while (!work_list.empty()) {
     auto [_, inst] = GetUnwrapped(sem_ir, work_list.pop_back_val());
-    if (auto tuple_patt = inst.TryAs<SemIR::TuplePattern>()) {
+    if (auto tuple_patt = inst.TryAs<TuplePattern>()) {
       auto block = sem_ir.inst_blocks().Get(tuple_patt->elements_id);
       work_list.append(block.rbegin(), block.rend());
       continue;

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -170,14 +170,12 @@ auto TypeStore::GetIntTypeInfo(TypeId int_type_id) const -> IntTypeInfo {
   return *int_info;
 }
 
-auto ExtractScrutineeType(const File& sem_ir, SemIR::TypeId type_id)
-    -> SemIR::TypeId {
-  if (auto pattern_type =
-          sem_ir.types().TryGetAs<SemIR::PatternType>(type_id)) {
+auto ExtractScrutineeType(const File& sem_ir, TypeId type_id) -> TypeId {
+  if (auto pattern_type = sem_ir.types().TryGetAs<PatternType>(type_id)) {
     return sem_ir.types().GetTypeIdForTypeInstId(
         pattern_type->scrutinee_type_inst_id);
   }
-  CARBON_CHECK(type_id == SemIR::ErrorInst::TypeId,
+  CARBON_CHECK(type_id == ErrorInst::TypeId,
                "Inst kind doesn't have scrutinee type: {0}",
                sem_ir.types().GetAsInst(type_id).kind());
   return type_id;

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -255,8 +255,7 @@ class TypeStore : public Yaml::Printable<TypeStore> {
 };
 
 // Returns the scrutinee type of `type_id`, which must be a `PatternType`.
-auto ExtractScrutineeType(const File& sem_ir, SemIR::TypeId type_id)
-    -> SemIR::TypeId;
+auto ExtractScrutineeType(const File& sem_ir, TypeId type_id) -> TypeId;
 
 }  // namespace Carbon::SemIR
 


### PR DESCRIPTION
Also cleaned up some in #6105, which is what got me looking for more.