### PR TITLE
Const cleanup in `Set` and `Map`

### DIFF
--- a/common/map.h
+++ b/common/map.h
@@ -26,6 +26,23 @@ template <typename KeyT, typename ValueT, ssize_t SmallSize,
           typename KeyContextT>
 class Map;
 
+// This type represents the result of map lookup operations. It encodes whether
+// the lookup was a success as well as accessors for the key and value.
+template <typename KeyT, typename ValueT, typename EntryT>
+class MapLookupResult {
+ public:
+  MapLookupResult() = default;
+  explicit MapLookupResult(EntryT* entry) : entry_(entry) {}
+
+  explicit operator bool() const { return entry_ != nullptr; }
+
+  auto key() const -> KeyT& { return entry_->key(); }
+  auto value() const -> ValueT& { return entry_->value(); }
+
+ private:
+  EntryT* entry_ = nullptr;
+};
+
 // A read-only view type for a map from key to value.
 //
 // This view is a cheap-to-copy type that should be passed by value, but
@@ -69,22 +86,6 @@ class MapView
   using KeyContextT = typename ImplT::KeyContextT;
   using MetricsT = typename ImplT::MetricsT;
 
-  // This type represents the result of lookup operations. It encodes whether
-  // the lookup was a success as well as accessors for the key and value.
-  class LookupKVResult {
-   public:
-    LookupKVResult() = default;
-    explicit LookupKVResult(EntryT* entry) : entry_(entry) {}
-
-    explicit operator bool() const { return entry_ != nullptr; }
-
-    auto key() const -> KeyT& { return entry_->key(); }
-    auto value() const -> ValueT& { return entry_->value(); }
-
-   private:
-    EntryT* entry_ = nullptr;
-  };
-
   // Enable implicit conversions that add `const`-ness to either key or value
   // type. This is always safe to do with a view. We use a template to avoid
   // needing all 3 versions.
@@ -103,7 +104,8 @@ class MapView
   // Lookup a key in the map.
   template <typename LookupKeyT>
   auto Lookup(LookupKeyT lookup_key,
-              KeyContextT key_context = KeyContextT()) const -> LookupKVResult;
+              KeyContextT key_context = KeyContextT()) const
+      -> MapLookupResult<KeyT, ValueT, EntryT>;
 
   // Lookup a key in the map and try to return a pointer to its value. Returns
   // null on a missing key.
@@ -113,7 +115,7 @@ class MapView
 
   // Run the provided callback for every key and value in the map.
   template <typename CallbackT>
-  auto ForEach(CallbackT callback) -> void
+  auto ForEach(CallbackT callback) const -> void
     requires(std::invocable<CallbackT, KeyT&, ValueT&>);
 
   // This routine is relatively inefficient and only intended for use in
@@ -129,6 +131,8 @@ class MapView
             typename KeyContextT>
   friend class Map;
   friend class MapBase<KeyT, ValueT, KeyContextT>;
+  friend class MapBase<std::remove_const_t<KeyT>, std::remove_const_t<ValueT>,
+                       KeyContextT>;
   friend class MapView<const KeyT, ValueT, KeyContextT>;
   friend class MapView<KeyT, const ValueT, KeyContextT>;
   friend class MapView<const KeyT, const ValueT, KeyContextT>;
@@ -159,7 +163,7 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   using ValueT = typename ImplT::ValueT;
   using KeyContextT = typename ImplT::KeyContextT;
   using ViewT = MapView<KeyT, ValueT, KeyContextT>;
-  using LookupKVResult = typename ViewT::LookupKVResult;
+  using ConstViewT = MapView<const KeyT, const ValueT, KeyContextT>;
   using MetricsT = typename ImplT::MetricsT;
 
   // The result type for insertion operations both indicates whether an insert
@@ -184,13 +188,15 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   // Implicitly convertible to the relevant view type.
   //
   // NOLINTNEXTLINE(google-explicit-constructor): Designed to implicitly decay.
