### PR TITLE
Dump all non-indexed ids as hex

### DIFF
--- a/scripts/lldbinit.py
+++ b/scripts/lldbinit.py
@@ -75,30 +75,27 @@ Example usage:
 
     context = args[0]
 
-    DECIMAL = 10
-    HEX = 16
-
     # The set of "Make" functions in dump.cpp, and whether the ids are printed
     # in decimal or hex.
     id_types = {
-        "class": ("SemIR::MakeClassId", HEX),
-        "constant": ("SemIR::MakeConstantId", DECIMAL),
-        "symbolic_constant": ("SemIR::MakeSymbolicConstantId", DECIMAL),
-        "entity_name": ("SemIR::MakeEntityNameId", DECIMAL),
-        "facet_type": ("SemIR::MakeFacetTypeId", DECIMAL),
-        "function": ("SemIR::MakeFunctionId", HEX),
-        "generic": ("SemIR::MakeGenericId", DECIMAL),
-        "impl": ("SemIR::MakeImplId", HEX),
-        "inst_block": ("SemIR::MakeInstBlockId", DECIMAL),
-        "inst": ("SemIR::MakeInstId", HEX),
-        "interface": ("SemIR::MakeInterfaceId", DECIMAL),
-        "name": ("SemIR::MakeNameId", DECIMAL),
-        "name_scope": ("SemIR::MakeNameScopeId", DECIMAL),
-        "identified_facet_type": ("SemIR::MakeIdentifiedFacetTypeId", DECIMAL),
-        "specific": ("SemIR::MakeSpecificId", DECIMAL),
-        "specific_interface": ("SemIR::MakeSpecificInterfaceId", HEX),
-        "struct_type_fields": ("SemIR::MakeStructTypeFieldsId", DECIMAL),
-        "type": ("SemIR::MakeTypeId", DECIMAL),
+        "class": "SemIR::MakeClassId",
+        "constant": "SemIR::MakeConstantId",
+        "symbolic_constant": "SemIR::MakeSymbolicConstantId",
+        "entity_name": "SemIR::MakeEntityNameId",
+        "facet_type": "SemIR::MakeFacetTypeId",
+        "function": "SemIR::MakeFunctionId",
+        "generic": "SemIR::MakeGenericId",
+        "impl": "SemIR::MakeImplId",
+        "inst_block": "SemIR::MakeInstBlockId",
+        "inst": "SemIR::MakeInstId",
+        "interface": "SemIR::MakeInterfaceId",
+        "name": "SemIR::MakeNameId",
+        "name_scope": "SemIR::MakeNameScopeId",
+        "identified_facet_type": "SemIR::MakeIdentifiedFacetTypeId",
+        "specific": "SemIR::MakeSpecificId",
+        "specific_interface": "SemIR::MakeSpecificInterfaceId",
+        "struct_type_fields": "SemIR::MakeStructTypeFieldsId",
+        "type": "SemIR::MakeTypeId",
     }
 
     def print_dump(context: str, expr: str) -> None:
@@ -123,8 +120,8 @@ Example usage:
             if len(args) != 2:
                 print_usage()
                 return
-            (make_id_fn, base) = id_types[m[1]]
-            id = int(m[2], base)
+            make_id_fn = id_types[m[1]]
+            id = int(m[2], 16)
             print_dump(context, f"{make_id_fn}({id})")
             found_id_type = True
 

