### PR TITLE
Call GetAttached less frequently in import

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1343,9 +1343,8 @@ static auto ResolveAsUnique(ImportRefResolver& resolver,
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::AdaptDecl inst,
                                 SemIR::InstId import_inst_id) -> ResolveResult {
-  auto adapted_type_const_id = GetLocalConstantId(
-      resolver,
-      resolver.import_constant_values().GetAttached(inst.adapted_type_inst_id));
+  auto adapted_type_const_id =
+      GetLocalConstantId(resolver, inst.adapted_type_inst_id);
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
@@ -1528,9 +1527,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::BaseDecl inst,
                                 SemIR::InstId import_inst_id) -> ResolveResult {
   auto type_const_id = GetLocalConstantId(resolver, inst.type_id);
-  auto base_type_const_id = GetLocalConstantId(
-      resolver,
-      resolver.import_constant_values().GetAttached(inst.base_type_inst_id));
+  auto base_type_const_id =
+      GetLocalConstantId(resolver, inst.base_type_inst_id);
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
@@ -2164,9 +2162,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   llvm::SmallVector<SemIR::InstId> lazy_virtual_functions;
   lazy_virtual_functions.reserve(virtual_functions.size());
   for (auto vtable_entry_id : virtual_functions) {
-    auto local_attached_constant_id = GetLocalConstantId(
-        resolver,
-        resolver.import_constant_values().GetAttached(vtable_entry_id));
+    auto local_attached_constant_id =
+        GetLocalConstantId(resolver, vtable_entry_id);
     lazy_virtual_functions.push_back(
         resolver.local_constant_values().GetInstIdIfValid(
             local_attached_constant_id));
@@ -2400,12 +2397,9 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto implicit_param_patterns = GetLocalInstBlockContents(
       resolver, import_impl.implicit_param_patterns_id);
   auto generic_data = GetLocalGenericData(resolver, import_impl.generic_id);
-  auto self_const_id = GetLocalConstantId(
-      resolver,
-      resolver.import_constant_values().GetAttached(import_impl.self_id));
-  auto constraint_const_id = GetLocalConstantId(
-      resolver,
-      resolver.import_constant_values().GetAttached(import_impl.constraint_id));
+  auto self_const_id = GetLocalConstantId(resolver, import_impl.self_id);
+  auto constraint_const_id =
+      GetLocalConstantId(resolver, import_impl.constraint_id);
   auto& new_impl = resolver.local_impls().Get(impl_id);
 
   if (resolver.HasNewWork()) {
@@ -2456,8 +2450,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Done(constant_id);
   }
 
-  auto new_constant_id = GetLocalConstantId(
-      resolver, resolver.import_constant_values().GetInstId(constant_id));
+  auto new_constant_id = GetLocalConstantId(resolver, constant_id);
   return RetryOrDone(resolver, new_constant_id);
 }
 

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
@@ -375,9 +375,9 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst60000047)}
 // CHECK:STDOUT:     'type(inst(SpecificFunctionType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     'type(symbolic_constant600000FD)':
+// CHECK:STDOUT:     'type(symbolic_constant60000101)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000024)}
-// CHECK:STDOUT:     'type(symbolic_constant60000100)':
+// CHECK:STDOUT:     'type(symbolic_constant60000104)':
 // CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000024)}
 // CHECK:STDOUT:     'type(inst(BoundMethodType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(BoundMethodType))}
