### PR TITLE
Add unit tagging to AssociatedConstantId

### DIFF
--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -36,6 +36,7 @@ File::File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
       value_stores_(&value_stores),
       filename_(std::move(filename)),
       classes_(IdTag(check_ir_id.index, 0)),
+      associated_constants_(IdTag(check_ir_id.index, 0)),
       impls_(*this),
       // The `+1` prevents adding a tag to the global `NameSpace::PackageInstId`
       // instruction. It's not a "singleton" instruction, but it's a unique

--- a/toolchain/sem_ir/ids.cpp
+++ b/toolchain/sem_ir/ids.cpp
@@ -54,6 +54,10 @@ auto ClassId::Print(llvm::raw_ostream& out) const -> void {
   IdBase::PrintHex(out);
 }
 
+auto AssociatedConstantId::Print(llvm::raw_ostream& out) const -> void {
+  IdBase::PrintHex(out);
+}
+
 auto GenericInstIndex::Print(llvm::raw_ostream& out) const -> void {
   out << "generic_inst";
   if (has_value()) {

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -327,6 +327,8 @@ struct AssociatedConstantId : public IdBase<AssociatedConstantId> {
   static constexpr llvm::StringLiteral Label = "assoc_const";
 
   using IdBase::IdBase;
+
+  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of a `FacetTypeInfo`.

--- a/toolchain/sem_ir/inst_namer.h
+++ b/toolchain/sem_ir/inst_namer.h
@@ -53,6 +53,8 @@ class InstNamer {
     auto index = id.index;
     if constexpr (std::is_same_v<IdT, ClassId>) {
       index = sem_ir_->classes().GetRawIndex(id);
+    } else if constexpr (std::is_same_v<IdT, AssociatedConstantId>) {
+      index = sem_ir_->associated_constants().GetRawIndex(id);
     }
     return static_cast<ScopeId>(GetScopeIdOffset(ScopeIdTypeEnum::For<IdT>) +
                                 index);


### PR DESCRIPTION
No update to lldbinit.py because we don't currently have
dumping/debugging support for AssociatedConstantId anyway.
