### PR TITLE
C++ interop: Correctly report the unsupported param type when using explicit object param

### DIFF
--- a/toolchain/check/testdata/interop/cpp/class/method.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/method.carbon
@@ -176,6 +176,24 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
   //@dump-sem-ir-end
 }
 
+// --- fail_call_explicit_object_param_with_unsupported_type_param.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+struct ExplicitObjectParam {
+  void F(this ExplicitObjectParam, _BitInt(23) x);
+};
+''';
+
+fn Call(e: Cpp.ExplicitObjectParam) {
+  // CHECK:STDERR: fail_call_explicit_object_param_with_unsupported_type_param.carbon:[[@LINE+4]]:3: error: semantics TODO: `Unsupported: parameter type: _BitInt(23)` [SemanticsTodo]
+  // CHECK:STDERR:   e.(Cpp.ExplicitObjectParam.F)(1);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  e.(Cpp.ExplicitObjectParam.F)(1);
+}
+
 // --- explicit_object_param_overloaded.h
 
 struct Another {


### PR DESCRIPTION
This fixes a bug, which seems to have been introduced in #6108.

In the new test, without this change, we will diagnose with
```
error: semantics TODO: `Unsupported: parameter type: ExplicitObjectParam` [SemanticsTodo]
```