### PR TITLE
Add special-casing for tidy with boost_unordered

### DIFF
--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -66,6 +66,10 @@ jobs:
         if: steps.filter.outputs.has_cpp == 'true'
         run: ./scripts/create_compdb.py
 
+      - name: Build deps for clangd-tidy
+        if: steps.filter.outputs.has_cpp == 'true'
+        run: ./scripts/run_bazel.py build //scripts:deps_for_clangd_tidy
+
       - name: Install clangd-tidy
         if: steps.filter.outputs.has_cpp == 'true'
         run: pip install clangd-tidy==1.1.0.post2

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
@@ -9,4 +10,18 @@ py_test(
     size = "small",
     srcs = ["no_op_test.py"],
     main = "no_op_test.py",
+)
+
+cc_library(
+    name = "deps_for_clangd_tidy",
+    srcs = ["deps_for_clangd_tidy.cpp"],
+    deps = [
+        # `@boost_unordered` uses `strip_prefix`, which results in
+        # `_virtual_includes` being part of the `compile_commands.json`. To
+        # support tools like `clangd-tidy`, this is intended to generate that directory.
+        #
+        # For example:
+        # bazel-out/<mode>/bin/external/+_repo_rules+boost_unordered/_virtual_includes/boost_unordered
+        "@boost_unordered",
+    ],
 )

--- a/scripts/deps_for_clangd_tidy.cpp
+++ b/scripts/deps_for_clangd_tidy.cpp
@@ -1,0 +1,8 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// This file is only validating expected includes exist. See the BUILD target
+// for more information.
+
+#include <boost/unordered/unordered_flat_map.hpp>


### PR DESCRIPTION
Tested locally in relation to https://github.com/carbon-language/carbon-lang/pull/6182, difficult to test server-side because of the action change combined with the edge-case issue.