### PR TITLE
Update LLVM

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -103,14 +103,14 @@ bazel_dep(name = "zstd", version = "1.5.7", repo_name = "llvm_zstd")
 
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
-# HEAD as of 2025-09-07.
-llvm_project_version = "c000c9e4bf737c1cc0e5c7b435b24ea73d21ee05"
+# HEAD as of 2025-10-08.
+llvm_project_version = "e706a30ad5ad6acc7e7f20fe04be8d085613a23d"
 
 # Load a repository for the raw llvm-project, pre-overlay.
 http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
-    integrity = "sha256-6URudXFgqoCuQI4hbb7AlN4Wj7WzLHFB4AWGjUV0UAI=",
+    integrity = "sha256-c4tB09pGlsgrL1nKBpBV5F9NK0J2Gol6mdyP2C8TrJA=",
     patch_args = ["-p1"],
     patches = [
         "@carbon//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",

--- a/common/raw_hashtable_benchmark_helpers.cpp
+++ b/common/raw_hashtable_benchmark_helpers.cpp
@@ -61,7 +61,7 @@ static_assert(llvm::isPowerOf2_64(NumFourCharStrs));
 static auto MakeFourCharStrs(llvm::ArrayRef<char> characters, absl::BitGen& gen)
     -> llvm::OwningArrayRef<std::array<char, 4>> {
   constexpr ssize_t NumCharsMask = NumChars - 1;
-  constexpr ssize_t NumCharsShift = llvm::CTLog2<NumChars>();
+  constexpr ssize_t NumCharsShift = llvm::ConstantLog2<NumChars>();
   llvm::OwningArrayRef<std::array<char, 4>> four_char_strs(NumFourCharStrs);
   for (auto [i, str] : llvm::enumerate(four_char_strs)) {
     str[0] = characters[i & NumCharsMask];
@@ -372,7 +372,7 @@ auto DumpHashStatistics(llvm::ArrayRef<T> keys) -> void {
   ssize_t expected_size =
       llvm::NextPowerOf2(keys.size() + (keys.size() / 7) - 1);
 
-  constexpr int GroupShift = llvm::CTLog2<GroupSize>();
+  constexpr int GroupShift = llvm::ConstantLog2<GroupSize>();
 
   size_t mask = ComputeProbeMaskFromSize(expected_size);
   uint64_t salt = ComputeSeed();

--- a/common/raw_hashtable_metadata_group.h
+++ b/common/raw_hashtable_metadata_group.h
@@ -124,7 +124,7 @@ class BitIndex
       return reinterpret_cast<T*>(
           &reinterpret_cast<std::byte*>(pointer)[index]);
     } else if constexpr (llvm::isPowerOf2_64(sizeof(T))) {
-      constexpr size_t ScaleShift = llvm::CTLog2<sizeof(T)>();
+      constexpr size_t ScaleShift = llvm::ConstantLog2<sizeof(T)>();
       static_assert(ScaleShift <= ByteEncodingShift,
                     "Scaling by >=8 should be handled above!");
       constexpr size_t FoldedShift = ByteEncodingShift - ScaleShift;

--- a/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/thunk_ast.carbon
@@ -64,7 +64,7 @@ auto foo(short a) -> void;
 // CHECK:STDOUT: | |-ParmVarDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> implicit 'std::align_val_t'
 // CHECK:STDOUT: | `-VisibilityAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit Default
 // CHECK:STDOUT: |-FunctionDecl {{0x[a-f0-9]+}} <<carbon-internal>:8:1, line:14:1> line:8:7 operator new 'void *(unsigned long, void *) noexcept'
-// CHECK:STDOUT: | |-ParmVarDecl {{0x[a-f0-9]+}} <<built-in>:173:23, col:37> <carbon-internal>:8:33 'unsigned long'
+// CHECK:STDOUT: | |-ParmVarDecl {{0x[a-f0-9]+}} <<built-in>:174:23, col:37> <carbon-internal>:8:33 'unsigned long'
 // CHECK:STDOUT: | `-ParmVarDecl {{0x[a-f0-9]+}} <col:35, col:39> col:40 'void *'
 // CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <./thunk_required.h:[[@LINE-51]]:6> col:6 foo__carbon_thunk 'void (short * _Nonnull)' extern
 // CHECK:STDOUT:   |-ParmVarDecl {{0x[a-f0-9]+}} <col:6> col:6 used a 'short * _Nonnull':'short *'

--- a/toolchain/codegen/codegen.cpp
+++ b/toolchain/codegen/codegen.cpp
@@ -20,11 +20,11 @@ namespace Carbon {
 auto CodeGen::Make(llvm::Module* module, llvm::StringRef target_triple_str,
                    Diagnostics::Consumer* consumer) -> std::optional<CodeGen> {
   std::string error;
+  llvm::Triple target_triple(target_triple_str);
   const llvm::Target* target =
-      llvm::TargetRegistry::lookupTarget(target_triple_str, error);
+      llvm::TargetRegistry::lookupTarget(target_triple, error);
   CARBON_CHECK(target, "Target should be validated before codegen: {0}", error);
 
-  llvm::Triple target_triple(target_triple_str);
   module->setTargetTriple(target_triple);
 
   constexpr llvm::StringLiteral CPU = "generic";

--- a/toolchain/driver/clang_runner.cpp
+++ b/toolchain/driver/clang_runner.cpp
@@ -298,6 +298,7 @@ auto ClangRunner::RunCC1(llvm::SmallVectorImpl<const char*>& cc1_args) -> int {
   // discard the pointer without destroying or deallocating it.
   auto clang_instance = std::make_unique<clang::CompilerInstance>(
       std::move(invocation), std::move(pch_ops));
+  clang_instance->setVirtualFileSystem(fs_);
 
   // Override the disabling of free when we don't want to leak memory.
   if (!enable_leaking_) {
@@ -327,7 +328,7 @@ auto ClangRunner::RunCC1(llvm::SmallVectorImpl<const char*>& cc1_args) -> int {
   }
 
   // Create the actual diagnostics engine.
-  clang_instance->createDiagnostics(*fs_);
+  clang_instance->createDiagnostics();
   if (!clang_instance->hasDiagnostics()) {
     return EXIT_FAILURE;
   }
@@ -374,7 +375,7 @@ auto ClangRunner::RunCC1(llvm::SmallVectorImpl<const char*>& cc1_args) -> int {
     // options are stored in the compiler invocation and we can recreate the VFS
     // from the compiler invocation.
     if (!clang_instance->hasFileManager()) {
-      clang_instance->createFileManager(fs_);
+      clang_instance->createFileManager();
     }
 
     if (auto profiler_output = clang_instance->createOutputFile(

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -884,8 +884,9 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
 
   // Validate the target before passing it to Clang.
   std::string target_error;
-  const llvm::Target* target = llvm::TargetRegistry::lookupTarget(
-      options_.codegen_options.target, target_error);
+  llvm::Triple target_triple(options_.codegen_options.target);
+  const llvm::Target* target =
+      llvm::TargetRegistry::lookupTarget(target_triple, target_error);
   if (!target) {
     CARBON_DIAGNOSTIC(CompileTargetInvalid, Error, "invalid target: {0}",
                       std::string);


### PR DESCRIPTION
This is in particular to pick up fixes in https://github.com/llvm/llvm-project/pull/160804 (so that a more recent LLVM compiler can be used with Carbon), but also addresses a few deprecations.