### PR TITLE
Unify "needs thunk" logic.

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -1738,14 +1738,15 @@ static auto ImportFunctionDecl(Context& context, SemIR::LocId loc_id,
           builder.Note(loc_id, InCppThunk);
         });
 
-    clang::FunctionDecl* thunk_clang_decl =
-        BuildCppThunk(context, function_info);
-    if (thunk_clang_decl) {
-      SemIR::FunctionId thunk_function_id = *ImportFunction(
-          context, loc_id, thunk_clang_decl, thunk_clang_decl->getNumParams());
-      SemIR::InstId thunk_function_decl_id =
-          context.functions().Get(thunk_function_id).first_owning_decl_id;
-      function_info.SetHasCppThunk(thunk_function_decl_id);
+    if (clang::FunctionDecl* thunk_clang_decl =
+            BuildCppThunk(context, function_info)) {
+      if (auto thunk_function_id =
+              ImportFunction(context, loc_id, thunk_clang_decl,
+                             thunk_clang_decl->getNumParams())) {
+        SemIR::InstId thunk_function_decl_id =
+            context.functions().Get(*thunk_function_id).first_owning_decl_id;
+        function_info.SetHasCppThunk(thunk_function_decl_id);
+      }
     }
   }
 

--- a/toolchain/check/testdata/interop/cpp/enum/anonymous.carbon
+++ b/toolchain/check/testdata/interop/cpp/enum/anonymous.carbon
@@ -47,9 +47,8 @@ fn G() {
 // CHECK:STDOUT:   %F.cpp_overload_set.value: %F.cpp_overload_set.type = cpp_overload_set_value @F.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %.4f0: type = class_type @.1 [concrete]
 // CHECK:STDOUT:   %int_1.81a: %.4f0 = int_value 1 [concrete]
-// CHECK:STDOUT:   %ptr.793: type = ptr_type %.4f0 [concrete]
-// CHECK:STDOUT:   %F__carbon_thunk.type.eda1ac.1: type = fn_type @F__carbon_thunk.1 [concrete]
-// CHECK:STDOUT:   %F__carbon_thunk.0cd6a8.1: %F__carbon_thunk.type.eda1ac.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
 // CHECK:STDOUT:   %C.C.cpp_overload_set.type: type = cpp_overload_set_type @C.C.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %C.C.cpp_overload_set.value: %C.C.cpp_overload_set.type = cpp_overload_set_value @C.C.cpp_overload_set [concrete]
@@ -60,19 +59,12 @@ fn G() {
 // CHECK:STDOUT:   %C.F.cpp_overload_set.value: %C.F.cpp_overload_set.type = cpp_overload_set_value @C.F.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %.bb7: type = class_type @.2 [concrete]
 // CHECK:STDOUT:   %int_1.1d6: %.bb7 = int_value 1 [concrete]
-// CHECK:STDOUT:   %ptr.73d: type = ptr_type %.bb7 [concrete]
-// CHECK:STDOUT:   %F__carbon_thunk.type.eda1ac.2: type = fn_type @F__carbon_thunk.2 [concrete]
-// CHECK:STDOUT:   %F__carbon_thunk.0cd6a8.2: %F__carbon_thunk.type.eda1ac.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %C.F.type: type = fn_type @C.F [concrete]
+// CHECK:STDOUT:   %C.F: %C.F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %type_where: type = facet_type <type where .Self impls <CanDestroy>> [concrete]
-// CHECK:STDOUT:   %facet_value.597: %type_where = facet_value %.bb7, () [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.52d: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value.597) [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.afc: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.52d = struct_value () [concrete]
-// CHECK:STDOUT:   %facet_value.b21: %type_where = facet_value %C, () [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.b92: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value.b21) [concrete]
+// CHECK:STDOUT:   %facet_value: %type_where = facet_value %C, () [concrete]
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.b92: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value) [concrete]
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.841: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.b92 = struct_value () [concrete]
-// CHECK:STDOUT:   %facet_value.21d: %type_where = facet_value %.4f0, () [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.type.02d: type = fn_type @DestroyT.binding.as_type.as.Destroy.impl.Op, @DestroyT.binding.as_type.as.Destroy.impl(%facet_value.21d) [concrete]
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.246: %DestroyT.binding.as_type.as.Destroy.impl.Op.type.02d = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -84,7 +76,7 @@ fn G() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.cpp_overload_set.value: %F.cpp_overload_set.type = cpp_overload_set_value @F.cpp_overload_set [concrete = constants.%F.cpp_overload_set.value]
 // CHECK:STDOUT:   %int_1.81a: %.4f0 = int_value 1 [concrete = constants.%int_1.81a]
-// CHECK:STDOUT:   %F__carbon_thunk.decl.e1b8ec.1: %F__carbon_thunk.type.eda1ac.1 = fn_decl @F__carbon_thunk.1 [concrete = constants.%F__carbon_thunk.0cd6a8.1] {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
@@ -98,7 +90,7 @@ fn G() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.F.cpp_overload_set.value: %C.F.cpp_overload_set.type = cpp_overload_set_value @C.F.cpp_overload_set [concrete = constants.%C.F.cpp_overload_set.value]
 // CHECK:STDOUT:   %int_1.1d6: %.bb7 = int_value 1 [concrete = constants.%int_1.1d6]
-// CHECK:STDOUT:   %F__carbon_thunk.decl.e1b8ec.2: %F__carbon_thunk.type.eda1ac.2 = fn_decl @F__carbon_thunk.2 [concrete = constants.%F__carbon_thunk.0cd6a8.2] {
+// CHECK:STDOUT:   %C.F.decl: %C.F.type = fn_decl @C.F [concrete = constants.%C.F] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
@@ -115,10 +107,7 @@ fn G() {
 // CHECK:STDOUT:   %F.ref.loc8: %F.cpp_overload_set.type = name_ref F, imports.%F.cpp_overload_set.value [concrete = constants.%F.cpp_overload_set.value]
 // CHECK:STDOUT:   %Cpp.ref.loc8_9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %b.ref: %.4f0 = name_ref b, imports.%int_1.81a [concrete = constants.%int_1.81a]
-// CHECK:STDOUT:   %.loc8_12.1: ref %.4f0 = temporary_storage
-// CHECK:STDOUT:   %.loc8_12.2: ref %.4f0 = temporary %.loc8_12.1, %b.ref
-// CHECK:STDOUT:   %addr.loc8_14: %ptr.793 = addr_of %.loc8_12.2
-// CHECK:STDOUT:   %F__carbon_thunk.call.loc8: init %empty_tuple.type = call imports.%F__carbon_thunk.decl.e1b8ec.1(%addr.loc8_14)
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call imports.%F.decl(%b.ref)
 // CHECK:STDOUT:   %Cpp.ref.loc10_3: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %C.ref.loc10_6: type = name_ref C, imports.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %C.ref.loc10_8: %C.C.cpp_overload_set.type = name_ref C, imports.%C.C.cpp_overload_set.value [concrete = constants.%C.C.cpp_overload_set.value]
@@ -133,25 +122,12 @@ fn G() {
 // CHECK:STDOUT:   %C.ref.loc10_18: type = name_ref C, imports.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %e.ref: %.bb7 = name_ref e, imports.%int_1.1d6 [concrete = constants.%int_1.1d6]
 // CHECK:STDOUT:   %addr.loc10_11.2: %ptr.d9e = addr_of %.loc10_11.3
-// CHECK:STDOUT:   %.loc10_20.1: ref %.bb7 = temporary_storage
-// CHECK:STDOUT:   %.loc10_20.2: ref %.bb7 = temporary %.loc10_20.1, %e.ref
-// CHECK:STDOUT:   %addr.loc10_22: %ptr.73d = addr_of %.loc10_20.2
-// CHECK:STDOUT:   %F__carbon_thunk.call.loc10: init %empty_tuple.type = call imports.%F__carbon_thunk.decl.e1b8ec.2(%addr.loc10_11.2, %addr.loc10_22)
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc10_20: <bound method> = bound_method %.loc10_20.2, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.afc
+// CHECK:STDOUT:   %C.F.call: init %empty_tuple.type = call imports.%C.F.decl(%addr.loc10_11.2, %e.ref)
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound: <bound method> = bound_method %.loc10_11.3, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.841
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc10_20: <bound method> = bound_method %.loc10_20.2, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.1
-// CHECK:STDOUT:   %addr.loc10_20: %ptr.73d = addr_of %.loc10_20.2
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc10_20: init %empty_tuple.type = call %bound_method.loc10_20(%addr.loc10_20)
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc10_11: <bound method> = bound_method %.loc10_11.3, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.841
-// CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc10_11: <bound method> = bound_method %.loc10_11.3, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.2
+// CHECK:STDOUT:   %bound_method.loc10_11: <bound method> = bound_method %.loc10_11.3, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn
 // CHECK:STDOUT:   %addr.loc10_11.3: %ptr.d9e = addr_of %.loc10_11.3
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc10_11: init %empty_tuple.type = call %bound_method.loc10_11(%addr.loc10_11.3)
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc8: <bound method> = bound_method %.loc8_12.2, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.246
-// CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %.loc8_12.2, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.3
-// CHECK:STDOUT:   %addr.loc8_12: %ptr.793 = addr_of %.loc8_12.2
-// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call.loc8: init %empty_tuple.type = call %bound_method.loc8(%addr.loc8_12)
+// CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.call: init %empty_tuple.type = call %bound_method.loc10_11(%addr.loc10_11.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/function/decayed_param.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/decayed_param.carbon
@@ -117,8 +117,8 @@ fn F() {
 // CHECK:STDOUT:   %OptionalStorage.impl_witness.01b: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.377, @ptr.as.OptionalStorage.impl(%i32) [concrete]
 // CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.235, (%OptionalStorage.impl_witness.01b) [concrete]
 // CHECK:STDOUT:   %Optional.8fd: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %TakesArray__carbon_thunk.type: type = fn_type @TakesArray__carbon_thunk [concrete]
-// CHECK:STDOUT:   %TakesArray__carbon_thunk: %TakesArray__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %TakesArray.type: type = fn_type @TakesArray [concrete]
+// CHECK:STDOUT:   %TakesArray: %TakesArray.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.6cc: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.8fd)> [concrete]
 // CHECK:STDOUT:   %ImplicitAs.Convert.type.770: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Optional.8fd) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.ImplicitAs.impl.Convert.type.6f7: type = fn_type @T.binding.as_type.as.ImplicitAs.impl.Convert.2, @T.binding.as_type.as.ImplicitAs.impl.3a5(%T.76d) [symbolic]
@@ -153,7 +153,7 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6db = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.5a7 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %OptionalStorage.impl_witness_table.377 = impl_witness_table (%Core.import_ref.8c0, %Core.import_ref.566, %Core.import_ref.637, %Core.import_ref.6db, %Core.import_ref.5a7), @ptr.as.OptionalStorage.impl [concrete]
-// CHECK:STDOUT:   %TakesArray__carbon_thunk.decl: %TakesArray__carbon_thunk.type = fn_decl @TakesArray__carbon_thunk [concrete = constants.%TakesArray__carbon_thunk] {
+// CHECK:STDOUT:   %TakesArray.decl: %TakesArray.type = fn_decl @TakesArray [concrete = constants.%TakesArray] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
@@ -207,7 +207,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc11_18.2: init %Optional.8fd = converted %addr.loc11_18.1, %T.binding.as_type.as.ImplicitAs.impl.Convert.call
 // CHECK:STDOUT:   %.loc11_18.3: ref %Optional.8fd = temporary %.loc11_18.1, %.loc11_18.2
 // CHECK:STDOUT:   %.loc11_18.4: %Optional.8fd = bind_value %.loc11_18.3
-// CHECK:STDOUT:   %TakesArray__carbon_thunk.call: init %empty_tuple.type = call imports.%TakesArray__carbon_thunk.decl(%.loc11_18.4)
+// CHECK:STDOUT:   %TakesArray.call: init %empty_tuple.type = call imports.%TakesArray.decl(%.loc11_18.4)
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc11: <bound method> = bound_method %.loc11_18.3, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.af3
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method.loc11_18.3: <bound method> = bound_method %.loc11_18.3, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.1

--- a/toolchain/check/testdata/interop/cpp/function/pointer.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/pointer.carbon
@@ -663,8 +663,8 @@ fn F() {
 // CHECK:STDOUT:   %OptionalStorage.impl_witness.707: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.377, @ptr.as.OptionalStorage.impl(%S) [concrete]
 // CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.5c7, (%OptionalStorage.impl_witness.707) [concrete]
 // CHECK:STDOUT:   %Optional.143: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %foo__carbon_thunk.type: type = fn_type @foo__carbon_thunk [concrete]
-// CHECK:STDOUT:   %foo__carbon_thunk: %foo__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
+// CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.06b: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.143)> [concrete]
 // CHECK:STDOUT:   %ImplicitAs.Convert.type.e1b: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Optional.143) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.ImplicitAs.impl.Convert.type.6f7: type = fn_type @T.binding.as_type.as.ImplicitAs.impl.Convert.1, @T.binding.as_type.as.ImplicitAs.impl.3a5(%T.76d) [symbolic]
@@ -699,7 +699,7 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6db = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.5a7 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %OptionalStorage.impl_witness_table.377 = impl_witness_table (%Core.import_ref.8c0, %Core.import_ref.566, %Core.import_ref.637, %Core.import_ref.6db, %Core.import_ref.5a7), @ptr.as.OptionalStorage.impl [concrete]
-// CHECK:STDOUT:   %foo__carbon_thunk.decl: %foo__carbon_thunk.type = fn_decl @foo__carbon_thunk [concrete = constants.%foo__carbon_thunk] {
+// CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
@@ -743,7 +743,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc9_11.2: init %Optional.143 = converted %addr.loc9_11.1, %T.binding.as_type.as.ImplicitAs.impl.Convert.call
 // CHECK:STDOUT:   %.loc9_11.3: ref %Optional.143 = temporary %.loc9_11.1, %.loc9_11.2
 // CHECK:STDOUT:   %.loc9_11.4: %Optional.143 = bind_value %.loc9_11.3
-// CHECK:STDOUT:   %foo__carbon_thunk.call: init %empty_tuple.type = call imports.%foo__carbon_thunk.decl(%.loc9_11.4)
+// CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc9_11.4)
 // CHECK:STDOUT:   %DestroyT.binding.as_type.as.Destroy.impl.Op.bound.loc9: <bound method> = bound_method %.loc9_11.3, constants.%DestroyT.binding.as_type.as.Destroy.impl.Op.465
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %bound_method.loc9_11.3: <bound method> = bound_method %.loc9_11.3, %DestroyT.binding.as_type.as.Destroy.impl.Op.specific_fn.1
@@ -925,8 +925,8 @@ fn F() {
 // CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.5c7, (%OptionalStorage.impl_witness.707) [concrete]
 // CHECK:STDOUT:   %Optional.143: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %pattern_type.aa5: type = pattern_type %Optional.143 [concrete]
-// CHECK:STDOUT:   %Direct__carbon_thunk.type: type = fn_type @Direct__carbon_thunk [concrete]
-// CHECK:STDOUT:   %Direct__carbon_thunk: %Direct__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Direct.type: type = fn_type @Direct [concrete]
+// CHECK:STDOUT:   %Direct: %Direct.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
 // CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.cc7 = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.06b: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.143)> [concrete]
@@ -977,7 +977,7 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6db = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.5a7 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %OptionalStorage.impl_witness_table.377 = impl_witness_table (%Core.import_ref.8c0, %Core.import_ref.566, %Core.import_ref.637, %Core.import_ref.6db, %Core.import_ref.5a7), @ptr.as.OptionalStorage.impl [concrete]
-// CHECK:STDOUT:   %Direct__carbon_thunk.decl: %Direct__carbon_thunk.type = fn_decl @Direct__carbon_thunk [concrete = constants.%Direct__carbon_thunk] {
+// CHECK:STDOUT:   %Direct.decl: %Direct.type = fn_decl @Direct [concrete = constants.%Direct] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %OptionalStorage.facet.loc11_16.1: %OptionalStorage.type = facet_value constants.%ptr.5c7, (constants.%OptionalStorage.impl_witness.707) [concrete = constants.%OptionalStorage.facet]
@@ -1036,8 +1036,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc11_14.2: init %Optional.143 = converted %addr.loc11_14.1, %T.binding.as_type.as.ImplicitAs.impl.Convert.call
 // CHECK:STDOUT:   %.loc11_14.3: ref %Optional.143 = temporary %.loc11_14.1, %.loc11_14.2
 // CHECK:STDOUT:   %.loc11_14.4: %Optional.143 = bind_value %.loc11_14.3
-// CHECK:STDOUT:   %Direct__carbon_thunk.call: init %Optional.143 = call imports.%Direct__carbon_thunk.decl(%.loc11_14.4) to %.loc11_16.1
-// CHECK:STDOUT:   %.loc11_16.2: ref %Optional.143 = temporary %.loc11_16.1, %Direct__carbon_thunk.call
+// CHECK:STDOUT:   %Direct.call: init %Optional.143 = call imports.%Direct.decl(%.loc11_14.4) to %.loc11_16.1
+// CHECK:STDOUT:   %.loc11_16.2: ref %Optional.143 = temporary %.loc11_16.1, %Direct.call
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %a.patt: %pattern_type.aa5 = value_binding_pattern a [concrete]
 // CHECK:STDOUT:   }

--- a/toolchain/lower/testdata/interop/cpp/parameters.carbon
+++ b/toolchain/lower/testdata/interop/cpp/parameters.carbon
@@ -121,49 +121,43 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT:   %.loc7_22.3.temp = alloca i16, align 2, !dbg !11
 // CHECK:STDOUT:   %.loc9_21.3.temp = alloca i8, align 1, !dbg !12
 // CHECK:STDOUT:   %.loc9_24.3.temp = alloca i16, align 2, !dbg !13
-// CHECK:STDOUT:   %.loc9_27.3.temp = alloca i32, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc9_30.3.temp = alloca i64, align 8, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_19.3.temp), !dbg !10
 // CHECK:STDOUT:   store i8 1, ptr %.loc7_19.3.temp, align 1, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_22.3.temp), !dbg !11
 // CHECK:STDOUT:   store i16 2, ptr %.loc7_22.3.temp, align 2, !dbg !11
-// CHECK:STDOUT:   call void @_Z11pass_signedasil.carbon_thunk(ptr %.loc7_19.3.temp, ptr %.loc7_22.3.temp, i32 3, i64 4), !dbg !16
+// CHECK:STDOUT:   call void @_Z11pass_signedasil.carbon_thunk(ptr %.loc7_19.3.temp, ptr %.loc7_22.3.temp, i32 3, i64 4), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_21.3.temp), !dbg !12
 // CHECK:STDOUT:   store i8 1, ptr %.loc9_21.3.temp, align 1, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_24.3.temp), !dbg !13
 // CHECK:STDOUT:   store i16 2, ptr %.loc9_24.3.temp, align 2, !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_27.3.temp), !dbg !14
-// CHECK:STDOUT:   store i32 3, ptr %.loc9_27.3.temp, align 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_30.3.temp), !dbg !15
-// CHECK:STDOUT:   store i64 4, ptr %.loc9_30.3.temp, align 4, !dbg !15
-// CHECK:STDOUT:   call void @_Z13pass_unsignedhtjm.carbon_thunk(ptr %.loc9_21.3.temp, ptr %.loc9_24.3.temp, ptr %.loc9_27.3.temp, ptr %.loc9_30.3.temp), !dbg !17
-// CHECK:STDOUT:   ret void, !dbg !18
+// CHECK:STDOUT:   call void @_Z13pass_unsignedhtjm.carbon_thunk(ptr %.loc9_21.3.temp, ptr %.loc9_24.3.temp, i32 3, i64 4), !dbg !15
+// CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i16 @_CMakeShort.Main()
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @_CPassShort.Main(i16 %a, ptr %b) !dbg !19 {
+// CHECK:STDOUT: define void @_CPassShort.Main(i16 %a, ptr %b) !dbg !17 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc17_18.1.temp = alloca i16, align 2, !dbg !20
-// CHECK:STDOUT:   %.loc18_18.3.temp = alloca i16, align 2, !dbg !21
-// CHECK:STDOUT:   %.loc19_18.2.temp = alloca i16, align 2, !dbg !22
-// CHECK:STDOUT:   %.loc20_28.3.temp = alloca i16, align 2, !dbg !23
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_18.1.temp), !dbg !20
-// CHECK:STDOUT:   store i16 %a, ptr %.loc17_18.1.temp, align 2, !dbg !20
-// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc17_18.1.temp), !dbg !24
-// CHECK:STDOUT:   %.loc18_18.2 = load i16, ptr %b, align 2, !dbg !21
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_18.3.temp), !dbg !21
-// CHECK:STDOUT:   store i16 %.loc18_18.2, ptr %.loc18_18.3.temp, align 2, !dbg !21
-// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc18_18.3.temp), !dbg !25
-// CHECK:STDOUT:   %.loc19_18.1 = load i16, ptr @_Cc.Main, align 2, !dbg !22
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_18.2.temp), !dbg !22
-// CHECK:STDOUT:   store i16 %.loc19_18.1, ptr %.loc19_18.2.temp, align 2, !dbg !22
-// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc19_18.2.temp), !dbg !26
-// CHECK:STDOUT:   %MakeShort.call = call i16 @_CMakeShort.Main(), !dbg !23
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_28.3.temp), !dbg !23
-// CHECK:STDOUT:   store i16 %MakeShort.call, ptr %.loc20_28.3.temp, align 2, !dbg !23
-// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc20_28.3.temp), !dbg !27
-// CHECK:STDOUT:   ret void, !dbg !28
+// CHECK:STDOUT:   %.loc17_18.1.temp = alloca i16, align 2, !dbg !18
+// CHECK:STDOUT:   %.loc18_18.3.temp = alloca i16, align 2, !dbg !19
+// CHECK:STDOUT:   %.loc19_18.2.temp = alloca i16, align 2, !dbg !20
+// CHECK:STDOUT:   %.loc20_28.3.temp = alloca i16, align 2, !dbg !21
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_18.1.temp), !dbg !18
+// CHECK:STDOUT:   store i16 %a, ptr %.loc17_18.1.temp, align 2, !dbg !18
+// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc17_18.1.temp), !dbg !22
+// CHECK:STDOUT:   %.loc18_18.2 = load i16, ptr %b, align 2, !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_18.3.temp), !dbg !19
+// CHECK:STDOUT:   store i16 %.loc18_18.2, ptr %.loc18_18.3.temp, align 2, !dbg !19
+// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc18_18.3.temp), !dbg !23
+// CHECK:STDOUT:   %.loc19_18.1 = load i16, ptr @_Cc.Main, align 2, !dbg !20
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_18.2.temp), !dbg !20
+// CHECK:STDOUT:   store i16 %.loc19_18.1, ptr %.loc19_18.2.temp, align 2, !dbg !20
+// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc19_18.2.temp), !dbg !24
+// CHECK:STDOUT:   %MakeShort.call = call i16 @_CMakeShort.Main(), !dbg !21
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_28.3.temp), !dbg !21
+// CHECK:STDOUT:   store i16 %MakeShort.call, ptr %.loc20_28.3.temp, align 2, !dbg !21
+// CHECK:STDOUT:   call void @_Z10pass_shorts.carbon_thunk(ptr %.loc20_28.3.temp), !dbg !25
+// CHECK:STDOUT:   ret void, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -193,25 +187,23 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: declare void @_Z11pass_signedasil(i8 signext, i16 signext, i32, i64) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
-// CHECK:STDOUT: define dso_local void @_Z13pass_unsignedhtjm.carbon_thunk(ptr %0, ptr %1, ptr %2, ptr %3) #1 {
+// CHECK:STDOUT: define dso_local void @_Z13pass_unsignedhtjm.carbon_thunk(ptr %0, ptr %1, i32 %2, i64 %3) #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca ptr, align 8
 // CHECK:STDOUT:   %.addr1 = alloca ptr, align 8
