### PR TITLE
Refactor AddLoadedImportRef, particularly for types

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -699,7 +699,7 @@ static auto AddLoadedImportRef(ImportContext& context,
 
 // Like `AddLoadedImportRef`, but only for types, and returns a `TypeInstId`.
 static auto AddLoadedImportRefForType(ImportContext& context,
-                                      SemIR::InstId import_inst_id,
+                                      SemIR::TypeInstId import_inst_id,
                                       SemIR::ConstantId local_const_id)
     -> SemIR::TypeInstId {
   return context.local_types().GetAsTypeInstId(AddLoadedImportRef(

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -101,29 +101,6 @@ auto AddImportRef(Context& context, SemIR::ImportIRInst import_ir_inst,
   return import_ref_id;
 }
 
-// Adds an import_ref instruction for an instruction that we have already loaded
-// from an imported IR, with a known constant value. This is useful when the
-// instruction has a symbolic constant value, in order to produce an instruction
-// that hold that symbolic constant.
-static auto AddLoadedImportRef(Context& context, SemIR::TypeId type_id,
-                               SemIR::ImportIRInst import_ir_inst,
-                               SemIR::ConstantId const_id) -> SemIR::InstId {
-  auto import_ir_inst_id = context.import_ir_insts().Add(import_ir_inst);
-  SemIR::ImportRefLoaded inst = {.type_id = type_id,
-                                 .import_ir_inst_id = import_ir_inst_id,
-                                 .entity_name_id = SemIR::EntityNameId::None};
-  auto inst_id = AddPlaceholderInstInNoBlock(
-      context, MakeImportedLocIdAndInst(context, import_ir_inst_id, inst));
-  context.imports().push_back(inst_id);
-
-  context.constant_values().Set(inst_id, const_id);
-  context
-      .import_ir_constant_values()[context.sem_ir().import_irs().GetRawIndex(
-          import_ir_inst.ir_id())]
-      .Set(import_ir_inst.inst_id(), const_id);
-  return inst_id;
-}
-
 static auto GetCanonicalImportIRInst(Context& context,
                                      const SemIR::File* target_ir,
                                      SemIR::InstId target_inst_id)
@@ -685,6 +662,7 @@ class ImportRefResolver : public ImportContext {
 };
 }  // namespace
 
+// Wrapper for `AddImportRef` that provides the `import_ir_id`.
 static auto AddImportRef(ImportContext& context, SemIR::InstId inst_id,
                          SemIR::EntityNameId entity_name_id =
                              SemIR::EntityNameId::None) -> SemIR::InstId {
@@ -693,12 +671,39 @@ static auto AddImportRef(ImportContext& context, SemIR::InstId inst_id,
                       entity_name_id);
 }
 
-static auto AddLoadedImportRef(ImportContext& context, SemIR::TypeId type_id,
-                               SemIR::InstId inst_id,
-                               SemIR::ConstantId const_id) -> SemIR::InstId {
-  return AddLoadedImportRef(
-      context.local_context(), type_id,
-      SemIR::ImportIRInst(context.import_ir_id(), inst_id), const_id);
+// Adds an import_ref instruction for an instruction that we have already loaded
+// from an imported IR, with a known constant value. This is useful when the
+// instruction has a symbolic constant value, in order to produce an instruction
+// that hold that symbolic constant.
+static auto AddLoadedImportRef(ImportContext& context,
+                               SemIR::TypeId local_type_id,
+                               SemIR::InstId import_inst_id,
+                               SemIR::ConstantId local_const_id)
+    -> SemIR::InstId {
+  auto import_ir_inst_id = context.local_import_ir_insts().Add(
+      SemIR::ImportIRInst(context.import_ir_id(), import_inst_id));
+  SemIR::ImportRefLoaded inst = {.type_id = local_type_id,
+                                 .import_ir_inst_id = import_ir_inst_id,
+                                 .entity_name_id = SemIR::EntityNameId::None};
+  auto inst_id = AddPlaceholderInstInNoBlock(
+      context.local_context(),
+      MakeImportedLocIdAndInst(context.local_context(), import_ir_inst_id,
+                               inst));
+  context.local_context().imports().push_back(inst_id);
+
+  context.local_constant_values().Set(inst_id, local_const_id);
+  context.local_constant_values_for_import_insts().Set(import_inst_id,
+                                                       local_const_id);
+  return inst_id;
+}
+
+// Like `AddLoadedImportRef`, but only for types, and returns a `TypeInstId`.
+static auto AddLoadedImportRefForType(ImportContext& context,
+                                      SemIR::InstId import_inst_id,
+                                      SemIR::ConstantId local_const_id)
+    -> SemIR::TypeInstId {
+  return context.local_types().GetAsTypeInstId(AddLoadedImportRef(
+      context, SemIR::TypeType::TypeId, import_inst_id, local_const_id));
 }
 
 static auto AddImportIRInst(ImportContext& context, SemIR::InstId inst_id)
@@ -1350,9 +1355,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  auto adapted_type_inst_id = resolver.local_ir().types().GetAsTypeInstId(
-      AddLoadedImportRef(resolver, SemIR::TypeType::TypeId,
-                         inst.adapted_type_inst_id, adapted_type_const_id));
+  auto adapted_type_inst_id = AddLoadedImportRefForType(
+      resolver, inst.adapted_type_inst_id, adapted_type_const_id);
 
   // Create a corresponding instruction to represent the declaration.
   return ResolveAsUnique<SemIR::AdaptDecl>(
@@ -1535,9 +1539,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  auto base_type_inst_id = resolver.local_ir().types().GetAsTypeInstId(
-      AddLoadedImportRef(resolver, SemIR::TypeType::TypeId,
-                         inst.base_type_inst_id, base_type_const_id));
+  auto base_type_inst_id = AddLoadedImportRefForType(
+      resolver, inst.base_type_inst_id, base_type_const_id);
 
   // Create a corresponding instruction to represent the declaration.
   return ResolveAsUnique<SemIR::BaseDecl>(
@@ -2421,12 +2424,10 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   // Create instructions for self and constraint to hold the symbolic constant
   // value for a generic impl.
-  new_impl.self_id = resolver.local_ir().types().GetAsTypeInstId(
-      AddLoadedImportRef(resolver, SemIR::TypeType::TypeId, import_impl.self_id,
-                         self_const_id));
-  new_impl.constraint_id = resolver.local_ir().types().GetAsTypeInstId(
-      AddLoadedImportRef(resolver, SemIR::TypeType::TypeId,
-                         import_impl.constraint_id, constraint_const_id));
+  new_impl.self_id =
+      AddLoadedImportRefForType(resolver, import_impl.self_id, self_const_id);
+  new_impl.constraint_id = AddLoadedImportRefForType(
+      resolver, import_impl.constraint_id, constraint_const_id);
   new_impl.interface = GetLocalSpecificInterface(
       resolver, import_impl.interface, specific_interface_data);
   if (import_impl.is_complete()) {


### PR DESCRIPTION
I was looking at this due to the addition of more `GetAsTypeInstId(AddLoadedImportRef(` in #6344. Looking at `AddLoadedImportRef`, it also felt like the first declaration would be clearer if collapsed into its overload (the overload is the only caller). Note one benefit of using `ImportContext` in `AddLoadedImportRef` is being able to call `local_constant_values_for_import_insts` to handle the `GetRawIndex` code.