-  explicit(false) operator ViewT() const { return this->view_impl(); }
+  explicit(false) operator ViewT() { return this->view_impl(); }
+  // NOLINTNEXTLINE(google-explicit-constructor): Designed to implicitly decay.
+  explicit(false) operator ConstViewT() const { return this->view_impl(); }
 
   // We can't chain the above conversion with the conversions on `ViewT` to add
   // const, so explicitly support adding const to produce a view here.
   template <typename OtherKeyT, typename OtherValueT>
   // NOLINTNEXTLINE(google-explicit-constructor)
-  explicit(false) operator MapView<OtherKeyT, OtherValueT, KeyContextT>() const
+  explicit(false) operator MapView<OtherKeyT, OtherValueT, KeyContextT>()
     requires(SameAsOneOf<OtherKeyT, KeyT, const KeyT> &&
              SameAsOneOf<OtherValueT, ValueT, const ValueT>)
   {
@@ -201,35 +207,51 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
   template <typename LookupKeyT>
   auto Contains(LookupKeyT lookup_key,
                 KeyContextT key_context = KeyContextT()) const -> bool {
-    return ViewT(*this).Contains(lookup_key, key_context);
+    return ConstViewT(*this).Contains(lookup_key, key_context);
   }
 
   // Convenience forwarder to the view type.
   template <typename LookupKeyT>
-  auto Lookup(LookupKeyT lookup_key,
-              KeyContextT key_context = KeyContextT()) const -> LookupKVResult {
+  auto Lookup(LookupKeyT lookup_key, KeyContextT key_context = KeyContextT())
+      -> MapLookupResult<KeyT, ValueT, EntryT> {
     return ViewT(*this).Lookup(lookup_key, key_context);
   }
+  template <typename LookupKeyT>
+  auto Lookup(LookupKeyT lookup_key,
+              KeyContextT key_context = KeyContextT()) const
+      -> MapLookupResult<const KeyT, const ValueT, EntryT> {
+    return ConstViewT(*this).Lookup(lookup_key, key_context);
+  }
 
   // Convenience forwarder to the view type.
   template <typename LookupKeyT>
-  auto operator[](LookupKeyT lookup_key) const
+  auto operator[](LookupKeyT lookup_key)
       -> ValueT* requires(std::default_initializable<KeyContextT>) {
         return ViewT(*this)[lookup_key];
+      } template <typename LookupKeyT>
+      auto operator[](LookupKeyT lookup_key) const
+      -> const ValueT* requires(std::default_initializable<KeyContextT>) {
+        return ConstViewT(*this)[lookup_key];
       }
 
   // Convenience forwarder to the view type.
   template <typename CallbackT>
-  auto ForEach(CallbackT callback) const -> void
+  auto ForEach(CallbackT callback) -> void
     requires(std::invocable<CallbackT, KeyT&, ValueT&>)
   {
     return ViewT(*this).ForEach(callback);
+  }
+  template <typename CallbackT>
+  auto ForEach(CallbackT callback) const -> void
+    requires(std::invocable<CallbackT, const KeyT&, const ValueT&>)
+  {
+    return ConstViewT(*this).ForEach(callback);
   }
 
   // Convenience forwarder to the view type.
   auto ComputeMetrics(KeyContextT key_context = KeyContextT()) const
       -> MetricsT {
-    return ViewT(*this).ComputeMetrics(key_context);
+    return ConstViewT(*this).ComputeMetrics(key_context);
   }
 
   // Insert a key and value into the map. If the key is already present, the new
@@ -399,8 +421,10 @@ auto MapView<InputKeyT, InputValueT, InputKeyContextT>::Contains(
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
 template <typename LookupKeyT>
 auto MapView<InputKeyT, InputValueT, InputKeyContextT>::Lookup(
-    LookupKeyT lookup_key, KeyContextT key_context) const -> LookupKVResult {
-  return LookupKVResult(this->LookupEntry(lookup_key, key_context));
+    LookupKeyT lookup_key, KeyContextT key_context) const
+    -> MapLookupResult<KeyT, ValueT, EntryT> {
+  return MapLookupResult<KeyT, ValueT, EntryT>(
+      this->LookupEntry(lookup_key, key_context));
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
@@ -415,7 +439,7 @@ auto MapView<InputKeyT, InputValueT, InputKeyContextT>::operator[](
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
 template <typename CallbackT>
 auto MapView<InputKeyT, InputValueT, InputKeyContextT>::ForEach(
-    CallbackT callback) -> void
+    CallbackT callback) const -> void
   requires(std::invocable<CallbackT, KeyT&, ValueT&>)
 {
   this->ForEachEntry(

--- a/common/map_test.cpp
+++ b/common/map_test.cpp
@@ -808,6 +808,66 @@ TYPED_TEST(MapCollisionTest, Basic) {
       m, MakeKeyValues([](int k) { return k * 100 + 2; }, llvm::seq(1, 256)));
 }
 
+struct KeyValue {
+  explicit KeyValue(int i) : key(i), value(i) {}
+
+  int key;
+  int value;
+
+  friend auto operator==(const KeyValue& lhs, const KeyValue& rhs) {
+    return lhs.key == rhs.key;
+  }
+
+  auto CarbonHashValue(const KeyValue& value, uint64_t seed) -> HashCode {
+    Hasher hasher(seed);
+    hasher.Hash(value.key);
+    return static_cast<HashCode>(hasher);
+  }
+};
+
+TEST(ConstMapTest, Basic) {
+  Map<KeyValue, int> map;
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(map.Insert(KeyValue(i), i).is_inserted());
+  }
+  auto view = MapView<KeyValue, int>(map);
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(map.Contains(KeyValue(i)));
+    EXPECT_TRUE(view.Contains(KeyValue(i)));
+
+    auto result = map.Lookup(KeyValue(i));
+    ASSERT_TRUE(result);
+    ++result.key().value;
+    ++result.value();
+
+    result = view.Lookup(KeyValue(i));
+    ASSERT_TRUE(result);
+    ++result.key().value;
+    ++result.value();
+  }
+  map.ForEach([](KeyValue& key, int& value) {
+    ++key.value;
+    ++value;
+  });
+
+  const Map<KeyValue, int>& const_map = map;
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(const_map.Contains(KeyValue(i)));
+  }
+  auto const_view = MapView<const KeyValue, const int>(map);
+  auto view_of_const = MapView<const KeyValue, const int>(const_map);
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(const_map.Lookup(KeyValue(i)));
+    EXPECT_TRUE(const_view.Lookup(KeyValue(i)));
+    EXPECT_TRUE(view_of_const.Lookup(KeyValue(i)));
+  }
+  const_map.ForEach([](const KeyValue&, const int&) {});
+}
+
 TEST(MapContextTest, Basic) {
   llvm::SmallVector<TestData> keys;
   for (int i : llvm::seq(0, 513)) {

--- a/common/raw_hashtable.h
+++ b/common/raw_hashtable.h
@@ -357,10 +357,12 @@ class ViewImpl {
   using KeyT = InputKeyT;
   using ValueT = InputValueT;
   using KeyContextT = InputKeyContextT;
-  using EntryT = StorageEntry<KeyT, ValueT>;
+  using EntryT =
+      StorageEntry<std::remove_const_t<KeyT>, std::remove_const_t<ValueT>>;
   using MetricsT = Metrics;
 
-  friend class BaseImpl<KeyT, ValueT, KeyContextT>;
+  template <typename KeyT, typename ValueT, typename KeyContextT>
+  friend class BaseImpl;
   template <typename InputBaseT, ssize_t SmallSize>
   friend class TableImpl;
 
@@ -474,6 +476,7 @@ class BaseImpl {
   using ValueT = InputValueT;
   using KeyContextT = InputKeyContextT;
   using ViewImplT = ViewImpl<KeyT, ValueT, KeyContextT>;
+  using ConstViewImplT = ViewImpl<const KeyT, const ValueT, KeyContextT>;
   using EntryT = typename ViewImplT::EntryT;
   using MetricsT = typename ViewImplT::MetricsT;
 
@@ -493,9 +496,12 @@ class BaseImpl {
   ~BaseImpl() = default;
 
   // NOLINTNEXTLINE(google-explicit-constructor): Designed to implicitly decay.
-  explicit(false) operator ViewImplT() const { return view_impl(); }
+  explicit(false) operator ViewImplT() { return view_impl(); }
+  // NOLINTNEXTLINE(google-explicit-constructor): Designed to implicitly decay.
+  explicit(false) operator ConstViewImplT() const { return view_impl(); }
 
-  auto view_impl() const -> ViewImplT { return view_impl_; }
+  auto view_impl() -> ViewImplT { return view_impl_; }
+  auto view_impl() const -> ConstViewImplT { return view_impl_; }
 
   // Looks up the provided key in the hashtable. If found, returns a pointer to
   // that entry and `false`.
@@ -537,8 +543,8 @@ class BaseImpl {
   template <typename InputBaseT, ssize_t SmallSize>
   friend class TableImpl;
 
-  static constexpr ssize_t Alignment = std::max<ssize_t>(
-      alignof(MetadataGroup), alignof(StorageEntry<KeyT, ValueT>));
+  static constexpr ssize_t Alignment =
+      std::max<ssize_t>(alignof(MetadataGroup), alignof(EntryT));
 
   // Implementation of inline small storage for the provided key type, value
   // type, and small size. Specialized for a zero small size to be an empty
@@ -546,7 +552,7 @@ class BaseImpl {
   template <ssize_t SmallSize>
   struct SmallStorage : Storage {
     alignas(Alignment) uint8_t metadata[SmallSize];
-    mutable StorageEntry<KeyT, ValueT> entries[SmallSize];
+    mutable EntryT entries[SmallSize];
   };
   // Specialized storage with no inline buffer to avoid any extra alignment.
   template <>
@@ -1690,7 +1696,7 @@ auto TableImpl<InputBaseT, SmallSize>::small_storage() const -> Storage* {
     static_assert(SmallSize >= GroupSize);
     static_assert((SmallSize % GroupSize) == 0);
 
-    static_assert(SmallSize >= alignof(StorageEntry<KeyT, ValueT>),
+    static_assert(SmallSize >= alignof(EntryT),
                   "Requested a small size that would require padding between "
                   "metadata bytes and correctly aligned key and value types. "
                   "Either a larger small size or a zero small size and heap "

--- a/common/set.h
+++ b/common/set.h
@@ -23,6 +23,22 @@ class SetBase;
 template <typename KeyT, ssize_t SmallSize, typename KeyContextT>
 class Set;
 
+// This type represents the result of set lookup operations. It encodes whether
+// the lookup was a success as well as accessors for the key.
+template <typename KeyT>
+class SetLookupResult {
+ public:
+  SetLookupResult() = default;
+  explicit SetLookupResult(KeyT& key) : key_(&key) {}
+
+  explicit operator bool() const { return key_ != nullptr; }
+
+  auto key() const -> KeyT& { return *key_; }
+
+ private:
+  KeyT* key_ = nullptr;
+};
+
 // A read-only view type for a set of keys.
 //
 // This view is a cheap-to-copy type that should be passed by value, but
@@ -54,28 +70,14 @@ class Set;
 // hashing and comparing keys. For more details about the key context, see
 // `hashtable_key_context.h`.
 template <typename InputKeyT, typename InputKeyContextT = DefaultKeyContext>
-class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
-  using ImplT = RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT>;
+class SetView
+    : RawHashtable::ViewImpl<InputKeyT, const void, InputKeyContextT> {
+  using ImplT = RawHashtable::ViewImpl<InputKeyT, const void, InputKeyContextT>;
 
  public:
   using KeyT = typename ImplT::KeyT;
   using KeyContextT = typename ImplT::KeyContextT;
   using MetricsT = typename ImplT::MetricsT;
-
-  // This type represents the result of lookup operations. It encodes whether
-  // the lookup was a success as well as accessors for the key.
-  class LookupResult {
-   public:
-    LookupResult() = default;
-    explicit LookupResult(KeyT& key) : key_(&key) {}
-
-    explicit operator bool() const { return key_ != nullptr; }
-
-    auto key() const -> KeyT& { return *key_; }
-
-   private:
-    KeyT* key_ = nullptr;
-  };
 
   // Enable implicit conversions that add `const`-ness to the key type.
   explicit(false)
@@ -91,7 +93,8 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
   // Lookup a key in the set.
   template <typename LookupKeyT>
   auto Lookup(LookupKeyT lookup_key,
-              KeyContextT key_context = KeyContextT()) const -> LookupResult;
+              KeyContextT key_context = KeyContextT()) const
+      -> SetLookupResult<KeyT>;
 
   // Run the provided callback for every key in the set.
   template <typename CallbackT>
@@ -110,6 +113,8 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
   template <typename SetKeyT, ssize_t SmallSize, typename KeyContextT>
   friend class Set;
   friend class SetBase<KeyT, KeyContextT>;
+  friend class SetBase<std::remove_const_t<KeyT>, KeyContextT>;
+  friend class SetBase<const KeyT, KeyContextT>;
   friend class SetView<const KeyT, KeyContextT>;
 
   using EntryT = typename ImplT::EntryT;
@@ -127,16 +132,16 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
 // handle to a `Set` type across API boundaries as it avoids encoding specific
 // SSO sizing information while providing a near-complete mutable API.
 template <typename InputKeyT, typename InputKeyContextT>
-class SetBase
-    : protected RawHashtable::BaseImpl<InputKeyT, void, InputKeyContextT> {
+class SetBase : protected RawHashtable::BaseImpl<InputKeyT, const void,
+                                                 InputKeyContextT> {
  protected:
-  using ImplT = RawHashtable::BaseImpl<InputKeyT, void, InputKeyContextT>;
+  using ImplT = RawHashtable::BaseImpl<InputKeyT, const void, InputKeyContextT>;
 
  public:
   using KeyT = typename ImplT::KeyT;
   using KeyContextT = typename ImplT::KeyContextT;
   using ViewT = SetView<KeyT, KeyContextT>;
-  using LookupResult = typename ViewT::LookupResult;
+  using ConstViewT = SetView<const KeyT, KeyContextT>;
   using MetricsT = typename ImplT::MetricsT;
 
   // The result type for insertion operations both indicates whether an insert
@@ -160,27 +165,27 @@ class SetBase
   // Implicitly convertible to the relevant view type.
   //
   // NOLINTNEXTLINE(google-explicit-constructor): Designed to implicitly decay.
-  explicit(false) operator ViewT() const { return this->view_impl(); }
-
-  // We can't chain the above conversion with the conversions on `ViewT` to add
-  // const, so explicitly support adding const to produce a view here.
-  //
+  explicit(false) operator ViewT() { return this->view_impl(); }
   // NOLINTNEXTLINE(google-explicit-constructor): Designed to implicitly decay.
-  explicit(false) operator SetView<const KeyT, KeyContextT>() const {
-    return ViewT(*this);
-  }
+  explicit(false) operator ConstViewT() const { return this->view_impl(); }
 
   // Convenience forwarder to the view type.
   template <typename LookupKeyT>
   auto Contains(LookupKeyT lookup_key,
                 KeyContextT key_context = KeyContextT()) const -> bool {
-    return ViewT(*this).Contains(lookup_key, key_context);
+    return ConstViewT(*this).Contains(lookup_key, key_context);
   }
 
   // Convenience forwarder to the view type.
   template <typename LookupKeyT>
   auto Lookup(LookupKeyT lookup_key,
-              KeyContextT key_context = KeyContextT()) const -> LookupResult {
+              KeyContextT key_context = KeyContextT()) const
+      -> SetLookupResult<const KeyT> {
+    return ConstViewT(*this).Lookup(lookup_key, key_context);
+  }
+  template <typename LookupKeyT>
+  auto Lookup(LookupKeyT lookup_key, KeyContextT key_context = KeyContextT())
+      -> SetLookupResult<KeyT> {
     return ViewT(*this).Lookup(lookup_key, key_context);
   }
 
@@ -191,11 +196,17 @@ class SetBase
   {
     return ViewT(*this).ForEach(callback);
   }
+  template <typename CallbackT>
+  auto ForEach(CallbackT callback) const -> void
+    requires(std::invocable<CallbackT, KeyT&>)
+  {
+    return ConstViewT(*this).ForEach(callback);
+  }
 
   // Convenience forwarder to the view type.
   auto ComputeMetrics(KeyContextT key_context = KeyContextT()) const
       -> MetricsT {
-    return ViewT(*this).ComputeMetrics(key_context);
+    return ConstViewT(*this).ComputeMetrics(key_context);
   }
 
   // Insert a key into the set. If the key is already present, no insertion is
@@ -317,13 +328,13 @@ template <typename InputKeyT, typename InputKeyContextT>
 template <typename LookupKeyT>
 auto SetView<InputKeyT, InputKeyContextT>::Lookup(LookupKeyT lookup_key,
                                                   KeyContextT key_context) const
-    -> LookupResult {
+    -> SetLookupResult<KeyT> {
   EntryT* entry = this->LookupEntry(lookup_key, key_context);
   if (!entry) {
-    return LookupResult();
+    return SetLookupResult<KeyT>();
   }
 
-  return LookupResult(entry->key());
+  return SetLookupResult<KeyT>(entry->key());
 }
 
 template <typename InputKeyT, typename InputKeyContextT>

--- a/common/set_test.cpp
+++ b/common/set_test.cpp
@@ -388,6 +388,62 @@ TYPED_TEST(SetTest, GrowForInsert) {
   EXPECT_EQ(storage_bytes, s.ComputeMetrics().storage_bytes);
 }
 
+struct KeyValue {
+  explicit KeyValue(int i) : key(i), value(i) {}
+
+  int key;
+  int value;
+
+  friend auto operator==(const KeyValue& lhs, const KeyValue& rhs) {
+    return lhs.key == rhs.key;
+  }
+
+  auto CarbonHashValue(const KeyValue& value, uint64_t seed) -> HashCode {
+    Hasher hasher(seed);
+    hasher.Hash(value.key);
+    return static_cast<HashCode>(hasher);
+  }
+};
+
+TEST(ConstSetTest, Basic) {
+  Set<KeyValue> set;
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(set.Insert(KeyValue(i)).is_inserted());
+  }
+  auto view = SetView<KeyValue>(set);
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(set.Contains(KeyValue(i)));
+    EXPECT_TRUE(view.Contains(KeyValue(i)));
+
+    auto result = set.Lookup(KeyValue(i));
+    ASSERT_TRUE(result);
+    ++result.key().value;
+
+    result = view.Lookup(KeyValue(i));
+    ASSERT_TRUE(result);
+    ++result.key().value;
+  }
+  set.ForEach([](KeyValue& entry) { ++entry.value; });
+  [[]]
+
+      const Set<KeyValue>& const_set = set;
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(const_set.Contains(KeyValue(i)));
+  }
+  auto const_view = SetView<const KeyValue>(set);
+  auto view_of_const = SetView<const KeyValue>(const_set);
+  for (int i : llvm::seq(1, 42)) {
+    SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
+    EXPECT_TRUE(const_set.Lookup(KeyValue(i)));
+    EXPECT_TRUE(const_view.Lookup(KeyValue(i)));
+    EXPECT_TRUE(view_of_const.Lookup(KeyValue(i)));
+  }
+  const_set.ForEach([](const KeyValue&) {});
+}
+
 TEST(SetContextTest, Basic) {
   llvm::SmallVector<TestData> keys;
   for (int i : llvm::seq(0, 513)) {


### PR DESCRIPTION
This change disallows non-const access to a `const Set` or `const Map` via `Lookup` or view construction. For consistency, it also adds `ForEach` support on const containers (giving only const access to the elements).

