### PR TITLE
Return SymbolicBindingType separately in TypeIterator

### DIFF
--- a/toolchain/check/type_structure.cpp
+++ b/toolchain/check/type_structure.cpp
@@ -229,6 +229,10 @@ auto TypeStructureBuilder::Build(SemIR::TypeIterator type_iter)
         AppendStructuralSymbolic();
         break;
       }
+      case CARBON_KIND(Step::SymbolicBinding _): {
+        AppendStructuralSymbolic();
+        break;
+      }
       case CARBON_KIND(Step::TemplateType _): {
         AppendStructuralSymbolic();
         break;

--- a/toolchain/sem_ir/type_iterator.cpp
+++ b/toolchain/sem_ir/type_iterator.cpp
@@ -77,11 +77,7 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
       return Step::SymbolicType{.facet_type_id = facet_type_id};
     }
     case CARBON_KIND(SemIR::SymbolicBindingType bind): {
-      // TODO: Look in ScopeStack with the entity_name_id to find the facet
-      // value.
-      auto facet_type_id =
-          sem_ir_->insts().Get(bind.facet_value_inst_id).type_id();
-      return Step::SymbolicType{.facet_type_id = facet_type_id};
+      return Step::SymbolicBinding{.entity_name_id = bind.entity_name_id};
     }
 
       // ==== Concrete types ====

--- a/toolchain/sem_ir/type_iterator.h
+++ b/toolchain/sem_ir/type_iterator.h
@@ -165,6 +165,10 @@ class TypeIterator::Step {
     // Either a FacetType or the TypeType singleton.
     TypeId facet_type_id;
   };
+  // A symbolic type value, that comes from a binding named by `entity_name_id`.
+  struct SymbolicBinding {
+    EntityNameId entity_name_id;
+  };
   // A symbolic template type value.
   struct TemplateType {};
   // A concrete non-type value, which can be found as a generic parameter for a
@@ -195,13 +199,12 @@ class TypeIterator::Step {
   struct Error {};
 
   // Each step is one of these.
-  using Any =
-      std::variant<ConcreteType, SymbolicType, TemplateType, ConcreteValue,
-                   SymbolicValue, StructFieldName, ClassStartOnly,
-                   StructStartOnly, TupleStartOnly, InterfaceStartOnly,
-                   ClassStart, StructStart, TupleStart, InterfaceStart,
-                   IntStart, ArrayStart, ConstStart, MaybeUnformedStart,
-                   PartialStart, PointerStart, End, Done, Error>;
+  using Any = std::variant<
+      ConcreteType, SymbolicType, SymbolicBinding, TemplateType, ConcreteValue,
+      SymbolicValue, StructFieldName, ClassStartOnly, StructStartOnly,
+      TupleStartOnly, InterfaceStartOnly, ClassStart, StructStart, TupleStart,
+      InterfaceStart, IntStart, ArrayStart, ConstStart, MaybeUnformedStart,
+      PartialStart, PointerStart, End, Done, Error>;
 
   template <typename T>
   auto Is() const -> bool {


### PR DESCRIPTION
A SymbolicBindingType is going to only have EntityNameId as its field, and we will use the ScopeStack to use that to find a facet. The ScopeStack is a check/ thing, so this won't be possible in SemIR::TypeIterator. And TypeStructure throws away the details for symbolic types anyways. So this drops the TODO and returns the EntityName from TypeIterator for any future user who would want it in check/.