### PR TITLE
Import NamedConstraintDecl instruction names

### DIFF
--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -74,6 +74,11 @@ static auto GetImportName(const SemIR::File& import_sem_ir,
           import_sem_ir.name_scopes().Get(ns.name_scope_id));
     }
 
+    case CARBON_KIND(SemIR::NamedConstraintDecl named_constraint_decl): {
+      return GetImportNameForEntity(import_sem_ir.named_constraints().Get(
+          named_constraint_decl.named_constraint_id));
+    }
+
     default:
       CARBON_FATAL("Unsupported export kind: {0}", import_inst);
   }

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -3187,6 +3187,8 @@ static auto TryResolveInstCanonical(ImportRefResolver& resolver,
     case CARBON_KIND(SemIR::InterfaceDecl inst): {
       return TryResolveTypedInst(resolver, inst, const_id);
     }
+    // TODO: Import NamedConstraintDecl once its FacetType constant value
+    // contains the NamedConstraintId.
     default:
       break;
   }

--- a/toolchain/check/testdata/interface/import_interface_decl.carbon
+++ b/toolchain/check/testdata/interface/import_interface_decl.carbon
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
-// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
-// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -17,6 +15,7 @@ library "[[@TEST_NAME]]";
 interface A;
 
 // --- a.impl.carbon
+//@include-in-dumps
 impl library "[[@TEST_NAME]]";
 
 // --- fail_b.carbon
@@ -29,23 +28,9 @@ interface B {}
 impl () as B;
 
 // --- b.impl.carbon
+//@include-in-dumps
 impl library "[[@TEST_NAME]]";
 
-// CHECK:STDOUT: --- a.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %A.type: type = facet_type <@A> [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .A = %A.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %A.decl: type = interface_decl @A [concrete = constants.%A.type] {} {}
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @A;
-// CHECK:STDOUT:
 // CHECK:STDOUT: --- a.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -56,42 +41,9 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .A = imports.%Main.A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc1_17.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc1_17.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.2 = import <none>
 // CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_b.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %B.type: type = facet_type <@B> [concrete]
-// CHECK:STDOUT:   %Self: %B.type = symbolic_binding Self, 0 [symbolic]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %B.impl_witness: <witness> = impl_witness file.%B.impl_witness_table [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .B = %B.decl
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %B.decl: type = interface_decl @B [concrete = constants.%B.type] {} {}
-// CHECK:STDOUT:   impl_decl @empty_tuple.type.as.B.impl [concrete] {} {
-// CHECK:STDOUT:     %.loc7_7.1: %empty_tuple.type = tuple_literal ()
-// CHECK:STDOUT:     %.loc7_7.2: type = converted %.loc7_7.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %B.impl_witness_table = impl_witness_table (), @empty_tuple.type.as.B.impl [concrete]
-// CHECK:STDOUT:   %B.impl_witness: <witness> = impl_witness %B.impl_witness_table [concrete = constants.%B.impl_witness]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @B {
-// CHECK:STDOUT:   %Self: %B.type = symbolic_binding Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   witness = ()
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: impl @empty_tuple.type.as.B.impl: %.loc7_7.2 as %B.ref;
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.impl.carbon
 // CHECK:STDOUT:
@@ -111,8 +63,8 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %default.import.loc1_17.1 = import <none>
-// CHECK:STDOUT:   %default.import.loc1_17.2 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.2 = import <none>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @B [from "fail_b.carbon"] {

--- a/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+++ b/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
@@ -1,0 +1,101 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+
+// --- a.carbon
+library "[[@TEST_NAME]]";
+constraint A;
+
+// --- a.impl.carbon
+//@include-in-dumps
+impl library "[[@TEST_NAME]]";
+
+// --- b.carbon
+library "[[@TEST_NAME]]";
+interface I {}
+constraint B {
+  // CHECK:STDERR: b.carbon:[[@LINE+4]]:3: error: semantics TODO: `require` [SemanticsTodo]
+  // CHECK:STDERR:   require impls I;
+  // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
+  require impls I;
+}
+
+// --- b.impl.carbon
+//@include-in-dumps
+impl library "[[@TEST_NAME]]";
+
+fn F(T:! B) {}
+
+// CHECK:STDOUT: --- a.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.A = import_ref Main//a, A, unloaded
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .A = imports.%Main.A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import.loc2_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.2 = import <none>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- b.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %T: %type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %type [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.I = import_ref Main//b, I, unloaded
+// CHECK:STDOUT:   %Main.B: type = import_ref Main//b, B, loaded [concrete = constants.%type]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .I = imports.%Main.I
+// CHECK:STDOUT:     .B = imports.%Main.B
+// CHECK:STDOUT:     .F = %F.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import.loc2_17.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc2_17.2 = import <none>
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.loc4: type = splice_block %B.ref [concrete = constants.%type] {
+// CHECK:STDOUT:       %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:       %B.ref: type = name_ref B, imports.%Main.B [concrete = constants.%type]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T.loc4_6.2: %type = symbolic_binding T, 0 [symbolic = %T.loc4_6.1 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(%T.loc4_6.2: %type) {
+// CHECK:STDOUT:   %T.loc4_6.1: %type = symbolic_binding T, 0 [symbolic = %T.loc4_6.1 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%T) {
+// CHECK:STDOUT:   %T.loc4_6.1 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+++ b/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
@@ -12,6 +12,7 @@
 
 // --- a.carbon
 library "[[@TEST_NAME]]";
+
 constraint A;
 
 // --- a.impl.carbon
@@ -20,14 +21,8 @@ impl library "[[@TEST_NAME]]";
 
 // --- b.carbon
 library "[[@TEST_NAME]]";
-interface I {}
-constraint B {
-  // CHECK:STDERR: b.carbon:[[@LINE+4]]:3: error: semantics TODO: `require` [SemanticsTodo]
-  // CHECK:STDERR:   require impls I;
-  // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR:
-  require impls I;
-}
+
+constraint B {}
 
 // --- b.impl.carbon
 //@include-in-dumps
@@ -61,13 +56,11 @@ fn F(T:! B) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %Main.I = import_ref Main//b, I, unloaded
 // CHECK:STDOUT:   %Main.B: type = import_ref Main//b, B, loaded [concrete = constants.%type]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
-// CHECK:STDOUT:     .I = imports.%Main.I
 // CHECK:STDOUT:     .B = imports.%Main.B
 // CHECK:STDOUT:     .F = %F.decl
 // CHECK:STDOUT:   }


### PR DESCRIPTION
For now, they are imported as their constant value, so there's little to do, we just need to support getting their NameId. In the future we will need to import the full named constraint in order to ["identify"](https://github.com/carbon-language/carbon-lang/blob/656150593c1e3fc2b6ccd83c7256a61e4bd04030/proposals/p5168.md#proposed-rules) them. But we need FacetTypeInfo to hold named constraints first.