### PR TITLE
Move the FacetAccessType special case out of name lookup, and generalize it

### DIFF
--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -882,6 +882,9 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
     }
   }
 
+  // Ensure specifics don't substitute in weird things for the query self.
+  CARBON_CHECK(context.types().IsFacetType(
+      context.insts().Get(eval_query.query_self_inst_id).type_id()));
   SemIR::ConstantId query_self_const_id =
       context.constant_values().Get(eval_query.query_self_inst_id);
 

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -473,6 +473,23 @@ auto PerformMemberAccess(Context& context, SemIR::LocId loc_id,
   }
 }
 
+// Returns a type that is never a facet. For facets, this returns the FacetType
+// of that facet. This always gives a TypeId which we can do name lookup with.
+static auto ExtractFacetTypeForFacet(Context& context, SemIR::TypeId type_id)
+    -> SemIR::TypeId {
+  auto facet_inst_id =
+      GetCanonicalFacetOrTypeValue(context, context.types().GetInstId(type_id));
+  auto facet_inst_type_id = context.insts().Get(facet_inst_id).type_id();
+
+  if (facet_inst_type_id == SemIR::TypeType::TypeId) {
+    // `type_id` is not a facet, return it unchanged.
+    return type_id;
+  } else {
+    // Return the type of the facet.
+    return facet_inst_type_id;
+  }
+}
+
 // Common logic for `AccessMemberAction` and `AccessOptionalMemberAction`.
 static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
                                 SemIR::InstId base_id, SemIR::NameId name_id,
@@ -490,8 +507,16 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
     }
   }
 
-  // If the base isn't a scope, it must have a complete type.
+  // Otherwise, handle `x.F` by performing lookup into the type of `x` (where
+  // `x` is `base_id`).
   auto base_type_id = context.insts().Get(base_id).type_id();