@@ -478,17 +478,17 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst6000006B:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst6000006A, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000006C:    {kind: ConstType, arg0: inst6000006B, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000006D:    {kind: ImplWitness, arg0: inst60000068, arg1: specific60000003, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000006E:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(symbolic_constant60000026)}
+// CHECK:STDOUT:     inst6000006E:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(symbolic_constant60000027)}
 // CHECK:STDOUT:     inst6000006F:    {kind: FunctionType, arg0: function60000002, arg1: specific60000002, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000070:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000026)}
+// CHECK:STDOUT:     inst60000070:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000027)}
 // CHECK:STDOUT:     inst60000071:    {kind: PatternType, arg0: inst60000061, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000072:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant6000002B)}
-// CHECK:STDOUT:     inst60000073:    {kind: OutParamPattern, arg0: inst60000072, arg1: call_param1, type: type(symbolic_constant6000002B)}
-// CHECK:STDOUT:     inst60000074:    {kind: ValueBindingPattern, arg0: entity_name60000011, type: type(symbolic_constant6000002B)}
-// CHECK:STDOUT:     inst60000075:    {kind: ValueParamPattern, arg0: inst60000074, arg1: call_param0, type: type(symbolic_constant6000002B)}
+// CHECK:STDOUT:     inst60000072:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant6000002C)}
+// CHECK:STDOUT:     inst60000073:    {kind: OutParamPattern, arg0: inst60000072, arg1: call_param1, type: type(symbolic_constant6000002C)}
+// CHECK:STDOUT:     inst60000074:    {kind: ValueBindingPattern, arg0: entity_name60000011, type: type(symbolic_constant6000002C)}
+// CHECK:STDOUT:     inst60000075:    {kind: ValueParamPattern, arg0: inst60000074, arg1: call_param0, type: type(symbolic_constant6000002C)}
 // CHECK:STDOUT:     inst60000076:    {kind: ImportRefLoaded, arg0: import_ir_inst20, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000077:    {kind: FunctionType, arg0: function60000002, arg1: specific60000003, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000078:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant6000002D)}
+// CHECK:STDOUT:     inst60000078:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant6000002E)}
 // CHECK:STDOUT:     inst60000079:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000007A:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000079, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000007B:    {kind: ConstType, arg0: inst6000007A, type: type(TypeType)}
@@ -497,13 +497,13 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst6000007E:    {kind: RequireCompleteType, arg0: inst60000060, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000007F:    {kind: LookupImplWitness, arg0: inst6000005F, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000080:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000005F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000081:    {kind: ImplWitnessAccess, arg0: inst6000007F, arg1: element0, type: type(symbolic_constant6000003C)}
+// CHECK:STDOUT:     inst60000081:    {kind: ImplWitnessAccess, arg0: inst6000007F, arg1: element0, type: type(symbolic_constant6000003D)}
 // CHECK:STDOUT:     inst60000082:    {kind: SpecificImplFunction, arg0: inst60000081, arg1: specific60000005, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000083:    {kind: RequireCompleteType, arg0: inst6000007B, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000084:    {kind: RequireCompleteType, arg0: inst6000007A, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000085:    {kind: LookupImplWitness, arg0: inst60000079, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000086:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst60000079, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000087:    {kind: ImplWitnessAccess, arg0: inst60000085, arg1: element0, type: type(symbolic_constant60000045)}
+// CHECK:STDOUT:     inst60000087:    {kind: ImplWitnessAccess, arg0: inst60000085, arg1: element0, type: type(symbolic_constant60000046)}
 // CHECK:STDOUT:     inst60000088:    {kind: SpecificImplFunction, arg0: inst60000087, arg1: specific60000006, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000089:    {kind: PatternType, arg0: inst60000060, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000008A:    {kind: ImportRefUnloaded, arg0: import_ir_inst2D, arg1: entity_name<none>}
@@ -534,16 +534,16 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000A3:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000A4:    {kind: PointerType, arg0: inst600000A3, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000A5:    {kind: ImplWitness, arg0: inst600000A1, arg1: specific60000008, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000A6:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block_empty, type: type(symbolic_constant60000051)}
+// CHECK:STDOUT:     inst600000A6:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block_empty, type: type(symbolic_constant60000053)}
 // CHECK:STDOUT:     inst600000A7:    {kind: FunctionType, arg0: function60000003, arg1: specific60000007, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A8:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000051)}
-// CHECK:STDOUT:     inst600000A9:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant60000055)}
-// CHECK:STDOUT:     inst600000AA:    {kind: OutParamPattern, arg0: inst600000A9, arg1: call_param1, type: type(symbolic_constant60000055)}
-// CHECK:STDOUT:     inst600000AB:    {kind: ValueBindingPattern, arg0: entity_name60000018, type: type(symbolic_constant60000055)}
-// CHECK:STDOUT:     inst600000AC:    {kind: ValueParamPattern, arg0: inst600000AB, arg1: call_param0, type: type(symbolic_constant60000055)}
+// CHECK:STDOUT:     inst600000A8:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000053)}
+// CHECK:STDOUT:     inst600000A9:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant60000057)}
+// CHECK:STDOUT:     inst600000AA:    {kind: OutParamPattern, arg0: inst600000A9, arg1: call_param1, type: type(symbolic_constant60000057)}
+// CHECK:STDOUT:     inst600000AB:    {kind: ValueBindingPattern, arg0: entity_name60000018, type: type(symbolic_constant60000057)}
+// CHECK:STDOUT:     inst600000AC:    {kind: ValueParamPattern, arg0: inst600000AB, arg1: call_param0, type: type(symbolic_constant60000057)}
 // CHECK:STDOUT:     inst600000AD:    {kind: ImportRefLoaded, arg0: import_ir_inst4D, arg1: entity_name<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000AE:    {kind: FunctionType, arg0: function60000003, arg1: specific60000008, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000AF:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000058)}
+// CHECK:STDOUT:     inst600000AF:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant6000005A)}
 // CHECK:STDOUT:     inst600000B0:    {kind: RequireCompleteType, arg0: inst600000A4, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000B1:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000B2:    {kind: PointerType, arg0: inst600000B1, type: type(TypeType)}
@@ -576,18 +576,18 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000CD:    {kind: SymbolicBindingType, arg0: entity_name6000001A, arg1: inst600000CB, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000CE:    {kind: TupleType, arg0: inst_block6000003E, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000CF:    {kind: ImplWitness, arg0: inst600000C8, arg1: specific6000000B, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000D0:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block_empty, type: type(symbolic_constant60000072)}
+// CHECK:STDOUT:     inst600000D0:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block_empty, type: type(symbolic_constant60000075)}
 // CHECK:STDOUT:     inst600000D1:    {kind: FunctionType, arg0: function60000004, arg1: specific6000000A, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D2:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000072)}
+// CHECK:STDOUT:     inst600000D2:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000075)}
 // CHECK:STDOUT:     inst600000D3:    {kind: PatternType, arg0: inst600000C0, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D4:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant60000077)}
-// CHECK:STDOUT:     inst600000D5:    {kind: OutParamPattern, arg0: inst600000D4, arg1: call_param1, type: type(symbolic_constant60000077)}
-// CHECK:STDOUT:     inst600000D6:    {kind: ValueBindingPattern, arg0: entity_name60000024, type: type(symbolic_constant60000077)}
-// CHECK:STDOUT:     inst600000D7:    {kind: ValueParamPattern, arg0: inst600000D6, arg1: call_param0, type: type(symbolic_constant60000077)}
+// CHECK:STDOUT:     inst600000D4:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant6000007A)}
+// CHECK:STDOUT:     inst600000D5:    {kind: OutParamPattern, arg0: inst600000D4, arg1: call_param1, type: type(symbolic_constant6000007A)}
+// CHECK:STDOUT:     inst600000D6:    {kind: ValueBindingPattern, arg0: entity_name60000024, type: type(symbolic_constant6000007A)}
+// CHECK:STDOUT:     inst600000D7:    {kind: ValueParamPattern, arg0: inst600000D6, arg1: call_param0, type: type(symbolic_constant6000007A)}
 // CHECK:STDOUT:     inst600000D8:    {kind: ImportRefLoaded, arg0: import_ir_inst71, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst600000D9:    {kind: ImportRefLoaded, arg0: import_ir_inst72, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst600000DA:    {kind: FunctionType, arg0: function60000004, arg1: specific6000000B, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000DB:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000079)}
+// CHECK:STDOUT:     inst600000DB:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant6000007C)}
 // CHECK:STDOUT:     inst600000DC:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst600000DD:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst600000DC, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000DE:    {kind: SymbolicBinding, arg0: entity_name6000001A, arg1: inst<none>, type: type(inst60000047)}
@@ -598,18 +598,18 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst600000E3:    {kind: RequireCompleteType, arg0: inst600000BF, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E4:    {kind: LookupImplWitness, arg0: inst600000BE, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E5:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000BE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000E6:    {kind: ImplWitnessAccess, arg0: inst600000E4, arg1: element0, type: type(symbolic_constant60000091)}
+// CHECK:STDOUT:     inst600000E6:    {kind: ImplWitnessAccess, arg0: inst600000E4, arg1: element0, type: type(symbolic_constant60000094)}
 // CHECK:STDOUT:     inst600000E7:    {kind: SpecificImplFunction, arg0: inst600000E6, arg1: specific6000000D, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst600000E8:    {kind: RequireCompleteType, arg0: inst600000E0, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000E9:    {kind: RequireCompleteType, arg0: inst600000DD, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000EA:    {kind: LookupImplWitness, arg0: inst600000DC, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000EB:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000DC, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000EC:    {kind: ImplWitnessAccess, arg0: inst600000EA, arg1: element0, type: type(symbolic_constant6000009A)}
+// CHECK:STDOUT:     inst600000EC:    {kind: ImplWitnessAccess, arg0: inst600000EA, arg1: element0, type: type(symbolic_constant6000009D)}
 // CHECK:STDOUT:     inst600000ED:    {kind: SpecificImplFunction, arg0: inst600000EC, arg1: specific6000000E, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst600000EE:    {kind: RequireCompleteType, arg0: inst600000DF, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000EF:    {kind: LookupImplWitness, arg0: inst600000DE, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst600000F0:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000DE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F1:    {kind: ImplWitnessAccess, arg0: inst600000EF, arg1: element0, type: type(symbolic_constant6000009F)}
+// CHECK:STDOUT:     inst600000F1:    {kind: ImplWitnessAccess, arg0: inst600000EF, arg1: element0, type: type(symbolic_constant600000A2)}
 // CHECK:STDOUT:     inst600000F2:    {kind: SpecificImplFunction, arg0: inst600000F1, arg1: specific6000000F, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst600000F3:    {kind: PatternType, arg0: inst600000BF, type: type(TypeType)}
 // CHECK:STDOUT:     inst600000F4:    {kind: ImportRefUnloaded, arg0: import_ir_inst86, arg1: entity_name<none>}
@@ -636,19 +636,19 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst60000109:    {kind: SymbolicBindingType, arg0: entity_name60000029, arg1: inst60000106, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000010A:    {kind: TupleType, arg0: inst_block60000054, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000010B:    {kind: ImplWitness, arg0: inst60000102, arg1: specific60000011, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000010C:    {kind: FunctionDecl, arg0: function60000005, arg1: inst_block_empty, type: type(symbolic_constant600000BA)}
+// CHECK:STDOUT:     inst6000010C:    {kind: FunctionDecl, arg0: function60000005, arg1: inst_block_empty, type: type(symbolic_constant600000BE)}
 // CHECK:STDOUT:     inst6000010D:    {kind: FunctionType, arg0: function60000005, arg1: specific60000010, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000010E:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000BA)}
+// CHECK:STDOUT:     inst6000010E:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000BE)}
 // CHECK:STDOUT:     inst6000010F:    {kind: PatternType, arg0: inst600000F8, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000110:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant600000BF)}
-// CHECK:STDOUT:     inst60000111:    {kind: OutParamPattern, arg0: inst60000110, arg1: call_param1, type: type(symbolic_constant600000BF)}
-// CHECK:STDOUT:     inst60000112:    {kind: ValueBindingPattern, arg0: entity_name60000037, type: type(symbolic_constant600000BF)}
-// CHECK:STDOUT:     inst60000113:    {kind: ValueParamPattern, arg0: inst60000112, arg1: call_param0, type: type(symbolic_constant600000BF)}
+// CHECK:STDOUT:     inst60000110:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant600000C3)}
+// CHECK:STDOUT:     inst60000111:    {kind: OutParamPattern, arg0: inst60000110, arg1: call_param1, type: type(symbolic_constant600000C3)}
+// CHECK:STDOUT:     inst60000112:    {kind: ValueBindingPattern, arg0: entity_name60000037, type: type(symbolic_constant600000C3)}
+// CHECK:STDOUT:     inst60000113:    {kind: ValueParamPattern, arg0: inst60000112, arg1: call_param0, type: type(symbolic_constant600000C3)}
 // CHECK:STDOUT:     inst60000114:    {kind: ImportRefLoaded, arg0: import_ir_inst9F, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000115:    {kind: ImportRefLoaded, arg0: import_ir_instA0, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000116:    {kind: ImportRefLoaded, arg0: import_ir_instA1, arg1: entity_name<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst60000117:    {kind: FunctionType, arg0: function60000005, arg1: specific60000011, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000118:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000C1)}
+// CHECK:STDOUT:     inst60000118:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000C5)}
 // CHECK:STDOUT:     inst60000119:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000011A:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000119, type: type(TypeType)}
 // CHECK:STDOUT:     inst6000011B:    {kind: SymbolicBinding, arg0: entity_name6000001A, arg1: inst<none>, type: type(inst60000047)}
@@ -661,34 +661,34 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:     inst60000122:    {kind: RequireCompleteType, arg0: inst600000F7, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000123:    {kind: LookupImplWitness, arg0: inst600000F6, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000124:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst600000F6, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000125:    {kind: ImplWitnessAccess, arg0: inst60000123, arg1: element0, type: type(symbolic_constant600000E2)}
+// CHECK:STDOUT:     inst60000125:    {kind: ImplWitnessAccess, arg0: inst60000123, arg1: element0, type: type(symbolic_constant600000E6)}
 // CHECK:STDOUT:     inst60000126:    {kind: SpecificImplFunction, arg0: inst60000125, arg1: specific60000013, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000127:    {kind: RequireCompleteType, arg0: inst6000011F, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000128:    {kind: RequireCompleteType, arg0: inst6000011A, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000129:    {kind: LookupImplWitness, arg0: inst60000119, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000012A:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst60000119, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000012B:    {kind: ImplWitnessAccess, arg0: inst60000129, arg1: element0, type: type(symbolic_constant600000EB)}
+// CHECK:STDOUT:     inst6000012B:    {kind: ImplWitnessAccess, arg0: inst60000129, arg1: element0, type: type(symbolic_constant600000EF)}
 // CHECK:STDOUT:     inst6000012C:    {kind: SpecificImplFunction, arg0: inst6000012B, arg1: specific60000014, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst6000012D:    {kind: RequireCompleteType, arg0: inst6000011C, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000012E:    {kind: LookupImplWitness, arg0: inst6000011B, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000012F:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000011B, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000130:    {kind: ImplWitnessAccess, arg0: inst6000012E, arg1: element0, type: type(symbolic_constant600000F0)}
+// CHECK:STDOUT:     inst60000130:    {kind: ImplWitnessAccess, arg0: inst6000012E, arg1: element0, type: type(symbolic_constant600000F4)}
 // CHECK:STDOUT:     inst60000131:    {kind: SpecificImplFunction, arg0: inst60000130, arg1: specific60000015, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000132:    {kind: RequireCompleteType, arg0: inst6000011E, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000133:    {kind: LookupImplWitness, arg0: inst6000011D, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000134:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000011D, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000135:    {kind: ImplWitnessAccess, arg0: inst60000133, arg1: element0, type: type(symbolic_constant600000F5)}
+// CHECK:STDOUT:     inst60000135:    {kind: ImplWitnessAccess, arg0: inst60000133, arg1: element0, type: type(symbolic_constant600000F9)}
 // CHECK:STDOUT:     inst60000136:    {kind: SpecificImplFunction, arg0: inst60000135, arg1: specific60000016, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000137:    {kind: PatternType, arg0: inst600000F7, type: type(TypeType)}
 // CHECK:STDOUT:     inst60000138:    {kind: LookupImplWitness, arg0: inst6000001B, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst60000139:    {kind: LookupImplWitness, arg0: inst6000001C, arg1: specific_interface60000000, type: type(inst(WitnessType))}
 // CHECK:STDOUT:     inst6000013A:    {kind: FacetValue, arg0: inst6000001B, arg1: inst_block60000067, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000013B:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000013A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000013C:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant60000100)}
-// CHECK:STDOUT:     inst6000013D:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant600000FD)}
+// CHECK:STDOUT:     inst6000013C:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant60000104)}
+// CHECK:STDOUT:     inst6000013D:    {kind: ImplWitnessAccess, arg0: inst60000138, arg1: element0, type: type(symbolic_constant60000101)}
 // CHECK:STDOUT:     inst6000013E:    {kind: FacetValue, arg0: inst6000001C, arg1: inst_block60000068, type: type(inst60000047)}
 // CHECK:STDOUT:     inst6000013F:    {kind: FunctionTypeWithSelfType, arg0: inst60000050, arg1: inst6000013E, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000140:    {kind: ImplWitnessAccess, arg0: inst60000139, arg1: element0, type: type(symbolic_constant60000100)}
+// CHECK:STDOUT:     inst60000140:    {kind: ImplWitnessAccess, arg0: inst60000139, arg1: element0, type: type(symbolic_constant60000104)}
 // CHECK:STDOUT:     inst60000141:    {kind: BoundMethod, arg0: inst6000003F, arg1: inst6000013C, type: type(inst(BoundMethodType))}
 // CHECK:STDOUT:     inst60000142:    {kind: SpecificImplFunction, arg0: inst6000013C, arg1: specific60000017, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     inst60000143:    {kind: SpecificImplFunction, arg0: inst6000013D, arg1: specific60000017, type: type(inst(SpecificFunctionType))}
@@ -773,7 +773,7 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst60000059:    symbolic_constant60000016
 // CHECK:STDOUT:       inst6000005A:    symbolic_constant60000017
 // CHECK:STDOUT:       inst6000005B:    symbolic_constant60000018
-// CHECK:STDOUT:       inst6000005C:    symbolic_constant600000FB
+// CHECK:STDOUT:       inst6000005C:    symbolic_constant600000FF
 // CHECK:STDOUT:       inst6000005D:    constant<none>
 // CHECK:STDOUT:       inst6000005E:    concrete_constant(inst6000005E)
 // CHECK:STDOUT:       inst6000005F:    symbolic_constant60000019
@@ -786,39 +786,39 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst60000066:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst60000067:    constant<none>
 // CHECK:STDOUT:       inst60000068:    concrete_constant(inst60000068)
-// CHECK:STDOUT:       inst60000069:    symbolic_constant60000020
-// CHECK:STDOUT:       inst6000006A:    symbolic_constant60000022
-// CHECK:STDOUT:       inst6000006B:    symbolic_constant60000023
-// CHECK:STDOUT:       inst6000006C:    symbolic_constant60000024
-// CHECK:STDOUT:       inst6000006D:    symbolic_constant60000025
-// CHECK:STDOUT:       inst6000006E:    symbolic_constant60000028
-// CHECK:STDOUT:       inst6000006F:    symbolic_constant60000026
-// CHECK:STDOUT:       inst60000070:    symbolic_constant60000027
-// CHECK:STDOUT:       inst60000071:    symbolic_constant6000002A
+// CHECK:STDOUT:       inst60000069:    symbolic_constant60000021
+// CHECK:STDOUT:       inst6000006A:    symbolic_constant60000023
+// CHECK:STDOUT:       inst6000006B:    symbolic_constant60000024
+// CHECK:STDOUT:       inst6000006C:    symbolic_constant60000025
+// CHECK:STDOUT:       inst6000006D:    symbolic_constant60000026
+// CHECK:STDOUT:       inst6000006E:    symbolic_constant60000029
+// CHECK:STDOUT:       inst6000006F:    symbolic_constant60000027
+// CHECK:STDOUT:       inst60000070:    symbolic_constant60000028
+// CHECK:STDOUT:       inst60000071:    symbolic_constant6000002B
 // CHECK:STDOUT:       inst60000072:    concrete_constant(inst60000072)
 // CHECK:STDOUT:       inst60000073:    concrete_constant(inst60000073)
 // CHECK:STDOUT:       inst60000074:    concrete_constant(inst60000074)
 // CHECK:STDOUT:       inst60000075:    concrete_constant(inst60000075)
 // CHECK:STDOUT:       inst60000076:    symbolic_constant6000001D
-// CHECK:STDOUT:       inst60000077:    symbolic_constant6000002D
-// CHECK:STDOUT:       inst60000078:    symbolic_constant6000002E
-// CHECK:STDOUT:       inst60000079:    symbolic_constant60000032
-// CHECK:STDOUT:       inst6000007A:    symbolic_constant60000033
-// CHECK:STDOUT:       inst6000007B:    symbolic_constant60000034
-// CHECK:STDOUT:       inst6000007C:    symbolic_constant60000035
-// CHECK:STDOUT:       inst6000007D:    symbolic_constant60000036
-// CHECK:STDOUT:       inst6000007E:    symbolic_constant60000038
-// CHECK:STDOUT:       inst6000007F:    symbolic_constant6000003A
-// CHECK:STDOUT:       inst60000080:    symbolic_constant6000003C
-// CHECK:STDOUT:       inst60000081:    symbolic_constant6000003E
-// CHECK:STDOUT:       inst60000082:    symbolic_constant60000040
-// CHECK:STDOUT:       inst60000083:    symbolic_constant60000042
-// CHECK:STDOUT:       inst60000084:    symbolic_constant60000043
-// CHECK:STDOUT:       inst60000085:    symbolic_constant60000044
-// CHECK:STDOUT:       inst60000086:    symbolic_constant60000045
-// CHECK:STDOUT:       inst60000087:    symbolic_constant60000046
-// CHECK:STDOUT:       inst60000088:    symbolic_constant60000047
-// CHECK:STDOUT:       inst60000089:    symbolic_constant60000048
+// CHECK:STDOUT:       inst60000077:    symbolic_constant6000002E
+// CHECK:STDOUT:       inst60000078:    symbolic_constant6000002F
+// CHECK:STDOUT:       inst60000079:    symbolic_constant60000033
+// CHECK:STDOUT:       inst6000007A:    symbolic_constant60000034
+// CHECK:STDOUT:       inst6000007B:    symbolic_constant60000035
+// CHECK:STDOUT:       inst6000007C:    symbolic_constant60000036
+// CHECK:STDOUT:       inst6000007D:    symbolic_constant60000037
+// CHECK:STDOUT:       inst6000007E:    symbolic_constant60000039
+// CHECK:STDOUT:       inst6000007F:    symbolic_constant6000003B
+// CHECK:STDOUT:       inst60000080:    symbolic_constant6000003D
+// CHECK:STDOUT:       inst60000081:    symbolic_constant6000003F
+// CHECK:STDOUT:       inst60000082:    symbolic_constant60000041
+// CHECK:STDOUT:       inst60000083:    symbolic_constant60000043
+// CHECK:STDOUT:       inst60000084:    symbolic_constant60000044
+// CHECK:STDOUT:       inst60000085:    symbolic_constant60000045
+// CHECK:STDOUT:       inst60000086:    symbolic_constant60000046
+// CHECK:STDOUT:       inst60000087:    symbolic_constant60000047
+// CHECK:STDOUT:       inst60000088:    symbolic_constant60000048
+// CHECK:STDOUT:       inst60000089:    symbolic_constant60000049
 // CHECK:STDOUT:       inst6000008A:    constant<none>
 // CHECK:STDOUT:       inst6000008B:    concrete_constant(inst6000008B)
 // CHECK:STDOUT:       inst6000008C:    concrete_constant(inst(BoolType))
@@ -835,32 +835,32 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst60000097:    concrete_constant(inst60000097)
 // CHECK:STDOUT:       inst60000098:    concrete_constant(inst(IntLiteralType))
 // CHECK:STDOUT:       inst60000099:    concrete_constant(inst60000047)
-// CHECK:STDOUT:       inst6000009A:    symbolic_constant600000F9
+// CHECK:STDOUT:       inst6000009A:    symbolic_constant600000FD
 // CHECK:STDOUT:       inst6000009B:    concrete_constant(inst6000009B)
 // CHECK:STDOUT:       inst6000009C:    concrete_constant(inst6000009C)
-// CHECK:STDOUT:       inst6000009D:    symbolic_constant6000004A
-// CHECK:STDOUT:       inst6000009E:    symbolic_constant60000049
+// CHECK:STDOUT:       inst6000009D:    symbolic_constant6000004B
+// CHECK:STDOUT:       inst6000009E:    symbolic_constant6000004A
 // CHECK:STDOUT:       inst6000009F:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst600000A0:    constant<none>
 // CHECK:STDOUT:       inst600000A1:    concrete_constant(inst600000A1)
-// CHECK:STDOUT:       inst600000A2:    symbolic_constant6000004C
-// CHECK:STDOUT:       inst600000A3:    symbolic_constant6000004E
-// CHECK:STDOUT:       inst600000A4:    symbolic_constant6000004F
-// CHECK:STDOUT:       inst600000A5:    symbolic_constant60000050
-// CHECK:STDOUT:       inst600000A6:    symbolic_constant60000053
-// CHECK:STDOUT:       inst600000A7:    symbolic_constant60000051
-// CHECK:STDOUT:       inst600000A8:    symbolic_constant60000052
+// CHECK:STDOUT:       inst600000A2:    symbolic_constant6000004E
+// CHECK:STDOUT:       inst600000A3:    symbolic_constant60000050
+// CHECK:STDOUT:       inst600000A4:    symbolic_constant60000051
+// CHECK:STDOUT:       inst600000A5:    symbolic_constant60000052
+// CHECK:STDOUT:       inst600000A6:    symbolic_constant60000055
+// CHECK:STDOUT:       inst600000A7:    symbolic_constant60000053
+// CHECK:STDOUT:       inst600000A8:    symbolic_constant60000054
 // CHECK:STDOUT:       inst600000A9:    concrete_constant(inst600000A9)
 // CHECK:STDOUT:       inst600000AA:    concrete_constant(inst600000AA)
 // CHECK:STDOUT:       inst600000AB:    concrete_constant(inst600000AB)
 // CHECK:STDOUT:       inst600000AC:    concrete_constant(inst600000AC)
-// CHECK:STDOUT:       inst600000AD:    symbolic_constant6000004A
-// CHECK:STDOUT:       inst600000AE:    symbolic_constant60000058
-// CHECK:STDOUT:       inst600000AF:    symbolic_constant60000059
-// CHECK:STDOUT:       inst600000B0:    symbolic_constant6000005A
-// CHECK:STDOUT:       inst600000B1:    symbolic_constant6000005D
-// CHECK:STDOUT:       inst600000B2:    symbolic_constant6000005E
-// CHECK:STDOUT:       inst600000B3:    symbolic_constant6000005F
+// CHECK:STDOUT:       inst600000AD:    symbolic_constant6000004B
+// CHECK:STDOUT:       inst600000AE:    symbolic_constant6000005A
+// CHECK:STDOUT:       inst600000AF:    symbolic_constant6000005B
+// CHECK:STDOUT:       inst600000B0:    symbolic_constant6000005C
+// CHECK:STDOUT:       inst600000B1:    symbolic_constant6000005F
+// CHECK:STDOUT:       inst600000B2:    symbolic_constant60000060
+// CHECK:STDOUT:       inst600000B3:    symbolic_constant60000061
 // CHECK:STDOUT:       inst600000B4:    constant<none>
 // CHECK:STDOUT:       inst600000B5:    concrete_constant(inst600000B5)
 // CHECK:STDOUT:       inst600000B6:    concrete_constant(inst(TypeType))
@@ -871,140 +871,140 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       inst600000BB:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst600000BC:    constant<none>
 // CHECK:STDOUT:       inst600000BD:    concrete_constant(inst600000BD)
-// CHECK:STDOUT:       inst600000BE:    symbolic_constant60000060
-// CHECK:STDOUT:       inst600000BF:    symbolic_constant60000061
-// CHECK:STDOUT:       inst600000C0:    symbolic_constant60000062
+// CHECK:STDOUT:       inst600000BE:    symbolic_constant60000062
+// CHECK:STDOUT:       inst600000BF:    symbolic_constant60000063
+// CHECK:STDOUT:       inst600000C0:    symbolic_constant60000064
 // CHECK:STDOUT:       inst600000C1:    concrete_constant(inst600000C1)
 // CHECK:STDOUT:       inst600000C2:    concrete_constant(inst600000C2)
-// CHECK:STDOUT:       inst600000C3:    symbolic_constant60000064
-// CHECK:STDOUT:       inst600000C4:    symbolic_constant60000065
-// CHECK:STDOUT:       inst600000C5:    symbolic_constant60000063
+// CHECK:STDOUT:       inst600000C3:    symbolic_constant60000066
+// CHECK:STDOUT:       inst600000C4:    symbolic_constant60000067
+// CHECK:STDOUT:       inst600000C5:    symbolic_constant60000065
 // CHECK:STDOUT:       inst600000C6:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst600000C7:    constant<none>
 // CHECK:STDOUT:       inst600000C8:    concrete_constant(inst600000C8)
-// CHECK:STDOUT:       inst600000C9:    symbolic_constant6000006A
-// CHECK:STDOUT:       inst600000CA:    symbolic_constant6000006C
-// CHECK:STDOUT:       inst600000CB:    symbolic_constant6000006D
-// CHECK:STDOUT:       inst600000CC:    symbolic_constant6000006E
-// CHECK:STDOUT:       inst600000CD:    symbolic_constant6000006F
-// CHECK:STDOUT:       inst600000CE:    symbolic_constant60000070
-// CHECK:STDOUT:       inst600000CF:    symbolic_constant60000071
-// CHECK:STDOUT:       inst600000D0:    symbolic_constant60000074
-// CHECK:STDOUT:       inst600000D1:    symbolic_constant60000072
-// CHECK:STDOUT:       inst600000D2:    symbolic_constant60000073
-// CHECK:STDOUT:       inst600000D3:    symbolic_constant60000076
+// CHECK:STDOUT:       inst600000C9:    symbolic_constant6000006D
+// CHECK:STDOUT:       inst600000CA:    symbolic_constant6000006F
+// CHECK:STDOUT:       inst600000CB:    symbolic_constant60000070
+// CHECK:STDOUT:       inst600000CC:    symbolic_constant60000071
+// CHECK:STDOUT:       inst600000CD:    symbolic_constant60000072
+// CHECK:STDOUT:       inst600000CE:    symbolic_constant60000073
+// CHECK:STDOUT:       inst600000CF:    symbolic_constant60000074
+// CHECK:STDOUT:       inst600000D0:    symbolic_constant60000077
+// CHECK:STDOUT:       inst600000D1:    symbolic_constant60000075
+// CHECK:STDOUT:       inst600000D2:    symbolic_constant60000076
+// CHECK:STDOUT:       inst600000D3:    symbolic_constant60000079
 // CHECK:STDOUT:       inst600000D4:    concrete_constant(inst600000D4)
 // CHECK:STDOUT:       inst600000D5:    concrete_constant(inst600000D5)
 // CHECK:STDOUT:       inst600000D6:    concrete_constant(inst600000D6)
 // CHECK:STDOUT:       inst600000D7:    concrete_constant(inst600000D7)
-// CHECK:STDOUT:       inst600000D8:    symbolic_constant60000064
-// CHECK:STDOUT:       inst600000D9:    symbolic_constant60000065
-// CHECK:STDOUT:       inst600000DA:    symbolic_constant60000079
-// CHECK:STDOUT:       inst600000DB:    symbolic_constant6000007A
-// CHECK:STDOUT:       inst600000DC:    symbolic_constant60000080
-// CHECK:STDOUT:       inst600000DD:    symbolic_constant60000081
-// CHECK:STDOUT:       inst600000DE:    symbolic_constant60000082
-// CHECK:STDOUT:       inst600000DF:    symbolic_constant60000083
-// CHECK:STDOUT:       inst600000E0:    symbolic_constant60000084
-// CHECK:STDOUT:       inst600000E1:    symbolic_constant60000085
-// CHECK:STDOUT:       inst600000E2:    symbolic_constant60000086
-// CHECK:STDOUT:       inst600000E3:    symbolic_constant6000008D
-// CHECK:STDOUT:       inst600000E4:    symbolic_constant6000008F
-// CHECK:STDOUT:       inst600000E5:    symbolic_constant60000091
-// CHECK:STDOUT:       inst600000E6:    symbolic_constant60000093
-// CHECK:STDOUT:       inst600000E7:    symbolic_constant60000095
-// CHECK:STDOUT:       inst600000E8:    symbolic_constant60000097
-// CHECK:STDOUT:       inst600000E9:    symbolic_constant60000098
-// CHECK:STDOUT:       inst600000EA:    symbolic_constant60000099
-// CHECK:STDOUT:       inst600000EB:    symbolic_constant6000009A
-// CHECK:STDOUT:       inst600000EC:    symbolic_constant6000009B
-// CHECK:STDOUT:       inst600000ED:    symbolic_constant6000009C
-// CHECK:STDOUT:       inst600000EE:    symbolic_constant6000009D
-// CHECK:STDOUT:       inst600000EF:    symbolic_constant6000009E
-// CHECK:STDOUT:       inst600000F0:    symbolic_constant6000009F
-// CHECK:STDOUT:       inst600000F1:    symbolic_constant600000A0
-// CHECK:STDOUT:       inst600000F2:    symbolic_constant600000A1
-// CHECK:STDOUT:       inst600000F3:    symbolic_constant600000A2
+// CHECK:STDOUT:       inst600000D8:    symbolic_constant60000066
+// CHECK:STDOUT:       inst600000D9:    symbolic_constant60000067
+// CHECK:STDOUT:       inst600000DA:    symbolic_constant6000007C
+// CHECK:STDOUT:       inst600000DB:    symbolic_constant6000007D
+// CHECK:STDOUT:       inst600000DC:    symbolic_constant60000083
+// CHECK:STDOUT:       inst600000DD:    symbolic_constant60000084
+// CHECK:STDOUT:       inst600000DE:    symbolic_constant60000085
+// CHECK:STDOUT:       inst600000DF:    symbolic_constant60000086
+// CHECK:STDOUT:       inst600000E0:    symbolic_constant60000087
+// CHECK:STDOUT:       inst600000E1:    symbolic_constant60000088
+// CHECK:STDOUT:       inst600000E2:    symbolic_constant60000089
+// CHECK:STDOUT:       inst600000E3:    symbolic_constant60000090
+// CHECK:STDOUT:       inst600000E4:    symbolic_constant60000092
+// CHECK:STDOUT:       inst600000E5:    symbolic_constant60000094
+// CHECK:STDOUT:       inst600000E6:    symbolic_constant60000096
+// CHECK:STDOUT:       inst600000E7:    symbolic_constant60000098
+// CHECK:STDOUT:       inst600000E8:    symbolic_constant6000009A
+// CHECK:STDOUT:       inst600000E9:    symbolic_constant6000009B
+// CHECK:STDOUT:       inst600000EA:    symbolic_constant6000009C
+// CHECK:STDOUT:       inst600000EB:    symbolic_constant6000009D
+// CHECK:STDOUT:       inst600000EC:    symbolic_constant6000009E
+// CHECK:STDOUT:       inst600000ED:    symbolic_constant6000009F
+// CHECK:STDOUT:       inst600000EE:    symbolic_constant600000A0
+// CHECK:STDOUT:       inst600000EF:    symbolic_constant600000A1
+// CHECK:STDOUT:       inst600000F0:    symbolic_constant600000A2
+// CHECK:STDOUT:       inst600000F1:    symbolic_constant600000A3
+// CHECK:STDOUT:       inst600000F2:    symbolic_constant600000A4
+// CHECK:STDOUT:       inst600000F3:    symbolic_constant600000A5
 // CHECK:STDOUT:       inst600000F4:    constant<none>
 // CHECK:STDOUT:       inst600000F5:    concrete_constant(inst600000F5)
-// CHECK:STDOUT:       inst600000F6:    symbolic_constant600000A3
-// CHECK:STDOUT:       inst600000F7:    symbolic_constant600000A4
-// CHECK:STDOUT:       inst600000F8:    symbolic_constant600000A5
+// CHECK:STDOUT:       inst600000F6:    symbolic_constant600000A6
+// CHECK:STDOUT:       inst600000F7:    symbolic_constant600000A7
+// CHECK:STDOUT:       inst600000F8:    symbolic_constant600000A8
 // CHECK:STDOUT:       inst600000F9:    concrete_constant(inst600000F9)
 // CHECK:STDOUT:       inst600000FA:    concrete_constant(inst600000FA)
 // CHECK:STDOUT:       inst600000FB:    concrete_constant(inst600000FB)
-// CHECK:STDOUT:       inst600000FC:    symbolic_constant600000A7
-// CHECK:STDOUT:       inst600000FD:    symbolic_constant600000A8
-// CHECK:STDOUT:       inst600000FE:    symbolic_constant600000A9
-// CHECK:STDOUT:       inst600000FF:    symbolic_constant600000A6
+// CHECK:STDOUT:       inst600000FC:    symbolic_constant600000AA
+// CHECK:STDOUT:       inst600000FD:    symbolic_constant600000AB
+// CHECK:STDOUT:       inst600000FE:    symbolic_constant600000AC
+// CHECK:STDOUT:       inst600000FF:    symbolic_constant600000A9
 // CHECK:STDOUT:       inst60000100:    concrete_constant(inst60000047)
 // CHECK:STDOUT:       inst60000101:    constant<none>
 // CHECK:STDOUT:       inst60000102:    concrete_constant(inst60000102)
-// CHECK:STDOUT:       inst60000103:    symbolic_constant600000B0
-// CHECK:STDOUT:       inst60000104:    symbolic_constant600000B2
-// CHECK:STDOUT:       inst60000105:    symbolic_constant600000B3
-// CHECK:STDOUT:       inst60000106:    symbolic_constant600000B4
-// CHECK:STDOUT:       inst60000107:    symbolic_constant600000B5
-// CHECK:STDOUT:       inst60000108:    symbolic_constant600000B6
-// CHECK:STDOUT:       inst60000109:    symbolic_constant600000B7
-// CHECK:STDOUT:       inst6000010A:    symbolic_constant600000B8
-// CHECK:STDOUT:       inst6000010B:    symbolic_constant600000B9
-// CHECK:STDOUT:       inst6000010C:    symbolic_constant600000BC
-// CHECK:STDOUT:       inst6000010D:    symbolic_constant600000BA
-// CHECK:STDOUT:       inst6000010E:    symbolic_constant600000BB
-// CHECK:STDOUT:       inst6000010F:    symbolic_constant600000BE
+// CHECK:STDOUT:       inst60000103:    symbolic_constant600000B4
+// CHECK:STDOUT:       inst60000104:    symbolic_constant600000B6
+// CHECK:STDOUT:       inst60000105:    symbolic_constant600000B7
+// CHECK:STDOUT:       inst60000106:    symbolic_constant600000B8
+// CHECK:STDOUT:       inst60000107:    symbolic_constant600000B9
+// CHECK:STDOUT:       inst60000108:    symbolic_constant600000BA
+// CHECK:STDOUT:       inst60000109:    symbolic_constant600000BB
+// CHECK:STDOUT:       inst6000010A:    symbolic_constant600000BC
+// CHECK:STDOUT:       inst6000010B:    symbolic_constant600000BD
+// CHECK:STDOUT:       inst6000010C:    symbolic_constant600000C0
+// CHECK:STDOUT:       inst6000010D:    symbolic_constant600000BE
+// CHECK:STDOUT:       inst6000010E:    symbolic_constant600000BF
+// CHECK:STDOUT:       inst6000010F:    symbolic_constant600000C2
 // CHECK:STDOUT:       inst60000110:    concrete_constant(inst60000110)
 // CHECK:STDOUT:       inst60000111:    concrete_constant(inst60000111)
 // CHECK:STDOUT:       inst60000112:    concrete_constant(inst60000112)
 // CHECK:STDOUT:       inst60000113:    concrete_constant(inst60000113)
-// CHECK:STDOUT:       inst60000114:    symbolic_constant600000A7
-// CHECK:STDOUT:       inst60000115:    symbolic_constant600000A8
-// CHECK:STDOUT:       inst60000116:    symbolic_constant600000A9
-// CHECK:STDOUT:       inst60000117:    symbolic_constant600000C1
-// CHECK:STDOUT:       inst60000118:    symbolic_constant600000C2
-// CHECK:STDOUT:       inst60000119:    symbolic_constant600000CA
-// CHECK:STDOUT:       inst6000011A:    symbolic_constant600000CB
-// CHECK:STDOUT:       inst6000011B:    symbolic_constant600000CC
-// CHECK:STDOUT:       inst6000011C:    symbolic_constant600000CD
-// CHECK:STDOUT:       inst6000011D:    symbolic_constant600000CE
-// CHECK:STDOUT:       inst6000011E:    symbolic_constant600000CF
-// CHECK:STDOUT:       inst6000011F:    symbolic_constant600000D0
-// CHECK:STDOUT:       inst60000120:    symbolic_constant600000D1
-// CHECK:STDOUT:       inst60000121:    symbolic_constant600000D2
-// CHECK:STDOUT:       inst60000122:    symbolic_constant600000DE
-// CHECK:STDOUT:       inst60000123:    symbolic_constant600000E0
-// CHECK:STDOUT:       inst60000124:    symbolic_constant600000E2
-// CHECK:STDOUT:       inst60000125:    symbolic_constant600000E4
-// CHECK:STDOUT:       inst60000126:    symbolic_constant600000E6
-// CHECK:STDOUT:       inst60000127:    symbolic_constant600000E8
-// CHECK:STDOUT:       inst60000128:    symbolic_constant600000E9
-// CHECK:STDOUT:       inst60000129:    symbolic_constant600000EA
-// CHECK:STDOUT:       inst6000012A:    symbolic_constant600000EB
-// CHECK:STDOUT:       inst6000012B:    symbolic_constant600000EC
-// CHECK:STDOUT:       inst6000012C:    symbolic_constant600000ED
-// CHECK:STDOUT:       inst6000012D:    symbolic_constant600000EE
-// CHECK:STDOUT:       inst6000012E:    symbolic_constant600000EF
-// CHECK:STDOUT:       inst6000012F:    symbolic_constant600000F0
-// CHECK:STDOUT:       inst60000130:    symbolic_constant600000F1
-// CHECK:STDOUT:       inst60000131:    symbolic_constant600000F2
-// CHECK:STDOUT:       inst60000132:    symbolic_constant600000F3
-// CHECK:STDOUT:       inst60000133:    symbolic_constant600000F4
-// CHECK:STDOUT:       inst60000134:    symbolic_constant600000F5
-// CHECK:STDOUT:       inst60000135:    symbolic_constant600000F6
-// CHECK:STDOUT:       inst60000136:    symbolic_constant600000F7
-// CHECK:STDOUT:       inst60000137:    symbolic_constant600000F8
-// CHECK:STDOUT:       inst60000138:    symbolic_constant600000FA
-// CHECK:STDOUT:       inst60000139:    symbolic_constant600000FB
-// CHECK:STDOUT:       inst6000013A:    symbolic_constant600000FC
-// CHECK:STDOUT:       inst6000013B:    symbolic_constant600000FD
-// CHECK:STDOUT:       inst6000013C:    symbolic_constant60000101
-// CHECK:STDOUT:       inst6000013D:    symbolic_constant600000FE
-// CHECK:STDOUT:       inst6000013E:    symbolic_constant600000FF
-// CHECK:STDOUT:       inst6000013F:    symbolic_constant60000100
-// CHECK:STDOUT:       inst60000140:    symbolic_constant60000101
-// CHECK:STDOUT:       inst60000142:    symbolic_constant60000103
-// CHECK:STDOUT:       inst60000143:    symbolic_constant60000102
-// CHECK:STDOUT:       inst60000144:    symbolic_constant60000103
+// CHECK:STDOUT:       inst60000114:    symbolic_constant600000AA
+// CHECK:STDOUT:       inst60000115:    symbolic_constant600000AB
+// CHECK:STDOUT:       inst60000116:    symbolic_constant600000AC
+// CHECK:STDOUT:       inst60000117:    symbolic_constant600000C5
+// CHECK:STDOUT:       inst60000118:    symbolic_constant600000C6
+// CHECK:STDOUT:       inst60000119:    symbolic_constant600000CE
+// CHECK:STDOUT:       inst6000011A:    symbolic_constant600000CF
+// CHECK:STDOUT:       inst6000011B:    symbolic_constant600000D0
+// CHECK:STDOUT:       inst6000011C:    symbolic_constant600000D1
+// CHECK:STDOUT:       inst6000011D:    symbolic_constant600000D2
+// CHECK:STDOUT:       inst6000011E:    symbolic_constant600000D3
+// CHECK:STDOUT:       inst6000011F:    symbolic_constant600000D4
+// CHECK:STDOUT:       inst60000120:    symbolic_constant600000D5
+// CHECK:STDOUT:       inst60000121:    symbolic_constant600000D6
+// CHECK:STDOUT:       inst60000122:    symbolic_constant600000E2
+// CHECK:STDOUT:       inst60000123:    symbolic_constant600000E4
+// CHECK:STDOUT:       inst60000124:    symbolic_constant600000E6
+// CHECK:STDOUT:       inst60000125:    symbolic_constant600000E8
+// CHECK:STDOUT:       inst60000126:    symbolic_constant600000EA
+// CHECK:STDOUT:       inst60000127:    symbolic_constant600000EC
+// CHECK:STDOUT:       inst60000128:    symbolic_constant600000ED
+// CHECK:STDOUT:       inst60000129:    symbolic_constant600000EE
+// CHECK:STDOUT:       inst6000012A:    symbolic_constant600000EF
+// CHECK:STDOUT:       inst6000012B:    symbolic_constant600000F0
+// CHECK:STDOUT:       inst6000012C:    symbolic_constant600000F1
+// CHECK:STDOUT:       inst6000012D:    symbolic_constant600000F2
+// CHECK:STDOUT:       inst6000012E:    symbolic_constant600000F3
+// CHECK:STDOUT:       inst6000012F:    symbolic_constant600000F4
+// CHECK:STDOUT:       inst60000130:    symbolic_constant600000F5
+// CHECK:STDOUT:       inst60000131:    symbolic_constant600000F6
+// CHECK:STDOUT:       inst60000132:    symbolic_constant600000F7
+// CHECK:STDOUT:       inst60000133:    symbolic_constant600000F8
+// CHECK:STDOUT:       inst60000134:    symbolic_constant600000F9
+// CHECK:STDOUT:       inst60000135:    symbolic_constant600000FA
+// CHECK:STDOUT:       inst60000136:    symbolic_constant600000FB
+// CHECK:STDOUT:       inst60000137:    symbolic_constant600000FC
+// CHECK:STDOUT:       inst60000138:    symbolic_constant600000FE
+// CHECK:STDOUT:       inst60000139:    symbolic_constant600000FF
+// CHECK:STDOUT:       inst6000013A:    symbolic_constant60000100
+// CHECK:STDOUT:       inst6000013B:    symbolic_constant60000101
+// CHECK:STDOUT:       inst6000013C:    symbolic_constant60000105
+// CHECK:STDOUT:       inst6000013D:    symbolic_constant60000102
+// CHECK:STDOUT:       inst6000013E:    symbolic_constant60000103
+// CHECK:STDOUT:       inst6000013F:    symbolic_constant60000104
+// CHECK:STDOUT:       inst60000140:    symbolic_constant60000105
+// CHECK:STDOUT:       inst60000142:    symbolic_constant60000107
+// CHECK:STDOUT:       inst60000143:    symbolic_constant60000106
+// CHECK:STDOUT:       inst60000144:    symbolic_constant60000107
 // CHECK:STDOUT:       inst60000146:    symbolic_constant6000000F
 // CHECK:STDOUT:       inst6000014A:    concrete_constant(inst6000014B)
 // CHECK:STDOUT:       inst6000014B:    concrete_constant(inst6000014B)
@@ -1042,234 +1042,238 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       symbolic_constant6000001D: {inst: inst6000005F, generic: generic60000002, index: generic_inst_in_decl0, kind: checked}
 // CHECK:STDOUT:       symbolic_constant6000001E: {inst: inst6000005F, generic: generic60000002, index: generic_inst_in_decl0, kind: checked}
 // CHECK:STDOUT:       symbolic_constant6000001F: {inst: inst60000060, generic: generic60000002, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000020: {inst: inst60000069, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000021: {inst: inst60000069, generic: generic60000002, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000022: {inst: inst6000005F, generic: generic60000002, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000023: {inst: inst60000060, generic: generic60000002, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000024: {inst: inst60000061, generic: generic60000002, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000025: {inst: inst60000069, generic: generic60000002, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000026: {inst: inst6000006F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000027: {inst: inst60000070, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000028: {inst: inst60000070, generic: generic60000002, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000029: {inst: inst6000006F, generic: generic60000002, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000002A: {inst: inst60000071, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000002B: {inst: inst60000071, generic: generic60000003, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000002C: {inst: inst60000070, generic: generic60000002, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000002D: {inst: inst6000006F, generic: generic60000002, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000002E: {inst: inst60000070, generic: generic60000002, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000002F: {inst: inst6000005F, generic: generic60000003, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000030: {inst: inst60000060, generic: generic60000003, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000031: {inst: inst60000061, generic: generic60000003, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000032: {inst: inst6000005F, generic: generic60000003, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000033: {inst: inst60000060, generic: generic60000003, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000034: {inst: inst60000061, generic: generic60000003, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000035: {inst: inst60000071, generic: generic60000003, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000036: {inst: inst6000007D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000037: {inst: inst6000007D, generic: generic60000003, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000038: {inst: inst6000007E, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000039: {inst: inst6000007E, generic: generic60000003, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000003A: {inst: inst6000007F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000003B: {inst: inst6000007F, generic: generic60000003, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000003C: {inst: inst60000080, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000003D: {inst: inst60000080, generic: generic60000003, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000003E: {inst: inst60000081, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000003F: {inst: inst60000081, generic: generic60000003, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000040: {inst: inst60000082, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000041: {inst: inst60000082, generic: generic60000003, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000042: {inst: inst6000007D, generic: generic60000003, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000043: {inst: inst6000007E, generic: generic60000003, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000044: {inst: inst6000007F, generic: generic60000003, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000045: {inst: inst60000080, generic: generic60000003, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000046: {inst: inst60000081, generic: generic60000003, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000047: {inst: inst60000082, generic: generic60000003, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000048: {inst: inst60000089, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000049: {inst: inst6000001B, generic: generic60000004, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000004A: {inst: inst60000015, generic: generic60000004, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000020: {inst: inst60000061, generic: generic60000002, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000021: {inst: inst60000069, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000022: {inst: inst60000069, generic: generic60000002, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000023: {inst: inst6000005F, generic: generic60000002, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000024: {inst: inst60000060, generic: generic60000002, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000025: {inst: inst60000061, generic: generic60000002, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000026: {inst: inst60000069, generic: generic60000002, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000027: {inst: inst6000006F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000028: {inst: inst60000070, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000029: {inst: inst60000070, generic: generic60000002, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000002A: {inst: inst6000006F, generic: generic60000002, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000002B: {inst: inst60000071, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000002C: {inst: inst60000071, generic: generic60000003, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000002D: {inst: inst60000070, generic: generic60000002, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000002E: {inst: inst6000006F, generic: generic60000002, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000002F: {inst: inst60000070, generic: generic60000002, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000030: {inst: inst6000005F, generic: generic60000003, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000031: {inst: inst60000060, generic: generic60000003, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000032: {inst: inst60000061, generic: generic60000003, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000033: {inst: inst6000005F, generic: generic60000003, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000034: {inst: inst60000060, generic: generic60000003, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000035: {inst: inst60000061, generic: generic60000003, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000036: {inst: inst60000071, generic: generic60000003, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000037: {inst: inst6000007D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000038: {inst: inst6000007D, generic: generic60000003, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000039: {inst: inst6000007E, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000003A: {inst: inst6000007E, generic: generic60000003, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000003B: {inst: inst6000007F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000003C: {inst: inst6000007F, generic: generic60000003, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000003D: {inst: inst60000080, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000003E: {inst: inst60000080, generic: generic60000003, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000003F: {inst: inst60000081, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000040: {inst: inst60000081, generic: generic60000003, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000041: {inst: inst60000082, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000042: {inst: inst60000082, generic: generic60000003, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000043: {inst: inst6000007D, generic: generic60000003, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000044: {inst: inst6000007E, generic: generic60000003, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000045: {inst: inst6000007F, generic: generic60000003, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000046: {inst: inst60000080, generic: generic60000003, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000047: {inst: inst60000081, generic: generic60000003, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000048: {inst: inst60000082, generic: generic60000003, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000049: {inst: inst60000089, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000004A: {inst: inst6000001B, generic: generic60000004, index: generic_inst_in_decl1, kind: checked}
 // CHECK:STDOUT:       symbolic_constant6000004B: {inst: inst60000015, generic: generic60000004, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000004C: {inst: inst600000A2, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000004D: {inst: inst600000A2, generic: generic60000004, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000004E: {inst: inst60000015, generic: generic60000004, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000004F: {inst: inst6000001B, generic: generic60000004, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000050: {inst: inst600000A2, generic: generic60000004, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000051: {inst: inst600000A7, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000052: {inst: inst600000A8, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000053: {inst: inst600000A8, generic: generic60000004, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000054: {inst: inst600000A7, generic: generic60000004, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000055: {inst: inst6000001E, generic: generic60000005, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000056: {inst: inst600000A8, generic: generic60000004, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000057: {inst: inst6000003D, generic: generic60000004, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000058: {inst: inst600000A7, generic: generic60000004, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000059: {inst: inst600000A8, generic: generic60000004, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000005A: {inst: inst6000003D, generic: generic60000004, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000005B: {inst: inst60000015, generic: generic60000005, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000005C: {inst: inst6000001B, generic: generic60000005, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000004C: {inst: inst60000015, generic: generic60000004, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000004D: {inst: inst6000001B, generic: generic60000004, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000004E: {inst: inst600000A2, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000004F: {inst: inst600000A2, generic: generic60000004, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000050: {inst: inst60000015, generic: generic60000004, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000051: {inst: inst6000001B, generic: generic60000004, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000052: {inst: inst600000A2, generic: generic60000004, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000053: {inst: inst600000A7, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000054: {inst: inst600000A8, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000055: {inst: inst600000A8, generic: generic60000004, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000056: {inst: inst600000A7, generic: generic60000004, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000057: {inst: inst6000001E, generic: generic60000005, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000058: {inst: inst600000A8, generic: generic60000004, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000059: {inst: inst6000003D, generic: generic60000004, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000005A: {inst: inst600000A7, generic: generic60000004, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000005B: {inst: inst600000A8, generic: generic60000004, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000005C: {inst: inst6000003D, generic: generic60000004, index: generic_inst_in_def2, kind: checked}
 // CHECK:STDOUT:       symbolic_constant6000005D: {inst: inst60000015, generic: generic60000005, index: generic_inst_in_decl0, kind: checked}
 // CHECK:STDOUT:       symbolic_constant6000005E: {inst: inst6000001B, generic: generic60000005, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000005F: {inst: inst6000001E, generic: generic60000005, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000060: {inst: inst600000BE, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000061: {inst: inst600000BF, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000062: {inst: inst600000C0, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000063: {inst: inst600000C0, generic: generic60000006, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000064: {inst: inst6000005F, generic: generic60000006, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000065: {inst: inst600000BE, generic: generic60000006, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000005F: {inst: inst60000015, generic: generic60000005, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000060: {inst: inst6000001B, generic: generic60000005, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000061: {inst: inst6000001E, generic: generic60000005, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000062: {inst: inst600000BE, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000063: {inst: inst600000BF, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000064: {inst: inst600000C0, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000065: {inst: inst600000C0, generic: generic60000006, index: generic_inst_in_decl4, kind: checked}
 // CHECK:STDOUT:       symbolic_constant60000066: {inst: inst6000005F, generic: generic60000006, index: generic_inst_in_decl0, kind: checked}
 // CHECK:STDOUT:       symbolic_constant60000067: {inst: inst600000BE, generic: generic60000006, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000068: {inst: inst60000060, generic: generic60000006, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000069: {inst: inst600000BF, generic: generic60000006, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000006A: {inst: inst600000C9, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000006B: {inst: inst600000C9, generic: generic60000006, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000006C: {inst: inst6000005F, generic: generic60000006, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000006D: {inst: inst600000BE, generic: generic60000006, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000006E: {inst: inst60000060, generic: generic60000006, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000006F: {inst: inst600000BF, generic: generic60000006, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000070: {inst: inst600000C0, generic: generic60000006, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000071: {inst: inst600000C9, generic: generic60000006, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000072: {inst: inst600000D1, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000073: {inst: inst600000D2, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000074: {inst: inst600000D2, generic: generic60000006, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000075: {inst: inst600000D1, generic: generic60000006, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000076: {inst: inst600000D3, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000077: {inst: inst600000D3, generic: generic60000007, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000078: {inst: inst600000D2, generic: generic60000006, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000079: {inst: inst600000D1, generic: generic60000006, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000007A: {inst: inst600000D2, generic: generic60000006, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000007B: {inst: inst6000005F, generic: generic60000007, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000007C: {inst: inst60000060, generic: generic60000007, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000007D: {inst: inst600000BE, generic: generic60000007, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000007E: {inst: inst600000BF, generic: generic60000007, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000007F: {inst: inst600000C0, generic: generic60000007, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000080: {inst: inst6000005F, generic: generic60000007, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000081: {inst: inst60000060, generic: generic60000007, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000082: {inst: inst600000BE, generic: generic60000007, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000083: {inst: inst600000BF, generic: generic60000007, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000084: {inst: inst600000C0, generic: generic60000007, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000085: {inst: inst600000D3, generic: generic60000007, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000086: {inst: inst600000E2, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000087: {inst: inst600000E2, generic: generic60000007, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000088: {inst: inst6000007E, generic: generic60000007, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000089: {inst: inst6000007F, generic: generic60000007, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000008A: {inst: inst60000080, generic: generic60000007, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000008B: {inst: inst60000081, generic: generic60000007, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000008C: {inst: inst60000082, generic: generic60000007, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000008D: {inst: inst600000E3, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000008E: {inst: inst600000E3, generic: generic60000007, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000008F: {inst: inst600000E4, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000090: {inst: inst600000E4, generic: generic60000007, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000091: {inst: inst600000E5, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000092: {inst: inst600000E5, generic: generic60000007, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000093: {inst: inst600000E6, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000094: {inst: inst600000E6, generic: generic60000007, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000095: {inst: inst600000E7, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000096: {inst: inst600000E7, generic: generic60000007, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000097: {inst: inst600000E2, generic: generic60000007, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000098: {inst: inst6000007E, generic: generic60000007, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000099: {inst: inst6000007F, generic: generic60000007, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000009A: {inst: inst60000080, generic: generic60000007, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000009B: {inst: inst60000081, generic: generic60000007, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000009C: {inst: inst60000082, generic: generic60000007, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000009D: {inst: inst600000E3, generic: generic60000007, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000009E: {inst: inst600000E4, generic: generic60000007, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant6000009F: {inst: inst600000E5, generic: generic60000007, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A0: {inst: inst600000E6, generic: generic60000007, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A1: {inst: inst600000E7, generic: generic60000007, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A2: {inst: inst600000F3, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A3: {inst: inst600000F6, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A4: {inst: inst600000F7, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A5: {inst: inst600000F8, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A6: {inst: inst600000F8, generic: generic60000008, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A7: {inst: inst6000005F, generic: generic60000008, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A8: {inst: inst600000BE, generic: generic60000008, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000A9: {inst: inst600000F6, generic: generic60000008, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000068: {inst: inst6000005F, generic: generic60000006, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000069: {inst: inst600000BE, generic: generic60000006, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000006A: {inst: inst60000060, generic: generic60000006, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000006B: {inst: inst600000BF, generic: generic60000006, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000006C: {inst: inst600000C0, generic: generic60000006, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000006D: {inst: inst600000C9, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000006E: {inst: inst600000C9, generic: generic60000006, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000006F: {inst: inst6000005F, generic: generic60000006, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000070: {inst: inst600000BE, generic: generic60000006, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000071: {inst: inst60000060, generic: generic60000006, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000072: {inst: inst600000BF, generic: generic60000006, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000073: {inst: inst600000C0, generic: generic60000006, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000074: {inst: inst600000C9, generic: generic60000006, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000075: {inst: inst600000D1, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000076: {inst: inst600000D2, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000077: {inst: inst600000D2, generic: generic60000006, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000078: {inst: inst600000D1, generic: generic60000006, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000079: {inst: inst600000D3, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000007A: {inst: inst600000D3, generic: generic60000007, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000007B: {inst: inst600000D2, generic: generic60000006, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000007C: {inst: inst600000D1, generic: generic60000006, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000007D: {inst: inst600000D2, generic: generic60000006, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000007E: {inst: inst6000005F, generic: generic60000007, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000007F: {inst: inst60000060, generic: generic60000007, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000080: {inst: inst600000BE, generic: generic60000007, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000081: {inst: inst600000BF, generic: generic60000007, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000082: {inst: inst600000C0, generic: generic60000007, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000083: {inst: inst6000005F, generic: generic60000007, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000084: {inst: inst60000060, generic: generic60000007, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000085: {inst: inst600000BE, generic: generic60000007, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000086: {inst: inst600000BF, generic: generic60000007, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000087: {inst: inst600000C0, generic: generic60000007, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000088: {inst: inst600000D3, generic: generic60000007, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000089: {inst: inst600000E2, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000008A: {inst: inst600000E2, generic: generic60000007, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000008B: {inst: inst6000007E, generic: generic60000007, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000008C: {inst: inst6000007F, generic: generic60000007, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000008D: {inst: inst60000080, generic: generic60000007, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000008E: {inst: inst60000081, generic: generic60000007, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000008F: {inst: inst60000082, generic: generic60000007, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000090: {inst: inst600000E3, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000091: {inst: inst600000E3, generic: generic60000007, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000092: {inst: inst600000E4, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000093: {inst: inst600000E4, generic: generic60000007, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000094: {inst: inst600000E5, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000095: {inst: inst600000E5, generic: generic60000007, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000096: {inst: inst600000E6, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000097: {inst: inst600000E6, generic: generic60000007, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000098: {inst: inst600000E7, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000099: {inst: inst600000E7, generic: generic60000007, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000009A: {inst: inst600000E2, generic: generic60000007, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000009B: {inst: inst6000007E, generic: generic60000007, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000009C: {inst: inst6000007F, generic: generic60000007, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000009D: {inst: inst60000080, generic: generic60000007, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000009E: {inst: inst60000081, generic: generic60000007, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant6000009F: {inst: inst60000082, generic: generic60000007, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A0: {inst: inst600000E3, generic: generic60000007, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A1: {inst: inst600000E4, generic: generic60000007, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A2: {inst: inst600000E5, generic: generic60000007, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A3: {inst: inst600000E6, generic: generic60000007, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A4: {inst: inst600000E7, generic: generic60000007, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A5: {inst: inst600000F3, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A6: {inst: inst600000F6, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A7: {inst: inst600000F7, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A8: {inst: inst600000F8, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000A9: {inst: inst600000F8, generic: generic60000008, index: generic_inst_in_decl6, kind: checked}
 // CHECK:STDOUT:       symbolic_constant600000AA: {inst: inst6000005F, generic: generic60000008, index: generic_inst_in_decl0, kind: checked}
 // CHECK:STDOUT:       symbolic_constant600000AB: {inst: inst600000BE, generic: generic60000008, index: generic_inst_in_decl1, kind: checked}
 // CHECK:STDOUT:       symbolic_constant600000AC: {inst: inst600000F6, generic: generic60000008, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000AD: {inst: inst60000060, generic: generic60000008, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000AE: {inst: inst600000BF, generic: generic60000008, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000AF: {inst: inst600000F7, generic: generic60000008, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B0: {inst: inst60000103, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B1: {inst: inst60000103, generic: generic60000008, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B2: {inst: inst6000005F, generic: generic60000008, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B3: {inst: inst600000BE, generic: generic60000008, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B4: {inst: inst600000F6, generic: generic60000008, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B5: {inst: inst60000060, generic: generic60000008, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B6: {inst: inst600000BF, generic: generic60000008, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B7: {inst: inst600000F7, generic: generic60000008, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B8: {inst: inst600000F8, generic: generic60000008, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000B9: {inst: inst60000103, generic: generic60000008, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000BA: {inst: inst6000010D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000BB: {inst: inst6000010E, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000BC: {inst: inst6000010E, generic: generic60000008, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000BD: {inst: inst6000010D, generic: generic60000008, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000BE: {inst: inst6000010F, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000BF: {inst: inst6000010F, generic: generic60000009, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000AD: {inst: inst6000005F, generic: generic60000008, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000AE: {inst: inst600000BE, generic: generic60000008, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000AF: {inst: inst600000F6, generic: generic60000008, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B0: {inst: inst60000060, generic: generic60000008, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B1: {inst: inst600000BF, generic: generic60000008, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B2: {inst: inst600000F7, generic: generic60000008, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B3: {inst: inst600000F8, generic: generic60000008, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B4: {inst: inst60000103, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B5: {inst: inst60000103, generic: generic60000008, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B6: {inst: inst6000005F, generic: generic60000008, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B7: {inst: inst600000BE, generic: generic60000008, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B8: {inst: inst600000F6, generic: generic60000008, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000B9: {inst: inst60000060, generic: generic60000008, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000BA: {inst: inst600000BF, generic: generic60000008, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000BB: {inst: inst600000F7, generic: generic60000008, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000BC: {inst: inst600000F8, generic: generic60000008, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000BD: {inst: inst60000103, generic: generic60000008, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000BE: {inst: inst6000010D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000BF: {inst: inst6000010E, generic: generic<none>, index: generic_inst<none>, kind: checked}
 // CHECK:STDOUT:       symbolic_constant600000C0: {inst: inst6000010E, generic: generic60000008, index: generic_inst_in_def1, kind: checked}
 // CHECK:STDOUT:       symbolic_constant600000C1: {inst: inst6000010D, generic: generic60000008, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C2: {inst: inst6000010E, generic: generic60000008, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C3: {inst: inst6000005F, generic: generic60000009, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C4: {inst: inst60000060, generic: generic60000009, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C5: {inst: inst600000BE, generic: generic60000009, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C6: {inst: inst600000BF, generic: generic60000009, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C7: {inst: inst600000F6, generic: generic60000009, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C8: {inst: inst600000F7, generic: generic60000009, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000C9: {inst: inst600000F8, generic: generic60000009, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000CA: {inst: inst6000005F, generic: generic60000009, index: generic_inst_in_decl0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000CB: {inst: inst60000060, generic: generic60000009, index: generic_inst_in_decl1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000CC: {inst: inst600000BE, generic: generic60000009, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000CD: {inst: inst600000BF, generic: generic60000009, index: generic_inst_in_decl3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000CE: {inst: inst600000F6, generic: generic60000009, index: generic_inst_in_decl4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000CF: {inst: inst600000F7, generic: generic60000009, index: generic_inst_in_decl5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D0: {inst: inst600000F8, generic: generic60000009, index: generic_inst_in_decl6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D1: {inst: inst6000010F, generic: generic60000009, index: generic_inst_in_decl7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D2: {inst: inst60000121, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D3: {inst: inst60000121, generic: generic60000009, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D4: {inst: inst6000007E, generic: generic60000009, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D5: {inst: inst6000007F, generic: generic60000009, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D6: {inst: inst60000080, generic: generic60000009, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D7: {inst: inst60000081, generic: generic60000009, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D8: {inst: inst60000082, generic: generic60000009, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000D9: {inst: inst600000E3, generic: generic60000009, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000DA: {inst: inst600000E4, generic: generic60000009, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000DB: {inst: inst600000E5, generic: generic60000009, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000DC: {inst: inst600000E6, generic: generic60000009, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000DD: {inst: inst600000E7, generic: generic60000009, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000DE: {inst: inst60000122, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000DF: {inst: inst60000122, generic: generic60000009, index: generic_inst_in_def11, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E0: {inst: inst60000123, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E1: {inst: inst60000123, generic: generic60000009, index: generic_inst_in_def12, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E2: {inst: inst60000124, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E3: {inst: inst60000124, generic: generic60000009, index: generic_inst_in_def13, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E4: {inst: inst60000125, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E5: {inst: inst60000125, generic: generic60000009, index: generic_inst_in_def14, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E6: {inst: inst60000126, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E7: {inst: inst60000126, generic: generic60000009, index: generic_inst_in_def15, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E8: {inst: inst60000121, generic: generic60000009, index: generic_inst_in_def0, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000E9: {inst: inst6000007E, generic: generic60000009, index: generic_inst_in_def1, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000EA: {inst: inst6000007F, generic: generic60000009, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000EB: {inst: inst60000080, generic: generic60000009, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000EC: {inst: inst60000081, generic: generic60000009, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000ED: {inst: inst60000082, generic: generic60000009, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000EE: {inst: inst600000E3, generic: generic60000009, index: generic_inst_in_def6, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000EF: {inst: inst600000E4, generic: generic60000009, index: generic_inst_in_def7, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F0: {inst: inst600000E5, generic: generic60000009, index: generic_inst_in_def8, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F1: {inst: inst600000E6, generic: generic60000009, index: generic_inst_in_def9, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F2: {inst: inst600000E7, generic: generic60000009, index: generic_inst_in_def10, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F3: {inst: inst60000122, generic: generic60000009, index: generic_inst_in_def11, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F4: {inst: inst60000123, generic: generic60000009, index: generic_inst_in_def12, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F5: {inst: inst60000124, generic: generic60000009, index: generic_inst_in_def13, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F6: {inst: inst60000125, generic: generic60000009, index: generic_inst_in_def14, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F7: {inst: inst60000126, generic: generic60000009, index: generic_inst_in_def15, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F8: {inst: inst60000137, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000F9: {inst: inst600000A2, generic: generic60000004, index: generic_inst_in_decl2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000FA: {inst: inst60000138, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000FB: {inst: inst60000138, generic: generic60000000, index: generic_inst_in_def2, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000FC: {inst: inst6000013A, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000FD: {inst: inst6000013B, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000FE: {inst: inst6000013D, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant600000FF: {inst: inst6000013A, generic: generic60000000, index: generic_inst_in_def3, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000100: {inst: inst6000013B, generic: generic60000000, index: generic_inst_in_def4, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000101: {inst: inst6000013D, generic: generic60000000, index: generic_inst_in_def5, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000102: {inst: inst60000143, generic: generic<none>, index: generic_inst<none>, kind: checked}
-// CHECK:STDOUT:       symbolic_constant60000103: {inst: inst60000143, generic: generic60000000, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C2: {inst: inst6000010F, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C3: {inst: inst6000010F, generic: generic60000009, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C4: {inst: inst6000010E, generic: generic60000008, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C5: {inst: inst6000010D, generic: generic60000008, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C6: {inst: inst6000010E, generic: generic60000008, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C7: {inst: inst6000005F, generic: generic60000009, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C8: {inst: inst60000060, generic: generic60000009, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000C9: {inst: inst600000BE, generic: generic60000009, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000CA: {inst: inst600000BF, generic: generic60000009, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000CB: {inst: inst600000F6, generic: generic60000009, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000CC: {inst: inst600000F7, generic: generic60000009, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000CD: {inst: inst600000F8, generic: generic60000009, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000CE: {inst: inst6000005F, generic: generic60000009, index: generic_inst_in_decl0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000CF: {inst: inst60000060, generic: generic60000009, index: generic_inst_in_decl1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D0: {inst: inst600000BE, generic: generic60000009, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D1: {inst: inst600000BF, generic: generic60000009, index: generic_inst_in_decl3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D2: {inst: inst600000F6, generic: generic60000009, index: generic_inst_in_decl4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D3: {inst: inst600000F7, generic: generic60000009, index: generic_inst_in_decl5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D4: {inst: inst600000F8, generic: generic60000009, index: generic_inst_in_decl6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D5: {inst: inst6000010F, generic: generic60000009, index: generic_inst_in_decl7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D6: {inst: inst60000121, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D7: {inst: inst60000121, generic: generic60000009, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D8: {inst: inst6000007E, generic: generic60000009, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000D9: {inst: inst6000007F, generic: generic60000009, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000DA: {inst: inst60000080, generic: generic60000009, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000DB: {inst: inst60000081, generic: generic60000009, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000DC: {inst: inst60000082, generic: generic60000009, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000DD: {inst: inst600000E3, generic: generic60000009, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000DE: {inst: inst600000E4, generic: generic60000009, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000DF: {inst: inst600000E5, generic: generic60000009, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E0: {inst: inst600000E6, generic: generic60000009, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E1: {inst: inst600000E7, generic: generic60000009, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E2: {inst: inst60000122, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E3: {inst: inst60000122, generic: generic60000009, index: generic_inst_in_def11, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E4: {inst: inst60000123, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E5: {inst: inst60000123, generic: generic60000009, index: generic_inst_in_def12, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E6: {inst: inst60000124, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E7: {inst: inst60000124, generic: generic60000009, index: generic_inst_in_def13, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E8: {inst: inst60000125, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000E9: {inst: inst60000125, generic: generic60000009, index: generic_inst_in_def14, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000EA: {inst: inst60000126, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000EB: {inst: inst60000126, generic: generic60000009, index: generic_inst_in_def15, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000EC: {inst: inst60000121, generic: generic60000009, index: generic_inst_in_def0, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000ED: {inst: inst6000007E, generic: generic60000009, index: generic_inst_in_def1, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000EE: {inst: inst6000007F, generic: generic60000009, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000EF: {inst: inst60000080, generic: generic60000009, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F0: {inst: inst60000081, generic: generic60000009, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F1: {inst: inst60000082, generic: generic60000009, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F2: {inst: inst600000E3, generic: generic60000009, index: generic_inst_in_def6, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F3: {inst: inst600000E4, generic: generic60000009, index: generic_inst_in_def7, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F4: {inst: inst600000E5, generic: generic60000009, index: generic_inst_in_def8, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F5: {inst: inst600000E6, generic: generic60000009, index: generic_inst_in_def9, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F6: {inst: inst600000E7, generic: generic60000009, index: generic_inst_in_def10, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F7: {inst: inst60000122, generic: generic60000009, index: generic_inst_in_def11, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F8: {inst: inst60000123, generic: generic60000009, index: generic_inst_in_def12, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000F9: {inst: inst60000124, generic: generic60000009, index: generic_inst_in_def13, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000FA: {inst: inst60000125, generic: generic60000009, index: generic_inst_in_def14, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000FB: {inst: inst60000126, generic: generic60000009, index: generic_inst_in_def15, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000FC: {inst: inst60000137, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000FD: {inst: inst600000A2, generic: generic60000004, index: generic_inst_in_decl2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000FE: {inst: inst60000138, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant600000FF: {inst: inst60000138, generic: generic60000000, index: generic_inst_in_def2, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000100: {inst: inst6000013A, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000101: {inst: inst6000013B, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000102: {inst: inst6000013D, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000103: {inst: inst6000013A, generic: generic60000000, index: generic_inst_in_def3, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000104: {inst: inst6000013B, generic: generic60000000, index: generic_inst_in_def4, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000105: {inst: inst6000013D, generic: generic60000000, index: generic_inst_in_def5, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000106: {inst: inst60000143, generic: generic<none>, index: generic_inst<none>, kind: checked}
+// CHECK:STDOUT:       symbolic_constant60000107: {inst: inst60000143, generic: generic60000000, index: generic_inst_in_def6, kind: checked}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:


### PR DESCRIPTION
This has subtle effects on the number of imported instructions, but seems more standard for how this code is being written... `GetLocalConstantId` calls `GetLocalConstantValueOrPush` which does `local_constant_values_for_import_insts().GetAttached`. So what this is really doing is causing some intermediate import steps to be skipped. But per test changes, that doesn't really affect SemIR and will probably have negligible effect. This *seems* right to me, otherwise I'd expect we should probably refactor all `GetLocalConstantId(InstId)` calls.