### PR TITLE
Add unit tagging to ImportCppId

### DIFF
--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -51,6 +51,7 @@ File::File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
       // The `2` prevents adding a tag for the global ids
       // `ImportIRId::{ApiForImpl,Cpp}`.
       import_irs_(IdTag(check_ir_id.index, 2)),
+      import_cpps_(check_ir_id),
       clang_decls_(check_ir_id),
       // The `+1` prevents adding a tag to the global `NameSpace::PackageInstId`
       // instruction. It's not a "singleton" instruction, but it's a unique


### PR DESCRIPTION
Another case of an id that isn't used in SemIR, but seems valuable to tag them
just in case they evolve such a use.