-// CHECK:STDOUT:   %.addr2 = alloca ptr, align 8
-// CHECK:STDOUT:   %.addr3 = alloca ptr, align 8
+// CHECK:STDOUT:   %.addr2 = alloca i32, align 4
+// CHECK:STDOUT:   %.addr3 = alloca i64, align 8
 // CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8
 // CHECK:STDOUT:   store ptr %1, ptr %.addr1, align 8
-// CHECK:STDOUT:   store ptr %2, ptr %.addr2, align 8
-// CHECK:STDOUT:   store ptr %3, ptr %.addr3, align 8
+// CHECK:STDOUT:   store i32 %2, ptr %.addr2, align 4
+// CHECK:STDOUT:   store i64 %3, ptr %.addr3, align 8
 // CHECK:STDOUT:   %4 = load ptr, ptr %.addr, align 8
 // CHECK:STDOUT:   %5 = load i8, ptr %4, align 1
 // CHECK:STDOUT:   %6 = load ptr, ptr %.addr1, align 8
 // CHECK:STDOUT:   %7 = load i16, ptr %6, align 2
-// CHECK:STDOUT:   %8 = load ptr, ptr %.addr2, align 8
-// CHECK:STDOUT:   %9 = load i32, ptr %8, align 4
-// CHECK:STDOUT:   %10 = load ptr, ptr %.addr3, align 8
-// CHECK:STDOUT:   %11 = load i64, ptr %10, align 8
-// CHECK:STDOUT:   call void @_Z13pass_unsignedhtjm(i8 zeroext %5, i16 zeroext %7, i32 %9, i64 %11)
+// CHECK:STDOUT:   %8 = load i32, ptr %.addr2, align 4
+// CHECK:STDOUT:   %9 = load i64, ptr %.addr3, align 8
+// CHECK:STDOUT:   call void @_Z13pass_unsignedhtjm(i8 zeroext %5, i16 zeroext %7, i32 %8, i64 %9)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -231,7 +223,7 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: declare void @_Z10pass_shorts(i16 signext) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 7, 6, 5, 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
@@ -254,21 +246,19 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: !11 = !DILocation(line: 7, column: 22, scope: !7)
 // CHECK:STDOUT: !12 = !DILocation(line: 9, column: 21, scope: !7)
 // CHECK:STDOUT: !13 = !DILocation(line: 9, column: 24, scope: !7)
