### PR TITLE
Make dumping work with the `irM.instN` tagged InstId format

### DIFF
--- a/scripts/lldbinit.py
+++ b/scripts/lldbinit.py
@@ -44,14 +44,16 @@ def cmd_dump(debugger: Any, command: Any, result: Any, dict: Any) -> None:
 Dumps the value of an associated ID, using the C++ Dump() functions.
 
 Usage:
-  dump <CONTEXT> [<EXPR>|-- <EXPR>|<TYPE><ID>|<IR>.<TYPE><ID>]
+  dump <CONTEXT> [<EXPR>|-- <EXPR>|[<IR>.]<TYPE><ID>]
 
 Args:
   CONTEXT is the dump context, such a SemIR::Context reference, a SemIR::File,
           a Parse::Context, or a Lex::TokenizeBuffer.
   EXPR is a C++ expression such as a variable name. Use `--` to prevent it from
        being treated as a TYPE and ID.
-  IR is the CheckIRId(N) in the form `irN`.
+  IR is the CheckIRId(N) in the form `irN`. Not all ID types have an `ir`
+       prefix, the ones which do are dumped with that prefix, such as for
+       InstId as `ir1.inst2`.
   TYPE can be `inst`, `constant`, `generic`, `impl`, `entity_name`, etc. See
        the `Label` string in `IdBase` classes to find possible TYPE names,
        though only Id types that have a matching `Make...Id()` function are
@@ -76,7 +78,7 @@ Example usage:
     context = args[0]
 
     # The set of "Make" functions in dump.cpp. These use ADL to find the factory
-    # function in `context/` or in `sem_ir/`.
+    # function in `check/` or in `sem_ir/`.
     id_types = {
         "inst": "MakeInstId",
     }

--- a/scripts/lldbinit.py
+++ b/scripts/lldbinit.py
@@ -53,7 +53,7 @@ Args:
        being treated as a TYPE and ID.
   IR is the CheckIRId(N) in the form `irN`. Not all ID types have an `ir`
        prefix, the ones which do are dumped with that prefix, such as for
-       InstId as `ir1.inst2`.
+       `inst` as `ir1.inst2`.
   TYPE can be `inst`, `constant`, `generic`, `impl`, `entity_name`, etc. See
        the `Label` string in `IdBase` classes to find possible TYPE names,
        though only Id types that have a matching `Make...Id()` function are

--- a/scripts/lldbinit.py
+++ b/scripts/lldbinit.py
@@ -44,13 +44,14 @@ def cmd_dump(debugger: Any, command: Any, result: Any, dict: Any) -> None:
 Dumps the value of an associated ID, using the C++ Dump() functions.
 
 Usage:
-  dump <CONTEXT> [<EXPR>|-- <EXPR>|<TYPE><ID>|<TYPE> <ID>]
+  dump <CONTEXT> [<EXPR>|-- <EXPR>|<TYPE><ID>|<IR>.<TYPE><ID>]
 
 Args:
   CONTEXT is the dump context, such a SemIR::Context reference, a SemIR::File,
           a Parse::Context, or a Lex::TokenizeBuffer.
   EXPR is a C++ expression such as a variable name. Use `--` to prevent it from
        being treated as a TYPE and ID.
+  IR is the CheckIRId(N) in the form `irN`.
   TYPE can be `inst`, `constant`, `generic`, `impl`, `entity_name`, etc. See
        the `Label` string in `IdBase` classes to find possible TYPE names,
        though only Id types that have a matching `Make...Id()` function are
@@ -74,8 +75,13 @@ Example usage:
 
     context = args[0]
 
