### PR TITLE
Remove unused `ImportCppId` and list of `Cpp` imports in `File`

### DIFF
--- a/toolchain/base/value_ids.h
+++ b/toolchain/base/value_ids.h
@@ -83,6 +83,7 @@ struct PackageNameId : public IdBase<PackageNameId> {
   static constexpr llvm::StringLiteral Label = "package";
   static const PackageNameId None;
   static const PackageNameId Core;
+  static constexpr llvm::StringLiteral CppName = "Cpp";
 
   // Returns the PackageNameId corresponding to a particular IdentifierId.
   static auto ForIdentifier(IdentifierId id) -> PackageNameId {

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -52,7 +52,6 @@ static auto GetImportKey(UnitAndImports& unit_info,
   return {package_name, library_name};
 }
 
-static constexpr llvm::StringLiteral CppPackageName = "Cpp";
 static constexpr llvm::StringLiteral MainPackageName = "Main";
 
 static auto RenderImportKey(ImportKey import_key) -> std::string {
@@ -81,7 +80,7 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
   const auto import_key = GetImportKey(unit_info, file_package_id, import);
   const auto& [import_package_name, import_library_name] = import_key;
 
-  if (import_package_name == CppPackageName) {
+  if (import_package_name == PackageNameId::CppName) {
     if (!explicit_import_map) {
       // Don't diagnose the implicit import in `impl package Cpp`, because we'll
       // have diagnosed the use of `Cpp` in the declaration.
@@ -265,7 +264,8 @@ static auto BuildApiMapAndDiagnosePackaging(
                              import_key.second.empty() ? ExplicitMainPackage
                                                        : ExplicitMainLibrary);
       continue;
-    } else if (import_key.first == CppPackageName) {
+    }
+    if (import_key.first == PackageNameId::CppName) {
       CARBON_DIAGNOSTIC(CppPackageDeclaration, Error,
                         "`Cpp` cannot be used by a `package` declaration");
       unit_info.emitter.Emit(packaging->names.node_id, CppPackageDeclaration);

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -440,15 +440,6 @@ static auto GenerateAst(
 static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
                          llvm::ArrayRef<Parse::Tree::PackagingNames> imports)
     -> SemIR::NameScopeId {
-  auto& import_cpps = context.sem_ir().import_cpps();
-  import_cpps.reserve(imports.size());
-  for (const Parse::Tree::PackagingNames& import : imports) {
-    import_cpps.push_back(
-        {.node_id =
-             context.parse_tree().As<Parse::ImportDeclId>(import.node_id),
-         .library_id = import.library_id});
-  }
-
   return AddImportNamespaceToScope(
              context,
              GetSingletonType(context, SemIR::NamespaceType::TypeInstId),

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -441,11 +441,12 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
                          llvm::ArrayRef<Parse::Tree::PackagingNames> imports)
     -> SemIR::NameScopeId {
   auto& import_cpps = context.sem_ir().import_cpps();
-  import_cpps.Reserve(imports.size());
+  import_cpps.reserve(imports.size());
   for (const Parse::Tree::PackagingNames& import : imports) {
-    import_cpps.Add({.node_id = context.parse_tree().As<Parse::ImportDeclId>(
-                         import.node_id),
-                     .library_id = import.library_id});
+    import_cpps.push_back(
+        {.node_id =
+             context.parse_tree().As<Parse::ImportDeclId>(import.node_id),
+         .library_id = import.library_id});
   }
 
   return AddImportNamespaceToScope(

--- a/toolchain/sem_ir/absolute_node_id.cpp
+++ b/toolchain/sem_ir/absolute_node_id.cpp
@@ -16,7 +16,6 @@ static auto FollowImportRef(
     ImportIRInstId import_ir_inst_id) -> bool {
   auto import_ir_inst = cursor_ir->import_ir_insts().Get(import_ir_inst_id);
   if (import_ir_inst.ir_id() == ImportIRId::Cpp) {
-    CARBON_CHECK(cursor_ir->import_cpps().size() > 0);
     absolute_node_ids.push_back(
         AbsoluteNodeId(import_ir_inst.clang_source_loc_id()));
     return true;

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -51,7 +51,6 @@ File::File(const Parse::Tree* parse_tree, CheckIRId check_ir_id,
       // The `2` prevents adding a tag for the global ids
       // `ImportIRId::{ApiForImpl,Cpp}`.
       import_irs_(IdTag(check_ir_id.index, 2)),
-      import_cpps_(check_ir_id),
       clang_decls_(check_ir_id),
       // The `+1` prevents adding a tag to the global `NameSpace::PackageInstId`
       // instruction. It's not a "singleton" instruction, but it's a unique

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -211,8 +211,10 @@ class File : public Printable<File> {
   auto import_ir_insts() const -> const ImportIRInstStore& {
     return import_ir_insts_;
   }
-  auto import_cpps() -> ImportCppStore& { return import_cpps_; }
-  auto import_cpps() const -> const ImportCppStore& { return import_cpps_; }
+  auto import_cpps() -> llvm::SmallVector<ImportCpp>& { return import_cpps_; }
+  auto import_cpps() const -> const llvm::SmallVector<ImportCpp>& {
+    return import_cpps_;
+  }
   auto clang_ast_unit() -> clang::ASTUnit* { return clang_ast_unit_; }
   auto clang_ast_unit() const -> const clang::ASTUnit* {
     return clang_ast_unit_;
@@ -361,7 +363,7 @@ class File : public Printable<File> {
   ImportIRInstStore import_ir_insts_;
 
   // List of Cpp imports.
-  ImportCppStore import_cpps_;
+  llvm::SmallVector<ImportCpp> import_cpps_;
 
   // The Clang AST to use when looking up `Cpp` names. Null if there are no
   // `Cpp` imports.

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -211,10 +211,6 @@ class File : public Printable<File> {
   auto import_ir_insts() const -> const ImportIRInstStore& {
     return import_ir_insts_;
   }
-  auto import_cpps() -> llvm::SmallVector<ImportCpp>& { return import_cpps_; }
-  auto import_cpps() const -> const llvm::SmallVector<ImportCpp>& {
-    return import_cpps_;
-  }
   auto clang_ast_unit() -> clang::ASTUnit* { return clang_ast_unit_; }
   auto clang_ast_unit() const -> const clang::ASTUnit* {
     return clang_ast_unit_;
@@ -361,9 +357,6 @@ class File : public Printable<File> {
   // Related IR instructions. These are created for LocIds for instructions
   // that are import-related.
   ImportIRInstStore import_ir_insts_;
-
-  // List of Cpp imports.
-  llvm::SmallVector<ImportCpp> import_cpps_;
 
   // The Clang AST to use when looking up `Cpp` names. Null if there are no
   // `Cpp` imports.

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1253,13 +1253,21 @@ auto Formatter::FormatCallRhs(Call inst) -> void {
 auto Formatter::FormatImportCppDeclRhs() -> void {
   out_ << " ";
   OpenBrace();
-  for (ImportCpp import_cpp : sem_ir_->import_cpps()) {
+  for (const Parse::Tree::PackagingNames& import :
+       sem_ir_->parse_tree().imports()) {
+    if (auto package_ident_id = import.package_id.AsIdentifierId();
+        !package_ident_id.has_value() ||
+        sem_ir_->identifiers().Get(package_ident_id) !=
+            PackageNameId::CppName) {
+      continue;
+    }
+
     Indent();
     out_ << "import Cpp ";
-    if (import_cpp.library_id.has_value()) {
+    if (import.library_id.has_value()) {
       out_ << "\""
            << FormatEscaped(
-                  sem_ir_->string_literal_values().Get(import_cpp.library_id))
+                  sem_ir_->string_literal_values().Get(import.library_id))
            << "\"";
     } else {
       out_ << "inline";

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1253,7 +1253,7 @@ auto Formatter::FormatCallRhs(Call inst) -> void {
 auto Formatter::FormatImportCppDeclRhs() -> void {
   out_ << " ";
   OpenBrace();
-  for (ImportCpp import_cpp : sem_ir_->import_cpps().values()) {
+  for (ImportCpp import_cpp : sem_ir_->import_cpps()) {
     Indent();
     out_ << "import Cpp ";
     if (import_cpp.library_id.has_value()) {

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -440,13 +440,6 @@ struct GenericInstIndex : public IndexBase<GenericInstIndex> {
 constexpr GenericInstIndex GenericInstIndex::None =
     GenericInstIndex::MakeNone();
 
-// The ID of an `ImportCpp`.
-struct ImportCppId : public IdBase<ImportCppId> {
-  static constexpr llvm::StringLiteral Label = "import_cpp";
-
-  using IdBase::IdBase;
-};
-
 // The ID of an `ImportIR` within the set of imported IRs, both direct and
 // indirect.
 struct ImportIRId : public IdBase<ImportIRId> {

--- a/toolchain/sem_ir/import_cpp.h
+++ b/toolchain/sem_ir/import_cpp.h
@@ -20,8 +20,6 @@ struct ImportCpp : Printable<ImportCpp> {
   StringLiteralValueId library_id;
 };
 
-using ImportCppStore = ValueStore<ImportCppId, ImportCpp>;
-
 }  // namespace Carbon::SemIR
 
 #endif  // CARBON_TOOLCHAIN_SEM_IR_IMPORT_CPP_H_


### PR DESCRIPTION
See discussion: https://discord.com/channels/655572317891461132/655578254970716160/1432518191350808659

Part of #5245.