-// CHECK:STDOUT: !14 = !DILocation(line: 9, column: 27, scope: !7)
-// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 30, scope: !7)
-// CHECK:STDOUT: !16 = !DILocation(line: 7, column: 3, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 9, column: 3, scope: !7)
-// CHECK:STDOUT: !18 = !DILocation(line: 6, column: 1, scope: !7)
-// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "PassShort", linkageName: "_CPassShort.Main", scope: null, file: !6, line: 16, type: !8, spFlags: DISPFlagDefinition, unit: !5)
-// CHECK:STDOUT: !20 = !DILocation(line: 17, column: 18, scope: !19)
-// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 18, scope: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 19, column: 18, scope: !19)
-// CHECK:STDOUT: !23 = !DILocation(line: 20, column: 18, scope: !19)
-// CHECK:STDOUT: !24 = !DILocation(line: 17, column: 3, scope: !19)
-// CHECK:STDOUT: !25 = !DILocation(line: 18, column: 3, scope: !19)
-// CHECK:STDOUT: !26 = !DILocation(line: 19, column: 3, scope: !19)
-// CHECK:STDOUT: !27 = !DILocation(line: 20, column: 3, scope: !19)
-// CHECK:STDOUT: !28 = !DILocation(line: 16, column: 1, scope: !19)
+// CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 6, column: 1, scope: !7)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "PassShort", linkageName: "_CPassShort.Main", scope: null, file: !6, line: 16, type: !8, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 18, scope: !17)
+// CHECK:STDOUT: !19 = !DILocation(line: 18, column: 18, scope: !17)
+// CHECK:STDOUT: !20 = !DILocation(line: 19, column: 18, scope: !17)
+// CHECK:STDOUT: !21 = !DILocation(line: 20, column: 18, scope: !17)
+// CHECK:STDOUT: !22 = !DILocation(line: 17, column: 3, scope: !17)
+// CHECK:STDOUT: !23 = !DILocation(line: 18, column: 3, scope: !17)
+// CHECK:STDOUT: !24 = !DILocation(line: 19, column: 3, scope: !17)
+// CHECK:STDOUT: !25 = !DILocation(line: 20, column: 3, scope: !17)
+// CHECK:STDOUT: !26 = !DILocation(line: 16, column: 1, scope: !17)
 // CHECK:STDOUT: ; ModuleID = 'import_struct.carbon'
 // CHECK:STDOUT: source_filename = "import_struct.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"