-    # The set of "Make" functions in dump.cpp.
+    # The set of "Make" functions in dump.cpp. These use ADL to find the factory
+    # function in `context/` or in `sem_ir/`.
     id_types = {
+        "inst": "MakeInstId",
+    }
+    # These id types don't have an IdTag embedded in them.
+    untagged_id_types = {
         "class": "SemIR::MakeClassId",
         "constant": "SemIR::MakeConstantId",
         "symbolic_constant": "SemIR::MakeSymbolicConstantId",
@@ -85,7 +91,6 @@ Example usage:
         "generic": "SemIR::MakeGenericId",
         "impl": "SemIR::MakeImplId",
         "inst_block": "SemIR::MakeInstBlockId",
-        "inst": "SemIR::MakeInstId",
         "interface": "SemIR::MakeInterfaceId",
         "name": "SemIR::MakeNameId",
         "name_scope": "SemIR::MakeNameScopeId",
@@ -110,27 +115,31 @@ Example usage:
 
     # Try to find a type + id from the input args. If not, the id will be passed
     # through directly to C++, as it can be a variable name.
-    id_type = None
+    found_id_type = False
+
+    # Look for <irN>.<type><id> as a single argument.
+    if m := re.fullmatch("ir(\\d+)\\.([a-z_]+)(\\d+)", args[1]):
+        if m[2] in id_types:
+            if len(args) != 2:
+                print_usage()
+                return
+            id_type = m[2]
+            print_dump(
+                context, f"{id_types[id_type]}({context}, {m[1]}, {m[3]})"
+            )
+            found_id_type = True
 
     # Look for <type><id> as a single argument.
     if m := re.fullmatch("([a-z_]+)(\\d+)", args[1]):
-        if m[1] in id_types:
+        if m[1] in untagged_id_types:
             if len(args) != 2:
                 print_usage()
                 return
             id_type = m[1]
-            print_dump(context, f"{id_types[id_type]}({m[2]})")
+            print_dump(context, f"{untagged_id_types[id_type]}({m[2]})")
+            found_id_type = True
 
-    # Look for <type> <id> as two arguments.
-    if not id_type:
-        if args[1] in id_types:
-            if len(args) != 3:
-                print_usage()
-                return
-            id_type = args[1]
-            print_dump(context, f"{id_types[id_type]}({args[2]})")
-
-    if not id_type:
+    if not found_id_type:
         # Use `--` to escape a variable name like `inst22`.
         if args[1] == "--":
             expr = " ".join(args[2:])

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -180,6 +180,7 @@ cc_library(
         "//toolchain/parse:tree",
         "//toolchain/sem_ir:dump",
         "//toolchain/sem_ir:file",
+        "//toolchain/sem_ir:typed_insts",
     ],
     # Always link dump methods.
     alwayslink = 1,

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -243,6 +243,7 @@ class Context {
   // Directly expose SemIR::File data accessors for brevity in calls.
   // --------------------------------------------------------------------------
 
+  auto check_ir_id() -> SemIR::CheckIRId { return sem_ir().check_ir_id(); }
   auto identifiers() -> SharedValueStores::IdentifierStore& {
     return sem_ir().identifiers();
   }

--- a/toolchain/check/dump.cpp
+++ b/toolchain/check/dump.cpp
@@ -11,20 +11,21 @@
 // - lldb: `expr Dump(context, id)`
 // - gdb: `call Dump(context, id)`
 
-#include "toolchain/sem_ir/ids.h"
 #ifndef NDEBUG
+
+#include "toolchain/lex/dump.h"
 
 #include <string>
 
 #include "common/check.h"
 #include "common/raw_string_ostream.h"
 #include "toolchain/check/context.h"
-#include "toolchain/lex/dump.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/dump.h"
 #include "toolchain/parse/tree.h"
 #include "toolchain/sem_ir/dump.h"
 #include "toolchain/sem_ir/file.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/dump.cpp
+++ b/toolchain/check/dump.cpp
@@ -11,15 +11,15 @@
 // - lldb: `expr Dump(context, id)`
 // - gdb: `call Dump(context, id)`
 
+#include "toolchain/sem_ir/ids.h"
 #ifndef NDEBUG
-
-#include "toolchain/lex/dump.h"
 
 #include <string>
 
 #include "common/check.h"
 #include "common/raw_string_ostream.h"
 #include "toolchain/check/context.h"
+#include "toolchain/lex/dump.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/dump.h"
 #include "toolchain/parse/tree.h"
@@ -136,6 +136,17 @@ LLVM_DUMP_METHOD static auto Dump(
 LLVM_DUMP_METHOD static auto Dump(const Context& context, SemIR::TypeId type_id)
     -> std::string {
   return SemIR::Dump(context.sem_ir(), type_id);
+}
+
+LLVM_DUMP_METHOD static auto MakeInstId(Context& context, int check_ir_id,
+                                        int id) -> SemIR::InstId {
+  if (SemIR::CheckIRId(check_ir_id) == context.check_ir_id()) {
+    return SemIR::MakeInstId(context.sem_ir(), check_ir_id, id);
+  } else {
+    const auto& import_ir = context.import_irs().Get(
+        context.check_ir_map().Get(SemIR::CheckIRId(check_ir_id)));
+    return SemIR::MakeInstId(*import_ir.sem_ir, check_ir_id, id);
+  }
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -454,9 +454,12 @@ LLVM_DUMP_METHOD static auto MakeInstBlockId(int id) -> InstBlockId {
 }
 LLVM_DUMP_METHOD auto MakeInstId(const SemIR::File& file, int check_ir_id,
                                  int id) -> InstId {
-  CARBON_CHECK(file.check_ir_id() == SemIR::CheckIRId(check_ir_id),
-               "SemIR::MakeInstId given a CheckIRId for the wrong SemIR::File. "
-               "Maybe you want to dump from a Check::Context.");
+  if (file.check_ir_id() != SemIR::CheckIRId(check_ir_id)) {
+    llvm::errs()
+        << "SemIR::MakeInstId given a CheckIRId for the wrong SemIR::File. "
+           "Maybe you want to dump from a Check::Context.\n";
+    return SemIR::InstId::None;
+  }
   return InstId(file.insts().GetIdTag().Apply(id));
 }
 LLVM_DUMP_METHOD static auto MakeInterfaceId(int id) -> InterfaceId {

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -452,7 +452,13 @@ LLVM_DUMP_METHOD static auto MakeImplId(int id) -> ImplId { return ImplId(id); }
 LLVM_DUMP_METHOD static auto MakeInstBlockId(int id) -> InstBlockId {
   return InstBlockId(id);
 }
-LLVM_DUMP_METHOD static auto MakeInstId(int id) -> InstId { return InstId(id); }
+LLVM_DUMP_METHOD auto MakeInstId(const SemIR::File& file, int check_ir_id,
+                                 int id) -> InstId {
+  CARBON_CHECK(file.check_ir_id() == SemIR::CheckIRId(check_ir_id),
+               "SemIR::MakeInstId given a CheckIRId for the wrong SemIR::File. "
+               "Maybe you want to dump from a Check::Context.");
+  return InstId(file.insts().GetIdTag().Apply(id));
+}
 LLVM_DUMP_METHOD static auto MakeInterfaceId(int id) -> InterfaceId {
   return InterfaceId(id);
 }

--- a/toolchain/sem_ir/dump.h
+++ b/toolchain/sem_ir/dump.h
@@ -42,6 +42,8 @@ auto Dump(const File& file, StructTypeFieldsId struct_type_fields_id)
     -> std::string;
 auto Dump(const File& file, TypeId type_id) -> std::string;
 
+auto MakeInstId(const SemIR::File& file, int check_ir_id, int id) -> InstId;
+
 }  // namespace Carbon::SemIR
 
 #endif  // NDEBUG


### PR DESCRIPTION
As of #5997, InstId now contains a tag of the `CheckIRId` inside it, which works fine for debugging when dumping a C++ variable, but did not work anymore when trying to dump other InstIds that had been dumped. Teach lldb's `dump` command to pull apart the `ir1.inst2` format and change the `MakeInstId` methods in dump.cpp to take the `CheckIRId` as an input. Since you could now possibly dump inst ids from another IR, provide an overload in `Check::` that allows for this. And CHECK in `SemIR::` if you try to dump something from the wrong IR.

Now this works again:
```
(lldb) dump context ir1.inst21
ir1.inst21: {kind: ClassType, arg0: class0, arg1: specific<none>, type: type(TypeType)}
  - type: type(TypeType): type; {kind: TypeType, type: type(TypeType)}
  - value: concrete_constant(ir1.inst21)
  - loc: LocId(<none>)
```