### PR TITLE
Use `context.x()` instead of `context.sema_ir().x()` in `check/cpp/` when possible

### DIFF
--- a/toolchain/check/cpp/thunk.cpp
+++ b/toolchain/check/cpp/thunk.cpp
@@ -517,8 +517,7 @@ static auto BuildThunkBody(clang::Sema& sema,
 auto BuildCppThunk(Context& context, const SemIR::Function& callee_function)
     -> clang::FunctionDecl* {
   clang::FunctionDecl* callee_function_decl =
-      context.sem_ir()
-          .clang_decls()
+      context.clang_decls()
           .Get(callee_function.clang_decl_id)
           .decl->getAsFunction();
   CARBON_CHECK(callee_function_decl);


### PR DESCRIPTION
Avoid using `const Context&`. We always work with a cmutable `Context&` (https://github.com/carbon-language/carbon-lang/pull/6094#discussion_r2359199247).