--- a/toolchain/lower/testdata/interop/cpp/reference.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reference.carbon
@@ -222,24 +222,27 @@ fn GetRefs() {
 // CHECK:STDOUT:   %c3.var = alloca ptr, align 8, !dbg !12
 // CHECK:STDOUT:   %n1.var = alloca ptr, align 8, !dbg !13
 // CHECK:STDOUT:   %n2.var = alloca i32, align 4, !dbg !14
-// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !15
+// CHECK:STDOUT:   %.loc22_35.1.temp = alloca i32, align 4, !dbg !15
+// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c1.var), !dbg !10
-// CHECK:STDOUT:   %ReturnCRef.call = call ptr @_Z10ReturnCRefv(), !dbg !16
+// CHECK:STDOUT:   %ReturnCRef.call = call ptr @_Z10ReturnCRefv(), !dbg !17
 // CHECK:STDOUT:   store ptr %ReturnCRef.call, ptr %c1.var, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c2.var), !dbg !11
-// CHECK:STDOUT:   call void @_Z11ReturnCRRefv.carbon_thunk(ptr %c2.var), !dbg !17
+// CHECK:STDOUT:   call void @_Z11ReturnCRRefv.carbon_thunk(ptr %c2.var), !dbg !18
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c3.var), !dbg !12
-// CHECK:STDOUT:   %ReturnConstCRef.call = call ptr @_Z15ReturnConstCRefv(), !dbg !18
+// CHECK:STDOUT:   %ReturnConstCRef.call = call ptr @_Z15ReturnConstCRefv(), !dbg !19
 // CHECK:STDOUT:   store ptr %ReturnConstCRef.call, ptr %c3.var, align 8, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n1.var), !dbg !13
