### PR TITLE
Refine autoupdate crash output

### DIFF
--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -92,7 +93,12 @@ def main() -> None:
         argv.append("--file_tests=" + ",".join(file_tests))
     # Provide an empty stdin so that the driver tests that read from stdin
     # don't block waiting for input. This matches the behavior of `bazel test`.
-    subprocess.run(argv, check=True)
+    result = subprocess.run(argv)
+    if result.returncode != 0:
+        sys.exit(
+            f"Command `{shlex.join(argv)}` failed with exit code "
+            f"`{result.returncode}`"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before (after the stack):

```
Traceback (most recent call last):
  File "/usr/local/google/home/jperkins/dev/carbon-lang/toolchain/./autoupdate_testdata.py", line 100, in <module>
    main()
    ~~~~^^
  File "/usr/local/google/home/jperkins/dev/carbon-lang/toolchain/./autoupdate_testdata.py", line 95, in main
    subprocess.run(argv, check=True)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/local/google/home/jperkins/dev/carbon-lang/scripts/run_bazel.py', 'run', '-c', 'dbg', '--experimental_convenience_symlinks=ignore', '--ui_event_filters=-info,-stdout,-stderr,-finish', '//toolchain/testing:file_test', '--', '--autoupdate', '--print_slowest_tests', '0', '--file_tests=toolchain/check/testdata/interface/test.carbon']' returned non-zero exit status 255.
```

After:

```
Command `/usr/local/google/home/jperkins/dev/carbon-lang/scripts/run_bazel.py run -c dbg --experimental_convenience_symlinks=ignore --ui_event_filters=-info,-stdout,-stderr,-finish //toolchain/testing:file_test -- --autoupdate --print_slowest_tests 0 --file_tests=toolchain/check/testdata/interface/test.carbon` failed with exit code `255`
```