### PR TITLE
CLI and separate compilation

### DIFF
--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -187,7 +187,7 @@ carbon link foo.o -o program
 
 It will be typical to link multiple object files into a single output file. The
 output file flag will be optional, defaulting to `program`, possibly with a
-target-specific extension; for example, `platform.exe` for Windows.
+target-specific extension; for example, `program.exe` for Windows.
 
 This requires implicit `compile`-equivalent invocations for `Core` files (not
 just prelude), and includes their object files in output. It should be possible

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -161,9 +161,8 @@ replacement for `carbon compile`. It will:
 -   Load provided files.
 -   For packages with directory mappings, particularly `Core`, add all `.carbon`
     files as inputs.
-    -   For `Core`, we expect `.o` files to be produced as part of on-demand
-        runtimes. They should be cached, not be compiled per `build` invocation
-        (in contrast with other artifacts, which this does not propose caching).
+    -   For `Core`, we expect `.o` files to be produced in the same way as for
+        `carbon link`.
     -   For other packages, all files in the directory will be compiled,
         although there may be some support added for using pre-compiled state
         (not explicitly proposed).
@@ -191,9 +190,10 @@ It will be typical to link multiple object files into a single output file. The
 output file flag will be optional, defaulting to `program`, possibly with a
 target-specific extension; for example, `program.exe` for Windows.
 
