### PR TITLE
Rework handling of C++ references.

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -1212,8 +1212,7 @@ static auto MapQualifiedType(Context& context, clang::QualType type,
 
   if (quals.hasConst()) {
     auto type_id = GetConstType(context, type_expr.inst_id);
-    type_expr = {.inst_id = context.types().GetInstId(type_id),
-                 .type_id = type_id};
+    type_expr = TypeExpr::ForUnsugared(context, type_id);
     quals.removeConst();
   }
 
@@ -1371,8 +1370,8 @@ static auto MapParameterType(Context& context, SemIR::LocId loc_id,
   info.type = MapType(context, loc_id, param_type);
   if (info.want_addr_pattern && info.type.inst_id.has_value()) {
     info.pointee_type = info.type;
-    info.type.type_id = GetPointerType(context, info.pointee_type.inst_id);
-    info.type.inst_id = context.types().GetInstId(info.type.type_id);
+    info.type = TypeExpr::ForUnsugared(
+        context, GetPointerType(context, info.pointee_type.inst_id));
   }
   return info;
 }

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -1260,19 +1260,18 @@ static auto MapPointerType(Context& context, SemIR::LocId loc_id,
   return pointer_type_expr;
 }
 
-// Maps a C++ reference type to a Carbon type.
-// We map `T&` to `T*`, and `T&&` to `T`.
+// Maps a C++ reference type to a Carbon type. We map all references to
+// pointers for now. Note that when mapping function parameters and return
+// types, a different rule is used; see MapParameterType for details.
 // TODO: Revisit this and decide what we really want to do here.
 static auto MapReferenceType(Context& context, clang::QualType type,
                              TypeExpr referenced_type_expr) -> TypeExpr {
   CARBON_CHECK(type->isReferenceType());
-
-  if (!type->isLValueReferenceType()) {
-    return referenced_type_expr;
-  }
-
-  return TypeExpr::ForUnsugared(
-      context, GetPointerType(context, referenced_type_expr.inst_id));
+  SemIR::TypeId pointer_type_id =
+      GetPointerType(context, referenced_type_expr.inst_id);
+  pointer_type_id =
+      GetConstType(context, context.types().GetInstId(pointer_type_id));
+  return TypeExpr::ForUnsugared(context, pointer_type_id);
 }
 
 // Maps a C++ type to a Carbon type. `type` should not be canonicalized because
@@ -1318,6 +1317,81 @@ static auto MapType(Context& context, SemIR::LocId loc_id, clang::QualType type)
   return mapped;
 }
 
+namespace {
+// Information about how to map a C++ parameter type into Carbon.
+struct ParameterTypeInfo {
+  // The type to use for the Carbon parameter.
+  TypeExpr type;
+  // Whether to build an `addr` pattern.
+  bool want_addr_pattern;
+  // If building an `addr` pattern, the type matched by that pattern.
+  TypeExpr pointee_type;
+};
+}  // namespace
+
+// Given the type of a C++ function parameter, returns information about the
+// type to use for the corresponding Carbon parameter.
+//
+// Note that if the parameter has a type for which `IsSimpleAbiType` returns
+// true, we must produce a parameter type that has the same calling convention
+// as the C++ type.
+//
+// TODO: Use `ref` instead of `addr`.
+static auto MapParameterType(Context& context, SemIR::LocId loc_id,
+                             clang::QualType param_type) -> ParameterTypeInfo {
+  ParameterTypeInfo info = {.type = TypeExpr::None,
+                            .want_addr_pattern = false,
+                            .pointee_type = TypeExpr::None};
+
+  // Perform some custom mapping for parameters of reference type:
+  //
+  //   * `T& x` -> `addr x: T*`.
+  //   * `const T& x` -> `x: T`.
+  //   * `T&& x` -> `x: T`.
+  //
+  // TODO: For the `&&` mapping, we allow an rvalue reference to bind to a
+  // durable reference expression. This should not be allowed.
+  if (param_type->isReferenceType()) {
+    clang::QualType pointee_type = param_type->getPointeeType();
+    if (param_type->isLValueReferenceType()) {
+      if (pointee_type.isConstQualified()) {
+        // TODO: Consider only doing this if `const` is the only qualifier. For
+        // now, any other qualifier will fail when mapping the type.
+        auto split_type = pointee_type.getSplitUnqualifiedType();
+        split_type.Quals.removeConst();
+        pointee_type = context.ast_context().getQualifiedType(split_type);
+      } else {
+        // The reference will map to a pointer. Request an `addr` pattern.
+        info.want_addr_pattern = true;
+      }
+    }
+    param_type = pointee_type;
+  }
+
+  info.type = MapType(context, loc_id, param_type);
+  if (info.want_addr_pattern && info.type.inst_id.has_value()) {
+    info.pointee_type = info.type;
+    info.type.type_id = GetPointerType(context, info.pointee_type.inst_id);
+    info.type.inst_id = context.types().GetInstId(info.type.type_id);
+  }
+  return info;
+}
+
+// Finishes building the pattern to use for a function parameter, given the
+// binding pattern and information about how the parameter is being mapped into
+// Carbon.
+static auto FinishParameterPattern(Context& context, SemIR::InstId pattern_id,
+                                   ParameterTypeInfo info) -> SemIR::InstId {
+  if (!info.want_addr_pattern || pattern_id == SemIR::ErrorInst::InstId) {
+    return pattern_id;
+  }
+  return AddPatternInst(
+      context, {SemIR::LocId(pattern_id),
+                SemIR::AddrPattern({.type_id = GetPatternType(
+                                        context, info.pointee_type.type_id),
+                                    .inner_id = pattern_id})});
+}
+
 // Returns a block for the implicit parameters of the given function
 // declaration. Because function templates are not yet supported, this currently
 // only contains the `self` parameter. On error, produces a diagnostic and
@@ -1334,32 +1408,10 @@ static auto MakeImplicitParamPatternsBlockId(
   // Build a `self` parameter from the object parameter.
   BeginSubpattern(context);
 
-  // Perform some special-case mapping for the object parameter:
-  //
-  //  - If it's a const reference to T, produce a by-value `self: T` parameter.
-  //  - If it's a non-const reference to T, produce an `addr self: T*`
-  //    parameter.
-  //  - Otherwise, map it directly, which will currently fail for `&&`-qualified
-  //    methods.
-  //
-  // TODO: Some of this mapping should be performed for all parameters.
   clang::QualType param_type =
       method_decl->getFunctionObjectParameterReferenceType();
-  bool addr_self = false;
-  if (param_type->isLValueReferenceType()) {
-    param_type = param_type.getNonReferenceType();
-    if (param_type.isConstQualified()) {
-      // TODO: Consider only doing this if `const` is the only qualifier. For
-      // now, any other qualifier will fail when mapping the type.
-      auto split_type = param_type.getSplitUnqualifiedType();
-      split_type.Quals.removeConst();
-      param_type = method_decl->getASTContext().getQualifiedType(split_type);
-    } else {
-      addr_self = true;
-    }
-  }
-
-  auto [type_inst_id, type_id] = MapType(context, loc_id, param_type);
+  auto param_info = MapParameterType(context, loc_id, param_type);
+  auto [type_inst_id, type_id] = param_info.type;
   SemIR::ExprRegionId type_expr_region_id =
       EndSubpatternAsExpr(context, type_inst_id);
 
@@ -1372,10 +1424,8 @@ static auto MakeImplicitParamPatternsBlockId(
 
   // TODO: Fill in a location once available.
   auto pattern_id =
-      addr_self ? AddAddrSelfParamPattern(context, SemIR::LocId::None,
-                                          type_expr_region_id, type_inst_id)
-                : AddSelfParamPattern(context, SemIR::LocId::None,
-                                      type_expr_region_id, type_id);
+      AddSelfParamPattern(context, loc_id, type_expr_region_id, type_id);
+  pattern_id = FinishParameterPattern(context, pattern_id, param_info);
 
   return context.inst_blocks().Add({pattern_id});
 }
@@ -1409,12 +1459,11 @@ static auto MakeParamPatternsBlockId(Context& context, SemIR::LocId loc_id,
     // TODO: The presence of qualifiers here is probably a Clang bug.
     clang::QualType param_type = orig_param_type.getUnqualifiedType();
 
-    bool is_ref_param = param_type->isLValueReferenceType();
-
     // Mark the start of a region of insts, needed for the type expression
     // created later with the call of `EndSubpatternAsExpr()`.
     BeginSubpattern(context);
-    auto [orig_type_inst_id, type_id] = MapType(context, loc_id, param_type);
+    auto param_info = MapParameterType(context, loc_id, param_type);
+    auto [orig_type_inst_id, type_id] = param_info.type;
     // Type expression of the binding pattern - a single-entry/single-exit
     // region that allows control flow in the type expression e.g. fn F(x: if C
     // then i32 else i64).
@@ -1452,17 +1501,7 @@ static auto MakeParamPatternsBlockId(Context& context, SemIR::LocId loc_id,
                       {.type_id = context.insts().Get(pattern_id).type_id(),
                        .subpattern_id = pattern_id,
                        .index = SemIR::CallParamIndex::None})});
-    if (is_ref_param) {
-      // We map `T&` parameters to `addr param: T*`.
-      // TODO: Revisit this and decide what we really want to do here.
-      pattern_id = AddPatternInst(
-          context, {param_loc_id,
-                    SemIR::AddrPattern(
-                        {.type_id = GetPatternType(
-                             context, context.types().GetTypeIdForTypeInstId(
-                                          orig_type_inst_id)),
-                         .inner_id = pattern_id})});
-    }
+    pattern_id = FinishParameterPattern(context, pattern_id, param_info);
     params.push_back(pattern_id);
   }
   return context.inst_blocks().Add(params);
