### PR TITLE
Avoid extra work when `thunk_required` is already true in `IsCppThunkRequired()`

### DIFF
--- a/toolchain/check/cpp/thunk.cpp
+++ b/toolchain/check/cpp/thunk.cpp
@@ -110,6 +110,7 @@ auto IsCppThunkRequired(Context& context, const SemIR::Function& function)
     for (auto* param : decl->parameters()) {
       if (param->getType()->isReferenceType()) {
         thunk_required = true;
+        break;
       }
     }
   }
@@ -129,12 +130,10 @@ auto IsCppThunkRequired(Context& context, const SemIR::Function& function)
     if (param_id == SemIR::ErrorInst::InstId) {
       return false;
     }
-    if (!thunk_required &&
+    thunk_required =
+        thunk_required ||
         IsThunkRequiredForType(
-            context,
-            context.insts().GetAs<SemIR::AnyParam>(param_id).type_id)) {
-      thunk_required = true;
-    }
+            context, context.insts().GetAs<SemIR::AnyParam>(param_id).type_id);
   }
 
   return thunk_required;


### PR DESCRIPTION
Also set `thunk_required` in a more consistent way, to avoid bugs like the one fixed in #6152.

Part #6148.