### PR TITLE
Use Overload of lookupTarget Accepting Triple

### DIFF
--- a/toolchain/codegen/codegen.cpp
+++ b/toolchain/codegen/codegen.cpp
@@ -19,12 +19,12 @@ namespace Carbon {
 
 auto CodeGen::Make(llvm::Module* module, llvm::StringRef target_triple_str,
                    Diagnostics::Consumer* consumer) -> std::optional<CodeGen> {
+  llvm::Triple target_triple(target_triple_str);
   std::string error;
   const llvm::Target* target =
-      llvm::TargetRegistry::lookupTarget(target_triple_str, error);
+      llvm::TargetRegistry::lookupTarget(target_triple, error);
   CARBON_CHECK(target, "Target should be validated before codegen: {0}", error);
 
-  llvm::Triple target_triple(target_triple_str);
   module->setTargetTriple(target_triple);
 
   constexpr llvm::StringLiteral CPU = "generic";

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -885,7 +885,7 @@ auto CompileSubcommand::Run(DriverEnv& driver_env) -> DriverResult {
   // Validate the target before passing it to Clang.
   std::string target_error;
   const llvm::Target* target = llvm::TargetRegistry::lookupTarget(
-      options_.codegen_options.target, target_error);
+      llvm::Triple(options_.codegen_options.target), target_error);
   if (!target) {
     CARBON_DIAGNOSTIC(CompileTargetInvalid, Error, "invalid target: {0}",
                       std::string);


### PR DESCRIPTION
The overload accepting a string/llvm::StringRef is deprecated and will be removed when LLVM 22 branches.