@@ -1476,6 +1515,9 @@ static auto GetReturnTypeExpr(Context& context, SemIR::LocId loc_id,
                               clang::FunctionDecl* clang_decl) -> TypeExpr {
   clang::QualType orig_ret_type = clang_decl->getReturnType();
   if (!orig_ret_type->isVoidType()) {
+    // TODO: We should eventually map reference returns to non-pointer types
+    // here. We should return by `ref` for `T&` return types once `ref` return
+    // is implemented.
     auto [orig_type_inst_id, type_id] = MapType(context, loc_id, orig_ret_type);
     if (!orig_type_inst_id.has_value()) {
       context.TODO(loc_id, llvm::formatv("Unsupported: return type: {0}",

--- a/toolchain/check/cpp/thunk.cpp
+++ b/toolchain/check/cpp/thunk.cpp
@@ -83,14 +83,6 @@ static auto IsSimpleAbiType(clang::ASTContext& ast_context,
     }
   }
 
-  if (const auto* enum_decl = type->getAsEnumDecl()) {
-    // An enum type has a simple ABI if its underlying type does.
-    type = enum_decl->getIntegerType();
-    if (type.isNull()) {
-      return false;
-    }
-  }
-
   if (const auto* builtin_type = type->getAs<clang::BuiltinType>()) {
     if (builtin_type->isIntegerType()) {
       uint64_t type_size = ast_context.getIntWidth(type);

--- a/toolchain/check/cpp/thunk.cpp
+++ b/toolchain/check/cpp/thunk.cpp
@@ -58,10 +58,29 @@ static auto IsSimpleAbiType(clang::ASTContext& ast_context,
     return true;
   }
 
-  if (!for_parameter && type->isLValueReferenceType()) {
-    // An lvalue reference return type maps to a pointer, which uses the same
-    // lowering rule.
+  if (type->isReferenceType()) {
+    if (for_parameter) {
+      // A reference parameter has a simple ABI if it's a non-const lvalue
+      // reference.  Otherwise, we map it to pass-by-value, and it's only simple
+      // if the type uses a pointer value representation.
+      //
+      // TODO: Check whether the pointee type maps to a Carbon type that uses a
+      // pointer value representation, and treat it as simple if so.
+      return type->isLValueReferenceType() &&
+             !type->getPointeeType().isConstQualified();
+    }
+
+    // A reference return type is always mapped to a Carbon pointer, which uses
+    // the same ABI rule as a C++ reference.
     return true;
+  }
+
+  if (const auto* enum_decl = type->getAsEnumDecl()) {
+    // An enum type has a simple ABI if its underlying type does.
+    type = enum_decl->getIntegerType();
+    if (type.isNull()) {
+      return false;
+    }
   }
 
   if (const auto* enum_decl = type->getAsEnumDecl()) {
@@ -93,7 +112,8 @@ struct CalleeFunctionInfo {
     bool is_ctor = isa<clang::CXXConstructorDecl>(decl);
     has_object_parameter = method_decl && !method_decl->isStatic() && !is_ctor;
     if (has_object_parameter && method_decl->isImplicitObjectMemberFunction()) {
-      implicit_this_type = method_decl->getThisType();
+      implicit_object_parameter_type =
+          method_decl->getFunctionObjectParameterReferenceType();
     }
     effective_return_type =
         is_ctor ? ast_context.getCanonicalTagType(method_decl->getParent())
@@ -104,7 +124,7 @@ struct CalleeFunctionInfo {
 
   // Returns whether this callee has an implicit `this` parameter.
   auto has_implicit_object_parameter() const -> bool {
-    return !implicit_this_type.isNull();
+    return !implicit_object_parameter_type.isNull();
   }
 
   // Returns whether this callee has an explicit `this` parameter.
@@ -143,9 +163,9 @@ struct CalleeFunctionInfo {
   // implicit.
   bool has_object_parameter;
 
-  // If the callee has an implicit object parameter, the corresponding `this`
-  // type. Otherwise a null type.
-  clang::QualType implicit_this_type;
+  // If the callee has an implicit object parameter, the type of that parameter,
+  // which will always be a reference type. Otherwise a null type.
+  clang::QualType implicit_object_parameter_type;
 
   // The return type that the callee has when viewed from Carbon. This is the
   // C++ return type, except that constructors return the class type in Carbon
@@ -180,16 +200,10 @@ auto IsCppThunkRequired(Context& context, const SemIR::Function& function)
   }
 
   auto& ast_context = context.ast_context();
-  if (callee_info.has_implicit_object_parameter()) {
-    // TODO: The object parameter is a reference parameter, but we don't force a
-    // thunk here like we do for explicit reference parameters in the case where
-    // we would map the parameter to an `addr` parameter. We should make this
-    // behavior consistent.
-    auto* method_decl = cast<clang::CXXMethodDecl>(decl);
-    if (method_decl->getRefQualifier() == clang::RQ_RValue ||
-        method_decl->getMethodQualifiers().hasConst()) {
-      return true;
-    }
+  if (callee_info.has_implicit_object_parameter() &&
+      !IsSimpleAbiType(ast_context, callee_info.implicit_object_parameter_type,
+                       /*for_parameter=*/true)) {
+    return true;
   }
 
   const auto* function_type =
@@ -238,8 +252,7 @@ static auto BuildThunkParameterTypes(clang::ASTContext& ast_context,
   llvm::SmallVector<clang::QualType> thunk_param_types;
   thunk_param_types.reserve(callee_info.num_thunk_params());
   if (callee_info.has_implicit_object_parameter()) {
-    thunk_param_types.push_back(
-        GetNonnullType(ast_context, callee_info.implicit_this_type));
+    thunk_param_types.push_back(callee_info.implicit_object_parameter_type);
   }
 
   const auto* function_type =
@@ -371,22 +384,21 @@ static auto BuildThunkParamRef(clang::Sema& sema,
     clang::ExprResult deref_result =
         sema.BuildUnaryOp(nullptr, clang_loc, clang::UO_Deref, call_arg);
     CARBON_CHECK(deref_result.isUsable());
-
-    // Cast to an rvalue when initializing an rvalue reference. The validity of
-    // the initialization of the reference should be validated by the caller of
-    // the thunk.
-    //
-    // TODO: Consider inserting a cast to an rvalue in more cases. Note that we
-    // currently pass pointers to non-temporary objects as the argument when
-    // calling a thunk, so we'll need to either change that or generate
-    // different thunks depending on whether we're moving from each parameter.
-    if (type->isRValueReferenceType()) {
-      deref_result = clang::ImplicitCastExpr::Create(
-          sema.getASTContext(), deref_result.get()->getType(), clang::CK_NoOp,
-          deref_result.get(), nullptr, clang::ExprValueKind::VK_XValue,
-          clang::FPOptionsOverride());
-    }
     call_arg = deref_result.get();
+  }
+
+  // Cast to an rvalue when initializing an rvalue reference. The validity of
+  // the initialization of the reference should be validated by the caller of
+  // the thunk.
+  //
+  // TODO: Consider inserting a cast to an rvalue in more cases. Note that we
+  // currently pass pointers to non-temporary objects as the argument when
+  // calling a thunk, so we'll need to either change that or generate
+  // different thunks depending on whether we're moving from each parameter.
+  if (!type.isNull() && type->isRValueReferenceType()) {
+    call_arg = clang::ImplicitCastExpr::Create(
+        sema.getASTContext(), call_arg->getType(), clang::CK_NoOp, call_arg,
+        nullptr, clang::ExprValueKind::VK_XValue, clang::FPOptionsOverride());
   }
   return call_arg;
 }
@@ -443,14 +455,14 @@ static auto BuildThunkBody(clang::Sema& sema,
                            callee_info.has_explicit_object_parameter()
                                ? callee_info.decl->getParamDecl(0)->getType()
                                : clang::QualType());
-    bool is_arrow = callee_info.has_implicit_object_parameter();
+    constexpr bool IsArrow = false;
     auto object =
-        sema.PerformMemberExprBaseConversion(object_param_ref, is_arrow);
+        sema.PerformMemberExprBaseConversion(object_param_ref, IsArrow);
     if (object.isInvalid()) {
       return clang::StmtError();
     }
     callee = sema.BuildMemberExpr(
-        object.get(), is_arrow, clang_loc, clang::NestedNameSpecifierLoc(),
+        object.get(), IsArrow, clang_loc, clang::NestedNameSpecifierLoc(),
         clang::SourceLocation(), callee_info.decl,
         clang::DeclAccessPair::make(callee_info.decl, clang::AS_public),
         /*HadMultipleCandidates=*/false, clang::DeclarationNameInfo(),

--- a/toolchain/check/pattern.cpp
+++ b/toolchain/check/pattern.cpp
@@ -157,15 +157,4 @@ auto AddSelfParamPattern(Context& context, SemIR::LocId loc_id,
   return pattern_id;
 }
 
-auto AddAddrSelfParamPattern(Context& context, SemIR::LocId loc_id,
-                             SemIR::ExprRegionId type_expr_region_id,
-                             SemIR::TypeInstId type_inst_id) -> SemIR::InstId {
-  auto pattern_id = AddSelfParamPattern(context, loc_id, type_expr_region_id,
-                                        GetPointerType(context, type_inst_id));
-  return AddPatternInst<SemIR::AddrPattern>(
-      context, loc_id,
-      {.type_id = GetPatternType(context, SemIR::AutoType::TypeId),
-       .inner_id = pattern_id});
-}
-
 }  // namespace Carbon::Check

--- a/toolchain/check/pattern.h
+++ b/toolchain/check/pattern.h
@@ -59,11 +59,6 @@ auto AddSelfParamPattern(Context& context, SemIR::LocId loc_id,
                          SemIR::ExprRegionId type_expr_region_id,
                          SemIR::TypeId type_id) -> SemIR::InstId;
 
-// As the above, but for `addr self: Self*`.
-auto AddAddrSelfParamPattern(Context& context, SemIR::LocId loc_id,
-                             SemIR::ExprRegionId type_expr_region_id,
-                             SemIR::TypeInstId type_inst_id) -> SemIR::InstId;
-
 }  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_CHECK_PATTERN_H_

--- a/toolchain/check/testdata/interop/cpp/builtins.carbon
+++ b/toolchain/check/testdata/interop/cpp/builtins.carbon
@@ -552,6 +552,7 @@ fn F() {
 // CHECK:STDOUT:   %unsigned_int.foo.cpp_overload_set.type: type = cpp_overload_set_type @unsigned_int.foo.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %unsigned_int.foo.cpp_overload_set.value: %unsigned_int.foo.cpp_overload_set.type = cpp_overload_set_value @unsigned_int.foo.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.d47: type = ptr_type %unsigned_int [concrete]
+// CHECK:STDOUT:   %pattern_type.539: type = pattern_type %ptr.d47 [concrete]
 // CHECK:STDOUT:   %unsigned_int.foo.type: type = fn_type @unsigned_int.foo [concrete]
 // CHECK:STDOUT:   %unsigned_int.foo: %unsigned_int.foo.type = struct_value () [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
@@ -568,8 +569,14 @@ fn F() {
 // CHECK:STDOUT:   %unsigned_int.decl: type = class_decl @unsigned_int [concrete = constants.%unsigned_int] {} {}
 // CHECK:STDOUT:   %unsigned_int.foo.cpp_overload_set.value: %unsigned_int.foo.cpp_overload_set.type = cpp_overload_set_value @unsigned_int.foo.cpp_overload_set [concrete = constants.%unsigned_int.foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %unsigned_int.foo.decl: %unsigned_int.foo.type = fn_decl @unsigned_int.foo [concrete = constants.%unsigned_int.foo] {
+// CHECK:STDOUT:     %self.patt: %pattern_type.539 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.539 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc13: %pattern_type.5ec = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.d47 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.d47 = value_binding self, %self.param
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interop/cpp/class/access.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/access.carbon
@@ -1588,9 +1588,11 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %S: type = class_type @S [concrete]
 // CHECK:STDOUT:   %ptr.5c7: type = ptr_type %S [concrete]
+// CHECK:STDOUT:   %pattern_type.259: type = pattern_type %ptr.5c7 [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %S.instance_fn.cpp_overload_set.type: type = cpp_overload_set_type @S.instance_fn.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %S.instance_fn.cpp_overload_set.value: %S.instance_fn.cpp_overload_set.type = cpp_overload_set_value @S.instance_fn.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %pattern_type.7da: type = pattern_type %S [concrete]
 // CHECK:STDOUT:   %S.instance_fn.type: type = fn_type @S.instance_fn [concrete]
 // CHECK:STDOUT:   %S.instance_fn: %S.instance_fn.type = struct_value () [concrete]
 // CHECK:STDOUT:   %S.static_fn.cpp_overload_set.type: type = cpp_overload_set_type @S.static_fn.cpp_overload_set [concrete]
@@ -1607,9 +1609,12 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
 // CHECK:STDOUT:   %S.instance_fn.cpp_overload_set.value: %S.instance_fn.cpp_overload_set.type = cpp_overload_set_value @S.instance_fn.cpp_overload_set [concrete = constants.%S.instance_fn.cpp_overload_set.value]
 // CHECK:STDOUT:   %S.instance_fn.decl: %S.instance_fn.type = fn_decl @S.instance_fn [concrete = constants.%S.instance_fn] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.259 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.259 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc8: %pattern_type.7da = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.5c7 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.5c7 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %S.static_fn.cpp_overload_set.value: %S.static_fn.cpp_overload_set.type = cpp_overload_set_value @S.static_fn.cpp_overload_set [concrete = constants.%S.static_fn.cpp_overload_set.value]
 // CHECK:STDOUT:   %S.static_fn.decl: %S.static_fn.type = fn_decl @S.static_fn [concrete = constants.%S.static_fn] {} {}
@@ -2363,6 +2368,8 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %Public.PublicInstance.cpp_overload_set.type: type = cpp_overload_set_type @Public.PublicInstance.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Public.PublicInstance.cpp_overload_set.value: %Public.PublicInstance.cpp_overload_set.type = cpp_overload_set_value @Public.PublicInstance.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.fb2: type = ptr_type %Base [concrete]
+// CHECK:STDOUT:   %pattern_type.72a: type = pattern_type %ptr.fb2 [concrete]
+// CHECK:STDOUT:   %pattern_type.a3a: type = pattern_type %Base [concrete]
 // CHECK:STDOUT:   %Base.PublicInstance.type: type = fn_type @Base.PublicInstance [concrete]
 // CHECK:STDOUT:   %Base.PublicInstance: %Base.PublicInstance.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ptr.1e8: type = ptr_type %Public [concrete]
@@ -2384,15 +2391,21 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %Base.ProtectedStatic.decl: %Base.ProtectedStatic.type = fn_decl @Base.ProtectedStatic [concrete = constants.%Base.ProtectedStatic] {} {}
 // CHECK:STDOUT:   %Public.PublicInstance.cpp_overload_set.value: %Public.PublicInstance.cpp_overload_set.type = cpp_overload_set_value @Public.PublicInstance.cpp_overload_set [concrete = constants.%Public.PublicInstance.cpp_overload_set.value]
 // CHECK:STDOUT:   %Base.PublicInstance.decl: %Base.PublicInstance.type = fn_decl @Base.PublicInstance [concrete = constants.%Base.PublicInstance] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.72a = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.72a = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc24: %pattern_type.a3a = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.fb2 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.fb2 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Public.ProtectedInstance.cpp_overload_set.value: %Public.ProtectedInstance.cpp_overload_set.type = cpp_overload_set_value @Public.ProtectedInstance.cpp_overload_set [concrete = constants.%Public.ProtectedInstance.cpp_overload_set.value]
 // CHECK:STDOUT:   %Base.ProtectedInstance.decl: %Base.ProtectedInstance.type = fn_decl @Base.ProtectedInstance [concrete = constants.%Base.ProtectedInstance] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.72a = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.72a = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc26: %pattern_type.a3a = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.fb2 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.fb2 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -2533,6 +2546,8 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %Protected.PublicInstance.cpp_overload_set.type: type = cpp_overload_set_type @Protected.PublicInstance.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Protected.PublicInstance.cpp_overload_set.value: %Protected.PublicInstance.cpp_overload_set.type = cpp_overload_set_value @Protected.PublicInstance.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.fb2: type = ptr_type %Base [concrete]
+// CHECK:STDOUT:   %pattern_type.72a: type = pattern_type %ptr.fb2 [concrete]
+// CHECK:STDOUT:   %pattern_type.a3a: type = pattern_type %Base [concrete]
 // CHECK:STDOUT:   %Base.PublicInstance.type: type = fn_type @Base.PublicInstance [concrete]
 // CHECK:STDOUT:   %Base.PublicInstance: %Base.PublicInstance.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ptr.f97: type = ptr_type %Protected [concrete]
@@ -2554,15 +2569,21 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %Base.ProtectedStatic.decl: %Base.ProtectedStatic.type = fn_decl @Base.ProtectedStatic [concrete = constants.%Base.ProtectedStatic] {} {}
 // CHECK:STDOUT:   %Protected.PublicInstance.cpp_overload_set.value: %Protected.PublicInstance.cpp_overload_set.type = cpp_overload_set_value @Protected.PublicInstance.cpp_overload_set [concrete = constants.%Protected.PublicInstance.cpp_overload_set.value]
 // CHECK:STDOUT:   %Base.PublicInstance.decl: %Base.PublicInstance.type = fn_decl @Base.PublicInstance [concrete = constants.%Base.PublicInstance] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.72a = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.72a = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc24: %pattern_type.a3a = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.fb2 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.fb2 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Protected.ProtectedInstance.cpp_overload_set.value: %Protected.ProtectedInstance.cpp_overload_set.type = cpp_overload_set_value @Protected.ProtectedInstance.cpp_overload_set [concrete = constants.%Protected.ProtectedInstance.cpp_overload_set.value]
 // CHECK:STDOUT:   %Base.ProtectedInstance.decl: %Base.ProtectedInstance.type = fn_decl @Base.ProtectedInstance [concrete = constants.%Base.ProtectedInstance] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.72a = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.72a = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc26: %pattern_type.a3a = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.fb2 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.fb2 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -2642,6 +2663,8 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %PublicProtected.PublicInstance.cpp_overload_set.type: type = cpp_overload_set_type @PublicProtected.PublicInstance.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %PublicProtected.PublicInstance.cpp_overload_set.value: %PublicProtected.PublicInstance.cpp_overload_set.type = cpp_overload_set_value @PublicProtected.PublicInstance.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.fb2: type = ptr_type %Base [concrete]
+// CHECK:STDOUT:   %pattern_type.72a: type = pattern_type %ptr.fb2 [concrete]
+// CHECK:STDOUT:   %pattern_type.a3a: type = pattern_type %Base [concrete]
 // CHECK:STDOUT:   %Base.PublicInstance.type: type = fn_type @Base.PublicInstance [concrete]
 // CHECK:STDOUT:   %Base.PublicInstance: %Base.PublicInstance.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ptr.dc4: type = ptr_type %PublicProtected [concrete]
@@ -2663,15 +2686,21 @@ fn Call(var instance: Cpp.PublicPrivate) {
 // CHECK:STDOUT:   %Base.ProtectedStatic.decl: %Base.ProtectedStatic.type = fn_decl @Base.ProtectedStatic [concrete = constants.%Base.ProtectedStatic] {} {}
 // CHECK:STDOUT:   %PublicProtected.PublicInstance.cpp_overload_set.value: %PublicProtected.PublicInstance.cpp_overload_set.type = cpp_overload_set_value @PublicProtected.PublicInstance.cpp_overload_set [concrete = constants.%PublicProtected.PublicInstance.cpp_overload_set.value]
 // CHECK:STDOUT:   %Base.PublicInstance.decl: %Base.PublicInstance.type = fn_decl @Base.PublicInstance [concrete = constants.%Base.PublicInstance] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.72a = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.72a = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc24: %pattern_type.a3a = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.fb2 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.fb2 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %PublicProtected.ProtectedInstance.cpp_overload_set.value: %PublicProtected.ProtectedInstance.cpp_overload_set.type = cpp_overload_set_value @PublicProtected.ProtectedInstance.cpp_overload_set [concrete = constants.%PublicProtected.ProtectedInstance.cpp_overload_set.value]
 // CHECK:STDOUT:   %Base.ProtectedInstance.decl: %Base.ProtectedInstance.type = fn_decl @Base.ProtectedInstance [concrete = constants.%Base.ProtectedInstance] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.72a = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.72a = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc26: %pattern_type.a3a = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.fb2 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.fb2 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/class/base.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/base.carbon
@@ -584,11 +584,8 @@ class V {
 // CHECK:STDOUT:   %Base: type = class_type @Base [concrete]
 // CHECK:STDOUT:   %Derived.f.cpp_overload_set.type: type = cpp_overload_set_type @Derived.f.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Derived.f.cpp_overload_set.value: %Derived.f.cpp_overload_set.type = cpp_overload_set_value @Derived.f.cpp_overload_set [concrete]
-// CHECK:STDOUT:   %const: type = const_type %Base [concrete]
-// CHECK:STDOUT:   %ptr.a97: type = ptr_type %const [concrete]
 // CHECK:STDOUT:   %f__carbon_thunk.type: type = fn_type @f__carbon_thunk [concrete]
 // CHECK:STDOUT:   %f__carbon_thunk: %f__carbon_thunk.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ptr.fb2: type = ptr_type %Base [concrete]
 // CHECK:STDOUT:   %Base.g.cpp_overload_set.type: type = cpp_overload_set_type @Base.g.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Base.g.cpp_overload_set.value: %Base.g.cpp_overload_set.type = cpp_overload_set_value @Base.g.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %g__carbon_thunk.type: type = fn_type @g__carbon_thunk [concrete]
@@ -625,11 +622,7 @@ class V {
 // CHECK:STDOUT:   %.loc8_3.1: ref %Base = class_element_access %d.ref, element0
 // CHECK:STDOUT:   %.loc8_3.2: ref %Base = converted %d.ref, %.loc8_3.1
 // CHECK:STDOUT:   %.loc8_3.3: %Base = bind_value %.loc8_3.2
-// CHECK:STDOUT:   %.loc8_3.4: ref %Base = value_as_ref %.loc8_3.3
-// CHECK:STDOUT:   %addr: %ptr.fb2 = addr_of %.loc8_3.4
-// CHECK:STDOUT:   %.loc8_7.1: %ptr.a97 = as_compatible %addr
-// CHECK:STDOUT:   %.loc8_7.2: %ptr.a97 = converted %addr, %.loc8_7.1
-// CHECK:STDOUT:   %f__carbon_thunk.call: init %empty_tuple.type = call imports.%f__carbon_thunk.decl(%.loc8_7.2)
+// CHECK:STDOUT:   %f__carbon_thunk.call: init %empty_tuple.type = call imports.%f__carbon_thunk.decl(%.loc8_3.3)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -643,11 +636,7 @@ class V {
 // CHECK:STDOUT:   %.loc14_3.1: ref %Base = class_element_access %d.ref, element0
 // CHECK:STDOUT:   %.loc14_3.2: ref %Base = converted %d.ref, %.loc14_3.1
 // CHECK:STDOUT:   %.loc14_3.3: %Base = bind_value %.loc14_3.2
-// CHECK:STDOUT:   %.loc14_3.4: ref %Base = value_as_ref %.loc14_3.3
-// CHECK:STDOUT:   %addr: %ptr.fb2 = addr_of %.loc14_3.4
-// CHECK:STDOUT:   %.loc14_18.1: %ptr.a97 = as_compatible %addr
-// CHECK:STDOUT:   %.loc14_18.2: %ptr.a97 = converted %addr, %.loc14_18.1
-// CHECK:STDOUT:   %g__carbon_thunk.call: init %empty_tuple.type = call imports.%g__carbon_thunk.decl(%.loc14_18.2)
+// CHECK:STDOUT:   %g__carbon_thunk.call: init %empty_tuple.type = call imports.%g__carbon_thunk.decl(%.loc14_3.3)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/class/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/class.carbon
@@ -464,6 +464,7 @@ fn MyF(bar: Cpp.Bar*);
 // CHECK:STDOUT:   %MyF: %MyF.type = struct_value () [concrete]
 // CHECK:STDOUT:   %Bar.f.cpp_overload_set.type: type = cpp_overload_set_type @Bar.f.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Bar.f.cpp_overload_set.value: %Bar.f.cpp_overload_set.type = cpp_overload_set_value @Bar.f.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %pattern_type.07b: type = pattern_type %Bar [concrete]
 // CHECK:STDOUT:   %Bar.f.type: type = fn_type @Bar.f [concrete]
 // CHECK:STDOUT:   %Bar.f: %Bar.f.type = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -476,9 +477,12 @@ fn MyF(bar: Cpp.Bar*);
 // CHECK:STDOUT:   %Bar.decl: type = class_decl @Bar [concrete = constants.%Bar] {} {}
 // CHECK:STDOUT:   %Bar.f.cpp_overload_set.value: %Bar.f.cpp_overload_set.type = cpp_overload_set_value @Bar.f.cpp_overload_set [concrete = constants.%Bar.f.cpp_overload_set.value]
 // CHECK:STDOUT:   %Bar.f.decl: %Bar.f.type = fn_decl @Bar.f [concrete = constants.%Bar.f] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.146 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.146 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc8: %pattern_type.07b = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.f68 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.f68 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/class/field.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/field.carbon
@@ -223,6 +223,8 @@ fn Test(m: Cpp.UnsupportedMembers*) {
 // CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.235, (%OptionalStorage.impl_witness.7fc) [concrete]
 // CHECK:STDOUT:   %Optional.884: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %Struct.elem.98c: type = unbound_element_type %Struct, %Optional.884 [concrete]
+// CHECK:STDOUT:   %const.12f: type = const_type %ptr.235 [concrete]
+// CHECK:STDOUT:   %Struct.elem.93e: type = unbound_element_type %Struct, %const.12f [concrete]
 // CHECK:STDOUT:   %Optional.Get.type.524: type = fn_type @Optional.Get, @Optional(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %Optional.Get.1ff: %Optional.Get.type.524 = struct_value () [concrete]
 // CHECK:STDOUT:   %Optional.Get.specific_fn: <specific function> = specific_function %Optional.Get.1ff, @Optional.Get(%OptionalStorage.facet) [concrete]
@@ -277,9 +279,9 @@ fn Test(m: Cpp.UnsupportedMembers*) {
 // CHECK:STDOUT:   %.loc8_36.2: %ptr.235 = converted %Optional.Get.call, %.loc8_36.1
 // CHECK:STDOUT:   %.loc8_27.1: ref %i32 = deref %.loc8_36.2
 // CHECK:STDOUT:   %s.ref.loc8_40: %Struct = name_ref s, %s
-// CHECK:STDOUT:   %r.ref: %Struct.elem.765 = name_ref r, @Struct.%.6 [concrete = @Struct.%.6]
-// CHECK:STDOUT:   %.loc8_41.1: ref %ptr.235 = class_element_access %s.ref.loc8_40, element4
-// CHECK:STDOUT:   %.loc8_41.2: %ptr.235 = bind_value %.loc8_41.1
+// CHECK:STDOUT:   %r.ref: %Struct.elem.93e = name_ref r, @Struct.%.6 [concrete = @Struct.%.6]
+// CHECK:STDOUT:   %.loc8_41.1: ref %const.12f = class_element_access %s.ref.loc8_40, element4
+// CHECK:STDOUT:   %.loc8_41.2: %const.12f = bind_value %.loc8_41.1
 // CHECK:STDOUT:   %.loc8_39.1: ref %i32 = deref %.loc8_41.2
 // CHECK:STDOUT:   %.loc8_43.1: %tuple.type.a78 = tuple_literal (%.loc8_12.2, %.loc8_17.2, %.loc8_21.1, %.loc8_27.1, %.loc8_39.1)
 // CHECK:STDOUT:   %impl.elem0.loc8_12: %.7fa = impl_witness_access constants.%Copy.impl_witness.a32, element0 [concrete = constants.%Int.as.Copy.impl.Op.f59]

--- a/toolchain/check/testdata/interop/cpp/class/method.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/method.carbon
@@ -79,23 +79,25 @@ fn Value(v: Cpp.HasQualifiers) {
   // CHECK:STDERR:       |        ^
   v.ref_ref_this();
 
-  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE+21]]:3: note: in thunk for C++ function used here [InCppThunk]
+  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE+23]]:3: note: in thunk for C++ function used here [InCppThunk]
   // CHECK:STDERR:   v.const_ref_ref_this();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
   // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-25]]:3: error: `addr self` method cannot be invoked on a value [AddrSelfIsNonRef]
   // CHECK:STDERR:   v.plain();
   // CHECK:STDERR:   ^
-  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon: note: initializing function parameter [InCallToFunctionParam]
+  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-28]]:3: note: initializing function parameter [InCallToFunctionParam]
+  // CHECK:STDERR:   v.plain();
+  // CHECK:STDERR:   ^~~~~~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-27]]:3: error: semantics TODO: `Unsupported: object parameter type: volatile struct HasQualifiers` [SemanticsTodo]
+  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-29]]:3: error: semantics TODO: `Unsupported: object parameter type: volatile struct HasQualifiers &` [SemanticsTodo]
   // CHECK:STDERR:   v.volatile_this();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-29]]:14: error: no matching function for call to 'ref_this' [CppInteropParseError]
+  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-31]]:14: error: no matching function for call to 'ref_this' [CppInteropParseError]
   // CHECK:STDERR:    20 |   v.ref_this();
   // CHECK:STDERR:       |              ^
-  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-40]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: fail_bad_object_param_qualifiers_by_value.carbon:[[@LINE-42]]:10: in file included here [InCppInclude]
   // CHECK:STDERR: ./object_param_qualifiers.h:7:8: note: candidate function not viable: expects an lvalue for object argument [CppInteropParseNote]
   // CHECK:STDERR:     7 |   void ref_this() &;
   // CHECK:STDERR:       |        ^
@@ -111,7 +113,7 @@ import Cpp library "object_param_qualifiers.h";
 
 fn Ref(p: Cpp.HasQualifiers*) {
   // TODO: This should eventually be accepted if we support `volatile`.
-  // CHECK:STDERR: fail_todo_bad_object_param_qualifiers_by_ref.carbon:[[@LINE+4]]:3: error: semantics TODO: `Unsupported: object parameter type: volatile struct HasQualifiers` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_bad_object_param_qualifiers_by_ref.carbon:[[@LINE+4]]:3: error: semantics TODO: `Unsupported: object parameter type: volatile struct HasQualifiers &` [SemanticsTodo]
   // CHECK:STDERR:   p->volatile_this();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -239,12 +241,12 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %HasQualifiers: type = class_type @HasQualifiers [concrete]
+// CHECK:STDOUT:   %pattern_type.e15: type = pattern_type %HasQualifiers [concrete]
 // CHECK:STDOUT:   %ptr.ec3: type = ptr_type %HasQualifiers [concrete]
+// CHECK:STDOUT:   %pattern_type.bc1: type = pattern_type %ptr.ec3 [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %HasQualifiers.const_this.cpp_overload_set.type: type = cpp_overload_set_type @HasQualifiers.const_this.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %HasQualifiers.const_this.cpp_overload_set.value: %HasQualifiers.const_this.cpp_overload_set.type = cpp_overload_set_value @HasQualifiers.const_this.cpp_overload_set [concrete]
-// CHECK:STDOUT:   %const: type = const_type %HasQualifiers [concrete]
-// CHECK:STDOUT:   %ptr.2cb: type = ptr_type %const [concrete]
 // CHECK:STDOUT:   %const_this__carbon_thunk.type: type = fn_type @const_this__carbon_thunk [concrete]
 // CHECK:STDOUT:   %const_this__carbon_thunk: %const_this__carbon_thunk.type = struct_value () [concrete]
 // CHECK:STDOUT:   %HasQualifiers.const_ref_this.cpp_overload_set.type: type = cpp_overload_set_type @HasQualifiers.const_ref_this.cpp_overload_set [concrete]
@@ -276,15 +278,21 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HasQualifiers.plain.cpp_overload_set.value: %HasQualifiers.plain.cpp_overload_set.type = cpp_overload_set_value @HasQualifiers.plain.cpp_overload_set [concrete = constants.%HasQualifiers.plain.cpp_overload_set.value]
 // CHECK:STDOUT:   %HasQualifiers.plain.decl: %HasQualifiers.plain.type = fn_decl @HasQualifiers.plain [concrete = constants.%HasQualifiers.plain] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.bc1 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.bc1 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc11: %pattern_type.e15 = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.ec3 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.ec3 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HasQualifiers.ref_this.cpp_overload_set.value: %HasQualifiers.ref_this.cpp_overload_set.type = cpp_overload_set_value @HasQualifiers.ref_this.cpp_overload_set [concrete = constants.%HasQualifiers.ref_this.cpp_overload_set.value]
 // CHECK:STDOUT:   %HasQualifiers.ref_this.decl: %HasQualifiers.ref_this.type = fn_decl @HasQualifiers.ref_this [concrete = constants.%HasQualifiers.ref_this] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.bc1 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.bc1 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc12: %pattern_type.e15 = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.ec3 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.ec3 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -293,19 +301,11 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   %v.ref.loc8: %HasQualifiers = name_ref v, %v
 // CHECK:STDOUT:   %const_this.ref.loc8: %HasQualifiers.const_this.cpp_overload_set.type = name_ref const_this, imports.%HasQualifiers.const_this.cpp_overload_set.value [concrete = constants.%HasQualifiers.const_this.cpp_overload_set.value]
 // CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %v.ref.loc8, %const_this.ref.loc8
-// CHECK:STDOUT:   %.loc8_3: ref %HasQualifiers = value_as_ref %v.ref.loc8
-// CHECK:STDOUT:   %addr.loc8: %ptr.ec3 = addr_of %.loc8_3
-// CHECK:STDOUT:   %.loc8_16.1: %ptr.2cb = as_compatible %addr.loc8
-// CHECK:STDOUT:   %.loc8_16.2: %ptr.2cb = converted %addr.loc8, %.loc8_16.1
-// CHECK:STDOUT:   %const_this__carbon_thunk.call.loc8: init %empty_tuple.type = call imports.%const_this__carbon_thunk.decl(%.loc8_16.2)
+// CHECK:STDOUT:   %const_this__carbon_thunk.call.loc8: init %empty_tuple.type = call imports.%const_this__carbon_thunk.decl(%v.ref.loc8)
 // CHECK:STDOUT:   %v.ref.loc9: %HasQualifiers = name_ref v, %v
 // CHECK:STDOUT:   %const_ref_this.ref.loc9: %HasQualifiers.const_ref_this.cpp_overload_set.type = name_ref const_ref_this, imports.%HasQualifiers.const_ref_this.cpp_overload_set.value [concrete = constants.%HasQualifiers.const_ref_this.cpp_overload_set.value]
 // CHECK:STDOUT:   %bound_method.loc9: <bound method> = bound_method %v.ref.loc9, %const_ref_this.ref.loc9
-// CHECK:STDOUT:   %.loc9_3: ref %HasQualifiers = value_as_ref %v.ref.loc9
-// CHECK:STDOUT:   %addr.loc9: %ptr.ec3 = addr_of %.loc9_3
-// CHECK:STDOUT:   %.loc9_20.1: %ptr.2cb = as_compatible %addr.loc9
-// CHECK:STDOUT:   %.loc9_20.2: %ptr.2cb = converted %addr.loc9, %.loc9_20.1
-// CHECK:STDOUT:   %const_ref_this__carbon_thunk.call.loc9: init %empty_tuple.type = call imports.%const_ref_this__carbon_thunk.decl(%.loc9_20.2)
+// CHECK:STDOUT:   %const_ref_this__carbon_thunk.call.loc9: init %empty_tuple.type = call imports.%const_ref_this__carbon_thunk.decl(%v.ref.loc9)
 // CHECK:STDOUT:   %p.ref.loc11: %ptr.ec3 = name_ref p, %p
 // CHECK:STDOUT:   %.loc11: ref %HasQualifiers = deref %p.ref.loc11
 // CHECK:STDOUT:   %plain.ref: %HasQualifiers.plain.cpp_overload_set.type = name_ref plain, imports.%HasQualifiers.plain.cpp_overload_set.value [concrete = constants.%HasQualifiers.plain.cpp_overload_set.value]
@@ -323,21 +323,13 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   %const_this.ref.loc13: %HasQualifiers.const_this.cpp_overload_set.type = name_ref const_this, imports.%HasQualifiers.const_this.cpp_overload_set.value [concrete = constants.%HasQualifiers.const_this.cpp_overload_set.value]
 // CHECK:STDOUT:   %bound_method.loc13: <bound method> = bound_method %.loc13_4.1, %const_this.ref.loc13
 // CHECK:STDOUT:   %.loc13_4.2: %HasQualifiers = bind_value %.loc13_4.1
-// CHECK:STDOUT:   %.loc13_4.3: ref %HasQualifiers = value_as_ref %.loc13_4.2
-// CHECK:STDOUT:   %addr.loc13: %ptr.ec3 = addr_of %.loc13_4.3
-// CHECK:STDOUT:   %.loc13_17.1: %ptr.2cb = as_compatible %addr.loc13
-// CHECK:STDOUT:   %.loc13_17.2: %ptr.2cb = converted %addr.loc13, %.loc13_17.1
-// CHECK:STDOUT:   %const_this__carbon_thunk.call.loc13: init %empty_tuple.type = call imports.%const_this__carbon_thunk.decl(%.loc13_17.2)
+// CHECK:STDOUT:   %const_this__carbon_thunk.call.loc13: init %empty_tuple.type = call imports.%const_this__carbon_thunk.decl(%.loc13_4.2)
 // CHECK:STDOUT:   %p.ref.loc14: %ptr.ec3 = name_ref p, %p
 // CHECK:STDOUT:   %.loc14_4.1: ref %HasQualifiers = deref %p.ref.loc14
 // CHECK:STDOUT:   %const_ref_this.ref.loc14: %HasQualifiers.const_ref_this.cpp_overload_set.type = name_ref const_ref_this, imports.%HasQualifiers.const_ref_this.cpp_overload_set.value [concrete = constants.%HasQualifiers.const_ref_this.cpp_overload_set.value]
 // CHECK:STDOUT:   %bound_method.loc14: <bound method> = bound_method %.loc14_4.1, %const_ref_this.ref.loc14
 // CHECK:STDOUT:   %.loc14_4.2: %HasQualifiers = bind_value %.loc14_4.1
-// CHECK:STDOUT:   %.loc14_4.3: ref %HasQualifiers = value_as_ref %.loc14_4.2
-// CHECK:STDOUT:   %addr.loc14: %ptr.ec3 = addr_of %.loc14_4.3
-// CHECK:STDOUT:   %.loc14_21.1: %ptr.2cb = as_compatible %addr.loc14
-// CHECK:STDOUT:   %.loc14_21.2: %ptr.2cb = converted %addr.loc14, %.loc14_21.1
-// CHECK:STDOUT:   %const_ref_this__carbon_thunk.call.loc14: init %empty_tuple.type = call imports.%const_ref_this__carbon_thunk.decl(%.loc14_21.2)
+// CHECK:STDOUT:   %const_ref_this__carbon_thunk.call.loc14: init %empty_tuple.type = call imports.%const_ref_this__carbon_thunk.decl(%.loc14_4.2)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -345,15 +337,15 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %HasQualifiers: type = class_type @HasQualifiers [concrete]
+// CHECK:STDOUT:   %pattern_type.e15: type = pattern_type %HasQualifiers [concrete]
 // CHECK:STDOUT:   %ptr.ec3: type = ptr_type %HasQualifiers [concrete]
+// CHECK:STDOUT:   %pattern_type.bc1: type = pattern_type %ptr.ec3 [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
 // CHECK:STDOUT:   %HasQualifiers.F.cpp_overload_set.type: type = cpp_overload_set_type @HasQualifiers.F.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %HasQualifiers.F.cpp_overload_set.value: %HasQualifiers.F.cpp_overload_set.type = cpp_overload_set_value @HasQualifiers.F.cpp_overload_set [concrete]
-// CHECK:STDOUT:   %const: type = const_type %HasQualifiers [concrete]
-// CHECK:STDOUT:   %ptr.2cb: type = ptr_type %const [concrete]
 // CHECK:STDOUT:   %F__carbon_thunk.type: type = fn_type @F__carbon_thunk [concrete]
 // CHECK:STDOUT:   %F__carbon_thunk: %F__carbon_thunk.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ptr.235: type = ptr_type %i32 [concrete]
@@ -378,8 +370,14 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %HasQualifiers.F.decl.f862ea.2: %HasQualifiers.F.type.d208f0.2 = fn_decl @HasQualifiers.F.2 [concrete = constants.%HasQualifiers.F.efd4e4.2] {
+// CHECK:STDOUT:     %self.patt: %pattern_type.bc1 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.bc1 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc9: %pattern_type.e15 = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.param: %ptr.ec3 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.ec3 = value_binding self, %self.param
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -394,13 +392,9 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   %v.ref: %HasQualifiers = name_ref v, %v
 // CHECK:STDOUT:   %F.ref.loc8: %HasQualifiers.F.cpp_overload_set.type = name_ref F, imports.%HasQualifiers.F.cpp_overload_set.value [concrete = constants.%HasQualifiers.F.cpp_overload_set.value]
 // CHECK:STDOUT:   %bound_method.loc8_17: <bound method> = bound_method %v.ref, %F.ref.loc8
-// CHECK:STDOUT:   %.loc8_16: ref %HasQualifiers = value_as_ref %v.ref
-// CHECK:STDOUT:   %addr.loc8_20: %ptr.ec3 = addr_of %.loc8_16
-// CHECK:STDOUT:   %.loc8_20.1: %ptr.2cb = as_compatible %addr.loc8_20
-// CHECK:STDOUT:   %.loc8_20.2: %ptr.2cb = converted %addr.loc8_20, %.loc8_20.1
-// CHECK:STDOUT:   %F__carbon_thunk.call: init %i32 = call imports.%F__carbon_thunk.decl(%.loc8_20.2)
+// CHECK:STDOUT:   %F__carbon_thunk.call: init %i32 = call imports.%F__carbon_thunk.decl(%v.ref)
 // CHECK:STDOUT:   assign %a.var, %F__carbon_thunk.call
-// CHECK:STDOUT:   %.loc8_10: type = splice_block %i32.loc8 [concrete = constants.%i32] {
+// CHECK:STDOUT:   %.loc8: type = splice_block %i32.loc8 [concrete = constants.%i32] {
 // CHECK:STDOUT:     %int_32.loc8: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:     %i32.loc8: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:   }
@@ -431,8 +425,8 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc8: <bound method> = bound_method %a.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.a57
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method.loc8_3: <bound method> = bound_method %a.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.2
-// CHECK:STDOUT:   %addr.loc8_3: %ptr.235 = addr_of %a.var
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc8: init %empty_tuple.type = call %bound_method.loc8_3(%addr.loc8_3)
+// CHECK:STDOUT:   %addr.loc8: %ptr.235 = addr_of %a.var
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc8: init %empty_tuple.type = call %bound_method.loc8_3(%addr.loc8)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -443,6 +437,7 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
 // CHECK:STDOUT:   %Another: type = class_type @Another [concrete]
 // CHECK:STDOUT:   %ExplicitObjectParam.F.cpp_overload_set.type: type = cpp_overload_set_type @ExplicitObjectParam.F.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ExplicitObjectParam.F.cpp_overload_set.value: %ExplicitObjectParam.F.cpp_overload_set.type = cpp_overload_set_value @ExplicitObjectParam.F.cpp_overload_set [concrete]
@@ -476,9 +471,12 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ExplicitObjectParam.G.cpp_overload_set.value: %ExplicitObjectParam.G.cpp_overload_set.type = cpp_overload_set_value @ExplicitObjectParam.G.cpp_overload_set [concrete = constants.%ExplicitObjectParam.G.cpp_overload_set.value]
 // CHECK:STDOUT:   %ExplicitObjectParam.G.decl: %ExplicitObjectParam.G.type = fn_decl @ExplicitObjectParam.G [concrete = constants.%ExplicitObjectParam.G] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.7ce = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.7ce = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %self.param: %i32 = value_param call_param0
 // CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self: %i32 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ExplicitObjectParam.H.cpp_overload_set.value: %ExplicitObjectParam.H.cpp_overload_set.type = cpp_overload_set_value @ExplicitObjectParam.H.cpp_overload_set [concrete = constants.%ExplicitObjectParam.H.cpp_overload_set.value]
 // CHECK:STDOUT:   %H__carbon_thunk.decl: %H__carbon_thunk.type = fn_decl @H__carbon_thunk [concrete = constants.%H__carbon_thunk] {
@@ -520,6 +518,7 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
 // CHECK:STDOUT:   %Another: type = class_type @Another [concrete]
 // CHECK:STDOUT:   %ExplicitObjectParam.F.cpp_overload_set.type: type = cpp_overload_set_type @ExplicitObjectParam.F.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ExplicitObjectParam.F.cpp_overload_set.value: %ExplicitObjectParam.F.cpp_overload_set.type = cpp_overload_set_value @ExplicitObjectParam.F.cpp_overload_set [concrete]
@@ -548,9 +547,12 @@ fn Call(e: Cpp.ExplicitObjectParam, n: i32, a: Cpp.Another) {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ExplicitObjectParam.F.decl.28f5af.2: %ExplicitObjectParam.F.type.5d25a8.2 = fn_decl @ExplicitObjectParam.F.2 [concrete = constants.%ExplicitObjectParam.F.28cf2e.2] {
-// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self.patt: %pattern_type.7ce = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.7ce = value_param_pattern %self.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %self.param: %i32 = value_param call_param0
 // CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:     %self: %i32 = value_binding self, %self.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F__carbon_thunk.decl.e1b8ec.2: %F__carbon_thunk.type.eda1ac.2 = fn_decl @F__carbon_thunk.2 [concrete = constants.%F__carbon_thunk.0cd6a8.2] {
 // CHECK:STDOUT:     <elided>

--- a/toolchain/check/testdata/interop/cpp/class/template.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/template.carbon
@@ -92,11 +92,8 @@ var y: Cpp.Xint.r#type = 0;
 // CHECK:STDOUT:   %A.elem.c3f: type = unbound_element_type %A.0bedf0.1, %i32 [concrete]
 // CHECK:STDOUT:   %A.f.cpp_overload_set.type: type = cpp_overload_set_type @A.f.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %A.f.cpp_overload_set.value: %A.f.cpp_overload_set.type = cpp_overload_set_value @A.f.cpp_overload_set [concrete]
-// CHECK:STDOUT:   %const.16f: type = const_type %A.0bedf0.1 [concrete]
-// CHECK:STDOUT:   %ptr.703: type = ptr_type %const.16f [concrete]
 // CHECK:STDOUT:   %f__carbon_thunk.type: type = fn_type @f__carbon_thunk [concrete]
 // CHECK:STDOUT:   %f__carbon_thunk: %f__carbon_thunk.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ptr.270828.1: type = ptr_type %A.0bedf0.1 [concrete]
 // CHECK:STDOUT:   %Copy.type: type = facet_type <@Copy> [concrete]
 // CHECK:STDOUT:   %Copy.Op.type: type = fn_type @Copy.Op [concrete]
 // CHECK:STDOUT:   %Int.as.Copy.impl.Op.type.afd: type = fn_type @Int.as.Copy.impl.Op, @Int.as.Copy.impl(%N) [symbolic]
@@ -111,7 +108,7 @@ var y: Cpp.Xint.r#type = 0;
 // CHECK:STDOUT:   %.7fa: type = fn_type_with_self_type %Copy.Op.type, %Copy.facet.c49 [concrete]
 // CHECK:STDOUT:   %Int.as.Copy.impl.Op.specific_fn: <specific function> = specific_function %Int.as.Copy.impl.Op.f59, @Int.as.Copy.impl.Op(%int_32) [concrete]
 // CHECK:STDOUT:   %A.0bedf0.2: type = class_type @A.2 [concrete]
-// CHECK:STDOUT:   %ptr.270828.2: type = ptr_type %A.0bedf0.2 [concrete]
+// CHECK:STDOUT:   %ptr.270: type = ptr_type %A.0bedf0.2 [concrete]
 // CHECK:STDOUT:   %ptr.fb2: type = ptr_type %Base [concrete]
 // CHECK:STDOUT:   %Copy.impl_witness.fe1: <witness> = impl_witness imports.%Copy.impl_witness_table.53c, @ptr.as.Copy.impl(%Base) [concrete]
 // CHECK:STDOUT:   %ptr.as.Copy.impl.Op.type.2d4: type = fn_type @ptr.as.Copy.impl.Op, @ptr.as.Copy.impl(%Base) [concrete]
@@ -139,11 +136,7 @@ var y: Cpp.Xint.r#type = 0;
 // CHECK:STDOUT:   %x.ref.loc9: %A.0bedf0.1 = name_ref x, %x
 // CHECK:STDOUT:   %f.ref: %A.f.cpp_overload_set.type = name_ref f, imports.%A.f.cpp_overload_set.value [concrete = constants.%A.f.cpp_overload_set.value]
 // CHECK:STDOUT:   %bound_method.loc9: <bound method> = bound_method %x.ref.loc9, %f.ref
-// CHECK:STDOUT:   %.loc9_3: ref %A.0bedf0.1 = value_as_ref %x.ref.loc9
-// CHECK:STDOUT:   %addr: %ptr.270828.1 = addr_of %.loc9_3
-// CHECK:STDOUT:   %.loc9_7.1: %ptr.703 = as_compatible %addr
-// CHECK:STDOUT:   %.loc9_7.2: %ptr.703 = converted %addr, %.loc9_7.1
-// CHECK:STDOUT:   %f__carbon_thunk.call: init %empty_tuple.type = call imports.%f__carbon_thunk.decl(%.loc9_7.2)
+// CHECK:STDOUT:   %f__carbon_thunk.call: init %empty_tuple.type = call imports.%f__carbon_thunk.decl(%x.ref.loc9)
 // CHECK:STDOUT:   %x.ref.loc10: %A.0bedf0.1 = name_ref x, %x
 // CHECK:STDOUT:   %n.ref: %A.elem.c3f = name_ref n, @A.1.%.2 [concrete = @A.1.%.2]
 // CHECK:STDOUT:   %.loc10_11.1: ref %i32 = class_element_access %x.ref.loc10, element1
@@ -156,9 +149,9 @@ var y: Cpp.Xint.r#type = 0;
 // CHECK:STDOUT:   return %Int.as.Copy.impl.Op.call to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G(%p.param: %ptr.270828.2) -> %ptr.fb2 {
+// CHECK:STDOUT: fn @G(%p.param: %ptr.270) -> %ptr.fb2 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %p.ref: %ptr.270828.2 = name_ref p, %p
+// CHECK:STDOUT:   %p.ref: %ptr.270 = name_ref p, %p
 // CHECK:STDOUT:   %.loc17_11.1: ref %A.0bedf0.2 = deref %p.ref
 // CHECK:STDOUT:   %.loc17_11.2: ref %Base = class_element_access %.loc17_11.1, element0
 // CHECK:STDOUT:   %addr: %ptr.fb2 = addr_of %.loc17_11.2

--- a/toolchain/check/testdata/interop/cpp/enum/anonymous.carbon
+++ b/toolchain/check/testdata/interop/cpp/enum/anonymous.carbon
@@ -52,7 +52,9 @@ fn G() {
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
 // CHECK:STDOUT:   %C.C.cpp_overload_set.type: type = cpp_overload_set_type @C.C.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %C.C.cpp_overload_set.value: %C.C.cpp_overload_set.type = cpp_overload_set_value @C.C.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %pattern_type.217: type = pattern_type %C [concrete]
 // CHECK:STDOUT:   %ptr.d9e: type = ptr_type %C [concrete]
+// CHECK:STDOUT:   %pattern_type.a31: type = pattern_type %ptr.d9e [concrete]
 // CHECK:STDOUT:   %C__carbon_thunk.type: type = fn_type @C__carbon_thunk [concrete]
 // CHECK:STDOUT:   %C__carbon_thunk: %C__carbon_thunk.type = struct_value () [concrete]
 // CHECK:STDOUT:   %C.F.cpp_overload_set.type: type = cpp_overload_set_type @C.F.cpp_overload_set [concrete]
@@ -91,8 +93,13 @@ fn G() {
 // CHECK:STDOUT:   %C.F.cpp_overload_set.value: %C.F.cpp_overload_set.type = cpp_overload_set_value @C.F.cpp_overload_set [concrete = constants.%C.F.cpp_overload_set.value]
 // CHECK:STDOUT:   %int_1.1d6: %.bb7 = int_value 1 [concrete = constants.%int_1.1d6]
 // CHECK:STDOUT:   %C.F.decl: %C.F.type = fn_decl @C.F [concrete = constants.%C.F] {
+// CHECK:STDOUT:     %self.patt: %pattern_type.a31 = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.a31 = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc10: %pattern_type.217 = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %self.param: %ptr.d9e = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.d9e = value_binding self, %self.param
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interop/cpp/function/default_arg.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/default_arg.carbon
@@ -183,6 +183,8 @@ fn Call() {
 // CHECK:STDOUT:   %X.B.cpp_overload_set.type: type = cpp_overload_set_type @X.B.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %X.B.cpp_overload_set.value: %X.B.cpp_overload_set.type = cpp_overload_set_value @X.B.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.1f9: type = ptr_type %X [concrete]
+// CHECK:STDOUT:   %pattern_type.45c: type = pattern_type %ptr.1f9 [concrete]
+// CHECK:STDOUT:   %pattern_type.46b: type = pattern_type %X [concrete]
 // CHECK:STDOUT:   %X.B.type: type = fn_type @X.B [concrete]
 // CHECK:STDOUT:   %X.B: %X.B.type = struct_value () [concrete]
 // CHECK:STDOUT:   %X.C.cpp_overload_set.type: type = cpp_overload_set_type @X.C.cpp_overload_set [concrete]
@@ -223,8 +225,13 @@ fn Call() {
 // CHECK:STDOUT:   %X.decl: type = class_decl @X [concrete = constants.%X] {} {}
 // CHECK:STDOUT:   %X.B.cpp_overload_set.value: %X.B.cpp_overload_set.type = cpp_overload_set_value @X.B.cpp_overload_set [concrete = constants.%X.B.cpp_overload_set.value]
 // CHECK:STDOUT:   %X.B.decl: %X.B.type = fn_decl @X.B [concrete = constants.%X.B] {
+// CHECK:STDOUT:     %self.patt: %pattern_type.45c = value_binding_pattern self [concrete]
+// CHECK:STDOUT:     %self.param_patt: %pattern_type.45c = value_param_pattern %self.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.loc10: %pattern_type.46b = addr_pattern %self.param_patt [concrete]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %self.param: %ptr.1f9 = value_param call_param0
+// CHECK:STDOUT:     %self: %ptr.1f9 = value_binding self, %self.param
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %X.C.cpp_overload_set.value: %X.C.cpp_overload_set.type = cpp_overload_set_value @X.C.cpp_overload_set [concrete = constants.%X.C.cpp_overload_set.value]
@@ -466,6 +473,7 @@ fn Call() {
 // CHECK:STDOUT:   %X.B.cpp_overload_set.value: %X.B.cpp_overload_set.type = cpp_overload_set_value @X.B.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.1f9: type = ptr_type %X [concrete]
 // CHECK:STDOUT:   %pattern_type.45c: type = pattern_type %ptr.1f9 [concrete]
+// CHECK:STDOUT:   %pattern_type.46b: type = pattern_type %X [concrete]
 // CHECK:STDOUT:   %B__carbon_thunk.type: type = fn_type @B__carbon_thunk [concrete]
 // CHECK:STDOUT:   %B__carbon_thunk: %B__carbon_thunk.type = struct_value () [concrete]
 // CHECK:STDOUT:   %X.C.cpp_overload_set.type: type = cpp_overload_set_type @X.C.cpp_overload_set [concrete]
@@ -580,13 +588,14 @@ fn Call() {
 // CHECK:STDOUT:   %B__carbon_thunk.decl: %B__carbon_thunk.type = fn_decl @B__carbon_thunk [concrete = constants.%B__carbon_thunk] {
 // CHECK:STDOUT:     %this.patt: %pattern_type.45c = value_binding_pattern this [concrete]
 // CHECK:STDOUT:     %this.param_patt: %pattern_type.45c = value_param_pattern %this.patt, call_param0 [concrete]
+// CHECK:STDOUT:     %.1: %pattern_type.46b = addr_pattern %this.param_patt [concrete]
 // CHECK:STDOUT:     %a.patt: %pattern_type.7ce = value_binding_pattern a [concrete]
 // CHECK:STDOUT:     %a.param_patt: %pattern_type.7ce = value_param_pattern %a.patt, call_param1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %this.param: %ptr.1f9 = value_param call_param0
 // CHECK:STDOUT:     %this: %ptr.1f9 = value_binding this, %this.param
 // CHECK:STDOUT:     %a.param: %i32 = value_param call_param1
-// CHECK:STDOUT:     %.1: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %.2: type = splice_block %i32 [concrete = constants.%i32] {
 // CHECK:STDOUT:       %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
 // CHECK:STDOUT:       %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
 // CHECK:STDOUT:     }

--- a/toolchain/check/testdata/interop/cpp/function/reference.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/reference.carbon
@@ -54,11 +54,21 @@ fn F() {
   // CHECK:STDERR:
   Cpp.TakesLValue(s);
 
+  // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE+8]]:35: error: no matching function for call to 'TakesLValue' [CppInteropParseError]
+  // CHECK:STDERR:    28 |   Cpp.TakesLValue(s as const Cpp.S);
+  // CHECK:STDERR:       |                                   ^
+  // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE-19]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: ./param_lvalue_ref.h:5:6: note: candidate function not viable: 1st argument ('const S') would lose const qualifier [CppInteropParseNote]
+  // CHECK:STDERR:     5 | auto TakesLValue(S&) -> void;
+  // CHECK:STDERR:       |      ^           ~~
+  // CHECK:STDERR:
+  Cpp.TakesLValue(s as const Cpp.S);
+
   var t: Cpp.T;
   // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE+8]]:20: error: no matching function for call to 'TakesLValue' [CppInteropParseError]
-  // CHECK:STDERR:    29 |   Cpp.TakesLValue(t);
+  // CHECK:STDERR:    39 |   Cpp.TakesLValue(t);
   // CHECK:STDERR:       |                    ^
-  // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE-20]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE-30]]:10: in file included here [InCppInclude]
   // CHECK:STDERR: ./param_lvalue_ref.h:5:6: note: candidate function not viable: no known conversion from 'T' to 'S &' for 1st argument [CppInteropParseNote]
   // CHECK:STDERR:     5 | auto TakesLValue(S&) -> void;
   // CHECK:STDERR:       |      ^           ~~
@@ -67,9 +77,9 @@ fn F() {
 
   var u: Cpp.S;
   // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE+8]]:35: error: no matching function for call to 'TakesLValue' [CppInteropParseError]
-  // CHECK:STDERR:    40 |   Cpp.TakesLValue(u as const Cpp.S);
+  // CHECK:STDERR:    50 |   Cpp.TakesLValue(u as const Cpp.S);
   // CHECK:STDERR:       |                                   ^
-  // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE-31]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: fail_param_lvalue_ref.carbon:[[@LINE-41]]:10: in file included here [InCppInclude]
   // CHECK:STDERR: ./param_lvalue_ref.h:5:6: note: candidate function not viable: 1st argument ('const S') would lose const qualifier [CppInteropParseNote]
   // CHECK:STDERR:     5 | auto TakesLValue(S&) -> void;
   // CHECK:STDERR:       |      ^           ~~
@@ -171,7 +181,7 @@ struct T {};
 
 auto TakesConstLValue(const S&) -> void;
 
-// --- call_param_const_lvalue_ref.carbon
+// --- call_param_const_lvalue_ref_with_ref.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -186,7 +196,7 @@ fn F() {
   //@dump-sem-ir-end
 }
 
-// --- fail_param_const_lvalue_ref.carbon
+// --- call_param_const_lvalue_ref_with_value.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -194,32 +204,30 @@ import Cpp library "param_const_lvalue_ref.h";
 
 fn F() {
   //@dump-sem-ir-begin
-  // TODO: Should this work? We could create a temporary. Overload resolution
-  // accepts this but the Carbon-side call fails.
-  // TODO: The diagnostic here is wrong; we're internally using `addr` but this
-  // is not `addr self`.
   let s: Cpp.S = {};
-  // CHECK:STDERR: fail_param_const_lvalue_ref.carbon:[[@LINE+8]]:24: error: `addr self` method cannot be invoked on a value [AddrSelfIsNonRef]
-  // CHECK:STDERR:   Cpp.TakesConstLValue(s);
-  // CHECK:STDERR:                        ^
-  // CHECK:STDERR: fail_param_const_lvalue_ref.carbon:[[@LINE-12]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./param_const_lvalue_ref.h:5:31: note: initializing function parameter [InCallToFunctionParam]
-  // CHECK:STDERR: auto TakesConstLValue(const S&) -> void;
-  // CHECK:STDERR:                               ^
-  // CHECK:STDERR:
   Cpp.TakesConstLValue(s);
 
+  Cpp.TakesConstLValue(s as const Cpp.S);
+  //@dump-sem-ir-end
+}
+
+// --- fail_call_param_const_lvalue_ref_with_wrong_type.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp library "param_const_lvalue_ref.h";
+
+fn F() {
   var t: Cpp.T;
-  // CHECK:STDERR: fail_param_const_lvalue_ref.carbon:[[@LINE+8]]:25: error: no matching function for call to 'TakesConstLValue' [CppInteropParseError]
-  // CHECK:STDERR:    32 |   Cpp.TakesConstLValue(t);
+  // CHECK:STDERR: fail_call_param_const_lvalue_ref_with_wrong_type.carbon:[[@LINE+8]]:25: error: no matching function for call to 'TakesConstLValue' [CppInteropParseError]
+  // CHECK:STDERR:    16 |   Cpp.TakesConstLValue(t);
   // CHECK:STDERR:       |                         ^
-  // CHECK:STDERR: fail_param_const_lvalue_ref.carbon:[[@LINE-23]]:10: in file included here [InCppInclude]
+  // CHECK:STDERR: fail_call_param_const_lvalue_ref_with_wrong_type.carbon:[[@LINE-7]]:10: in file included here [InCppInclude]
   // CHECK:STDERR: ./param_const_lvalue_ref.h:5:6: note: candidate function not viable: no known conversion from 'T' to 'const S' for 1st argument [CppInteropParseNote]
   // CHECK:STDERR:     5 | auto TakesConstLValue(const S&) -> void;
   // CHECK:STDERR:       |      ^                ~~~~~~~~
   // CHECK:STDERR:
   Cpp.TakesConstLValue(t);
-  //@dump-sem-ir-end
 }
 
 // ============================================================================
@@ -262,7 +270,7 @@ import Cpp library "return_rvalue_ref.h";
 
 fn F() {
   //@dump-sem-ir-begin
-  var s: Cpp.S = Cpp.ReturnsRValue();
+  var s: Cpp.S* = Cpp.ReturnsRValue();
   //@dump-sem-ir-end
 }
 
@@ -295,10 +303,10 @@ library "[[@TEST_NAME]]";
 import Cpp library "return_const_lvalue_ref.h";
 
 fn F() {
-  // CHECK:STDERR: fail_call_return_const_lvalue_ref_const_correctness.carbon:[[@LINE+7]]:3: error: cannot implicitly convert expression of type `const Cpp.S*` to `Cpp.S*` [ConversionFailure]
+  // CHECK:STDERR: fail_call_return_const_lvalue_ref_const_correctness.carbon:[[@LINE+7]]:3: error: cannot implicitly convert expression of type `const (const Cpp.S*)` to `Cpp.S*` [ConversionFailure]
   // CHECK:STDERR:   var s: Cpp.S* = Cpp.ReturnConstLValue();
   // CHECK:STDERR:   ^~~~~~~~~~~~~
-  // CHECK:STDERR: fail_call_return_const_lvalue_ref_const_correctness.carbon:[[@LINE+4]]:3: note: type `const Cpp.S*` does not implement interface `Core.ImplicitAs(Cpp.S*)` [MissingImplInMemberAccessNote]
+  // CHECK:STDERR: fail_call_return_const_lvalue_ref_const_correctness.carbon:[[@LINE+4]]:3: note: type `const (const Cpp.S*)` does not implement interface `Core.ImplicitAs(Cpp.S*)` [MissingImplInMemberAccessNote]
   // CHECK:STDERR:   var s: Cpp.S* = Cpp.ReturnConstLValue();
   // CHECK:STDERR:   ^~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -316,8 +324,8 @@ fn F() {
 // CHECK:STDOUT:   %TakesLValue.cpp_overload_set.type: type = cpp_overload_set_type @TakesLValue.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %TakesLValue.cpp_overload_set.value: %TakesLValue.cpp_overload_set.type = cpp_overload_set_value @TakesLValue.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ptr.5c7: type = ptr_type %S [concrete]
-// CHECK:STDOUT:   %TakesLValue__carbon_thunk.type: type = fn_type @TakesLValue__carbon_thunk [concrete]
-// CHECK:STDOUT:   %TakesLValue__carbon_thunk: %TakesLValue__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %TakesLValue.type: type = fn_type @TakesLValue [concrete]
+// CHECK:STDOUT:   %TakesLValue: %TakesLValue.type = struct_value () [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
 // CHECK:STDOUT:   %facet_value: %type_where = facet_value %S, () [concrete]
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value) [concrete]
@@ -332,7 +340,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
 // CHECK:STDOUT:   %TakesLValue.cpp_overload_set.value: %TakesLValue.cpp_overload_set.type = cpp_overload_set_value @TakesLValue.cpp_overload_set [concrete = constants.%TakesLValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %TakesLValue__carbon_thunk.decl: %TakesLValue__carbon_thunk.type = fn_decl @TakesLValue__carbon_thunk [concrete = constants.%TakesLValue__carbon_thunk] {
+// CHECK:STDOUT:   %TakesLValue.decl: %TakesLValue.type = fn_decl @TakesLValue [concrete = constants.%TakesLValue] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
@@ -359,7 +367,7 @@ fn F() {
 // CHECK:STDOUT:   %TakesLValue.ref: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
 // CHECK:STDOUT:   %s.ref: ref %S = name_ref s, %s
 // CHECK:STDOUT:   %addr.loc9: %ptr.5c7 = addr_of %s.ref
-// CHECK:STDOUT:   %TakesLValue__carbon_thunk.call: init %empty_tuple.type = call imports.%TakesLValue__carbon_thunk.decl(%addr.loc9)
+// CHECK:STDOUT:   %TakesLValue.call: init %empty_tuple.type = call imports.%TakesLValue.decl(%addr.loc9)
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %s.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %s.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn
@@ -376,9 +384,9 @@ fn F() {
 // CHECK:STDOUT:   %pattern_type.7da: type = pattern_type %S [concrete]
 // CHECK:STDOUT:   %TakesLValue.cpp_overload_set.type: type = cpp_overload_set_type @TakesLValue.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %TakesLValue.cpp_overload_set.value: %TakesLValue.cpp_overload_set.type = cpp_overload_set_value @TakesLValue.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %const: type = const_type %S [concrete]
 // CHECK:STDOUT:   %T: type = class_type @T [concrete]
 // CHECK:STDOUT:   %pattern_type.e6b: type = pattern_type %T [concrete]
-// CHECK:STDOUT:   %const: type = const_type %S [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
 // CHECK:STDOUT:   %facet_value.7bd: %type_where = facet_value %S, () [concrete]
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value.7bd) [concrete]
@@ -426,48 +434,56 @@ fn F() {
 // CHECK:STDOUT:   %s: %S = value_binding s, %.loc9_18
 // CHECK:STDOUT:   %Cpp.ref.loc18: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %TakesLValue.ref.loc18: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %s.ref: %S = name_ref s, %s
+// CHECK:STDOUT:   %s.ref.loc18: %S = name_ref s, %s
+// CHECK:STDOUT:   %Cpp.ref.loc28_3: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %TakesLValue.ref.loc28: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
+// CHECK:STDOUT:   %s.ref.loc28: %S = name_ref s, %s
+// CHECK:STDOUT:   %Cpp.ref.loc28_30: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %S.ref.loc28: type = name_ref S, imports.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:   %const.loc28: type = const_type %S.ref.loc28 [concrete = constants.%const]
+// CHECK:STDOUT:   %.loc28_21.1: %const = as_compatible %s.ref.loc28
+// CHECK:STDOUT:   %.loc28_21.2: %const = converted %s.ref.loc28, %.loc28_21.1
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %t.patt: %pattern_type.e6b = ref_binding_pattern t [concrete]
 // CHECK:STDOUT:     %t.var_patt: %pattern_type.e6b = var_pattern %t.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t.var: ref %T = var %t.var_patt
-// CHECK:STDOUT:   %.loc20: type = splice_block %T.ref [concrete = constants.%T] {
-// CHECK:STDOUT:     %Cpp.ref.loc20: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %.loc30: type = splice_block %T.ref [concrete = constants.%T] {
+// CHECK:STDOUT:     %Cpp.ref.loc30: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, imports.%T.decl [concrete = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %t: ref %T = ref_binding t, %t.var
-// CHECK:STDOUT:   %Cpp.ref.loc29: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %TakesLValue.ref.loc29: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
+// CHECK:STDOUT:   %Cpp.ref.loc39: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %TakesLValue.ref.loc39: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
 // CHECK:STDOUT:   %t.ref: ref %T = name_ref t, %t
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %u.patt: %pattern_type.7da = ref_binding_pattern u [concrete]
 // CHECK:STDOUT:     %u.var_patt: %pattern_type.7da = var_pattern %u.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %u.var: ref %S = var %u.var_patt
-// CHECK:STDOUT:   %.loc31: type = splice_block %S.ref.loc31 [concrete = constants.%S] {
-// CHECK:STDOUT:     %Cpp.ref.loc31: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %S.ref.loc31: type = name_ref S, imports.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:   %.loc41: type = splice_block %S.ref.loc41 [concrete = constants.%S] {
+// CHECK:STDOUT:     %Cpp.ref.loc41: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %S.ref.loc41: type = name_ref S, imports.%S.decl [concrete = constants.%S]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %u: ref %S = ref_binding u, %u.var
-// CHECK:STDOUT:   %Cpp.ref.loc40_3: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %TakesLValue.ref.loc40: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
+// CHECK:STDOUT:   %Cpp.ref.loc50_3: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %TakesLValue.ref.loc50: %TakesLValue.cpp_overload_set.type = name_ref TakesLValue, imports.%TakesLValue.cpp_overload_set.value [concrete = constants.%TakesLValue.cpp_overload_set.value]
 // CHECK:STDOUT:   %u.ref: ref %S = name_ref u, %u
-// CHECK:STDOUT:   %Cpp.ref.loc40_30: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %S.ref.loc40: type = name_ref S, imports.%S.decl [concrete = constants.%S]
-// CHECK:STDOUT:   %const: type = const_type %S.ref.loc40 [concrete = constants.%const]
-// CHECK:STDOUT:   %.loc40_21.1: ref %const = as_compatible %u.ref
-// CHECK:STDOUT:   %.loc40_21.2: ref %const = converted %u.ref, %.loc40_21.1
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc31: <bound method> = bound_method %u.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
+// CHECK:STDOUT:   %Cpp.ref.loc50_30: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %S.ref.loc50: type = name_ref S, imports.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:   %const.loc50: type = const_type %S.ref.loc50 [concrete = constants.%const]
+// CHECK:STDOUT:   %.loc50_21.1: ref %const = as_compatible %u.ref
+// CHECK:STDOUT:   %.loc50_21.2: ref %const = converted %u.ref, %.loc50_21.1
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc41: <bound method> = bound_method %u.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc31: <bound method> = bound_method %u.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.1
-// CHECK:STDOUT:   %addr.loc31: %ptr.5c7 = addr_of %u.var
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc31: init %empty_tuple.type = call %bound_method.loc31(%addr.loc31)
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc20: <bound method> = bound_method %t.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.2f0
+// CHECK:STDOUT:   %bound_method.loc41: <bound method> = bound_method %u.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.1
+// CHECK:STDOUT:   %addr.loc41: %ptr.5c7 = addr_of %u.var
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc41: init %empty_tuple.type = call %bound_method.loc41(%addr.loc41)
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc30: <bound method> = bound_method %t.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.2f0
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc20: <bound method> = bound_method %t.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.2
-// CHECK:STDOUT:   %addr.loc20: %ptr.b04 = addr_of %t.var
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc20: init %empty_tuple.type = call %bound_method.loc20(%addr.loc20)
+// CHECK:STDOUT:   %bound_method.loc30: <bound method> = bound_method %t.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.2
+// CHECK:STDOUT:   %addr.loc30: %ptr.b04 = addr_of %t.var
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc30: init %empty_tuple.type = call %bound_method.loc30(%addr.loc30)
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc8: <bound method> = bound_method %v.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %v.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.3
@@ -692,7 +708,7 @@ fn F() {
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- call_param_const_lvalue_ref.carbon
+// CHECK:STDOUT: --- call_param_const_lvalue_ref_with_ref.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
@@ -752,15 +768,23 @@ fn F() {
 // CHECK:STDOUT:   %const: type = const_type %S.ref.loc9 [concrete = constants.%const]
 // CHECK:STDOUT:   %.loc9_26.1: ref %const = as_compatible %s.ref.loc9
 // CHECK:STDOUT:   %.loc9_26.2: ref %const = converted %s.ref.loc9, %.loc9_26.1
-// CHECK:STDOUT:   %addr.loc9: %ptr.ff5 = addr_of %.loc9_26.2
-// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call.loc9: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%addr.loc9)
+// CHECK:STDOUT:   %.loc9_26.3: ref %S = as_compatible %.loc9_26.2
+// CHECK:STDOUT:   %.loc9_26.4: ref %S = converted %.loc9_26.2, %.loc9_26.3
+// CHECK:STDOUT:   %.loc9_26.5: %S = bind_value %.loc9_26.4
+// CHECK:STDOUT:   %.loc9_26.6: ref %S = value_as_ref %.loc9_26.5
+// CHECK:STDOUT:   %addr.loc9: %ptr.5c7 = addr_of %.loc9_26.6
+// CHECK:STDOUT:   %.loc9_40.1: %ptr.ff5 = as_compatible %addr.loc9
+// CHECK:STDOUT:   %.loc9_40.2: %ptr.ff5 = converted %addr.loc9, %.loc9_40.1
+// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call.loc9: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%.loc9_40.2)
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %TakesConstLValue.ref.loc11: %TakesConstLValue.cpp_overload_set.type = name_ref TakesConstLValue, imports.%TakesConstLValue.cpp_overload_set.value [concrete = constants.%TakesConstLValue.cpp_overload_set.value]
 // CHECK:STDOUT:   %s.ref.loc11: ref %S = name_ref s, %s
-// CHECK:STDOUT:   %addr.loc11: %ptr.5c7 = addr_of %s.ref.loc11
-// CHECK:STDOUT:   %.loc11_24.1: %ptr.ff5 = as_compatible %addr.loc11
-// CHECK:STDOUT:   %.loc11_24.2: %ptr.ff5 = converted %addr.loc11, %.loc11_24.1
-// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call.loc11: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%.loc11_24.2)
+// CHECK:STDOUT:   %.loc11_24.1: %S = bind_value %s.ref.loc11
+// CHECK:STDOUT:   %.loc11_24.2: ref %S = value_as_ref %.loc11_24.1
+// CHECK:STDOUT:   %addr.loc11: %ptr.5c7 = addr_of %.loc11_24.2
+// CHECK:STDOUT:   %.loc11_25.1: %ptr.ff5 = as_compatible %addr.loc11
+// CHECK:STDOUT:   %.loc11_25.2: %ptr.ff5 = converted %addr.loc11, %.loc11_25.1
+// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call.loc11: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%.loc11_25.2)
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %s.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %s.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn
@@ -769,7 +793,7 @@ fn F() {
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_param_const_lvalue_ref.carbon
+// CHECK:STDOUT: --- call_param_const_lvalue_ref_with_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
@@ -784,15 +808,9 @@ fn F() {
 // CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.type: type = fn_type @TakesConstLValue__carbon_thunk [concrete]
 // CHECK:STDOUT:   %TakesConstLValue__carbon_thunk: %TakesConstLValue__carbon_thunk.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ptr.5c7: type = ptr_type %S [concrete]
-// CHECK:STDOUT:   %T: type = class_type @T [concrete]
-// CHECK:STDOUT:   %pattern_type.e6b: type = pattern_type %T [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
-// CHECK:STDOUT:   %facet_value.19d: %type_where = facet_value %T, () [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.431: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value.19d) [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.2f0: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.431 = struct_value () [concrete]
-// CHECK:STDOUT:   %ptr.b04: type = ptr_type %T [concrete]
-// CHECK:STDOUT:   %facet_value.7bd: %type_where = facet_value %S, () [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value.7bd) [concrete]
+// CHECK:STDOUT:   %facet_value: %type_where = facet_value %S, () [concrete]
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value) [concrete]
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.016: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -800,7 +818,6 @@ fn F() {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
 // CHECK:STDOUT:     .S = %S.decl
 // CHECK:STDOUT:     .TakesConstLValue = %TakesConstLValue.cpp_overload_set.value
-// CHECK:STDOUT:     .T = %T.decl
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
@@ -810,7 +827,6 @@ fn F() {
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %T.decl: type = class_decl @T [concrete = constants.%T] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -818,61 +834,65 @@ fn F() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %s.patt: %pattern_type.7da = value_binding_pattern s [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc12_19.1: %empty_struct_type = struct_literal ()
-// CHECK:STDOUT:   %.loc12_13: type = splice_block %S.ref [concrete = constants.%S] {
-// CHECK:STDOUT:     %Cpp.ref.loc12: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %S.ref: type = name_ref S, imports.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:   %.loc8_19.1: %empty_struct_type = struct_literal ()
+// CHECK:STDOUT:   %.loc8_13: type = splice_block %S.ref.loc8 [concrete = constants.%S] {
+// CHECK:STDOUT:     %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %S.ref.loc8: type = name_ref S, imports.%S.decl [concrete = constants.%S]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc12_19.2: ref %S = temporary_storage
-// CHECK:STDOUT:   %.loc12_19.3: init %S = class_init (), %.loc12_19.2 [concrete = constants.%S.val]
-// CHECK:STDOUT:   %.loc12_19.4: ref %S = temporary %.loc12_19.2, %.loc12_19.3
-// CHECK:STDOUT:   %.loc12_19.5: ref %S = converted %.loc12_19.1, %.loc12_19.4
-// CHECK:STDOUT:   %.loc12_19.6: %S = bind_value %.loc12_19.5
-// CHECK:STDOUT:   %s: %S = value_binding s, %.loc12_19.6
-// CHECK:STDOUT:   %Cpp.ref.loc21: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %TakesConstLValue.ref.loc21: %TakesConstLValue.cpp_overload_set.type = name_ref TakesConstLValue, imports.%TakesConstLValue.cpp_overload_set.value [concrete = constants.%TakesConstLValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %s.ref: %S = name_ref s, %s
-// CHECK:STDOUT:   %.loc21_24.1: ref %S = temporary_storage
-// CHECK:STDOUT:   %addr.loc21: %ptr.5c7 = addr_of %.loc21_24.1
-// CHECK:STDOUT:   %.loc21_24.2: %ptr.ff5 = as_compatible %addr.loc21
-// CHECK:STDOUT:   %.loc21_24.3: %ptr.ff5 = converted %addr.loc21, %.loc21_24.2
-// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%.loc21_24.3)
-// CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %t.patt: %pattern_type.e6b = ref_binding_pattern t [concrete]
-// CHECK:STDOUT:     %t.var_patt: %pattern_type.e6b = var_pattern %t.patt [concrete]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %t.var: ref %T = var %t.var_patt
-// CHECK:STDOUT:   %.loc23: type = splice_block %T.ref [concrete = constants.%T] {
-// CHECK:STDOUT:     %Cpp.ref.loc23: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, imports.%T.decl [concrete = constants.%T]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %t: ref %T = ref_binding t, %t.var
-// CHECK:STDOUT:   %Cpp.ref.loc32: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %TakesConstLValue.ref.loc32: %TakesConstLValue.cpp_overload_set.type = name_ref TakesConstLValue, imports.%TakesConstLValue.cpp_overload_set.value [concrete = constants.%TakesConstLValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %t.ref: ref %T = name_ref t, %t
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc23: <bound method> = bound_method %t.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.2f0
+// CHECK:STDOUT:   %.loc8_19.2: ref %S = temporary_storage
+// CHECK:STDOUT:   %.loc8_19.3: init %S = class_init (), %.loc8_19.2 [concrete = constants.%S.val]
+// CHECK:STDOUT:   %.loc8_19.4: ref %S = temporary %.loc8_19.2, %.loc8_19.3
+// CHECK:STDOUT:   %.loc8_19.5: ref %S = converted %.loc8_19.1, %.loc8_19.4
+// CHECK:STDOUT:   %.loc8_19.6: %S = bind_value %.loc8_19.5
+// CHECK:STDOUT:   %s: %S = value_binding s, %.loc8_19.6
+// CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %TakesConstLValue.ref.loc9: %TakesConstLValue.cpp_overload_set.type = name_ref TakesConstLValue, imports.%TakesConstLValue.cpp_overload_set.value [concrete = constants.%TakesConstLValue.cpp_overload_set.value]
+// CHECK:STDOUT:   %s.ref.loc9: %S = name_ref s, %s
+// CHECK:STDOUT:   %.loc9_24: ref %S = value_as_ref %s.ref.loc9
+// CHECK:STDOUT:   %addr.loc9: %ptr.5c7 = addr_of %.loc9_24
+// CHECK:STDOUT:   %.loc9_25.1: %ptr.ff5 = as_compatible %addr.loc9
+// CHECK:STDOUT:   %.loc9_25.2: %ptr.ff5 = converted %addr.loc9, %.loc9_25.1
+// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call.loc9: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%.loc9_25.2)
+// CHECK:STDOUT:   %Cpp.ref.loc11_3: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %TakesConstLValue.ref.loc11: %TakesConstLValue.cpp_overload_set.type = name_ref TakesConstLValue, imports.%TakesConstLValue.cpp_overload_set.value [concrete = constants.%TakesConstLValue.cpp_overload_set.value]
+// CHECK:STDOUT:   %s.ref.loc11: %S = name_ref s, %s
+// CHECK:STDOUT:   %Cpp.ref.loc11_35: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %S.ref.loc11: type = name_ref S, imports.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:   %const: type = const_type %S.ref.loc11 [concrete = constants.%const]
+// CHECK:STDOUT:   %.loc11_26.1: %const = as_compatible %s.ref.loc11
+// CHECK:STDOUT:   %.loc11_26.2: %const = converted %s.ref.loc11, %.loc11_26.1
+// CHECK:STDOUT:   %.loc11_26.3: %S = as_compatible %.loc11_26.2
+// CHECK:STDOUT:   %.loc11_26.4: %S = converted %.loc11_26.2, %.loc11_26.3
+// CHECK:STDOUT:   %.loc11_26.5: ref %S = value_as_ref %.loc11_26.4
+// CHECK:STDOUT:   %addr.loc11: %ptr.5c7 = addr_of %.loc11_26.5
+// CHECK:STDOUT:   %.loc11_40.1: %ptr.ff5 = as_compatible %addr.loc11
+// CHECK:STDOUT:   %.loc11_40.2: %ptr.ff5 = converted %addr.loc11, %.loc11_40.1
+// CHECK:STDOUT:   %TakesConstLValue__carbon_thunk.call.loc11: init %empty_tuple.type = call imports.%TakesConstLValue__carbon_thunk.decl(%.loc11_40.2)
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %.loc8_19.4, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc23: <bound method> = bound_method %t.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.1
-// CHECK:STDOUT:   %addr.loc23: %ptr.b04 = addr_of %t.var
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc23: init %empty_tuple.type = call %bound_method.loc23(%addr.loc23)
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc12: <bound method> = bound_method %.loc12_19.4, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
-// CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc12: <bound method> = bound_method %.loc12_19.4, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.2
-// CHECK:STDOUT:   %addr.loc12: %ptr.5c7 = addr_of %.loc12_19.4
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc12: init %empty_tuple.type = call %bound_method.loc12(%addr.loc12)
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc8_19.4, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn
+// CHECK:STDOUT:   %addr.loc8: %ptr.5c7 = addr_of %.loc8_19.4
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method(%addr.loc8)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- call_return_lvalue_ref.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %S: type = class_type @S [concrete]
-// CHECK:STDOUT:   %ptr: type = ptr_type %S [concrete]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %ptr [concrete]
+// CHECK:STDOUT:   %ptr.5c7: type = ptr_type %S [concrete]
+// CHECK:STDOUT:   %pattern_type.259: type = pattern_type %ptr.5c7 [concrete]
 // CHECK:STDOUT:   %ReturnsLValue.cpp_overload_set.type: type = cpp_overload_set_type @ReturnsLValue.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ReturnsLValue.cpp_overload_set.value: %ReturnsLValue.cpp_overload_set.type = cpp_overload_set_value @ReturnsLValue.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %const: type = const_type %ptr.5c7 [concrete]
 // CHECK:STDOUT:   %ReturnsLValue.type: type = fn_type @ReturnsLValue [concrete]
 // CHECK:STDOUT:   %ReturnsLValue: %ReturnsLValue.type = struct_value () [concrete]
+// CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
+// CHECK:STDOUT:   %facet_value: %type_where = facet_value %ptr.5c7, () [concrete]
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.8de: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value) [concrete]
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.4bc: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.8de = struct_value () [concrete]
+// CHECK:STDOUT:   %ptr.dfe: type = ptr_type %ptr.5c7 [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -893,19 +913,27 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %s.patt: %pattern_type = value_binding_pattern s [concrete]
+// CHECK:STDOUT:     %s.patt: %pattern_type.259 = value_binding_pattern s [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8_19: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %ReturnsLValue.ref: %ReturnsLValue.cpp_overload_set.type = name_ref ReturnsLValue, imports.%ReturnsLValue.cpp_overload_set.value [concrete = constants.%ReturnsLValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %ReturnsLValue.call: init %ptr = call imports.%ReturnsLValue.decl()
-// CHECK:STDOUT:   %.loc8_15: type = splice_block %ptr [concrete = constants.%ptr] {
+// CHECK:STDOUT:   %ReturnsLValue.call: init %const = call imports.%ReturnsLValue.decl()
+// CHECK:STDOUT:   %.loc8_15: type = splice_block %ptr [concrete = constants.%ptr.5c7] {
 // CHECK:STDOUT:     %Cpp.ref.loc8_10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %S.ref: type = name_ref S, imports.%S.decl [concrete = constants.%S]
-// CHECK:STDOUT:     %ptr: type = ptr_type %S.ref [concrete = constants.%ptr]
+// CHECK:STDOUT:     %ptr: type = ptr_type %S.ref [concrete = constants.%ptr.5c7]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc8_37.1: %ptr = value_of_initializer %ReturnsLValue.call
-// CHECK:STDOUT:   %.loc8_37.2: %ptr = converted %ReturnsLValue.call, %.loc8_37.1
-// CHECK:STDOUT:   %s: %ptr = value_binding s, %.loc8_37.2
+// CHECK:STDOUT:   %.loc8_37.1: init %ptr.5c7 = as_compatible %ReturnsLValue.call
+// CHECK:STDOUT:   %.loc8_37.2: init %ptr.5c7 = converted %ReturnsLValue.call, %.loc8_37.1
+// CHECK:STDOUT:   %.loc8_37.3: ref %ptr.5c7 = temporary_storage
+// CHECK:STDOUT:   %.loc8_37.4: ref %ptr.5c7 = temporary %.loc8_37.3, %.loc8_37.2
+// CHECK:STDOUT:   %.loc8_37.5: %ptr.5c7 = bind_value %.loc8_37.4
+// CHECK:STDOUT:   %s: %ptr.5c7 = value_binding s, %.loc8_37.5
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %.loc8_37.4, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.4bc
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %.loc8_37.4, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn
+// CHECK:STDOUT:   %addr: %ptr.dfe = addr_of %.loc8_37.4
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method(%addr)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -914,16 +942,18 @@ fn F() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %S: type = class_type @S [concrete]
-// CHECK:STDOUT:   %pattern_type.7da: type = pattern_type %S [concrete]
+// CHECK:STDOUT:   %ptr.5c7: type = ptr_type %S [concrete]
+// CHECK:STDOUT:   %pattern_type.259: type = pattern_type %ptr.5c7 [concrete]
 // CHECK:STDOUT:   %ReturnsRValue.cpp_overload_set.type: type = cpp_overload_set_type @ReturnsRValue.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ReturnsRValue.cpp_overload_set.value: %ReturnsRValue.cpp_overload_set.type = cpp_overload_set_value @ReturnsRValue.cpp_overload_set [concrete]
-// CHECK:STDOUT:   %ptr.5c7: type = ptr_type %S [concrete]
-// CHECK:STDOUT:   %ReturnsRValue__carbon_thunk.type: type = fn_type @ReturnsRValue__carbon_thunk [concrete]
-// CHECK:STDOUT:   %ReturnsRValue__carbon_thunk: %ReturnsRValue__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %const: type = const_type %ptr.5c7 [concrete]
+// CHECK:STDOUT:   %ReturnsRValue.type: type = fn_type @ReturnsRValue [concrete]
+// CHECK:STDOUT:   %ReturnsRValue: %ReturnsRValue.type = struct_value () [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
-// CHECK:STDOUT:   %facet_value: %type_where = facet_value %S, () [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value) [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.016: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.34a = struct_value () [concrete]
+// CHECK:STDOUT:   %facet_value: %type_where = facet_value %ptr.5c7, () [concrete]
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.8de: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value) [concrete]
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.4bc: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.8de = struct_value () [concrete]
+// CHECK:STDOUT:   %ptr.dfe: type = ptr_type %ptr.5c7 [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -934,7 +964,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
 // CHECK:STDOUT:   %ReturnsRValue.cpp_overload_set.value: %ReturnsRValue.cpp_overload_set.type = cpp_overload_set_value @ReturnsRValue.cpp_overload_set [concrete = constants.%ReturnsRValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %ReturnsRValue__carbon_thunk.decl: %ReturnsRValue__carbon_thunk.type = fn_decl @ReturnsRValue__carbon_thunk [concrete = constants.%ReturnsRValue__carbon_thunk] {
+// CHECK:STDOUT:   %ReturnsRValue.decl: %ReturnsRValue.type = fn_decl @ReturnsRValue [concrete = constants.%ReturnsRValue] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
@@ -944,27 +974,27 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %s.patt: %pattern_type.7da = ref_binding_pattern s [concrete]
-// CHECK:STDOUT:     %s.var_patt: %pattern_type.7da = var_pattern %s.patt [concrete]
+// CHECK:STDOUT:     %s.patt: %pattern_type.259 = ref_binding_pattern s [concrete]
+// CHECK:STDOUT:     %s.var_patt: %pattern_type.259 = var_pattern %s.patt [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %s.var: ref %S = var %s.var_patt
-// CHECK:STDOUT:   %Cpp.ref.loc8_18: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %s.var: ref %ptr.5c7 = var %s.var_patt
+// CHECK:STDOUT:   %Cpp.ref.loc8_19: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %ReturnsRValue.ref: %ReturnsRValue.cpp_overload_set.type = name_ref ReturnsRValue, imports.%ReturnsRValue.cpp_overload_set.value [concrete = constants.%ReturnsRValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %.loc8_3: ref %S = splice_block %s.var {}
-// CHECK:STDOUT:   %addr.loc8_36: %ptr.5c7 = addr_of %.loc8_3
-// CHECK:STDOUT:   %ReturnsRValue__carbon_thunk.call: init %empty_tuple.type = call imports.%ReturnsRValue__carbon_thunk.decl(%addr.loc8_36)
-// CHECK:STDOUT:   %.loc8_36: init %S = in_place_init %ReturnsRValue__carbon_thunk.call, %.loc8_3
-// CHECK:STDOUT:   assign %s.var, %.loc8_36
-// CHECK:STDOUT:   %.loc8_13: type = splice_block %S.ref [concrete = constants.%S] {
+// CHECK:STDOUT:   %ReturnsRValue.call: init %const = call imports.%ReturnsRValue.decl()
+// CHECK:STDOUT:   %.loc8_3.1: init %ptr.5c7 = as_compatible %ReturnsRValue.call
+// CHECK:STDOUT:   %.loc8_3.2: init %ptr.5c7 = converted %ReturnsRValue.call, %.loc8_3.1
+// CHECK:STDOUT:   assign %s.var, %.loc8_3.2
+// CHECK:STDOUT:   %.loc8_15: type = splice_block %ptr [concrete = constants.%ptr.5c7] {
 // CHECK:STDOUT:     %Cpp.ref.loc8_10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %S.ref: type = name_ref S, imports.%S.decl [concrete = constants.%S]
+// CHECK:STDOUT:     %ptr: type = ptr_type %S.ref [concrete = constants.%ptr.5c7]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %s: ref %S = ref_binding s, %s.var
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %s.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.016
+// CHECK:STDOUT:   %s: ref %ptr.5c7 = ref_binding s, %s.var
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %s.var, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.4bc
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %s.var, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn
-// CHECK:STDOUT:   %addr.loc8_3: %ptr.5c7 = addr_of %s.var
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method(%addr.loc8_3)
+// CHECK:STDOUT:   %addr: %ptr.dfe = addr_of %s.var
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method(%addr)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -973,11 +1003,12 @@ fn F() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %S: type = class_type @S [concrete]
-// CHECK:STDOUT:   %const: type = const_type %S [concrete]
-// CHECK:STDOUT:   %ptr.ff5: type = ptr_type %const [concrete]
+// CHECK:STDOUT:   %const.e39: type = const_type %S [concrete]
+// CHECK:STDOUT:   %ptr.ff5: type = ptr_type %const.e39 [concrete]
 // CHECK:STDOUT:   %pattern_type.32f: type = pattern_type %ptr.ff5 [concrete]
 // CHECK:STDOUT:   %ReturnConstLValue.cpp_overload_set.type: type = cpp_overload_set_type @ReturnConstLValue.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %ReturnConstLValue.cpp_overload_set.value: %ReturnConstLValue.cpp_overload_set.type = cpp_overload_set_value @ReturnConstLValue.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %const.179: type = const_type %ptr.ff5 [concrete]
 // CHECK:STDOUT:   %ReturnConstLValue.type: type = fn_type @ReturnConstLValue [concrete]
 // CHECK:STDOUT:   %ReturnConstLValue: %ReturnConstLValue.type = struct_value () [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
@@ -1011,12 +1042,14 @@ fn F() {
 // CHECK:STDOUT:   %s.var: ref %ptr.ff5 = var %s.var_patt
 // CHECK:STDOUT:   %Cpp.ref.loc8_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %ReturnConstLValue.ref: %ReturnConstLValue.cpp_overload_set.type = name_ref ReturnConstLValue, imports.%ReturnConstLValue.cpp_overload_set.value [concrete = constants.%ReturnConstLValue.cpp_overload_set.value]
-// CHECK:STDOUT:   %ReturnConstLValue.call: init %ptr.ff5 = call imports.%ReturnConstLValue.decl()
-// CHECK:STDOUT:   assign %s.var, %ReturnConstLValue.call
-// CHECK:STDOUT:   %.loc8: type = splice_block %ptr [concrete = constants.%ptr.ff5] {
+// CHECK:STDOUT:   %ReturnConstLValue.call: init %const.179 = call imports.%ReturnConstLValue.decl()
+// CHECK:STDOUT:   %.loc8_3.1: init %ptr.ff5 = as_compatible %ReturnConstLValue.call
+// CHECK:STDOUT:   %.loc8_3.2: init %ptr.ff5 = converted %ReturnConstLValue.call, %.loc8_3.1
+// CHECK:STDOUT:   assign %s.var, %.loc8_3.2
+// CHECK:STDOUT:   %.loc8_21: type = splice_block %ptr [concrete = constants.%ptr.ff5] {
 // CHECK:STDOUT:     %Cpp.ref.loc8_16: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %S.ref: type = name_ref S, imports.%S.decl [concrete = constants.%S]
-// CHECK:STDOUT:     %const: type = const_type %S.ref [concrete = constants.%const]
+// CHECK:STDOUT:     %const: type = const_type %S.ref [concrete = constants.%const.e39]
 // CHECK:STDOUT:     %ptr: type = ptr_type %const [concrete = constants.%ptr.ff5]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %s: ref %ptr.ff5 = ref_binding s, %s.var

--- a/toolchain/check/testdata/interop/cpp/globals.carbon
+++ b/toolchain/check/testdata/interop/cpp/globals.carbon
@@ -101,6 +101,8 @@ fn MyF() {
 // CHECK:STDOUT:   %pattern_type.217: type = pattern_type %C [concrete]
 // CHECK:STDOUT:   %ptr.d9e: type = ptr_type %C [concrete]
 // CHECK:STDOUT:   %pattern_type.a31: type = pattern_type %ptr.d9e [concrete]
+// CHECK:STDOUT:   %const: type = const_type %ptr.d9e [concrete]
+// CHECK:STDOUT:   %global_ref.var: ref %ptr.d9e = var imports.%global_ref.var_patt [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -118,7 +120,7 @@ fn MyF() {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   %global.var: ref %C = var %global.var_patt [concrete]
 // CHECK:STDOUT:   %global_ptr.var: ref %ptr.d9e = var %global_ptr.var_patt [concrete]
-// CHECK:STDOUT:   %global_ref.var: ref %ptr.d9e = var %global_ref.var_patt [concrete]
+// CHECK:STDOUT:   %global_ref.var: ref %const = var %global_ref.var_patt [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -172,14 +174,16 @@ fn MyF() {
 // CHECK:STDOUT:     %local_ref.patt: %pattern_type.a31 = value_binding_pattern local_ref [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9_27: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %global_ref.ref: ref %ptr.d9e = name_ref global_ref, imports.%global_ref.var [concrete = imports.%global_ref.var]
+// CHECK:STDOUT:   %global_ref.ref: ref %const = name_ref global_ref, imports.%global_ref.var [concrete = imports.%global_ref.var]
 // CHECK:STDOUT:   %.loc9_23: type = splice_block %ptr.loc9 [concrete = constants.%ptr.d9e] {
 // CHECK:STDOUT:     %Cpp.ref.loc9_18: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, imports.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:     %ptr.loc9: type = ptr_type %C.ref.loc9 [concrete = constants.%ptr.d9e]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc9_30: %ptr.d9e = bind_value %global_ref.ref
-// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc9_30
+// CHECK:STDOUT:   %.loc9_30.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc9_30.2: ref %ptr.d9e = converted %global_ref.ref, %.loc9_30.1 [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc9_30.3: %ptr.d9e = bind_value %.loc9_30.2
+// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc9_30.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/method.carbon
+++ b/toolchain/lower/testdata/interop/cpp/method.carbon
@@ -90,11 +90,11 @@ fn Call(n: Cpp.NeedThunk) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local i32 @_ZNK1A6by_valEv.carbon_thunk(ptr %this) #0 {
+// CHECK:STDOUT: define dso_local i32 @_ZNK1A6by_valEv.carbon_thunk(ptr nonnull align 8 dereferenceable(12) %this) #0 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %this.addr = alloca ptr, align 8
 // CHECK:STDOUT:   store ptr %this, ptr %this.addr, align 8
-// CHECK:STDOUT:   %0 = load ptr, ptr %this.addr, align 8
+// CHECK:STDOUT:   %0 = load ptr, ptr %this.addr, align 8, !nonnull !9, !align !12
 // CHECK:STDOUT:   %call = call i32 @_ZNK1A6by_valEv(ptr nonnull align 8 dereferenceable(12) %0)
 // CHECK:STDOUT:   ret i32 %call
 // CHECK:STDOUT: }
@@ -128,6 +128,7 @@ fn Call(n: Cpp.NeedThunk) {
 // CHECK:STDOUT: !9 = !{}
 // CHECK:STDOUT: !10 = !DILocation(line: 7, column: 10, scope: !7)
 // CHECK:STDOUT: !11 = !DILocation(line: 7, column: 3, scope: !7)
+// CHECK:STDOUT: !12 = !{i64 8}
 // CHECK:STDOUT: ; ModuleID = 'call_by_ref.carbon'
 // CHECK:STDOUT: source_filename = "call_by_ref.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -235,13 +236,13 @@ fn Call(n: Cpp.NeedThunk) {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local void @_ZNK9NeedThunk8ImplicitEa.carbon_thunk(ptr %this, ptr %c) #1 {
+// CHECK:STDOUT: define dso_local void @_ZNK9NeedThunk8ImplicitEa.carbon_thunk(ptr nonnull align 1 dereferenceable(1) %this, ptr %c) #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %this.addr = alloca ptr, align 8
 // CHECK:STDOUT:   %c.addr = alloca ptr, align 8
 // CHECK:STDOUT:   store ptr %this, ptr %this.addr, align 8
 // CHECK:STDOUT:   store ptr %c, ptr %c.addr, align 8
-// CHECK:STDOUT:   %0 = load ptr, ptr %this.addr, align 8
+// CHECK:STDOUT:   %0 = load ptr, ptr %this.addr, align 8, !nonnull !9
 // CHECK:STDOUT:   %1 = load ptr, ptr %c.addr, align 8
 // CHECK:STDOUT:   %2 = load i8, ptr %1, align 1
 // CHECK:STDOUT:   call void @_ZNK9NeedThunk8ImplicitEa(ptr nonnull align 1 dereferenceable(1) %0, i8 signext %2)

--- a/toolchain/lower/testdata/interop/cpp/reference.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reference.carbon
@@ -42,6 +42,35 @@ fn PassRefs() {
   Cpp.TakeConstIntRef(n);
 }
 
+// --- pass_references_via_thunk.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+class C {};
+class ForceThunk {};
+
+auto TakeCRef(C&, ForceThunk = {}) -> void;
+auto TakeCRRef(const C&, ForceThunk = {}) -> void;
+auto TakeConstCRef(const C&, ForceThunk = {}) -> void;
+
+auto TakeIntRef(int&, ForceThunk = {}) -> void;
+auto TakeIntRRef(int&&, ForceThunk = {}) -> void;
+auto TakeConstIntRef(const int&, ForceThunk = {}) -> void;
+''';
+
+fn PassRefs() {
+  var c: Cpp.C;
+  Cpp.TakeCRef(c);
+  Cpp.TakeCRRef({} as Cpp.C);
+  Cpp.TakeConstCRef(c);
+
+  var n: i32;
+  Cpp.TakeIntRef(n);
+  Cpp.TakeIntRRef(42 as i32);
+  Cpp.TakeConstIntRef(n);
+}
+
 // ============================================================================
 // Reference return values
 // ============================================================================
@@ -64,11 +93,38 @@ auto ReturnConstIntRef() -> const int&;
 
 fn GetRefs() {
   var c1: Cpp.C* = Cpp.ReturnCRef();
-  var c2: Cpp.C = Cpp.ReturnCRRef();
+  var c2: Cpp.C* = Cpp.ReturnCRRef();
   var c3: const Cpp.C* = Cpp.ReturnConstCRef();
 
   var n1: i32* = Cpp.ReturnIntRef();
-  var n2: i32 = Cpp.ReturnIntRRef();
+  var n2: i32* = Cpp.ReturnIntRRef();
+  var n3: const i32* = Cpp.ReturnConstIntRef();
+}
+
+// --- return_references_via_thunk.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+class C {};
+class ForceThunk {};
+
+auto ReturnCRef(ForceThunk = {}) -> C&;
+auto ReturnCRRef(ForceThunk = {}) -> C&&;
+auto ReturnConstCRef(ForceThunk = {}) -> const C&;
+
+auto ReturnIntRef(ForceThunk = {}) -> int&;
+auto ReturnIntRRef(ForceThunk = {}) -> int&&;
+auto ReturnConstIntRef(ForceThunk = {}) -> const int&;
+''';
+
+fn GetRefs() {
+  var c1: Cpp.C* = Cpp.ReturnCRef();
+  var c2: Cpp.C* = Cpp.ReturnCRRef();
+  var c3: const Cpp.C* = Cpp.ReturnConstCRef();
+
+  var n1: i32* = Cpp.ReturnIntRef();
+  var n2: i32* = Cpp.ReturnIntRRef();
   var n3: const i32* = Cpp.ReturnConstIntRef();
 }
 
@@ -85,38 +141,34 @@ fn GetRefs() {
 // CHECK:STDOUT:   %.loc19_18.2.temp = alloca {}, align 8, !dbg !11
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !12
 // CHECK:STDOUT:   %.loc24_22.3.temp = alloca i32, align 4, !dbg !13
+// CHECK:STDOUT:   %.loc25_23.2.temp = alloca i32, align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !10
-// CHECK:STDOUT:   call void @_Z8TakeCRefR1C.carbon_thunk(ptr %c.var), !dbg !14
+// CHECK:STDOUT:   call void @_Z8TakeCRefR1C(ptr %c.var), !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_18.2.temp), !dbg !11
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc19_18.2.temp, ptr align 1 @C.val.loc19_18.3, i64 0, i1 false), !dbg !11
-// CHECK:STDOUT:   call void @_Z9TakeCRRefO1C.carbon_thunk(ptr %.loc19_18.2.temp), !dbg !15
-// CHECK:STDOUT:   call void @_Z13TakeConstCRefRK1C.carbon_thunk(ptr %c.var), !dbg !16
+// CHECK:STDOUT:   call void @_Z9TakeCRRefO1C.carbon_thunk(ptr %.loc19_18.2.temp), !dbg !16
+// CHECK:STDOUT:   call void @_Z13TakeConstCRefRK1C.carbon_thunk(ptr %c.var), !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !12
-// CHECK:STDOUT:   call void @_Z10TakeIntRefRi.carbon_thunk(ptr %n.var), !dbg !17
+// CHECK:STDOUT:   call void @_Z10TakeIntRefRi(ptr %n.var), !dbg !18
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc24_22.3.temp), !dbg !13
 // CHECK:STDOUT:   store i32 42, ptr %.loc24_22.3.temp, align 4, !dbg !13
-// CHECK:STDOUT:   call void @_Z11TakeIntRRefOi.carbon_thunk(ptr %.loc24_22.3.temp), !dbg !18
-// CHECK:STDOUT:   call void @_Z15TakeConstIntRefRKi.carbon_thunk(ptr %n.var), !dbg !19
-// CHECK:STDOUT:   ret void, !dbg !20
+// CHECK:STDOUT:   call void @_Z11TakeIntRRefOi.carbon_thunk(ptr %.loc24_22.3.temp), !dbg !19
+// CHECK:STDOUT:   %.loc25_23.1 = load i32, ptr %n.var, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_23.2.temp), !dbg !14
+// CHECK:STDOUT:   store i32 %.loc25_23.1, ptr %.loc25_23.2.temp, align 4, !dbg !14
+// CHECK:STDOUT:   call void @_Z15TakeConstIntRefRKi.carbon_thunk(ptr %.loc25_23.2.temp), !dbg !20
+// CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z8TakeCRefR1C(ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z10TakeIntRefRi(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local void @_Z8TakeCRefR1C.carbon_thunk(ptr %0) #2 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.addr = alloca ptr, align 8
-// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
-// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
-// CHECK:STDOUT:   call void @_Z8TakeCRefR1C(ptr nonnull align 1 dereferenceable(1) %1)
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_Z8TakeCRefR1C(ptr nonnull align 1 dereferenceable(1)) #3
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
 // CHECK:STDOUT: define dso_local void @_Z9TakeCRRefO1C.carbon_thunk(ptr %0) #2 {
@@ -143,18 +195,6 @@ fn GetRefs() {
 // CHECK:STDOUT: declare void @_Z13TakeConstCRefRK1C(ptr nonnull align 1 dereferenceable(1)) #3
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local void @_Z10TakeIntRefRi.carbon_thunk(ptr %0) #2 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.addr = alloca ptr, align 8
-// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
-// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
-// CHECK:STDOUT:   call void @_Z10TakeIntRefRi(ptr nonnull align 4 dereferenceable(4) %1)
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_Z10TakeIntRefRi(ptr nonnull align 4 dereferenceable(4)) #3
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
 // CHECK:STDOUT: define dso_local void @_Z11TakeIntRRefOi.carbon_thunk(ptr %0) #2 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca ptr, align 8
@@ -179,7 +219,7 @@ fn GetRefs() {
 // CHECK:STDOUT: declare void @_Z15TakeConstIntRefRKi(ptr nonnull align 4 dereferenceable(4)) #3
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT: attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
@@ -203,13 +243,166 @@ fn GetRefs() {
 // CHECK:STDOUT: !11 = !DILocation(line: 19, column: 17, scope: !7)
 // CHECK:STDOUT: !12 = !DILocation(line: 22, column: 3, scope: !7)
 // CHECK:STDOUT: !13 = !DILocation(line: 24, column: 19, scope: !7)
-// CHECK:STDOUT: !14 = !DILocation(line: 18, column: 3, scope: !7)
+// CHECK:STDOUT: !14 = !DILocation(line: 25, column: 23, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 18, column: 3, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 19, column: 3, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 20, column: 3, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 23, column: 3, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 24, column: 3, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 25, column: 3, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 16, column: 1, scope: !7)
+// CHECK:STDOUT: ; ModuleID = 'pass_references_via_thunk.carbon'
+// CHECK:STDOUT: source_filename = "pass_references_via_thunk.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %class.ForceThunk = type { i8 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: @C.val.loc20_18.3 = internal constant {} zeroinitializer
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CPassRefs.Main() !dbg !7 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !10
+// CHECK:STDOUT:   %.loc20_18.2.temp = alloca {}, align 8, !dbg !11
+// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !12
+// CHECK:STDOUT:   %.loc25_22.3.temp = alloca i32, align 4, !dbg !13
+// CHECK:STDOUT:   %.loc26_23.2.temp = alloca i32, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !10
+// CHECK:STDOUT:   call void @_Z8TakeCRefR1C10ForceThunk.carbon_thunk1(ptr %c.var), !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_18.2.temp), !dbg !11
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc20_18.2.temp, ptr align 1 @C.val.loc20_18.3, i64 0, i1 false), !dbg !11
+// CHECK:STDOUT:   call void @_Z9TakeCRRefRK1C10ForceThunk.carbon_thunk1(ptr %.loc20_18.2.temp), !dbg !16
+// CHECK:STDOUT:   call void @_Z13TakeConstCRefRK1C10ForceThunk.carbon_thunk1(ptr %c.var), !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !12
+// CHECK:STDOUT:   call void @_Z10TakeIntRefRi10ForceThunk.carbon_thunk1(ptr %n.var), !dbg !18
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_22.3.temp), !dbg !13
+// CHECK:STDOUT:   store i32 42, ptr %.loc25_22.3.temp, align 4, !dbg !13
+// CHECK:STDOUT:   call void @_Z11TakeIntRRefOi10ForceThunk.carbon_thunk1(ptr %.loc25_22.3.temp), !dbg !19
+// CHECK:STDOUT:   %.loc26_23.1 = load i32, ptr %n.var, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc26_23.2.temp), !dbg !14
+// CHECK:STDOUT:   store i32 %.loc26_23.1, ptr %.loc26_23.2.temp, align 4, !dbg !14
+// CHECK:STDOUT:   call void @_Z15TakeConstIntRefRKi10ForceThunk.carbon_thunk1(ptr %.loc26_23.2.temp), !dbg !20
+// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z8TakeCRefR1C10ForceThunk.carbon_thunk1(ptr nonnull align 1 dereferenceable(1) %0) #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8, !nonnull !9
+// CHECK:STDOUT:   call void @_Z8TakeCRefR1C10ForceThunk(ptr nonnull align 1 dereferenceable(1) %1)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z8TakeCRefR1C10ForceThunk(ptr nonnull align 1 dereferenceable(1)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z9TakeCRRefRK1C10ForceThunk.carbon_thunk1(ptr %0) #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
+// CHECK:STDOUT:   call void @_Z9TakeCRRefRK1C10ForceThunk(ptr nonnull align 1 dereferenceable(1) %1)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z9TakeCRRefRK1C10ForceThunk(ptr nonnull align 1 dereferenceable(1)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z13TakeConstCRefRK1C10ForceThunk.carbon_thunk1(ptr %0) #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
+// CHECK:STDOUT:   call void @_Z13TakeConstCRefRK1C10ForceThunk(ptr nonnull align 1 dereferenceable(1) %1)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z13TakeConstCRefRK1C10ForceThunk(ptr nonnull align 1 dereferenceable(1)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z10TakeIntRefRi10ForceThunk.carbon_thunk1(ptr nonnull align 4 dereferenceable(4) %0) #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8, !nonnull !9, !align !22
+// CHECK:STDOUT:   call void @_Z10TakeIntRefRi10ForceThunk(ptr nonnull align 4 dereferenceable(4) %1)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z10TakeIntRefRi10ForceThunk(ptr nonnull align 4 dereferenceable(4)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z11TakeIntRRefOi10ForceThunk.carbon_thunk1(ptr %0) #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
+// CHECK:STDOUT:   call void @_Z11TakeIntRRefOi10ForceThunk(ptr nonnull align 4 dereferenceable(4) %1)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z11TakeIntRRefOi10ForceThunk(ptr nonnull align 4 dereferenceable(4)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z15TakeConstIntRefRKi10ForceThunk.carbon_thunk1(ptr %0) #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8
+// CHECK:STDOUT:   call void @_Z15TakeConstIntRefRKi10ForceThunk(ptr nonnull align 4 dereferenceable(4) %1)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z15TakeConstIntRefRKi10ForceThunk(ptr nonnull align 4 dereferenceable(4)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 4, 3, 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #2 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #3 = { "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 1, !"wchar_size", i32 4}
+// CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 0}
+// CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "pass_references_via_thunk.carbon", directory: "")
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "PassRefs", linkageName: "_CPassRefs.Main", scope: null, file: !6, line: 17, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
+// CHECK:STDOUT: !9 = !{}
+// CHECK:STDOUT: !10 = !DILocation(line: 18, column: 3, scope: !7)
+// CHECK:STDOUT: !11 = !DILocation(line: 20, column: 17, scope: !7)
+// CHECK:STDOUT: !12 = !DILocation(line: 23, column: 3, scope: !7)
+// CHECK:STDOUT: !13 = !DILocation(line: 25, column: 19, scope: !7)
+// CHECK:STDOUT: !14 = !DILocation(line: 26, column: 23, scope: !7)
 // CHECK:STDOUT: !15 = !DILocation(line: 19, column: 3, scope: !7)
 // CHECK:STDOUT: !16 = !DILocation(line: 20, column: 3, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 23, column: 3, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 21, column: 3, scope: !7)
 // CHECK:STDOUT: !18 = !DILocation(line: 24, column: 3, scope: !7)
 // CHECK:STDOUT: !19 = !DILocation(line: 25, column: 3, scope: !7)
-// CHECK:STDOUT: !20 = !DILocation(line: 16, column: 1, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 26, column: 3, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 17, column: 1, scope: !7)
+// CHECK:STDOUT: !22 = !{i64 4}
 // CHECK:STDOUT: ; ModuleID = 'return_references.carbon'
 // CHECK:STDOUT: source_filename = "return_references.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -218,77 +411,51 @@ fn GetRefs() {
 // CHECK:STDOUT: define void @_CGetRefs.Main() !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c1.var = alloca ptr, align 8, !dbg !10
-// CHECK:STDOUT:   %c2.var = alloca {}, align 8, !dbg !11
+// CHECK:STDOUT:   %c2.var = alloca ptr, align 8, !dbg !11
 // CHECK:STDOUT:   %c3.var = alloca ptr, align 8, !dbg !12
 // CHECK:STDOUT:   %n1.var = alloca ptr, align 8, !dbg !13
-// CHECK:STDOUT:   %n2.var = alloca i32, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc22_35.1.temp = alloca i32, align 4, !dbg !15
-// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !16
+// CHECK:STDOUT:   %n2.var = alloca ptr, align 8, !dbg !14
+// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c1.var), !dbg !10
-// CHECK:STDOUT:   %ReturnCRef.call = call ptr @_Z10ReturnCRefv(), !dbg !17
+// CHECK:STDOUT:   %ReturnCRef.call = call ptr @_Z10ReturnCRefv(), !dbg !16
 // CHECK:STDOUT:   store ptr %ReturnCRef.call, ptr %c1.var, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c2.var), !dbg !11
-// CHECK:STDOUT:   call void @_Z11ReturnCRRefv.carbon_thunk(ptr %c2.var), !dbg !18
+// CHECK:STDOUT:   %ReturnCRRef.call = call ptr @_Z11ReturnCRRefv(), !dbg !17
+// CHECK:STDOUT:   store ptr %ReturnCRRef.call, ptr %c2.var, align 8, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c3.var), !dbg !12
-// CHECK:STDOUT:   %ReturnConstCRef.call = call ptr @_Z15ReturnConstCRefv(), !dbg !19
+// CHECK:STDOUT:   %ReturnConstCRef.call = call ptr @_Z15ReturnConstCRefv(), !dbg !18
 // CHECK:STDOUT:   store ptr %ReturnConstCRef.call, ptr %c3.var, align 8, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n1.var), !dbg !13
-// CHECK:STDOUT:   %ReturnIntRef.call = call ptr @_Z12ReturnIntRefv(), !dbg !20
+// CHECK:STDOUT:   %ReturnIntRef.call = call ptr @_Z12ReturnIntRefv(), !dbg !19
 // CHECK:STDOUT:   store ptr %ReturnIntRef.call, ptr %n1.var, align 8, !dbg !13
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n2.var), !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_35.1.temp), !dbg !15
-// CHECK:STDOUT:   call void @_Z13ReturnIntRRefv.carbon_thunk(ptr %.loc22_35.1.temp), !dbg !15
-// CHECK:STDOUT:   %.loc22_35.2 = load i32, ptr %.loc22_35.1.temp, align 4, !dbg !15
-// CHECK:STDOUT:   store i32 %.loc22_35.2, ptr %n2.var, align 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !16
+// CHECK:STDOUT:   %ReturnIntRRef.call = call ptr @_Z13ReturnIntRRefv(), !dbg !20
+// CHECK:STDOUT:   store ptr %ReturnIntRRef.call, ptr %n2.var, align 8, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !15
 // CHECK:STDOUT:   %ReturnConstIntRef.call = call ptr @_Z17ReturnConstIntRefv(), !dbg !21
-// CHECK:STDOUT:   store ptr %ReturnConstIntRef.call, ptr %n3.var, align 8, !dbg !16
+// CHECK:STDOUT:   store ptr %ReturnConstIntRef.call, ptr %n3.var, align 8, !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare ptr @_Z10ReturnCRefv()
 // CHECK:STDOUT:
+// CHECK:STDOUT: declare ptr @_Z11ReturnCRRefv()
+// CHECK:STDOUT:
 // CHECK:STDOUT: declare ptr @_Z15ReturnConstCRefv()
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare ptr @_Z12ReturnIntRefv()
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare ptr @_Z13ReturnIntRRefv()
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare ptr @_Z17ReturnConstIntRefv()
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
 // CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local void @_Z11ReturnCRRefv.carbon_thunk(ptr %return) #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
-// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8
-// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8
-// CHECK:STDOUT:   %call = call nonnull align 1 dereferenceable(1) ptr @_Z11ReturnCRRefv()
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare nonnull align 1 dereferenceable(1) ptr @_Z11ReturnCRRefv() #2
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local void @_Z13ReturnIntRRefv.carbon_thunk(ptr %return) #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
-// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8
-// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8
-// CHECK:STDOUT:   %call = call nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRefv()
-// CHECK:STDOUT:   %1 = load i32, ptr %call, align 4
-// CHECK:STDOUT:   store i32 %1, ptr %0, align 4
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRefv() #2
-// CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 6, 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 5, 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #2 = { "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!5}
@@ -308,11 +475,143 @@ fn GetRefs() {
 // CHECK:STDOUT: !12 = !DILocation(line: 19, column: 3, scope: !7)
 // CHECK:STDOUT: !13 = !DILocation(line: 21, column: 3, scope: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 22, column: 3, scope: !7)
-// CHECK:STDOUT: !15 = !DILocation(line: 22, column: 17, scope: !7)
-// CHECK:STDOUT: !16 = !DILocation(line: 23, column: 3, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 20, scope: !7)
-// CHECK:STDOUT: !18 = !DILocation(line: 18, column: 19, scope: !7)
-// CHECK:STDOUT: !19 = !DILocation(line: 19, column: 26, scope: !7)
-// CHECK:STDOUT: !20 = !DILocation(line: 21, column: 18, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 23, column: 3, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 20, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 18, column: 20, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 19, column: 26, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 21, column: 18, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 18, scope: !7)
 // CHECK:STDOUT: !21 = !DILocation(line: 23, column: 24, scope: !7)
 // CHECK:STDOUT: !22 = !DILocation(line: 16, column: 1, scope: !7)
+// CHECK:STDOUT: ; ModuleID = 'return_references_via_thunk.carbon'
+// CHECK:STDOUT: source_filename = "return_references_via_thunk.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %class.ForceThunk = type { i8 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CGetRefs.Main() !dbg !7 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %c1.var = alloca ptr, align 8, !dbg !10
+// CHECK:STDOUT:   %c2.var = alloca ptr, align 8, !dbg !11
+// CHECK:STDOUT:   %c3.var = alloca ptr, align 8, !dbg !12
+// CHECK:STDOUT:   %n1.var = alloca ptr, align 8, !dbg !13
+// CHECK:STDOUT:   %n2.var = alloca ptr, align 8, !dbg !14
+// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c1.var), !dbg !10
+// CHECK:STDOUT:   %ReturnCRef__carbon_thunk.call = call ptr @_Z10ReturnCRef10ForceThunk.carbon_thunk0(), !dbg !16
+// CHECK:STDOUT:   store ptr %ReturnCRef__carbon_thunk.call, ptr %c1.var, align 8, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c2.var), !dbg !11
+// CHECK:STDOUT:   %ReturnCRRef__carbon_thunk.call = call ptr @_Z11ReturnCRRef10ForceThunk.carbon_thunk0(), !dbg !17
+// CHECK:STDOUT:   store ptr %ReturnCRRef__carbon_thunk.call, ptr %c2.var, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c3.var), !dbg !12
+// CHECK:STDOUT:   %ReturnConstCRef__carbon_thunk.call = call ptr @_Z15ReturnConstCRef10ForceThunk.carbon_thunk0(), !dbg !18
+// CHECK:STDOUT:   store ptr %ReturnConstCRef__carbon_thunk.call, ptr %c3.var, align 8, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n1.var), !dbg !13
+// CHECK:STDOUT:   %ReturnIntRef__carbon_thunk.call = call ptr @_Z12ReturnIntRef10ForceThunk.carbon_thunk0(), !dbg !19
+// CHECK:STDOUT:   store ptr %ReturnIntRef__carbon_thunk.call, ptr %n1.var, align 8, !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n2.var), !dbg !14
+// CHECK:STDOUT:   %ReturnIntRRef__carbon_thunk.call = call ptr @_Z13ReturnIntRRef10ForceThunk.carbon_thunk0(), !dbg !20
+// CHECK:STDOUT:   store ptr %ReturnIntRRef__carbon_thunk.call, ptr %n2.var, align 8, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !15
+// CHECK:STDOUT:   %ReturnConstIntRef__carbon_thunk.call = call ptr @_Z17ReturnConstIntRef10ForceThunk.carbon_thunk0(), !dbg !21
+// CHECK:STDOUT:   store ptr %ReturnConstIntRef__carbon_thunk.call, ptr %n3.var, align 8, !dbg !15
+// CHECK:STDOUT:   ret void, !dbg !22
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local nonnull align 1 dereferenceable(1) ptr @_Z10ReturnCRef10ForceThunk.carbon_thunk0() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   %call = call nonnull align 1 dereferenceable(1) ptr @_Z10ReturnCRef10ForceThunk()
+// CHECK:STDOUT:   ret ptr %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 1 dereferenceable(1) ptr @_Z10ReturnCRef10ForceThunk() #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local nonnull align 1 dereferenceable(1) ptr @_Z11ReturnCRRef10ForceThunk.carbon_thunk0() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   %call = call nonnull align 1 dereferenceable(1) ptr @_Z11ReturnCRRef10ForceThunk()
+// CHECK:STDOUT:   ret ptr %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 1 dereferenceable(1) ptr @_Z11ReturnCRRef10ForceThunk() #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local nonnull align 1 dereferenceable(1) ptr @_Z15ReturnConstCRef10ForceThunk.carbon_thunk0() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   %call = call nonnull align 1 dereferenceable(1) ptr @_Z15ReturnConstCRef10ForceThunk()
+// CHECK:STDOUT:   ret ptr %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 1 dereferenceable(1) ptr @_Z15ReturnConstCRef10ForceThunk() #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local nonnull align 4 dereferenceable(4) ptr @_Z12ReturnIntRef10ForceThunk.carbon_thunk0() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   %call = call nonnull align 4 dereferenceable(4) ptr @_Z12ReturnIntRef10ForceThunk()
+// CHECK:STDOUT:   ret ptr %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 4 dereferenceable(4) ptr @_Z12ReturnIntRef10ForceThunk() #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRef10ForceThunk.carbon_thunk0() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   %call = call nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRef10ForceThunk()
+// CHECK:STDOUT:   ret ptr %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRef10ForceThunk() #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local nonnull align 4 dereferenceable(4) ptr @_Z17ReturnConstIntRef10ForceThunk.carbon_thunk0() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %agg.tmp = alloca %class.ForceThunk, align 1
+// CHECK:STDOUT:   %call = call nonnull align 4 dereferenceable(4) ptr @_Z17ReturnConstIntRef10ForceThunk()
+// CHECK:STDOUT:   ret ptr %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 4 dereferenceable(4) ptr @_Z17ReturnConstIntRef10ForceThunk() #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 1, !"wchar_size", i32 4}
+// CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 0}
+// CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "return_references_via_thunk.carbon", directory: "")
+// CHECK:STDOUT: !7 = distinct !DISubprogram(name: "GetRefs", linkageName: "_CGetRefs.Main", scope: null, file: !6, line: 17, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
+// CHECK:STDOUT: !9 = !{}
+// CHECK:STDOUT: !10 = !DILocation(line: 18, column: 3, scope: !7)
+// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 3, scope: !7)
+// CHECK:STDOUT: !12 = !DILocation(line: 20, column: 3, scope: !7)
+// CHECK:STDOUT: !13 = !DILocation(line: 22, column: 3, scope: !7)
+// CHECK:STDOUT: !14 = !DILocation(line: 23, column: 3, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 24, column: 3, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 18, column: 20, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 19, column: 20, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 20, column: 26, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 22, column: 18, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 23, column: 18, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 24, column: 24, scope: !7)
+// CHECK:STDOUT: !22 = !DILocation(line: 17, column: 1, scope: !7)


### PR DESCRIPTION
For now, map C++ reference types to const-qualified Carbon pointer types rather than picking between a (non-const) pointer or a value type. This fixes misbehavior in lowering for reference members in classes and reference return types.

Update the special-case handling for references as function parameters so that it continues to map const reference parameters to Carbon pass-by-value, and unify the code paths for `self` parameters and other parameters, which were mostly doing the same thing but had some subtle differences.

Add references to the list of types that we can pass to and from C++ directly, without needing an additional layer of thunks.

Part of #6148.