-This requires implicit `compile`-equivalent invocations for `Core` files (not
-just prelude), and includes their object files in output. It should be possible
-to opt out of this, for example so that the Bazel `carbon_binary` rule can use
+This requires that `Core` files (not just the prelude) will have been compiled,
+so that their object files can be included in output. It's expected that this
+will be provided through on-demand runtimes. It should be possible to opt out of
+including these, for example so that the Bazel `carbon_binary` rule can use
 `carbon link` while also providing its own `Core` object files. However, it
 should be on-by-default.
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
+    -   [Look-and-feel](#look-and-feel)
 -   [Details](#details)
     -   [Command changes](#command-changes)
         -   [Compile command](#compile-command)
@@ -121,9 +122,12 @@ At the end, it should be possible to:
     )
     ```
 
+### Look-and-feel
+
 Note the goal here is to align on look-and-feel of separate compilation.
 Although the `carbon` CLI is important to the language, most details aren't
-necessary to address through the proposal process.
+necessary to address through the proposal process. For example, we want to get
+flag names right here, but also we wouldn't expect a proposal for flag names.
 
 ## Details
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -15,30 +15,28 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Abstract](#abstract)
 -   [Problem](#problem)
 -   [Background](#background)
--   [Proposal](#proposal)
     -   [Look-and-feel](#look-and-feel)
+    -   [Bazel rule design](#bazel-rule-design)
+-   [Proposal](#proposal)
 -   [Details](#details)
     -   [Command changes](#command-changes)
         -   [Compile command](#compile-command)
         -   [Build command](#build-command)
         -   [Link command](#link-command)
+    -   [Mapping packaging directives to filenames](#mapping-packaging-directives-to-filenames)
+        -   [Disallow ambiguous library names](#disallow-ambiguous-library-names)
+-   [Example interaction with Bazel](#example-interaction-with-bazel)
     -   [carbon_library and carbon_binary](#carbon_library-and-carbon_binary)
         -   [Indirect API exposure](#indirect-api-exposure)
         -   [Core package rules](#core-package-rules)
-    -   [Mapping packaging directives to filenames](#mapping-packaging-directives-to-filenames)
-        -   [Disallow ambiguous library names](#disallow-ambiguous-library-names)
 -   [Future work](#future-work)
     -   [Caching checked IR, C++ AST, and other possible compile artifacts](#caching-checked-ir-c-ast-and-other-possible-compile-artifacts)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
     -   [Naming of commands and rules](#naming-of-commands-and-rules)
-    -   [apis versus hdrs](#apis-versus-hdrs)
     -   [Support a full-fledged build system](#support-a-full-fledged-build-system)
     -   [Don't support packaging directive to filename mappings](#dont-support-packaging-directive-to-filename-mappings)
     -   [Distribute pre-compiled versions of Core files](#distribute-pre-compiled-versions-of-core-files)
-    -   [Require C++ files be passed to clang directly](#require-c-files-be-passed-to-clang-directly)
-    -   [Allow indirect dependencies in carbon_library](#allow-indirect-dependencies-in-carbon_library)
-    -   [Implicit carbon_library dependency on Core versus prelude](#implicit-carbon_library-dependency-on-core-versus-prelude)
     -   [Create an explicit mapping from packaging directives to files](#create-an-explicit-mapping-from-packaging-directives-to-files)
 
 <!-- tocstop -->
@@ -47,8 +45,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 -   Change the look-and-feel of the `carbon` compilation command set to use
     `compile`, `link`, and `build`.
--   Rewrite `carbon_library` and `carbon_binary` based on the `compile` and
-    `link` commands.
 -   Build library-to-file discovery for `Core`, but support it in a general
     manner.
 
@@ -80,6 +76,21 @@ Key commands related to this proposal are `carbon compile`, `carbon clang`, and
 `carbon link`. The end result will likely compose multiple command elements in
 order to build the output.
 
+### Look-and-feel
+
+Note the goal here is to align on look-and-feel of separate compilation.
+Although the `carbon` CLI is important to the language, most details aren't
+necessary to address through the proposal process. For example, we want to get
+flag names right here, but also we wouldn't expect a proposal for flag name
+changes.
+
+### Bazel rule design
+
+This is a proposal for the command line. Bazel rules are mentioned because it
+can help illustrate interactions with build systems. However, this proposal is
+not intended to decide Bazel design, and the existing Bazel rules have not been
+through the proposal process.
+
 ## Proposal
 
 Restructure compilation into:
@@ -88,13 +99,6 @@ Restructure compilation into:
     `.o`.
 -   `carbon build`: Take multiple inputs in order to produce a linked binary.
     -   Overlaps with `carbon compile` and `carbon link`.
-
-Provide Bazel rules based on this:
-
--   `carbon_library` similar to `cc_library`.
--   `carbon_binary` similar to `cc_binary`.
--   In the `core` directory, `carbon_library` rules that assist with builds.
-    -   The prelude would be a default dependency of all `carbon_library` rules.
 
 These are intended to accept flexible inputs:
 
@@ -126,14 +130,6 @@ At the end, it should be possible to:
         deps = [":carbon_library"],
     )
     ```
-
-### Look-and-feel
-
-Note the goal here is to align on look-and-feel of separate compilation.
-Although the `carbon` CLI is important to the language, most details aren't
-necessary to address through the proposal process. For example, we want to get
-flag names right here, but also we wouldn't expect a proposal for flag name
-changes.
 
 ## Details
 
@@ -185,6 +181,54 @@ just prelude), and includes their object files in output. It should be possible
 to opt out of this, for example so that the Bazel `carbon_binary` rule can use
 `carbon link` while also providing its own `Core` object files. However, it
 should be on-by-default.
+
+### Mapping packaging directives to filenames
+
+When we need a file for a packaging directive:
+
+-   The package name will correspond to a root directory. For example,
+    `package Core ...` could correspond to `lib/carbon/core/...`.
+-   The library name will correspond to a path under that, suffixed by
+    `.carbon`. For example, `package Core library "prelude/types;` could
+    correspond to `lib/carbon/core/prelude/types.carbon`.
+    -   The default library will use the name `default.carbon`. For example,
+        `package Core;` could correspond to `lib/carbon/core/default.carbon`.
+
+Suppose we have some command line `carbon compile a.carbon`, and in `a.carbon`,
+it does `import Core library "map";`. This needs to load `core/map.carbon`, and
+without parsing every file matching `core/**/*.carbon`.
+
+In order to achieve this:
+
+-   The `compile` command will have a built-in directory mapping for the `Core`
+    package, for example to `/usr/lib/carbon/core` (when installed to the `/usr`
+    prefix).
+-   The `map` library name will need to match the filename, so
+    `/usr/lib/carbon/core/map.carbon`.
+    -   Slashes may be provided in the library name, for subdirectories.
+-   If `map.carbon` has other `Core` imports, they will be recursively loaded
+    once parsed.
+    -   Note that checking isn't required to process imports from a file.
+
+Because we'll build this for Core, it would probably be straightforward to
+expose this for other packages, too. So for example, we will support
+`--package-path=MyPackage:/my/package`.
+
+#### Disallow ambiguous library names
+
+For imports which rely on the implicit mapping (not in general), we will
+disallow ambiguous library names. This includes:
+
+-   Any name with a period in it.
+    -   For example of the ambiguity, given a file `foo.bar.impl.carbon`, it
+        would be unclear if this is an `impl` file for library "foo.bar" or one
+        of multiple `impl` files for library "foo". Under this rule, the library
+        name "foo.bar" is invalid, so meaning the second interpretation is the
+        only valid interpretation.
+-   An explicit `library "default"` string name which can be ambiguous with the
+    implicit `default` library.
+
+## Example interaction with Bazel
 
 ### carbon_library and carbon_binary
 
@@ -269,52 +313,6 @@ In the `core/` directory, we will set up corresponding `carbon_library` rules.
 These will need to pass flags to opt-out of normal behaviors, in particular the
 dependency on the prelude library.
 
-### Mapping packaging directives to filenames
-
-When we need a file for a packaging directive:
-
--   The package name will correspond to a root directory. For example,
-    `package Core ...` could correspond to `lib/carbon/core/...`.
--   The library name will correspond to a path under that, suffixed by
-    `.carbon`. For example, `package Core library "prelude/types;` could
-    correspond to `lib/carbon/core/prelude/types.carbon`.
-    -   The default library will use the name `default.carbon`. For example,
-        `package Core;` could correspond to `lib/carbon/core/default.carbon`.
-
-Suppose we have some command line `carbon compile a.carbon`, and in `a.carbon`,
-it does `import Core library "map";`. This needs to load `core/map.carbon`, and
-without parsing every file matching `core/**/*.carbon`.
-
-In order to achieve this:
-
--   The `compile` command will have a built-in directory mapping for the `Core`
-    package, for example to `/usr/lib/carbon/core` (when installed to the `/usr`
-    prefix).
--   The `map` library name will need to match the filename, so
-    `/usr/lib/carbon/core/map.carbon`.
-    -   Slashes may be provided in the library name, for subdirectories.
--   If `map.carbon` has other `Core` imports, they will be recursively loaded
-    once parsed.
-    -   Note that checking isn't required to process imports from a file.
-
-Because we'll build this for Core, it would probably be straightforward to
-expose this for other packages, too. So for example, we will support
-`--package-path=MyPackage:/my/package`.
-
-#### Disallow ambiguous library names
-
-For imports which rely on the implicit mapping (not in general), we will
-disallow ambiguous library names. This includes:
-
--   Any name with a period in it.
-    -   For example of the ambiguity, given a file `foo.bar.impl.carbon`, it
-        would be unclear if this is an `impl` file for library "foo.bar" or one
-        of multiple `impl` files for library "foo". Under this rule, the library
-        name "foo.bar" is invalid, so meaning the second interpretation is the
-        only valid interpretation.
--   An explicit `library "default"` string name which can be ambiguous with the
-    implicit `default` library.
-
 ## Future work
 
 ### Caching checked IR, C++ AST, and other possible compile artifacts
@@ -368,74 +366,12 @@ Some considered alternatives are:
     -   We expect that splitting these apart makes it easier to turn them into
         replacements in C++ builds, and easier to understand even in
         Carbon-specific builds.
--   Some other name for `exports`
-    -   I'm not really sure `exports` is the best name, but it's my best thought
-        for something to reflect the transitive nature of API exposure being
-        proposed.
 -   Have `carbon build` produce `a.out`
     -   `a.out` is the default output of most C++ compilers, but it reflects a
         legacy executable file format. Using the legacy name may reflect
         backwards compatibility that Carbon doesn't plan.
     -   Changing the default output name is probably low-cost, and people will
         get used to it.
-
-### apis versus hdrs
-
-For `apis` in specific, there are a couple nuanced naming choices due to
-`cc_library`'s `hdrs` naming. This is inherently a divergence, and we could have
-continued using `hdrs`.
-
-Advantages:
-
--   Naming consistency with C++.
--   Naming it `apis` could lead to confusion that it should contain _all_ API
-    files, not just ones intended to be public; however, similar confusion could
-    exist with `hdrs`.
-
-Disadvantages:
-
--   `apis` more clearly reflects the design intent of "API". `hdrs` is an opaque
-    naming choice for Carbon when considered independently of C++.
--   In `cc_library`, `hdrs` won't produce `.o` files, whereas `apis` will
-    generate `.o` files for `.carbon` files. The skew in behavior may be
-    confusing to developers.
-
-Another possible name would be something like `export_srcs` to match `exports`,
-or `public_srcs`. But, the `apis` concept is likely to be common and we might
-want to minimize typing. Also, longer names would further break vertical
-alignment (where `name`, `srcs`, `data`, `deps`, and so on are 4 characters).
-
-Another choice is that we could use `hdrs` for `.h` files, and rely fully on
-package-private visibility for Carbon code. In other words, drop `apis` because
-the language should take care of it; `srcs` would make all `.carbon` API files
-visible.
-
-Advantages:
-
--   Removes potential confusion between `hdrs`, `apis`, and `srcs`.
-    -   `hdrs` likely remains for C++ backwards-compatibility, but Carbon files
-        only occur in `srcs`.
--   In `bazel`, only providing `srcs` reflects more broadly how languages work.
-    -   The split in C++ likely exists because of the history of the `.h`/`.cpp`
-        semantics, with the actual behavior shifting over time as Bazel evolved.
-    -   Other languages could have had a similar Bazel rule semantic separating
-        "implementation" and "API" files, but don't do it this way.
--   Carbon's `.carbon` versus `.impl.carbon` file extension split gives the
-    build system the ability to reduce forwarded files in the common case,
-    without relying on user decisions.
-    -   This makes the `srcs` versus `apis` difference less meaningful.
-
-Disadvantages:
-
--   Puts more burden on language-level access control.
-    -   Particularly when considering commonly used libraries, library
-        maintainers are likely to want a greater ability to separate concepts
-        such as "exposed only to closely related libraries" versus "exposed to
-        all library consumers". Build visibility is one way to provide that, but
-        Carbon could also introduce things such as "package-private" visibility.
-
-Leads are choosing to provide `apis` here primarily for consistency with
-`cc_library`.
 
 ### Support a full-fledged build system
 
@@ -493,66 +429,6 @@ on-demand in a bespoke manner.
 
 We can probably add limited caching where it'd help, and support all platforms
 using similar logic that way with little performance penalty.
-
-### Require C++ files be passed to clang directly
-
-We could require C++ files to be passed to `clang` or `carbon clang` instead of
-`carbon build`, and similarly `cc_library` instead of `carbon_library`. Behind
-the scenes, `clang` will be equivalent to `carbon clang`, so Carbon will already
-be able to have control over how that compiles.
-
-For `carbon_library` in particular, we want to support situations where a `.cpp`
-file depends on a Carbon API file and the corresponding Carbon `impl` file
-depends on the corresponding `.h` file. This means a tight association that's
-well-served by having `carbon_library` support both.
-
-Similarly, we want `carbon build` to be able to take a combination of C++ and
-Carbon files, and decide what commands to run based on the file extension. Doing
-similar with `carbon compile` is then just an extension of the same desire to
-not make users choose which command to run based only on the filename.
-
-There may be some confusion because of `carbon_library` supporting both C++ and
-Carbon code. We are trying to think of this in terms of ecosystems, wherein the
-ecosystem includes both C++ and Carbon. But people already have a sense of what
-"C++" is in this context, so this proposal suggests using "Carbon" to be
-inclusive of C++ code. Hopefully then people can learn that the new thing works
-with both.
-
-What's really missing is a better name for this than "carbon".
-
-### Allow indirect dependencies in carbon_library
-
-As discussed under [Indirect API exposure](#indirect-api-exposure), this
-proposal suggests doing explicit layering of Carbon libraries.
-
-For C++ code, Bazel has some
-[layering capabilities](https://bazel.build/docs/bazel-and-cpp#toolchain-features)
-to prevent indirect dependencies in the build graph. These have limited support,
-but are intended to be used in similar ways as to what's proposed for Carbon
-here in order to prevent indirect dependencies in C++ code.
-
-A key difference is that in C++ compiles, header files do not generate a `.o`
-file; in Carbon files, they will. As a consequence, in C++, header files can be
-listed in `cc_library`'s `hdrs` in multiple targets in order to make the API
-directly exposed; in Carbon, API files cannot be.
-
-What `exports` is really doing for Carbon rules is providing a different way to
-get at a feature that exists for C++. We are choosing to make this default
-behavior in order to get cleaner builds.
-
-### Implicit carbon_library dependency on Core versus prelude
-
-As proposed, the implicit dependency for `carbon_library` will be all of `Core`.
-This could instead only be the prelude, with an explicit dependency required for
-either part or all of `Core`.
-
-We expect `Core` to contain frequently used parts of Carbon, including common
-data structures. Rather than requiring developers to add an explicit dependency
-for these, we think it'll be better to have the implicit dependency.
-
-Note it will still be possible to disable the implicit dependency. Some
-libraries, particularly the `Core` library implementation itself, are expected
-to do so.
 
 ### Create an explicit mapping from packaging directives to files
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -24,6 +24,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         -   [Build command](#build-command)
         -   [Link command](#link-command)
     -   [Mapping packaging directives to filenames](#mapping-packaging-directives-to-filenames)
+        -   [Support for other packages](#support-for-other-packages)
         -   [Disallow ambiguous library names](#disallow-ambiguous-library-names)
 -   [Example interaction with Bazel](#example-interaction-with-bazel)
     -   [carbon_library and carbon_binary](#carbon_library-and-carbon_binary)
@@ -210,9 +211,13 @@ In order to achieve this:
     once parsed.
     -   Note that checking isn't required to process imports from a file.
 
+#### Support for other packages
+
 Because we'll build this for Core, it would probably be straightforward to
-expose this for other packages, too. So for example, we will support
-`--package-path=MyPackage:/my/package`.
+expose this for other packages, too. So for example, we could support
+`--package-path=MyPackage:/my/package` for getting API files. However, that is
+secondary to the `Core` behavior, so any support may become more of an
+implementation detail for what makes sense.
 
 #### Disallow ambiguous library names
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -109,7 +109,7 @@ At the end, it should be possible to:
     non-prelude `Core` imports, and get an executable `program`.
 -   Have Bazel rules that mix C++ code and Carbon code. For example:
 
-    ```
+    ```bazel
     carbon_library(
         name = "foo",
         srcs = ["foo.cpp", "foo.impl.carbon"],
@@ -168,7 +168,7 @@ also want it to be capable of producing `.a` and `.so` files.
 
 The `carbon link` command will change to make the following work:
 
-```
+```sh
 carbon compile foo.carbon -o foo.o
 carbon link foo.o -o program
 ```
@@ -184,7 +184,7 @@ should be on-by-default.
 The Bazel build rules will expose `carbon compile` and `carbon link` behaviors
 in a slightly more Bazel-idiomatic way. For example, given:
 
-```
+```bazel
 carbon_library(
     name = "lib",
     srcs = ["a.impl.carbon", "b.impl.carbon", "b.carbon"],
@@ -223,7 +223,7 @@ just the prelude. This is because we want the Core package to be easy to access.
 The `apis` attribute is suggested to support only _direct_ dependencies. For
 example:
 
-```
+```bazel
 carbon_library(
     name = "a",
     apis = ["a.carbon"],

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -115,8 +115,8 @@ These are intended to accept flexible inputs:
 
 At the end, it should be possible to:
 
--   Run `carbon build main.carbon` (or even just `carbon build`) with
-    non-prelude `Core` imports, and get an executable program.
+-   Run `carbon build program.carbon` with non-prelude `Core` imports, and get
+    an executable program.
 -   Have Bazel rules that mix C++ code and Carbon code. For example:
 
     ```bazel
@@ -144,7 +144,11 @@ single output command. Dependencies will be provided through a combination of:
 -   Given a package name to directory mapping, a
     [filename mapping](#mapping-packaging-directives-to-filenames) based on the
     library name.
--   Explicitly provided input files.
+-   Potentially other input files passed through a flag, for use in imports (not
+    producing their own object files).
+-   A single input source file for primary compilation.
+-   A single optional output file, which for `<filename>.carbon` will default to
+    `<filename>.o` (including `.impl.carbon` becoming `.impl.o`).
 
 As part of supporting a mix of C++ and Carbon files, we will support
 `carbon compile foo.cpp` with results similar to `carbon clang -- -c foo.cpp`.
@@ -155,8 +159,12 @@ The `carbon build` command will be the new, simple way to compile, as a
 replacement for `carbon compile`. It will:
 
 -   Load provided files.
--   For packages with directory mappings, particularly `Core`, figure out the
-    right files to load.
+-   For packages with directory mappings, particularly `Core`, add all `.carbon`
+    files as inputs.
+    -   For `Core`, we should expect `.o` files are already available.
+    -   For other packages, all files in the directory will be compiled,
+        although there may be some support added for using pre-compiled state
+        (not explicitly proposed).
 -   Do something similar to the appropriate series of `carbon compile`
     invocations.
     -   A key divergence is that we should avoid re-checking files that would be
@@ -176,6 +184,10 @@ The `carbon link` command will change to make the following work:
 carbon compile foo.carbon -o foo.o
 carbon link foo.o -o program
 ```
+
+It will be typical to link multiple object files into a single output file. The
+output file flag will be optional, defaulting to `program`, possibly with a
+target-specific extension; for example, `platform.exe` for Windows.
 
 This requires implicit `compile`-equivalent invocations for `Core` files (not
 just prelude), and includes their object files in output. It should be possible
@@ -202,14 +214,19 @@ without parsing every file matching `core/**/*.carbon`.
 In order to achieve this:
 
 -   The `compile` command will have a built-in directory mapping for the `Core`
-    package, for example to `/usr/share/carbon/core` (when installed to the `/usr`
-    prefix).
+    package, for example to `/usr/share/carbon/core` (when installed to the
+    `/usr` prefix).
 -   The `map` library name will need to match the filename, so
     `/usr/share/carbon/core/map.carbon`.
     -   Slashes may be provided in the library name, for subdirectories.
 -   If `map.carbon` has other `Core` imports, they will be recursively loaded
     once parsed.
     -   Note that checking isn't required to process imports from a file.
+
+Note we never need to map `impl` files by filename to a library; they cannot be
+discovered through an `import`, and we always need to parse them in order to
+discover their imports. As a consequence, there is no need to define rules
+mapping libraries to `.impl.carbon` files.
 
 #### Support for other packages
 
@@ -222,16 +239,9 @@ implementation detail for what makes sense.
 #### Disallow ambiguous library names
 
 For imports which rely on the implicit mapping (not in general), we will
-disallow ambiguous library names. This includes:
-
--   Any name with a period in it.
-    -   For example of the ambiguity, given a file `foo.bar.impl.carbon`, it
-        would be unclear if this is an `impl` file for library "foo.bar" or one
-        of multiple `impl` files for library "foo". Under this rule, the library
-        name "foo.bar" is invalid, so meaning the second interpretation is the
-        only valid interpretation.
--   An explicit `library "default"` string name which can be ambiguous with the
-    implicit `default` library.
+disallow ambiguous library names. This includes an explicit `library "default"`
+string name, which can be ambiguous with the implicit `default` library (both
+would map to `default.carbon`).
 
 ## Example interaction with Bazel
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -161,7 +161,9 @@ replacement for `carbon compile`. It will:
 -   Load provided files.
 -   For packages with directory mappings, particularly `Core`, add all `.carbon`
     files as inputs.
-    -   For `Core`, we should expect `.o` files are already available.
+    -   For `Core`, we expect `.o` files to be produced as part of on-demand
+        runtimes. They should be cached, not be compiled per `build` invocation
+        (in contrast with other artifacts, which this does not propose caching).
     -   For other packages, all files in the directory will be compiled,
         although there may be some support added for using pre-compiled state
         (not explicitly proposed).

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -127,7 +127,8 @@ At the end, it should be possible to:
 Note the goal here is to align on look-and-feel of separate compilation.
 Although the `carbon` CLI is important to the language, most details aren't
 necessary to address through the proposal process. For example, we want to get
-flag names right here, but also we wouldn't expect a proposal for flag names.
+flag names right here, but also we wouldn't expect a proposal for flag name
+changes.
 
 ## Details
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -30,7 +30,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Caching checked IR, C++ AST, and other possible compile artifacts](#caching-checked-ir-c-ast-and-other-possible-compile-artifacts)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [Provide a full build system](#provide-a-full-build-system)
     -   [Naming of commands and rules](#naming-of-commands-and-rules)
     -   [apis versus hdrs](#apis-versus-hdrs)
     -   [Support a full-fledged build system](#support-a-full-fledged-build-system)
@@ -82,7 +81,7 @@ Restructure compilation into:
 -   `carbon compile`: Take a single input to build, and produce a single output
     `.o`.
 -   `carbon build`: Take multiple inputs in order to produce a linked binary.
-    -   Overlaps with `carbon compile` and `carbon link`
+    -   Overlaps with `carbon compile` and `carbon link`.
 
 Provide Bazel rules based on this:
 
@@ -97,9 +96,10 @@ These are intended to accept flexible inputs:
     compilation.
 -   For `carbon build` in particular, it should not be necessary to pass in
     `Core` files that are required.
-    -   We will require a correlation between library names inside Core and
-        directory structure. For example, `prelude/types` will be
-        `prelude/types.carbon`.
+    -   We will require a correlation between library names inside `Core` and
+        directory structure. For example, `prelude/types`
+        [maps to](#mapping-packaging-directives-to-filenames)
+        `core/prelude/types.carbon`.
     -   The same strict correlation will be supported for other packages.
 
 At the end, it should be possible to:
@@ -134,9 +134,9 @@ necessary to address through the proposal process.
 The `carbon compile` command is intended to be a straightforward single input,
 single output command. Dependencies will be provided through a combination of:
 
--   Given a package name to directory mapping, an
-    [additional mapping](#mapping-packaging-directives-to-filenames) based on
-    the library name.
+-   Given a package name to directory mapping, a
+    [filename mapping](#mapping-packaging-directives-to-filenames) based on the
+    library name.
 -   Explicitly provided input files.
 
 As part of supporting a mix of C++ and Carbon files, we will support
@@ -335,39 +335,6 @@ leads don't want support to be built right now.
 
 ## Alternatives considered
 
-### Provide a full build system
-
-The `build` command as proposed here is intended to be sufficient for quick
-testing and simple tools. However, it would not have the capabilities of a
-system such as CMake or Bazel.
-
-Instead, we could provide a full build system. Multiple other languages have
-gone in that direction:
-
--   In Rust, `cargo` combines a
-    [build system](https://doc.rust-lang.org/cargo/commands/cargo-build.html)
-    and package manager.
--   In Swift,
-    [SwiftPM](https://www.swift.org/documentation/server/guides/building.html)
-    provides a similar offering as to `cargo`.
--   In Zig, there are
-    [multiple build system](https://ziglang.org/learn/build-system/) commands.
-
-Carbon's
-[project goal](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
-is migration of existing C++ developers, particularly "This means integrating
-into the existing C++ ecosystem by supporting incremental migration from C++ to
-Carbon."
-
-The expectation is that C++ users will already be using a fully featured build
-system, such as CMake. Migration should be easier if users can retain their
-existing build system, particularly since a typical migration can be expected to
-mix both Carbon and C++ code.
-
-While Carbon could provide _both_ a separate compilation system _and_ a fully
-featured build system, a build system is a substantial undertaking and we expect
-C++ developers to already have one.
-
 ### Naming of commands and rules
 
 For `carbon compile` and `carbon build`, this is trying to split apart concepts.
@@ -446,11 +413,37 @@ Leads are choosing to provide `apis` here primarily for consistency with
 
 ### Support a full-fledged build system
 
-`carbon build` is aiming to provide a relatively simple build system. However,
-it's not intended to be flexible with custom rules, plugins, and so on.
+The `build` command as proposed here is intended to be sufficient for quick
+testing and simple tools. However, it's not intended to be flexible with custom
+rules, plugins, and so on. These are features offered by systems such as CMake
+or Bazel.
 
-Carbon is prioritizing plugging into existing C++ builds over creating a new
-build setup.
+Instead, we could provide a full build system. Multiple other languages have
+gone in that direction:
+
+-   In Rust, `cargo` combines a
+    [build system](https://doc.rust-lang.org/cargo/commands/cargo-build.html)
+    and package manager.
+-   In Swift,
+    [SwiftPM](https://www.swift.org/documentation/server/guides/building.html)
+    provides a similar offering as to `cargo`.
+-   In Zig, there are
+    [multiple build system](https://ziglang.org/learn/build-system/) commands.
+
+Carbon's
+[project goal](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+is migration of existing C++ developers, particularly "This means integrating
+into the existing C++ ecosystem by supporting incremental migration from C++ to
+Carbon."
+
+The expectation is that C++ users will already be using a fully featured build
+system, such as CMake. Migration should be easier if users can retain their
+existing build system, particularly since a typical migration can be expected to
+mix both Carbon and C++ code.
+
+While Carbon could provide _both_ a separate compilation system _and_ a fully
+featured build system, a build system is a substantial undertaking and we expect
+C++ developers to already have one.
 
 ### Don't support packaging directive to filename mappings
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -221,12 +221,12 @@ In order to achieve this:
     -   Slashes may be provided in the library name, for subdirectories.
 -   If `map.carbon` has other `Core` imports, they will be recursively loaded
     once parsed.
-    -   Note that checking isn't required to process imports from a file.
+    -   Checking isn't required to process imports from a file.
 
-Note we never need to map `impl` files by filename to a library; they cannot be
-discovered through an `import`, and we always need to parse them in order to
-discover their imports. As a consequence, there is no need to define rules
-mapping libraries to `.impl.carbon` files.
+We never need to map `impl` files by library name to a filename, or the other
+way around; they cannot be discovered through an `import`, and we always need to
+parse them in order to discover their imports. As a consequence, there is no
+need to define rules mapping libraries to `.impl.carbon` files.
 
 #### Support for other packages
 

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -190,7 +190,7 @@ When we need a file for a packaging directive:
 -   The package name will correspond to a root directory. For example,
     `package Core ...` could correspond to `lib/carbon/core/...`.
 -   The library name will correspond to a path under that, suffixed by
-    `.carbon`. For example, `package Core library "prelude/types;` could
+    `.carbon`. For example, `package Core library "prelude/types";` could
     correspond to `lib/carbon/core/prelude/types.carbon`.
     -   The default library will use the name `default.carbon`. For example,
         `package Core;` could correspond to `lib/carbon/core/default.carbon`.
@@ -202,10 +202,10 @@ without parsing every file matching `core/**/*.carbon`.
 In order to achieve this:
 
 -   The `compile` command will have a built-in directory mapping for the `Core`
-    package, for example to `/usr/lib/carbon/core` (when installed to the `/usr`
+    package, for example to `/usr/share/carbon/core` (when installed to the `/usr`
     prefix).
 -   The `map` library name will need to match the filename, so
-    `/usr/lib/carbon/core/map.carbon`.
+    `/usr/share/carbon/core/map.carbon`.
     -   Slashes may be provided in the library name, for subdirectories.
 -   If `map.carbon` has other `Core` imports, they will be recursively loaded
     once parsed.

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -1,0 +1,70 @@
+# CLI and separate compilation
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/6333)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -17,54 +17,572 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Background](#background)
 -   [Proposal](#proposal)
 -   [Details](#details)
+    -   [Command changes](#command-changes)
+        -   [Compile command](#compile-command)
+        -   [Build command](#build-command)
+        -   [Link command](#link-command)
+    -   [carbon_library and carbon_binary](#carbon_library-and-carbon_binary)
+        -   [Indirect API exposure](#indirect-api-exposure)
+        -   [Core package rules](#core-package-rules)
+    -   [Mapping packaging directives to filenames](#mapping-packaging-directives-to-filenames)
+        -   [Disallow ambiguous library names](#disallow-ambiguous-library-names)
+-   [Future work](#future-work)
+    -   [Caching checked IR, C++ AST, and other possible compile artifacts](#caching-checked-ir-c-ast-and-other-possible-compile-artifacts)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [Provide a full build system](#provide-a-full-build-system)
+    -   [Naming of commands and rules](#naming-of-commands-and-rules)
+    -   [apis versus hdrs](#apis-versus-hdrs)
+    -   [Support a full-fledged build system](#support-a-full-fledged-build-system)
+    -   [Don't support packaging directive to filename mappings](#dont-support-packaging-directive-to-filename-mappings)
+    -   [Distribute pre-compiled versions of Core files](#distribute-pre-compiled-versions-of-core-files)
+    -   [Require C++ files be passed to clang directly](#require-c-files-be-passed-to-clang-directly)
+    -   [Allow indirect dependencies in carbon_library](#allow-indirect-dependencies-in-carbon_library)
+    -   [Implicit carbon_library dependency on Core versus prelude](#implicit-carbon_library-dependency-on-core-versus-prelude)
+    -   [Create an explicit mapping from packaging directives to files](#create-an-explicit-mapping-from-packaging-directives-to-files)
 
 <!-- tocstop -->
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+-   Change the look-and-feel of the `carbon` compilation command set to use
+    `compile`, `link`, and `build`.
+-   Rewrite `carbon_library` and `carbon_binary` based on the `compile` and
+    `link` commands.
+-   Build library-to-file discovery for `Core`, but support it in a general
+    manner.
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+Right now, `carbon compile` produces an object file per input file. This has a
+few issues, for example when it comes to compiling prelude files: it's not clear
+how to get a prelude `.o` file.
+
+Additionally, the compilation setup doesn't work well with the prelude because
+symbols don't get emitted for prelude files. Right now, we generally don't
+notice this because the prelude has been implemented in a way that typically
+doesn't require separate object files, but it will likely become an issue.
+
+Essentially, we have a decent setup for testing, but not one that's easy to use
+in real-world situations.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+In C++, `clang++ main.cpp` is a way to produce `program`. This is trying to
+reach a similar goal to make it easy to build and test small programs.
+
+Key commands related to this proposal are `carbon compile`, `carbon clang`, and
+`carbon link`. The end result will likely compose multiple command elements in
+order to build the output.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+Restructure compilation into:
+
+-   `carbon compile`: Take a single input to build, and produce a single output
+    `.o`.
+-   `carbon build`: Take multiple inputs in order to produce a linked binary.
+    -   Overlaps with `carbon compile` and `carbon link`
+
+Provide Bazel rules based on this:
+
+-   `carbon_library` similar to `cc_library`.
+-   `carbon_binary` similar to `cc_binary`.
+-   In the `core` directory, `carbon_library` rules that assist with builds.
+    -   The prelude would be a default dependency of all `carbon_library` rules.
+
+These are intended to accept flexible inputs:
+
+-   Support passing in standard C++ file extensions to any of these for
+    compilation.
+-   For `carbon build` in particular, it should not be necessary to pass in
+    `Core` files that are required.
+    -   We will require a correlation between library names inside Core and
+        directory structure. For example, `prelude/types` will be
+        `prelude/types.carbon`.
+    -   The same strict correlation will be supported for other packages.
+
+At the end, it should be possible to:
+
+-   Run `carbon build main.carbon` (or even just `carbon build`) with
+    non-prelude `Core` imports, and get an executable `program`.
+-   Have Bazel rules that mix C++ code and Carbon code. For example:
+
+    ```
+    carbon_library(
+        name = "foo",
+        srcs = ["foo.cpp", "foo.impl.carbon"],
+        apis = ["foo.carbon"],
+    )
+    carbon_binary(
+        name = "bar",
+        srcs = ["main.cpp"],
+        deps = [":carbon_library"],
+    )
+    ```
+
+Note the goal here is to align on look-and-feel of separate compilation.
+Although the `carbon` CLI is important to the language, most details aren't
+necessary to address through the proposal process.
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+### Command changes
+
+#### Compile command
+
+The `carbon compile` command is intended to be a straightforward single input,
+single output command. Dependencies will be provided through a combination of:
+
+-   Given a package name to directory mapping, an
+    [additional mapping](#mapping-packaging-directives-to-filenames) based on
+    the library name.
+-   Explicitly provided input files.
+
+As part of supporting a mix of C++ and Carbon files, we will support
+`carbon compile foo.cpp` with results similar to `carbon clang -- -c foo.cpp`.
+
+#### Build command
+
+The `carbon build` command will be the new, simple way to compile, as a
+replacement for `carbon compile`. It will:
+
+-   Load provided files.
+-   For packages with directory mappings, particularly `Core`, figure out the
+    right files to load.
+-   Do something similar to the appropriate series of `carbon compile`
+    invocations.
+    -   A key divergence is that we should avoid re-checking files that would be
+        used across multiple `carbon compile` invocations.
+-   Run the equivalent of `carbon link` over produced inputs.
+
+While the build command will default to providing an executable `program`, we'll
+also want it to be capable of producing `.a` and `.so` files.
+
+#### Link command
+
+The `carbon link` command will change to make the following work:
+
+```
+carbon compile foo.carbon -o foo.o
+carbon link foo.o -o program
+```
+
+This requires implicit `compile`-equivalent invocations for `Core` files (not
+just prelude), and includes their object files in output. It should be possible
+to opt out of this, for example so that the Bazel `carbon_binary` rule can use
+`carbon link` while also providing its own `Core` object files. However, it
+should be on-by-default.
+
+### carbon_library and carbon_binary
+
+The Bazel build rules will expose `carbon compile` and `carbon link` behaviors
+in a slightly more Bazel-idiomatic way. For example, given:
+
+```
+carbon_library(
+    name = "lib",
+    srcs = ["a.impl.carbon", "b.impl.carbon", "b.carbon"],
+    apis = ["a.carbon"],
+)
+carbon_binary(
+    name = "bin",
+    srcs = ["main.carbon"],
+    deps = [":lib"],
+)
+```
+
+The way this will approximately work is:
+
+-   `carbon_library` will have an implicit dependency on a set of `Core`
+    libraries (such as a build target `//carbon/lang:core`).
+    -   This will have a network of `carbon_library` rules, some of which may
+        look like `lib`.
+-   For `lib`, we'll delegate to `carbon build`:
+    -   Examine the four files, and determine a compile order.
+    -   Invoke the four `carbon compile` behaviors, producing a `.o` file.
+-   For `bin`, we'll again delegate to `carbon build`:
+    -   Given one file, determine the trivial compile order.
+    -   Invoke `carbon compile` to produce a `.o`
+        -   `a.carbon` and `b.carbon` will be available for imports, but it
+            should be an error if `b.carbon` is imported directly. This is
+            required because `a.carbon` can expose `b.carbon` on the import
+            boundary, meaning an indirect import of `b.carbon` must work..
+    -   Link object files into an executable.
+
+For both, there should be an implicit dependency on the full Core package, not
+just the prelude. This is because we want the Core package to be easy to access.
+
+#### Indirect API exposure
+
+The `apis` attribute is suggested to support only _direct_ dependencies. For
+example:
+
+```
+carbon_library(
+    name = "a",
+    apis = ["a.carbon"],
+)
+carbon_library(
+    name = "b",
+    apis = ["b.carbon"],
+    deps = [":a"],
+)
+carbon_library(
+    name = "c",
+    srcs = ["c.carbon"],
+    deps = [":b"],
+)
+```
+
+If `c.carbon` imports `a.carbon`, the build should error that `a.carbon`
+requires a direct dependency. We should allow forwarding, so that the same could
+compile without requiring `c` to have a direct dependency on `a`. This should
+look like `public_deps = [":a"]`, added to `b` (and superseding the need to list
+`:a` in `deps`).
+
+This feature may see frequent use, for example in `Core` to allow writing it as
+multiple libraries instead of one large glob. But it's probably also something
+that can be delayed a little, because we can just use a big glob and force
+direct dependencies.
+
+#### Core package rules
+
+In the `core/` directory, we will set up corresponding `carbon_library` rules.
+These will need to pass flags to opt-out of normal behaviors, in particular the
+dependency on the prelude library.
+
+### Mapping packaging directives to filenames
+
+Suppose we have some command line `carbon compile a.carbon`, and in `a.carbon`,
+it does `import Core library "map";`. This needs to load `core/map.carbon`, and
+without parsing every file matching `core/**/*.carbon`.
+
+In order to achieve this:
+
+-   The `compile` command will have a built-in directory mapping for the `Core`
+    package, for example to `/usr/lib/carbon/core` (when installed to the `/usr`
+    prefix).
+-   The `map` library name will need to match the filename, so
+    `/usr/lib/carbon/core/map.carbon`.
+    -   Slashes may be provided in the library name, for subdirectories.
+-   If `map.carbon` has other `Core` imports, they will be recursively loaded
+    once parsed.
+    -   Note that checking isn't required to process imports from a file.
+-   When determining which `impl` files need to be associated with a given
+    `api`, we will support both `<library name>.impl.carbon` and
+    `<library name>.*.impl.carbon`, with the latter supporting arbitrary names
+    for cases where there are multiple impl files.
+
+Because we'll build this for Core, it would probably be straightforward to
+expose this for other packages, too. So for example, we will support
+`--package_path=MyPackage:/my/package`.
+
+#### Disallow ambiguous library names
+
+For imports which rely on the implicit mapping (not in general), we will
+disallow ambiguous library names. This includes:
+
+-   Any name with a period in it.
+    -   For example of the ambiguity, given a file `foo.bar.impl.carbon`, it
+        would be unclear if this is an `impl` file for library "foo.bar" or one
+        of multiple `impl` files for library "foo". Under this rule, the library
+        name "foo.bar" is invalid, so meaning the second interpretation is the
+        only valid interpretation.
+-   An explicit `library "default"` string name which can be ambiguous with the
+    implicit `default`.
+
+## Future work
+
+### Caching checked IR, C++ AST, and other possible compile artifacts
+
+As designed, every time any of the `build`, `compile`, or `link` commands are
+used, all prelude files and possibly more of the `Core` package will be
+re-checked, along with C++ ASTs being reproduced.
+
+Instead, Carbon could serialize checked IR, store produced C++ ASTs, and so on.
+C++ ASTs in particular could be substantially constructed based on parsed Carbon
+state, rather than checked Carbon state, allowing more build parallelism. In
+distributed or cached build systems, being able to reuse portions of the build
+may increase performance.
+
+The specific build outputs we want to store may substantially affect how we
+would set up a build process. The absence of a decision may lead to the
+implementation diverging from what's actually needed, meaning parts will be
+reimplemented later. This isn't expected to be too high cost.
+
+There are also ways to improve build performance without taking these steps.
+[Clang modules](https://clang.llvm.org/docs/Modules.html) might be used for
+improving Clang compile performance without significant support from Carbon.
+
+For now we will rely on whatever caching Bazel does for the `.a` output of a
+`carbon_library`. No other outputs will be made available. That may change, but
+leads don't want support to be built right now.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
 -   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+    -   `carbon build` should support easy experimentation with Carbon, and also
+        small projects.
+    -   Other build support is intended to scale up for larger codebases.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+    -   The intent is to be able to migrate from a CMake, Makefile, or other
+        build at relatively low cost. An invocation to `clang` can typically be
+        replaced with `carbon clang`, linking a binary becomes `carbon link`,
+        and so on.
+    -   Similarly, `carbon_library` and `carbon_binary` are important to us for
+        Bazel support and a migration from `cc_library` and `cc_binary`.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+### Provide a full build system
+
+The `build` command as proposed here is intended to be sufficient for quick
+testing and simple tools. However, it would not have the capabilities of a
+system such as CMake or Bazel.
+
+Instead, we could provide a full build system. Multiple other languages have
+gone in that direction:
+
+-   In Rust, `cargo` combines a
+    [build system](https://doc.rust-lang.org/cargo/commands/cargo-build.html)
+    and package manager.
+-   In Swift,
+    [SwiftPM](https://www.swift.org/documentation/server/guides/building.html)
+    provides a similar offering as to `cargo`.
+-   In Zig, there are
+    [multiple build system](https://ziglang.org/learn/build-system/) commands.
+
+Carbon's
+[project goal](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+is migration of existing C++ developers, particularly "This means integrating
+into the existing C++ ecosystem by supporting incremental migration from C++ to
+Carbon."
+
+The expectation is that C++ users will already be using a fully featured build
+system, such as CMake. Migration should be easier if users can retain their
+existing build system, particularly since a typical migration can be expected to
+mix both Carbon and C++ code.
+
+While Carbon could provide _both_ a separate compilation system _and_ a fully
+featured build system, a build system is a substantial undertaking and we expect
+C++ developers to already have one.
+
+### Naming of commands and rules
+
+For `carbon compile` and `carbon build`, this is trying to split apart concepts.
+Some considered alternatives are:
+
+-   Merge `compile`, and possibly also `link`, into `build`. Flags could be used
+    to differentiate between the versions desired, rather than subcommand names.
+    -   We expect that splitting these apart makes it easier to turn them into
+        replacements in C++ builds, and easier to understand even in
+        Carbon-specific builds.
+-   Some other name for `public_deps`
+    -   I'm not really sure `public_deps` is the best name, but it's my best
+        thought for something to reflect the transitive nature of API exposure
+        being proposed.
+-   Have `carbon build` produce `a.out`
+    -   `a.out` is the default output of most C++ compilers, but it reflects a
+        legacy executable file format. Using the legacy name may reflect
+        backwards compatibility that Carbon doesn't plan.
+    -   Changing the default output name is probably low-cost, and people will
+        get used to it.
+
+### apis versus hdrs
+
+For `apis` in specific, there are a couple nuanced naming choices due to
+`cc_library`'s `hdrs` naming. This is inherently a divergence, and we could have
+continued using `hdrs`.
+
+Advantages:
+
+-   Naming consistency with C++.
+-   Naming it `apis` could lead to confusion that it should contain _all_ API
+    files, not just ones intended to be public; however, similar confusion could
+    exist with `hdrs`.
+
+Disadvantages:
+
+-   `apis` more clearly reflects the design intent of "API". `hdrs` is an opaque
+    naming choice for Carbon when considered independently of C++.
+
+Another possible name would be something like `export_srcs` to match `exports`,
+or `public_srcs`. But, the `apis` concept is likely to be common and we might
+want to minimize typing Also, longer names would further break vertical
+alignment (where `name`, `srcs`, `data`, `deps`, and so on are 4 characters).
+
+Another choice is that we could use `hdrs` for `.h` files, and rely fully on
+package-private visibility for Carbon code. In other words, drop `apis` because
+the language should take care of it; `srcs` would make all `.carbon` API files
+visible.
+
+Advantages:
+
+-   Removes potential confusion between `hdrs`, `apis`, and `srcs`.
+    -   `hdrs` likely remains for C++ backwards-compatibility, but Carbon files
+        only occur in `srcs`.
+-   In `bazel`, only providing `srcs` reflects more broadly how languages work.
+    -   The split in C++ likely exists because of the history of the `.h`/`.cpp`
+        semantics, with the actual behavior shifting over time as Bazel evolved.
+    -   Other languages could have had a similar Bazel rule semantic separating
+        "implementation" and "API" files, but don't do it this way.
+-   Carbon's `.carbon` versus `.impl.carbon` file extension split gives the
+    build system the ability to reduce forwarded files in the common case,
+    without relying on user decisions.
+    -   This makes the `srcs` versus `apis` difference less meaningful.
+
+Disadvantages:
+
+-   Puts more burden on language-level access control.
+    -   Particularly when considering commonly used libraries, library
+        maintainers are likely to want a greater ability to separate concepts
+        such as "exposed only to closely related libraries" versus "exposed to
+        all library consumers". Build visibility is one way to provide that, but
+        Carbon could also introduce things such as "package-private" visibility.
+
+Leads are choosing to provide `apis` here primarily for consistency with
+`cc_library`.
+
+### Support a full-fledged build system
+
+`carbon build` is aiming to provide a relatively simple build system. However,
+it's not intended to be flexible with custom rules, plugins, and so on.
+
+Carbon is prioritizing plugging into existing C++ builds over creating a new
+build setup.
+
+### Don't support packaging directive to filename mappings
+
+Instead of making a mapping from packaging directives to filenames, we could
+generate a list specific to the `Core` package, and not expose that for other
+packages.
+
+We shouldn't manually maintain a mapping for the `Core` package; it should be
+automated. It's likely that whatever we do in this space, however we would
+support a mapping, would be of interest to small projects. It will probably be
+low cost for us to build support things other than `Core`, so we should just do
+that.
+
+### Distribute pre-compiled versions of Core files
+
+Instead of building object files for `Core` on demand, we could distribute them
+as part of Carbon. The upside of this is it would make builds a little faster;
+the downside is that we'd end up in more of a situation where supported target
+platforms were enumerated, or perhaps where special platforms could be built
+on-demand in a bespoke manner.
+
+We can probably add limited caching where it'd help, and support all platforms
+using similar logic that way with little performance penalty.
+
+### Require C++ files be passed to clang directly
+
+We could require C++ files to be passed to clang or carbon clang instead of
+carbon build, and similarly cc_library instead of carbon_library. Behind the
+scenes, clang will be equivalent to carbon clang, so Carbon will already be able
+to have control over how that compiles.
+
+For `carbon_library` in particular, we want to support situations where a `.cpp`
+file depends on a Carbon API file and the corresponding Carbon `impl` file
+depends on the corresponding `.h` file. This means a tight association that's
+well-served by having `carbon_library` support both.
+
+Similarly, we want `carbon build` to be able to take a combination of C++ and
+Carbon files, and decide what commands to run based on the file extension. Doing
+similar with `carbon compile` is then just an extension of the same desire to
+not make users choose which command to run based only on the filename.
+
+There may be some confusion because of `carbon_library` supporting both C++ and
+Carbon code. We are trying to think of this in terms of ecosystems, wherein the
+ecosystem includes both C++ and Carbon. But people already have a sense of what
+"C++" is in this context, so this proposal suggests using "Carbon" to be
+inclusive of C++ code. Hopefully then people can learn that the new thing works
+with both.
+
+What's really missing is a better name for this than "carbon".
+
+### Allow indirect dependencies in carbon_library
+
+As discussed under [Indirect API exposure](#indirect-api-exposure), this
+proposal suggests doing explicit layering of Carbon libraries.
+
+For C++ code, Bazel has some
+[layering capabilities](https://bazel.build/docs/bazel-and-cpp#toolchain-features)
+to prevent indirect dependencies in the build graph. These have limited support,
+but are intended to be used in similar ways as to what's proposed for Carbon
+here in order to prevent indirect dependencies in C++ code.
+
+A key difference is that in C++ compiles, header files do not generate a `.o`
+file; in Carbon files, they will. As a consequence, in C++, header files can be
+listed in `cc_library`'s `hdrs` in multiple targets in order to make the API
+directly exposed; in Carbon, API files cannot be.
+
+What `public_deps` is really doing for Carbon rules is providing a different way
+to get at a feature that exists for C++. We are choosing to make this default
+behavior in order to get cleaner builds.
+
+### Implicit carbon_library dependency on Core versus prelude
+
+As proposed, the implicit dependency for `carbon_library` will be all of `Core`.
+This could instead only be the prelude, with an explicit dependency required for
+either part or all of `Core`.
+
+We expect `Core` to contain frequently used parts of Carbon, including common
+data structures. Rather than requiring developers to add an explicit dependency
+for these, we think it'll be better to have the implicit dependency.
+
+Note it will still be possible to disable the implicit dependency. Some
+libraries, particularly the `Core` library implementation itself, are expected
+to do so.
+
+### Create an explicit mapping from packaging directives to files
+
+The current `package` and `library` directive design means a given `api` file
+may have 0 or more `impl` files.
+
+We could make it clear from the declaration in an `api` file what `impl` files
+exist. This would require a split to describe the possible situations. For
+example:
+
+-   `library "foo";`: The common case of 1 `impl` file.
+-   `library "foo" api_only;`: Add a single keyword that indicates this is a
+    library with no `impl` file.
+-   `library "foo" multi_impl 3;`: Indicates this is an unusual library with 3
+    `impl` files.
+    -   Multiple impl files are expected to be rare.
+    -   We could require numbered filenames (such as `a.impl.carbon`,
+        `a.1.impl.carbon`, `a.2.impl.carbon`), but even knowing how many exist
+        would allow compiles to do validation. If we didn't do this, then it may
+        be equivalent to not require specifying the number of `impl` files (in
+        the example, `multi_impl;` instead of `multi_impl 3;`).
+
+Some advantages are:
+
+-   In the common cases of API-only or 1 impl file, we could avoid scanning the
+    file system for more files. In other words, it reduces file I/O for better
+    performance.
+-   Changes most "missing definition" failures from linker errors to
+    compile-time.
+    -   For example at present, if a forward declaration is in an `api` file,
+        then even if we find an `impl` file that is missing the definition we
+        don't know if there's another `impl` file that contains the definition.
+        With this feature, we could diagnose while compiling the common 0 or 1
+        `impl` file cases.
+-   Allows diagnosing unexpected or missing `impl` files, which can indicate a
+    developer mistake in the build.
+-   If multi-`impl` filenames were constrained to be numbered, we could:
+    -   When building, look for specific filenames, instead of doing a file
+        system glob for `impl` filenames.
+    -   Loosen the ambiguity constraint on library names to only disallow
+        library names ending with `\.\d+`.
+
+Some disadvantages are:
+
+-   Adds more keywords to the packaging declaration.
+-   Requires updating the API file's declaration in order to modify the number
+    of `impl` files.
+
+This has been discussed in the past, but does not seem to be outlined in any
+proposals as a considered alternative, and this proposal adds new trade-offs for
+file mappings. Leads have declined this option in order to keep packaging
+directives simple.

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -68,7 +68,7 @@ in real-world situations.
 
 ## Background
 
-In C++, `clang++ main.cpp` is a way to produce `program`. This is trying to
+In C++, `clang++ main.cpp -o program` is a way to produce `program`. This is trying to
 reach a similar goal to make it easy to build and test small programs.
 
 Key commands related to this proposal are `carbon compile`, `carbon clang`, and
@@ -212,7 +212,7 @@ The way this will approximately work is:
         -   `a.carbon` and `b.carbon` will be available for imports, but it
             should be an error if `b.carbon` is imported directly. This is
             required because `a.carbon` can expose `b.carbon` on the import
-            boundary, meaning an indirect import of `b.carbon` must work..
+            boundary, meaning an indirect import of `b.carbon` must work.
     -   Link object files into an executable.
 
 For both, there should be an implicit dependency on the full Core package, not
@@ -281,7 +281,7 @@ In order to achieve this:
 
 Because we'll build this for Core, it would probably be straightforward to
 expose this for other packages, too. So for example, we will support
-`--package_path=MyPackage:/my/package`.
+`--package-path=MyPackage:/my/package`.
 
 #### Disallow ambiguous library names
 
@@ -322,7 +322,8 @@ improving Clang compile performance without significant support from Carbon.
 
 For now we will rely on whatever caching Bazel does for the `.a` output of a
 `carbon_library`. No other outputs will be made available. That may change, but
-leads don't want support to be built right now.
+leads want to spend our limited development and review time on other features
+for the 0.1 milestone.
 
 ## Rationale
 
@@ -331,7 +332,7 @@ leads don't want support to be built right now.
         small projects.
     -   Other build support is intended to scale up for larger codebases.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
-    -   The intent is to be able to migrate from a CMake, Makefile, or other
+    -   The intent is to be able to migrate a CMake, Makefile, or other
         build at relatively low cost. An invocation to `clang` can typically be
         replaced with `carbon clang`, linking a binary becomes `carbon link`,
         and so on.
@@ -381,7 +382,7 @@ Disadvantages:
 
 Another possible name would be something like `export_srcs` to match `exports`,
 or `public_srcs`. But, the `apis` concept is likely to be common and we might
-want to minimize typing Also, longer names would further break vertical
+want to minimize typing. Also, longer names would further break vertical
 alignment (where `name`, `srcs`, `data`, `deps`, and so on are 4 characters).
 
 Another choice is that we could use `hdrs` for `.h` files, and rely fully on
@@ -459,7 +460,7 @@ packages.
 We shouldn't manually maintain a mapping for the `Core` package; it should be
 automated. It's likely that whatever we do in this space, however we would
 support a mapping, would be of interest to small projects. It will probably be
-low cost for us to build support things other than `Core`, so we should just do
+low cost for us to build support for things other than `Core`, so we should just do
 that.
 
 ### Distribute pre-compiled versions of Core files
@@ -475,9 +476,9 @@ using similar logic that way with little performance penalty.
 
 ### Require C++ files be passed to clang directly
 
-We could require C++ files to be passed to clang or carbon clang instead of
-carbon build, and similarly cc_library instead of carbon_library. Behind the
-scenes, clang will be equivalent to carbon clang, so Carbon will already be able
+We could require C++ files to be passed to `clang` or `carbon clang` instead of
+`carbon build`, and similarly `cc_library` instead of `carbon_library`. Behind the
+scenes, `clang` will be equivalent to `carbon clang`, so Carbon will already be able
 to have control over how that compiles.
 
 For `carbon_library` in particular, we want to support situations where a `.cpp`

--- a/proposals/p6333.md
+++ b/proposals/p6333.md
@@ -54,22 +54,27 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-Right now, `carbon compile` produces an object file per input file. This has a
-few issues, for example when it comes to compiling prelude files: it's not clear
-how to get a prelude `.o` file.
+The current command line is still a prototype, and lacks support for regular
+use. For example:
 
-Additionally, the compilation setup doesn't work well with the prelude because
-symbols don't get emitted for prelude files. Right now, we generally don't
-notice this because the prelude has been implemented in a way that typically
-doesn't require separate object files, but it will likely become an issue.
+-   `carbon compile` produces one object file per input file. When
+    `--output-file` is specified and there are multiple inputs, the output is
+    repeatedly overwritten.
+-   `carbon compile` doesn't provide a trivial way to produce object files for
+    the prelude. The `carbon_binary` rule is, behind the scenes, separately
+    compiling all the prelude files individually and doing its own custom
+    linking with those.
+-   When writing a small test program (for example "hello world") it would be
+    nice to have a single command to run to produce a program. Right now,
+    `carbon compile` and `carbon link` must be used in combination.
 
 Essentially, we have a decent setup for testing, but not one that's easy to use
 in real-world situations.
 
 ## Background
 
-In C++, `clang++ main.cpp -o program` is a way to produce `program`. This is trying to
-reach a similar goal to make it easy to build and test small programs.
+In C++, `clang++ main.cpp -o program` is a way to produce `program`. This is
+trying to reach a similar goal to make it easy to build and test small programs.
 
 Key commands related to this proposal are `carbon compile`, `carbon clang`, and
 `carbon link`. The end result will likely compose multiple command elements in
@@ -106,7 +111,7 @@ These are intended to accept flexible inputs:
 At the end, it should be possible to:
 
 -   Run `carbon build main.carbon` (or even just `carbon build`) with
-    non-prelude `Core` imports, and get an executable `program`.
+    non-prelude `Core` imports, and get an executable program.
 -   Have Bazel rules that mix C++ code and Carbon code. For example:
 
     ```bazel
@@ -161,8 +166,10 @@ replacement for `carbon compile`. It will:
         used across multiple `carbon compile` invocations.
 -   Run the equivalent of `carbon link` over produced inputs.
 
-While the build command will default to providing an executable `program`, we'll
-also want it to be capable of producing `.a` and `.so` files.
+While the build command will default to providing an executable program, we may
+also want it to be capable of producing `.a` and `.so` files. However, we can
+decide whether `carbon build` should be required for these kinds of outputs as
+an implementation detail.
 
 #### Link command
 
@@ -203,17 +210,22 @@ The way this will approximately work is:
     libraries (such as a build target `//carbon/lang:core`).
     -   This will have a network of `carbon_library` rules, some of which may
         look like `lib`.
--   For `lib`, we'll delegate to `carbon build`:
-    -   Examine the four files, and determine a compile order.
-    -   Invoke the four `carbon compile` behaviors, producing a `.o` file.
--   For `bin`, we'll again delegate to `carbon build`:
-    -   Given one file, determine the trivial compile order.
-    -   Invoke `carbon compile` to produce a `.o`
-        -   `a.carbon` and `b.carbon` will be available for imports, but it
-            should be an error if `b.carbon` is imported directly. This is
-            required because `a.carbon` can expose `b.carbon` on the import
-            boundary, meaning an indirect import of `b.carbon` must work.
+-   For `lib`:
+    -   Invoke `carbon compile` four times, producing a `.o` file for each
+        input.
+    -   The API files will be additional inputs to the `impl` file compilations.
+-   For `bin`:
+    -   Source files will be compiled similarly to `lib`.
+        -   The `deps` means `a.carbon` and `b.carbon` will be additional
+            inputs, but it should ideally be an error if `b.carbon` is imported
+            directly. This is required because `a.carbon` can expose `b.carbon`
+            on the import boundary, meaning an indirect import of `b.carbon`
+            must work.
     -   Link object files into an executable.
+
+It's possible that we may use `carbon build` where `carbon compile` is
+mentioned, but if so, it should not make a significant difference in the
+user-visible behavior.
 
 For both, there should be an implicit dependency on the full Core package, not
 just the prelude. This is because we want the Core package to be easy to access.
@@ -243,7 +255,7 @@ carbon_library(
 If `c.carbon` imports `a.carbon`, the build should error that `a.carbon`
 requires a direct dependency. We should allow forwarding, so that the same could
 compile without requiring `c` to have a direct dependency on `a`. This should
-look like `public_deps = [":a"]`, added to `b` (and superseding the need to list
+look like `exports = [":a"]`, added to `b` (and superseding the need to list
 `:a` in `deps`).
 
 This feature may see frequent use, for example in `Core` to allow writing it as
@@ -258,6 +270,16 @@ These will need to pass flags to opt-out of normal behaviors, in particular the
 dependency on the prelude library.
 
 ### Mapping packaging directives to filenames
+
+When we need a file for a packaging directive:
+
+-   The package name will correspond to a root directory. For example,
+    `package Core ...` could correspond to `lib/carbon/core/...`.
+-   The library name will correspond to a path under that, suffixed by
+    `.carbon`. For example, `package Core library "prelude/types;` could
+    correspond to `lib/carbon/core/prelude/types.carbon`.
+    -   The default library will use the name `default.carbon`. For example,
+        `package Core;` could correspond to `lib/carbon/core/default.carbon`.
 
 Suppose we have some command line `carbon compile a.carbon`, and in `a.carbon`,
 it does `import Core library "map";`. This needs to load `core/map.carbon`, and
@@ -274,10 +296,6 @@ In order to achieve this:
 -   If `map.carbon` has other `Core` imports, they will be recursively loaded
     once parsed.
     -   Note that checking isn't required to process imports from a file.
--   When determining which `impl` files need to be associated with a given
-    `api`, we will support both `<library name>.impl.carbon` and
-    `<library name>.*.impl.carbon`, with the latter supporting arbitrary names
-    for cases where there are multiple impl files.
 
 Because we'll build this for Core, it would probably be straightforward to
 expose this for other packages, too. So for example, we will support
@@ -295,7 +313,7 @@ disallow ambiguous library names. This includes:
         name "foo.bar" is invalid, so meaning the second interpretation is the
         only valid interpretation.
 -   An explicit `library "default"` string name which can be ambiguous with the
-    implicit `default`.
+    implicit `default` library.
 
 ## Future work
 
@@ -332,10 +350,9 @@ for the 0.1 milestone.
         small projects.
     -   Other build support is intended to scale up for larger codebases.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
-    -   The intent is to be able to migrate a CMake, Makefile, or other
-        build at relatively low cost. An invocation to `clang` can typically be
-        replaced with `carbon clang`, linking a binary becomes `carbon link`,
-        and so on.
+    -   The intent is to be able to migrate a CMake, Makefile, or other build at
+        relatively low cost. An invocation to `clang` can typically be replaced
+        with `carbon clang`, linking a binary becomes `carbon link`, and so on.
     -   Similarly, `carbon_library` and `carbon_binary` are important to us for
         Bazel support and a migration from `cc_library` and `cc_binary`.
 
@@ -351,10 +368,10 @@ Some considered alternatives are:
     -   We expect that splitting these apart makes it easier to turn them into
         replacements in C++ builds, and easier to understand even in
         Carbon-specific builds.
--   Some other name for `public_deps`
-    -   I'm not really sure `public_deps` is the best name, but it's my best
-        thought for something to reflect the transitive nature of API exposure
-        being proposed.
+-   Some other name for `exports`
+    -   I'm not really sure `exports` is the best name, but it's my best thought
+        for something to reflect the transitive nature of API exposure being
+        proposed.
 -   Have `carbon build` produce `a.out`
     -   `a.out` is the default output of most C++ compilers, but it reflects a
         legacy executable file format. Using the legacy name may reflect
@@ -379,6 +396,9 @@ Disadvantages:
 
 -   `apis` more clearly reflects the design intent of "API". `hdrs` is an opaque
     naming choice for Carbon when considered independently of C++.
+-   In `cc_library`, `hdrs` won't produce `.o` files, whereas `apis` will
+    generate `.o` files for `.carbon` files. The skew in behavior may be
+    confusing to developers.
 
 Another possible name would be something like `export_srcs` to match `exports`,
 or `public_srcs`. But, the `apis` concept is likely to be common and we might
@@ -460,8 +480,8 @@ packages.
 We shouldn't manually maintain a mapping for the `Core` package; it should be
 automated. It's likely that whatever we do in this space, however we would
 support a mapping, would be of interest to small projects. It will probably be
-low cost for us to build support for things other than `Core`, so we should just do
-that.
+low cost for us to build support for things other than `Core`, so we should just
+do that.
 
 ### Distribute pre-compiled versions of Core files
 
@@ -477,9 +497,9 @@ using similar logic that way with little performance penalty.
 ### Require C++ files be passed to clang directly
 
 We could require C++ files to be passed to `clang` or `carbon clang` instead of
-`carbon build`, and similarly `cc_library` instead of `carbon_library`. Behind the
-scenes, `clang` will be equivalent to `carbon clang`, so Carbon will already be able
-to have control over how that compiles.
+`carbon build`, and similarly `cc_library` instead of `carbon_library`. Behind
+the scenes, `clang` will be equivalent to `carbon clang`, so Carbon will already
+be able to have control over how that compiles.
 
 For `carbon_library` in particular, we want to support situations where a `.cpp`
 file depends on a Carbon API file and the corresponding Carbon `impl` file
@@ -516,8 +536,8 @@ file; in Carbon files, they will. As a consequence, in C++, header files can be
 listed in `cc_library`'s `hdrs` in multiple targets in order to make the API
 directly exposed; in Carbon, API files cannot be.
 
-What `public_deps` is really doing for Carbon rules is providing a different way
-to get at a feature that exists for C++. We are choosing to make this default
+What `exports` is really doing for Carbon rules is providing a different way to
+get at a feature that exists for C++. We are choosing to make this default
 behavior in order to get cleaner builds.
 
 ### Implicit carbon_library dependency on Core versus prelude


### PR DESCRIPTION
-   Change the look-and-feel of the `carbon` compilation command set to use
    `compile`, `link`, and `build`.
-   Build library-to-file discovery for `Core`, but support it in a general
    manner.

Drafted [in Docs](https://docs.google.com/document/d/19UvmU0znIFDj32hMj7TvE_WkZ_zEHygQHfOiFELKiMU/edit?tab=t.0)