### PR TITLE
Adds extracted principles that are underlying Carbon safety

### DIFF
--- a/docs/project/principles/README.md
+++ b/docs/project/principles/README.md
@@ -25,5 +25,6 @@ wants to pursue, as well as those we want to exclude.
 -   [Information accumulation](information_accumulation.md)
 -   [Low context-sensitivity](low_context_sensitivity.md)
 -   [Prefer providing only one way to do a given thing](one_way.md)
+-   [Safety](safety.md)
 -   [One static open extension mechanism](static_open_extension.md)
 -   [Success criteria](success_criteria.md)

--- a/docs/project/principles/safety.md
+++ b/docs/project/principles/safety.md
@@ -1,0 +1,62 @@
+# Safety
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+<!-- toc -->
+
+## Distinction between Strict and Permissive Carbon
+
+For any sufficiently expressive programming language, it is 
+undecidable whether the execution of programs in that language
+will have interesting properties.
+
+Any language that aims to provides rigorous memory safety guarantees 
+thus needs to navigate a tension between safety and 
+expressivity.
+
+For Carbon, we distinguish between a *strict* and a *permissive*
+variant of the Carbon language, which provides rigorous memory safety guarantees,
+and a *permissive* variant that provides no such guarantees.
+
+A strict-Carbon program fragment is only accepted by the compiler
+if execution is guaranteed to be free of safety-related execution errors 
+and its behavior with respect to safety is predictable.
+
+A permissive-Carbon program is accepted independent of whether it may 
+or may not have safety errors. In particular, a permissive-Carbon program
+can call C++ code without the programmer having to give any additional
+information that may be required for checking safety.
+
+## Partial Safety and Gradual Ramp-up
+
+While absence of safety-related errors is a property of a program as
+a whole, the design must specify the boundary and interaction between 
+strict-Carbon and permissive-Carbon fragments in a way that benefits
+from partial safety guarantees.
+
+In particular, it must be possible to turn permissive-Carbon code that 
+calls C++ or was migrated from C++ into safe-Carbon by gradual adoption
+of safety-related annotations.
+
+Annotations for static checking need to be [easy to read and write](../goals.md#code-that-is-easy-to-read-understand-and-write), and program safety must
+be attainable without being forced to fully rewrite migrated C++ and
+without performance cost.
+
+Annotations may include programmer adding assumptions that enable
+the compiler to apply the rules of safe-Carbon to obtain a proof of 
+safety.
+
+## Simplicity
+
+The rules that determine whether a safe-Carbon program is accepted
+should be easy to understand and documented.
+
+Different build modes never change the rules that make
+safe-Carbon safe (safe-Carbon is safe in any build mode), but 
+they may affect behavior and performance characteristics of 
+Carbon programs as a whole.
+

--- a/docs/project/principles/safety.md
+++ b/docs/project/principles/safety.md
@@ -17,24 +17,28 @@ will have interesting properties.
 *Static checking* is a compile-time method to ensure program properties through
 analysis and annotations that describe intended behavior.
 
-A language that aims to provides rigorous memory safety guarantees 
-through static checking needs to navigate a tension between safety and 
-expressivity. Carbon aims to provide a memory-safe language, which
-means statically checked language that covers realistic programming
-use cases.
+Carbon aims to provides rigorous memory safety guarantees 
+through static checking. This requires navigating a field of tension 
+between safety and expressivity. Carbon's statically checked safety 
+guarantees should not come at the price of losing possibility to cover
+realistic programming use cases.
+
+Static checking cannot fully eliminate the need for dynamic techniques
+for safety (e.g. bounds checks) but it can provide constraints on
+runtime program behaviors to minimize such checks.
 
 ## Strict and Permissive Carbon
 
-The goals of Carbon include incremental migration from C++. Further,
+The goals of Carbon include incremental migration from C++, which does not
+come withs statically checked safety guarantees. Further,
 interactions with system components not written in Carbon place a limit 
 on safety guarantees.
 
-For this reason, we distinguish between a *strict* and a *permissive* variant of the Carbon 
-language. The strict variant provides rigorous memory safety guarantees,
-whereas the *permissive* variant does not provides no such guarantees.
+For this reason, Carbon's design distinguishes between a *strict* and a *permissive* variant of the
+language and clarifies the interaction and boundary between these variants.
 
 A strict-Carbon program fragment is only accepted by the compiler
-if execution is guaranteed to be free of safety-related execution errors 
+if execution is guaranteed to be entirely free of safety-related execution errors 
 and its behavior with respect to safety is predictable.
 
 A permissive-Carbon program is accepted independent without any guarantee

--- a/docs/project/principles/safety.md
+++ b/docs/project/principles/safety.md
@@ -8,28 +8,40 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <!-- toc -->
 
-## Distinction between Strict and Permissive Carbon
+## Static Checking
 
 For any sufficiently expressive programming language, it is 
 undecidable whether the execution of programs in that language
 will have interesting properties.
 
-Any language that aims to provides rigorous memory safety guarantees 
-thus needs to navigate a tension between safety and 
-expressivity.
+*Static checking* is a compile-time method to ensure program properties through
+analysis and annotations that describe intended behavior.
 
-For Carbon, we distinguish between a *strict* and a *permissive*
-variant of the Carbon language, which provides rigorous memory safety guarantees,
-and a *permissive* variant that provides no such guarantees.
+A language that aims to provides rigorous memory safety guarantees 
+through static checking needs to navigate a tension between safety and 
+expressivity. Carbon aims to provide a memory-safe language, which
+means statically checked language that covers realistic programming
+use cases.
+
+## Strict and Permissive Carbon
+
+The goals of Carbon include incremental migration from C++. Further,
+interactions with system components not written in Carbon place a limit 
+on safety guarantees.
+
+For this reason, we distinguish between a *strict* and a *permissive* variant of the Carbon 
+language. The strict variant provides rigorous memory safety guarantees,
+whereas the *permissive* variant does not provides no such guarantees.
 
 A strict-Carbon program fragment is only accepted by the compiler
 if execution is guaranteed to be free of safety-related execution errors 
 and its behavior with respect to safety is predictable.
 
-A permissive-Carbon program is accepted independent of whether it may 
-or may not have safety errors. In particular, a permissive-Carbon program
-can call C++ code without the programmer having to give any additional
-information that may be required for checking safety.
+A permissive-Carbon program is accepted independent without any guarantee
+whether its execution may lead to safety errors. In particular, a 
+permissive-Carbon program fragment can call C++ code. The 
+programmer does not have to give additional information to the compiler
+which is necessary for checking safety.
 
 ## Partial Safety and Gradual Ramp-up
 
@@ -38,25 +50,28 @@ a whole, the design must specify the boundary and interaction between
 strict-Carbon and permissive-Carbon fragments in a way that benefits
 from partial safety guarantees.
 
-In particular, it must be possible to turn permissive-Carbon code that 
-calls C++ or was migrated from C++ into safe-Carbon by gradual adoption
+A strict-Carbon program fragment may safely interact with a permissive-Carbon fragment
+if the conditions for safe execution are met. 
+
+It will be possible and necessary to *assume* such safety conditions. In permissive
+code, the responsibility for safety lies with the programmer.
+Carbon's safety model may support communicating part or all of the assumed
+information to the compiler which can make use of it for safety checking.
+
+It must further be possible to turn permissive-Carbon code into safe-Carbon by gradual adoption
 of safety-related annotations.
+
+## Simplicity and Ease of Understanding
 
 Annotations for static checking need to be [easy to read and write](../goals.md#code-that-is-easy-to-read-understand-and-write), and program safety must
 be attainable without being forced to fully rewrite migrated C++ and
 without performance cost.
 
-Annotations may include programmer adding assumptions that enable
-the compiler to apply the rules of safe-Carbon to obtain a proof of 
-safety.
-
-## Simplicity
-
-The rules that determine whether a safe-Carbon program is accepted
-should be easy to understand and documented.
+The rules that determine whether a strict-Carbon program is accepted
+should be documented and easy to understand.
 
 Different build modes never change the rules that make
-safe-Carbon safe (safe-Carbon is safe in any build mode), but 
-they may affect behavior and performance characteristics of 
+safe-Carbon safe (safe-Carbon is safe in any build mode).
+They may affect behavior and performance characteristics of 
 Carbon programs as a whole.
 

--- a/docs/project/principles/safety.md
+++ b/docs/project/principles/safety.md
@@ -8,74 +8,86 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <!-- toc -->
 
+## Table of contents
+
+-   [Static Checking](#static-checking)
+-   [Strict and Permissive Carbon](#strict-and-permissive-carbon)
+-   [Partial Safety and Gradual Ramp-up](#partial-safety-and-gradual-ramp-up)
+-   [Simplicity and Ease of Understanding](#simplicity-and-ease-of-understanding)
+
+<!-- tocstop -->
+
 ## Static Checking
 
-For any sufficiently expressive programming language, it is 
-undecidable whether the execution of programs in that language
-will have interesting properties.
+For any sufficiently expressive programming language, it is undecidable whether
+the execution of programs in that language will have interesting properties.
 
-*Static checking* is a compile-time method to ensure program properties through
+_Static checking_ is a compile-time method to ensure program properties through
 analysis and annotations that describe intended behavior.
 
-Carbon aims to provides rigorous memory safety guarantees 
-through static checking. This requires navigating a field of tension 
-between safety and expressivity. Carbon's statically checked safety 
-guarantees should not come at the price of losing possibility to cover
-realistic programming use cases.
+Carbon aims to provides rigorous memory safety guarantees through static
+checking. This requires navigating a field of tension between safety and
+expressivity. Carbon's statically checked safety guarantees should not come at
+the price of losing possibility to cover realistic programming use cases.
 
-Static checking cannot fully eliminate the need for dynamic techniques
-for safety (e.g. bounds checks) but it can provide constraints on
-runtime program behaviors to minimize such checks.
+Static checking cannot fully eliminate the need for dynamic techniques for
+safety (for example bounds checks) but it can provide constraints on runtime
+program behaviors to minimize such checks.
 
 ## Strict and Permissive Carbon
 
-The goals of Carbon include incremental migration from C++, which does not
-come withs statically checked safety guarantees. Further,
-interactions with system components not written in Carbon place a limit 
-on safety guarantees.
+The goals of Carbon include incremental migration from C++, which does not come
+with an overall statically checked safety guarantee. Further, interactions with
+system components not written in Carbon place a limit on safety guarantees.
 
-For this reason, Carbon's design distinguishes between a *strict* and a *permissive* variant of the
-language and clarifies the interaction and boundary between these variants.
+For this reason, Carbon's design distinguishes between a _strict_ and a
+_permissive_ variant of the language and clarifies the interaction and boundary
+between these variants.
 
-A strict-Carbon program fragment is only accepted by the compiler
-if execution is guaranteed to be entirely free of safety-related execution errors 
-and its behavior with respect to safety is predictable.
+A strict-Carbon program fragment is only accepted by the compiler if execution
+is guaranteed to be entirely free of safety-related execution errors and its
+behavior with respect to safety is predictable. Where strict Carbon may call
+operations where the compiler cannot prove ("unsafe operations"), a marker and
+an alternative safety argument must be provided in some form.
 
-A permissive-Carbon program is accepted independent without any guarantee
-whether its execution may lead to safety errors. In particular, a 
-permissive-Carbon program fragment can call C++ code. The 
-programmer does not have to give additional information to the compiler
-which is necessary for checking safety.
+A permissive-Carbon program is accepted without an overall safety guarantee, so
+its execution may lead to safety errors. Permissive Carbon should still perform
+safety checks wherever possible, and signal errors. A permissive-Carbon program
+fragment can call C++ code without a safety argument of any form. Where
+additional information can enable safety checks, permissive Carbon can provide
+ways to perform such check and thus obtain partial (weak) safety. Crucially, the
+programmer is not obliged to give additional information to the compiler which
+would be necessary for checking partial safety.
 
 ## Partial Safety and Gradual Ramp-up
 
-While absence of safety-related errors is a property of a program as
-a whole, the design must specify the boundary and interaction between 
-strict-Carbon and permissive-Carbon fragments in a way that benefits
-from partial safety guarantees.
+While absence of safety-related errors is a property of a program as a whole,
+the design must specify the boundary and interaction between strict-Carbon and
+permissive-Carbon fragments in a way that benefits from partial safety
+guarantees.
 
-A strict-Carbon program fragment may safely interact with a permissive-Carbon fragment
-if the conditions for safe execution are met. 
+A strict-Carbon program fragment may safely interact with a permissive-Carbon
+fragment if the conditions for safe execution are met.
 
-It will be possible and necessary to *assume* such safety conditions. In permissive
-code, the responsibility for safety lies with the programmer.
+It will be possible and necessary to _assume_ such safety conditions. In
+permissive code, the responsibility for safety lies with the programmer.
 Carbon's safety model may support communicating part or all of the assumed
 information to the compiler which can make use of it for safety checking.
 
-It must further be possible to turn permissive-Carbon code into safe-Carbon by gradual adoption
-of safety-related annotations.
+It must further be possible to migrate permissive-Carbon code into strict-Carbon
+by gradual adoption of safety-related annotations, until it is fully annotated
+and benefits from statically checked overall safety guarantee of strict Carbon.
 
 ## Simplicity and Ease of Understanding
 
-Annotations for static checking need to be [easy to read and write](../goals.md#code-that-is-easy-to-read-understand-and-write), and program safety must
-be attainable without being forced to fully rewrite migrated C++ and
-without performance cost.
+Annotations for static checking need to be
+[easy to read and write](../goals.md#code-that-is-easy-to-read-understand-and-write),
+and program safety must be attainable without being forced to fully rewrite
+migrated C++ and without performance cost.
 
-The rules that determine whether a strict-Carbon program is accepted
-should be documented and easy to understand.
+The rules that determine whether a strict-Carbon program is accepted should be
+documented and easy to understand.
 
-Different build modes never change the rules that make
-safe-Carbon safe (safe-Carbon is safe in any build mode).
-They may affect behavior and performance characteristics of 
-Carbon programs as a whole.
-
+Different build modes never change the rules that make safe-Carbon safe
+(safe-Carbon is safe in any build mode). They may affect behavior and
+performance characteristics of Carbon programs as a whole.


### PR DESCRIPTION
These are the safety principles I extracted from docs/project/principles/safety_strategy.md page.
This outdated file was supposed to be deleted #5914 and its actual deletion is part of #6013.

In the context of that PR, Josh suggested we may want keep some safety principles, which are at a higher level that safety design

This is not a proposal.

It is (my understanding of) the principles underlying the updated safety strategy.
The safety design introduced in #5914 goes into more detail.

If I have read too much into the udpated safety strategy and design, or something is missing that shouldn't be missing, please let me know.
