### PR TITLE
Actually do fingerprinting for InstFingerprinter::GetOrCompute with a CppOverloadSet

### DIFF
--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -419,8 +419,7 @@ struct Worklist {
         // the `contents`.
         CARBON_KIND_SWITCH(next) {
           case CARBON_KIND(InstId _):
-            // InstId is checked for above.
-            CARBON_FATAL();
+            CARBON_FATAL("InstId is checked for above.");
           case CARBON_KIND(ImplId impl_id):
             Add(impl_id);
             break;

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StableHashing.h"
 #include "toolchain/base/fixed_size_value_store.h"
+#include "toolchain/base/kind_switch.h"
 #include "toolchain/base/value_ids.h"
 #include "toolchain/sem_ir/cpp_overload_set.h"
 #include "toolchain/sem_ir/entity_with_params_base.h"
@@ -416,10 +417,19 @@ struct Worklist {
       if (!std::holds_alternative<InstId>(next)) {
         // Add the contents of the `next` instruction so they all contribute to
         // the `contents`.
-        if (auto* impl_id = std::get_if<ImplId>(&next)) {
-          Add(*impl_id);
-        } else if (auto* inst_block_id = std::get_if<InstBlockId>(&next)) {
-          Add(*inst_block_id);
+        CARBON_KIND_SWITCH(next) {
+          case CARBON_KIND(InstId _):
+            // InstId is checked for above.
+            CARBON_FATAL();
+          case CARBON_KIND(ImplId impl_id):
+            Add(impl_id);
+            break;
+          case CARBON_KIND(InstBlockId inst_block_id):
+            Add(inst_block_id);
+            break;
+          case CARBON_KIND(CppOverloadSetId overload_set_id):
+            Add(overload_set_id);
+            break;
         }
 
         // If we didn't add any more work, then we have a fingerprint for the


### PR DESCRIPTION
Currently we schedule work on the CppOverloadSet but then never `Add()` it to add its contents to be fingerprinted, and just immediately return an empty fingerprint.

Use CARBON_KIND_SWITCH to prevent this sort of thing from happening in the future, now that we can use it for std::variant.