### PR TITLE
Remove TODO that was based on a misunderstanding on my part

### DIFF
--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -372,9 +372,6 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
       break;
     }
     case SemIR::CppVoidType::Kind: {
-      // TODO: Consider checking `VoidTy` for completeness and checking whether
-      // this extra check triggers an error. For that, reuse the code in
-      // https://github.com/carbon-language/carbon-lang/blob/ca3f95faa610fdb9412c9e58ece524abf30c7a9e/toolchain/check/cpp/import.cpp#L2317-L2325.
       if (diagnoser_) {
         CARBON_DIAGNOSTIC(CppVoidIncomplete, Note,
                           "`Cpp.void` is always-incomplete");


### PR DESCRIPTION
I was thinking that the incompleteness diagnostic for C++ types would've
been produced by Clang for record types, but seems they're produced by
Carbon & we already /are/ sharing that diagnostic (with #6302), and that
patch only adds an extra note rather than being a whole separate
codepath for effectively the same diagnostic.
