### PR TITLE
Add tests of .Self given for an interface parameter that has constraints

### DIFF
--- a/toolchain/check/testdata/facet/period_self.carbon
+++ b/toolchain/check/testdata/facet/period_self.carbon
@@ -313,6 +313,23 @@ interface I(T:! Core.Destroy) {}
 // The `.Self` can see the LHS of the `where` to know `U` impls Core.Destroy.
 fn F(U:! Core.Destroy where .Self impls I(.Self)) {}
 
+// --- fail_todo_period_self_parameter_constraint_satisfied_with_type_and.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! Core.Destroy) {}
+
+// TODO: Implied constraints that `.Self` impls `Core.Destroy` are satisfied by
+// the `&` expression.
+//
+// CHECK:STDERR: fail_todo_period_self_parameter_constraint_satisfied_with_type_and.carbon:[[@LINE+7]]:25: error: cannot convert type `.Self` that implements `type` into type implementing `Core.Destroy` [ConversionFailureFacetToFacet]
+// CHECK:STDERR: fn F(U:! Core.Destroy & I(.Self)) {}
+// CHECK:STDERR:                         ^~~~~~~~
+// CHECK:STDERR: fail_todo_period_self_parameter_constraint_satisfied_with_type_and.carbon:[[@LINE-8]]:13: note: initializing generic parameter `T` declared here [InitializingGenericParam]
+// CHECK:STDERR: interface I(T:! Core.Destroy) {}
+// CHECK:STDERR:             ^
+// CHECK:STDERR:
+fn F(U:! Core.Destroy & I(.Self)) {}
+
 // --- fail_todo_compound_lookup_on_returned_period_self_parameter.carbon
 library "[[@TEST_NAME]]";
 

--- a/toolchain/check/testdata/facet/period_self.carbon
+++ b/toolchain/check/testdata/facet/period_self.carbon
@@ -313,6 +313,25 @@ interface I(T:! Core.Destroy) {}
 // The `.Self` can see the LHS of the `where` to know `U` impls Core.Destroy.
 fn F(U:! Core.Destroy where .Self impls I(.Self)) {}
 
+// --- fail_todo_compound_lookup_on_returned_period_self_parameter.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! Core.Destroy) {
+  fn G[self: Self]() -> T;
+}
+
+fn F[U:! Core.Destroy where .Self impls I(.Self)](u: U) {
+  // This tests that both `I.G` is accessible and that `Destroy` is preserved;
+  // we'd get an error for missing Destroy otherwise since G() returns an
+  // initializing expression.
+
+  // CHECK:STDERR: fail_todo_compound_lookup_on_returned_period_self_parameter.carbon:[[@LINE+4]]:3: error: cannot access member of interface `I(U as Core.Destroy)` in type `U` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   u.(I(U).G)().(I(U).G)().(I(U).G)();
+  // CHECK:STDERR:   ^~~~~~~~~~
+  // CHECK:STDERR:
+  u.(I(U).G)().(I(U).G)().(I(U).G)();
+}
+
 // CHECK:STDOUT: --- period_self_param.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {


### PR DESCRIPTION
This tests that `.Self` in an interface generic parameter preserves the facet type information of the binding when returned, and allows compound member lookup back into that interface.

And add a failing-todo test that `.Self` gets implied constraints which can be satisfied through `&` for the facet type `I(.Self)` is part of.