### PR TITLE
Add `import Cpp;` for C++ built-in entities

### DIFF
--- a/proposals/p6331.md
+++ b/proposals/p6331.md
@@ -94,7 +94,9 @@ built-in types, making them available by default enhances the user experience.
 **Explicitness over Magic:** This directive provides a clear, non-magical
 opt-in. It prevents the `Cpp` namespace from being automatically available to
 users who have not explicitly declared their intent to use C++ interoperability,
-aligning with Carbon's design principles.
+aligning with Carbon's "principle of least surprise", which is part of Carbon's
+goal to have
+[Code that is easy to read, understand, and write](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 
 ## Alternatives Considered
 
@@ -102,8 +104,9 @@ aligning with Carbon's design principles.
     relies on a side effect of the `inline` import implementation, rather than
     being a clear, intentional feature.
 2.  **Implicit Activation:** Rejected. Automatically making `Cpp.long` available
-    in all files would be unexpected and would violate Carbon's design
-    principles.
+    in all files would be unexpected and doesn't follow "principle of least
+    surprise", which is part of Carbon's goal to have
+    [Code that is easy to read, understand, and write](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 3.  **Magic Header (`import Cpp library "<cpp_builtins>";`)**: Rejected. This is
     a confusing anti-pattern. The `library` keyword implies that a file is being
     parsed, which is not the case here, breaking the user's mental model.

--- a/proposals/p6331.md
+++ b/proposals/p6331.md
@@ -1,4 +1,4 @@
-# Import Cpp;
+# Add `import Cpp;` for C++ built-in entities
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -17,54 +17,93 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Background](#background)
 -   [Proposal](#proposal)
 -   [Details](#details)
+    -   [Activated Entities](#activated-entities)
+    -   [Interaction with Other Imports](#interaction-with-other-imports)
 -   [Rationale](#rationale)
--   [Alternatives considered](#alternatives-considered)
+-   [Alternatives Considered](#alternatives-considered)
 
 <!-- tocstop -->
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+This proposal introduces an `import Cpp;` directive. This directive makes C++
+built-in types, such as `long`, available in Carbon through a clear and explicit
+mechanism.
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+Carbon's C++ interoperability requires seamless, bidirectional access. The
+primary mechanism for this is `import Cpp library "header.h";`, which parses a
+C++ header file and maps its AST into Carbon's `Cpp` namespace.
+
+However, this mechanism falls short when a developer only needs C++ built-in
+types (for example, `long`, `long long`, `unsigned long`), as these are not
+defined in any header file.
+
+Furthermore, some C++ types are **nominally distinct**. For example, on many
+64-bit systems, `long` and `long long` share the same 64-bit representation, but
+C++ treats them as distinct types - a critical feature for function overloading.
+If Carbon were to map both types to its canonical `i64`, this semantic
+distinction would be lost, breaking interoperability.
+
+To address this, Carbon must provide its own distinct mirror types, such as
+`Cpp.long` and `Cpp.long_long`. The language currently lacks a clear and direct
+way to "activate" or import only these compiler-provided, built-in C++ entities.
+While `import Cpp inline "";` can achieve this, it is an unintuitive and
+indirect solution.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+Currently, C++ built-in types can be brought into the `Cpp` namespace using
+`import Cpp inline "";`. This works because the `inline` import implicitly makes
+the built-in types available. However, this is a side effect of the `inline`
+import's behavior, not an obvious or intentional feature.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+We propose a new import directive:
+
+```carbon
+import Cpp;
+```
+
+This file-level statement instructs the Carbon compiler to populate the `Cpp`
+namespace with all C++ built-in entities required for interoperability. This
+acts as a compiler-level activation and does not involve reading any files.
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+### Activated Entities
+
+The set of entities activated by `import Cpp;` is determined by the compiler's
+interoperability model. This will include C++ primitive types, including those
+necessary to preserve nominal distinction (for example, `Cpp.long`,
+`Cpp.unsigned_long`, `Cpp.long_long`).
+
+### Interaction with Other Imports
+
+The `import Cpp;` directive is **not** mutually exclusive with
+`import Cpp library "..."` or `import Cpp inline "..."`.
+
+Both `import Cpp library "..."` and `import Cpp inline "..."` will implicitly
+trigger the effects of `import Cpp;`. Since any C++ code is likely to use
+built-in types, making them available by default enhances the user experience.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
+**Explicitness over Magic:** This directive provides a clear, non-magical
+opt-in. It prevents the `Cpp` namespace from being automatically available to
+users who have not explicitly declared their intent to use C++ interoperability,
+aligning with Carbon's design principles.
 
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+## Alternatives Considered
 
-## Alternatives considered
-
-TODO: What alternative solutions have you considered?
+1.  **Use `import Cpp inline "";`:** Rejected. This approach is not obvious and
+    relies on a side effect of the `inline` import implementation, rather than
+    being a clear, intentional feature.
+2.  **Implicit Activation:** Rejected. Automatically making `Cpp.long` available
+    in all files would be unexpected and would violate Carbon's design
+    principles.
+3.  **Magic Header (`import Cpp library "<cpp_builtins>";`)**: Rejected. This is
+    a confusing anti-pattern. The `library` keyword implies that a file is being
+    parsed, which is not the case here, breaking the user's mental model.

--- a/proposals/p6331.md
+++ b/proposals/p6331.md
@@ -1,0 +1,70 @@
+# Import Cpp;
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/6331)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?


### PR DESCRIPTION
This proposal introduces an `import Cpp;` directive. This directive makes C++ built-in types, such as `long`, available in Carbon through a clear and explicit mechanism.