### PR TITLE
Set the completed flag in NamedConstraint after the defn is complete

### DIFF
--- a/toolchain/check/handle_named_constraint.cpp
+++ b/toolchain/check/handle_named_constraint.cpp
@@ -156,8 +156,8 @@ auto HandleParseNode(Context& context,
           .Pop<Parse::NodeKind::NamedConstraintDefinitionStart>();
   context.inst_block_stack().Pop();
 
-  const auto& constraint_info =
-      context.named_constraints().Get(named_constraint_id);
+  auto& constraint_info = context.named_constraints().Get(named_constraint_id);
+  constraint_info.complete = true;
 
   // TODO: Do something with `require` and `alias` statements in the body of the
   // constraint.

--- a/toolchain/check/handle_named_constraint.cpp
+++ b/toolchain/check/handle_named_constraint.cpp
@@ -156,8 +156,8 @@ auto HandleParseNode(Context& context,
           .Pop<Parse::NodeKind::NamedConstraintDefinitionStart>();
   context.inst_block_stack().Pop();
 
-  auto& constraint_info = context.named_constraints().Get(named_constraint_id);
-  constraint_info.complete = true;
+  const auto& constraint_info =
+      context.named_constraints().Get(named_constraint_id);
 
   // TODO: Do something with `require` and `alias` statements in the body of the
   // constraint.

--- a/toolchain/sem_ir/named_constraint.h
+++ b/toolchain/sem_ir/named_constraint.h
@@ -23,8 +23,6 @@ struct NamedConstraintFields {
   InstId self_param_id = InstId::None;
 
   // The following members are set at the `}` of the constraint definition.
-
-  bool complete = false;
 };
 
 // A named constraint. See EntityWithParamsBase regarding the inheritance here.
@@ -35,15 +33,6 @@ struct NamedConstraint : public EntityWithParamsBase,
     out << "{";
     PrintBaseFields(out);
     out << "}";
-  }
-
-  // This is false until we reach the `}` of the constraint definition.
-  auto is_complete() const -> bool { return complete; }
-
-  // Determines whether we're currently defining the constraint. This is true
-  // between the braces of the constraint.
-  auto is_being_defined() const -> bool {
-    return has_definition_started() && !is_complete();
   }
 };
 

--- a/toolchain/sem_ir/named_constraint.h
+++ b/toolchain/sem_ir/named_constraint.h
@@ -23,6 +23,8 @@ struct NamedConstraintFields {
   InstId self_param_id = InstId::None;
 
   // The following members are set at the `}` of the constraint definition.
+
+  bool complete = false;
 };
 
 // A named constraint. See EntityWithParamsBase regarding the inheritance here.
@@ -33,6 +35,15 @@ struct NamedConstraint : public EntityWithParamsBase,
     out << "{";
     PrintBaseFields(out);
     out << "}";
+  }
+
+  // This is false until we reach the `}` of the constraint definition.
+  auto is_complete() const -> bool { return complete; }
+
+  // Determines whether we're currently defining the constraint. This is true
+  // between the braces of the constraint.
+  auto is_being_defined() const -> bool {
+    return has_definition_started() && !is_complete();
   }
 };
 


### PR DESCRIPTION
A named constraint can not be [identified](https://github.com/carbon-language/carbon-lang/blob/656150593c1e3fc2b6ccd83c7256a61e4bd04030/proposals/p5168.md#proposed-rules) until its definition is complete, so this flag will be used to determine if the named constraint is ready to be identified.