### PR TITLE
Build the binding EntityName in CompileTimeBindingPatternStart

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -1423,13 +1423,15 @@ static auto MakeParamPatternsBlockId(Context& context, SemIR::LocId loc_id,
     SemIR::LocId param_loc_id =
         AddImportIRInst(context.sem_ir(), param->getLocation());
 
-    // TODO: Fix this once templates are supported.
-    bool is_template = false;
-    // TODO: Fix this once generics are supported.
-    bool is_generic = false;
+    auto entity_name_id = context.entity_names().AddSymbolicBindingName(
+        name_id, context.scope_stack().PeekNameScopeId(),
+        // TODO: Fix this once generics are supported.
+        SemIR::CompileTimeBindIndex::None,
+        // TODO: Fix this once templates are supported.
+        /*is_template=*/false);
     SemIR::InstId pattern_id =
-        AddBindingPattern(context, param_loc_id, name_id, type_id,
-                          type_expr_region_id, is_generic, is_template)
+        AddBindingPatternWithEntityName(context, param_loc_id, entity_name_id,
+                                        type_id, type_expr_region_id)
             .pattern_id;
     pattern_id = AddPatternInst(
         context, {param_loc_id,

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -30,24 +30,22 @@ auto HandleParseNode(Context& context, Parse::UnderscoreNameId node_id)
 
 // TODO: make this function shorter by factoring pieces out.
 static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
+                                    Parse::NodeId name_node,
+                                    SemIR::EntityNameId entity_name_id,
+                                    Parse::NodeId type_node,
+                                    SemIR::InstId parsed_type_inst_id,
                                     Parse::NodeKind node_kind) -> bool {
   // TODO: split this into smaller, more focused functions.
-  auto [type_node, parsed_type_id] = context.node_stack().PopExprWithNodeId();
   auto [cast_type_inst_id, cast_type_id] =
-      ExprAsType(context, type_node, parsed_type_id);
+      ExprAsType(context, type_node, parsed_type_inst_id);
 
   SemIR::ExprRegionId type_expr_region_id =
       EndSubpatternAsExpr(context, cast_type_inst_id);
 
-  // The name in a template binding may be wrapped in `template`.
-  bool is_generic = node_kind == Parse::NodeKind::CompileTimeBindingPattern;
-  auto is_template =
-      context.node_stack()
-          .PopAndDiscardSoloNodeIdIf<Parse::NodeKind::TemplateBindingName>();
-  // A non-generic template binding is diagnosed by the parser.
-  is_template &= is_generic;
-
-  auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
+  const auto& entity_name = context.entity_names().Get(entity_name_id);
+  auto name_id = entity_name.name_id;
+  CARBON_CHECK((node_kind == Parse::NodeKind::CompileTimeBindingPattern) ==
+               entity_name.bind_index().has_value());
 
   const DeclIntroducerState& introducer =
       context.decl_introducer_state_stack().innermost();
@@ -55,15 +53,8 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   auto make_binding_pattern = [&]() -> SemIR::InstId {
     // TODO: Eventually the name will need to support associations with other
     // scopes, but right now we don't support qualified names here.
-    auto binding =
-        AddBindingPattern(context, name_node, name_id, cast_type_id,
-                          type_expr_region_id, is_generic, is_template);
-
-    // TODO: If `is_generic`, then `binding.bind_id is a BindSymbolicName. Subst
-    // the `.Self` of type `type` in the `cast_type_id` type (a `FacetType`)
-    // with the `binding.bind_id` itself, and build a new pattern with that.
-    // This is kind of cyclical. So we need to reuse the EntityNameId, which
-    // will also reuse the CompileTimeBinding for the new BindSymbolicName.
+    auto binding = AddBindingPatternWithEntityName(
+        context, name_node, entity_name_id, cast_type_id, type_expr_region_id);
 
     if (name_id != SemIR::NameId::Underscore) {
       // Add name to lookup immediately, so it can be used in the rest of the
@@ -100,7 +91,8 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
         case Lex::TokenKind::Fn: {
           if (context.full_pattern_stack().CurrentKind() ==
                   FullPatternStack::Kind::ImplicitParamList &&
-              !(is_generic || name_id == SemIR::NameId::SelfValue)) {
+              (node_kind != Parse::NodeKind::CompileTimeBindingPattern &&
+               name_id != SemIR::NameId::SelfValue)) {
             CARBON_DIAGNOSTIC(
                 ImplictParamMustBeConstant, Error,
                 "implicit parameters of functions must be constant or `self`");
@@ -130,7 +122,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
                               "`self` parameter only allowed on functions");
             context.emitter().Emit(node_id, SelfParameterNotAllowed);
             had_error = true;
-          } else if (!is_generic) {
+          } else if (node_kind != Parse::NodeKind::CompileTimeBindingPattern) {
             CARBON_DIAGNOSTIC(GenericParamMustBeConstant, Error,
                               "parameters of generic types must be constant");
             context.emitter().Emit(node_id, GenericParamMustBeConstant);
@@ -149,6 +141,12 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
         // Replace the parameter with `ErrorInst` so that we don't try
         // constructing a generic based on it.
         result_inst_id = SemIR::ErrorInst::InstId;
+        if (node_kind == Parse::NodeKind::CompileTimeBindingPattern) {
+          // Push an error for the EntityName's binding index, since we're not
+          // constructing an entity with make_binding_pattern().
+          context.scope_stack().PushCompileTimeBinding(
+              SemIR::ErrorInst::InstId);
+        }
       } else {
         result_inst_id = make_binding_pattern();
         if (node_kind == Parse::NodeKind::LetBindingPattern) {
@@ -193,8 +191,6 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
       }
       auto binding_pattern_id = make_binding_pattern();
       if (node_kind == Parse::NodeKind::VarBindingPattern) {
-        CARBON_CHECK(!is_generic);
-
         if (introducer.modifier_set.HasAnyOf(KeywordModifierSet::Returned)) {
           // TODO: Should we check this for the `var` as a whole, rather than
           // for the name binding?
@@ -216,45 +212,49 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
 
 auto HandleParseNode(Context& context, Parse::LetBindingPatternId node_id)
     -> bool {
-  return HandleAnyBindingPattern(context, node_id,
+  auto [type_node, type_inst_id] = context.node_stack().PopExprWithNodeId();
+
+  // `template` is incorrect here, but is diagnosed in parse.
+  context.node_stack()
+      .PopAndDiscardSoloNodeIdIf<Parse::NodeKind::TemplateBindingName>();
+
+  auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
+  auto entity_name_id = context.entity_names().Add(
+      {.name_id = name_id,
+       .parent_scope_id = context.scope_stack().PeekNameScopeId()});
+
+  return HandleAnyBindingPattern(context, node_id, name_node, entity_name_id,
+                                 type_node, type_inst_id,
                                  Parse::NodeKind::LetBindingPattern);
 }
 
 auto HandleParseNode(Context& context, Parse::VarBindingPatternId node_id)
     -> bool {
-  return HandleAnyBindingPattern(context, node_id,
+  auto [type_node, type_inst_id] = context.node_stack().PopExprWithNodeId();
+
+  // `template` is incorrect here, but is diagnosed in parse.
+  context.node_stack()
+      .PopAndDiscardSoloNodeIdIf<Parse::NodeKind::TemplateBindingName>();
+
+  auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
+  auto entity_name_id = context.entity_names().Add(
+      {.name_id = name_id,
+       .parent_scope_id = context.scope_stack().PeekNameScopeId()});
+
+  return HandleAnyBindingPattern(context, node_id, name_node, entity_name_id,
+                                 type_node, type_inst_id,
                                  Parse::NodeKind::VarBindingPattern);
 }
 
 auto HandleParseNode(Context& context,
                      Parse::CompileTimeBindingPatternStartId node_id) -> bool {
-  // Make a scope to contain the `.Self` facet value for use in the type of the
-  // compile time binding. This is popped when handling the
-  // CompileTimeBindingPatternId.
-  context.scope_stack().PushForSameRegion();
+  auto is_template =
+      context.node_stack()
+          .PopAndDiscardSoloNodeIdIf<Parse::NodeKind::TemplateBindingName>();
 
-  // The `.Self` must have a type of `FacetType`, so that it gets wrapped in
-  // `FacetAccessType` when used in a type position, such as in `U:! I(.Self)`.
-  // This allows substitution with other facet values without requiring an
-  // additional `FacetAccessType` to be inserted.
-  SemIR::FacetTypeId facet_type_id =
-      context.facet_types().Add(SemIR::FacetTypeInfo{});
-  auto const_id = EvalOrAddInst<SemIR::FacetType>(
-      context, node_id,
-      {.type_id = SemIR::TypeType::TypeId, .facet_type_id = facet_type_id});
-  auto type_id = context.types().GetTypeIdForTypeConstantId(const_id);
+  auto name_id = context.node_stack().PeekNameId();
+  auto entity_name_id = SemIR::EntityNameId::None;
 
-  MakePeriodSelfFacetValue(context, type_id);
-  return true;
-}
-
-auto HandleParseNode(Context& context,
-                     Parse::CompileTimeBindingPatternId node_id) -> bool {
-  // Pop the `.Self` facet value name introduced by the
-  // CompileTimeBindingPatternStart.
-  context.scope_stack().Pop();
-
-  auto node_kind = Parse::NodeKind::CompileTimeBindingPattern;
   const DeclIntroducerState& introducer =
       context.decl_introducer_state_stack().innermost();
   if (introducer.kind == Lex::TokenKind::Let) {
@@ -272,12 +272,83 @@ auto HandleParseNode(Context& context,
         context.TODO(
             node_id,
             "`let` compile time binding outside function or interface");
-        node_kind = Parse::NodeKind::LetBindingPattern;
+        entity_name_id = context.entity_names().Add(
+            {.name_id = name_id,
+             .parent_scope_id = context.scope_stack().PeekNameScopeId()});
       }
     }
   }
 
-  return HandleAnyBindingPattern(context, node_id, node_kind);
+  // This compile time binding is added but not pushed because we don't have the
+  // BindSymbolicName for it until we get to the CompileTimeBindingPatternId
+  // node. This leaves the CompileTimeBinding stack in a fragile state while the
+  // binding's facet type is checked, but only the index is used during type
+  // checking. The instruction wouldn't be needed until building a generic,
+  // which we don't do in this scope.
+  //
+  // We avoid making a CompileTimeBinding in the case where a compile-time
+  // binding is disallowed. In that case, we already constructed an
+  // `entity_name_id` above.
+  if (!entity_name_id.has_value()) {
+    auto bind_index = context.scope_stack().AddCompileTimeBinding();
+    entity_name_id = context.entity_names().AddSymbolicBindingName(
+        name_id, context.scope_stack().PeekNameScopeId(), bind_index,
+        is_template);
+  }
+
+  // TODO: Construct a SymbolicBindingType for `entity_name_id` instead of a
+  // BindSymbolicName for a `PeriodSelf` EntityName.
+  //
+  // The `.Self` must have a type of `FacetType`, so that it gets wrapped in
+  // `FacetAccessType` when used in a type position, such as in `U:! I(.Self)`.
+  // This allows substitution with other facet values without requiring an
+  // additional `FacetAccessType` to be inserted.
+  SemIR::FacetTypeId facet_type_id =
+      context.facet_types().Add(SemIR::FacetTypeInfo{});
+  auto const_id = EvalOrAddInst<SemIR::FacetType>(
+      context, node_id,
+      {.type_id = SemIR::TypeType::TypeId, .facet_type_id = facet_type_id});
+  auto type_id = context.types().GetTypeIdForTypeConstantId(const_id);
+
+  // Make a scope to contain the `.Self` facet value for use in the type of the
+  // compile time binding. This is popped when handling the
+  // CompileTimeBindingPatternId.
+  context.scope_stack().PushForSameRegion();
+  MakePeriodSelfFacetValue(context, type_id);
+
+  context.node_stack().Push(node_id, entity_name_id);
+  return true;
+}
+
+auto HandleParseNode(Context& context,
+                     Parse::CompileTimeBindingPatternId node_id) -> bool {
+  // Pop the `.Self` facet value name introduced by the
+  // CompileTimeBindingPatternStart.
+  context.scope_stack().Pop();
+
+  auto [type_node, type_inst_id] = context.node_stack().PopExprWithNodeId();
+
+  auto entity_name_id =
+      context.node_stack()
+          .Pop<Parse::NodeKind::CompileTimeBindingPatternStart>();
+
+  // The NameId was already used to construct the `entity_name_id`.
+  auto [name_node, _] = context.node_stack().PopNameWithNodeId();
+
+  auto node_kind = Parse::NodeKind::CompileTimeBindingPattern;
+  if (!context.entity_names().Get(entity_name_id).bind_index().has_value()) {
+    // This indicates that CompileTimeBindingPatternStartId found a `let` in an
+    // incorrect scope. We treat them as runtime bindings instead of compile
+    // time bindings, since we avoided introducing a CompileTimeBindingIndex
+    // that won't be used.
+    node_kind = Parse::NodeKind::LetBindingPattern;
+  }
+
+  auto success =
+      HandleAnyBindingPattern(context, node_id, name_node, entity_name_id,
+                              type_node, type_inst_id, node_kind);
+
+  return success;
 }
 
 auto HandleParseNode(Context& context,

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -272,13 +272,11 @@ auto HandleParseNode(Context& context,
         context.TODO(
             node_id,
             "`let` compile time binding outside function or interface");
+        // We avoid making a CompileTimeBinding in the case where a compile-time
+        // binding is disallowed, and any `.Self` name.
         entity_name_id = context.entity_names().Add(
             {.name_id = name_id,
              .parent_scope_id = context.scope_stack().PeekNameScopeId()});
-        // We avoid making a CompileTimeBinding in the case where a compile-time
-        // binding is disallowed, and any `.Self` name. But we must still push a
-        // scope just for CompileTimeBindingPatternId to pop.
-        context.scope_stack().PushForSameRegion();
         context.node_stack().Push(node_id, entity_name_id);
         return true;
       }
@@ -326,10 +324,6 @@ auto HandleParseNode(Context& context,
 
 auto HandleParseNode(Context& context,
                      Parse::CompileTimeBindingPatternId node_id) -> bool {
-  // Pop the `.Self` facet value name introduced by the
-  // CompileTimeBindingPatternStart.
-  context.scope_stack().Pop();
-
   auto [type_node, type_inst_id] = context.node_stack().PopExprWithNodeId();
 
   auto entity_name_id =
@@ -339,13 +333,20 @@ auto HandleParseNode(Context& context,
   // The NameId was already used to construct the `entity_name_id`.
   auto [name_node, _] = context.node_stack().PopNameWithNodeId();
 
+  bool is_comptime_binding =
+      context.entity_names().Get(entity_name_id).bind_index().has_value();
+
   auto node_kind = Parse::NodeKind::CompileTimeBindingPattern;
-  if (!context.entity_names().Get(entity_name_id).bind_index().has_value()) {
+  if (!is_comptime_binding) {
     // This indicates that CompileTimeBindingPatternStartId found a `let` in an
     // incorrect scope. We treat them as runtime bindings instead of compile
     // time bindings, since we avoided introducing a CompileTimeBindingIndex
     // that won't be used.
     node_kind = Parse::NodeKind::LetBindingPattern;
+  } else {
+    // Pop the `.Self` facet value name introduced by the
+    // CompileTimeBindingPatternStart.
+    context.scope_stack().Pop();
   }
 
   return HandleAnyBindingPattern(context, node_id, name_node, entity_name_id,

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -275,6 +275,12 @@ auto HandleParseNode(Context& context,
         entity_name_id = context.entity_names().Add(
             {.name_id = name_id,
              .parent_scope_id = context.scope_stack().PeekNameScopeId()});
+        // We avoid making a CompileTimeBinding in the case where a compile-time
+        // binding is disallowed, and any `.Self` name. But we must still push a
+        // scope just for CompileTimeBindingPatternId to pop.
+        context.scope_stack().PushForSameRegion();
+        context.node_stack().Push(node_id, entity_name_id);
+        return true;
       }
     }
   }
@@ -289,20 +295,18 @@ auto HandleParseNode(Context& context,
   // We avoid making a CompileTimeBinding in the case where a compile-time
   // binding is disallowed. In that case, we already constructed an
   // `entity_name_id` above.
-  if (!entity_name_id.has_value()) {
-    auto bind_index = context.scope_stack().AddCompileTimeBinding();
-    entity_name_id = context.entity_names().AddSymbolicBindingName(
-        name_id, context.scope_stack().PeekNameScopeId(), bind_index,
-        is_template);
-  }
+  auto bind_index = context.scope_stack().AddCompileTimeBinding();
+  entity_name_id = context.entity_names().AddSymbolicBindingName(
+      name_id, context.scope_stack().PeekNameScopeId(), bind_index,
+      is_template);
 
   // TODO: Construct a SymbolicBindingType for `entity_name_id` instead of a
   // BindSymbolicName for a `PeriodSelf` EntityName.
   //
   // The `.Self` must have a type of `FacetType`, so that it gets wrapped in
-  // `FacetAccessType` when used in a type position, such as in `U:! I(.Self)`.
-  // This allows substitution with other facet values without requiring an
-  // additional `FacetAccessType` to be inserted.
+  // `FacetAccessType` when used in a type position, such as in `U:!
+  // I(.Self)`. This allows substitution with other facet values without
+  // requiring an additional `FacetAccessType` to be inserted.
   SemIR::FacetTypeId facet_type_id =
       context.facet_types().Add(SemIR::FacetTypeInfo{});
   auto const_id = EvalOrAddInst<SemIR::FacetType>(
@@ -310,8 +314,8 @@ auto HandleParseNode(Context& context,
       {.type_id = SemIR::TypeType::TypeId, .facet_type_id = facet_type_id});
   auto type_id = context.types().GetTypeIdForTypeConstantId(const_id);
 
-  // Make a scope to contain the `.Self` facet value for use in the type of the
-  // compile time binding. This is popped when handling the
+  // Make a scope to contain the `.Self` facet value for use in the type of
+  // the compile time binding. This is popped when handling the
   // CompileTimeBindingPatternId.
   context.scope_stack().PushForSameRegion();
   MakePeriodSelfFacetValue(context, type_id);
@@ -344,11 +348,8 @@ auto HandleParseNode(Context& context,
     node_kind = Parse::NodeKind::LetBindingPattern;
   }
 
-  auto success =
-      HandleAnyBindingPattern(context, node_id, name_node, entity_name_id,
-                              type_node, type_inst_id, node_kind);
-
-  return success;
+  return HandleAnyBindingPattern(context, node_id, name_node, entity_name_id,
+                                 type_node, type_inst_id, node_kind);
 }
 
 auto HandleParseNode(Context& context,

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -200,6 +200,9 @@ class NodeStack {
     return PopWithNodeId<SemIR::NameId>();
   }
 
+  // Peeks a name from the top of the stack.
+  auto PeekNameId() const -> SemIR::NameId;
+
   // Pops the top of the stack and returns the node_id and the ID.
   template <const Parse::NodeKind& RequiredParseKind>
   auto PopWithNodeId() -> auto {
@@ -442,6 +445,8 @@ class NodeStack {
       case Parse::NodeKind::DefaultLibrary:
       case Parse::NodeKind::LibraryName:
         return Id::KindFor<SemIR::LibraryNameId>();
+      case Parse::NodeKind::CompileTimeBindingPatternStart:
+        return Id::KindFor<SemIR::EntityNameId>();
       case Parse::NodeKind::BuiltinName:
       case Parse::NodeKind::ChoiceIntroducer:
       case Parse::NodeKind::ClassIntroducer:
@@ -481,7 +486,6 @@ class NodeStack {
       case Parse::NodeKind::CallExprComma:
       case Parse::NodeKind::ChoiceAlternativeListComma:
       case Parse::NodeKind::CodeBlock:
-      case Parse::NodeKind::CompileTimeBindingPatternStart:
       case Parse::NodeKind::ContinueStatementStart:
       case Parse::NodeKind::CorePackageName:
       case Parse::NodeKind::ExportIntroducer:
@@ -638,6 +642,10 @@ constexpr NodeStack::IdKindTableType NodeStack::IdKindTable =
 inline auto NodeStack::PopExprWithNodeId()
     -> std::pair<Parse::AnyExprId, SemIR::InstId> {
   return PopWithNodeId<Parse::NodeCategory::Expr>();
+}
+
+inline auto NodeStack::PeekNameId() const -> SemIR::NameId {
+  return Peek<Id::KindFor<SemIR::NameId>()>();
 }
 
 inline auto NodeStack::PeekPattern() const -> SemIR::InstId {

--- a/toolchain/check/pattern.cpp
+++ b/toolchain/check/pattern.cpp
@@ -48,13 +48,22 @@ auto EndSubpatternAsNonExpr(Context& context) -> void {
 
 auto AddBindingPattern(Context& context, SemIR::LocId name_loc,
                        SemIR::NameId name_id, SemIR::TypeId type_id,
-                       SemIR::ExprRegionId type_region_id, bool is_generic,
-                       bool is_template) -> BindingPatternInfo {
-  auto entity_name_id = context.entity_names().AddSymbolicBindingName(
-      name_id, context.scope_stack().PeekNameScopeId(),
-      is_generic ? context.scope_stack().AddCompileTimeBinding()
-                 : SemIR::CompileTimeBindIndex::None,
-      is_template);
+                       SemIR::ExprRegionId type_region_id)
+    -> BindingPatternInfo {
+  auto entity_name_id = context.entity_names().Add(
+      {.name_id = name_id,
+       .parent_scope_id = context.scope_stack().PeekNameScopeId()});
+  return AddBindingPatternWithEntityName(context, name_loc, entity_name_id,
+                                         type_id, type_region_id);
+}
+
+auto AddBindingPatternWithEntityName(Context& context, SemIR::LocId name_loc,
+                                     SemIR::EntityNameId entity_name_id,
+                                     SemIR::TypeId type_id,
+                                     SemIR::ExprRegionId type_region_id)
+    -> BindingPatternInfo {
+  auto& entity_name = context.entity_names().Get(entity_name_id);
+  bool is_generic = entity_name.bind_index().has_value();
 
   auto bind_id = SemIR::InstId::None;
   if (is_generic) {
@@ -138,8 +147,7 @@ auto AddSelfParamPattern(Context& context, SemIR::LocId loc_id,
                          SemIR::TypeId type_id) -> SemIR::InstId {
   SemIR::InstId pattern_id =
       AddBindingPattern(context, loc_id, SemIR::NameId::SelfValue, type_id,
-                        type_expr_region_id, /*is_generic=*/false,
-                        /*is_template=*/false)
+                        type_expr_region_id)
           .pattern_id;
 
   pattern_id = AddPatternInst<SemIR::ValueParamPattern>(

--- a/toolchain/check/pattern.h
+++ b/toolchain/check/pattern.h
@@ -35,12 +35,23 @@ struct BindingPatternInfo {
 
 // TODO: Add EndSubpatternAsPattern, when needed.
 
-// Creates a binding pattern. Returns the binding pattern and the bind name
-// instruction.
+// Creates a binding pattern and EntityName for a `name_id`. Returns the binding
+// pattern and the bind name instruction.
+//
+// To make a generic binding with a CompileTimeBindIndex, construct the
+// EntityName and use `AddBindingPatternWithEntityName()`.
 auto AddBindingPattern(Context& context, SemIR::LocId name_loc,
                        SemIR::NameId name_id, SemIR::TypeId type_id,
-                       SemIR::ExprRegionId type_region_id, bool is_generic,
-                       bool is_template) -> BindingPatternInfo;
+                       SemIR::ExprRegionId type_region_id)
+    -> BindingPatternInfo;
+
+// Creates a binding pattern with a pre-created EntityName. Returns the binding
+// pattern and the bind name instruction.
+auto AddBindingPatternWithEntityName(Context& context, SemIR::LocId name_loc,
+                                     SemIR::EntityNameId entity_name_id,
+                                     SemIR::TypeId type_id,
+                                     SemIR::ExprRegionId type_region_id)
+    -> BindingPatternInfo;
 
 // Creates storage for `var` patterns nested within the given pattern at the
 // current location in the output SemIR. For a `returned var`, this

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
@@ -232,8 +232,8 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     name_scope11:    {inst: inst600000BD, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:     name_scope12:    {inst: inst600000F5, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name(PeriodSelf), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name1:    {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name1:    {name: name(PeriodSelf), parent_scope: name_scope<none>, index: -1, is_template: 0}
 // CHECK:STDOUT:     entity_name2:    {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0}
 // CHECK:STDOUT:     entity_name3:    {name: name3, parent_scope: name_scope1, index: -1, is_template: 0}
 // CHECK:STDOUT:     entity_name4:    {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
@@ -384,13 +384,13 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst6000000F:    {kind: ImportDecl, arg0: name(Core)}
 // CHECK:STDOUT:     inst60000010:    {kind: Namespace, arg0: name_scope1, arg1: inst6000000F, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst60000011:    {kind: FacetType, arg0: facet_type0, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000012:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000013:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000014:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000015:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000016:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000012:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000011)}
+// CHECK:STDOUT:     inst60000013:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000011)}
+// CHECK:STDOUT:     inst60000014:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000015:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000016:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000017:    {kind: PatternType, arg0: inst(TypeType), type: type(TypeType)}
-// CHECK:STDOUT:     inst60000018:    {kind: SymbolicBindingPattern, arg0: entity_name1, type: type(inst60000017)}
+// CHECK:STDOUT:     inst60000018:    {kind: SymbolicBindingPattern, arg0: entity_name0, type: type(inst60000017)}
 // CHECK:STDOUT:     inst60000019:    {kind: NameRef, arg0: name1, arg1: inst60000014, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001A:    {kind: PointerType, arg0: inst60000019, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001B:    {kind: PointerType, arg0: inst60000015, type: type(TypeType)}
@@ -461,8 +461,8 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst6000005C:    {kind: LookupImplWitness, arg0: inst6000001B, arg1: specific_interface0, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000005D:    {kind: ImportRefUnloaded, arg0: import_ir_inst15, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst6000005E:    {kind: ImplDecl, arg0: impl60000000, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst6000005F:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000060:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst6000005F, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000005F:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000060:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst6000005F, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000061:    {kind: ConstType, arg0: inst60000060, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000062:    {kind: PatternType, arg0: inst60000047, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000063:    {kind: SymbolicBindingPattern, arg0: entity_name13, type: type(inst60000062)}
@@ -472,8 +472,8 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst60000067:    {kind: ImportRefUnloaded, arg0: import_ir_inst21, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst60000068:    {kind: ImplWitnessTable, arg0: inst_block30, arg1: impl60000000}
 // CHECK:STDOUT:     inst60000069:    {kind: ImplWitness, arg0: inst60000068, arg1: specific2, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000006A:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000006B:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst6000006A, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000006A:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000006B:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst6000006A, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000006C:    {kind: ConstType, arg0: inst6000006B, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000006D:    {kind: ImplWitness, arg0: inst60000068, arg1: specific3, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000006E:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(symbolic_constant38)}
@@ -487,8 +487,8 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst60000076:    {kind: ImportRefLoaded, arg0: import_ir_inst32, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000077:    {kind: FunctionType, arg0: function60000002, arg1: specific3, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000078:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant45)}
-// CHECK:STDOUT:     inst60000079:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000007A:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst60000079, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000079:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000007A:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst60000079, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007B:    {kind: ConstType, arg0: inst6000007A, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007C:    {kind: PatternType, arg0: inst6000007B, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007D:    {kind: RequireCompleteType, arg0: inst60000061, type: type(inst(WitnessType))}
@@ -529,7 +529,7 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000A0:    {kind: ImportRefUnloaded, arg0: import_ir_inst67, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst600000A1:    {kind: ImplWitnessTable, arg0: inst_block47, arg1: impl60000005}
 // CHECK:STDOUT:     inst600000A2:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific7, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000A3:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000A3:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000A4:    {kind: PointerType, arg0: inst600000A3, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000A5:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific8, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000A6:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block_empty, type: type(symbolic_constant81)}
@@ -543,7 +543,7 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000AE:    {kind: FunctionType, arg0: function60000003, arg1: specific8, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000AF:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant88)}
 // CHECK:STDOUT:     inst600000B0:    {kind: RequireCompleteType, arg0: inst600000A4, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000B1:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000B1:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000B2:    {kind: PointerType, arg0: inst600000B1, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000B3:    {kind: PatternType, arg0: inst600000B2, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000B4:    {kind: ImportRefUnloaded, arg0: import_ir_inst84, arg1: entity_name<none>}
@@ -568,9 +568,9 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000C7:    {kind: ImportRefUnloaded, arg0: import_ir_inst100, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst600000C8:    {kind: ImplWitnessTable, arg0: inst_block60, arg1: impl60000008}
 // CHECK:STDOUT:     inst600000C9:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific10, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000CA:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000CA:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst600000CB:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000CC:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst600000CA, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000CC:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst600000CA, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000CD:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst600000CB, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000CE:    {kind: TupleType, arg0: inst_block62, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000CF:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific11, type: type(inst(WitnessType))}
@@ -586,8 +586,8 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000D9:    {kind: ImportRefLoaded, arg0: import_ir_inst114, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst600000DA:    {kind: FunctionType, arg0: function60000004, arg1: specific11, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000DB:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant121)}
-// CHECK:STDOUT:     inst600000DC:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000DD:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst600000DC, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000DC:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000DD:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst600000DC, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000DE:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst600000DF:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst600000DE, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000E0:    {kind: TupleType, arg0: inst_block70, type: type(TypeType)}
@@ -626,10 +626,10 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst60000101:    {kind: ImportRefUnloaded, arg0: import_ir_inst144, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst60000102:    {kind: ImplWitnessTable, arg0: inst_block82, arg1: impl60000009}
 // CHECK:STDOUT:     inst60000103:    {kind: ImplWitness, arg0: inst60000102, arg1: specific16, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000104:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000104:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000105:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000106:    {kind: BindSymbolicName, arg0: entity_name41, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000107:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst60000104, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000107:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst60000104, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000108:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst60000105, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000109:    {kind: SymbolicBindingType, arg0: entity_name41, arg1: inst60000106, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000010A:    {kind: TupleType, arg0: inst_block84, type: type(TypeType)}
@@ -647,8 +647,8 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst60000116:    {kind: ImportRefLoaded, arg0: import_ir_inst161, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000117:    {kind: FunctionType, arg0: function60000005, arg1: specific17, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000118:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant193)}
-// CHECK:STDOUT:     inst60000119:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000011A:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst60000119, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000119:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000011A:    {kind: SymbolicBindingType, arg0: entity_name0, arg1: inst60000119, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000011B:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000011C:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst6000011B, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000011D:    {kind: BindSymbolicName, arg0: entity_name41, arg1: inst<none>, type: type(inst60000047)}

--- a/toolchain/check/testdata/class/comp_time_field.carbon
+++ b/toolchain/check/testdata/class/comp_time_field.carbon
@@ -58,8 +58,6 @@ var x: Class = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Class: type = class_type @Class [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
@@ -77,13 +75,11 @@ var x: Class = {};
 // CHECK:STDOUT:     %A.patt: %pattern_type = binding_pattern A [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.ref.loc9: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %.Self.1: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %A: type = bind_name A, %Class.ref.loc9
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %B.patt: %pattern_type = binding_pattern B [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.ref.loc15: type = name_ref Class, file.%Class.decl [concrete = constants.%Class]
-// CHECK:STDOUT:   %.Self.2: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %B: type = bind_name B, %Class.ref.loc15
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness constants.%empty_struct_type [concrete = constants.%complete_type]
 // CHECK:STDOUT:   complete_type_witness = %complete_type

--- a/toolchain/check/testdata/class/comp_time_field.carbon
+++ b/toolchain/check/testdata/class/comp_time_field.carbon
@@ -19,13 +19,13 @@ library "[[@TEST_NAME]]";
 class Class {
   // CHECK:STDERR: fail_let.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let A:! type = Class;
-  // CHECK:STDERR:       ^~~~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   let A:! type = Class;
 
   // CHECK:STDERR: fail_let.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let template B:! type = Class;
-  // CHECK:STDERR:       ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:       ^~~~~~~~~~~~
   // CHECK:STDERR:
   let template B:! type = Class;
 }

--- a/toolchain/check/testdata/let/compile_time_bindings.carbon
+++ b/toolchain/check/testdata/let/compile_time_bindings.carbon
@@ -24,7 +24,7 @@ class C {
   fn F() -> () { return x; }
   // CHECK:STDERR: fail_let_after.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let x:! () = ();
-  // CHECK:STDERR:       ^~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   let x:! () = ();
 }
@@ -36,7 +36,7 @@ library "[[@TEST_NAME]]";
 class C {
   // CHECK:STDERR: fail_let_before.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let x:! () = ();
-  // CHECK:STDERR:       ^~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   let x:! () = ();
   fn F() -> () { return x; }
@@ -49,7 +49,7 @@ library "[[@TEST_NAME]]";
 class C {
   // CHECK:STDERR: fail_multiple_lets.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let a:! () = ();
-  // CHECK:STDERR:       ^~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   let a:! () = ();
   fn F(b:! ((),)) {
@@ -62,7 +62,7 @@ class C {
   }
   // CHECK:STDERR: fail_multiple_lets.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let d:! ((), (), ()) = ((), (), ());
-  // CHECK:STDERR:       ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   let d:! ((), (), ()) = ((), (), ());
 }
@@ -75,7 +75,7 @@ class C {
   fn F() -> () { return x; }
   // CHECK:STDERR: fail_invalid_let_after.carbon:[[@LINE+8]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let x:! ();
-  // CHECK:STDERR:       ^~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   // CHECK:STDERR: fail_invalid_let_after.carbon:[[@LINE+4]]:13: error: expected `=`; `let` declaration must have an initializer [ExpectedInitializerAfterLet]
   // CHECK:STDERR:   let x:! ();
@@ -121,7 +121,7 @@ library "[[@TEST_NAME]]";
 class I {
   // CHECK:STDERR: fail_return_in_class.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let T:! type = i32;
-  // CHECK:STDERR:       ^~~~~~~~
+  // CHECK:STDERR:       ^~~
   // CHECK:STDERR:
   let T:! type = i32;
   // CHECK:STDERR: fail_return_in_class.carbon:[[@LINE+4]]:13: error: cannot evaluate type expression [TypeExprEvaluationFailure]
@@ -137,7 +137,7 @@ library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_return_in_package_scope.carbon:[[@LINE+4]]:5: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
 // CHECK:STDERR: let T:! type = i32;
-// CHECK:STDERR:     ^~~~~~~~
+// CHECK:STDERR:     ^~~
 // CHECK:STDERR:
 let T:! type = i32;
 // CHECK:STDERR: fail_return_in_package_scope.carbon:[[@LINE+4]]:11: error: cannot evaluate type expression [TypeExprEvaluationFailure]
@@ -155,7 +155,7 @@ interface Empty {}
 impl i32 as Empty {
   // CHECK:STDERR: fail_use_in_impl.carbon:[[@LINE+4]]:7: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
   // CHECK:STDERR:   let Zero:! i32 = 0;
-  // CHECK:STDERR:       ^~~~~~~~~~
+  // CHECK:STDERR:       ^~~~~~
   // CHECK:STDERR:
   let Zero:! i32 = 0;
 }

--- a/toolchain/check/testdata/let/compile_time_bindings.carbon
+++ b/toolchain/check/testdata/let/compile_time_bindings.carbon
@@ -168,8 +168,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %empty_tuple.type [concrete]
 // CHECK:STDOUT:   %C.F.type: type = fn_type @C.F [concrete]
 // CHECK:STDOUT:   %C.F: %C.F.type = struct_value () [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
@@ -206,7 +204,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_17.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:   %.loc10_12.1: type = splice_block %.loc10_12.3 [concrete = constants.%empty_tuple.type] {
-// CHECK:STDOUT:     %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %.loc10_12.2: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc10_12.3: type = converted %.loc10_12.2, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:   }
@@ -234,8 +231,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %empty_tuple.type [concrete]
 // CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
@@ -267,7 +262,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc9_17.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_12.1: type = splice_block %.loc9_12.3 [concrete = constants.%empty_tuple.type] {
-// CHECK:STDOUT:     %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %.loc9_12.2: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc9_12.3: type = converted %.loc9_12.2, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:   }
@@ -304,11 +298,11 @@ impl i32 as Empty {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %pattern_type.cb1: type = pattern_type %empty_tuple.type [concrete]
 // CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %tuple.type.9fb: type = tuple_type (%empty_tuple.type) [concrete]
 // CHECK:STDOUT:   %b: %tuple.type.9fb = bind_symbolic_name b, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type.559: type = pattern_type %tuple.type.9fb [concrete]
@@ -375,7 +369,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc9_17.1: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_12.1: type = splice_block %.loc9_12.3 [concrete = constants.%empty_tuple.type] {
-// CHECK:STDOUT:     %.Self.2: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %.loc9_12.2: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc9_12.3: type = converted %.loc9_12.2, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:   }
@@ -402,7 +395,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   %.loc22_36: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:   %.loc22_37.1: %tuple.type.2d5 = tuple_literal (%.loc22_28, %.loc22_32, %.loc22_36)
 // CHECK:STDOUT:   %.loc22_22.1: type = splice_block %.loc22_22.6 [concrete = constants.%tuple.type.2d5] {
-// CHECK:STDOUT:     %.Self.1: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %.loc22_13: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc22_17: %empty_tuple.type = tuple_literal ()
 // CHECK:STDOUT:     %.loc22_21: %empty_tuple.type = tuple_literal ()
@@ -632,12 +624,12 @@ impl i32 as Empty {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .F = %C.F.decl
-// CHECK:STDOUT:   .x = <unexpected>.inst48000023.loc14_7
+// CHECK:STDOUT:   .x = <unexpected>.inst48000020.loc14_7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @C.F() -> %empty_tuple.type {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %x.ref: %empty_tuple.type = name_ref x, <unexpected>.inst48000023.loc14_7
+// CHECK:STDOUT:   %x.ref: %empty_tuple.type = name_ref x, <unexpected>.inst48000020.loc14_7
 // CHECK:STDOUT:   %.loc5_25: init %empty_tuple.type = tuple_init () to %return [concrete = constants.%empty_tuple]
 // CHECK:STDOUT:   %.loc5_26: init %empty_tuple.type = converted %x.ref, %.loc5_25 [concrete = constants.%empty_tuple]
 // CHECK:STDOUT:   return %.loc5_26 to %return
@@ -966,8 +958,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %I: type = class_type @I [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
@@ -1003,7 +993,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %T: type = bind_name T, %i32
 // CHECK:STDOUT:   %I.F.decl: %I.F.type = fn_decl @I.F [concrete = constants.%I.F] {
 // CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern [concrete]
@@ -1027,8 +1016,6 @@ impl i32 as Empty {
 // CHECK:STDOUT: --- fail_return_in_package_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
@@ -1057,7 +1044,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = binding_pattern T [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %T: type = bind_name T, @__global_init.%i32
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern [concrete]
@@ -1088,8 +1074,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   %Int.generic: %Int.type = struct_value () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %Empty.impl_witness: <witness> = impl_witness file.%Empty.impl_witness_table [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
 // CHECK:STDOUT:   %int_0.5c6: Core.IntLiteral = int_value 0 [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
@@ -1153,7 +1137,6 @@ impl i32 as Empty {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
 // CHECK:STDOUT:   %.loc11_14: type = splice_block %i32.loc11 [concrete = constants.%i32] {
-// CHECK:STDOUT:     %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %int_32.loc11: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc11: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -18,7 +18,7 @@ package Implicit;
 
 // CHECK:STDERR: fail_implicit.carbon:[[@LINE+4]]:5: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
 // CHECK:STDERR: let T:! type = i32;
-// CHECK:STDERR:     ^~~~~~~~
+// CHECK:STDERR:     ^~~
 // CHECK:STDERR:
 let T:! type = i32;
 

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -36,8 +36,6 @@ let a: T = 0;
 // CHECK:STDOUT: --- fail_implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
@@ -63,7 +61,6 @@ let a: T = 0;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = binding_pattern T [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %T: type = bind_name T, @__global_init.%i32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -18,7 +18,7 @@ package Implicit;
 
 // CHECK:STDERR: fail_implicit.carbon:[[@LINE+4]]:5: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
 // CHECK:STDERR: let T:! type = i32;
-// CHECK:STDERR:     ^~~~~~~~
+// CHECK:STDERR:     ^~~
 // CHECK:STDERR:
 let T:! type = i32;
 

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -40,8 +40,6 @@ var b: T = *a;
 // CHECK:STDOUT: --- fail_implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
@@ -67,7 +65,6 @@ var b: T = *a;
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = binding_pattern T [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %T: type = bind_name T, @__global_init.%i32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -54,8 +54,6 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:   %Six.type: type = fn_type @Six [concrete]
 // CHECK:STDOUT:   %Six: %Six.type = struct_value () [concrete]
 // CHECK:STDOUT:   %int_6: Core.IntLiteral = int_value 6 [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = bind_symbolic_name .Self [symbolic_self]
 // CHECK:STDOUT:   %HalfDozen.type: type = fn_type @HalfDozen [concrete]
 // CHECK:STDOUT:   %HalfDozen: %HalfDozen.type = struct_value () [concrete]
 // CHECK:STDOUT:   %FirstPerfectNumber.type: type = fn_type @FirstPerfectNumber [concrete]
@@ -97,7 +95,6 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %y.patt: %pattern_type.98f = binding_pattern y [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.Self.1: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %y: type = bind_name y, @__global_init.%i32.loc27
 // CHECK:STDOUT:   %HalfDozen.decl: %HalfDozen.type = fn_decl @HalfDozen [concrete = constants.%HalfDozen] {
 // CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern [concrete]
@@ -110,7 +107,6 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %z.patt: %pattern_type.98f = binding_pattern z [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.Self.2: %type = bind_symbolic_name .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:   %z: type = bind_name z, @__global_init.%i32.loc39
 // CHECK:STDOUT:   %FirstPerfectNumber.decl: %FirstPerfectNumber.type = fn_decl @FirstPerfectNumber [concrete = constants.%FirstPerfectNumber] {
 // CHECK:STDOUT:     %return.patt: <error> = return_slot_pattern [concrete]

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -22,7 +22,7 @@ fn Six() -> x { return 6; }
 // TODO: This should probably work.
 // CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+4]]:5: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
 // CHECK:STDERR: let y:! type = i32;
-// CHECK:STDERR:     ^~~~~~~~
+// CHECK:STDERR:     ^~~
 // CHECK:STDERR:
 let y:! type = i32;
 // CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+4]]:19: error: cannot evaluate type expression [TypeExprEvaluationFailure]
@@ -34,7 +34,7 @@ fn HalfDozen() -> y { return 6; }
 // TODO: This should work.
 // CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+4]]:5: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
 // CHECK:STDERR: let template z:! type = i32;
-// CHECK:STDERR:     ^~~~~~~~~~~~~~~~~
+// CHECK:STDERR:     ^~~~~~~~~~~~
 // CHECK:STDERR:
 let template z:! type = i32;
 // CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+4]]:28: error: cannot evaluate type expression [TypeExprEvaluationFailure]

--- a/toolchain/check/testdata/where_expr/equal_rewrite.carbon
+++ b/toolchain/check/testdata/where_expr/equal_rewrite.carbon
@@ -186,7 +186,7 @@ impl D as A {}
 // TODO: Compile-time binding are not yet supported at file scope.
 // CHECK:STDERR: fail_todo_let_compile_time.carbon:[[@LINE+4]]:5: error: semantics TODO: ``let` compile time binding outside function or interface` [SemanticsTodo]
 // CHECK:STDERR: let B:! type where .Self impls A = D;
-// CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:     ^~~
 // CHECK:STDERR:
 let B:! type where .Self impls A = D;
 

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -73,10 +73,16 @@ static auto CloneBindingPattern(Context& context, SemIR::InstId pattern_id,
   auto type_expr_region_id = context.sem_ir().expr_regions().Add(
       {.block_ids = {SemIR::InstBlockId::Empty}, .result_id = type_inst_id});
 
-  // Rebuild the binding pattern.
-  return AddBindingPattern(context, SemIR::LocId(pattern_id),
-                           entity_name.name_id, type_id, type_expr_region_id,
-                           is_generic, entity_name.is_template)
+  // Rebuild the binding pattern, with its own CompileTimeBindingIndex.
+  auto cloned_entity_name_id = context.entity_names().AddSymbolicBindingName(
+      entity_name.name_id, entity_name.parent_scope_id,
+      entity_name.bind_index().has_value()
+          ? context.scope_stack().AddCompileTimeBinding()
+          : SemIR::CompileTimeBindIndex::None,
+      entity_name.is_template);
+  return AddBindingPatternWithEntityName(context, SemIR::LocId(pattern_id),
+                                         cloned_entity_name_id, type_id,
+                                         type_expr_region_id)
       .pattern_id;
 }
 


### PR DESCRIPTION
We want to build a `.Self` that is a SymbolicBindingType with the entity name of the binding being constructed. To do so, we will need to know that entity name in CompileTimeBindingPatternStart. This makes that change in isolation, leaving a TODO for the next step.

Since we create the EntityName ahead of time, and pass it through to HandleAnyBindingPattern, we also need to create it ahead of time in the handlers for runtime `let` and `var` binding patterns.

ScopeStack::Restore can not handle having a compile time binding introduced while suspended currently. Since this is not (yet?) a requirement, we take care to avoid adding the compile time binding at all in CompileTimeBindingPatternStart when the binding is in an incorrect scope. Currently ScopeStack::Suspend is only followed by a compile time binding in scopes that do not support compile time bindings, such as a class fn referring to a later compile time binding in the class.