### PR TITLE
Switch `EvalLookupSingleImplWitness` from "concrete" to "final" terminology

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -526,9 +526,9 @@ auto CheckUnit::CheckPoisonedConcreteImplLookupQueries() -> void {
   for (const auto& poison : poisoned_queries) {
     auto witness_result = EvalLookupSingleImplWitness(
         context_, poison.loc_id, poison.query, poison.query.query_self_inst_id,
-        /*poison_concrete_results=*/false);
-    CARBON_CHECK(witness_result.has_concrete_value());
-    auto found_witness_id = witness_result.concrete_witness();
+        /*poison_final_results=*/false);
+    CARBON_CHECK(witness_result.has_final_value());
+    auto found_witness_id = witness_result.final_witness();
     if (found_witness_id != poison.impl_witness) {
       auto witness_to_impl_id = [&](SemIR::InstId witness_id) {
         auto table_id = context_.insts()

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -295,7 +295,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
 
   auto result = EvalLookupSingleImplWitness(context, SemIR::LocId(inst_id),
                                             inst, self_facet_value_inst_id,
-                                            /*poison_concrete_results=*/true);
+                                            /*poison_final_results=*/true);
   if (!result.has_value()) {
     // We use NotConstant to communicate back to impl lookup that the lookup
     // failed. This can not happen for a deferred symbolic lookup in a generic
@@ -303,9 +303,9 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
     // evaluated here) to the SemIR if the lookup succeeds.
     return ConstantEvalResult::NotConstant;
   }
-  if (result.has_concrete_value()) {
+  if (result.has_final_value()) {
     return ConstantEvalResult::Existing(
-        context.constant_values().Get(result.concrete_witness()));
+        context.constant_values().Get(result.final_witness()));
   }
 
   return ConstantEvalResult::NewSamePhase(inst);

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -847,14 +847,14 @@ static auto CollectCandidateImplsForQuery(
 auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
                                  SemIR::LookupImplWitness eval_query,
                                  SemIR::InstId self_facet_value_inst_id,
-                                 bool poison_concrete_results)
+                                 bool poison_final_results)
     -> EvalImplLookupResult {
   auto query_specific_interface =
       context.specific_interfaces().Get(eval_query.query_specific_interface_id);
 
   auto facet_lookup_result = LookupImplWitnessInSelfFacetValue(
       context, self_facet_value_inst_id, query_specific_interface);
-  if (facet_lookup_result.has_concrete_value()) {
+  if (facet_lookup_result.has_final_value()) {
     return facet_lookup_result;
   }
 
@@ -927,19 +927,19 @@ auto EvalLookupSingleImplWitness(Context& context, SemIR::LocId loc_id,
         context, loc_id, query_is_concrete, query_self_const_id,
         query_specific_interface, candidate.impl_id);
     if (result.has_value()) {
-      // Record the query which found a concrete impl witness. It's illegal to
+      // Record the query which found a final impl witness. It's illegal to
       // write a final impl afterward that would match the same query.
       //
       // If the impl was effectively final, then we don't need to poison here. A
       // change of query result will already be diagnosed at the point where the
       // new impl decl was written that changes the result.
-      if (poison_concrete_results && result.has_concrete_value() &&
+      if (poison_final_results && result.has_final_value() &&
           !IsImplEffectivelyFinal(context,
                                   context.impls().Get(candidate.impl_id))) {
         context.poisoned_concrete_impl_lookup_queries().push_back(
             {.loc_id = loc_id,
              .query = eval_query,
-             .impl_witness = result.concrete_witness()});
+             .impl_witness = result.final_witness()});
       }
       return result;
     }


### PR DESCRIPTION
A `final impl` can have a symbolic witness, but that witness is still final. Using "final" here per discussion on [#generics-and-templates](https://discord.com/channels/655572317891461132/941071822756143115/1428851511672312120).

I'm also changing the variant a little because `concrete_witness` was only called when `has_concrete_value` was true, so it can be more careful about its contract. Having a more explicit `None` also simplifies `has_value`. I think it doesn't change the overall cost much past that.