### PR TITLE
Remove unnecessary TODO

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2181,8 +2181,6 @@ static auto IsIncompleteClass(Context& context, SemIR::NameScopeId scope_id)
              context.classes().Get(class_decl->class_id).self_type_id);
 }
 
-// TODO: Do we need to import the dependences for all functions in the overload
-// set?
 auto ImportNameFromCpp(Context& context, SemIR::LocId loc_id,
                        SemIR::NameScopeId scope_id, SemIR::NameId name_id)
     -> SemIR::ScopeLookupResult {


### PR DESCRIPTION
When importing the overload set the dependencies are not imported anymore, so this TODO is unnecessary.

Part of #5915