--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -56,7 +56,6 @@ struct IdBase : public AnyIdBase, public Printable<IdT> {
   // NOLINTNEXTLINE(readability-identifier-naming)
   static const IdT& None;
 
-  // TODO: Make Print() do the hex thing for all IDs and remove this function.
   auto Print(llvm::raw_ostream& out) const -> void {
     out << IdT::Label;
     if (has_value()) {
@@ -90,6 +89,8 @@ struct IndexBase : public IdBase<IdT> {
     return lhs.index <=> rhs.index;
   }
 
+  // Print indexed ids in decimal, since they won't have tagging (because, as
+  // the class comment explains, these ids are not entirely opaque).
   auto Print(llvm::raw_ostream& out) const -> void {
     out << IdT::Label;
     if (this->has_value()) {

--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -56,17 +56,8 @@ struct IdBase : public AnyIdBase, public Printable<IdT> {
   // NOLINTNEXTLINE(readability-identifier-naming)
   static const IdT& None;
 
-  auto Print(llvm::raw_ostream& out) const -> void {
-    out << IdT::Label;
-    if (has_value()) {
-      out << index;
-    } else {
-      out << "<none>";
-    }
-  }
-
   // TODO: Make Print() do the hex thing for all IDs and remove this function.
-  auto PrintHex(llvm::raw_ostream& out) const -> void {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << IdT::Label;
     if (has_value()) {
       out << llvm::format_hex_no_prefix(index, 8, /*Upper=*/true);
@@ -97,6 +88,15 @@ struct IndexBase : public IdBase<IdT> {
   friend auto operator<=>(IndexBase<IdT> lhs, IndexBase<IdT> rhs)
       -> std::strong_ordering {
     return lhs.index <=> rhs.index;
+  }
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << IdT::Label;
+    if (this->has_value()) {
+      out << this->index;
+    } else {
+      out << "<none>";
+    }
   }
 };
 

--- a/toolchain/base/shared_value_stores_test.cpp
+++ b/toolchain/base/shared_value_stores_test.cpp
@@ -52,12 +52,13 @@ TEST(SharedValueStores, PrintVals) {
   RawStringOstream out;
   value_stores.Print(out);
 
-  EXPECT_THAT(Yaml::Value::FromText(out.TakeStr()),
-              MatchSharedValues(
-                  ElementsAre(Pair("ap_int0", Yaml::Scalar("999999999999"))),
-                  ElementsAre(Pair("real0", Yaml::Scalar("8*10^8"))), IsEmpty(),
-                  ElementsAre(Pair("identifier0", Yaml::Scalar("a"))),
-                  ElementsAre(Pair("string0", Yaml::Scalar("foo'\"baz")))));
+  EXPECT_THAT(
+      Yaml::Value::FromText(out.TakeStr()),
+      MatchSharedValues(
+          ElementsAre(Pair("ap_int00000000", Yaml::Scalar("999999999999"))),
+          ElementsAre(Pair("real00000000", Yaml::Scalar("8*10^8"))), IsEmpty(),
+          ElementsAre(Pair("identifier00000000", Yaml::Scalar("a"))),
+          ElementsAre(Pair("string00000000", Yaml::Scalar("foo'\"baz")))));
 }
 
 }  // namespace

--- a/toolchain/check/testdata/basics/raw_sem_ir/builtins.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/builtins.carbon
@@ -20,7 +20,7 @@
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:       {}
@@ -28,7 +28,7 @@
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -51,7 +51,7 @@
 // CHECK:STDOUT:     'inst(SpecificFunctionType)': {kind: SpecificFunctionType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(VtableType)': {kind: VtableType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(WitnessType)': {kind: WitnessType, type: type(TypeType)}
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       'inst(TypeType)':  concrete_constant(inst(TypeType))
@@ -75,6 +75,6 @@
 // CHECK:STDOUT:     exports:         {}
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:
+// CHECK:STDOUT:     inst_block00000004:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/raw_sem_ir/cpp_interop.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/cpp_interop.carbon
@@ -39,45 +39,45 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc0}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc1}
-// CHECK:STDOUT:     import_ir_inst2: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc2}
+// CHECK:STDOUT:     import_ir_inst00000000: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc00000000}
+// CHECK:STDOUT:     import_ir_inst00000001: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc00000001}
+// CHECK:STDOUT:     import_ir_inst00000002: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc00000002}
 // CHECK:STDOUT:   clang_decls:
-// CHECK:STDOUT:     clang_decl_id0:  {key: "<translation unit>", inst_id: inst60000010}
-// CHECK:STDOUT:     clang_decl_id1:  {key: "struct X {}", inst_id: inst60000012}
-// CHECK:STDOUT:     clang_decl_id2:  {key: "X * _Nonnull p", inst_id: inst60000021}
-// CHECK:STDOUT:     clang_decl_id3:  {key: {decl: "void f(X x = {})", num_params: 0}, inst_id: inst6000002C}
-// CHECK:STDOUT:     clang_decl_id4:  {key: {decl: "extern void f__carbon_thunk()", num_params: 0}, inst_id: inst6000002F}
-// CHECK:STDOUT:     clang_decl_id5:  {key: {decl: "void f(X x = {})", num_params: 1}, inst_id: inst6000003A}
-// CHECK:STDOUT:     clang_decl_id6:  {key: {decl: "extern void f__carbon_thunk(X * _Nonnull x)", num_params: 1}, inst_id: inst60000042}
-// CHECK:STDOUT:     clang_decl_id7:  {key: "X * _Nonnull global", inst_id: inst6000004B}
+// CHECK:STDOUT:     clang_decl_id00000000: {key: "<translation unit>", inst_id: inst60000010}
+// CHECK:STDOUT:     clang_decl_id00000001: {key: "struct X {}", inst_id: inst60000012}
+// CHECK:STDOUT:     clang_decl_id00000002: {key: "X * _Nonnull p", inst_id: inst60000021}
+// CHECK:STDOUT:     clang_decl_id00000003: {key: {decl: "void f(X x = {})", num_params: 0}, inst_id: inst6000002C}
+// CHECK:STDOUT:     clang_decl_id00000004: {key: {decl: "extern void f__carbon_thunk()", num_params: 0}, inst_id: inst6000002F}
+// CHECK:STDOUT:     clang_decl_id00000005: {key: {decl: "void f(X x = {})", num_params: 1}, inst_id: inst6000003A}
+// CHECK:STDOUT:     clang_decl_id00000006: {key: {decl: "extern void f__carbon_thunk(X * _Nonnull x)", num_params: 1}, inst_id: inst60000042}
+// CHECK:STDOUT:     clang_decl_id00000007: {key: "X * _Nonnull global", inst_id: inst6000004B}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst60000010, name1: inst6000001B}}
-// CHECK:STDOUT:     name_scope1:     {inst: inst60000010, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name3: inst60000012, name4: inst60000029, name5: inst6000004B}}
-// CHECK:STDOUT:     name_scope2:     {inst: inst60000012, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name00000000: inst60000010, name00000001: inst6000001B}}
+// CHECK:STDOUT:     name_scope00000001: {inst: inst60000010, parent_scope: name_scope00000000, has_error: false, extended_scopes: [], names: {name00000003: inst60000012, name00000004: inst60000029, name00000005: inst6000004B}}
+// CHECK:STDOUT:     name_scope00000002: {inst: inst60000012, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name1:    {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name2:    {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name3:    {name: name5, parent_scope: name_scope1, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000000: {name: name00000002, parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000001: {name: name00000002, parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000002: {name: name00000002, parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000003: {name: name00000005, parent_scope: name_scope00000001, index: -1, is_template: 0}
 // CHECK:STDOUT:   cpp_global_vars:
-// CHECK:STDOUT:     cpp_global_var0: {key: {entity_name_id: entity_name3}, clang_decl_id: clang_decl_id7}
+// CHECK:STDOUT:     cpp_global_var00000000: {key: {entity_name_id: entity_name00000003}, clang_decl_id: clang_decl_id00000007}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name1, parent_scope: name_scope0, call_params_id: inst_block6, body: [inst_block9]}
-// CHECK:STDOUT:     function60000001: {name: name4, parent_scope: name_scope1, call_params_id: inst_block_empty}
-// CHECK:STDOUT:     function60000002: {name: name7, parent_scope: name_scope1, call_params_id: inst_block_empty}
-// CHECK:STDOUT:     function60000003: {name: name4, parent_scope: name_scope1, call_params_id: inst_block13}
-// CHECK:STDOUT:     function60000004: {name: name7, parent_scope: name_scope1, call_params_id: inst_block18}
+// CHECK:STDOUT:     function60000000: {name: name00000001, parent_scope: name_scope00000000, call_params_id: inst_block00000006, body: [inst_block00000009]}
+// CHECK:STDOUT:     function60000001: {name: name00000004, parent_scope: name_scope00000001, call_params_id: inst_block_empty}
+// CHECK:STDOUT:     function60000002: {name: name00000007, parent_scope: name_scope00000001, call_params_id: inst_block_empty}
+// CHECK:STDOUT:     function60000003: {name: name00000004, parent_scope: name_scope00000001, call_params_id: inst_block0000000D}
+// CHECK:STDOUT:     function60000004: {name: name00000007, parent_scope: name_scope00000001, call_params_id: inst_block00000012}
 // CHECK:STDOUT:   classes:
-// CHECK:STDOUT:     class60000000:   {name: name3, parent_scope: name_scope1, self_type_id: type(inst60000013), inheritance_kind: Base, is_dynamic: 0, scope_id: name_scope2, body_block_id: inst_block10, adapt_id: inst<none>, base_id: inst<none>, complete_type_witness_id: inst60000024, vtable_decl_id: inst<none>}}
+// CHECK:STDOUT:     class60000000:   {name: name00000003, parent_scope: name_scope00000001, self_type_id: type(inst60000013), inheritance_kind: Base, is_dynamic: 0, scope_id: name_scope00000002, body_block_id: inst_block0000000A, adapt_id: inst<none>, base_id: inst<none>, complete_type_witness_id: inst60000024, vtable_decl_id: inst<none>}}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
-// CHECK:STDOUT:     struct_type_fields1:
-// CHECK:STDOUT:       0:               {name_id: name6, type_inst_id: inst6000001F}
-// CHECK:STDOUT:     struct_type_fields2:
-// CHECK:STDOUT:       0:               {name_id: name6, type_inst_id: inst6000001F}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
+// CHECK:STDOUT:     struct_type_fields00000001:
+// CHECK:STDOUT:       0:               {name_id: name00000006, type_inst_id: inst6000001F}
+// CHECK:STDOUT:     struct_type_fields00000002:
+// CHECK:STDOUT:       0:               {name_id: name00000006, type_inst_id: inst6000001F}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -124,36 +124,36 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:     'inst(SpecificFunctionType)': {kind: SpecificFunctionType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(VtableType)': {kind: VtableType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(WitnessType)': {kind: WitnessType, type: type(TypeType)}
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst6000000F:    {kind: ImportCppDecl}
-// CHECK:STDOUT:     inst60000010:    {kind: Namespace, arg0: name_scope1, arg1: inst6000000F, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000011:    {kind: NameRef, arg0: name0, arg1: inst60000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000010:    {kind: Namespace, arg0: name_scope00000001, arg1: inst6000000F, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000011:    {kind: NameRef, arg0: name00000000, arg1: inst60000010, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst60000012:    {kind: ClassDecl, arg0: class60000000, arg1: inst_block<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000013:    {kind: ClassType, arg0: class60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000014:    {kind: NameRef, arg0: name3, arg1: inst60000012, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000015:    {kind: BindName, arg0: entity_name0, arg1: inst60000019, type: type(inst60000013)}
+// CHECK:STDOUT:     inst60000014:    {kind: NameRef, arg0: name00000003, arg1: inst60000012, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000015:    {kind: BindName, arg0: entity_name00000000, arg1: inst60000019, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000016:    {kind: PatternType, arg0: inst60000013, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000017:    {kind: BindingPattern, arg0: entity_name0, type: type(inst60000016)}
+// CHECK:STDOUT:     inst60000017:    {kind: BindingPattern, arg0: entity_name00000000, type: type(inst60000016)}
 // CHECK:STDOUT:     inst60000018:    {kind: ValueParamPattern, arg0: inst60000017, arg1: call_param0, type: type(inst60000016)}
-// CHECK:STDOUT:     inst60000019:    {kind: ValueParam, arg0: call_param0, arg1: name2, type: type(inst60000013)}
-// CHECK:STDOUT:     inst6000001A:    {kind: SpliceBlock, arg0: inst_block4, arg1: inst60000014, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001B:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block8, type: type(inst6000001C)}
+// CHECK:STDOUT:     inst60000019:    {kind: ValueParam, arg0: call_param0, arg1: name00000002, type: type(inst60000013)}
+// CHECK:STDOUT:     inst6000001A:    {kind: SpliceBlock, arg0: inst_block00000004, arg1: inst60000014, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000001B:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block00000008, type: type(inst6000001C)}
 // CHECK:STDOUT:     inst6000001C:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001D:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001E:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000001C)}
 // CHECK:STDOUT:     inst6000001F:    {kind: PointerType, arg0: inst60000013, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000020:    {kind: UnboundElementType, arg0: inst60000013, arg1: inst6000001F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000021:    {kind: FieldDecl, arg0: name6, arg1: element0, type: type(inst60000020)}
-// CHECK:STDOUT:     inst60000022:    {kind: CustomLayoutType, arg0: struct_type_fields1, arg1: custom_layout1, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000023:    {kind: CustomLayoutType, arg0: struct_type_fields2, arg1: custom_layout1, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000021:    {kind: FieldDecl, arg0: name00000006, arg1: element0, type: type(inst60000020)}
+// CHECK:STDOUT:     inst60000022:    {kind: CustomLayoutType, arg0: struct_type_fields00000001, arg1: custom_layout00000001, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000023:    {kind: CustomLayoutType, arg0: struct_type_fields00000002, arg1: custom_layout00000001, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000024:    {kind: CompleteTypeWitness, arg0: inst60000022, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000025:    {kind: CompleteTypeWitness, arg0: inst60000023, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000026:    {kind: PointerType, arg0: inst60000023, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000027:    {kind: NameRef, arg0: name0, arg1: inst60000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000027:    {kind: NameRef, arg0: name00000000, arg1: inst60000010, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst60000028:    {kind: CppOverloadSetType, arg0: cpp_overload_set60000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000029:    {kind: CppOverloadSetValue, arg0: cpp_overload_set60000000, type: type(inst60000028)}
 // CHECK:STDOUT:     inst6000002A:    {kind: CppOverloadSetValue, arg0: cpp_overload_set60000000, type: type(inst60000028)}
-// CHECK:STDOUT:     inst6000002B:    {kind: NameRef, arg0: name4, arg1: inst60000029, type: type(inst60000028)}
+// CHECK:STDOUT:     inst6000002B:    {kind: NameRef, arg0: name00000004, arg1: inst60000029, type: type(inst60000028)}
 // CHECK:STDOUT:     inst6000002C:    {kind: FunctionDecl, arg0: function60000001, arg1: inst_block_empty, type: type(inst6000002D)}
 // CHECK:STDOUT:     inst6000002D:    {kind: FunctionType, arg0: function60000001, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000002E:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000002D)}
@@ -161,41 +161,41 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:     inst60000030:    {kind: FunctionType, arg0: function60000002, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000031:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000030)}
 // CHECK:STDOUT:     inst60000032:    {kind: Call, arg0: inst6000002F, arg1: inst_block_empty, type: type(inst6000001D)}
-// CHECK:STDOUT:     inst60000033:    {kind: NameRef, arg0: name0, arg1: inst60000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000034:    {kind: NameRef, arg0: name4, arg1: inst60000029, type: type(inst60000028)}
-// CHECK:STDOUT:     inst60000035:    {kind: NameRef, arg0: name2, arg1: inst60000015, type: type(inst60000013)}
-// CHECK:STDOUT:     inst60000036:    {kind: BindName, arg0: entity_name1, arg1: inst60000039, type: type(inst60000013)}
-// CHECK:STDOUT:     inst60000037:    {kind: BindingPattern, arg0: entity_name1, type: type(inst60000016)}
+// CHECK:STDOUT:     inst60000033:    {kind: NameRef, arg0: name00000000, arg1: inst60000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000034:    {kind: NameRef, arg0: name00000004, arg1: inst60000029, type: type(inst60000028)}
+// CHECK:STDOUT:     inst60000035:    {kind: NameRef, arg0: name00000002, arg1: inst60000015, type: type(inst60000013)}
+// CHECK:STDOUT:     inst60000036:    {kind: BindName, arg0: entity_name00000001, arg1: inst60000039, type: type(inst60000013)}
+// CHECK:STDOUT:     inst60000037:    {kind: BindingPattern, arg0: entity_name00000001, type: type(inst60000016)}
 // CHECK:STDOUT:     inst60000038:    {kind: ValueParamPattern, arg0: inst60000037, arg1: call_param0, type: type(inst60000016)}
-// CHECK:STDOUT:     inst60000039:    {kind: ValueParam, arg0: call_param0, arg1: name2, type: type(inst60000013)}
-// CHECK:STDOUT:     inst6000003A:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block15, type: type(inst6000003B)}
+// CHECK:STDOUT:     inst60000039:    {kind: ValueParam, arg0: call_param0, arg1: name00000002, type: type(inst60000013)}
+// CHECK:STDOUT:     inst6000003A:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block0000000F, type: type(inst6000003B)}
 // CHECK:STDOUT:     inst6000003B:    {kind: FunctionType, arg0: function60000003, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000003C:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000003B)}
-// CHECK:STDOUT:     inst6000003D:    {kind: BindName, arg0: entity_name2, arg1: inst60000041, type: type(inst6000001F)}
+// CHECK:STDOUT:     inst6000003D:    {kind: BindName, arg0: entity_name00000002, arg1: inst60000041, type: type(inst6000001F)}
 // CHECK:STDOUT:     inst6000003E:    {kind: PatternType, arg0: inst6000001F, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000003F:    {kind: BindingPattern, arg0: entity_name2, type: type(inst6000003E)}
+// CHECK:STDOUT:     inst6000003F:    {kind: BindingPattern, arg0: entity_name00000002, type: type(inst6000003E)}
 // CHECK:STDOUT:     inst60000040:    {kind: ValueParamPattern, arg0: inst6000003F, arg1: call_param0, type: type(inst6000003E)}
-// CHECK:STDOUT:     inst60000041:    {kind: ValueParam, arg0: call_param0, arg1: name2, type: type(inst6000001F)}
-// CHECK:STDOUT:     inst60000042:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block20, type: type(inst60000043)}
+// CHECK:STDOUT:     inst60000041:    {kind: ValueParam, arg0: call_param0, arg1: name00000002, type: type(inst6000001F)}
+// CHECK:STDOUT:     inst60000042:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block00000014, type: type(inst60000043)}
 // CHECK:STDOUT:     inst60000043:    {kind: FunctionType, arg0: function60000004, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000044:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000043)}
 // CHECK:STDOUT:     inst60000045:    {kind: ValueAsRef, arg0: inst60000035, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000046:    {kind: AddrOf, arg0: inst60000045, type: type(inst6000001F)}
-// CHECK:STDOUT:     inst60000047:    {kind: Call, arg0: inst60000042, arg1: inst_block22, type: type(inst6000001D)}
-// CHECK:STDOUT:     inst60000048:    {kind: NameRef, arg0: name0, arg1: inst60000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000049:    {kind: NameRef, arg0: name4, arg1: inst60000029, type: type(inst60000028)}
-// CHECK:STDOUT:     inst6000004A:    {kind: NameRef, arg0: name0, arg1: inst60000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000047:    {kind: Call, arg0: inst60000042, arg1: inst_block00000016, type: type(inst6000001D)}
+// CHECK:STDOUT:     inst60000048:    {kind: NameRef, arg0: name00000000, arg1: inst60000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000049:    {kind: NameRef, arg0: name00000004, arg1: inst60000029, type: type(inst60000028)}
+// CHECK:STDOUT:     inst6000004A:    {kind: NameRef, arg0: name00000000, arg1: inst60000010, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst6000004B:    {kind: VarStorage, arg0: inst6000004D, type: type(inst6000001F)}
-// CHECK:STDOUT:     inst6000004C:    {kind: BindingPattern, arg0: entity_name3, type: type(inst6000003E)}
+// CHECK:STDOUT:     inst6000004C:    {kind: BindingPattern, arg0: entity_name00000003, type: type(inst6000003E)}
 // CHECK:STDOUT:     inst6000004D:    {kind: VarPattern, arg0: inst6000004C, type: type(inst6000003E)}
-// CHECK:STDOUT:     inst6000004E:    {kind: NameBindingDecl, arg0: inst_block23}
-// CHECK:STDOUT:     inst6000004F:    {kind: NameRef, arg0: name5, arg1: inst6000004B, type: type(inst6000001F)}
+// CHECK:STDOUT:     inst6000004E:    {kind: NameBindingDecl, arg0: inst_block00000017}
+// CHECK:STDOUT:     inst6000004F:    {kind: NameRef, arg0: name00000005, arg1: inst6000004B, type: type(inst6000001F)}
 // CHECK:STDOUT:     inst60000050:    {kind: BindValue, arg0: inst6000004F, type: type(inst6000001F)}
 // CHECK:STDOUT:     inst60000051:    {kind: Deref, arg0: inst60000050, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000052:    {kind: BindValue, arg0: inst60000051, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000053:    {kind: ValueAsRef, arg0: inst60000052, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000054:    {kind: AddrOf, arg0: inst60000053, type: type(inst6000001F)}
-// CHECK:STDOUT:     inst60000055:    {kind: Call, arg0: inst60000042, arg1: inst_block25, type: type(inst6000001D)}
+// CHECK:STDOUT:     inst60000055:    {kind: Call, arg0: inst60000042, arg1: inst_block00000019, type: type(inst6000001D)}
 // CHECK:STDOUT:     inst60000056:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
@@ -282,21 +282,21 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:       7:               inst6000004E
 // CHECK:STDOUT:       8:               inst6000004B
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:
+// CHECK:STDOUT:     inst_block00000004:
 // CHECK:STDOUT:       0:               inst60000011
 // CHECK:STDOUT:       1:               inst60000014
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst60000018
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst60000019
-// CHECK:STDOUT:     inst_block7:
+// CHECK:STDOUT:     inst_block00000007:
 // CHECK:STDOUT:       0:               inst60000017
 // CHECK:STDOUT:       1:               inst60000018
-// CHECK:STDOUT:     inst_block8:
+// CHECK:STDOUT:     inst_block00000008:
 // CHECK:STDOUT:       0:               inst60000019
 // CHECK:STDOUT:       1:               inst6000001A
 // CHECK:STDOUT:       2:               inst60000015
-// CHECK:STDOUT:     inst_block9:
+// CHECK:STDOUT:     inst_block00000009:
 // CHECK:STDOUT:       0:               inst60000027
 // CHECK:STDOUT:       1:               inst6000002B
 // CHECK:STDOUT:       2:               inst60000032
@@ -317,44 +317,44 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:       17:              inst60000054
 // CHECK:STDOUT:       18:              inst60000055
 // CHECK:STDOUT:       19:              inst60000056
-// CHECK:STDOUT:     inst_block10:
+// CHECK:STDOUT:     inst_block0000000A:
 // CHECK:STDOUT:       0:               inst60000021
 // CHECK:STDOUT:       1:               inst60000022
 // CHECK:STDOUT:       2:               inst60000024
-// CHECK:STDOUT:     inst_block11:    {}
-// CHECK:STDOUT:     inst_block12:
+// CHECK:STDOUT:     inst_block0000000B: {}
+// CHECK:STDOUT:     inst_block0000000C:
 // CHECK:STDOUT:       0:               inst60000038
-// CHECK:STDOUT:     inst_block13:
+// CHECK:STDOUT:     inst_block0000000D:
 // CHECK:STDOUT:       0:               inst60000039
-// CHECK:STDOUT:     inst_block14:
+// CHECK:STDOUT:     inst_block0000000E:
 // CHECK:STDOUT:       0:               inst60000037
 // CHECK:STDOUT:       1:               inst60000038
-// CHECK:STDOUT:     inst_block15:
+// CHECK:STDOUT:     inst_block0000000F:
 // CHECK:STDOUT:       0:               inst60000039
 // CHECK:STDOUT:       1:               inst60000036
-// CHECK:STDOUT:     inst_block16:    {}
-// CHECK:STDOUT:     inst_block17:
+// CHECK:STDOUT:     inst_block00000010: {}
+// CHECK:STDOUT:     inst_block00000011:
 // CHECK:STDOUT:       0:               inst60000040
-// CHECK:STDOUT:     inst_block18:
+// CHECK:STDOUT:     inst_block00000012:
 // CHECK:STDOUT:       0:               inst60000041
-// CHECK:STDOUT:     inst_block19:
+// CHECK:STDOUT:     inst_block00000013:
 // CHECK:STDOUT:       0:               inst6000003F
 // CHECK:STDOUT:       1:               inst60000040
-// CHECK:STDOUT:     inst_block20:
+// CHECK:STDOUT:     inst_block00000014:
 // CHECK:STDOUT:       0:               inst60000041
 // CHECK:STDOUT:       1:               inst6000003D
-// CHECK:STDOUT:     inst_block21:
+// CHECK:STDOUT:     inst_block00000015:
 // CHECK:STDOUT:       0:               inst60000035
-// CHECK:STDOUT:     inst_block22:
+// CHECK:STDOUT:     inst_block00000016:
 // CHECK:STDOUT:       0:               inst60000046
-// CHECK:STDOUT:     inst_block23:
+// CHECK:STDOUT:     inst_block00000017:
 // CHECK:STDOUT:       0:               inst6000004C
 // CHECK:STDOUT:       1:               inst6000004D
-// CHECK:STDOUT:     inst_block24:
+// CHECK:STDOUT:     inst_block00000018:
 // CHECK:STDOUT:       0:               inst60000052
-// CHECK:STDOUT:     inst_block25:
+// CHECK:STDOUT:     inst_block00000019:
 // CHECK:STDOUT:       0:               inst60000054
-// CHECK:STDOUT:     inst_block26:
+// CHECK:STDOUT:     inst_block0000001A:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst6000000F
 // CHECK:STDOUT:       2:               inst6000001B

--- a/toolchain/check/testdata/basics/raw_sem_ir/multifile.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/multifile.carbon
@@ -36,16 +36,16 @@ fn B() {
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst6000000F}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name00000000: inst6000000F}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_params_id: inst_block_empty, body: [inst_block5]}
+// CHECK:STDOUT:     function60000000: {name: name00000000, parent_scope: name_scope00000000, call_params_id: inst_block_empty, body: [inst_block00000005]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -58,7 +58,7 @@ fn B() {
 // CHECK:STDOUT:     'type(inst60000011)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000011)}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst6000000F:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block_empty, type: type(inst60000010)}
 // CHECK:STDOUT:     inst60000010:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000011:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
@@ -78,10 +78,10 @@ fn B() {
 // CHECK:STDOUT:       0:               inst6000000F
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:     {}
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000004: {}
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst60000013
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst6000000F
 // CHECK:STDOUT: ...
@@ -91,25 +91,25 @@ fn B() {
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
-// CHECK:STDOUT:     import_ir2:      {decl_id: inst5000000F, is_export: false}
+// CHECK:STDOUT:     import_ir00000002: {decl_id: inst5000000F, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir2, inst_id: inst6000000F}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir2, inst_id: inst6000000F}
+// CHECK:STDOUT:     import_ir_inst00000000: {ir_id: import_ir00000002, inst_id: inst6000000F}
+// CHECK:STDOUT:     import_ir_inst00000001: {ir_id: import_ir00000002, inst_id: inst6000000F}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst50000010, name0: inst50000011}}
-// CHECK:STDOUT:     name_scope1:     {inst: inst50000010, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst50000016}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name00000001: inst50000010, name00000000: inst50000011}}
+// CHECK:STDOUT:     name_scope00000001: {inst: inst50000010, parent_scope: name_scope00000000, has_error: false, extended_scopes: [], names: {name00000001: inst50000016}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000000: {name: name00000001, parent_scope: name_scope00000001, index: -1, is_template: 0}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_params_id: inst_block_empty, body: [inst_block5]}
-// CHECK:STDOUT:     function50000001: {name: name1, parent_scope: name_scope1}
+// CHECK:STDOUT:     function50000000: {name: name00000000, parent_scope: name_scope00000000, call_params_id: inst_block_empty, body: [inst_block00000005]}
+// CHECK:STDOUT:     function50000001: {name: name00000001, parent_scope: name_scope00000001}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -122,19 +122,19 @@ fn B() {
 // CHECK:STDOUT:     'type(inst50000013)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst5000000F:    {kind: ImportDecl, arg0: name1}
-// CHECK:STDOUT:     inst50000010:    {kind: Namespace, arg0: name_scope1, arg1: inst5000000F, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst5000000F:    {kind: ImportDecl, arg0: name00000001}
+// CHECK:STDOUT:     inst50000010:    {kind: Namespace, arg0: name_scope00000001, arg1: inst5000000F, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst50000011:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block_empty, type: type(inst50000012)}
 // CHECK:STDOUT:     inst50000012:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst50000013:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
 // CHECK:STDOUT:     inst50000014:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000012)}
-// CHECK:STDOUT:     inst50000015:    {kind: NameRef, arg0: name1, arg1: inst50000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000016:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst50000018)}
+// CHECK:STDOUT:     inst50000015:    {kind: NameRef, arg0: name00000001, arg1: inst50000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst50000016:    {kind: ImportRefLoaded, arg0: import_ir_inst00000000, arg1: entity_name00000000, type: type(inst50000018)}
 // CHECK:STDOUT:     inst50000017:    {kind: FunctionDecl, arg0: function50000001, arg1: inst_block_empty, type: type(inst50000018)}
 // CHECK:STDOUT:     inst50000018:    {kind: FunctionType, arg0: function50000001, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst50000019:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000018)}
-// CHECK:STDOUT:     inst5000001A:    {kind: NameRef, arg0: name1, arg1: inst50000016, type: type(inst50000018)}
+// CHECK:STDOUT:     inst5000001A:    {kind: NameRef, arg0: name00000001, arg1: inst50000016, type: type(inst50000018)}
 // CHECK:STDOUT:     inst5000001B:    {kind: Call, arg0: inst5000001A, arg1: inst_block_empty, type: type(inst50000013)}
 // CHECK:STDOUT:     inst5000001C:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
@@ -161,13 +161,13 @@ fn B() {
 // CHECK:STDOUT:       1:               inst50000016
 // CHECK:STDOUT:       2:               inst50000017
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:     {}
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000004: {}
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst50000015
 // CHECK:STDOUT:       1:               inst5000001A
 // CHECK:STDOUT:       2:               inst5000001B
 // CHECK:STDOUT:       3:               inst5000001C
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst5000000F
 // CHECK:STDOUT:       2:               inst50000011

--- a/toolchain/check/testdata/basics/raw_sem_ir/multifile_with_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/multifile_with_textual_ir.carbon
@@ -36,16 +36,16 @@ fn B() {
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst6000000F}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name00000000: inst6000000F}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_params_id: inst_block_empty, body: [inst_block5]}
+// CHECK:STDOUT:     function60000000: {name: name00000000, parent_scope: name_scope00000000, call_params_id: inst_block_empty, body: [inst_block00000005]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -58,7 +58,7 @@ fn B() {
 // CHECK:STDOUT:     'type(inst60000011)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000011)}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst6000000F:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block_empty, type: type(inst60000010)}
 // CHECK:STDOUT:     inst60000010:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000011:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
@@ -78,10 +78,10 @@ fn B() {
 // CHECK:STDOUT:       0:               inst6000000F
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:     {}
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000004: {}
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst60000013
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst6000000F
 // CHECK:STDOUT: ...
@@ -110,25 +110,25 @@ fn B() {
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
-// CHECK:STDOUT:     import_ir2:      {decl_id: inst5000000F, is_export: false}
+// CHECK:STDOUT:     import_ir00000002: {decl_id: inst5000000F, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir2, inst_id: inst6000000F}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir2, inst_id: inst6000000F}
+// CHECK:STDOUT:     import_ir_inst00000000: {ir_id: import_ir00000002, inst_id: inst6000000F}
+// CHECK:STDOUT:     import_ir_inst00000001: {ir_id: import_ir00000002, inst_id: inst6000000F}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst50000010, name0: inst50000011}}
-// CHECK:STDOUT:     name_scope1:     {inst: inst50000010, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst50000016}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name00000001: inst50000010, name00000000: inst50000011}}
+// CHECK:STDOUT:     name_scope00000001: {inst: inst50000010, parent_scope: name_scope00000000, has_error: false, extended_scopes: [], names: {name00000001: inst50000016}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope1, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000000: {name: name00000001, parent_scope: name_scope00000001, index: -1, is_template: 0}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_params_id: inst_block_empty, body: [inst_block5]}
-// CHECK:STDOUT:     function50000001: {name: name1, parent_scope: name_scope1}
+// CHECK:STDOUT:     function50000000: {name: name00000000, parent_scope: name_scope00000000, call_params_id: inst_block_empty, body: [inst_block00000005]}
+// CHECK:STDOUT:     function50000001: {name: name00000001, parent_scope: name_scope00000001}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -141,19 +141,19 @@ fn B() {
 // CHECK:STDOUT:     'type(inst50000013)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst5000000F:    {kind: ImportDecl, arg0: name1}
-// CHECK:STDOUT:     inst50000010:    {kind: Namespace, arg0: name_scope1, arg1: inst5000000F, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst5000000F:    {kind: ImportDecl, arg0: name00000001}
+// CHECK:STDOUT:     inst50000010:    {kind: Namespace, arg0: name_scope00000001, arg1: inst5000000F, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst50000011:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block_empty, type: type(inst50000012)}
 // CHECK:STDOUT:     inst50000012:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst50000013:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
 // CHECK:STDOUT:     inst50000014:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000012)}
-// CHECK:STDOUT:     inst50000015:    {kind: NameRef, arg0: name1, arg1: inst50000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000016:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name0, type: type(inst50000018)}
+// CHECK:STDOUT:     inst50000015:    {kind: NameRef, arg0: name00000001, arg1: inst50000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst50000016:    {kind: ImportRefLoaded, arg0: import_ir_inst00000000, arg1: entity_name00000000, type: type(inst50000018)}
 // CHECK:STDOUT:     inst50000017:    {kind: FunctionDecl, arg0: function50000001, arg1: inst_block_empty, type: type(inst50000018)}
 // CHECK:STDOUT:     inst50000018:    {kind: FunctionType, arg0: function50000001, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst50000019:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000018)}
-// CHECK:STDOUT:     inst5000001A:    {kind: NameRef, arg0: name1, arg1: inst50000016, type: type(inst50000018)}
+// CHECK:STDOUT:     inst5000001A:    {kind: NameRef, arg0: name00000001, arg1: inst50000016, type: type(inst50000018)}
 // CHECK:STDOUT:     inst5000001B:    {kind: Call, arg0: inst5000001A, arg1: inst_block_empty, type: type(inst50000013)}
 // CHECK:STDOUT:     inst5000001C:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
@@ -180,13 +180,13 @@ fn B() {
 // CHECK:STDOUT:       1:               inst50000016
 // CHECK:STDOUT:       2:               inst50000017
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:     {}
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000004: {}
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst50000015
 // CHECK:STDOUT:       1:               inst5000001A
 // CHECK:STDOUT:       2:               inst5000001B
 // CHECK:STDOUT:       3:               inst5000001C
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst5000000F
 // CHECK:STDOUT:       2:               inst50000011

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
@@ -23,325 +23,325 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
-// CHECK:STDOUT:     import_ir2:      {decl_id: inst6000000F, is_export: false}
-// CHECK:STDOUT:     import_ir3:      {decl_id: inst6000000F, is_export: false}
-// CHECK:STDOUT:     import_ir4:      {decl_id: inst6000000F, is_export: false}
-// CHECK:STDOUT:     import_ir5:      {decl_id: inst6000000F, is_export: false}
+// CHECK:STDOUT:     import_ir00000002: {decl_id: inst6000000F, is_export: false}
+// CHECK:STDOUT:     import_ir00000003: {decl_id: inst6000000F, is_export: false}
+// CHECK:STDOUT:     import_ir00000004: {decl_id: inst6000000F, is_export: false}
+// CHECK:STDOUT:     import_ir00000005: {decl_id: inst6000000F, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir4, inst_id: inst4800000F}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir4, inst_id: inst4800000F}
-// CHECK:STDOUT:     import_ir_inst2: {ir_id: import_ir4, inst_id: inst48000011}
-// CHECK:STDOUT:     import_ir_inst3: {ir_id: import_ir4, inst_id: inst4800002D}
-// CHECK:STDOUT:     import_ir_inst4: {ir_id: import_ir4, inst_id: inst48000028}
-// CHECK:STDOUT:     import_ir_inst5: {ir_id: import_ir4, inst_id: inst48000028}
-// CHECK:STDOUT:     import_ir_inst6: {ir_id: import_ir4, inst_id: inst48000028}
-// CHECK:STDOUT:     import_ir_inst7: {ir_id: import_ir4, inst_id: inst48000022}
-// CHECK:STDOUT:     import_ir_inst8: {ir_id: import_ir4, inst_id: inst48000023}
-// CHECK:STDOUT:     import_ir_inst9: {ir_id: import_ir4, inst_id: inst4800001C}
-// CHECK:STDOUT:     import_ir_inst10: {ir_id: import_ir4, inst_id: inst4800001E}
-// CHECK:STDOUT:     import_ir_inst11: {ir_id: import_ir4, inst_id: inst48000011}
-// CHECK:STDOUT:     import_ir_inst12: {ir_id: import_ir4, inst_id: inst48000015}
-// CHECK:STDOUT:     import_ir_inst13: {ir_id: import_ir4, inst_id: inst48000018}
-// CHECK:STDOUT:     import_ir_inst14: {ir_id: import_ir4, inst_id: inst4800001D}
-// CHECK:STDOUT:     import_ir_inst15: {ir_id: import_ir4, inst_id: inst48000061}
-// CHECK:STDOUT:     import_ir_inst16: {ir_id: import_ir4, inst_id: inst4800005F}
-// CHECK:STDOUT:     import_ir_inst17: {ir_id: import_ir4, inst_id: inst48000054}
-// CHECK:STDOUT:     import_ir_inst18: {ir_id: import_ir4, inst_id: inst48000050}
-// CHECK:STDOUT:     import_ir_inst19: {ir_id: import_ir4, inst_id: inst4800005A}
-// CHECK:STDOUT:     import_ir_inst20: {ir_id: import_ir4, inst_id: inst4800005D}
-// CHECK:STDOUT:     import_ir_inst21: {ir_id: import_ir4, inst_id: inst48000075}
-// CHECK:STDOUT:     import_ir_inst22: {ir_id: import_ir4, inst_id: inst48000060}
-// CHECK:STDOUT:     import_ir_inst23: {ir_id: import_ir4, inst_id: inst48000052}
-// CHECK:STDOUT:     import_ir_inst24: {ir_id: import_ir4, inst_id: inst48000058}
-// CHECK:STDOUT:     import_ir_inst25: {ir_id: import_ir4, inst_id: inst4800005C}
-// CHECK:STDOUT:     import_ir_inst26: {ir_id: import_ir4, inst_id: inst48000063}
-// CHECK:STDOUT:     import_ir_inst27: {ir_id: import_ir4, inst_id: inst48000075}
-// CHECK:STDOUT:     import_ir_inst28: {ir_id: import_ir4, inst_id: inst48000070}
-// CHECK:STDOUT:     import_ir_inst29: {ir_id: import_ir4, inst_id: inst48000071}
-// CHECK:STDOUT:     import_ir_inst30: {ir_id: import_ir4, inst_id: inst4800006C}
-// CHECK:STDOUT:     import_ir_inst31: {ir_id: import_ir4, inst_id: inst4800006E}
-// CHECK:STDOUT:     import_ir_inst32: {ir_id: import_ir4, inst_id: inst48000050}
-// CHECK:STDOUT:     import_ir_inst33: {ir_id: import_ir4, inst_id: inst48000078}
-// CHECK:STDOUT:     import_ir_inst34: {ir_id: import_ir4, inst_id: inst48000079}
-// CHECK:STDOUT:     import_ir_inst35: {ir_id: import_ir4, inst_id: inst48000067}
-// CHECK:STDOUT:     import_ir_inst36: {ir_id: import_ir4, inst_id: inst48000068}
-// CHECK:STDOUT:     import_ir_inst37: {ir_id: import_ir4, inst_id: inst48000069}
-// CHECK:STDOUT:     import_ir_inst38: {ir_id: import_ir4, inst_id: inst4800006D}
-// CHECK:STDOUT:     import_ir_inst39: {ir_id: import_ir4, inst_id: inst4800007D}
-// CHECK:STDOUT:     import_ir_inst40: {ir_id: import_ir4, inst_id: inst48000085}
-// CHECK:STDOUT:     import_ir_inst41: {ir_id: import_ir4, inst_id: inst4800008C}
-// CHECK:STDOUT:     import_ir_inst42: {ir_id: import_ir4, inst_id: inst48000090}
-// CHECK:STDOUT:     import_ir_inst43: {ir_id: import_ir4, inst_id: inst48000091}
-// CHECK:STDOUT:     import_ir_inst44: {ir_id: import_ir4, inst_id: inst48000096}
-// CHECK:STDOUT:     import_ir_inst45: {ir_id: import_ir4, inst_id: inst480000AB}
-// CHECK:STDOUT:     import_ir_inst46: {ir_id: import_ir4, inst_id: inst480000A9}
-// CHECK:STDOUT:     import_ir_inst47: {ir_id: import_ir4, inst_id: inst480000A7}
-// CHECK:STDOUT:     import_ir_inst48: {ir_id: import_ir4, inst_id: inst480000A8}
-// CHECK:STDOUT:     import_ir_inst49: {ir_id: import_ir4, inst_id: inst480000C3}
-// CHECK:STDOUT:     import_ir_inst50: {ir_id: import_ir4, inst_id: inst480000C1}
-// CHECK:STDOUT:     import_ir_inst51: {ir_id: import_ir4, inst_id: inst480000BF}
-// CHECK:STDOUT:     import_ir_inst52: {ir_id: import_ir4, inst_id: inst480000C0}
-// CHECK:STDOUT:     import_ir_inst53: {ir_id: import_ir4, inst_id: inst480000DB}
-// CHECK:STDOUT:     import_ir_inst54: {ir_id: import_ir4, inst_id: inst480000D9}
-// CHECK:STDOUT:     import_ir_inst55: {ir_id: import_ir4, inst_id: inst480000D7}
-// CHECK:STDOUT:     import_ir_inst56: {ir_id: import_ir4, inst_id: inst480000D8}
-// CHECK:STDOUT:     import_ir_inst57: {ir_id: import_ir4, inst_id: inst480000F3}
-// CHECK:STDOUT:     import_ir_inst58: {ir_id: import_ir4, inst_id: inst480000F1}
-// CHECK:STDOUT:     import_ir_inst59: {ir_id: import_ir4, inst_id: inst480000EF}
-// CHECK:STDOUT:     import_ir_inst60: {ir_id: import_ir4, inst_id: inst480000F0}
-// CHECK:STDOUT:     import_ir_inst61: {ir_id: import_ir4, inst_id: inst48000110}
-// CHECK:STDOUT:     import_ir_inst62: {ir_id: import_ir4, inst_id: inst4800010E}
-// CHECK:STDOUT:     import_ir_inst63: {ir_id: import_ir4, inst_id: inst48000108}
-// CHECK:STDOUT:     import_ir_inst64: {ir_id: import_ir4, inst_id: inst48000105}
-// CHECK:STDOUT:     import_ir_inst65: {ir_id: import_ir4, inst_id: inst4800010A}
-// CHECK:STDOUT:     import_ir_inst66: {ir_id: import_ir4, inst_id: inst4800010D}
-// CHECK:STDOUT:     import_ir_inst67: {ir_id: import_ir4, inst_id: inst48000121}
-// CHECK:STDOUT:     import_ir_inst68: {ir_id: import_ir4, inst_id: inst4800010F}
-// CHECK:STDOUT:     import_ir_inst69: {ir_id: import_ir4, inst_id: inst48000107}
-// CHECK:STDOUT:     import_ir_inst70: {ir_id: import_ir4, inst_id: inst4800010C}
-// CHECK:STDOUT:     import_ir_inst71: {ir_id: import_ir4, inst_id: inst48000112}
-// CHECK:STDOUT:     import_ir_inst72: {ir_id: import_ir4, inst_id: inst48000121}
-// CHECK:STDOUT:     import_ir_inst73: {ir_id: import_ir4, inst_id: inst4800011C}
-// CHECK:STDOUT:     import_ir_inst74: {ir_id: import_ir4, inst_id: inst4800011D}
-// CHECK:STDOUT:     import_ir_inst75: {ir_id: import_ir4, inst_id: inst48000118}
-// CHECK:STDOUT:     import_ir_inst76: {ir_id: import_ir4, inst_id: inst4800011A}
-// CHECK:STDOUT:     import_ir_inst77: {ir_id: import_ir4, inst_id: inst48000105}
-// CHECK:STDOUT:     import_ir_inst78: {ir_id: import_ir4, inst_id: inst48000124}
-// CHECK:STDOUT:     import_ir_inst79: {ir_id: import_ir4, inst_id: inst48000125}
-// CHECK:STDOUT:     import_ir_inst80: {ir_id: import_ir4, inst_id: inst48000128}
-// CHECK:STDOUT:     import_ir_inst81: {ir_id: import_ir4, inst_id: inst48000114}
-// CHECK:STDOUT:     import_ir_inst82: {ir_id: import_ir4, inst_id: inst48000115}
-// CHECK:STDOUT:     import_ir_inst83: {ir_id: import_ir4, inst_id: inst48000119}
-// CHECK:STDOUT:     import_ir_inst84: {ir_id: import_ir4, inst_id: inst4800012E}
-// CHECK:STDOUT:     import_ir_inst85: {ir_id: import_ir4, inst_id: inst4800012C}
-// CHECK:STDOUT:     import_ir_inst86: {ir_id: import_ir4, inst_id: inst(TypeType)}
-// CHECK:STDOUT:     import_ir_inst87: {ir_id: import_ir4, inst_id: inst4800012B}
-// CHECK:STDOUT:     import_ir_inst88: {ir_id: import_ir4, inst_id: inst48000143}
-// CHECK:STDOUT:     import_ir_inst89: {ir_id: import_ir4, inst_id: inst48000141}
-// CHECK:STDOUT:     import_ir_inst90: {ir_id: import_ir4, inst_id: inst4800013F}
-// CHECK:STDOUT:     import_ir_inst91: {ir_id: import_ir4, inst_id: inst48000140}
-// CHECK:STDOUT:     import_ir_inst92: {ir_id: import_ir4, inst_id: inst48000173}
-// CHECK:STDOUT:     import_ir_inst93: {ir_id: import_ir4, inst_id: inst48000171}
-// CHECK:STDOUT:     import_ir_inst94: {ir_id: import_ir4, inst_id: inst4800015E}
-// CHECK:STDOUT:     import_ir_inst95: {ir_id: import_ir4, inst_id: inst48000158}
-// CHECK:STDOUT:     import_ir_inst96: {ir_id: import_ir4, inst_id: inst48000156}
-// CHECK:STDOUT:     import_ir_inst97: {ir_id: import_ir4, inst_id: inst4800015B}
-// CHECK:STDOUT:     import_ir_inst98: {ir_id: import_ir4, inst_id: inst4800016C}
-// CHECK:STDOUT:     import_ir_inst99: {ir_id: import_ir4, inst_id: inst4800016E}
-// CHECK:STDOUT:     import_ir_inst100: {ir_id: import_ir4, inst_id: inst4800018B}
-// CHECK:STDOUT:     import_ir_inst101: {ir_id: import_ir4, inst_id: inst48000172}
-// CHECK:STDOUT:     import_ir_inst102: {ir_id: import_ir4, inst_id: inst48000157}
-// CHECK:STDOUT:     import_ir_inst103: {ir_id: import_ir4, inst_id: inst4800015D}
-// CHECK:STDOUT:     import_ir_inst104: {ir_id: import_ir4, inst_id: inst48000165}
-// CHECK:STDOUT:     import_ir_inst105: {ir_id: import_ir4, inst_id: inst48000169}
-// CHECK:STDOUT:     import_ir_inst106: {ir_id: import_ir4, inst_id: inst4800016D}
-// CHECK:STDOUT:     import_ir_inst107: {ir_id: import_ir4, inst_id: inst48000175}
-// CHECK:STDOUT:     import_ir_inst108: {ir_id: import_ir4, inst_id: inst4800018B}
-// CHECK:STDOUT:     import_ir_inst109: {ir_id: import_ir4, inst_id: inst48000186}
-// CHECK:STDOUT:     import_ir_inst110: {ir_id: import_ir4, inst_id: inst48000187}
-// CHECK:STDOUT:     import_ir_inst111: {ir_id: import_ir4, inst_id: inst48000182}
-// CHECK:STDOUT:     import_ir_inst112: {ir_id: import_ir4, inst_id: inst48000184}
-// CHECK:STDOUT:     import_ir_inst113: {ir_id: import_ir4, inst_id: inst48000156}
-// CHECK:STDOUT:     import_ir_inst114: {ir_id: import_ir4, inst_id: inst4800015B}
-// CHECK:STDOUT:     import_ir_inst115: {ir_id: import_ir4, inst_id: inst4800018E}
-// CHECK:STDOUT:     import_ir_inst116: {ir_id: import_ir4, inst_id: inst4800018F}
-// CHECK:STDOUT:     import_ir_inst117: {ir_id: import_ir4, inst_id: inst4800017B}
-// CHECK:STDOUT:     import_ir_inst118: {ir_id: import_ir4, inst_id: inst4800017C}
-// CHECK:STDOUT:     import_ir_inst119: {ir_id: import_ir4, inst_id: inst4800017D}
-// CHECK:STDOUT:     import_ir_inst120: {ir_id: import_ir4, inst_id: inst4800017E}
-// CHECK:STDOUT:     import_ir_inst121: {ir_id: import_ir4, inst_id: inst4800017F}
-// CHECK:STDOUT:     import_ir_inst122: {ir_id: import_ir4, inst_id: inst48000183}
-// CHECK:STDOUT:     import_ir_inst123: {ir_id: import_ir4, inst_id: inst48000194}
-// CHECK:STDOUT:     import_ir_inst124: {ir_id: import_ir4, inst_id: inst4800019C}
-// CHECK:STDOUT:     import_ir_inst125: {ir_id: import_ir4, inst_id: inst480001A0}
-// CHECK:STDOUT:     import_ir_inst126: {ir_id: import_ir4, inst_id: inst480001A2}
-// CHECK:STDOUT:     import_ir_inst127: {ir_id: import_ir4, inst_id: inst480001A3}
-// CHECK:STDOUT:     import_ir_inst128: {ir_id: import_ir4, inst_id: inst480001A6}
-// CHECK:STDOUT:     import_ir_inst129: {ir_id: import_ir4, inst_id: inst480001B2}
-// CHECK:STDOUT:     import_ir_inst130: {ir_id: import_ir4, inst_id: inst480001B7}
-// CHECK:STDOUT:     import_ir_inst131: {ir_id: import_ir4, inst_id: inst480001BB}
-// CHECK:STDOUT:     import_ir_inst132: {ir_id: import_ir4, inst_id: inst480001BC}
-// CHECK:STDOUT:     import_ir_inst133: {ir_id: import_ir4, inst_id: inst480001C1}
-// CHECK:STDOUT:     import_ir_inst134: {ir_id: import_ir4, inst_id: inst480001FA}
-// CHECK:STDOUT:     import_ir_inst135: {ir_id: import_ir4, inst_id: inst480001F8}
-// CHECK:STDOUT:     import_ir_inst136: {ir_id: import_ir4, inst_id: inst480001E0}
-// CHECK:STDOUT:     import_ir_inst137: {ir_id: import_ir4, inst_id: inst480001DA}
-// CHECK:STDOUT:     import_ir_inst138: {ir_id: import_ir4, inst_id: inst480001D5}
-// CHECK:STDOUT:     import_ir_inst139: {ir_id: import_ir4, inst_id: inst480001D3}
-// CHECK:STDOUT:     import_ir_inst140: {ir_id: import_ir4, inst_id: inst480001D8}
-// CHECK:STDOUT:     import_ir_inst141: {ir_id: import_ir4, inst_id: inst480001DD}
-// CHECK:STDOUT:     import_ir_inst142: {ir_id: import_ir4, inst_id: inst480001F2}
-// CHECK:STDOUT:     import_ir_inst143: {ir_id: import_ir4, inst_id: inst480001F4}
-// CHECK:STDOUT:     import_ir_inst144: {ir_id: import_ir4, inst_id: inst48000216}
-// CHECK:STDOUT:     import_ir_inst145: {ir_id: import_ir4, inst_id: inst480001F9}
-// CHECK:STDOUT:     import_ir_inst146: {ir_id: import_ir4, inst_id: inst480001D4}
-// CHECK:STDOUT:     import_ir_inst147: {ir_id: import_ir4, inst_id: inst480001D9}
-// CHECK:STDOUT:     import_ir_inst148: {ir_id: import_ir4, inst_id: inst480001DF}
-// CHECK:STDOUT:     import_ir_inst149: {ir_id: import_ir4, inst_id: inst480001E8}
-// CHECK:STDOUT:     import_ir_inst150: {ir_id: import_ir4, inst_id: inst480001EB}
-// CHECK:STDOUT:     import_ir_inst151: {ir_id: import_ir4, inst_id: inst480001EF}
-// CHECK:STDOUT:     import_ir_inst152: {ir_id: import_ir4, inst_id: inst480001F3}
-// CHECK:STDOUT:     import_ir_inst153: {ir_id: import_ir4, inst_id: inst480001FC}
-// CHECK:STDOUT:     import_ir_inst154: {ir_id: import_ir4, inst_id: inst48000216}
-// CHECK:STDOUT:     import_ir_inst155: {ir_id: import_ir4, inst_id: inst48000211}
-// CHECK:STDOUT:     import_ir_inst156: {ir_id: import_ir4, inst_id: inst48000212}
-// CHECK:STDOUT:     import_ir_inst157: {ir_id: import_ir4, inst_id: inst4800020D}
-// CHECK:STDOUT:     import_ir_inst158: {ir_id: import_ir4, inst_id: inst4800020F}
-// CHECK:STDOUT:     import_ir_inst159: {ir_id: import_ir4, inst_id: inst480001D3}
-// CHECK:STDOUT:     import_ir_inst160: {ir_id: import_ir4, inst_id: inst480001D8}
-// CHECK:STDOUT:     import_ir_inst161: {ir_id: import_ir4, inst_id: inst480001DD}
-// CHECK:STDOUT:     import_ir_inst162: {ir_id: import_ir4, inst_id: inst48000219}
-// CHECK:STDOUT:     import_ir_inst163: {ir_id: import_ir4, inst_id: inst4800021A}
-// CHECK:STDOUT:     import_ir_inst164: {ir_id: import_ir4, inst_id: inst48000204}
-// CHECK:STDOUT:     import_ir_inst165: {ir_id: import_ir4, inst_id: inst48000205}
-// CHECK:STDOUT:     import_ir_inst166: {ir_id: import_ir4, inst_id: inst48000206}
-// CHECK:STDOUT:     import_ir_inst167: {ir_id: import_ir4, inst_id: inst48000207}
-// CHECK:STDOUT:     import_ir_inst168: {ir_id: import_ir4, inst_id: inst48000208}
-// CHECK:STDOUT:     import_ir_inst169: {ir_id: import_ir4, inst_id: inst48000209}
-// CHECK:STDOUT:     import_ir_inst170: {ir_id: import_ir4, inst_id: inst4800020A}
-// CHECK:STDOUT:     import_ir_inst171: {ir_id: import_ir4, inst_id: inst4800020E}
-// CHECK:STDOUT:     import_ir_inst172: {ir_id: import_ir4, inst_id: inst4800021F}
-// CHECK:STDOUT:     import_ir_inst173: {ir_id: import_ir4, inst_id: inst48000226}
-// CHECK:STDOUT:     import_ir_inst174: {ir_id: import_ir4, inst_id: inst4800022A}
-// CHECK:STDOUT:     import_ir_inst175: {ir_id: import_ir4, inst_id: inst4800022C}
-// CHECK:STDOUT:     import_ir_inst176: {ir_id: import_ir4, inst_id: inst4800022D}
-// CHECK:STDOUT:     import_ir_inst177: {ir_id: import_ir4, inst_id: inst48000230}
-// CHECK:STDOUT:     import_ir_inst178: {ir_id: import_ir4, inst_id: inst4800023A}
-// CHECK:STDOUT:     import_ir_inst179: {ir_id: import_ir4, inst_id: inst4800023E}
-// CHECK:STDOUT:     import_ir_inst180: {ir_id: import_ir4, inst_id: inst48000240}
-// CHECK:STDOUT:     import_ir_inst181: {ir_id: import_ir4, inst_id: inst48000241}
-// CHECK:STDOUT:     import_ir_inst182: {ir_id: import_ir4, inst_id: inst48000244}
-// CHECK:STDOUT:     import_ir_inst183: {ir_id: import_ir4, inst_id: inst48000250}
-// CHECK:STDOUT:     import_ir_inst184: {ir_id: import_ir4, inst_id: inst48000255}
-// CHECK:STDOUT:     import_ir_inst185: {ir_id: import_ir4, inst_id: inst48000259}
-// CHECK:STDOUT:     import_ir_inst186: {ir_id: import_ir4, inst_id: inst4800025A}
-// CHECK:STDOUT:     import_ir_inst187: {ir_id: import_ir4, inst_id: inst4800025F}
+// CHECK:STDOUT:     import_ir_inst00000000: {ir_id: import_ir00000004, inst_id: inst4800000F}
+// CHECK:STDOUT:     import_ir_inst00000001: {ir_id: import_ir00000004, inst_id: inst4800000F}
+// CHECK:STDOUT:     import_ir_inst00000002: {ir_id: import_ir00000004, inst_id: inst48000011}
+// CHECK:STDOUT:     import_ir_inst00000003: {ir_id: import_ir00000004, inst_id: inst4800002D}
+// CHECK:STDOUT:     import_ir_inst00000004: {ir_id: import_ir00000004, inst_id: inst48000028}
+// CHECK:STDOUT:     import_ir_inst00000005: {ir_id: import_ir00000004, inst_id: inst48000028}
+// CHECK:STDOUT:     import_ir_inst00000006: {ir_id: import_ir00000004, inst_id: inst48000028}
+// CHECK:STDOUT:     import_ir_inst00000007: {ir_id: import_ir00000004, inst_id: inst48000022}
+// CHECK:STDOUT:     import_ir_inst00000008: {ir_id: import_ir00000004, inst_id: inst48000023}
+// CHECK:STDOUT:     import_ir_inst00000009: {ir_id: import_ir00000004, inst_id: inst4800001C}
+// CHECK:STDOUT:     import_ir_inst0000000A: {ir_id: import_ir00000004, inst_id: inst4800001E}
+// CHECK:STDOUT:     import_ir_inst0000000B: {ir_id: import_ir00000004, inst_id: inst48000011}
+// CHECK:STDOUT:     import_ir_inst0000000C: {ir_id: import_ir00000004, inst_id: inst48000015}
+// CHECK:STDOUT:     import_ir_inst0000000D: {ir_id: import_ir00000004, inst_id: inst48000018}
+// CHECK:STDOUT:     import_ir_inst0000000E: {ir_id: import_ir00000004, inst_id: inst4800001D}
+// CHECK:STDOUT:     import_ir_inst0000000F: {ir_id: import_ir00000004, inst_id: inst48000061}
+// CHECK:STDOUT:     import_ir_inst00000010: {ir_id: import_ir00000004, inst_id: inst4800005F}
+// CHECK:STDOUT:     import_ir_inst00000011: {ir_id: import_ir00000004, inst_id: inst48000054}
+// CHECK:STDOUT:     import_ir_inst00000012: {ir_id: import_ir00000004, inst_id: inst48000050}
+// CHECK:STDOUT:     import_ir_inst00000013: {ir_id: import_ir00000004, inst_id: inst4800005A}
+// CHECK:STDOUT:     import_ir_inst00000014: {ir_id: import_ir00000004, inst_id: inst4800005D}
+// CHECK:STDOUT:     import_ir_inst00000015: {ir_id: import_ir00000004, inst_id: inst48000075}
+// CHECK:STDOUT:     import_ir_inst00000016: {ir_id: import_ir00000004, inst_id: inst48000060}
+// CHECK:STDOUT:     import_ir_inst00000017: {ir_id: import_ir00000004, inst_id: inst48000052}
+// CHECK:STDOUT:     import_ir_inst00000018: {ir_id: import_ir00000004, inst_id: inst48000058}
+// CHECK:STDOUT:     import_ir_inst00000019: {ir_id: import_ir00000004, inst_id: inst4800005C}
+// CHECK:STDOUT:     import_ir_inst0000001A: {ir_id: import_ir00000004, inst_id: inst48000063}
+// CHECK:STDOUT:     import_ir_inst0000001B: {ir_id: import_ir00000004, inst_id: inst48000075}
+// CHECK:STDOUT:     import_ir_inst0000001C: {ir_id: import_ir00000004, inst_id: inst48000070}
+// CHECK:STDOUT:     import_ir_inst0000001D: {ir_id: import_ir00000004, inst_id: inst48000071}
+// CHECK:STDOUT:     import_ir_inst0000001E: {ir_id: import_ir00000004, inst_id: inst4800006C}
+// CHECK:STDOUT:     import_ir_inst0000001F: {ir_id: import_ir00000004, inst_id: inst4800006E}
+// CHECK:STDOUT:     import_ir_inst00000020: {ir_id: import_ir00000004, inst_id: inst48000050}
+// CHECK:STDOUT:     import_ir_inst00000021: {ir_id: import_ir00000004, inst_id: inst48000078}
+// CHECK:STDOUT:     import_ir_inst00000022: {ir_id: import_ir00000004, inst_id: inst48000079}
+// CHECK:STDOUT:     import_ir_inst00000023: {ir_id: import_ir00000004, inst_id: inst48000067}
+// CHECK:STDOUT:     import_ir_inst00000024: {ir_id: import_ir00000004, inst_id: inst48000068}
+// CHECK:STDOUT:     import_ir_inst00000025: {ir_id: import_ir00000004, inst_id: inst48000069}
+// CHECK:STDOUT:     import_ir_inst00000026: {ir_id: import_ir00000004, inst_id: inst4800006D}
+// CHECK:STDOUT:     import_ir_inst00000027: {ir_id: import_ir00000004, inst_id: inst4800007D}
+// CHECK:STDOUT:     import_ir_inst00000028: {ir_id: import_ir00000004, inst_id: inst48000085}
+// CHECK:STDOUT:     import_ir_inst00000029: {ir_id: import_ir00000004, inst_id: inst4800008C}
+// CHECK:STDOUT:     import_ir_inst0000002A: {ir_id: import_ir00000004, inst_id: inst48000090}
+// CHECK:STDOUT:     import_ir_inst0000002B: {ir_id: import_ir00000004, inst_id: inst48000091}
+// CHECK:STDOUT:     import_ir_inst0000002C: {ir_id: import_ir00000004, inst_id: inst48000096}
+// CHECK:STDOUT:     import_ir_inst0000002D: {ir_id: import_ir00000004, inst_id: inst480000AB}
+// CHECK:STDOUT:     import_ir_inst0000002E: {ir_id: import_ir00000004, inst_id: inst480000A9}
+// CHECK:STDOUT:     import_ir_inst0000002F: {ir_id: import_ir00000004, inst_id: inst480000A7}
+// CHECK:STDOUT:     import_ir_inst00000030: {ir_id: import_ir00000004, inst_id: inst480000A8}
+// CHECK:STDOUT:     import_ir_inst00000031: {ir_id: import_ir00000004, inst_id: inst480000C3}
+// CHECK:STDOUT:     import_ir_inst00000032: {ir_id: import_ir00000004, inst_id: inst480000C1}
+// CHECK:STDOUT:     import_ir_inst00000033: {ir_id: import_ir00000004, inst_id: inst480000BF}
+// CHECK:STDOUT:     import_ir_inst00000034: {ir_id: import_ir00000004, inst_id: inst480000C0}
+// CHECK:STDOUT:     import_ir_inst00000035: {ir_id: import_ir00000004, inst_id: inst480000DB}
+// CHECK:STDOUT:     import_ir_inst00000036: {ir_id: import_ir00000004, inst_id: inst480000D9}
+// CHECK:STDOUT:     import_ir_inst00000037: {ir_id: import_ir00000004, inst_id: inst480000D7}
+// CHECK:STDOUT:     import_ir_inst00000038: {ir_id: import_ir00000004, inst_id: inst480000D8}
+// CHECK:STDOUT:     import_ir_inst00000039: {ir_id: import_ir00000004, inst_id: inst480000F3}
+// CHECK:STDOUT:     import_ir_inst0000003A: {ir_id: import_ir00000004, inst_id: inst480000F1}
+// CHECK:STDOUT:     import_ir_inst0000003B: {ir_id: import_ir00000004, inst_id: inst480000EF}
+// CHECK:STDOUT:     import_ir_inst0000003C: {ir_id: import_ir00000004, inst_id: inst480000F0}
+// CHECK:STDOUT:     import_ir_inst0000003D: {ir_id: import_ir00000004, inst_id: inst48000110}
+// CHECK:STDOUT:     import_ir_inst0000003E: {ir_id: import_ir00000004, inst_id: inst4800010E}
+// CHECK:STDOUT:     import_ir_inst0000003F: {ir_id: import_ir00000004, inst_id: inst48000108}
+// CHECK:STDOUT:     import_ir_inst00000040: {ir_id: import_ir00000004, inst_id: inst48000105}
+// CHECK:STDOUT:     import_ir_inst00000041: {ir_id: import_ir00000004, inst_id: inst4800010A}
+// CHECK:STDOUT:     import_ir_inst00000042: {ir_id: import_ir00000004, inst_id: inst4800010D}
+// CHECK:STDOUT:     import_ir_inst00000043: {ir_id: import_ir00000004, inst_id: inst48000121}
+// CHECK:STDOUT:     import_ir_inst00000044: {ir_id: import_ir00000004, inst_id: inst4800010F}
+// CHECK:STDOUT:     import_ir_inst00000045: {ir_id: import_ir00000004, inst_id: inst48000107}
+// CHECK:STDOUT:     import_ir_inst00000046: {ir_id: import_ir00000004, inst_id: inst4800010C}
+// CHECK:STDOUT:     import_ir_inst00000047: {ir_id: import_ir00000004, inst_id: inst48000112}
+// CHECK:STDOUT:     import_ir_inst00000048: {ir_id: import_ir00000004, inst_id: inst48000121}
+// CHECK:STDOUT:     import_ir_inst00000049: {ir_id: import_ir00000004, inst_id: inst4800011C}
+// CHECK:STDOUT:     import_ir_inst0000004A: {ir_id: import_ir00000004, inst_id: inst4800011D}
+// CHECK:STDOUT:     import_ir_inst0000004B: {ir_id: import_ir00000004, inst_id: inst48000118}
+// CHECK:STDOUT:     import_ir_inst0000004C: {ir_id: import_ir00000004, inst_id: inst4800011A}
+// CHECK:STDOUT:     import_ir_inst0000004D: {ir_id: import_ir00000004, inst_id: inst48000105}
+// CHECK:STDOUT:     import_ir_inst0000004E: {ir_id: import_ir00000004, inst_id: inst48000124}
+// CHECK:STDOUT:     import_ir_inst0000004F: {ir_id: import_ir00000004, inst_id: inst48000125}
+// CHECK:STDOUT:     import_ir_inst00000050: {ir_id: import_ir00000004, inst_id: inst48000128}
+// CHECK:STDOUT:     import_ir_inst00000051: {ir_id: import_ir00000004, inst_id: inst48000114}
+// CHECK:STDOUT:     import_ir_inst00000052: {ir_id: import_ir00000004, inst_id: inst48000115}
+// CHECK:STDOUT:     import_ir_inst00000053: {ir_id: import_ir00000004, inst_id: inst48000119}
+// CHECK:STDOUT:     import_ir_inst00000054: {ir_id: import_ir00000004, inst_id: inst4800012E}
+// CHECK:STDOUT:     import_ir_inst00000055: {ir_id: import_ir00000004, inst_id: inst4800012C}
+// CHECK:STDOUT:     import_ir_inst00000056: {ir_id: import_ir00000004, inst_id: inst(TypeType)}
+// CHECK:STDOUT:     import_ir_inst00000057: {ir_id: import_ir00000004, inst_id: inst4800012B}
+// CHECK:STDOUT:     import_ir_inst00000058: {ir_id: import_ir00000004, inst_id: inst48000143}
+// CHECK:STDOUT:     import_ir_inst00000059: {ir_id: import_ir00000004, inst_id: inst48000141}
+// CHECK:STDOUT:     import_ir_inst0000005A: {ir_id: import_ir00000004, inst_id: inst4800013F}
+// CHECK:STDOUT:     import_ir_inst0000005B: {ir_id: import_ir00000004, inst_id: inst48000140}
+// CHECK:STDOUT:     import_ir_inst0000005C: {ir_id: import_ir00000004, inst_id: inst48000173}
+// CHECK:STDOUT:     import_ir_inst0000005D: {ir_id: import_ir00000004, inst_id: inst48000171}
+// CHECK:STDOUT:     import_ir_inst0000005E: {ir_id: import_ir00000004, inst_id: inst4800015E}
+// CHECK:STDOUT:     import_ir_inst0000005F: {ir_id: import_ir00000004, inst_id: inst48000158}
+// CHECK:STDOUT:     import_ir_inst00000060: {ir_id: import_ir00000004, inst_id: inst48000156}
+// CHECK:STDOUT:     import_ir_inst00000061: {ir_id: import_ir00000004, inst_id: inst4800015B}
+// CHECK:STDOUT:     import_ir_inst00000062: {ir_id: import_ir00000004, inst_id: inst4800016C}
+// CHECK:STDOUT:     import_ir_inst00000063: {ir_id: import_ir00000004, inst_id: inst4800016E}
+// CHECK:STDOUT:     import_ir_inst00000064: {ir_id: import_ir00000004, inst_id: inst4800018B}
+// CHECK:STDOUT:     import_ir_inst00000065: {ir_id: import_ir00000004, inst_id: inst48000172}
+// CHECK:STDOUT:     import_ir_inst00000066: {ir_id: import_ir00000004, inst_id: inst48000157}
+// CHECK:STDOUT:     import_ir_inst00000067: {ir_id: import_ir00000004, inst_id: inst4800015D}
+// CHECK:STDOUT:     import_ir_inst00000068: {ir_id: import_ir00000004, inst_id: inst48000165}
+// CHECK:STDOUT:     import_ir_inst00000069: {ir_id: import_ir00000004, inst_id: inst48000169}
+// CHECK:STDOUT:     import_ir_inst0000006A: {ir_id: import_ir00000004, inst_id: inst4800016D}
+// CHECK:STDOUT:     import_ir_inst0000006B: {ir_id: import_ir00000004, inst_id: inst48000175}
+// CHECK:STDOUT:     import_ir_inst0000006C: {ir_id: import_ir00000004, inst_id: inst4800018B}
+// CHECK:STDOUT:     import_ir_inst0000006D: {ir_id: import_ir00000004, inst_id: inst48000186}
+// CHECK:STDOUT:     import_ir_inst0000006E: {ir_id: import_ir00000004, inst_id: inst48000187}
+// CHECK:STDOUT:     import_ir_inst0000006F: {ir_id: import_ir00000004, inst_id: inst48000182}
+// CHECK:STDOUT:     import_ir_inst00000070: {ir_id: import_ir00000004, inst_id: inst48000184}
+// CHECK:STDOUT:     import_ir_inst00000071: {ir_id: import_ir00000004, inst_id: inst48000156}
+// CHECK:STDOUT:     import_ir_inst00000072: {ir_id: import_ir00000004, inst_id: inst4800015B}
+// CHECK:STDOUT:     import_ir_inst00000073: {ir_id: import_ir00000004, inst_id: inst4800018E}
+// CHECK:STDOUT:     import_ir_inst00000074: {ir_id: import_ir00000004, inst_id: inst4800018F}
+// CHECK:STDOUT:     import_ir_inst00000075: {ir_id: import_ir00000004, inst_id: inst4800017B}
+// CHECK:STDOUT:     import_ir_inst00000076: {ir_id: import_ir00000004, inst_id: inst4800017C}
+// CHECK:STDOUT:     import_ir_inst00000077: {ir_id: import_ir00000004, inst_id: inst4800017D}
+// CHECK:STDOUT:     import_ir_inst00000078: {ir_id: import_ir00000004, inst_id: inst4800017E}
+// CHECK:STDOUT:     import_ir_inst00000079: {ir_id: import_ir00000004, inst_id: inst4800017F}
+// CHECK:STDOUT:     import_ir_inst0000007A: {ir_id: import_ir00000004, inst_id: inst48000183}
+// CHECK:STDOUT:     import_ir_inst0000007B: {ir_id: import_ir00000004, inst_id: inst48000194}
+// CHECK:STDOUT:     import_ir_inst0000007C: {ir_id: import_ir00000004, inst_id: inst4800019C}
+// CHECK:STDOUT:     import_ir_inst0000007D: {ir_id: import_ir00000004, inst_id: inst480001A0}
+// CHECK:STDOUT:     import_ir_inst0000007E: {ir_id: import_ir00000004, inst_id: inst480001A2}
+// CHECK:STDOUT:     import_ir_inst0000007F: {ir_id: import_ir00000004, inst_id: inst480001A3}
+// CHECK:STDOUT:     import_ir_inst00000080: {ir_id: import_ir00000004, inst_id: inst480001A6}
+// CHECK:STDOUT:     import_ir_inst00000081: {ir_id: import_ir00000004, inst_id: inst480001B2}
+// CHECK:STDOUT:     import_ir_inst00000082: {ir_id: import_ir00000004, inst_id: inst480001B7}
+// CHECK:STDOUT:     import_ir_inst00000083: {ir_id: import_ir00000004, inst_id: inst480001BB}
+// CHECK:STDOUT:     import_ir_inst00000084: {ir_id: import_ir00000004, inst_id: inst480001BC}
+// CHECK:STDOUT:     import_ir_inst00000085: {ir_id: import_ir00000004, inst_id: inst480001C1}
+// CHECK:STDOUT:     import_ir_inst00000086: {ir_id: import_ir00000004, inst_id: inst480001FA}
+// CHECK:STDOUT:     import_ir_inst00000087: {ir_id: import_ir00000004, inst_id: inst480001F8}
+// CHECK:STDOUT:     import_ir_inst00000088: {ir_id: import_ir00000004, inst_id: inst480001E0}
+// CHECK:STDOUT:     import_ir_inst00000089: {ir_id: import_ir00000004, inst_id: inst480001DA}
+// CHECK:STDOUT:     import_ir_inst0000008A: {ir_id: import_ir00000004, inst_id: inst480001D5}
+// CHECK:STDOUT:     import_ir_inst0000008B: {ir_id: import_ir00000004, inst_id: inst480001D3}
+// CHECK:STDOUT:     import_ir_inst0000008C: {ir_id: import_ir00000004, inst_id: inst480001D8}
+// CHECK:STDOUT:     import_ir_inst0000008D: {ir_id: import_ir00000004, inst_id: inst480001DD}
+// CHECK:STDOUT:     import_ir_inst0000008E: {ir_id: import_ir00000004, inst_id: inst480001F2}
+// CHECK:STDOUT:     import_ir_inst0000008F: {ir_id: import_ir00000004, inst_id: inst480001F4}
+// CHECK:STDOUT:     import_ir_inst00000090: {ir_id: import_ir00000004, inst_id: inst48000216}
+// CHECK:STDOUT:     import_ir_inst00000091: {ir_id: import_ir00000004, inst_id: inst480001F9}
+// CHECK:STDOUT:     import_ir_inst00000092: {ir_id: import_ir00000004, inst_id: inst480001D4}
+// CHECK:STDOUT:     import_ir_inst00000093: {ir_id: import_ir00000004, inst_id: inst480001D9}
+// CHECK:STDOUT:     import_ir_inst00000094: {ir_id: import_ir00000004, inst_id: inst480001DF}
+// CHECK:STDOUT:     import_ir_inst00000095: {ir_id: import_ir00000004, inst_id: inst480001E8}
+// CHECK:STDOUT:     import_ir_inst00000096: {ir_id: import_ir00000004, inst_id: inst480001EB}
+// CHECK:STDOUT:     import_ir_inst00000097: {ir_id: import_ir00000004, inst_id: inst480001EF}
+// CHECK:STDOUT:     import_ir_inst00000098: {ir_id: import_ir00000004, inst_id: inst480001F3}
+// CHECK:STDOUT:     import_ir_inst00000099: {ir_id: import_ir00000004, inst_id: inst480001FC}
+// CHECK:STDOUT:     import_ir_inst0000009A: {ir_id: import_ir00000004, inst_id: inst48000216}
+// CHECK:STDOUT:     import_ir_inst0000009B: {ir_id: import_ir00000004, inst_id: inst48000211}
+// CHECK:STDOUT:     import_ir_inst0000009C: {ir_id: import_ir00000004, inst_id: inst48000212}
+// CHECK:STDOUT:     import_ir_inst0000009D: {ir_id: import_ir00000004, inst_id: inst4800020D}
+// CHECK:STDOUT:     import_ir_inst0000009E: {ir_id: import_ir00000004, inst_id: inst4800020F}
+// CHECK:STDOUT:     import_ir_inst0000009F: {ir_id: import_ir00000004, inst_id: inst480001D3}
+// CHECK:STDOUT:     import_ir_inst000000A0: {ir_id: import_ir00000004, inst_id: inst480001D8}
+// CHECK:STDOUT:     import_ir_inst000000A1: {ir_id: import_ir00000004, inst_id: inst480001DD}
+// CHECK:STDOUT:     import_ir_inst000000A2: {ir_id: import_ir00000004, inst_id: inst48000219}
+// CHECK:STDOUT:     import_ir_inst000000A3: {ir_id: import_ir00000004, inst_id: inst4800021A}
+// CHECK:STDOUT:     import_ir_inst000000A4: {ir_id: import_ir00000004, inst_id: inst48000204}
+// CHECK:STDOUT:     import_ir_inst000000A5: {ir_id: import_ir00000004, inst_id: inst48000205}
+// CHECK:STDOUT:     import_ir_inst000000A6: {ir_id: import_ir00000004, inst_id: inst48000206}
+// CHECK:STDOUT:     import_ir_inst000000A7: {ir_id: import_ir00000004, inst_id: inst48000207}
+// CHECK:STDOUT:     import_ir_inst000000A8: {ir_id: import_ir00000004, inst_id: inst48000208}
+// CHECK:STDOUT:     import_ir_inst000000A9: {ir_id: import_ir00000004, inst_id: inst48000209}
+// CHECK:STDOUT:     import_ir_inst000000AA: {ir_id: import_ir00000004, inst_id: inst4800020A}
+// CHECK:STDOUT:     import_ir_inst000000AB: {ir_id: import_ir00000004, inst_id: inst4800020E}
+// CHECK:STDOUT:     import_ir_inst000000AC: {ir_id: import_ir00000004, inst_id: inst4800021F}
+// CHECK:STDOUT:     import_ir_inst000000AD: {ir_id: import_ir00000004, inst_id: inst48000226}
+// CHECK:STDOUT:     import_ir_inst000000AE: {ir_id: import_ir00000004, inst_id: inst4800022A}
+// CHECK:STDOUT:     import_ir_inst000000AF: {ir_id: import_ir00000004, inst_id: inst4800022C}
+// CHECK:STDOUT:     import_ir_inst000000B0: {ir_id: import_ir00000004, inst_id: inst4800022D}
+// CHECK:STDOUT:     import_ir_inst000000B1: {ir_id: import_ir00000004, inst_id: inst48000230}
+// CHECK:STDOUT:     import_ir_inst000000B2: {ir_id: import_ir00000004, inst_id: inst4800023A}
+// CHECK:STDOUT:     import_ir_inst000000B3: {ir_id: import_ir00000004, inst_id: inst4800023E}
+// CHECK:STDOUT:     import_ir_inst000000B4: {ir_id: import_ir00000004, inst_id: inst48000240}
+// CHECK:STDOUT:     import_ir_inst000000B5: {ir_id: import_ir00000004, inst_id: inst48000241}
+// CHECK:STDOUT:     import_ir_inst000000B6: {ir_id: import_ir00000004, inst_id: inst48000244}
+// CHECK:STDOUT:     import_ir_inst000000B7: {ir_id: import_ir00000004, inst_id: inst48000250}
+// CHECK:STDOUT:     import_ir_inst000000B8: {ir_id: import_ir00000004, inst_id: inst48000255}
+// CHECK:STDOUT:     import_ir_inst000000B9: {ir_id: import_ir00000004, inst_id: inst48000259}
+// CHECK:STDOUT:     import_ir_inst000000BA: {ir_id: import_ir00000004, inst_id: inst4800025A}
+// CHECK:STDOUT:     import_ir_inst000000BB: {ir_id: import_ir00000004, inst_id: inst4800025F}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name(Core): inst60000010, name0: inst60000035}}
-// CHECK:STDOUT:     name_scope1:     {inst: inst60000010, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name3: inst60000045}}
-// CHECK:STDOUT:     name_scope2:     {inst: inst60000046, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {name(SelfType): inst60000049, name4: inst6000004A}}
-// CHECK:STDOUT:     name_scope3:     {inst: inst6000005E, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope4:     {inst: inst6000008B, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope5:     {inst: inst6000008F, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope6:     {inst: inst60000093, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope7:     {inst: inst60000097, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope8:     {inst: inst6000009B, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope9:     {inst: inst600000B5, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope10:    {inst: inst600000B9, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope11:    {inst: inst600000BD, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope12:    {inst: inst600000F5, parent_scope: name_scope1, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name(Core): inst60000010, name00000000: inst60000035}}
+// CHECK:STDOUT:     name_scope00000001: {inst: inst60000010, parent_scope: name_scope00000000, has_error: false, extended_scopes: [], names: {name00000003: inst60000045}}
+// CHECK:STDOUT:     name_scope00000002: {inst: inst60000046, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {name(SelfType): inst60000049, name00000004: inst6000004A}}
+// CHECK:STDOUT:     name_scope00000003: {inst: inst6000005E, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000004: {inst: inst6000008B, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000005: {inst: inst6000008F, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000006: {inst: inst60000093, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000007: {inst: inst60000097, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000008: {inst: inst6000009B, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000009: {inst: inst600000B5, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0000000A: {inst: inst600000B9, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0000000B: {inst: inst600000BD, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0000000C: {inst: inst600000F5, parent_scope: name_scope00000001, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name(PeriodSelf), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name1:    {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name2:    {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name3:    {name: name3, parent_scope: name_scope1, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name4:    {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name5:    {name: name4, parent_scope: name_scope2, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name6:    {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name7:    {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name8:    {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name9:    {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name10:   {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name11:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name12:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name13:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name14:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name15:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name16:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name17:   {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name18:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name19:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name20:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name21:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name22:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name23:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name24:   {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name25:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name26:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name27:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name28:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name29:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name30:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name31:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name32:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name33:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name34:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name35:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name36:   {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name37:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name38:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name39:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name40:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name41:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name42:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name43:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name44:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name45:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name46:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name47:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name48:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name49:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name50:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name51:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name52:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name53:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name54:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name55:   {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
-// CHECK:STDOUT:     entity_name56:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name57:   {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0}
-// CHECK:STDOUT:     entity_name58:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name59:   {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0}
-// CHECK:STDOUT:     entity_name60:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
-// CHECK:STDOUT:     entity_name61:   {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name00000000: {name: name(PeriodSelf), parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000001: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000002: {name: name00000002, parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000003: {name: name00000003, parent_scope: name_scope00000001, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000004: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000005: {name: name00000004, parent_scope: name_scope00000002, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000006: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000007: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000008: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000009: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000000A: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000000B: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000000C: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000000D: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000000E: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000000F: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000010: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000011: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000012: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000013: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000014: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000015: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000016: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000017: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000018: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000019: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000001A: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name0000001B: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name0000001C: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name0000001D: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000001E: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000001F: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000020: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000021: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000022: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000023: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000024: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000025: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000026: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000027: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000028: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000029: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name0000002A: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name0000002B: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name0000002C: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name0000002D: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000002E: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000002F: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000030: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name00000031: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000032: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000033: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name00000034: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000035: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000036: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name00000037: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000038: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name00000039: {name: name00000001, parent_scope: name_scope<none>, index: 0, is_template: 0}
+// CHECK:STDOUT:     entity_name0000003A: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name0000003B: {name: name00000005, parent_scope: name_scope<none>, index: 1, is_template: 0}
+// CHECK:STDOUT:     entity_name0000003C: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
+// CHECK:STDOUT:     entity_name0000003D: {name: name00000006, parent_scope: name_scope<none>, index: 2, is_template: 0}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_params_id: inst_block13, return_slot_pattern: inst60000030, body: [inst_block20]}
-// CHECK:STDOUT:     function60000001: {name: name4, parent_scope: name_scope2, return_slot_pattern: inst60000055}
-// CHECK:STDOUT:     function60000002: {name: name4, parent_scope: name_scope3, return_slot_pattern: inst60000073}
-// CHECK:STDOUT:     function60000003: {name: name4, parent_scope: name_scope8, return_slot_pattern: inst600000AA}
-// CHECK:STDOUT:     function60000004: {name: name4, parent_scope: name_scope11, return_slot_pattern: inst600000D5}
-// CHECK:STDOUT:     function60000005: {name: name4, parent_scope: name_scope12, return_slot_pattern: inst60000111}
+// CHECK:STDOUT:     function60000000: {name: name00000000, parent_scope: name_scope00000000, call_params_id: inst_block0000000D, return_slot_pattern: inst60000030, body: [inst_block00000014]}
+// CHECK:STDOUT:     function60000001: {name: name00000004, parent_scope: name_scope00000002, return_slot_pattern: inst60000055}
+// CHECK:STDOUT:     function60000002: {name: name00000004, parent_scope: name_scope00000003, return_slot_pattern: inst60000073}
+// CHECK:STDOUT:     function60000003: {name: name00000004, parent_scope: name_scope00000008, return_slot_pattern: inst600000AA}
+// CHECK:STDOUT:     function60000004: {name: name00000004, parent_scope: name_scope0000000B, return_slot_pattern: inst600000D5}
+// CHECK:STDOUT:     function60000005: {name: name00000004, parent_scope: name_scope0000000C, return_slot_pattern: inst60000111}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:
-// CHECK:STDOUT:     generic0:        {decl: inst60000035, bindings: inst_block16}
-// CHECK:STDOUT:     generic1:        {decl: inst6000004F, bindings: inst_block24}
-// CHECK:STDOUT:     generic2:        {decl: inst6000005E, bindings: inst_block29}
-// CHECK:STDOUT:     generic3:        {decl: inst6000006E, bindings: inst_block36}
-// CHECK:STDOUT:     generic4:        {decl: inst6000009B, bindings: inst_block46}
-// CHECK:STDOUT:     generic5:        {decl: inst600000A6, bindings: inst_block52}
-// CHECK:STDOUT:     generic6:        {decl: inst600000BD, bindings: inst_block59}
-// CHECK:STDOUT:     generic7:        {decl: inst600000D0, bindings: inst_block67}
-// CHECK:STDOUT:     generic8:        {decl: inst600000F5, bindings: inst_block81}
-// CHECK:STDOUT:     generic9:        {decl: inst6000010C, bindings: inst_block89}
+// CHECK:STDOUT:     generic00000000: {decl: inst60000035, bindings: inst_block00000010}
+// CHECK:STDOUT:     generic00000001: {decl: inst6000004F, bindings: inst_block00000018}
+// CHECK:STDOUT:     generic00000002: {decl: inst6000005E, bindings: inst_block0000001D}
+// CHECK:STDOUT:     generic00000003: {decl: inst6000006E, bindings: inst_block00000024}
+// CHECK:STDOUT:     generic00000004: {decl: inst6000009B, bindings: inst_block0000002E}
+// CHECK:STDOUT:     generic00000005: {decl: inst600000A6, bindings: inst_block00000034}
+// CHECK:STDOUT:     generic00000006: {decl: inst600000BD, bindings: inst_block0000003B}
+// CHECK:STDOUT:     generic00000007: {decl: inst600000D0, bindings: inst_block00000043}
+// CHECK:STDOUT:     generic00000008: {decl: inst600000F5, bindings: inst_block00000051}
+// CHECK:STDOUT:     generic00000009: {decl: inst6000010C, bindings: inst_block00000059}
 // CHECK:STDOUT:   specifics:
-// CHECK:STDOUT:     specific0:       {generic: generic0, args: inst_block17}
-// CHECK:STDOUT:     specific1:       {generic: generic1, args: inst_block26}
-// CHECK:STDOUT:     specific2:       {generic: generic2, args: inst_block31}
-// CHECK:STDOUT:     specific3:       {generic: generic2, args: inst_block32}
-// CHECK:STDOUT:     specific4:       {generic: generic3, args: inst_block31}
-// CHECK:STDOUT:     specific5:       {generic: generic1, args: inst_block31}
-// CHECK:STDOUT:     specific6:       {generic: generic1, args: inst_block41}
-// CHECK:STDOUT:     specific7:       {generic: generic4, args: inst_block17}
-// CHECK:STDOUT:     specific8:       {generic: generic4, args: inst_block48}
-// CHECK:STDOUT:     specific9:       {generic: generic5, args: inst_block17}
-// CHECK:STDOUT:     specific10:      {generic: generic6, args: inst_block61}
-// CHECK:STDOUT:     specific11:      {generic: generic6, args: inst_block63}
-// CHECK:STDOUT:     specific12:      {generic: generic7, args: inst_block61}
-// CHECK:STDOUT:     specific13:      {generic: generic1, args: inst_block73}
-// CHECK:STDOUT:     specific14:      {generic: generic1, args: inst_block74}
-// CHECK:STDOUT:     specific15:      {generic: generic1, args: inst_block75}
-// CHECK:STDOUT:     specific16:      {generic: generic8, args: inst_block83}
-// CHECK:STDOUT:     specific17:      {generic: generic8, args: inst_block85}
-// CHECK:STDOUT:     specific18:      {generic: generic9, args: inst_block83}
-// CHECK:STDOUT:     specific19:      {generic: generic1, args: inst_block95}
-// CHECK:STDOUT:     specific20:      {generic: generic1, args: inst_block96}
-// CHECK:STDOUT:     specific21:      {generic: generic1, args: inst_block97}
-// CHECK:STDOUT:     specific22:      {generic: generic1, args: inst_block98}
-// CHECK:STDOUT:     specific23:      {generic: generic1, args: inst_block105}
-// CHECK:STDOUT:     specific24:      {generic: generic1, args: inst_block107}
+// CHECK:STDOUT:     specific00000000: {generic: generic00000000, args: inst_block00000011}
+// CHECK:STDOUT:     specific00000001: {generic: generic00000001, args: inst_block0000001A}
+// CHECK:STDOUT:     specific00000002: {generic: generic00000002, args: inst_block0000001F}
+// CHECK:STDOUT:     specific00000003: {generic: generic00000002, args: inst_block00000020}
+// CHECK:STDOUT:     specific00000004: {generic: generic00000003, args: inst_block0000001F}
+// CHECK:STDOUT:     specific00000005: {generic: generic00000001, args: inst_block0000001F}
+// CHECK:STDOUT:     specific00000006: {generic: generic00000001, args: inst_block00000029}
+// CHECK:STDOUT:     specific00000007: {generic: generic00000004, args: inst_block00000011}
+// CHECK:STDOUT:     specific00000008: {generic: generic00000004, args: inst_block00000030}
+// CHECK:STDOUT:     specific00000009: {generic: generic00000005, args: inst_block00000011}
+// CHECK:STDOUT:     specific0000000A: {generic: generic00000006, args: inst_block0000003D}
+// CHECK:STDOUT:     specific0000000B: {generic: generic00000006, args: inst_block0000003F}
+// CHECK:STDOUT:     specific0000000C: {generic: generic00000007, args: inst_block0000003D}
+// CHECK:STDOUT:     specific0000000D: {generic: generic00000001, args: inst_block00000049}
+// CHECK:STDOUT:     specific0000000E: {generic: generic00000001, args: inst_block0000004A}
+// CHECK:STDOUT:     specific0000000F: {generic: generic00000001, args: inst_block0000004B}
+// CHECK:STDOUT:     specific00000010: {generic: generic00000008, args: inst_block00000053}
+// CHECK:STDOUT:     specific00000011: {generic: generic00000008, args: inst_block00000055}
+// CHECK:STDOUT:     specific00000012: {generic: generic00000009, args: inst_block00000053}
+// CHECK:STDOUT:     specific00000013: {generic: generic00000001, args: inst_block0000005F}
+// CHECK:STDOUT:     specific00000014: {generic: generic00000001, args: inst_block00000060}
+// CHECK:STDOUT:     specific00000015: {generic: generic00000001, args: inst_block00000061}
+// CHECK:STDOUT:     specific00000016: {generic: generic00000001, args: inst_block00000062}
+// CHECK:STDOUT:     specific00000017: {generic: generic00000001, args: inst_block00000069}
+// CHECK:STDOUT:     specific00000018: {generic: generic00000001, args: inst_block0000006B}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -357,69 +357,69 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst60000028)}
 // CHECK:STDOUT:     'type(inst60000036)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000024)}
-// CHECK:STDOUT:     'type(symbolic_constant3)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant3)}
-// CHECK:STDOUT:     'type(symbolic_constant7)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant11)}
-// CHECK:STDOUT:     'type(symbolic_constant11)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant11)}
+// CHECK:STDOUT:     'type(symbolic_constant00000003)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant00000003)}
+// CHECK:STDOUT:     'type(symbolic_constant00000007)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant0000000B)}
+// CHECK:STDOUT:     'type(symbolic_constant0000000B)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant0000000B)}
 // CHECK:STDOUT:     'type(inst(WitnessType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     'type(symbolic_constant4)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant4)}
-// CHECK:STDOUT:     'type(symbolic_constant8)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant11)}
+// CHECK:STDOUT:     'type(symbolic_constant00000004)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant00000004)}
+// CHECK:STDOUT:     'type(symbolic_constant00000008)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant0000000B)}
 // CHECK:STDOUT:     'type(inst60000047)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst60000047)}
 // CHECK:STDOUT:     'type(inst(SpecificFunctionType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     'type(symbolic_constant253)':
+// CHECK:STDOUT:     'type(symbolic_constant000000FD)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000024)}
-// CHECK:STDOUT:     'type(symbolic_constant256)':
+// CHECK:STDOUT:     'type(symbolic_constant00000100)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000024)}
 // CHECK:STDOUT:     'type(inst(BoundMethodType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(BoundMethodType))}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst6000000F:    {kind: ImportDecl, arg0: name(Core)}
-// CHECK:STDOUT:     inst60000010:    {kind: Namespace, arg0: name_scope1, arg1: inst6000000F, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000011:    {kind: FacetType, arg0: facet_type0, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000012:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000013:    {kind: BindSymbolicName, arg0: entity_name0, arg1: inst<none>, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000014:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000015:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000016:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000010:    {kind: Namespace, arg0: name_scope00000001, arg1: inst6000000F, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst60000011:    {kind: FacetType, arg0: facet_type00000000, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000012:    {kind: BindSymbolicName, arg0: entity_name00000000, arg1: inst<none>, type: type(inst60000011)}
+// CHECK:STDOUT:     inst60000013:    {kind: BindSymbolicName, arg0: entity_name00000000, arg1: inst<none>, type: type(inst60000011)}
+// CHECK:STDOUT:     inst60000014:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000015:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000016:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000017:    {kind: PatternType, arg0: inst(TypeType), type: type(TypeType)}
-// CHECK:STDOUT:     inst60000018:    {kind: SymbolicBindingPattern, arg0: entity_name1, type: type(inst60000017)}
-// CHECK:STDOUT:     inst60000019:    {kind: NameRef, arg0: name1, arg1: inst60000014, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000018:    {kind: SymbolicBindingPattern, arg0: entity_name00000001, type: type(inst60000017)}
+// CHECK:STDOUT:     inst60000019:    {kind: NameRef, arg0: name00000001, arg1: inst60000014, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001A:    {kind: PointerType, arg0: inst60000019, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001B:    {kind: PointerType, arg0: inst60000015, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001C:    {kind: PointerType, arg0: inst60000016, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001D:    {kind: BindName, arg0: entity_name2, arg1: inst60000031, type: type(symbolic_constant4)}
+// CHECK:STDOUT:     inst6000001D:    {kind: BindName, arg0: entity_name00000002, arg1: inst60000031, type: type(symbolic_constant00000004)}
 // CHECK:STDOUT:     inst6000001E:    {kind: PatternType, arg0: inst6000001B, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001F:    {kind: BindingPattern, arg0: entity_name2, type: type(symbolic_constant6)}
+// CHECK:STDOUT:     inst6000001F:    {kind: BindingPattern, arg0: entity_name00000002, type: type(symbolic_constant00000006)}
 // CHECK:STDOUT:     inst60000020:    {kind: PatternType, arg0: inst6000001C, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000021:    {kind: ValueParamPattern, arg0: inst6000001F, arg1: call_param0, type: type(symbolic_constant6)}
-// CHECK:STDOUT:     inst60000022:    {kind: NameRef, arg0: name1, arg1: inst60000014, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000021:    {kind: ValueParamPattern, arg0: inst6000001F, arg1: call_param0, type: type(symbolic_constant00000006)}
+// CHECK:STDOUT:     inst60000022:    {kind: NameRef, arg0: name00000001, arg1: inst60000014, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000023:    {kind: PointerType, arg0: inst60000022, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000024:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000025:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000024)}
-// CHECK:STDOUT:     inst60000026:    {kind: TupleType, arg0: inst_block9, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000027:    {kind: TupleLiteral, arg0: inst_block8, type: type(inst60000026)}
+// CHECK:STDOUT:     inst60000026:    {kind: TupleType, arg0: inst_block00000009, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000027:    {kind: TupleLiteral, arg0: inst_block00000008, type: type(inst60000026)}
 // CHECK:STDOUT:     inst60000028:    {kind: PointerType, arg0: inst60000026, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000029:    {kind: Converted, arg0: inst60000025, arg1: inst60000024, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002A:    {kind: TupleType, arg0: inst_block11, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000002A:    {kind: TupleType, arg0: inst_block0000000B, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000002B:    {kind: Converted, arg0: inst60000027, arg1: inst6000002A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002C:    {kind: TupleType, arg0: inst_block12, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000002C:    {kind: TupleType, arg0: inst_block0000000C, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000002D:    {kind: PatternType, arg0: inst6000002A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002E:    {kind: ReturnSlotPattern, arg0: inst6000002B, type: type(symbolic_constant10)}
+// CHECK:STDOUT:     inst6000002E:    {kind: ReturnSlotPattern, arg0: inst6000002B, type: type(symbolic_constant0000000A)}
 // CHECK:STDOUT:     inst6000002F:    {kind: PatternType, arg0: inst6000002C, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000030:    {kind: OutParamPattern, arg0: inst6000002E, arg1: call_param1, type: type(symbolic_constant10)}
-// CHECK:STDOUT:     inst60000031:    {kind: ValueParam, arg0: call_param0, arg1: name2, type: type(symbolic_constant4)}
-// CHECK:STDOUT:     inst60000032:    {kind: SpliceBlock, arg0: inst_block6, arg1: inst6000001A, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000033:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(symbolic_constant8)}
-// CHECK:STDOUT:     inst60000034:    {kind: ReturnSlot, arg0: inst6000002A, arg1: inst60000033, type: type(symbolic_constant8)}
-// CHECK:STDOUT:     inst60000035:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block15, type: type(inst60000036)}
+// CHECK:STDOUT:     inst60000030:    {kind: OutParamPattern, arg0: inst6000002E, arg1: call_param1, type: type(symbolic_constant0000000A)}
+// CHECK:STDOUT:     inst60000031:    {kind: ValueParam, arg0: call_param0, arg1: name00000002, type: type(symbolic_constant00000004)}
+// CHECK:STDOUT:     inst60000032:    {kind: SpliceBlock, arg0: inst_block00000006, arg1: inst6000001A, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000033:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(symbolic_constant00000008)}
+// CHECK:STDOUT:     inst60000034:    {kind: ReturnSlot, arg0: inst6000002A, arg1: inst60000033, type: type(symbolic_constant00000008)}
+// CHECK:STDOUT:     inst60000035:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block0000000F, type: type(inst60000036)}
 // CHECK:STDOUT:     inst60000036:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000037:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000036)}
 // CHECK:STDOUT:     inst60000038:    {kind: PointerType, arg0: inst6000002A, type: type(TypeType)}
@@ -429,329 +429,329 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst6000003C:    {kind: RequireCompleteType, arg0: inst6000001B, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000003D:    {kind: RequireCompleteType, arg0: inst6000001B, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000003E:    {kind: RequireCompleteType, arg0: inst6000001C, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000003F:    {kind: NameRef, arg0: name2, arg1: inst6000001D, type: type(symbolic_constant4)}
+// CHECK:STDOUT:     inst6000003F:    {kind: NameRef, arg0: name00000002, arg1: inst6000001D, type: type(symbolic_constant00000004)}
 // CHECK:STDOUT:     inst60000040:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000024)}
-// CHECK:STDOUT:     inst60000041:    {kind: TupleLiteral, arg0: inst_block21, type: type(symbolic_constant8)}
+// CHECK:STDOUT:     inst60000041:    {kind: TupleLiteral, arg0: inst_block00000015, type: type(symbolic_constant00000008)}
 // CHECK:STDOUT:     inst60000042:    {kind: RequireCompleteType, arg0: inst6000002A, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000043:    {kind: TupleAccess, arg0: inst60000034, arg1: element0, type: type(symbolic_constant4)}
+// CHECK:STDOUT:     inst60000043:    {kind: TupleAccess, arg0: inst60000034, arg1: element0, type: type(symbolic_constant00000004)}
 // CHECK:STDOUT:     inst60000044:    {kind: RequireCompleteType, arg0: inst6000001B, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000045:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name3, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000046:    {kind: InterfaceDecl, arg0: interface0, arg1: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000047:    {kind: FacetType, arg0: facet_type1, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000048:    {kind: BindSymbolicName, arg0: entity_name4, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000049:    {kind: ImportRefUnloaded, arg0: import_ir_inst2, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst6000004A:    {kind: ImportRefLoaded, arg0: import_ir_inst3, arg1: entity_name<none>, type: type(inst6000004C)}
-// CHECK:STDOUT:     inst6000004B:    {kind: ImportRefUnloaded, arg0: import_ir_inst4, arg1: entity_name5}
-// CHECK:STDOUT:     inst6000004C:    {kind: AssociatedEntityType, arg0: interface0, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000004D:    {kind: ImportRefLoaded, arg0: import_ir_inst5, arg1: entity_name<none>, type: type(inst60000050)}
+// CHECK:STDOUT:     inst60000045:    {kind: ImportRefLoaded, arg0: import_ir_inst00000000, arg1: entity_name00000003, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000046:    {kind: InterfaceDecl, arg0: interface00000000, arg1: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000047:    {kind: FacetType, arg0: facet_type00000001, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000048:    {kind: BindSymbolicName, arg0: entity_name00000004, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000049:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000002, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst6000004A:    {kind: ImportRefLoaded, arg0: import_ir_inst00000003, arg1: entity_name<none>, type: type(inst6000004C)}
+// CHECK:STDOUT:     inst6000004B:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000004, arg1: entity_name00000005}
+// CHECK:STDOUT:     inst6000004C:    {kind: AssociatedEntityType, arg0: interface00000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000004D:    {kind: ImportRefLoaded, arg0: import_ir_inst00000005, arg1: entity_name<none>, type: type(inst60000050)}
 // CHECK:STDOUT:     inst6000004E:    {kind: AssociatedEntity, arg0: element0, arg1: inst6000004D, type: type(inst6000004C)}
 // CHECK:STDOUT:     inst6000004F:    {kind: FunctionDecl, arg0: function60000001, arg1: inst_block_empty, type: type(inst60000050)}
 // CHECK:STDOUT:     inst60000050:    {kind: FunctionType, arg0: function60000001, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000051:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000052:    {kind: SymbolicBindingType, arg0: entity_name4, arg1: inst60000048, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000052:    {kind: SymbolicBindingType, arg0: entity_name00000004, arg1: inst60000048, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000053:    {kind: PatternType, arg0: inst60000052, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000054:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant19)}
-// CHECK:STDOUT:     inst60000055:    {kind: OutParamPattern, arg0: inst60000054, arg1: call_param1, type: type(symbolic_constant19)}
-// CHECK:STDOUT:     inst60000056:    {kind: BindingPattern, arg0: entity_name8, type: type(symbolic_constant19)}
-// CHECK:STDOUT:     inst60000057:    {kind: ValueParamPattern, arg0: inst60000056, arg1: call_param0, type: type(symbolic_constant19)}
-// CHECK:STDOUT:     inst60000058:    {kind: ImportRefLoaded, arg0: import_ir_inst11, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000059:    {kind: BindSymbolicName, arg0: entity_name4, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000005A:    {kind: SymbolicBindingType, arg0: entity_name4, arg1: inst60000059, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000054:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant00000013)}
+// CHECK:STDOUT:     inst60000055:    {kind: OutParamPattern, arg0: inst60000054, arg1: call_param1, type: type(symbolic_constant00000013)}
+// CHECK:STDOUT:     inst60000056:    {kind: BindingPattern, arg0: entity_name00000008, type: type(symbolic_constant00000013)}
+// CHECK:STDOUT:     inst60000057:    {kind: ValueParamPattern, arg0: inst60000056, arg1: call_param0, type: type(symbolic_constant00000013)}
+// CHECK:STDOUT:     inst60000058:    {kind: ImportRefLoaded, arg0: import_ir_inst0000000B, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000059:    {kind: BindSymbolicName, arg0: entity_name00000004, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000005A:    {kind: SymbolicBindingType, arg0: entity_name00000004, arg1: inst60000059, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000005B:    {kind: PatternType, arg0: inst6000005A, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000005C:    {kind: LookupImplWitness, arg0: inst6000001B, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000005D:    {kind: ImportRefUnloaded, arg0: import_ir_inst15, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst6000005D:    {kind: ImportRefUnloaded, arg0: import_ir_inst0000000F, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst6000005E:    {kind: ImplDecl, arg0: impl60000000, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst6000005F:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000060:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst6000005F, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000005F:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000060:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst6000005F, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000061:    {kind: ConstType, arg0: inst60000060, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000062:    {kind: PatternType, arg0: inst60000047, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000063:    {kind: SymbolicBindingPattern, arg0: entity_name13, type: type(inst60000062)}
-// CHECK:STDOUT:     inst60000064:    {kind: ImportRefLoaded, arg0: import_ir_inst18, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000065:    {kind: ImportRefLoaded, arg0: import_ir_inst19, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000066:    {kind: ImportRefLoaded, arg0: import_ir_inst20, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000067:    {kind: ImportRefUnloaded, arg0: import_ir_inst21, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst60000068:    {kind: ImplWitnessTable, arg0: inst_block30, arg1: impl60000000}
-// CHECK:STDOUT:     inst60000069:    {kind: ImplWitness, arg0: inst60000068, arg1: specific2, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000006A:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000006B:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst6000006A, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000063:    {kind: SymbolicBindingPattern, arg0: entity_name0000000D, type: type(inst60000062)}
+// CHECK:STDOUT:     inst60000064:    {kind: ImportRefLoaded, arg0: import_ir_inst00000012, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000065:    {kind: ImportRefLoaded, arg0: import_ir_inst00000013, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000066:    {kind: ImportRefLoaded, arg0: import_ir_inst00000014, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000067:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000015, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst60000068:    {kind: ImplWitnessTable, arg0: inst_block0000001E, arg1: impl60000000}
+// CHECK:STDOUT:     inst60000069:    {kind: ImplWitness, arg0: inst60000068, arg1: specific00000002, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst6000006A:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000006B:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst6000006A, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000006C:    {kind: ConstType, arg0: inst6000006B, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000006D:    {kind: ImplWitness, arg0: inst60000068, arg1: specific3, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000006E:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(symbolic_constant38)}
-// CHECK:STDOUT:     inst6000006F:    {kind: FunctionType, arg0: function60000002, arg1: specific2, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000070:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant38)}
+// CHECK:STDOUT:     inst6000006D:    {kind: ImplWitness, arg0: inst60000068, arg1: specific00000003, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst6000006E:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(symbolic_constant00000026)}
+// CHECK:STDOUT:     inst6000006F:    {kind: FunctionType, arg0: function60000002, arg1: specific00000002, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000070:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant00000026)}
 // CHECK:STDOUT:     inst60000071:    {kind: PatternType, arg0: inst60000061, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000072:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant43)}
-// CHECK:STDOUT:     inst60000073:    {kind: OutParamPattern, arg0: inst60000072, arg1: call_param1, type: type(symbolic_constant43)}
-// CHECK:STDOUT:     inst60000074:    {kind: BindingPattern, arg0: entity_name17, type: type(symbolic_constant43)}
-// CHECK:STDOUT:     inst60000075:    {kind: ValueParamPattern, arg0: inst60000074, arg1: call_param0, type: type(symbolic_constant43)}
-// CHECK:STDOUT:     inst60000076:    {kind: ImportRefLoaded, arg0: import_ir_inst32, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000077:    {kind: FunctionType, arg0: function60000002, arg1: specific3, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000078:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant45)}
-// CHECK:STDOUT:     inst60000079:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000007A:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst60000079, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000072:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant0000002B)}
+// CHECK:STDOUT:     inst60000073:    {kind: OutParamPattern, arg0: inst60000072, arg1: call_param1, type: type(symbolic_constant0000002B)}
+// CHECK:STDOUT:     inst60000074:    {kind: BindingPattern, arg0: entity_name00000011, type: type(symbolic_constant0000002B)}
+// CHECK:STDOUT:     inst60000075:    {kind: ValueParamPattern, arg0: inst60000074, arg1: call_param0, type: type(symbolic_constant0000002B)}
+// CHECK:STDOUT:     inst60000076:    {kind: ImportRefLoaded, arg0: import_ir_inst00000020, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000077:    {kind: FunctionType, arg0: function60000002, arg1: specific00000003, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000078:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant0000002D)}
+// CHECK:STDOUT:     inst60000079:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000007A:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst60000079, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007B:    {kind: ConstType, arg0: inst6000007A, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007C:    {kind: PatternType, arg0: inst6000007B, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007D:    {kind: RequireCompleteType, arg0: inst60000061, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000007E:    {kind: RequireCompleteType, arg0: inst60000060, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000007F:    {kind: LookupImplWitness, arg0: inst6000005F, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000080:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000005F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000081:    {kind: ImplWitnessAccess, arg0: inst6000007F, arg1: element0, type: type(symbolic_constant60)}
-// CHECK:STDOUT:     inst60000082:    {kind: SpecificImplFunction, arg0: inst60000081, arg1: specific5, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000081:    {kind: ImplWitnessAccess, arg0: inst6000007F, arg1: element0, type: type(symbolic_constant0000003C)}
+// CHECK:STDOUT:     inst60000082:    {kind: SpecificImplFunction, arg0: inst60000081, arg1: specific00000005, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000083:    {kind: RequireCompleteType, arg0: inst6000007B, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000084:    {kind: RequireCompleteType, arg0: inst6000007A, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000085:    {kind: LookupImplWitness, arg0: inst60000079, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000086:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst60000079, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000087:    {kind: ImplWitnessAccess, arg0: inst60000085, arg1: element0, type: type(symbolic_constant69)}
-// CHECK:STDOUT:     inst60000088:    {kind: SpecificImplFunction, arg0: inst60000087, arg1: specific6, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000087:    {kind: ImplWitnessAccess, arg0: inst60000085, arg1: element0, type: type(symbolic_constant00000045)}
+// CHECK:STDOUT:     inst60000088:    {kind: SpecificImplFunction, arg0: inst60000087, arg1: specific00000006, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000089:    {kind: PatternType, arg0: inst60000060, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000008A:    {kind: ImportRefUnloaded, arg0: import_ir_inst45, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst6000008A:    {kind: ImportRefUnloaded, arg0: import_ir_inst0000002D, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst6000008B:    {kind: ImplDecl, arg0: impl60000001, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst6000008C:    {kind: ImportRefLoaded, arg0: import_ir_inst47, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000008D:    {kind: ImportRefLoaded, arg0: import_ir_inst48, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000008E:    {kind: ImportRefUnloaded, arg0: import_ir_inst49, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst6000008C:    {kind: ImportRefLoaded, arg0: import_ir_inst0000002F, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000008D:    {kind: ImportRefLoaded, arg0: import_ir_inst00000030, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000008E:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000031, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst6000008F:    {kind: ImplDecl, arg0: impl60000002, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst60000090:    {kind: ImportRefLoaded, arg0: import_ir_inst51, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000091:    {kind: ImportRefLoaded, arg0: import_ir_inst52, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000092:    {kind: ImportRefUnloaded, arg0: import_ir_inst53, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst60000090:    {kind: ImportRefLoaded, arg0: import_ir_inst00000033, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000091:    {kind: ImportRefLoaded, arg0: import_ir_inst00000034, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000092:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000035, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst60000093:    {kind: ImplDecl, arg0: impl60000003, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst60000094:    {kind: ImportRefLoaded, arg0: import_ir_inst55, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000095:    {kind: ImportRefLoaded, arg0: import_ir_inst56, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000096:    {kind: ImportRefUnloaded, arg0: import_ir_inst57, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst60000094:    {kind: ImportRefLoaded, arg0: import_ir_inst00000037, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000095:    {kind: ImportRefLoaded, arg0: import_ir_inst00000038, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000096:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000039, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst60000097:    {kind: ImplDecl, arg0: impl60000004, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst60000098:    {kind: ImportRefLoaded, arg0: import_ir_inst59, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000099:    {kind: ImportRefLoaded, arg0: import_ir_inst60, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000009A:    {kind: ImportRefLoaded, arg0: import_ir_inst61, arg1: entity_name<none>, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst60000098:    {kind: ImportRefLoaded, arg0: import_ir_inst0000003B, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000099:    {kind: ImportRefLoaded, arg0: import_ir_inst0000003C, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000009A:    {kind: ImportRefLoaded, arg0: import_ir_inst0000003D, arg1: entity_name<none>, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000009B:    {kind: ImplDecl, arg0: impl60000005, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst6000009C:    {kind: SymbolicBindingPattern, arg0: entity_name21, type: type(inst60000017)}
-// CHECK:STDOUT:     inst6000009D:    {kind: ImportRefLoaded, arg0: import_ir_inst64, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000009E:    {kind: ImportRefLoaded, arg0: import_ir_inst65, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000009F:    {kind: ImportRefLoaded, arg0: import_ir_inst66, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A0:    {kind: ImportRefUnloaded, arg0: import_ir_inst67, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000A1:    {kind: ImplWitnessTable, arg0: inst_block47, arg1: impl60000005}
-// CHECK:STDOUT:     inst600000A2:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific7, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000A3:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000009C:    {kind: SymbolicBindingPattern, arg0: entity_name00000015, type: type(inst60000017)}
+// CHECK:STDOUT:     inst6000009D:    {kind: ImportRefLoaded, arg0: import_ir_inst00000040, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000009E:    {kind: ImportRefLoaded, arg0: import_ir_inst00000041, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000009F:    {kind: ImportRefLoaded, arg0: import_ir_inst00000042, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000A0:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000043, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst600000A1:    {kind: ImplWitnessTable, arg0: inst_block0000002F, arg1: impl60000005}
+// CHECK:STDOUT:     inst600000A2:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific00000007, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst600000A3:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000A4:    {kind: PointerType, arg0: inst600000A3, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A5:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific8, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000A6:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block_empty, type: type(symbolic_constant81)}
-// CHECK:STDOUT:     inst600000A7:    {kind: FunctionType, arg0: function60000003, arg1: specific7, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A8:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant81)}
-// CHECK:STDOUT:     inst600000A9:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant85)}
-// CHECK:STDOUT:     inst600000AA:    {kind: OutParamPattern, arg0: inst600000A9, arg1: call_param1, type: type(symbolic_constant85)}
-// CHECK:STDOUT:     inst600000AB:    {kind: BindingPattern, arg0: entity_name24, type: type(symbolic_constant85)}
-// CHECK:STDOUT:     inst600000AC:    {kind: ValueParamPattern, arg0: inst600000AB, arg1: call_param0, type: type(symbolic_constant85)}
-// CHECK:STDOUT:     inst600000AD:    {kind: ImportRefLoaded, arg0: import_ir_inst77, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000AE:    {kind: FunctionType, arg0: function60000003, arg1: specific8, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000AF:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant88)}
+// CHECK:STDOUT:     inst600000A5:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific00000008, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst600000A6:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block_empty, type: type(symbolic_constant00000051)}
+// CHECK:STDOUT:     inst600000A7:    {kind: FunctionType, arg0: function60000003, arg1: specific00000007, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000A8:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant00000051)}
+// CHECK:STDOUT:     inst600000A9:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant00000055)}
+// CHECK:STDOUT:     inst600000AA:    {kind: OutParamPattern, arg0: inst600000A9, arg1: call_param1, type: type(symbolic_constant00000055)}
+// CHECK:STDOUT:     inst600000AB:    {kind: BindingPattern, arg0: entity_name00000018, type: type(symbolic_constant00000055)}
+// CHECK:STDOUT:     inst600000AC:    {kind: ValueParamPattern, arg0: inst600000AB, arg1: call_param0, type: type(symbolic_constant00000055)}
+// CHECK:STDOUT:     inst600000AD:    {kind: ImportRefLoaded, arg0: import_ir_inst0000004D, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000AE:    {kind: FunctionType, arg0: function60000003, arg1: specific00000008, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000AF:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant00000058)}
 // CHECK:STDOUT:     inst600000B0:    {kind: RequireCompleteType, arg0: inst600000A4, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000B1:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000B1:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000B2:    {kind: PointerType, arg0: inst600000B1, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000B3:    {kind: PatternType, arg0: inst600000B2, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000B4:    {kind: ImportRefUnloaded, arg0: import_ir_inst84, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst600000B4:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000054, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst600000B5:    {kind: ImplDecl, arg0: impl60000006, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000B6:    {kind: ImportRefLoaded, arg0: import_ir_inst86, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000B7:    {kind: ImportRefLoaded, arg0: import_ir_inst87, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000B8:    {kind: ImportRefUnloaded, arg0: import_ir_inst88, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst600000B6:    {kind: ImportRefLoaded, arg0: import_ir_inst00000056, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000B7:    {kind: ImportRefLoaded, arg0: import_ir_inst00000057, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000B8:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000058, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst600000B9:    {kind: ImplDecl, arg0: impl60000007, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000BA:    {kind: ImportRefLoaded, arg0: import_ir_inst90, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BB:    {kind: ImportRefLoaded, arg0: import_ir_inst91, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BC:    {kind: ImportRefUnloaded, arg0: import_ir_inst92, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst600000BA:    {kind: ImportRefLoaded, arg0: import_ir_inst0000005A, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000BB:    {kind: ImportRefLoaded, arg0: import_ir_inst0000005B, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000BC:    {kind: ImportRefUnloaded, arg0: import_ir_inst0000005C, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst600000BD:    {kind: ImplDecl, arg0: impl60000008, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000BE:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000BF:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst600000BE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000C0:    {kind: TupleType, arg0: inst_block57, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000C1:    {kind: SymbolicBindingPattern, arg0: entity_name28, type: type(inst60000062)}
-// CHECK:STDOUT:     inst600000C2:    {kind: SymbolicBindingPattern, arg0: entity_name29, type: type(inst60000062)}
-// CHECK:STDOUT:     inst600000C3:    {kind: ImportRefLoaded, arg0: import_ir_inst96, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000C4:    {kind: ImportRefLoaded, arg0: import_ir_inst97, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000C5:    {kind: ImportRefLoaded, arg0: import_ir_inst98, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000C6:    {kind: ImportRefLoaded, arg0: import_ir_inst99, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000C7:    {kind: ImportRefUnloaded, arg0: import_ir_inst100, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000C8:    {kind: ImplWitnessTable, arg0: inst_block60, arg1: impl60000008}
-// CHECK:STDOUT:     inst600000C9:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific10, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000CA:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000CB:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000CC:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst600000CA, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CD:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst600000CB, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CE:    {kind: TupleType, arg0: inst_block62, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CF:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific11, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000D0:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block_empty, type: type(symbolic_constant114)}
-// CHECK:STDOUT:     inst600000D1:    {kind: FunctionType, arg0: function60000004, arg1: specific10, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D2:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant114)}
+// CHECK:STDOUT:     inst600000BE:    {kind: BindSymbolicName, arg0: entity_name0000001A, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000BF:    {kind: SymbolicBindingType, arg0: entity_name0000001A, arg1: inst600000BE, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000C0:    {kind: TupleType, arg0: inst_block00000039, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000C1:    {kind: SymbolicBindingPattern, arg0: entity_name0000001C, type: type(inst60000062)}
+// CHECK:STDOUT:     inst600000C2:    {kind: SymbolicBindingPattern, arg0: entity_name0000001D, type: type(inst60000062)}
+// CHECK:STDOUT:     inst600000C3:    {kind: ImportRefLoaded, arg0: import_ir_inst00000060, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000C4:    {kind: ImportRefLoaded, arg0: import_ir_inst00000061, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000C5:    {kind: ImportRefLoaded, arg0: import_ir_inst00000062, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000C6:    {kind: ImportRefLoaded, arg0: import_ir_inst00000063, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000C7:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000064, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst600000C8:    {kind: ImplWitnessTable, arg0: inst_block0000003C, arg1: impl60000008}
+// CHECK:STDOUT:     inst600000C9:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific0000000A, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst600000CA:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000CB:    {kind: BindSymbolicName, arg0: entity_name0000001A, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000CC:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst600000CA, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000CD:    {kind: SymbolicBindingType, arg0: entity_name0000001A, arg1: inst600000CB, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000CE:    {kind: TupleType, arg0: inst_block0000003E, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000CF:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific0000000B, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst600000D0:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block_empty, type: type(symbolic_constant00000072)}
+// CHECK:STDOUT:     inst600000D1:    {kind: FunctionType, arg0: function60000004, arg1: specific0000000A, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000D2:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant00000072)}
 // CHECK:STDOUT:     inst600000D3:    {kind: PatternType, arg0: inst600000C0, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D4:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant119)}
-// CHECK:STDOUT:     inst600000D5:    {kind: OutParamPattern, arg0: inst600000D4, arg1: call_param1, type: type(symbolic_constant119)}
-// CHECK:STDOUT:     inst600000D6:    {kind: BindingPattern, arg0: entity_name36, type: type(symbolic_constant119)}
-// CHECK:STDOUT:     inst600000D7:    {kind: ValueParamPattern, arg0: inst600000D6, arg1: call_param0, type: type(symbolic_constant119)}
-// CHECK:STDOUT:     inst600000D8:    {kind: ImportRefLoaded, arg0: import_ir_inst113, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000D9:    {kind: ImportRefLoaded, arg0: import_ir_inst114, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000DA:    {kind: FunctionType, arg0: function60000004, arg1: specific11, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000DB:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant121)}
-// CHECK:STDOUT:     inst600000DC:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000DD:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst600000DC, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000DE:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000DF:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst600000DE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000E0:    {kind: TupleType, arg0: inst_block70, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000D4:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant00000077)}
+// CHECK:STDOUT:     inst600000D5:    {kind: OutParamPattern, arg0: inst600000D4, arg1: call_param1, type: type(symbolic_constant00000077)}
+// CHECK:STDOUT:     inst600000D6:    {kind: BindingPattern, arg0: entity_name00000024, type: type(symbolic_constant00000077)}
+// CHECK:STDOUT:     inst600000D7:    {kind: ValueParamPattern, arg0: inst600000D6, arg1: call_param0, type: type(symbolic_constant00000077)}
+// CHECK:STDOUT:     inst600000D8:    {kind: ImportRefLoaded, arg0: import_ir_inst00000071, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000D9:    {kind: ImportRefLoaded, arg0: import_ir_inst00000072, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000DA:    {kind: FunctionType, arg0: function60000004, arg1: specific0000000B, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000DB:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant00000079)}
+// CHECK:STDOUT:     inst600000DC:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000DD:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst600000DC, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000DE:    {kind: BindSymbolicName, arg0: entity_name0000001A, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000DF:    {kind: SymbolicBindingType, arg0: entity_name0000001A, arg1: inst600000DE, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000E0:    {kind: TupleType, arg0: inst_block00000046, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000E1:    {kind: PatternType, arg0: inst600000E0, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000E2:    {kind: RequireCompleteType, arg0: inst600000C0, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E3:    {kind: RequireCompleteType, arg0: inst600000BF, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E4:    {kind: LookupImplWitness, arg0: inst600000BE, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E5:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000BE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000E6:    {kind: ImplWitnessAccess, arg0: inst600000E4, arg1: element0, type: type(symbolic_constant145)}
-// CHECK:STDOUT:     inst600000E7:    {kind: SpecificImplFunction, arg0: inst600000E6, arg1: specific13, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst600000E6:    {kind: ImplWitnessAccess, arg0: inst600000E4, arg1: element0, type: type(symbolic_constant00000091)}
+// CHECK:STDOUT:     inst600000E7:    {kind: SpecificImplFunction, arg0: inst600000E6, arg1: specific0000000D, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst600000E8:    {kind: RequireCompleteType, arg0: inst600000E0, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E9:    {kind: RequireCompleteType, arg0: inst600000DD, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000EA:    {kind: LookupImplWitness, arg0: inst600000DC, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000EB:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000DC, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000EC:    {kind: ImplWitnessAccess, arg0: inst600000EA, arg1: element0, type: type(symbolic_constant154)}
-// CHECK:STDOUT:     inst600000ED:    {kind: SpecificImplFunction, arg0: inst600000EC, arg1: specific14, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst600000EC:    {kind: ImplWitnessAccess, arg0: inst600000EA, arg1: element0, type: type(symbolic_constant0000009A)}
+// CHECK:STDOUT:     inst600000ED:    {kind: SpecificImplFunction, arg0: inst600000EC, arg1: specific0000000E, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst600000EE:    {kind: RequireCompleteType, arg0: inst600000DF, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000EF:    {kind: LookupImplWitness, arg0: inst600000DE, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000F0:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000DE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F1:    {kind: ImplWitnessAccess, arg0: inst600000EF, arg1: element0, type: type(symbolic_constant159)}
-// CHECK:STDOUT:     inst600000F2:    {kind: SpecificImplFunction, arg0: inst600000F1, arg1: specific15, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst600000F1:    {kind: ImplWitnessAccess, arg0: inst600000EF, arg1: element0, type: type(symbolic_constant0000009F)}
+// CHECK:STDOUT:     inst600000F2:    {kind: SpecificImplFunction, arg0: inst600000F1, arg1: specific0000000F, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst600000F3:    {kind: PatternType, arg0: inst600000BF, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F4:    {kind: ImportRefUnloaded, arg0: import_ir_inst134, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst600000F4:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000086, arg1: entity_name<none>}
 // CHECK:STDOUT:     inst600000F5:    {kind: ImplDecl, arg0: impl60000009, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000F6:    {kind: BindSymbolicName, arg0: entity_name41, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000F7:    {kind: SymbolicBindingType, arg0: entity_name41, arg1: inst600000F6, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F8:    {kind: TupleType, arg0: inst_block79, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F9:    {kind: SymbolicBindingPattern, arg0: entity_name43, type: type(inst60000062)}
-// CHECK:STDOUT:     inst600000FA:    {kind: SymbolicBindingPattern, arg0: entity_name44, type: type(inst60000062)}
-// CHECK:STDOUT:     inst600000FB:    {kind: SymbolicBindingPattern, arg0: entity_name45, type: type(inst60000062)}
-// CHECK:STDOUT:     inst600000FC:    {kind: ImportRefLoaded, arg0: import_ir_inst139, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000FD:    {kind: ImportRefLoaded, arg0: import_ir_inst140, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000FE:    {kind: ImportRefLoaded, arg0: import_ir_inst141, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst600000FF:    {kind: ImportRefLoaded, arg0: import_ir_inst142, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000100:    {kind: ImportRefLoaded, arg0: import_ir_inst143, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000101:    {kind: ImportRefUnloaded, arg0: import_ir_inst144, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst60000102:    {kind: ImplWitnessTable, arg0: inst_block82, arg1: impl60000009}
-// CHECK:STDOUT:     inst60000103:    {kind: ImplWitness, arg0: inst60000102, arg1: specific16, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000104:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000105:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000106:    {kind: BindSymbolicName, arg0: entity_name41, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000107:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst60000104, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000108:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst60000105, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000109:    {kind: SymbolicBindingType, arg0: entity_name41, arg1: inst60000106, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000010A:    {kind: TupleType, arg0: inst_block84, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000010B:    {kind: ImplWitness, arg0: inst60000102, arg1: specific17, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000010C:    {kind: FunctionDecl, arg0: function60000005, arg1: inst_block_empty, type: type(symbolic_constant186)}
-// CHECK:STDOUT:     inst6000010D:    {kind: FunctionType, arg0: function60000005, arg1: specific16, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000010E:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant186)}
+// CHECK:STDOUT:     inst600000F6:    {kind: BindSymbolicName, arg0: entity_name00000029, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000F7:    {kind: SymbolicBindingType, arg0: entity_name00000029, arg1: inst600000F6, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000F8:    {kind: TupleType, arg0: inst_block0000004F, type: type(TypeType)}
+// CHECK:STDOUT:     inst600000F9:    {kind: SymbolicBindingPattern, arg0: entity_name0000002B, type: type(inst60000062)}
+// CHECK:STDOUT:     inst600000FA:    {kind: SymbolicBindingPattern, arg0: entity_name0000002C, type: type(inst60000062)}
+// CHECK:STDOUT:     inst600000FB:    {kind: SymbolicBindingPattern, arg0: entity_name0000002D, type: type(inst60000062)}
+// CHECK:STDOUT:     inst600000FC:    {kind: ImportRefLoaded, arg0: import_ir_inst0000008B, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000FD:    {kind: ImportRefLoaded, arg0: import_ir_inst0000008C, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000FE:    {kind: ImportRefLoaded, arg0: import_ir_inst0000008D, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst600000FF:    {kind: ImportRefLoaded, arg0: import_ir_inst0000008E, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000100:    {kind: ImportRefLoaded, arg0: import_ir_inst0000008F, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000101:    {kind: ImportRefUnloaded, arg0: import_ir_inst00000090, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst60000102:    {kind: ImplWitnessTable, arg0: inst_block00000052, arg1: impl60000009}
+// CHECK:STDOUT:     inst60000103:    {kind: ImplWitness, arg0: inst60000102, arg1: specific00000010, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst60000104:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000105:    {kind: BindSymbolicName, arg0: entity_name0000001A, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000106:    {kind: BindSymbolicName, arg0: entity_name00000029, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000107:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst60000104, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000108:    {kind: SymbolicBindingType, arg0: entity_name0000001A, arg1: inst60000105, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000109:    {kind: SymbolicBindingType, arg0: entity_name00000029, arg1: inst60000106, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000010A:    {kind: TupleType, arg0: inst_block00000054, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000010B:    {kind: ImplWitness, arg0: inst60000102, arg1: specific00000011, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst6000010C:    {kind: FunctionDecl, arg0: function60000005, arg1: inst_block_empty, type: type(symbolic_constant000000BA)}
+// CHECK:STDOUT:     inst6000010D:    {kind: FunctionType, arg0: function60000005, arg1: specific00000010, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000010E:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant000000BA)}
 // CHECK:STDOUT:     inst6000010F:    {kind: PatternType, arg0: inst600000F8, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000110:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant191)}
-// CHECK:STDOUT:     inst60000111:    {kind: OutParamPattern, arg0: inst60000110, arg1: call_param1, type: type(symbolic_constant191)}
-// CHECK:STDOUT:     inst60000112:    {kind: BindingPattern, arg0: entity_name55, type: type(symbolic_constant191)}
-// CHECK:STDOUT:     inst60000113:    {kind: ValueParamPattern, arg0: inst60000112, arg1: call_param0, type: type(symbolic_constant191)}
-// CHECK:STDOUT:     inst60000114:    {kind: ImportRefLoaded, arg0: import_ir_inst159, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000115:    {kind: ImportRefLoaded, arg0: import_ir_inst160, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000116:    {kind: ImportRefLoaded, arg0: import_ir_inst161, arg1: entity_name<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst60000117:    {kind: FunctionType, arg0: function60000005, arg1: specific17, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000118:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant193)}
-// CHECK:STDOUT:     inst60000119:    {kind: BindSymbolicName, arg0: entity_name1, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000011A:    {kind: SymbolicBindingType, arg0: entity_name1, arg1: inst60000119, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000011B:    {kind: BindSymbolicName, arg0: entity_name26, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000011C:    {kind: SymbolicBindingType, arg0: entity_name26, arg1: inst6000011B, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000011D:    {kind: BindSymbolicName, arg0: entity_name41, arg1: inst<none>, type: type(inst60000047)}
-// CHECK:STDOUT:     inst6000011E:    {kind: SymbolicBindingType, arg0: entity_name41, arg1: inst6000011D, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000011F:    {kind: TupleType, arg0: inst_block92, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000110:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant000000BF)}
+// CHECK:STDOUT:     inst60000111:    {kind: OutParamPattern, arg0: inst60000110, arg1: call_param1, type: type(symbolic_constant000000BF)}
+// CHECK:STDOUT:     inst60000112:    {kind: BindingPattern, arg0: entity_name00000037, type: type(symbolic_constant000000BF)}
+// CHECK:STDOUT:     inst60000113:    {kind: ValueParamPattern, arg0: inst60000112, arg1: call_param0, type: type(symbolic_constant000000BF)}
+// CHECK:STDOUT:     inst60000114:    {kind: ImportRefLoaded, arg0: import_ir_inst0000009F, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000115:    {kind: ImportRefLoaded, arg0: import_ir_inst000000A0, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000116:    {kind: ImportRefLoaded, arg0: import_ir_inst000000A1, arg1: entity_name<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst60000117:    {kind: FunctionType, arg0: function60000005, arg1: specific00000011, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000118:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant000000C1)}
+// CHECK:STDOUT:     inst60000119:    {kind: BindSymbolicName, arg0: entity_name00000001, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000011A:    {kind: SymbolicBindingType, arg0: entity_name00000001, arg1: inst60000119, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000011B:    {kind: BindSymbolicName, arg0: entity_name0000001A, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000011C:    {kind: SymbolicBindingType, arg0: entity_name0000001A, arg1: inst6000011B, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000011D:    {kind: BindSymbolicName, arg0: entity_name00000029, arg1: inst<none>, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000011E:    {kind: SymbolicBindingType, arg0: entity_name00000029, arg1: inst6000011D, type: type(TypeType)}
+// CHECK:STDOUT:     inst6000011F:    {kind: TupleType, arg0: inst_block0000005C, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000120:    {kind: PatternType, arg0: inst6000011F, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000121:    {kind: RequireCompleteType, arg0: inst600000F8, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000122:    {kind: RequireCompleteType, arg0: inst600000F7, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000123:    {kind: LookupImplWitness, arg0: inst600000F6, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000124:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000F6, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000125:    {kind: ImplWitnessAccess, arg0: inst60000123, arg1: element0, type: type(symbolic_constant226)}
-// CHECK:STDOUT:     inst60000126:    {kind: SpecificImplFunction, arg0: inst60000125, arg1: specific19, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000125:    {kind: ImplWitnessAccess, arg0: inst60000123, arg1: element0, type: type(symbolic_constant000000E2)}
+// CHECK:STDOUT:     inst60000126:    {kind: SpecificImplFunction, arg0: inst60000125, arg1: specific00000013, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000127:    {kind: RequireCompleteType, arg0: inst6000011F, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000128:    {kind: RequireCompleteType, arg0: inst6000011A, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000129:    {kind: LookupImplWitness, arg0: inst60000119, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000012A:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst60000119, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000012B:    {kind: ImplWitnessAccess, arg0: inst60000129, arg1: element0, type: type(symbolic_constant235)}
-// CHECK:STDOUT:     inst6000012C:    {kind: SpecificImplFunction, arg0: inst6000012B, arg1: specific20, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst6000012B:    {kind: ImplWitnessAccess, arg0: inst60000129, arg1: element0, type: type(symbolic_constant000000EB)}
+// CHECK:STDOUT:     inst6000012C:    {kind: SpecificImplFunction, arg0: inst6000012B, arg1: specific00000014, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst6000012D:    {kind: RequireCompleteType, arg0: inst6000011C, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000012E:    {kind: LookupImplWitness, arg0: inst6000011B, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000012F:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000011B, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000130:    {kind: ImplWitnessAccess, arg0: inst6000012E, arg1: element0, type: type(symbolic_constant240)}
-// CHECK:STDOUT:     inst60000131:    {kind: SpecificImplFunction, arg0: inst60000130, arg1: specific21, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000130:    {kind: ImplWitnessAccess, arg0: inst6000012E, arg1: element0, type: type(symbolic_constant000000F0)}
+// CHECK:STDOUT:     inst60000131:    {kind: SpecificImplFunction, arg0: inst60000130, arg1: specific00000015, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000132:    {kind: RequireCompleteType, arg0: inst6000011E, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000133:    {kind: LookupImplWitness, arg0: inst6000011D, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000134:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000011D, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000135:    {kind: ImplWitnessAccess, arg0: inst60000133, arg1: element0, type: type(symbolic_constant245)}
-// CHECK:STDOUT:     inst60000136:    {kind: SpecificImplFunction, arg0: inst60000135, arg1: specific22, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000135:    {kind: ImplWitnessAccess, arg0: inst60000133, arg1: element0, type: type(symbolic_constant000000F5)}
+// CHECK:STDOUT:     inst60000136:    {kind: SpecificImplFunction, arg0: inst60000135, arg1: specific00000016, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000137:    {kind: PatternType, arg0: inst600000F7, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000138:    {kind: LookupImplWitness, arg0: inst6000001B, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000139:    {kind: LookupImplWitness, arg0: inst6000001C, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000013A:    {kind: FacetValue, arg0: inst6000001B, arg1: inst_block103, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000013A:    {kind: FacetValue, arg0: inst6000001B, arg1: inst_block00000067, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000013B:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000013A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000013C:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant256)}
-// CHECK:STDOUT:     inst6000013D:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant253)}
-// CHECK:STDOUT:     inst6000013E:    {kind: FacetValue, arg0: inst6000001C, arg1: inst_block104, type: type(inst60000047)}
+// CHECK:STDOUT:     inst6000013C:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant00000100)}
+// CHECK:STDOUT:     inst6000013D:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant000000FD)}
+// CHECK:STDOUT:     inst6000013E:    {kind: FacetValue, arg0: inst6000001C, arg1: inst_block00000068, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000013F:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000013E, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000140:    {kind: ImplWitnessAccess, arg0: inst60000139, arg1: element0, type: type(symbolic_constant256)}
+// CHECK:STDOUT:     inst60000140:    {kind: ImplWitnessAccess, arg0: inst60000139, arg1: element0, type: type(symbolic_constant00000100)}
 // CHECK:STDOUT:     inst60000141:    {kind: BoundMethod, arg0: inst6000003F, arg1: inst6000013C, type: type(inst(BoundMethodType))}
-// CHECK:STDOUT:     inst60000142:    {kind: SpecificImplFunction, arg0: inst6000013C, arg1: specific23, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000143:    {kind: SpecificImplFunction, arg0: inst6000013D, arg1: specific23, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000144:    {kind: SpecificImplFunction, arg0: inst60000140, arg1: specific24, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000142:    {kind: SpecificImplFunction, arg0: inst6000013C, arg1: specific00000017, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000143:    {kind: SpecificImplFunction, arg0: inst6000013D, arg1: specific00000017, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst60000144:    {kind: SpecificImplFunction, arg0: inst60000140, arg1: specific00000018, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000145:    {kind: BoundMethod, arg0: inst6000003F, arg1: inst60000142, type: type(inst(BoundMethodType))}
 // CHECK:STDOUT:     inst60000146:    {kind: RequireCompleteType, arg0: inst6000001B, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000147:    {kind: Call, arg0: inst60000145, arg1: inst_block108, type: type(symbolic_constant4)}
-// CHECK:STDOUT:     inst60000148:    {kind: InitializeFrom, arg0: inst60000147, arg1: inst60000043, type: type(symbolic_constant4)}
+// CHECK:STDOUT:     inst60000147:    {kind: Call, arg0: inst60000145, arg1: inst_block0000006C, type: type(symbolic_constant00000004)}
+// CHECK:STDOUT:     inst60000148:    {kind: InitializeFrom, arg0: inst60000147, arg1: inst60000043, type: type(symbolic_constant00000004)}
 // CHECK:STDOUT:     inst60000149:    {kind: TupleAccess, arg0: inst60000034, arg1: element1, type: type(inst60000024)}
 // CHECK:STDOUT:     inst6000014A:    {kind: TupleInit, arg0: inst_block_empty, arg1: inst60000149, type: type(inst60000024)}
 // CHECK:STDOUT:     inst6000014B:    {kind: TupleValue, arg0: inst_block_empty, type: type(inst60000024)}
 // CHECK:STDOUT:     inst6000014C:    {kind: Converted, arg0: inst60000040, arg1: inst6000014A, type: type(inst60000024)}
-// CHECK:STDOUT:     inst6000014D:    {kind: TupleInit, arg0: inst_block109, arg1: inst60000034, type: type(symbolic_constant8)}
-// CHECK:STDOUT:     inst6000014E:    {kind: Converted, arg0: inst60000041, arg1: inst6000014D, type: type(symbolic_constant8)}
+// CHECK:STDOUT:     inst6000014D:    {kind: TupleInit, arg0: inst_block0000006D, arg1: inst60000034, type: type(symbolic_constant00000008)}
+// CHECK:STDOUT:     inst6000014E:    {kind: Converted, arg0: inst60000041, arg1: inst6000014D, type: type(symbolic_constant00000008)}
 // CHECK:STDOUT:     inst6000014F:    {kind: ReturnExpr, arg0: inst6000014E, arg1: inst60000034}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       inst0000000E:    concrete_constant(inst0000000E)
 // CHECK:STDOUT:       inst60000010:    concrete_constant(inst60000010)
 // CHECK:STDOUT:       inst60000011:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000012:    symbolic_constant0
-// CHECK:STDOUT:       inst60000013:    symbolic_constant0
-// CHECK:STDOUT:       inst60000014:    symbolic_constant2
-// CHECK:STDOUT:       inst60000015:    symbolic_constant1
-// CHECK:STDOUT:       inst60000016:    symbolic_constant2
+// CHECK:STDOUT:       inst60000012:    symbolic_constant00000000
+// CHECK:STDOUT:       inst60000013:    symbolic_constant00000000
+// CHECK:STDOUT:       inst60000014:    symbolic_constant00000002
+// CHECK:STDOUT:       inst60000015:    symbolic_constant00000001
+// CHECK:STDOUT:       inst60000016:    symbolic_constant00000002
 // CHECK:STDOUT:       inst60000017:    concrete_constant(inst60000017)
 // CHECK:STDOUT:       inst60000018:    concrete_constant(inst60000018)
-// CHECK:STDOUT:       inst60000019:    symbolic_constant2
-// CHECK:STDOUT:       inst6000001A:    symbolic_constant4
-// CHECK:STDOUT:       inst6000001B:    symbolic_constant3
-// CHECK:STDOUT:       inst6000001C:    symbolic_constant4
-// CHECK:STDOUT:       inst6000001E:    symbolic_constant5
+// CHECK:STDOUT:       inst60000019:    symbolic_constant00000002
+// CHECK:STDOUT:       inst6000001A:    symbolic_constant00000004
+// CHECK:STDOUT:       inst6000001B:    symbolic_constant00000003
+// CHECK:STDOUT:       inst6000001C:    symbolic_constant00000004
+// CHECK:STDOUT:       inst6000001E:    symbolic_constant00000005
 // CHECK:STDOUT:       inst6000001F:    concrete_constant(inst6000001F)
-// CHECK:STDOUT:       inst60000020:    symbolic_constant6
+// CHECK:STDOUT:       inst60000020:    symbolic_constant00000006
 // CHECK:STDOUT:       inst60000021:    concrete_constant(inst60000021)
-// CHECK:STDOUT:       inst60000022:    symbolic_constant2
-// CHECK:STDOUT:       inst60000023:    symbolic_constant4
+// CHECK:STDOUT:       inst60000022:    symbolic_constant00000002
+// CHECK:STDOUT:       inst60000023:    symbolic_constant00000004
 // CHECK:STDOUT:       inst60000024:    concrete_constant(inst60000024)
 // CHECK:STDOUT:       inst60000026:    concrete_constant(inst60000026)
 // CHECK:STDOUT:       inst60000028:    concrete_constant(inst60000028)
 // CHECK:STDOUT:       inst60000029:    concrete_constant(inst60000024)
-// CHECK:STDOUT:       inst6000002A:    symbolic_constant7
-// CHECK:STDOUT:       inst6000002B:    symbolic_constant8
-// CHECK:STDOUT:       inst6000002C:    symbolic_constant8
-// CHECK:STDOUT:       inst6000002D:    symbolic_constant9
+// CHECK:STDOUT:       inst6000002A:    symbolic_constant00000007
+// CHECK:STDOUT:       inst6000002B:    symbolic_constant00000008
+// CHECK:STDOUT:       inst6000002C:    symbolic_constant00000008
+// CHECK:STDOUT:       inst6000002D:    symbolic_constant00000009
 // CHECK:STDOUT:       inst6000002E:    concrete_constant(inst6000002E)
-// CHECK:STDOUT:       inst6000002F:    symbolic_constant10
+// CHECK:STDOUT:       inst6000002F:    symbolic_constant0000000A
 // CHECK:STDOUT:       inst60000030:    concrete_constant(inst60000030)
-// CHECK:STDOUT:       inst60000032:    symbolic_constant4
+// CHECK:STDOUT:       inst60000032:    symbolic_constant00000004
 // CHECK:STDOUT:       inst60000035:    concrete_constant(inst60000037)
 // CHECK:STDOUT:       inst60000036:    concrete_constant(inst60000036)
 // CHECK:STDOUT:       inst60000037:    concrete_constant(inst60000037)
-// CHECK:STDOUT:       inst60000038:    symbolic_constant11
-// CHECK:STDOUT:       inst60000039:    symbolic_constant13
-// CHECK:STDOUT:       inst6000003A:    symbolic_constant12
-// CHECK:STDOUT:       inst6000003B:    symbolic_constant13
-// CHECK:STDOUT:       inst6000003C:    symbolic_constant15
-// CHECK:STDOUT:       inst6000003D:    symbolic_constant14
-// CHECK:STDOUT:       inst6000003E:    symbolic_constant15
-// CHECK:STDOUT:       inst60000042:    symbolic_constant13
-// CHECK:STDOUT:       inst60000044:    symbolic_constant15
+// CHECK:STDOUT:       inst60000038:    symbolic_constant0000000B
+// CHECK:STDOUT:       inst60000039:    symbolic_constant0000000D
+// CHECK:STDOUT:       inst6000003A:    symbolic_constant0000000C
+// CHECK:STDOUT:       inst6000003B:    symbolic_constant0000000D
+// CHECK:STDOUT:       inst6000003C:    symbolic_constant0000000F
+// CHECK:STDOUT:       inst6000003D:    symbolic_constant0000000E
+// CHECK:STDOUT:       inst6000003E:    symbolic_constant0000000F
+// CHECK:STDOUT:       inst60000042:    symbolic_constant0000000D
+// CHECK:STDOUT:       inst60000044:    symbolic_constant0000000F
 // CHECK:STDOUT:       inst60000045:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst60000046:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst60000047:    concrete_constant(inst60000047)
-// CHECK:STDOUT:       inst60000048:    symbolic_constant16
+// CHECK:STDOUT:       inst60000048:    symbolic_constant00000010
 // CHECK:STDOUT:       inst60000049:    constant<none>
 // CHECK:STDOUT:       inst6000004A:    concrete_constant(inst6000004E)
 // CHECK:STDOUT:       inst6000004B:    constant<none>
@@ -761,62 +761,62 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst6000004F:    concrete_constant(inst60000051)
 // CHECK:STDOUT:       inst60000050:    concrete_constant(inst60000050)
 // CHECK:STDOUT:       inst60000051:    concrete_constant(inst60000051)
-// CHECK:STDOUT:       inst60000052:    symbolic_constant17
-// CHECK:STDOUT:       inst60000053:    symbolic_constant18
+// CHECK:STDOUT:       inst60000052:    symbolic_constant00000011
+// CHECK:STDOUT:       inst60000053:    symbolic_constant00000012
 // CHECK:STDOUT:       inst60000054:    concrete_constant(inst60000054)
 // CHECK:STDOUT:       inst60000055:    concrete_constant(inst60000055)
 // CHECK:STDOUT:       inst60000056:    concrete_constant(inst60000056)
 // CHECK:STDOUT:       inst60000057:    concrete_constant(inst60000057)
-// CHECK:STDOUT:       inst60000058:    symbolic_constant16
-// CHECK:STDOUT:       inst60000059:    symbolic_constant22
-// CHECK:STDOUT:       inst6000005A:    symbolic_constant23
-// CHECK:STDOUT:       inst6000005B:    symbolic_constant24
-// CHECK:STDOUT:       inst6000005C:    symbolic_constant251
+// CHECK:STDOUT:       inst60000058:    symbolic_constant00000010
+// CHECK:STDOUT:       inst60000059:    symbolic_constant00000016
+// CHECK:STDOUT:       inst6000005A:    symbolic_constant00000017
+// CHECK:STDOUT:       inst6000005B:    symbolic_constant00000018
+// CHECK:STDOUT:       inst6000005C:    symbolic_constant000000FB
 // CHECK:STDOUT:       inst6000005D:    constant<none>
 // CHECK:STDOUT:       inst6000005E:    concrete_constant(inst6000005E)
-// CHECK:STDOUT:       inst6000005F:    symbolic_constant25
-// CHECK:STDOUT:       inst60000060:    symbolic_constant26
-// CHECK:STDOUT:       inst60000061:    symbolic_constant27
+// CHECK:STDOUT:       inst6000005F:    symbolic_constant00000019
+// CHECK:STDOUT:       inst60000060:    symbolic_constant0000001A
+// CHECK:STDOUT:       inst60000061:    symbolic_constant0000001B
 // CHECK:STDOUT:       inst60000062:    concrete_constant(inst60000062)
 // CHECK:STDOUT:       inst60000063:    concrete_constant(inst60000063)
-// CHECK:STDOUT:       inst60000064:    symbolic_constant29
-// CHECK:STDOUT:       inst60000065:    symbolic_constant28
+// CHECK:STDOUT:       inst60000064:    symbolic_constant0000001D
+// CHECK:STDOUT:       inst60000065:    symbolic_constant0000001C
 // CHECK:STDOUT:       inst60000066:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst60000067:    constant<none>
 // CHECK:STDOUT:       inst60000068:    concrete_constant(inst60000068)
-// CHECK:STDOUT:       inst60000069:    symbolic_constant32
-// CHECK:STDOUT:       inst6000006A:    symbolic_constant34
-// CHECK:STDOUT:       inst6000006B:    symbolic_constant35
-// CHECK:STDOUT:       inst6000006C:    symbolic_constant36
-// CHECK:STDOUT:       inst6000006D:    symbolic_constant37
-// CHECK:STDOUT:       inst6000006E:    symbolic_constant40
-// CHECK:STDOUT:       inst6000006F:    symbolic_constant38
-// CHECK:STDOUT:       inst60000070:    symbolic_constant39
-// CHECK:STDOUT:       inst60000071:    symbolic_constant42
+// CHECK:STDOUT:       inst60000069:    symbolic_constant00000020
+// CHECK:STDOUT:       inst6000006A:    symbolic_constant00000022
+// CHECK:STDOUT:       inst6000006B:    symbolic_constant00000023
+// CHECK:STDOUT:       inst6000006C:    symbolic_constant00000024
+// CHECK:STDOUT:       inst6000006D:    symbolic_constant00000025
+// CHECK:STDOUT:       inst6000006E:    symbolic_constant00000028
+// CHECK:STDOUT:       inst6000006F:    symbolic_constant00000026
+// CHECK:STDOUT:       inst60000070:    symbolic_constant00000027
+// CHECK:STDOUT:       inst60000071:    symbolic_constant0000002A
 // CHECK:STDOUT:       inst60000072:    concrete_constant(inst60000072)
 // CHECK:STDOUT:       inst60000073:    concrete_constant(inst60000073)
 // CHECK:STDOUT:       inst60000074:    concrete_constant(inst60000074)
 // CHECK:STDOUT:       inst60000075:    concrete_constant(inst60000075)
-// CHECK:STDOUT:       inst60000076:    symbolic_constant29
-// CHECK:STDOUT:       inst60000077:    symbolic_constant45
-// CHECK:STDOUT:       inst60000078:    symbolic_constant46
-// CHECK:STDOUT:       inst60000079:    symbolic_constant50
-// CHECK:STDOUT:       inst6000007A:    symbolic_constant51
-// CHECK:STDOUT:       inst6000007B:    symbolic_constant52
-// CHECK:STDOUT:       inst6000007C:    symbolic_constant53
-// CHECK:STDOUT:       inst6000007D:    symbolic_constant54
-// CHECK:STDOUT:       inst6000007E:    symbolic_constant56
-// CHECK:STDOUT:       inst6000007F:    symbolic_constant58
-// CHECK:STDOUT:       inst60000080:    symbolic_constant60
-// CHECK:STDOUT:       inst60000081:    symbolic_constant62
-// CHECK:STDOUT:       inst60000082:    symbolic_constant64
-// CHECK:STDOUT:       inst60000083:    symbolic_constant66
-// CHECK:STDOUT:       inst60000084:    symbolic_constant67
-// CHECK:STDOUT:       inst60000085:    symbolic_constant68
-// CHECK:STDOUT:       inst60000086:    symbolic_constant69
-// CHECK:STDOUT:       inst60000087:    symbolic_constant70
-// CHECK:STDOUT:       inst60000088:    symbolic_constant71
-// CHECK:STDOUT:       inst60000089:    symbolic_constant72
+// CHECK:STDOUT:       inst60000076:    symbolic_constant0000001D
+// CHECK:STDOUT:       inst60000077:    symbolic_constant0000002D
+// CHECK:STDOUT:       inst60000078:    symbolic_constant0000002E
+// CHECK:STDOUT:       inst60000079:    symbolic_constant00000032
+// CHECK:STDOUT:       inst6000007A:    symbolic_constant00000033
+// CHECK:STDOUT:       inst6000007B:    symbolic_constant00000034
+// CHECK:STDOUT:       inst6000007C:    symbolic_constant00000035
+// CHECK:STDOUT:       inst6000007D:    symbolic_constant00000036
+// CHECK:STDOUT:       inst6000007E:    symbolic_constant00000038
+// CHECK:STDOUT:       inst6000007F:    symbolic_constant0000003A
+// CHECK:STDOUT:       inst60000080:    symbolic_constant0000003C
+// CHECK:STDOUT:       inst60000081:    symbolic_constant0000003E
+// CHECK:STDOUT:       inst60000082:    symbolic_constant00000040
+// CHECK:STDOUT:       inst60000083:    symbolic_constant00000042
+// CHECK:STDOUT:       inst60000084:    symbolic_constant00000043
+// CHECK:STDOUT:       inst60000085:    symbolic_constant00000044
+// CHECK:STDOUT:       inst60000086:    symbolic_constant00000045
+// CHECK:STDOUT:       inst60000087:    symbolic_constant00000046
+// CHECK:STDOUT:       inst60000088:    symbolic_constant00000047
+// CHECK:STDOUT:       inst60000089:    symbolic_constant00000048
 // CHECK:STDOUT:       inst6000008A:    constant<none>
 // CHECK:STDOUT:       inst6000008B:    concrete_constant(inst6000008B)
 // CHECK:STDOUT:       inst6000008C:    concrete_constant(inst(BoolType))
@@ -833,32 +833,32 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst60000097:    concrete_constant(inst60000097)
 // CHECK:STDOUT:       inst60000098:    concrete_constant(inst(IntLiteralType))
 // CHECK:STDOUT:       inst60000099:    concrete_constant(inst60000047)
-// CHECK:STDOUT:       inst6000009A:    symbolic_constant249
+// CHECK:STDOUT:       inst6000009A:    symbolic_constant000000F9
 // CHECK:STDOUT:       inst6000009B:    concrete_constant(inst6000009B)
 // CHECK:STDOUT:       inst6000009C:    concrete_constant(inst6000009C)
-// CHECK:STDOUT:       inst6000009D:    symbolic_constant74
-// CHECK:STDOUT:       inst6000009E:    symbolic_constant73
+// CHECK:STDOUT:       inst6000009D:    symbolic_constant0000004A
+// CHECK:STDOUT:       inst6000009E:    symbolic_constant00000049
 // CHECK:STDOUT:       inst6000009F:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst600000A0:    constant<none>
 // CHECK:STDOUT:       inst600000A1:    concrete_constant(inst600000A1)
-// CHECK:STDOUT:       inst600000A2:    symbolic_constant76
-// CHECK:STDOUT:       inst600000A3:    symbolic_constant78
-// CHECK:STDOUT:       inst600000A4:    symbolic_constant79
-// CHECK:STDOUT:       inst600000A5:    symbolic_constant80
-// CHECK:STDOUT:       inst600000A6:    symbolic_constant83
-// CHECK:STDOUT:       inst600000A7:    symbolic_constant81
-// CHECK:STDOUT:       inst600000A8:    symbolic_constant82
+// CHECK:STDOUT:       inst600000A2:    symbolic_constant0000004C
+// CHECK:STDOUT:       inst600000A3:    symbolic_constant0000004E
+// CHECK:STDOUT:       inst600000A4:    symbolic_constant0000004F
+// CHECK:STDOUT:       inst600000A5:    symbolic_constant00000050
+// CHECK:STDOUT:       inst600000A6:    symbolic_constant00000053
+// CHECK:STDOUT:       inst600000A7:    symbolic_constant00000051
+// CHECK:STDOUT:       inst600000A8:    symbolic_constant00000052
 // CHECK:STDOUT:       inst600000A9:    concrete_constant(inst600000A9)
 // CHECK:STDOUT:       inst600000AA:    concrete_constant(inst600000AA)
 // CHECK:STDOUT:       inst600000AB:    concrete_constant(inst600000AB)
 // CHECK:STDOUT:       inst600000AC:    concrete_constant(inst600000AC)
-// CHECK:STDOUT:       inst600000AD:    symbolic_constant74
-// CHECK:STDOUT:       inst600000AE:    symbolic_constant88
-// CHECK:STDOUT:       inst600000AF:    symbolic_constant89
-// CHECK:STDOUT:       inst600000B0:    symbolic_constant90
-// CHECK:STDOUT:       inst600000B1:    symbolic_constant93
-// CHECK:STDOUT:       inst600000B2:    symbolic_constant94
-// CHECK:STDOUT:       inst600000B3:    symbolic_constant95
+// CHECK:STDOUT:       inst600000AD:    symbolic_constant0000004A
+// CHECK:STDOUT:       inst600000AE:    symbolic_constant00000058
+// CHECK:STDOUT:       inst600000AF:    symbolic_constant00000059
+// CHECK:STDOUT:       inst600000B0:    symbolic_constant0000005A
+// CHECK:STDOUT:       inst600000B1:    symbolic_constant0000005D
+// CHECK:STDOUT:       inst600000B2:    symbolic_constant0000005E
+// CHECK:STDOUT:       inst600000B3:    symbolic_constant0000005F
 // CHECK:STDOUT:       inst600000B4:    constant<none>
 // CHECK:STDOUT:       inst600000B5:    concrete_constant(inst600000B5)
 // CHECK:STDOUT:       inst600000B6:    concrete_constant(inst(TypeType))
@@ -869,405 +869,405 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst600000BB:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst600000BC:    constant<none>
 // CHECK:STDOUT:       inst600000BD:    concrete_constant(inst600000BD)
-// CHECK:STDOUT:       inst600000BE:    symbolic_constant96
-// CHECK:STDOUT:       inst600000BF:    symbolic_constant97
-// CHECK:STDOUT:       inst600000C0:    symbolic_constant98
+// CHECK:STDOUT:       inst600000BE:    symbolic_constant00000060
+// CHECK:STDOUT:       inst600000BF:    symbolic_constant00000061
+// CHECK:STDOUT:       inst600000C0:    symbolic_constant00000062
 // CHECK:STDOUT:       inst600000C1:    concrete_constant(inst600000C1)
 // CHECK:STDOUT:       inst600000C2:    concrete_constant(inst600000C2)
-// CHECK:STDOUT:       inst600000C3:    symbolic_constant100
-// CHECK:STDOUT:       inst600000C4:    symbolic_constant101
-// CHECK:STDOUT:       inst600000C5:    symbolic_constant99
+// CHECK:STDOUT:       inst600000C3:    symbolic_constant00000064
+// CHECK:STDOUT:       inst600000C4:    symbolic_constant00000065
+// CHECK:STDOUT:       inst600000C5:    symbolic_constant00000063
 // CHECK:STDOUT:       inst600000C6:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst600000C7:    constant<none>
 // CHECK:STDOUT:       inst600000C8:    concrete_constant(inst600000C8)
-// CHECK:STDOUT:       inst600000C9:    symbolic_constant106
-// CHECK:STDOUT:       inst600000CA:    symbolic_constant108
-// CHECK:STDOUT:       inst600000CB:    symbolic_constant109
-// CHECK:STDOUT:       inst600000CC:    symbolic_constant110
-// CHECK:STDOUT:       inst600000CD:    symbolic_constant111
-// CHECK:STDOUT:       inst600000CE:    symbolic_constant112
-// CHECK:STDOUT:       inst600000CF:    symbolic_constant113
-// CHECK:STDOUT:       inst600000D0:    symbolic_constant116
-// CHECK:STDOUT:       inst600000D1:    symbolic_constant114
-// CHECK:STDOUT:       inst600000D2:    symbolic_constant115
-// CHECK:STDOUT:       inst600000D3:    symbolic_constant118
+// CHECK:STDOUT:       inst600000C9:    symbolic_constant0000006A
+// CHECK:STDOUT:       inst600000CA:    symbolic_constant0000006C
+// CHECK:STDOUT:       inst600000CB:    symbolic_constant0000006D
+// CHECK:STDOUT:       inst600000CC:    symbolic_constant0000006E
+// CHECK:STDOUT:       inst600000CD:    symbolic_constant0000006F
+// CHECK:STDOUT:       inst600000CE:    symbolic_constant00000070
+// CHECK:STDOUT:       inst600000CF:    symbolic_constant00000071
+// CHECK:STDOUT:       inst600000D0:    symbolic_constant00000074
+// CHECK:STDOUT:       inst600000D1:    symbolic_constant00000072
+// CHECK:STDOUT:       inst600000D2:    symbolic_constant00000073
+// CHECK:STDOUT:       inst600000D3:    symbolic_constant00000076
 // CHECK:STDOUT:       inst600000D4:    concrete_constant(inst600000D4)
 // CHECK:STDOUT:       inst600000D5:    concrete_constant(inst600000D5)
 // CHECK:STDOUT:       inst600000D6:    concrete_constant(inst600000D6)
 // CHECK:STDOUT:       inst600000D7:    concrete_constant(inst600000D7)
-// CHECK:STDOUT:       inst600000D8:    symbolic_constant100
-// CHECK:STDOUT:       inst600000D9:    symbolic_constant101
-// CHECK:STDOUT:       inst600000DA:    symbolic_constant121
-// CHECK:STDOUT:       inst600000DB:    symbolic_constant122
-// CHECK:STDOUT:       inst600000DC:    symbolic_constant128
-// CHECK:STDOUT:       inst600000DD:    symbolic_constant129
-// CHECK:STDOUT:       inst600000DE:    symbolic_constant130
-// CHECK:STDOUT:       inst600000DF:    symbolic_constant131
-// CHECK:STDOUT:       inst600000E0:    symbolic_constant132
-// CHECK:STDOUT:       inst600000E1:    symbolic_constant133
-// CHECK:STDOUT:       inst600000E2:    symbolic_constant134
-// CHECK:STDOUT:       inst600000E3:    symbolic_constant141
-// CHECK:STDOUT:       inst600000E4:    symbolic_constant143
-// CHECK:STDOUT:       inst600000E5:    symbolic_constant145
-// CHECK:STDOUT:       inst600000E6:    symbolic_constant147
-// CHECK:STDOUT:       inst600000E7:    symbolic_constant149
-// CHECK:STDOUT:       inst600000E8:    symbolic_constant151
-// CHECK:STDOUT:       inst600000E9:    symbolic_constant152
-// CHECK:STDOUT:       inst600000EA:    symbolic_constant153
-// CHECK:STDOUT:       inst600000EB:    symbolic_constant154
-// CHECK:STDOUT:       inst600000EC:    symbolic_constant155
-// CHECK:STDOUT:       inst600000ED:    symbolic_constant156
-// CHECK:STDOUT:       inst600000EE:    symbolic_constant157
-// CHECK:STDOUT:       inst600000EF:    symbolic_constant158
-// CHECK:STDOUT:       inst600000F0:    symbolic_constant159
-// CHECK:STDOUT:       inst600000F1:    symbolic_constant160
-// CHECK:STDOUT:       inst600000F2:    symbolic_constant161
-// CHECK:STDOUT:       inst600000F3:    symbolic_constant162
+// CHECK:STDOUT:       inst600000D8:    symbolic_constant00000064
+// CHECK:STDOUT:       inst600000D9:    symbolic_constant00000065
+// CHECK:STDOUT:       inst600000DA:    symbolic_constant00000079
+// CHECK:STDOUT:       inst600000DB:    symbolic_constant0000007A
+// CHECK:STDOUT:       inst600000DC:    symbolic_constant00000080
+// CHECK:STDOUT:       inst600000DD:    symbolic_constant00000081
+// CHECK:STDOUT:       inst600000DE:    symbolic_constant00000082
+// CHECK:STDOUT:       inst600000DF:    symbolic_constant00000083
+// CHECK:STDOUT:       inst600000E0:    symbolic_constant00000084
+// CHECK:STDOUT:       inst600000E1:    symbolic_constant00000085
+// CHECK:STDOUT:       inst600000E2:    symbolic_constant00000086
+// CHECK:STDOUT:       inst600000E3:    symbolic_constant0000008D
+// CHECK:STDOUT:       inst600000E4:    symbolic_constant0000008F
+// CHECK:STDOUT:       inst600000E5:    symbolic_constant00000091
+// CHECK:STDOUT:       inst600000E6:    symbolic_constant00000093
+// CHECK:STDOUT:       inst600000E7:    symbolic_constant00000095
+// CHECK:STDOUT:       inst600000E8:    symbolic_constant00000097
+// CHECK:STDOUT:       inst600000E9:    symbolic_constant00000098
+// CHECK:STDOUT:       inst600000EA:    symbolic_constant00000099
+// CHECK:STDOUT:       inst600000EB:    symbolic_constant0000009A
+// CHECK:STDOUT:       inst600000EC:    symbolic_constant0000009B
+// CHECK:STDOUT:       inst600000ED:    symbolic_constant0000009C
+// CHECK:STDOUT:       inst600000EE:    symbolic_constant0000009D
+// CHECK:STDOUT:       inst600000EF:    symbolic_constant0000009E
+// CHECK:STDOUT:       inst600000F0:    symbolic_constant0000009F
+// CHECK:STDOUT:       inst600000F1:    symbolic_constant000000A0
+// CHECK:STDOUT:       inst600000F2:    symbolic_constant000000A1
+// CHECK:STDOUT:       inst600000F3:    symbolic_constant000000A2
 // CHECK:STDOUT:       inst600000F4:    constant<none>
 // CHECK:STDOUT:       inst600000F5:    concrete_constant(inst600000F5)
-// CHECK:STDOUT:       inst600000F6:    symbolic_constant163
-// CHECK:STDOUT:       inst600000F7:    symbolic_constant164
-// CHECK:STDOUT:       inst600000F8:    symbolic_constant165
+// CHECK:STDOUT:       inst600000F6:    symbolic_constant000000A3
+// CHECK:STDOUT:       inst600000F7:    symbolic_constant000000A4
+// CHECK:STDOUT:       inst600000F8:    symbolic_constant000000A5
 // CHECK:STDOUT:       inst600000F9:    concrete_constant(inst600000F9)
 // CHECK:STDOUT:       inst600000FA:    concrete_constant(inst600000FA)
 // CHECK:STDOUT:       inst600000FB:    concrete_constant(inst600000FB)
-// CHECK:STDOUT:       inst600000FC:    symbolic_constant167
-// CHECK:STDOUT:       inst600000FD:    symbolic_constant168
-// CHECK:STDOUT:       inst600000FE:    symbolic_constant169
-// CHECK:STDOUT:       inst600000FF:    symbolic_constant166
+// CHECK:STDOUT:       inst600000FC:    symbolic_constant000000A7
+// CHECK:STDOUT:       inst600000FD:    symbolic_constant000000A8
+// CHECK:STDOUT:       inst600000FE:    symbolic_constant000000A9
+// CHECK:STDOUT:       inst600000FF:    symbolic_constant000000A6
 // CHECK:STDOUT:       inst60000100:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst60000101:    constant<none>
 // CHECK:STDOUT:       inst60000102:    concrete_constant(inst60000102)
-// CHECK:STDOUT:       inst60000103:    symbolic_constant176
-// CHECK:STDOUT:       inst60000104:    symbolic_constant178
-// CHECK:STDOUT:       inst60000105:    symbolic_constant179
-// CHECK:STDOUT:       inst60000106:    symbolic_constant180
-// CHECK:STDOUT:       inst60000107:    symbolic_constant181
-// CHECK:STDOUT:       inst60000108:    symbolic_constant182
-// CHECK:STDOUT:       inst60000109:    symbolic_constant183
-// CHECK:STDOUT:       inst6000010A:    symbolic_constant184
-// CHECK:STDOUT:       inst6000010B:    symbolic_constant185
-// CHECK:STDOUT:       inst6000010C:    symbolic_constant188
-// CHECK:STDOUT:       inst6000010D:    symbolic_constant186
-// CHECK:STDOUT:       inst6000010E:    symbolic_constant187
-// CHECK:STDOUT:       inst6000010F:    symbolic_constant190
+// CHECK:STDOUT:       inst60000103:    symbolic_constant000000B0
+// CHECK:STDOUT:       inst60000104:    symbolic_constant000000B2
+// CHECK:STDOUT:       inst60000105:    symbolic_constant000000B3
+// CHECK:STDOUT:       inst60000106:    symbolic_constant000000B4
+// CHECK:STDOUT:       inst60000107:    symbolic_constant000000B5
+// CHECK:STDOUT:       inst60000108:    symbolic_constant000000B6
+// CHECK:STDOUT:       inst60000109:    symbolic_constant000000B7
+// CHECK:STDOUT:       inst6000010A:    symbolic_constant000000B8
+// CHECK:STDOUT:       inst6000010B:    symbolic_constant000000B9
+// CHECK:STDOUT:       inst6000010C:    symbolic_constant000000BC
+// CHECK:STDOUT:       inst6000010D:    symbolic_constant000000BA
+// CHECK:STDOUT:       inst6000010E:    symbolic_constant000000BB
+// CHECK:STDOUT:       inst6000010F:    symbolic_constant000000BE
 // CHECK:STDOUT:       inst60000110:    concrete_constant(inst60000110)
 // CHECK:STDOUT:       inst60000111:    concrete_constant(inst60000111)
 // CHECK:STDOUT:       inst60000112:    concrete_constant(inst60000112)
 // CHECK:STDOUT:       inst60000113:    concrete_constant(inst60000113)
-// CHECK:STDOUT:       inst60000114:    symbolic_constant167
-// CHECK:STDOUT:       inst60000115:    symbolic_constant168
-// CHECK:STDOUT:       inst60000116:    symbolic_constant169
-// CHECK:STDOUT:       inst60000117:    symbolic_constant193
-// CHECK:STDOUT:       inst60000118:    symbolic_constant194
-// CHECK:STDOUT:       inst60000119:    symbolic_constant202
-// CHECK:STDOUT:       inst6000011A:    symbolic_constant203
-// CHECK:STDOUT:       inst6000011B:    symbolic_constant204
-// CHECK:STDOUT:       inst6000011C:    symbolic_constant205
-// CHECK:STDOUT:       inst6000011D:    symbolic_constant206
-// CHECK:STDOUT:       inst6000011E:    symbolic_constant207
-// CHECK:STDOUT:       inst6000011F:    symbolic_constant208
-// CHECK:STDOUT:       inst60000120:    symbolic_constant209
-// CHECK:STDOUT:       inst60000121:    symbolic_constant210
-// CHECK:STDOUT:       inst60000122:    symbolic_constant222
-// CHECK:STDOUT:       inst60000123:    symbolic_constant224
-// CHECK:STDOUT:       inst60000124:    symbolic_constant226
-// CHECK:STDOUT:       inst60000125:    symbolic_constant228
-// CHECK:STDOUT:       inst60000126:    symbolic_constant230
-// CHECK:STDOUT:       inst60000127:    symbolic_constant232
-// CHECK:STDOUT:       inst60000128:    symbolic_constant233
-// CHECK:STDOUT:       inst60000129:    symbolic_constant234
-// CHECK:STDOUT:       inst6000012A:    symbolic_constant235
-// CHECK:STDOUT:       inst6000012B:    symbolic_constant236
-// CHECK:STDOUT:       inst6000012C:    symbolic_constant237
-// CHECK:STDOUT:       inst6000012D:    symbolic_constant238
-// CHECK:STDOUT:       inst6000012E:    symbolic_constant239
-// CHECK:STDOUT:       inst6000012F:    symbolic_constant240
-// CHECK:STDOUT:       inst60000130:    symbolic_constant241
-// CHECK:STDOUT:       inst60000131:    symbolic_constant242
-// CHECK:STDOUT:       inst60000132:    symbolic_constant243
-// CHECK:STDOUT:       inst60000133:    symbolic_constant244
-// CHECK:STDOUT:       inst60000134:    symbolic_constant245
-// CHECK:STDOUT:       inst60000135:    symbolic_constant246
-// CHECK:STDOUT:       inst60000136:    symbolic_constant247
-// CHECK:STDOUT:       inst60000137:    symbolic_constant248
-// CHECK:STDOUT:       inst60000138:    symbolic_constant250
-// CHECK:STDOUT:       inst60000139:    symbolic_constant251
-// CHECK:STDOUT:       inst6000013A:    symbolic_constant252
-// CHECK:STDOUT:       inst6000013B:    symbolic_constant253
-// CHECK:STDOUT:       inst6000013C:    symbolic_constant257
-// CHECK:STDOUT:       inst6000013D:    symbolic_constant254
-// CHECK:STDOUT:       inst6000013E:    symbolic_constant255
-// CHECK:STDOUT:       inst6000013F:    symbolic_constant256
-// CHECK:STDOUT:       inst60000140:    symbolic_constant257
-// CHECK:STDOUT:       inst60000142:    symbolic_constant259
-// CHECK:STDOUT:       inst60000143:    symbolic_constant258
-// CHECK:STDOUT:       inst60000144:    symbolic_constant259
-// CHECK:STDOUT:       inst60000146:    symbolic_constant15
+// CHECK:STDOUT:       inst60000114:    symbolic_constant000000A7
+// CHECK:STDOUT:       inst60000115:    symbolic_constant000000A8
+// CHECK:STDOUT:       inst60000116:    symbolic_constant000000A9
+// CHECK:STDOUT:       inst60000117:    symbolic_constant000000C1
+// CHECK:STDOUT:       inst60000118:    symbolic_constant000000C2
+// CHECK:STDOUT:       inst60000119:    symbolic_constant000000CA
+// CHECK:STDOUT:       inst6000011A:    symbolic_constant000000CB
+// CHECK:STDOUT:       inst6000011B:    symbolic_constant000000CC
+// CHECK:STDOUT:       inst6000011C:    symbolic_constant000000CD
+// CHECK:STDOUT:       inst6000011D:    symbolic_constant000000CE
+// CHECK:STDOUT:       inst6000011E:    symbolic_constant000000CF
+// CHECK:STDOUT:       inst6000011F:    symbolic_constant000000D0
+// CHECK:STDOUT:       inst60000120:    symbolic_constant000000D1
+// CHECK:STDOUT:       inst60000121:    symbolic_constant000000D2
+// CHECK:STDOUT:       inst60000122:    symbolic_constant000000DE
+// CHECK:STDOUT:       inst60000123:    symbolic_constant000000E0
+// CHECK:STDOUT:       inst60000124:    symbolic_constant000000E2
+// CHECK:STDOUT:       inst60000125:    symbolic_constant000000E4
+// CHECK:STDOUT:       inst60000126:    symbolic_constant000000E6
+// CHECK:STDOUT:       inst60000127:    symbolic_constant000000E8
+// CHECK:STDOUT:       inst60000128:    symbolic_constant000000E9
+// CHECK:STDOUT:       inst60000129:    symbolic_constant000000EA
+// CHECK:STDOUT:       inst6000012A:    symbolic_constant000000EB
+// CHECK:STDOUT:       inst6000012B:    symbolic_constant000000EC
+// CHECK:STDOUT:       inst6000012C:    symbolic_constant000000ED
+// CHECK:STDOUT:       inst6000012D:    symbolic_constant000000EE
+// CHECK:STDOUT:       inst6000012E:    symbolic_constant000000EF
+// CHECK:STDOUT:       inst6000012F:    symbolic_constant000000F0
+// CHECK:STDOUT:       inst60000130:    symbolic_constant000000F1
+// CHECK:STDOUT:       inst60000131:    symbolic_constant000000F2
+// CHECK:STDOUT:       inst60000132:    symbolic_constant000000F3
+// CHECK:STDOUT:       inst60000133:    symbolic_constant000000F4
+// CHECK:STDOUT:       inst60000134:    symbolic_constant000000F5
+// CHECK:STDOUT:       inst60000135:    symbolic_constant000000F6
+// CHECK:STDOUT:       inst60000136:    symbolic_constant000000F7
+// CHECK:STDOUT:       inst60000137:    symbolic_constant000000F8
+// CHECK:STDOUT:       inst60000138:    symbolic_constant000000FA
+// CHECK:STDOUT:       inst60000139:    symbolic_constant000000FB
+// CHECK:STDOUT:       inst6000013A:    symbolic_constant000000FC
+// CHECK:STDOUT:       inst6000013B:    symbolic_constant000000FD
+// CHECK:STDOUT:       inst6000013C:    symbolic_constant00000101
+// CHECK:STDOUT:       inst6000013D:    symbolic_constant000000FE
+// CHECK:STDOUT:       inst6000013E:    symbolic_constant000000FF
+// CHECK:STDOUT:       inst6000013F:    symbolic_constant00000100
+// CHECK:STDOUT:       inst60000140:    symbolic_constant00000101
+// CHECK:STDOUT:       inst60000142:    symbolic_constant00000103
+// CHECK:STDOUT:       inst60000143:    symbolic_constant00000102
+// CHECK:STDOUT:       inst60000144:    symbolic_constant00000103
+// CHECK:STDOUT:       inst60000146:    symbolic_constant0000000F
 // CHECK:STDOUT:       inst6000014A:    concrete_constant(inst6000014B)
 // CHECK:STDOUT:       inst6000014B:    concrete_constant(inst6000014B)
 // CHECK:STDOUT:       inst6000014C:    concrete_constant(inst6000014B)
 // CHECK:STDOUT:     symbolic_constants:
-// CHECK:STDOUT:       symbolic_constant0: {inst: inst60000013, generic: generic<none>, index: generic_inst<none>, kind: self}
-// CHECK:STDOUT:       symbolic_constant1: {inst: inst60000015, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant2: {inst: inst60000015, generic: generic0, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant3: {inst: inst6000001B, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant4: {inst: inst6000001B, generic: generic0, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant5: {inst: inst6000001E, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6: {inst: inst6000001E, generic: generic0, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant7: {inst: inst6000002A, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant8: {inst: inst6000002A, generic: generic0, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant9: {inst: inst6000002D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant10: {inst: inst6000002D, generic: generic0, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant11: {inst: inst60000038, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant12: {inst: inst6000003A, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant13: {inst: inst6000003A, generic: generic0, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant14: {inst: inst6000003D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant15: {inst: inst6000003D, generic: generic0, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant16: {inst: inst60000048, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant17: {inst: inst60000052, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant18: {inst: inst60000053, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant19: {inst: inst60000053, generic: generic1, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant20: {inst: inst60000048, generic: generic1, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant21: {inst: inst60000052, generic: generic1, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant22: {inst: inst60000048, generic: generic1, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant23: {inst: inst60000052, generic: generic1, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant24: {inst: inst60000053, generic: generic1, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant25: {inst: inst6000005F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant26: {inst: inst60000060, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant27: {inst: inst60000061, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant28: {inst: inst60000061, generic: generic2, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant29: {inst: inst6000005F, generic: generic2, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant30: {inst: inst6000005F, generic: generic2, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant31: {inst: inst60000060, generic: generic2, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant32: {inst: inst60000069, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant33: {inst: inst60000069, generic: generic2, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant34: {inst: inst6000005F, generic: generic2, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant35: {inst: inst60000060, generic: generic2, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant36: {inst: inst60000061, generic: generic2, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant37: {inst: inst60000069, generic: generic2, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant38: {inst: inst6000006F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant39: {inst: inst60000070, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant40: {inst: inst60000070, generic: generic2, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant41: {inst: inst6000006F, generic: generic2, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant42: {inst: inst60000071, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant43: {inst: inst60000071, generic: generic3, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant44: {inst: inst60000070, generic: generic2, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant45: {inst: inst6000006F, generic: generic2, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant46: {inst: inst60000070, generic: generic2, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant47: {inst: inst6000005F, generic: generic3, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant48: {inst: inst60000060, generic: generic3, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant49: {inst: inst60000061, generic: generic3, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant50: {inst: inst6000005F, generic: generic3, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant51: {inst: inst60000060, generic: generic3, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant52: {inst: inst60000061, generic: generic3, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant53: {inst: inst60000071, generic: generic3, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant54: {inst: inst6000007D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant55: {inst: inst6000007D, generic: generic3, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant56: {inst: inst6000007E, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant57: {inst: inst6000007E, generic: generic3, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant58: {inst: inst6000007F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant59: {inst: inst6000007F, generic: generic3, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60: {inst: inst60000080, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant61: {inst: inst60000080, generic: generic3, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant62: {inst: inst60000081, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant63: {inst: inst60000081, generic: generic3, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant64: {inst: inst60000082, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant65: {inst: inst60000082, generic: generic3, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant66: {inst: inst6000007D, generic: generic3, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant67: {inst: inst6000007E, generic: generic3, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant68: {inst: inst6000007F, generic: generic3, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant69: {inst: inst60000080, generic: generic3, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant70: {inst: inst60000081, generic: generic3, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant71: {inst: inst60000082, generic: generic3, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant72: {inst: inst60000089, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant73: {inst: inst6000001B, generic: generic4, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant74: {inst: inst60000015, generic: generic4, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant75: {inst: inst60000015, generic: generic4, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant76: {inst: inst600000A2, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant77: {inst: inst600000A2, generic: generic4, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant78: {inst: inst60000015, generic: generic4, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant79: {inst: inst6000001B, generic: generic4, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant80: {inst: inst600000A2, generic: generic4, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant81: {inst: inst600000A7, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant82: {inst: inst600000A8, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant83: {inst: inst600000A8, generic: generic4, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant84: {inst: inst600000A7, generic: generic4, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant85: {inst: inst6000001E, generic: generic5, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant86: {inst: inst600000A8, generic: generic4, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant87: {inst: inst6000003D, generic: generic4, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant88: {inst: inst600000A7, generic: generic4, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant89: {inst: inst600000A8, generic: generic4, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant90: {inst: inst6000003D, generic: generic4, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant91: {inst: inst60000015, generic: generic5, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant92: {inst: inst6000001B, generic: generic5, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant93: {inst: inst60000015, generic: generic5, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant94: {inst: inst6000001B, generic: generic5, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant95: {inst: inst6000001E, generic: generic5, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant96: {inst: inst600000BE, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant97: {inst: inst600000BF, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant98: {inst: inst600000C0, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant99: {inst: inst600000C0, generic: generic6, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant100: {inst: inst6000005F, generic: generic6, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant101: {inst: inst600000BE, generic: generic6, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant102: {inst: inst6000005F, generic: generic6, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant103: {inst: inst600000BE, generic: generic6, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant104: {inst: inst60000060, generic: generic6, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant105: {inst: inst600000BF, generic: generic6, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant106: {inst: inst600000C9, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant107: {inst: inst600000C9, generic: generic6, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant108: {inst: inst6000005F, generic: generic6, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant109: {inst: inst600000BE, generic: generic6, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant110: {inst: inst60000060, generic: generic6, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant111: {inst: inst600000BF, generic: generic6, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant112: {inst: inst600000C0, generic: generic6, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant113: {inst: inst600000C9, generic: generic6, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant114: {inst: inst600000D1, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant115: {inst: inst600000D2, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant116: {inst: inst600000D2, generic: generic6, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant117: {inst: inst600000D1, generic: generic6, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant118: {inst: inst600000D3, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant119: {inst: inst600000D3, generic: generic7, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant120: {inst: inst600000D2, generic: generic6, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant121: {inst: inst600000D1, generic: generic6, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant122: {inst: inst600000D2, generic: generic6, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant123: {inst: inst6000005F, generic: generic7, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant124: {inst: inst60000060, generic: generic7, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant125: {inst: inst600000BE, generic: generic7, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant126: {inst: inst600000BF, generic: generic7, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant127: {inst: inst600000C0, generic: generic7, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant128: {inst: inst6000005F, generic: generic7, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant129: {inst: inst60000060, generic: generic7, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant130: {inst: inst600000BE, generic: generic7, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant131: {inst: inst600000BF, generic: generic7, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant132: {inst: inst600000C0, generic: generic7, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant133: {inst: inst600000D3, generic: generic7, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant134: {inst: inst600000E2, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant135: {inst: inst600000E2, generic: generic7, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant136: {inst: inst6000007E, generic: generic7, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant137: {inst: inst6000007F, generic: generic7, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant138: {inst: inst60000080, generic: generic7, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant139: {inst: inst60000081, generic: generic7, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant140: {inst: inst60000082, generic: generic7, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant141: {inst: inst600000E3, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant142: {inst: inst600000E3, generic: generic7, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant143: {inst: inst600000E4, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant144: {inst: inst600000E4, generic: generic7, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant145: {inst: inst600000E5, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant146: {inst: inst600000E5, generic: generic7, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant147: {inst: inst600000E6, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant148: {inst: inst600000E6, generic: generic7, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant149: {inst: inst600000E7, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant150: {inst: inst600000E7, generic: generic7, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant151: {inst: inst600000E2, generic: generic7, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant152: {inst: inst6000007E, generic: generic7, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant153: {inst: inst6000007F, generic: generic7, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant154: {inst: inst60000080, generic: generic7, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant155: {inst: inst60000081, generic: generic7, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant156: {inst: inst60000082, generic: generic7, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant157: {inst: inst600000E3, generic: generic7, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant158: {inst: inst600000E4, generic: generic7, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant159: {inst: inst600000E5, generic: generic7, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant160: {inst: inst600000E6, generic: generic7, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant161: {inst: inst600000E7, generic: generic7, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant162: {inst: inst600000F3, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant163: {inst: inst600000F6, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant164: {inst: inst600000F7, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant165: {inst: inst600000F8, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant166: {inst: inst600000F8, generic: generic8, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant167: {inst: inst6000005F, generic: generic8, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant168: {inst: inst600000BE, generic: generic8, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant169: {inst: inst600000F6, generic: generic8, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant170: {inst: inst6000005F, generic: generic8, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant171: {inst: inst600000BE, generic: generic8, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant172: {inst: inst600000F6, generic: generic8, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant173: {inst: inst60000060, generic: generic8, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant174: {inst: inst600000BF, generic: generic8, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant175: {inst: inst600000F7, generic: generic8, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant176: {inst: inst60000103, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant177: {inst: inst60000103, generic: generic8, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant178: {inst: inst6000005F, generic: generic8, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant179: {inst: inst600000BE, generic: generic8, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant180: {inst: inst600000F6, generic: generic8, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant181: {inst: inst60000060, generic: generic8, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant182: {inst: inst600000BF, generic: generic8, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant183: {inst: inst600000F7, generic: generic8, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant184: {inst: inst600000F8, generic: generic8, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant185: {inst: inst60000103, generic: generic8, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant186: {inst: inst6000010D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant187: {inst: inst6000010E, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant188: {inst: inst6000010E, generic: generic8, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant189: {inst: inst6000010D, generic: generic8, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant190: {inst: inst6000010F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant191: {inst: inst6000010F, generic: generic9, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant192: {inst: inst6000010E, generic: generic8, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant193: {inst: inst6000010D, generic: generic8, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant194: {inst: inst6000010E, generic: generic8, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant195: {inst: inst6000005F, generic: generic9, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant196: {inst: inst60000060, generic: generic9, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant197: {inst: inst600000BE, generic: generic9, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant198: {inst: inst600000BF, generic: generic9, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant199: {inst: inst600000F6, generic: generic9, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant200: {inst: inst600000F7, generic: generic9, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant201: {inst: inst600000F8, generic: generic9, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant202: {inst: inst6000005F, generic: generic9, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant203: {inst: inst60000060, generic: generic9, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant204: {inst: inst600000BE, generic: generic9, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant205: {inst: inst600000BF, generic: generic9, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant206: {inst: inst600000F6, generic: generic9, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant207: {inst: inst600000F7, generic: generic9, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant208: {inst: inst600000F8, generic: generic9, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant209: {inst: inst6000010F, generic: generic9, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant210: {inst: inst60000121, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant211: {inst: inst60000121, generic: generic9, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant212: {inst: inst6000007E, generic: generic9, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant213: {inst: inst6000007F, generic: generic9, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant214: {inst: inst60000080, generic: generic9, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant215: {inst: inst60000081, generic: generic9, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant216: {inst: inst60000082, generic: generic9, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant217: {inst: inst600000E3, generic: generic9, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant218: {inst: inst600000E4, generic: generic9, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant219: {inst: inst600000E5, generic: generic9, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant220: {inst: inst600000E6, generic: generic9, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant221: {inst: inst600000E7, generic: generic9, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant222: {inst: inst60000122, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant223: {inst: inst60000122, generic: generic9, index: generic_inst_in_def11, kind: checked}
-// CHECK:STDOUT:       symbolic_constant224: {inst: inst60000123, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant225: {inst: inst60000123, generic: generic9, index: generic_inst_in_def12, kind: checked}
-// CHECK:STDOUT:       symbolic_constant226: {inst: inst60000124, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant227: {inst: inst60000124, generic: generic9, index: generic_inst_in_def13, kind: checked}
-// CHECK:STDOUT:       symbolic_constant228: {inst: inst60000125, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant229: {inst: inst60000125, generic: generic9, index: generic_inst_in_def14, kind: checked}
-// CHECK:STDOUT:       symbolic_constant230: {inst: inst60000126, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant231: {inst: inst60000126, generic: generic9, index: generic_inst_in_def15, kind: checked}
-// CHECK:STDOUT:       symbolic_constant232: {inst: inst60000121, generic: generic9, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant233: {inst: inst6000007E, generic: generic9, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant234: {inst: inst6000007F, generic: generic9, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant235: {inst: inst60000080, generic: generic9, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant236: {inst: inst60000081, generic: generic9, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant237: {inst: inst60000082, generic: generic9, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant238: {inst: inst600000E3, generic: generic9, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant239: {inst: inst600000E4, generic: generic9, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant240: {inst: inst600000E5, generic: generic9, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant241: {inst: inst600000E6, generic: generic9, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant242: {inst: inst600000E7, generic: generic9, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant243: {inst: inst60000122, generic: generic9, index: generic_inst_in_def11, kind: checked}
-// CHECK:STDOUT:       symbolic_constant244: {inst: inst60000123, generic: generic9, index: generic_inst_in_def12, kind: checked}
-// CHECK:STDOUT:       symbolic_constant245: {inst: inst60000124, generic: generic9, index: generic_inst_in_def13, kind: checked}
-// CHECK:STDOUT:       symbolic_constant246: {inst: inst60000125, generic: generic9, index: generic_inst_in_def14, kind: checked}
-// CHECK:STDOUT:       symbolic_constant247: {inst: inst60000126, generic: generic9, index: generic_inst_in_def15, kind: checked}
-// CHECK:STDOUT:       symbolic_constant248: {inst: inst60000137, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant249: {inst: inst600000A2, generic: generic4, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant250: {inst: inst60000138, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant251: {inst: inst60000138, generic: generic0, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant252: {inst: inst6000013A, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant253: {inst: inst6000013B, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant254: {inst: inst6000013D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant255: {inst: inst6000013A, generic: generic0, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant256: {inst: inst6000013B, generic: generic0, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant257: {inst: inst6000013D, generic: generic0, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant258: {inst: inst60000143, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant259: {inst: inst60000143, generic: generic0, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000000: {inst: inst60000013, generic: generic<none>, index: generic_inst<none>, kind: self}
+// CHECK:STDOUT:       symbolic_constant00000001: {inst: inst60000015, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000002: {inst: inst60000015, generic: generic00000000, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000003: {inst: inst6000001B, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000004: {inst: inst6000001B, generic: generic00000000, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000005: {inst: inst6000001E, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000006: {inst: inst6000001E, generic: generic00000000, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000007: {inst: inst6000002A, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000008: {inst: inst6000002A, generic: generic00000000, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000009: {inst: inst6000002D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000000A: {inst: inst6000002D, generic: generic00000000, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000000B: {inst: inst60000038, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000000C: {inst: inst6000003A, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000000D: {inst: inst6000003A, generic: generic00000000, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000000E: {inst: inst6000003D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000000F: {inst: inst6000003D, generic: generic00000000, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000010: {inst: inst60000048, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000011: {inst: inst60000052, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000012: {inst: inst60000053, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000013: {inst: inst60000053, generic: generic00000001, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000014: {inst: inst60000048, generic: generic00000001, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000015: {inst: inst60000052, generic: generic00000001, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000016: {inst: inst60000048, generic: generic00000001, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000017: {inst: inst60000052, generic: generic00000001, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000018: {inst: inst60000053, generic: generic00000001, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000019: {inst: inst6000005F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000001A: {inst: inst60000060, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000001B: {inst: inst60000061, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000001C: {inst: inst60000061, generic: generic00000002, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000001D: {inst: inst6000005F, generic: generic00000002, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000001E: {inst: inst6000005F, generic: generic00000002, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000001F: {inst: inst60000060, generic: generic00000002, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000020: {inst: inst60000069, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000021: {inst: inst60000069, generic: generic00000002, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000022: {inst: inst6000005F, generic: generic00000002, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000023: {inst: inst60000060, generic: generic00000002, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000024: {inst: inst60000061, generic: generic00000002, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000025: {inst: inst60000069, generic: generic00000002, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000026: {inst: inst6000006F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000027: {inst: inst60000070, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000028: {inst: inst60000070, generic: generic00000002, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000029: {inst: inst6000006F, generic: generic00000002, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000002A: {inst: inst60000071, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000002B: {inst: inst60000071, generic: generic00000003, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000002C: {inst: inst60000070, generic: generic00000002, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000002D: {inst: inst6000006F, generic: generic00000002, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000002E: {inst: inst60000070, generic: generic00000002, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000002F: {inst: inst6000005F, generic: generic00000003, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000030: {inst: inst60000060, generic: generic00000003, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000031: {inst: inst60000061, generic: generic00000003, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000032: {inst: inst6000005F, generic: generic00000003, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000033: {inst: inst60000060, generic: generic00000003, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000034: {inst: inst60000061, generic: generic00000003, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000035: {inst: inst60000071, generic: generic00000003, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000036: {inst: inst6000007D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000037: {inst: inst6000007D, generic: generic00000003, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000038: {inst: inst6000007E, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000039: {inst: inst6000007E, generic: generic00000003, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000003A: {inst: inst6000007F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000003B: {inst: inst6000007F, generic: generic00000003, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000003C: {inst: inst60000080, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000003D: {inst: inst60000080, generic: generic00000003, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000003E: {inst: inst60000081, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000003F: {inst: inst60000081, generic: generic00000003, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000040: {inst: inst60000082, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000041: {inst: inst60000082, generic: generic00000003, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000042: {inst: inst6000007D, generic: generic00000003, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000043: {inst: inst6000007E, generic: generic00000003, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000044: {inst: inst6000007F, generic: generic00000003, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000045: {inst: inst60000080, generic: generic00000003, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000046: {inst: inst60000081, generic: generic00000003, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000047: {inst: inst60000082, generic: generic00000003, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000048: {inst: inst60000089, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000049: {inst: inst6000001B, generic: generic00000004, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000004A: {inst: inst60000015, generic: generic00000004, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000004B: {inst: inst60000015, generic: generic00000004, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000004C: {inst: inst600000A2, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000004D: {inst: inst600000A2, generic: generic00000004, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000004E: {inst: inst60000015, generic: generic00000004, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000004F: {inst: inst6000001B, generic: generic00000004, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000050: {inst: inst600000A2, generic: generic00000004, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000051: {inst: inst600000A7, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000052: {inst: inst600000A8, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000053: {inst: inst600000A8, generic: generic00000004, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000054: {inst: inst600000A7, generic: generic00000004, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000055: {inst: inst6000001E, generic: generic00000005, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000056: {inst: inst600000A8, generic: generic00000004, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000057: {inst: inst6000003D, generic: generic00000004, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000058: {inst: inst600000A7, generic: generic00000004, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000059: {inst: inst600000A8, generic: generic00000004, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000005A: {inst: inst6000003D, generic: generic00000004, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000005B: {inst: inst60000015, generic: generic00000005, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000005C: {inst: inst6000001B, generic: generic00000005, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000005D: {inst: inst60000015, generic: generic00000005, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000005E: {inst: inst6000001B, generic: generic00000005, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000005F: {inst: inst6000001E, generic: generic00000005, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000060: {inst: inst600000BE, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000061: {inst: inst600000BF, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000062: {inst: inst600000C0, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000063: {inst: inst600000C0, generic: generic00000006, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000064: {inst: inst6000005F, generic: generic00000006, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000065: {inst: inst600000BE, generic: generic00000006, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000066: {inst: inst6000005F, generic: generic00000006, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000067: {inst: inst600000BE, generic: generic00000006, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000068: {inst: inst60000060, generic: generic00000006, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000069: {inst: inst600000BF, generic: generic00000006, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000006A: {inst: inst600000C9, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000006B: {inst: inst600000C9, generic: generic00000006, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000006C: {inst: inst6000005F, generic: generic00000006, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000006D: {inst: inst600000BE, generic: generic00000006, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000006E: {inst: inst60000060, generic: generic00000006, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000006F: {inst: inst600000BF, generic: generic00000006, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000070: {inst: inst600000C0, generic: generic00000006, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000071: {inst: inst600000C9, generic: generic00000006, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000072: {inst: inst600000D1, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000073: {inst: inst600000D2, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000074: {inst: inst600000D2, generic: generic00000006, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000075: {inst: inst600000D1, generic: generic00000006, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000076: {inst: inst600000D3, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000077: {inst: inst600000D3, generic: generic00000007, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000078: {inst: inst600000D2, generic: generic00000006, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000079: {inst: inst600000D1, generic: generic00000006, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000007A: {inst: inst600000D2, generic: generic00000006, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000007B: {inst: inst6000005F, generic: generic00000007, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000007C: {inst: inst60000060, generic: generic00000007, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000007D: {inst: inst600000BE, generic: generic00000007, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000007E: {inst: inst600000BF, generic: generic00000007, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000007F: {inst: inst600000C0, generic: generic00000007, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000080: {inst: inst6000005F, generic: generic00000007, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000081: {inst: inst60000060, generic: generic00000007, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000082: {inst: inst600000BE, generic: generic00000007, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000083: {inst: inst600000BF, generic: generic00000007, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000084: {inst: inst600000C0, generic: generic00000007, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000085: {inst: inst600000D3, generic: generic00000007, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000086: {inst: inst600000E2, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000087: {inst: inst600000E2, generic: generic00000007, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000088: {inst: inst6000007E, generic: generic00000007, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000089: {inst: inst6000007F, generic: generic00000007, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000008A: {inst: inst60000080, generic: generic00000007, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000008B: {inst: inst60000081, generic: generic00000007, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000008C: {inst: inst60000082, generic: generic00000007, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000008D: {inst: inst600000E3, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000008E: {inst: inst600000E3, generic: generic00000007, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000008F: {inst: inst600000E4, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000090: {inst: inst600000E4, generic: generic00000007, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000091: {inst: inst600000E5, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000092: {inst: inst600000E5, generic: generic00000007, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000093: {inst: inst600000E6, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000094: {inst: inst600000E6, generic: generic00000007, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000095: {inst: inst600000E7, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000096: {inst: inst600000E7, generic: generic00000007, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000097: {inst: inst600000E2, generic: generic00000007, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000098: {inst: inst6000007E, generic: generic00000007, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000099: {inst: inst6000007F, generic: generic00000007, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000009A: {inst: inst60000080, generic: generic00000007, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000009B: {inst: inst60000081, generic: generic00000007, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000009C: {inst: inst60000082, generic: generic00000007, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000009D: {inst: inst600000E3, generic: generic00000007, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000009E: {inst: inst600000E4, generic: generic00000007, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant0000009F: {inst: inst600000E5, generic: generic00000007, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A0: {inst: inst600000E6, generic: generic00000007, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A1: {inst: inst600000E7, generic: generic00000007, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A2: {inst: inst600000F3, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A3: {inst: inst600000F6, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A4: {inst: inst600000F7, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A5: {inst: inst600000F8, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A6: {inst: inst600000F8, generic: generic00000008, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A7: {inst: inst6000005F, generic: generic00000008, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A8: {inst: inst600000BE, generic: generic00000008, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000A9: {inst: inst600000F6, generic: generic00000008, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000AA: {inst: inst6000005F, generic: generic00000008, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000AB: {inst: inst600000BE, generic: generic00000008, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000AC: {inst: inst600000F6, generic: generic00000008, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000AD: {inst: inst60000060, generic: generic00000008, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000AE: {inst: inst600000BF, generic: generic00000008, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000AF: {inst: inst600000F7, generic: generic00000008, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B0: {inst: inst60000103, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B1: {inst: inst60000103, generic: generic00000008, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B2: {inst: inst6000005F, generic: generic00000008, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B3: {inst: inst600000BE, generic: generic00000008, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B4: {inst: inst600000F6, generic: generic00000008, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B5: {inst: inst60000060, generic: generic00000008, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B6: {inst: inst600000BF, generic: generic00000008, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B7: {inst: inst600000F7, generic: generic00000008, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B8: {inst: inst600000F8, generic: generic00000008, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000B9: {inst: inst60000103, generic: generic00000008, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000BA: {inst: inst6000010D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000BB: {inst: inst6000010E, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000BC: {inst: inst6000010E, generic: generic00000008, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000BD: {inst: inst6000010D, generic: generic00000008, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000BE: {inst: inst6000010F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000BF: {inst: inst6000010F, generic: generic00000009, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C0: {inst: inst6000010E, generic: generic00000008, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C1: {inst: inst6000010D, generic: generic00000008, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C2: {inst: inst6000010E, generic: generic00000008, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C3: {inst: inst6000005F, generic: generic00000009, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C4: {inst: inst60000060, generic: generic00000009, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C5: {inst: inst600000BE, generic: generic00000009, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C6: {inst: inst600000BF, generic: generic00000009, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C7: {inst: inst600000F6, generic: generic00000009, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C8: {inst: inst600000F7, generic: generic00000009, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000C9: {inst: inst600000F8, generic: generic00000009, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000CA: {inst: inst6000005F, generic: generic00000009, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000CB: {inst: inst60000060, generic: generic00000009, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000CC: {inst: inst600000BE, generic: generic00000009, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000CD: {inst: inst600000BF, generic: generic00000009, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000CE: {inst: inst600000F6, generic: generic00000009, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000CF: {inst: inst600000F7, generic: generic00000009, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D0: {inst: inst600000F8, generic: generic00000009, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D1: {inst: inst6000010F, generic: generic00000009, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D2: {inst: inst60000121, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D3: {inst: inst60000121, generic: generic00000009, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D4: {inst: inst6000007E, generic: generic00000009, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D5: {inst: inst6000007F, generic: generic00000009, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D6: {inst: inst60000080, generic: generic00000009, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D7: {inst: inst60000081, generic: generic00000009, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D8: {inst: inst60000082, generic: generic00000009, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000D9: {inst: inst600000E3, generic: generic00000009, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000DA: {inst: inst600000E4, generic: generic00000009, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000DB: {inst: inst600000E5, generic: generic00000009, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000DC: {inst: inst600000E6, generic: generic00000009, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000DD: {inst: inst600000E7, generic: generic00000009, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000DE: {inst: inst60000122, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000DF: {inst: inst60000122, generic: generic00000009, index: generic_inst_in_def11, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E0: {inst: inst60000123, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E1: {inst: inst60000123, generic: generic00000009, index: generic_inst_in_def12, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E2: {inst: inst60000124, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E3: {inst: inst60000124, generic: generic00000009, index: generic_inst_in_def13, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E4: {inst: inst60000125, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E5: {inst: inst60000125, generic: generic00000009, index: generic_inst_in_def14, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E6: {inst: inst60000126, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E7: {inst: inst60000126, generic: generic00000009, index: generic_inst_in_def15, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E8: {inst: inst60000121, generic: generic00000009, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000E9: {inst: inst6000007E, generic: generic00000009, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000EA: {inst: inst6000007F, generic: generic00000009, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000EB: {inst: inst60000080, generic: generic00000009, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000EC: {inst: inst60000081, generic: generic00000009, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000ED: {inst: inst60000082, generic: generic00000009, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000EE: {inst: inst600000E3, generic: generic00000009, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000EF: {inst: inst600000E4, generic: generic00000009, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F0: {inst: inst600000E5, generic: generic00000009, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F1: {inst: inst600000E6, generic: generic00000009, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F2: {inst: inst600000E7, generic: generic00000009, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F3: {inst: inst60000122, generic: generic00000009, index: generic_inst_in_def11, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F4: {inst: inst60000123, generic: generic00000009, index: generic_inst_in_def12, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F5: {inst: inst60000124, generic: generic00000009, index: generic_inst_in_def13, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F6: {inst: inst60000125, generic: generic00000009, index: generic_inst_in_def14, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F7: {inst: inst60000126, generic: generic00000009, index: generic_inst_in_def15, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F8: {inst: inst60000137, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000F9: {inst: inst600000A2, generic: generic00000004, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000FA: {inst: inst60000138, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000FB: {inst: inst60000138, generic: generic00000000, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000FC: {inst: inst6000013A, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000FD: {inst: inst6000013B, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000FE: {inst: inst6000013D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant000000FF: {inst: inst6000013A, generic: generic00000000, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000100: {inst: inst6000013B, generic: generic00000000, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000101: {inst: inst6000013D, generic: generic00000000, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000102: {inst: inst60000143, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant00000103: {inst: inst60000143, generic: generic00000000, index: generic_inst_in_def6, kind: checked}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
@@ -1376,40 +1376,40 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       100:             inst60000115
 // CHECK:STDOUT:       101:             inst60000116
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:
+// CHECK:STDOUT:     inst_block00000004:
 // CHECK:STDOUT:       0:               inst60000012
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst60000018
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst60000019
 // CHECK:STDOUT:       1:               inst6000001A
-// CHECK:STDOUT:     inst_block7:
+// CHECK:STDOUT:     inst_block00000007:
 // CHECK:STDOUT:       0:               inst60000021
-// CHECK:STDOUT:     inst_block8:
+// CHECK:STDOUT:     inst_block00000008:
 // CHECK:STDOUT:       0:               inst60000023
 // CHECK:STDOUT:       1:               inst60000025
-// CHECK:STDOUT:     inst_block9:
+// CHECK:STDOUT:     inst_block00000009:
 // CHECK:STDOUT:       0:               inst(TypeType)
 // CHECK:STDOUT:       1:               inst60000024
-// CHECK:STDOUT:     inst_block10:
+// CHECK:STDOUT:     inst_block0000000A:
 // CHECK:STDOUT:       0:               inst60000023
 // CHECK:STDOUT:       1:               inst60000029
-// CHECK:STDOUT:     inst_block11:
+// CHECK:STDOUT:     inst_block0000000B:
 // CHECK:STDOUT:       0:               inst6000001B
 // CHECK:STDOUT:       1:               inst60000024
-// CHECK:STDOUT:     inst_block12:
+// CHECK:STDOUT:     inst_block0000000C:
 // CHECK:STDOUT:       0:               inst6000001C
 // CHECK:STDOUT:       1:               inst60000024
-// CHECK:STDOUT:     inst_block13:
+// CHECK:STDOUT:     inst_block0000000D:
 // CHECK:STDOUT:       0:               inst60000031
 // CHECK:STDOUT:       1:               inst60000033
-// CHECK:STDOUT:     inst_block14:
+// CHECK:STDOUT:     inst_block0000000E:
 // CHECK:STDOUT:       0:               inst60000018
 // CHECK:STDOUT:       1:               inst6000001F
 // CHECK:STDOUT:       2:               inst60000021
 // CHECK:STDOUT:       3:               inst6000002E
 // CHECK:STDOUT:       4:               inst60000030
-// CHECK:STDOUT:     inst_block15:
+// CHECK:STDOUT:     inst_block0000000F:
 // CHECK:STDOUT:       0:               inst60000022
 // CHECK:STDOUT:       1:               inst60000023
 // CHECK:STDOUT:       2:               inst60000025
@@ -1423,23 +1423,23 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       10:              inst6000001D
 // CHECK:STDOUT:       11:              inst60000033
 // CHECK:STDOUT:       12:              inst60000034
-// CHECK:STDOUT:     inst_block16:
+// CHECK:STDOUT:     inst_block00000010:
 // CHECK:STDOUT:       0:               inst60000014
-// CHECK:STDOUT:     inst_block17:
+// CHECK:STDOUT:     inst_block00000011:
 // CHECK:STDOUT:       0:               inst60000015
-// CHECK:STDOUT:     inst_block18:
+// CHECK:STDOUT:     inst_block00000012:
 // CHECK:STDOUT:       0:               inst60000016
 // CHECK:STDOUT:       1:               inst6000001C
 // CHECK:STDOUT:       2:               inst60000020
 // CHECK:STDOUT:       3:               inst6000002C
 // CHECK:STDOUT:       4:               inst6000002F
-// CHECK:STDOUT:     inst_block19:
+// CHECK:STDOUT:     inst_block00000013:
 // CHECK:STDOUT:       0:               inst60000015
 // CHECK:STDOUT:       1:               inst6000001B
 // CHECK:STDOUT:       2:               inst6000001E
 // CHECK:STDOUT:       3:               inst6000002A
 // CHECK:STDOUT:       4:               inst6000002D
-// CHECK:STDOUT:     inst_block20:
+// CHECK:STDOUT:     inst_block00000014:
 // CHECK:STDOUT:       0:               inst6000003F
 // CHECK:STDOUT:       1:               inst60000040
 // CHECK:STDOUT:       2:               inst60000041
@@ -1456,183 +1456,183 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       13:              inst6000014D
 // CHECK:STDOUT:       14:              inst6000014E
 // CHECK:STDOUT:       15:              inst6000014F
-// CHECK:STDOUT:     inst_block21:
+// CHECK:STDOUT:     inst_block00000015:
 // CHECK:STDOUT:       0:               inst6000003F
 // CHECK:STDOUT:       1:               inst60000040
-// CHECK:STDOUT:     inst_block22:
+// CHECK:STDOUT:     inst_block00000016:
 // CHECK:STDOUT:       0:               inst6000004B
-// CHECK:STDOUT:     inst_block23:
+// CHECK:STDOUT:     inst_block00000017:
 // CHECK:STDOUT:       0:               inst60000057
-// CHECK:STDOUT:     inst_block24:
+// CHECK:STDOUT:     inst_block00000018:
 // CHECK:STDOUT:       0:               inst60000058
-// CHECK:STDOUT:     inst_block25:
+// CHECK:STDOUT:     inst_block00000019:
 // CHECK:STDOUT:       0:               inst60000059
 // CHECK:STDOUT:       1:               inst6000005A
 // CHECK:STDOUT:       2:               inst6000005B
-// CHECK:STDOUT:     inst_block26:
+// CHECK:STDOUT:     inst_block0000001A:
 // CHECK:STDOUT:       0:               inst60000048
-// CHECK:STDOUT:     inst_block27:
+// CHECK:STDOUT:     inst_block0000001B:
 // CHECK:STDOUT:       0:               inst60000048
 // CHECK:STDOUT:       1:               inst60000052
 // CHECK:STDOUT:       2:               inst60000053
-// CHECK:STDOUT:     inst_block28:
+// CHECK:STDOUT:     inst_block0000001C:
 // CHECK:STDOUT:       0:               inst60000063
-// CHECK:STDOUT:     inst_block29:
+// CHECK:STDOUT:     inst_block0000001D:
 // CHECK:STDOUT:       0:               inst60000064
-// CHECK:STDOUT:     inst_block30:
+// CHECK:STDOUT:     inst_block0000001E:
 // CHECK:STDOUT:       0:               inst60000067
-// CHECK:STDOUT:     inst_block31:
+// CHECK:STDOUT:     inst_block0000001F:
 // CHECK:STDOUT:       0:               inst6000005F
-// CHECK:STDOUT:     inst_block32:
+// CHECK:STDOUT:     inst_block00000020:
 // CHECK:STDOUT:       0:               inst6000006A
-// CHECK:STDOUT:     inst_block33:
+// CHECK:STDOUT:     inst_block00000021:
 // CHECK:STDOUT:       0:               inst6000006A
 // CHECK:STDOUT:       1:               inst6000006B
 // CHECK:STDOUT:       2:               inst6000006C
 // CHECK:STDOUT:       3:               inst6000006D
-// CHECK:STDOUT:     inst_block34:
+// CHECK:STDOUT:     inst_block00000022:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst60000060
 // CHECK:STDOUT:       2:               inst60000061
 // CHECK:STDOUT:       3:               inst60000069
-// CHECK:STDOUT:     inst_block35:
+// CHECK:STDOUT:     inst_block00000023:
 // CHECK:STDOUT:       0:               inst60000075
-// CHECK:STDOUT:     inst_block36:
+// CHECK:STDOUT:     inst_block00000024:
 // CHECK:STDOUT:       0:               inst60000076
-// CHECK:STDOUT:     inst_block37:
+// CHECK:STDOUT:     inst_block00000025:
 // CHECK:STDOUT:       0:               inst6000006A
-// CHECK:STDOUT:     inst_block38:
+// CHECK:STDOUT:     inst_block00000026:
 // CHECK:STDOUT:       0:               inst60000077
 // CHECK:STDOUT:       1:               inst60000078
-// CHECK:STDOUT:     inst_block39:
+// CHECK:STDOUT:     inst_block00000027:
 // CHECK:STDOUT:       0:               inst60000079
 // CHECK:STDOUT:       1:               inst6000007A
 // CHECK:STDOUT:       2:               inst6000007B
 // CHECK:STDOUT:       3:               inst6000007C
-// CHECK:STDOUT:     inst_block40:
+// CHECK:STDOUT:     inst_block00000028:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst60000060
 // CHECK:STDOUT:       2:               inst60000061
 // CHECK:STDOUT:       3:               inst60000071
-// CHECK:STDOUT:     inst_block41:
+// CHECK:STDOUT:     inst_block00000029:
 // CHECK:STDOUT:       0:               inst60000079
-// CHECK:STDOUT:     inst_block42:
+// CHECK:STDOUT:     inst_block0000002A:
 // CHECK:STDOUT:       0:               inst60000083
 // CHECK:STDOUT:       1:               inst60000084
 // CHECK:STDOUT:       2:               inst60000085
 // CHECK:STDOUT:       3:               inst60000086
 // CHECK:STDOUT:       4:               inst60000087
 // CHECK:STDOUT:       5:               inst60000088
-// CHECK:STDOUT:     inst_block43:
+// CHECK:STDOUT:     inst_block0000002B:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst60000060
 // CHECK:STDOUT:       2:               inst60000089
-// CHECK:STDOUT:     inst_block44:
+// CHECK:STDOUT:     inst_block0000002C:
 // CHECK:STDOUT:       0:               inst6000006F
 // CHECK:STDOUT:       1:               inst60000070
-// CHECK:STDOUT:     inst_block45:
+// CHECK:STDOUT:     inst_block0000002D:
 // CHECK:STDOUT:       0:               inst6000009C
-// CHECK:STDOUT:     inst_block46:
+// CHECK:STDOUT:     inst_block0000002E:
 // CHECK:STDOUT:       0:               inst6000009D
-// CHECK:STDOUT:     inst_block47:
+// CHECK:STDOUT:     inst_block0000002F:
 // CHECK:STDOUT:       0:               inst600000A0
-// CHECK:STDOUT:     inst_block48:
+// CHECK:STDOUT:     inst_block00000030:
 // CHECK:STDOUT:       0:               inst600000A3
-// CHECK:STDOUT:     inst_block49:
+// CHECK:STDOUT:     inst_block00000031:
 // CHECK:STDOUT:       0:               inst600000A3
 // CHECK:STDOUT:       1:               inst600000A4
 // CHECK:STDOUT:       2:               inst600000A5
-// CHECK:STDOUT:     inst_block50:
+// CHECK:STDOUT:     inst_block00000032:
 // CHECK:STDOUT:       0:               inst60000015
 // CHECK:STDOUT:       1:               inst6000001B
 // CHECK:STDOUT:       2:               inst600000A2
-// CHECK:STDOUT:     inst_block51:
+// CHECK:STDOUT:     inst_block00000033:
 // CHECK:STDOUT:       0:               inst600000AC
-// CHECK:STDOUT:     inst_block52:
+// CHECK:STDOUT:     inst_block00000034:
 // CHECK:STDOUT:       0:               inst600000AD
-// CHECK:STDOUT:     inst_block53:
+// CHECK:STDOUT:     inst_block00000035:
 // CHECK:STDOUT:       0:               inst600000A3
-// CHECK:STDOUT:     inst_block54:
+// CHECK:STDOUT:     inst_block00000036:
 // CHECK:STDOUT:       0:               inst600000AE
 // CHECK:STDOUT:       1:               inst600000AF
 // CHECK:STDOUT:       2:               inst600000B0
-// CHECK:STDOUT:     inst_block55:
+// CHECK:STDOUT:     inst_block00000037:
 // CHECK:STDOUT:       0:               inst600000B1
 // CHECK:STDOUT:       1:               inst600000B2
 // CHECK:STDOUT:       2:               inst600000B3
-// CHECK:STDOUT:     inst_block56:
+// CHECK:STDOUT:     inst_block00000038:
 // CHECK:STDOUT:       0:               inst60000015
 // CHECK:STDOUT:       1:               inst6000001B
 // CHECK:STDOUT:       2:               inst6000001E
-// CHECK:STDOUT:     inst_block57:
+// CHECK:STDOUT:     inst_block00000039:
 // CHECK:STDOUT:       0:               inst60000060
 // CHECK:STDOUT:       1:               inst600000BF
-// CHECK:STDOUT:     inst_block58:
+// CHECK:STDOUT:     inst_block0000003A:
 // CHECK:STDOUT:       0:               inst600000C2
 // CHECK:STDOUT:       1:               inst600000C1
-// CHECK:STDOUT:     inst_block59:
+// CHECK:STDOUT:     inst_block0000003B:
 // CHECK:STDOUT:       0:               inst600000C3
 // CHECK:STDOUT:       1:               inst600000C4
-// CHECK:STDOUT:     inst_block60:
+// CHECK:STDOUT:     inst_block0000003C:
 // CHECK:STDOUT:       0:               inst600000C7
-// CHECK:STDOUT:     inst_block61:
+// CHECK:STDOUT:     inst_block0000003D:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst600000BE
-// CHECK:STDOUT:     inst_block62:
+// CHECK:STDOUT:     inst_block0000003E:
 // CHECK:STDOUT:       0:               inst600000CC
 // CHECK:STDOUT:       1:               inst600000CD
-// CHECK:STDOUT:     inst_block63:
+// CHECK:STDOUT:     inst_block0000003F:
 // CHECK:STDOUT:       0:               inst600000CA
 // CHECK:STDOUT:       1:               inst600000CB
-// CHECK:STDOUT:     inst_block64:
+// CHECK:STDOUT:     inst_block00000040:
 // CHECK:STDOUT:       0:               inst600000CA
 // CHECK:STDOUT:       1:               inst600000CB
 // CHECK:STDOUT:       2:               inst600000CC
 // CHECK:STDOUT:       3:               inst600000CD
 // CHECK:STDOUT:       4:               inst600000CE
 // CHECK:STDOUT:       5:               inst600000CF
-// CHECK:STDOUT:     inst_block65:
+// CHECK:STDOUT:     inst_block00000041:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst600000BE
 // CHECK:STDOUT:       2:               inst60000060
 // CHECK:STDOUT:       3:               inst600000BF
 // CHECK:STDOUT:       4:               inst600000C0
 // CHECK:STDOUT:       5:               inst600000C9
-// CHECK:STDOUT:     inst_block66:
+// CHECK:STDOUT:     inst_block00000042:
 // CHECK:STDOUT:       0:               inst600000D7
-// CHECK:STDOUT:     inst_block67:
+// CHECK:STDOUT:     inst_block00000043:
 // CHECK:STDOUT:       0:               inst600000D8
 // CHECK:STDOUT:       1:               inst600000D9
-// CHECK:STDOUT:     inst_block68:
+// CHECK:STDOUT:     inst_block00000044:
 // CHECK:STDOUT:       0:               inst600000CA
 // CHECK:STDOUT:       1:               inst600000CB
-// CHECK:STDOUT:     inst_block69:
+// CHECK:STDOUT:     inst_block00000045:
 // CHECK:STDOUT:       0:               inst600000DA
 // CHECK:STDOUT:       1:               inst600000DB
-// CHECK:STDOUT:     inst_block70:
+// CHECK:STDOUT:     inst_block00000046:
 // CHECK:STDOUT:       0:               inst600000DD
 // CHECK:STDOUT:       1:               inst600000DF
-// CHECK:STDOUT:     inst_block71:
+// CHECK:STDOUT:     inst_block00000047:
 // CHECK:STDOUT:       0:               inst600000DC
 // CHECK:STDOUT:       1:               inst600000DD
 // CHECK:STDOUT:       2:               inst600000DE
 // CHECK:STDOUT:       3:               inst600000DF
 // CHECK:STDOUT:       4:               inst600000E0
 // CHECK:STDOUT:       5:               inst600000E1
-// CHECK:STDOUT:     inst_block72:
+// CHECK:STDOUT:     inst_block00000048:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst60000060
 // CHECK:STDOUT:       2:               inst600000BE
 // CHECK:STDOUT:       3:               inst600000BF
 // CHECK:STDOUT:       4:               inst600000C0
 // CHECK:STDOUT:       5:               inst600000D3
-// CHECK:STDOUT:     inst_block73:
+// CHECK:STDOUT:     inst_block00000049:
 // CHECK:STDOUT:       0:               inst600000BE
-// CHECK:STDOUT:     inst_block74:
+// CHECK:STDOUT:     inst_block0000004A:
 // CHECK:STDOUT:       0:               inst600000DC
-// CHECK:STDOUT:     inst_block75:
+// CHECK:STDOUT:     inst_block0000004B:
 // CHECK:STDOUT:       0:               inst600000DE
-// CHECK:STDOUT:     inst_block76:
+// CHECK:STDOUT:     inst_block0000004C:
 // CHECK:STDOUT:       0:               inst600000E8
 // CHECK:STDOUT:       1:               inst600000E9
 // CHECK:STDOUT:       2:               inst600000EA
@@ -1644,40 +1644,40 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       8:               inst600000F0
 // CHECK:STDOUT:       9:               inst600000F1
 // CHECK:STDOUT:       10:              inst600000F2
-// CHECK:STDOUT:     inst_block77:
+// CHECK:STDOUT:     inst_block0000004D:
 // CHECK:STDOUT:       0:               inst600000BE
 // CHECK:STDOUT:       1:               inst600000BF
 // CHECK:STDOUT:       2:               inst600000F3
-// CHECK:STDOUT:     inst_block78:
+// CHECK:STDOUT:     inst_block0000004E:
 // CHECK:STDOUT:       0:               inst600000D1
 // CHECK:STDOUT:       1:               inst600000D2
-// CHECK:STDOUT:     inst_block79:
+// CHECK:STDOUT:     inst_block0000004F:
 // CHECK:STDOUT:       0:               inst60000060
 // CHECK:STDOUT:       1:               inst600000BF
 // CHECK:STDOUT:       2:               inst600000F7
-// CHECK:STDOUT:     inst_block80:
+// CHECK:STDOUT:     inst_block00000050:
 // CHECK:STDOUT:       0:               inst600000FB
 // CHECK:STDOUT:       1:               inst600000FA
 // CHECK:STDOUT:       2:               inst600000F9
-// CHECK:STDOUT:     inst_block81:
+// CHECK:STDOUT:     inst_block00000051:
 // CHECK:STDOUT:       0:               inst600000FC
 // CHECK:STDOUT:       1:               inst600000FD
 // CHECK:STDOUT:       2:               inst600000FE
-// CHECK:STDOUT:     inst_block82:
+// CHECK:STDOUT:     inst_block00000052:
 // CHECK:STDOUT:       0:               inst60000101
-// CHECK:STDOUT:     inst_block83:
+// CHECK:STDOUT:     inst_block00000053:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst600000BE
 // CHECK:STDOUT:       2:               inst600000F6
-// CHECK:STDOUT:     inst_block84:
+// CHECK:STDOUT:     inst_block00000054:
 // CHECK:STDOUT:       0:               inst60000107
 // CHECK:STDOUT:       1:               inst60000108
 // CHECK:STDOUT:       2:               inst60000109
-// CHECK:STDOUT:     inst_block85:
+// CHECK:STDOUT:     inst_block00000055:
 // CHECK:STDOUT:       0:               inst60000104
 // CHECK:STDOUT:       1:               inst60000105
 // CHECK:STDOUT:       2:               inst60000106
-// CHECK:STDOUT:     inst_block86:
+// CHECK:STDOUT:     inst_block00000056:
 // CHECK:STDOUT:       0:               inst60000104
 // CHECK:STDOUT:       1:               inst60000105
 // CHECK:STDOUT:       2:               inst60000106
@@ -1686,7 +1686,7 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       5:               inst60000109
 // CHECK:STDOUT:       6:               inst6000010A
 // CHECK:STDOUT:       7:               inst6000010B
-// CHECK:STDOUT:     inst_block87:
+// CHECK:STDOUT:     inst_block00000057:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst600000BE
 // CHECK:STDOUT:       2:               inst600000F6
@@ -1695,24 +1695,24 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       5:               inst600000F7
 // CHECK:STDOUT:       6:               inst600000F8
 // CHECK:STDOUT:       7:               inst60000103
-// CHECK:STDOUT:     inst_block88:
+// CHECK:STDOUT:     inst_block00000058:
 // CHECK:STDOUT:       0:               inst60000113
-// CHECK:STDOUT:     inst_block89:
+// CHECK:STDOUT:     inst_block00000059:
 // CHECK:STDOUT:       0:               inst60000114
 // CHECK:STDOUT:       1:               inst60000115
 // CHECK:STDOUT:       2:               inst60000116
-// CHECK:STDOUT:     inst_block90:
+// CHECK:STDOUT:     inst_block0000005A:
 // CHECK:STDOUT:       0:               inst60000104
 // CHECK:STDOUT:       1:               inst60000105
 // CHECK:STDOUT:       2:               inst60000106
-// CHECK:STDOUT:     inst_block91:
+// CHECK:STDOUT:     inst_block0000005B:
 // CHECK:STDOUT:       0:               inst60000117
 // CHECK:STDOUT:       1:               inst60000118
-// CHECK:STDOUT:     inst_block92:
+// CHECK:STDOUT:     inst_block0000005C:
 // CHECK:STDOUT:       0:               inst6000011A
 // CHECK:STDOUT:       1:               inst6000011C
 // CHECK:STDOUT:       2:               inst6000011E
-// CHECK:STDOUT:     inst_block93:
+// CHECK:STDOUT:     inst_block0000005D:
 // CHECK:STDOUT:       0:               inst60000119
 // CHECK:STDOUT:       1:               inst6000011A
 // CHECK:STDOUT:       2:               inst6000011B
@@ -1721,7 +1721,7 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       5:               inst6000011E
 // CHECK:STDOUT:       6:               inst6000011F
 // CHECK:STDOUT:       7:               inst60000120
-// CHECK:STDOUT:     inst_block94:
+// CHECK:STDOUT:     inst_block0000005E:
 // CHECK:STDOUT:       0:               inst6000005F
 // CHECK:STDOUT:       1:               inst60000060
 // CHECK:STDOUT:       2:               inst600000BE
@@ -1730,15 +1730,15 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       5:               inst600000F7
 // CHECK:STDOUT:       6:               inst600000F8
 // CHECK:STDOUT:       7:               inst6000010F
-// CHECK:STDOUT:     inst_block95:
+// CHECK:STDOUT:     inst_block0000005F:
 // CHECK:STDOUT:       0:               inst600000F6
-// CHECK:STDOUT:     inst_block96:
+// CHECK:STDOUT:     inst_block00000060:
 // CHECK:STDOUT:       0:               inst60000119
-// CHECK:STDOUT:     inst_block97:
+// CHECK:STDOUT:     inst_block00000061:
 // CHECK:STDOUT:       0:               inst6000011B
-// CHECK:STDOUT:     inst_block98:
+// CHECK:STDOUT:     inst_block00000062:
 // CHECK:STDOUT:       0:               inst6000011D
-// CHECK:STDOUT:     inst_block99:
+// CHECK:STDOUT:     inst_block00000063:
 // CHECK:STDOUT:       0:               inst60000127
 // CHECK:STDOUT:       1:               inst60000128
 // CHECK:STDOUT:       2:               inst60000129
@@ -1755,35 +1755,35 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       13:              inst60000134
 // CHECK:STDOUT:       14:              inst60000135
 // CHECK:STDOUT:       15:              inst60000136
-// CHECK:STDOUT:     inst_block100:
+// CHECK:STDOUT:     inst_block00000064:
 // CHECK:STDOUT:       0:               inst600000F6
 // CHECK:STDOUT:       1:               inst600000F7
 // CHECK:STDOUT:       2:               inst60000137
-// CHECK:STDOUT:     inst_block101:
+// CHECK:STDOUT:     inst_block00000065:
 // CHECK:STDOUT:       0:               inst6000010D
 // CHECK:STDOUT:       1:               inst6000010E
-// CHECK:STDOUT:     inst_block102:
+// CHECK:STDOUT:     inst_block00000066:
 // CHECK:STDOUT:       0:               inst600000A7
 // CHECK:STDOUT:       1:               inst600000A8
 // CHECK:STDOUT:       2:               inst6000003D
-// CHECK:STDOUT:     inst_block103:
+// CHECK:STDOUT:     inst_block00000067:
 // CHECK:STDOUT:       0:               inst60000138
-// CHECK:STDOUT:     inst_block104:
+// CHECK:STDOUT:     inst_block00000068:
 // CHECK:STDOUT:       0:               inst60000139
-// CHECK:STDOUT:     inst_block105:
+// CHECK:STDOUT:     inst_block00000069:
 // CHECK:STDOUT:       0:               inst6000013A
-// CHECK:STDOUT:     inst_block106:
+// CHECK:STDOUT:     inst_block0000006A:
 // CHECK:STDOUT:       0:               inst6000013A
 // CHECK:STDOUT:       1:               inst6000001B
 // CHECK:STDOUT:       2:               inst6000001E
-// CHECK:STDOUT:     inst_block107:
+// CHECK:STDOUT:     inst_block0000006B:
 // CHECK:STDOUT:       0:               inst6000013E
-// CHECK:STDOUT:     inst_block108:
+// CHECK:STDOUT:     inst_block0000006C:
 // CHECK:STDOUT:       0:               inst6000003F
-// CHECK:STDOUT:     inst_block109:
+// CHECK:STDOUT:     inst_block0000006D:
 // CHECK:STDOUT:       0:               inst60000148
 // CHECK:STDOUT:       1:               inst6000014C
-// CHECK:STDOUT:     inst_block110:
+// CHECK:STDOUT:     inst_block0000006E:
 // CHECK:STDOUT:       0:               inst6000003B
 // CHECK:STDOUT:       1:               inst6000003E
 // CHECK:STDOUT:       2:               inst60000139
@@ -1791,7 +1791,7 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       4:               inst6000013F
 // CHECK:STDOUT:       5:               inst60000140
 // CHECK:STDOUT:       6:               inst60000144
-// CHECK:STDOUT:     inst_block111:
+// CHECK:STDOUT:     inst_block0000006F:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst6000000F
 // CHECK:STDOUT:       2:               inst60000035

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file_with_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file_with_textual_ir.carbon
@@ -26,17 +26,17 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst60000025}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name00000000: inst60000025}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name0:    {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0}
+// CHECK:STDOUT:     entity_name00000000: {name: name00000001, parent_scope: name_scope<none>, index: -1, is_template: 0}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_params_id: inst_block9, return_slot_pattern: inst60000020, body: [inst_block12]}
+// CHECK:STDOUT:     function60000000: {name: name00000000, parent_scope: name_scope00000000, call_params_id: inst_block00000009, return_slot_pattern: inst60000020, body: [inst_block0000000C]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -53,18 +53,18 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     'type(inst60000026)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst6000000F)}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     inst6000000F:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000010:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst60000011:    {kind: Converted, arg0: inst60000010, arg1: inst6000000F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000012:    {kind: BindName, arg0: entity_name0, arg1: inst60000021, type: type(inst6000000F)}
+// CHECK:STDOUT:     inst60000012:    {kind: BindName, arg0: entity_name00000000, arg1: inst60000021, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst60000013:    {kind: PatternType, arg0: inst6000000F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000014:    {kind: BindingPattern, arg0: entity_name0, type: type(inst60000013)}
+// CHECK:STDOUT:     inst60000014:    {kind: BindingPattern, arg0: entity_name00000000, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000015:    {kind: ValueParamPattern, arg0: inst60000014, arg1: call_param0, type: type(inst60000013)}
 // CHECK:STDOUT:     inst60000016:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst60000017:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst6000000F)}
-// CHECK:STDOUT:     inst60000018:    {kind: TupleType, arg0: inst_block7, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000019:    {kind: TupleLiteral, arg0: inst_block6, type: type(inst60000018)}
+// CHECK:STDOUT:     inst60000018:    {kind: TupleType, arg0: inst_block00000007, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000019:    {kind: TupleLiteral, arg0: inst_block00000006, type: type(inst60000018)}
 // CHECK:STDOUT:     inst6000001A:    {kind: PointerType, arg0: inst60000018, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001B:    {kind: Converted, arg0: inst60000016, arg1: inst6000000F, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001C:    {kind: Converted, arg0: inst60000017, arg1: inst6000000F, type: type(TypeType)}
@@ -72,25 +72,25 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     inst6000001E:    {kind: PatternType, arg0: inst60000018, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000001F:    {kind: ReturnSlotPattern, arg0: inst6000001D, type: type(inst6000001E)}
 // CHECK:STDOUT:     inst60000020:    {kind: OutParamPattern, arg0: inst6000001F, arg1: call_param1, type: type(inst6000001E)}
-// CHECK:STDOUT:     inst60000021:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst6000000F)}
-// CHECK:STDOUT:     inst60000022:    {kind: SpliceBlock, arg0: inst_block4, arg1: inst60000011, type: type(TypeType)}
+// CHECK:STDOUT:     inst60000021:    {kind: ValueParam, arg0: call_param0, arg1: name00000001, type: type(inst6000000F)}
+// CHECK:STDOUT:     inst60000022:    {kind: SpliceBlock, arg0: inst_block00000004, arg1: inst60000011, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000023:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(inst60000018)}
 // CHECK:STDOUT:     inst60000024:    {kind: ReturnSlot, arg0: inst60000018, arg1: inst60000023, type: type(inst60000018)}
-// CHECK:STDOUT:     inst60000025:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block11, type: type(inst60000026)}
+// CHECK:STDOUT:     inst60000025:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block0000000B, type: type(inst60000026)}
 // CHECK:STDOUT:     inst60000026:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000027:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000026)}
-// CHECK:STDOUT:     inst60000028:    {kind: NameRef, arg0: name1, arg1: inst60000012, type: type(inst6000000F)}
+// CHECK:STDOUT:     inst60000028:    {kind: NameRef, arg0: name00000001, arg1: inst60000012, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst60000029:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst6000000F)}
-// CHECK:STDOUT:     inst6000002A:    {kind: TupleLiteral, arg0: inst_block13, type: type(inst60000018)}
+// CHECK:STDOUT:     inst6000002A:    {kind: TupleLiteral, arg0: inst_block0000000D, type: type(inst60000018)}
 // CHECK:STDOUT:     inst6000002B:    {kind: TupleAccess, arg0: inst60000024, arg1: element0, type: type(inst6000000F)}
-// CHECK:STDOUT:     inst6000002C:    {kind: TupleInit, arg0: inst_block14, arg1: inst6000002B, type: type(inst6000000F)}
+// CHECK:STDOUT:     inst6000002C:    {kind: TupleInit, arg0: inst_block0000000E, arg1: inst6000002B, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst6000002D:    {kind: TupleValue, arg0: inst_block_empty, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst6000002E:    {kind: Converted, arg0: inst60000028, arg1: inst6000002C, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst6000002F:    {kind: TupleAccess, arg0: inst60000024, arg1: element1, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst60000030:    {kind: TupleInit, arg0: inst_block_empty, arg1: inst6000002F, type: type(inst6000000F)}
 // CHECK:STDOUT:     inst60000031:    {kind: Converted, arg0: inst60000029, arg1: inst60000030, type: type(inst6000000F)}
-// CHECK:STDOUT:     inst60000032:    {kind: TupleInit, arg0: inst_block15, arg1: inst60000024, type: type(inst60000018)}
-// CHECK:STDOUT:     inst60000033:    {kind: TupleValue, arg0: inst_block16, type: type(inst60000018)}
+// CHECK:STDOUT:     inst60000032:    {kind: TupleInit, arg0: inst_block0000000F, arg1: inst60000024, type: type(inst60000018)}
+// CHECK:STDOUT:     inst60000033:    {kind: TupleValue, arg0: inst_block00000010, type: type(inst60000018)}
 // CHECK:STDOUT:     inst60000034:    {kind: Converted, arg0: inst6000002A, arg1: inst60000032, type: type(inst60000018)}
 // CHECK:STDOUT:     inst60000035:    {kind: ReturnExpr, arg0: inst60000034, arg1: inst60000024}
 // CHECK:STDOUT:   constant_values:
@@ -128,29 +128,29 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:       0:               inst60000025
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:
+// CHECK:STDOUT:     inst_block00000004:
 // CHECK:STDOUT:       0:               inst60000010
 // CHECK:STDOUT:       1:               inst60000011
-// CHECK:STDOUT:     inst_block5:
+// CHECK:STDOUT:     inst_block00000005:
 // CHECK:STDOUT:       0:               inst60000015
-// CHECK:STDOUT:     inst_block6:
+// CHECK:STDOUT:     inst_block00000006:
 // CHECK:STDOUT:       0:               inst60000016
 // CHECK:STDOUT:       1:               inst60000017
-// CHECK:STDOUT:     inst_block7:
+// CHECK:STDOUT:     inst_block00000007:
 // CHECK:STDOUT:       0:               inst6000000F
 // CHECK:STDOUT:       1:               inst6000000F
-// CHECK:STDOUT:     inst_block8:
+// CHECK:STDOUT:     inst_block00000008:
 // CHECK:STDOUT:       0:               inst6000001B
 // CHECK:STDOUT:       1:               inst6000001C
-// CHECK:STDOUT:     inst_block9:
+// CHECK:STDOUT:     inst_block00000009:
 // CHECK:STDOUT:       0:               inst60000021
 // CHECK:STDOUT:       1:               inst60000023
-// CHECK:STDOUT:     inst_block10:
+// CHECK:STDOUT:     inst_block0000000A:
 // CHECK:STDOUT:       0:               inst60000014
 // CHECK:STDOUT:       1:               inst60000015
 // CHECK:STDOUT:       2:               inst6000001F
 // CHECK:STDOUT:       3:               inst60000020
-// CHECK:STDOUT:     inst_block11:
+// CHECK:STDOUT:     inst_block0000000B:
 // CHECK:STDOUT:       0:               inst60000016
 // CHECK:STDOUT:       1:               inst60000017
 // CHECK:STDOUT:       2:               inst60000019
@@ -162,7 +162,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:       8:               inst60000012
 // CHECK:STDOUT:       9:               inst60000023
 // CHECK:STDOUT:       10:              inst60000024
-// CHECK:STDOUT:     inst_block12:
+// CHECK:STDOUT:     inst_block0000000C:
 // CHECK:STDOUT:       0:               inst60000028
 // CHECK:STDOUT:       1:               inst60000029
 // CHECK:STDOUT:       2:               inst6000002A
@@ -175,17 +175,17 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:       9:               inst60000032
 // CHECK:STDOUT:       10:              inst60000034
 // CHECK:STDOUT:       11:              inst60000035
-// CHECK:STDOUT:     inst_block13:
+// CHECK:STDOUT:     inst_block0000000D:
 // CHECK:STDOUT:       0:               inst60000028
 // CHECK:STDOUT:       1:               inst60000029
-// CHECK:STDOUT:     inst_block14:    {}
-// CHECK:STDOUT:     inst_block15:
+// CHECK:STDOUT:     inst_block0000000E: {}
+// CHECK:STDOUT:     inst_block0000000F:
 // CHECK:STDOUT:       0:               inst6000002E
 // CHECK:STDOUT:       1:               inst60000031
-// CHECK:STDOUT:     inst_block16:
+// CHECK:STDOUT:     inst_block00000010:
 // CHECK:STDOUT:       0:               inst6000002D
 // CHECK:STDOUT:       1:               inst6000002D
-// CHECK:STDOUT:     inst_block17:
+// CHECK:STDOUT:     inst_block00000011:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT:       1:               inst60000025
 // CHECK:STDOUT: ...

--- a/toolchain/driver/testdata/dump_shared_values.carbon
+++ b/toolchain/driver/testdata/dump_shared_values.carbon
@@ -24,19 +24,19 @@ var str2: str = "ab'\"c";
 // CHECK:STDOUT: shared_values:
 // CHECK:STDOUT:   ints:            {}
 // CHECK:STDOUT:   reals:
-// CHECK:STDOUT:     real0:           10*10^-1
-// CHECK:STDOUT:     real1:           8*10^7
-// CHECK:STDOUT:     real2:           8*10^8
+// CHECK:STDOUT:     real00000000:    10*10^-1
+// CHECK:STDOUT:     real00000001:    8*10^7
+// CHECK:STDOUT:     real00000002:    8*10^8
 // CHECK:STDOUT:   floats:          {}
 // CHECK:STDOUT:   identifiers:
-// CHECK:STDOUT:     identifier0:     int1
-// CHECK:STDOUT:     identifier1:     int2
-// CHECK:STDOUT:     identifier2:     real1
-// CHECK:STDOUT:     identifier3:     real2
-// CHECK:STDOUT:     identifier4:     real3
-// CHECK:STDOUT:     identifier5:     str1
-// CHECK:STDOUT:     identifier6:     str2
+// CHECK:STDOUT:     identifier00000000: int1
+// CHECK:STDOUT:     identifier00000001: int2
+// CHECK:STDOUT:     identifier00000002: real1
+// CHECK:STDOUT:     identifier00000003: real2
+// CHECK:STDOUT:     identifier00000004: real3
+// CHECK:STDOUT:     identifier00000005: str1
+// CHECK:STDOUT:     identifier00000006: str2
 // CHECK:STDOUT:   strings:
-// CHECK:STDOUT:     string0:         abc
-// CHECK:STDOUT:     string1:         ab'"c
+// CHECK:STDOUT:     string00000000:  abc
+// CHECK:STDOUT:     string00000001:  ab'"c
 // CHECK:STDOUT: ...

--- a/toolchain/driver/testdata/stdin.carbon
+++ b/toolchain/driver/testdata/stdin.carbon
@@ -32,7 +32,7 @@
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope00000000: {inst: inst0000000E, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:       {}
@@ -40,7 +40,7 @@
 // CHECK:STDOUT:   generics:        {}
 // CHECK:STDOUT:   specifics:       {}
 // CHECK:STDOUT:   struct_type_fields:
-// CHECK:STDOUT:     struct_type_fields0: {}
+// CHECK:STDOUT:     struct_type_fields00000000: {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -49,7 +49,7 @@
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst0000000E:    {kind: Namespace, arg0: name_scope00000000, arg1: inst<none>, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       inst0000000E:    concrete_constant(inst0000000E)
@@ -59,7 +59,7 @@
 // CHECK:STDOUT:     exports:         {}
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block4:
+// CHECK:STDOUT:     inst_block00000004:
 // CHECK:STDOUT:       0:               inst0000000E
 // CHECK:STDOUT: ...
 // CHECK:STDOUT: --- -

--- a/toolchain/sem_ir/ids.cpp
+++ b/toolchain/sem_ir/ids.cpp
@@ -16,7 +16,7 @@ auto InstId::Print(llvm::raw_ostream& out) const -> void {
   if (IsSingletonInstId(*this)) {
     out << Label << "(" << SingletonInstKinds[index] << ")";
   } else {
-    IdBase::PrintHex(out);
+    IdBase::Print(out);
   }
 }
 
@@ -42,36 +42,12 @@ auto ConstantId::Print(llvm::raw_ostream& out, bool disambiguate) const
   }
 }
 
-auto CppOverloadSetId::Print(llvm::raw_ostream& out) const -> void {
-  IdBase::PrintHex(out);
-}
-
-auto FunctionId::Print(llvm::raw_ostream& out) const -> void {
-  IdBase::PrintHex(out);
-}
-
 auto CheckIRId::Print(llvm::raw_ostream& out) const -> void {
   if (*this == Cpp) {
     out << Label << "(Cpp)";
   } else {
     IdBase::Print(out);
   }
-}
-
-auto ClassId::Print(llvm::raw_ostream& out) const -> void {
-  IdBase::PrintHex(out);
-}
-
-auto AssociatedConstantId::Print(llvm::raw_ostream& out) const -> void {
-  IdBase::PrintHex(out);
-}
-
-auto ImplId::Print(llvm::raw_ostream& out) const -> void {
-  IdBase::PrintHex(out);
-}
-
-auto SpecificInterfaceId::Print(llvm::raw_ostream& out) const -> void {
-  IdBase::PrintHex(out);
 }
 
 auto GenericInstIndex::Print(llvm::raw_ostream& out) const -> void {

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -283,8 +283,6 @@ struct CppOverloadSetId : public IdBase<CppOverloadSetId> {
   static constexpr llvm::StringLiteral Label = "cpp_overload_set";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of a function.
@@ -292,8 +290,6 @@ struct FunctionId : public IdBase<FunctionId> {
   static constexpr llvm::StringLiteral Label = "function";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of an IR within the set of all IRs being evaluated in the current
@@ -315,8 +311,6 @@ struct ClassId : public IdBase<ClassId> {
   static constexpr llvm::StringLiteral Label = "class";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of a `Vtable`.
@@ -338,8 +332,6 @@ struct AssociatedConstantId : public IdBase<AssociatedConstantId> {
   static constexpr llvm::StringLiteral Label = "assoc_const";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of a `FacetTypeInfo`.
@@ -363,8 +355,6 @@ struct ImplId : public IdBase<ImplId> {
   static constexpr llvm::StringLiteral Label = "impl";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of a `Generic`.
@@ -391,8 +381,6 @@ struct SpecificInterfaceId : public IdBase<SpecificInterfaceId> {
   static constexpr llvm::StringLiteral Label = "specific_interface";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The index of an instruction that depends on generic parameters within a

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -318,8 +318,6 @@ struct VtableId : public IdBase<VtableId> {
   static constexpr llvm::StringLiteral Label = "vtable";
 
   using IdBase::IdBase;
-
-  auto Print(llvm::raw_ostream& out) const -> void;
 };
 
 // The ID of an `Interface`.

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -91,17 +91,19 @@ TEST(SemIRTest, Yaml) {
                Pair("values",
                     Yaml::Mapping(AllOf(Each(Pair(inst_id, constant_id))))),
                Pair("symbolic_constants", Yaml::Mapping(SizeIs(0)))))),
-      Pair("inst_blocks",
-           Yaml::Mapping(ElementsAre(
-               Pair("inst_block_empty", Yaml::Mapping(IsEmpty())),
-               Pair("exports", Yaml::Mapping(Each(Pair(_, inst_id)))),
-               Pair("imports", Yaml::Mapping(IsEmpty())),
-               Pair("global_init", Yaml::Mapping(IsEmpty())),
-               Pair("inst_block4", Yaml::Mapping(Each(Pair(_, inst_id)))),
-               Pair("inst_block5", Yaml::Mapping(Each(Pair(_, inst_id)))),
-               Pair("inst_block6", Yaml::Mapping(Each(Pair(_, inst_id)))),
-               Pair("inst_block7", Yaml::Mapping(Each(Pair(_, inst_id)))),
-               Pair("inst_block8", Yaml::Mapping(Each(Pair(_, inst_id)))))))));
+      Pair(
+          "inst_blocks",
+          Yaml::Mapping(ElementsAre(
+              Pair("inst_block_empty", Yaml::Mapping(IsEmpty())),
+              Pair("exports", Yaml::Mapping(Each(Pair(_, inst_id)))),
+              Pair("imports", Yaml::Mapping(IsEmpty())),
+              Pair("global_init", Yaml::Mapping(IsEmpty())),
+              Pair("inst_block00000004", Yaml::Mapping(Each(Pair(_, inst_id)))),
+              Pair("inst_block00000005", Yaml::Mapping(Each(Pair(_, inst_id)))),
+              Pair("inst_block00000006", Yaml::Mapping(Each(Pair(_, inst_id)))),
+              Pair("inst_block00000007", Yaml::Mapping(Each(Pair(_, inst_id)))),
+              Pair("inst_block00000008",
+                   Yaml::Mapping(Each(Pair(_, inst_id)))))))));
 
   auto root = Yaml::Sequence(ElementsAre(Yaml::Mapping(
       ElementsAre(Pair("filename", "test.carbon"), Pair("sem_ir", file)))));


### PR DESCRIPTION
The indexed ids are kept in decimal since they won't get tagging because
their ordered-ness is significant to their usage, as I understand it.

Addressing https://github.com/carbon-language/carbon-lang/pull/6215#discussion_r2430180953 feedback