-// CHECK:STDOUT:   %ReturnIntRef.call = call ptr @_Z12ReturnIntRefv(), !dbg !19
+// CHECK:STDOUT:   %ReturnIntRef.call = call ptr @_Z12ReturnIntRefv(), !dbg !20
 // CHECK:STDOUT:   store ptr %ReturnIntRef.call, ptr %n1.var, align 8, !dbg !13
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n2.var), !dbg !14
-// CHECK:STDOUT:   %ReturnIntRRef.call = call i32 @_Z13ReturnIntRRefv(), !dbg !20
-// CHECK:STDOUT:   store i32 %ReturnIntRRef.call, ptr %n2.var, align 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_35.1.temp), !dbg !15
+// CHECK:STDOUT:   call void @_Z13ReturnIntRRefv.carbon_thunk(ptr %.loc22_35.1.temp), !dbg !15
+// CHECK:STDOUT:   %.loc22_35.2 = load i32, ptr %.loc22_35.1.temp, align 4, !dbg !15
+// CHECK:STDOUT:   store i32 %.loc22_35.2, ptr %n2.var, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !16
 // CHECK:STDOUT:   %ReturnConstIntRef.call = call ptr @_Z17ReturnConstIntRefv(), !dbg !21
-// CHECK:STDOUT:   store ptr %ReturnConstIntRef.call, ptr %n3.var, align 8, !dbg !15
+// CHECK:STDOUT:   store ptr %ReturnConstIntRef.call, ptr %n3.var, align 8, !dbg !16
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -248,8 +251,6 @@ fn GetRefs() {
 // CHECK:STDOUT: declare ptr @_Z15ReturnConstCRefv()
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare ptr @_Z12ReturnIntRefv()
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare i32 @_Z13ReturnIntRRefv()
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare ptr @_Z17ReturnConstIntRefv()
 // CHECK:STDOUT:
@@ -268,8 +269,22 @@ fn GetRefs() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare nonnull align 1 dereferenceable(1) ptr @_Z11ReturnCRRefv() #2
 // CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress
+// CHECK:STDOUT: define dso_local void @_Z13ReturnIntRRefv.carbon_thunk(ptr %return) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8
+// CHECK:STDOUT:   %call = call nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRefv()
+// CHECK:STDOUT:   %1 = load i32, ptr %call, align 4
+// CHECK:STDOUT:   store i32 %1, ptr %0, align 4
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare nonnull align 4 dereferenceable(4) ptr @_Z13ReturnIntRRefv() #2
+// CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 6, 5, 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
@@ -293,11 +308,11 @@ fn GetRefs() {
 // CHECK:STDOUT: !12 = !DILocation(line: 19, column: 3, scope: !7)
 // CHECK:STDOUT: !13 = !DILocation(line: 21, column: 3, scope: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 22, column: 3, scope: !7)
-// CHECK:STDOUT: !15 = !DILocation(line: 23, column: 3, scope: !7)
-// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 20, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 18, column: 19, scope: !7)
-// CHECK:STDOUT: !18 = !DILocation(line: 19, column: 26, scope: !7)
-// CHECK:STDOUT: !19 = !DILocation(line: 21, column: 18, scope: !7)
-// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 17, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 22, column: 17, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 23, column: 3, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 20, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 18, column: 19, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 19, column: 26, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 21, column: 18, scope: !7)
 // CHECK:STDOUT: !21 = !DILocation(line: 23, column: 24, scope: !7)
 // CHECK:STDOUT: !22 = !DILocation(line: 16, column: 1, scope: !7)


### PR DESCRIPTION
Remove duplication between determining whether a parameter needs custom
thunk mapping and whether a function needs a thunk. Now a function needs
a thunk if any parameter or the return type does.

This fixes some inconsistencies; previously:
- We would not require a thunk when passing an `unsigned int`, but if we
  had a thunk we'd pass `unsigned int` indirectly.
- We would always require a thunk for an enum parameter, even though
  we'd actually pass it directly if its underlying type is a 32- or
  64-bit integer.
- We would require a thunk for a nullable pointer, even though
  we arrange for all pointer types to have the same ABI in Carbon and
  C++, including nullable pointers / Optional(T*).

This also causes us to use a thunk for rvalue reference return types,
which we used to miscompile.

Depends on #6276.