+
+  // Require a complete type explicitly. Materializing a temporary will too, but
+  // we can produce a better diagnostic here with context about what operation
+  // is being done (member access) that requires the complete type.
+  //
+  // TODO: ConvertToValueOrRefExpr could take context about the operation being
+  // done to give a better error than "invalid use of" an incomplete type?
   if (!RequireCompleteType(context, base_type_id, SemIR::LocId(base_id), [&] {
         CARBON_DIAGNOSTIC(IncompleteTypeInMemberAccess, Error,
                           "member access into object of incomplete type {0}",
@@ -502,70 +527,79 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
     return SemIR::ErrorInst::InstId;
   }
 
-  // Materialize a temporary for the base expression if necessary.
-  base_id = ConvertToValueOrRefExpr(context, base_id);
-  base_type_id = context.insts().Get(base_id).type_id();
-  auto base_type_const_id = context.types().GetConstantId(base_type_id);
-
-  // Find the scope corresponding to the base type.
-  llvm::SmallVector<LookupScope> lookup_scopes;
-  if (!AppendLookupScopesForConstant(context, loc_id, base_type_const_id,
-                                     &lookup_scopes)) {
-    // The base type is not a name scope. Try some fallback options.
-    if (auto struct_type = context.insts().TryGetAs<SemIR::StructType>(
-            context.constant_values().GetInstId(base_type_const_id))) {
-      // TODO: Do we need to optimize this with a lookup table for O(1)?
-      for (auto [i, field] : llvm::enumerate(
-               context.struct_type_fields().Get(struct_type->fields_id))) {
-        if (name_id == field.name_id) {
-          // TODO: Model this as producing a lookup result, and do instance
-          // binding separately. Perhaps a struct type should be a name scope.
-          return GetOrAddInst<SemIR::StructAccess>(
-              context, loc_id,
-              {.type_id =
-                   context.types().GetTypeIdForTypeInstId(field.type_inst_id),
-               .struct_id = base_id,
-               .index = SemIR::ElementIndex(i)});
-        }
-      }
-      if (required) {
-        CARBON_DIAGNOSTIC(QualifiedExprNameNotFound, Error,
-                          "type {0} does not have a member `{1}`", TypeOfInstId,
-                          SemIR::NameId);
-        context.emitter().Emit(loc_id, QualifiedExprNameNotFound, base_id,
-                               name_id);
-        return SemIR::ErrorInst::InstId;
-      } else {
-        return SemIR::InstId::None;
-      }
-    }
-
-    if (base_type_id != SemIR::ErrorInst::TypeId) {
-      CARBON_DIAGNOSTIC(QualifiedExprUnsupported, Error,
-                        "type {0} does not support qualified expressions",
-                        TypeOfInstId);
-      context.emitter().Emit(loc_id, QualifiedExprUnsupported, base_id);
-    }
-    return SemIR::ErrorInst::InstId;
-  }
-
-  // Perform lookup into the base type.
-  auto member_id = LookupMemberNameInScope(
-      context, loc_id, base_id, name_id, base_type_const_id, lookup_scopes,
-      /*lookup_in_type_of_base=*/true, /*required=*/required);
-
   // For name lookup into a facet, never perform instance binding.
   // TODO: According to the design, this should be a "lookup in base" lookup,
   // not a "lookup in type of base" lookup, and the facet itself should have
   // member names that directly name members of the `impl`.
-  if (context.types().IsFacetType(base_type_id)) {
-    return member_id;
+  bool perform_instance_binding =
+      !context.types().Is<SemIR::FacetType>(base_type_id);
+
+  // Materialize a temporary for the base expression if necessary.
+  base_id = ConvertToValueOrRefExpr(context, base_id);
+  base_type_id = context.insts().Get(base_id).type_id();
+
+  {
+    // If `base_type_id` is a facet, we don't know its eventual type yet, but we
+    // don't produce a symbolic instruction to do the name lookup later. We want
+    // to do that lookup into the scope of the facet's FacetType, so we extract
+    // that here.
+    auto lookup_type_id = ExtractFacetTypeForFacet(context, base_type_id);
+    auto lookup_type_const_id = context.types().GetConstantId(lookup_type_id);
+
+    llvm::SmallVector<LookupScope> lookup_scopes;
+    if (AppendLookupScopesForConstant(context, loc_id, lookup_type_const_id,
+                                      &lookup_scopes)) {
+      // Perform lookup into the base type.
+      auto member_id = LookupMemberNameInScope(
+          context, loc_id, base_id, name_id, lookup_type_const_id,
+          lookup_scopes,
+          /*lookup_in_type_of_base=*/true, /*required=*/required);
+
+      if (perform_instance_binding) {
+        // Perform instance binding if we found an instance member.
+        member_id = PerformInstanceBinding(context, loc_id, base_id, member_id);
+      }
+
+      return member_id;
+    }
   }
 
-  // Perform instance binding if we found an instance member.
-  member_id = PerformInstanceBinding(context, loc_id, base_id, member_id);
+  // The base type is not a name scope. Try some fallback options.
+  if (auto struct_type = context.insts().TryGetAs<SemIR::StructType>(
+          context.types().GetInstId(base_type_id))) {
+    // TODO: Do we need to optimize this with a lookup table for O(1)?
+    for (auto [i, field] : llvm::enumerate(
+             context.struct_type_fields().Get(struct_type->fields_id))) {
+      if (name_id == field.name_id) {
+        // TODO: Model this as producing a lookup result, and do instance
+        // binding separately. Perhaps a struct type should be a name scope.
+        return GetOrAddInst<SemIR::StructAccess>(
+            context, loc_id,
+            {.type_id =
+                 context.types().GetTypeIdForTypeInstId(field.type_inst_id),
+             .struct_id = base_id,
+             .index = SemIR::ElementIndex(i)});
+      }
+    }
+    if (required) {
+      CARBON_DIAGNOSTIC(QualifiedExprNameNotFound, Error,
+                        "type {0} does not have a member `{1}`", TypeOfInstId,
+                        SemIR::NameId);
+      context.emitter().Emit(loc_id, QualifiedExprNameNotFound, base_id,
+                             name_id);
+      return SemIR::ErrorInst::InstId;
+    } else {
+      return SemIR::InstId::None;
+    }
+  }
 
-  return member_id;
+  if (base_type_id != SemIR::ErrorInst::TypeId) {
+    CARBON_DIAGNOSTIC(QualifiedExprUnsupported, Error,
+                      "type {0} does not support qualified expressions",
+                      TypeOfInstId);
+    context.emitter().Emit(loc_id, QualifiedExprUnsupported, base_id);
+  }
+  return SemIR::ErrorInst::InstId;
 }
 
 auto PerformAction(Context& context, SemIR::LocId loc_id,

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -284,18 +284,6 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
   auto base_id = context.constant_values().GetInstId(base_const_id);
   auto base = context.insts().Get(base_id);
 
-  if (auto base_as_facet_access_type = base.TryAs<SemIR::FacetAccessType>()) {
-    // Move from the symbolic facet value up in typish-ness to its FacetType to
-    // find a lookup scope.
-    auto facet_type_type_id =
-        context.insts()
-            .Get(base_as_facet_access_type->facet_value_inst_id)
-            .type_id();
-    base_const_id = context.types().GetConstantId(facet_type_type_id);
-    base_id = context.constant_values().GetInstId(base_const_id);
-    base = context.insts().Get(base_id);
-  }
-
   if (auto base_as_namespace = base.TryAs<SemIR::Namespace>()) {
     scopes->push_back(
         LookupScope{.name_scope_id = base_as_namespace->name_scope_id,

--- a/toolchain/check/type.cpp
+++ b/toolchain/check/type.cpp
@@ -240,14 +240,6 @@ auto GetUnboundElementType(Context& context, SemIR::TypeInstId class_type_id,
 
 auto GetCanonicalFacetOrTypeValue(Context& context, SemIR::InstId inst_id)
     -> SemIR::InstId {
-  if (inst_id == SemIR::ErrorInst::InstId) {
-    return inst_id;
-  }
-
-  CARBON_CHECK(
-      context.types().IsFacetType(context.insts().Get(inst_id).type_id()),
-      "{0}", context.insts().Get(inst_id).type_id());
-
   auto const_inst_id = context.constant_values().GetConstantInstId(inst_id);
 
   if (auto access =


### PR DESCRIPTION
The `AppendLookupScopesForConstant` function had a special case for `facet as type` which was overly broad (applying to all callers to the function when only one caller needs it), and was confusingly overly specific (applying to `facet as type` but not to `facet` constants).

We clarify all of this by moving it out to member access, and applying it only to the case of looking into the type of `base_id`. In that case we are doing member lookup into the facet itself, but since it's symbolic we don't know the type to look into. And we don't defer the lookup with a symbolic instruction, so we do the lookup into the facet's type instead.

We add a helper function in member access, `ExtractFacetTypeForFacet` to encapsulate this slightly-odd operation. It's odd because it ends up getting *the type of the type* when the `base_id` has a facet as its type.

The helper is now built on top of GetCanonicalFacetOrTypeValue() instead of explicitly looking for FacetAccessType, which makes it work more generally for any type instructions that represent a facet, including SymbolicBindingType in the future.

While here document and improve clarity throughout the `PerformActionHelper` for member access.