### PR TITLE
docs: mark principles/safety_strategy as outdated, refer to update.

### DIFF
--- a/docs/project/principles/safety_strategy.md
+++ b/docs/project/principles/safety_strategy.md
@@ -37,6 +37,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Background
 
+TODO: This is outdated in some places (philosophy, emphasis on runtime
+checks and build modes), see the more recent 
+[Updating Carbon's safety strategy](../../../proposals/p5914.md) and 
+[Safety Design](../../design/safety/README.md).
+
 Carbon's goal is to provide
 [practical safety and testing mechanisms](../goals.md#practical-safety-and-testing-mechanisms).
 


### PR DESCRIPTION
Adds a note to the slightly outdated principles/safety strategy page. I was very confused when I encountered this page which does not mention memory safety, I believe prospective readers are well advised to consult the update to safety strategy proposal and the safety design page instead.
