### PR TITLE
Add unit tagging to ExprRegionId

### DIFF
--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -60,7 +60,8 @@ File::File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
       inst_blocks_(allocator_, check_ir_id),
       constants_(this),
       // 1 reserved id for `StructTypeFields::Empty`.
-      struct_type_fields_(allocator_, IdTag(check_ir_id.index, 1)) {
+      struct_type_fields_(allocator_, IdTag(check_ir_id.index, 1)),
+      expr_regions_(check_ir_id) {
   // `type` and the error type are both complete & concrete types.
   types_.SetComplete(
       TypeType::TypeId,


### PR DESCRIPTION
This doesn't show up in the raw SemIR dumps (I don't think that's due to
a lack of coverage, but due to the fact that ExprRegionId isn't used as
an operand of any instructions).
