### PR TITLE
Refactor ResolveResult with its factory methods

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -166,36 +166,6 @@ auto VerifySameCanonicalImportIRInst(Context& context, SemIR::NameId name_id,
 }
 
 namespace {
-// The result of attempting to resolve an imported instruction to a constant.
-struct ResolveResult {
-  // The new constant value, if known.
-  SemIR::ConstantId const_id;
-  // Newly created declaration whose value is being resolved, if any.
-  SemIR::InstId decl_id = SemIR::InstId::None;
-  // Whether resolution has been attempted once and needs to be retried.
-  bool retry = false;
-
-  // Produces a resolve result that tries resolving this instruction again. If
-  // `const_id` is specified, then this is the end of the second phase, and the
-  // constant value will be passed to the next resolution attempt. Otherwise,
-  // this is the end of the first phase.
-  static auto Retry(SemIR::ConstantId const_id = SemIR::ConstantId::None,
-                    SemIR::InstId decl_id = SemIR::InstId::None)
-      -> ResolveResult {
-    return {.const_id = const_id, .decl_id = decl_id, .retry = true};
-  }
-
-  // Produces a resolve result that provides the given constant value. Requires
-  // that there is no new work.
-  static auto Done(SemIR::ConstantId const_id,
-                   SemIR::InstId decl_id = SemIR::InstId::None)
-      -> ResolveResult {
-    return {.const_id = const_id, .decl_id = decl_id};
-  }
-};
-}  // namespace
-
-namespace {
 // A context within which we are performing an import. Tracks information about
 // the source and destination. This provides a restricted interface compared to
 // ImportResolver: in particular, it does not have access to a work list.
@@ -448,7 +418,7 @@ class ImportContext {
 //    In the common case where the second phase cannot add new work (because the
 //    inst doesn't represent a declaration of an entity that can be forward
 //    declared), the second and third phases are usually expressed as a call to
-//    ResolveAsDeduplicated or ResolveAsUnique.
+//    ResolveResult::Deduplicated or ResolveResult::Unique.
 //
 // 3. If resolve didn't return Retry(), pop the work. Otherwise, it needs to
 //    remain, and may no longer be at the top of the stack; update the state of
@@ -1135,70 +1105,101 @@ static auto AddAssociatedEntities(ImportContext& context,
   return context.local_inst_blocks().Add(new_associated_entities);
 }
 
-// Produces a resolve result that provides the given constant value. Retries
-// instead if work has been added.
-static auto RetryOrDone(ImportRefResolver& resolver, SemIR::ConstantId const_id)
-    -> ResolveResult {
-  if (resolver.HasNewWork()) {
-    return ResolveResult::Retry();
-  }
-  return ResolveResult::Done(const_id);
-}
-
+namespace {
+namespace Internal {
 // Internal concept for instruction kinds that produce unique constants.
 template <typename InstT>
 concept HasUniqueConstantKind =
     InstT::Kind.constant_kind() == SemIR::InstConstantKind::AlwaysUnique ||
     InstT::Kind.constant_kind() == SemIR::InstConstantKind::ConditionalUnique;
+}  // namespace Internal
 
-// Adds `inst` to the local context as a deduplicated constant and returns a
-// successful `ResolveResult`. Requires that there is no new work.
-//
-// This implements phases 2 and 3 of resolving the inst (as described above) for
-// the common case where those phases are combined. Cases where that isn't
-// applicable should instead use `AddPlaceholderImportedInst` and
-// `ReplacePlaceholderImportedInst`.
-//
-// This should not be used for instructions that represent declarations, or
-// other instructions with `constant_kind == InstConstantKind::Unique`, because
-// they should not be deduplicated.
-template <typename InstT>
-  requires(!HasUniqueConstantKind<InstT>)
-static auto ResolveAsDeduplicated(ImportRefResolver& resolver, InstT inst)
-    -> ResolveResult {
-  CARBON_CHECK(!resolver.HasNewWork());
-  // AddImportedConstant produces an unattached constant, so its type must
-  // be unattached as well.
-  inst.type_id =
-      resolver.local_context().types().GetUnattachedType(inst.type_id);
-  auto const_id = AddImportedConstant(resolver.local_context(), inst);
-  CARBON_CHECK(const_id.is_constant(), "{0} is not constant", inst);
-  return ResolveResult::Done(const_id);
-}
+// The result of attempting to resolve an imported instruction to a constant.
+struct ResolveResult {
+  // The new constant value, if known.
+  SemIR::ConstantId const_id;
+  // Newly created declaration whose value is being resolved, if any.
+  SemIR::InstId decl_id = SemIR::InstId::None;
+  // Whether resolution has been attempted once and needs to be retried.
+  bool retry = false;
 
-// Adds `inst` to the local context as a unique constant and returns a
-// successful `ResolveResult`. `import_inst_id` is the corresponding inst ID in
-// the local context. Requires that there is no new work.
-//
-// This implements phases 2 and 3 of resolving the inst (as described above) for
-// the common case where those phases are combined. Cases where that isn't
-// applicable should instead use `AddPlaceholderImportedInst` and
-// `ReplacePlaceholderImportedInst`.
-//
-// This should only be used for instructions that represent declarations, or
-// other instructions with `constant_kind == InstConstantKind::Unique`, because
-// it does not perform deduplication.
-template <typename InstT>
-  requires HasUniqueConstantKind<InstT>
-static auto ResolveAsUnique(ImportRefResolver& resolver,
-                            SemIR::InstId import_inst_id, InstT inst)
-    -> ResolveResult {
-  CARBON_CHECK(!resolver.HasNewWork());
-  auto inst_id = AddPlaceholderImportedInst(resolver, import_inst_id, inst);
-  auto const_id = SetConstantValue(resolver.local_context(), inst_id, inst);
-  CARBON_CHECK(const_id.is_constant(), "{0} is not constant", inst);
-  return ResolveResult::Done(const_id, inst_id);
-}
+  // Produces a resolve result that tries resolving this instruction again. If
+  // `const_id` is specified, then this is the end of the second phase, and the
+  // constant value will be passed to the next resolution attempt. Otherwise,
+  // this is the end of the first phase.
+  static auto Retry(SemIR::ConstantId const_id = SemIR::ConstantId::None,
+                    SemIR::InstId decl_id = SemIR::InstId::None)
+      -> ResolveResult {
+    return {.const_id = const_id, .decl_id = decl_id, .retry = true};
+  }
+
+  // Produces a resolve result that provides the given constant value. Requires
+  // that there is no new work.
+  static auto Done(SemIR::ConstantId const_id,
+                   SemIR::InstId decl_id = SemIR::InstId::None)
+      -> ResolveResult {
+    return {.const_id = const_id, .decl_id = decl_id};
+  }
+
+  // Produces a resolve result that provides the given constant value. Retries
+  // instead if work has been added.
+  static auto RetryOrDone(ImportRefResolver& resolver,
+                          SemIR::ConstantId const_id) -> ResolveResult {
+    if (resolver.HasNewWork()) {
+      return Retry();
+    }
+    return Done(const_id);
+  }
+
+  // Adds `inst` to the local context as a deduplicated constant and returns a
+  // successful `ResolveResult`. Requires that there is no new work.
+  //
+  // This implements phases 2 and 3 of resolving the inst (as described above)
+  // for the common case where those phases are combined. Cases where that isn't
+  // applicable should instead use `AddPlaceholderImportedInst` and
+  // `ReplacePlaceholderImportedInst`.
+  //
+  // This should not be used for instructions that represent declarations, or
+  // other instructions with `constant_kind == InstConstantKind::Unique`,
+  // because they should not be deduplicated.
+  template <typename InstT>
+    requires(!Internal::HasUniqueConstantKind<InstT>)
+  static auto Deduplicated(ImportRefResolver& resolver, InstT inst)
+      -> ResolveResult {
+    CARBON_CHECK(!resolver.HasNewWork());
+    // AddImportedConstant produces an unattached constant, so its type must
+    // be unattached as well.
+    inst.type_id =
+        resolver.local_context().types().GetUnattachedType(inst.type_id);
+    auto const_id = AddImportedConstant(resolver.local_context(), inst);
+    CARBON_CHECK(const_id.is_constant(), "{0} is not constant", inst);
+    return Done(const_id);
+  }
+
+  // Adds `inst` to the local context as a unique constant and returns a
+  // successful `ResolveResult`. `import_inst_id` is the corresponding inst ID
+  // in the local context. Requires that there is no new work.
+  //
+  // This implements phases 2 and 3 of resolving the inst (as described above)
+  // for the common case where those phases are combined. Cases where that isn't
+  // applicable should instead use `AddPlaceholderImportedInst` and
+  // `ReplacePlaceholderImportedInst`.
+  //
+  // This should only be used for instructions that represent declarations, or
+  // other instructions with `constant_kind == InstConstantKind::Unique`,
+  // because it does not perform deduplication.
+  template <typename InstT>
+    requires Internal::HasUniqueConstantKind<InstT>
+  static auto Unique(ImportRefResolver& resolver, SemIR::InstId import_inst_id,
+                     InstT inst) -> ResolveResult {
+    CARBON_CHECK(!resolver.HasNewWork());
+    auto inst_id = AddPlaceholderImportedInst(resolver, import_inst_id, inst);
+    auto const_id = SetConstantValue(resolver.local_context(), inst_id, inst);
+    CARBON_CHECK(const_id.is_constant(), "{0} is not constant", inst);
+    return Done(const_id, inst_id);
+  }
+};
+}  // namespace
 
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::AdaptDecl inst,
@@ -1215,7 +1216,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                          inst.adapted_type_inst_id, adapted_type_const_id));
 
   // Create a corresponding instruction to represent the declaration.
-  return ResolveAsUnique<SemIR::AdaptDecl>(
+  return ResolveResult::Unique<SemIR::AdaptDecl>(
       resolver, import_inst_id, {.adapted_type_inst_id = adapted_type_inst_id});
 }
 
@@ -1228,7 +1229,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsUnique<SemIR::AddrPattern>(
+  return ResolveResult::Unique<SemIR::AddrPattern>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -1246,7 +1247,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver, ParamPatternT inst,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsUnique<ParamPatternT>(
+  return ResolveResult::Unique<ParamPatternT>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -1264,7 +1265,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::ArrayType>(
+  return ResolveResult::Deduplicated<SemIR::ArrayType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .bound_id = bound_id,
                  .element_type_inst_id = element_type_inst_id});
@@ -1357,7 +1358,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   // Add a lazy reference to the target declaration.
   auto decl_id = AddImportRef(resolver, inst.decl_id);
 
-  return ResolveAsDeduplicated<SemIR::AssociatedEntity>(
+  return ResolveResult::Deduplicated<SemIR::AssociatedEntity>(
       resolver,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -1378,7 +1379,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   auto specific_interface =
       GetLocalSpecificInterface(resolver, inst.GetSpecificInterface(), data);
-  return ResolveAsDeduplicated<SemIR::AssociatedEntityType>(
+  return ResolveResult::Deduplicated<SemIR::AssociatedEntityType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .interface_id = specific_interface.interface_id,
                  .interface_specific_id = specific_interface.specific_id});
@@ -1400,7 +1401,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                          inst.base_type_inst_id, base_type_const_id));
 
   // Create a corresponding instruction to represent the declaration.
-  return ResolveAsUnique<SemIR::BaseDecl>(
+  return ResolveResult::Unique<SemIR::BaseDecl>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -1411,7 +1412,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::AliasBinding inst) -> ResolveResult {
   auto value_id = GetLocalConstantId(resolver, inst.value_id);
-  return RetryOrDone(resolver, value_id);
+  return ResolveResult::RetryOrDone(resolver, value_id);
 }
 
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
@@ -1423,7 +1424,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   auto entity_name_id =
       GetLocalSymbolicEntityNameId(resolver, inst.entity_name_id);
-  return ResolveAsDeduplicated<SemIR::SymbolicBinding>(
+  return ResolveResult::Deduplicated<SemIR::SymbolicBinding>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -1452,7 +1453,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
        .parent_scope_id = parent_scope_id,
        .bind_index_value = import_entity_name.bind_index().index,
        .is_template = import_entity_name.is_template});
-  return ResolveAsUnique<BindingPatternT>(
+  return ResolveResult::Unique<BindingPatternT>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -1466,7 +1467,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   CARBON_CHECK(!resolver.HasNewWork());
 
-  return ResolveAsDeduplicated<SemIR::BoolLiteral>(
+  return ResolveResult::Deduplicated<SemIR::BoolLiteral>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
                                              SemIR::BoolType::TypeInstId),
                  .value = inst.value});
@@ -1484,7 +1485,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::BoundMethod>(
+  return ResolveResult::Deduplicated<SemIR::BoundMethod>(
       resolver,
       {.type_id = GetSingletonType(resolver.local_context(),
                                    SemIR::BoundMethodType::TypeInstId),
@@ -1502,7 +1503,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver, SemIR::Call inst)
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::Call>(
+  return ResolveResult::Deduplicated<SemIR::Call>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -1517,7 +1518,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   CARBON_CHECK(!resolver.HasNewWork());
 
-  return ResolveAsDeduplicated<SemIR::CharLiteralValue>(
+  return ResolveResult::Deduplicated<SemIR::CharLiteralValue>(
       resolver,
       {.type_id = GetSingletonType(resolver.local_context(),
                                    SemIR::CharLiteralType::TypeInstId),
@@ -1734,7 +1735,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
             class_const_inst.type_id());
     auto specific_id =
         GetOrAddLocalSpecific(resolver, inst.specific_id, specific_data);
-    return ResolveAsDeduplicated<SemIR::ClassType>(
+    return ResolveResult::Deduplicated<SemIR::ClassType>(
         resolver, {.type_id = SemIR::TypeType::TypeId,
                    .class_id = generic_class_type.class_id,
                    .specific_id = specific_id});
@@ -1751,7 +1752,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
-  return ResolveAsDeduplicated<SemIR::CompleteTypeWitness>(
+  return ResolveResult::Deduplicated<SemIR::CompleteTypeWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
                                              SemIR::WitnessType::TypeInstId),
                  .object_repr_type_inst_id = object_repr_type_inst_id});
@@ -1766,7 +1767,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver, InstT inst)
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
-  return ResolveAsDeduplicated<InstT>(
+  return ResolveResult::Deduplicated<InstT>(
       resolver, {.type_id = SemIR::TypeType::TypeId, .inner_id = inner_id});
 }
 
@@ -1800,7 +1801,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::ExportDecl inst) -> ResolveResult {
   auto value_id = GetLocalConstantId(resolver, inst.value_id);
-  return RetryOrDone(resolver, value_id);
+  return ResolveResult::RetryOrDone(resolver, value_id);
 }
 
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
@@ -1810,7 +1811,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
-  return ResolveAsUnique<SemIR::FieldDecl>(
+  return ResolveResult::Unique<SemIR::FieldDecl>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            const_id),
@@ -1829,7 +1830,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto real_id = resolver.local_ir().reals().Add(
       resolver.import_ir().reals().Get(inst.real_id));
 
-  return ResolveAsDeduplicated<SemIR::FloatLiteralValue>(
+  return ResolveResult::Deduplicated<SemIR::FloatLiteralValue>(
       resolver,
       {.type_id = GetSingletonType(resolver.local_context(),
                                    SemIR::FloatLiteralType::TypeInstId),
@@ -1844,7 +1845,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::FloatType>(
+  return ResolveResult::Deduplicated<SemIR::FloatType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .bit_width_id = bit_width_id,
                  .float_kind = inst.float_kind});
@@ -1860,7 +1861,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto float_id = resolver.local_ir().floats().Add(
       resolver.import_ir().floats().Get(inst.float_id));
 
-  return ResolveAsDeduplicated<SemIR::FloatValue>(
+  return ResolveResult::Deduplicated<SemIR::FloatValue>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -2068,7 +2069,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
         .virtual_functions_id =
             resolver.local_inst_blocks().Add(lazy_virtual_functions)}});
 
-  return ResolveAsDeduplicated<SemIR::VtableDecl>(
+  return ResolveResult::Deduplicated<SemIR::VtableDecl>(
       resolver, {.type_id = GetPointerType(resolver.local_context(),
                                            SemIR::VtableType::TypeInstId),
                  .vtable_id = new_vtable_id});
@@ -2088,7 +2089,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::VtablePtr>(
+  return ResolveResult::Deduplicated<SemIR::VtablePtr>(
       resolver,
       {.type_id = GetPointerType(resolver.local_context(),
                                  SemIR::VtableType::TypeInstId),
@@ -2109,7 +2110,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
   auto fn_type_id = resolver.local_insts().Get(fn_val_id).type_id();
-  return ResolveAsDeduplicated<SemIR::FunctionType>(
+  return ResolveResult::Deduplicated<SemIR::FunctionType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .function_id = resolver.local_types()
                                     .GetAs<SemIR::FunctionType>(fn_type_id)
@@ -2129,7 +2130,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::FunctionTypeWithSelfType>(
+  return ResolveResult::Deduplicated<SemIR::FunctionTypeWithSelfType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .interface_function_type_id = interface_function_type_id,
                  .self_id = self_id});
@@ -2318,7 +2319,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   auto new_constant_id = GetLocalConstantId(
       resolver, resolver.import_constant_values().GetInstId(constant_id));
-  return RetryOrDone(resolver, new_constant_id);
+  return ResolveResult::RetryOrDone(resolver, new_constant_id);
 }
 
 // Make a declaration of an interface. This is done as a separate step from
@@ -2631,7 +2632,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::FacetAccessType>(
+  return ResolveResult::Deduplicated<SemIR::FacetAccessType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .facet_value_inst_id = facet_value_inst_id});
 }
@@ -2687,7 +2688,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   // TODO: Also process the other requirements.
   SemIR::FacetTypeId facet_type_id =
       resolver.local_facet_types().Add(std::move(local_facet_type_info));
-  return ResolveAsDeduplicated<SemIR::FacetType>(
+  return ResolveResult::Deduplicated<SemIR::FacetType>(
       resolver,
       {.type_id = SemIR::TypeType::TypeId, .facet_type_id = facet_type_id});
 }
@@ -2701,7 +2702,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::FacetValue>(
+  return ResolveResult::Deduplicated<SemIR::FacetValue>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -2733,7 +2734,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       GetLocalSpecificInterface(resolver, import_specific_interface, data);
   auto query_specific_interface_id =
       resolver.local_specific_interfaces().Add(specific_interface);
-  return ResolveAsDeduplicated<SemIR::LookupImplWitness>(
+  return ResolveResult::Deduplicated<SemIR::LookupImplWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
                                              SemIR::WitnessType::TypeInstId),
                  .query_self_inst_id = query_self_inst_id,
@@ -2754,7 +2755,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   auto specific_id =
       GetOrAddLocalSpecific(resolver, inst.specific_id, specific_data);
-  return ResolveAsDeduplicated<SemIR::ImplWitness>(
+  return ResolveResult::Deduplicated<SemIR::ImplWitness>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
                                              SemIR::WitnessType::TypeInstId),
                  .witness_table_id = witness_table_id,
@@ -2770,7 +2771,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::ImplWitnessAccess>(
+  return ResolveResult::Deduplicated<SemIR::ImplWitnessAccess>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -2795,7 +2796,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   auto elements_id = GetLocalImportRefInstBlock(resolver, inst.elements_id);
 
   // Create a corresponding instruction to represent the table.
-  return ResolveAsUnique<SemIR::ImplWitnessTable>(
+  return ResolveResult::Unique<SemIR::ImplWitnessTable>(
       resolver, import_inst_id,
       {.elements_id = elements_id, .impl_id = impl_id});
 }
@@ -2814,7 +2815,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                     : resolver.local_ints().AddSigned(
                           resolver.import_ints().Get(inst.int_id));
 
-  return ResolveAsDeduplicated<SemIR::IntValue>(
+  return ResolveResult::Deduplicated<SemIR::IntValue>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -2829,7 +2830,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::IntType>(
+  return ResolveResult::Deduplicated<SemIR::IntType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .int_kind = inst.int_kind,
                  .bit_width_id = bit_width_id});
@@ -2882,7 +2883,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::PatternType>(
+  return ResolveResult::Deduplicated<SemIR::PatternType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .scrutinee_type_inst_id = scrutinee_type_inst_id});
 }
@@ -2895,7 +2896,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::PointerType>(
+  return ResolveResult::Deduplicated<SemIR::PointerType>(
       resolver, {.type_id = SemIR::TypeType::TypeId, .pointee_id = pointee_id});
 }
 
@@ -2911,7 +2912,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::RequireCompleteType>(
+  return ResolveResult::Deduplicated<SemIR::RequireCompleteType>(
       resolver, {.type_id = GetSingletonType(resolver.local_context(),
                                              SemIR::WitnessType::TypeInstId),
                  .complete_type_inst_id = complete_type_inst_id});
@@ -2925,7 +2926,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsUnique<SemIR::ReturnSlotPattern>(
+  return ResolveResult::Unique<SemIR::ReturnSlotPattern>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -2945,7 +2946,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       type_const_id);
   auto specific_id =
       GetOrAddLocalSpecific(resolver, inst.specific_id, specific_data);
-  return ResolveAsDeduplicated<SemIR::SpecificFunction>(
+  return ResolveResult::Deduplicated<SemIR::SpecificFunction>(
       resolver,
       {.type_id = type_id, .callee_id = callee_id, .specific_id = specific_id});
 }
@@ -2963,7 +2964,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                   SemIR::SpecificFunctionType::TypeInstId);
   auto specific_id =
       GetOrAddLocalSpecific(resolver, inst.specific_id, specific_data);
-  return ResolveAsDeduplicated<SemIR::SpecificImplFunction>(
+  return ResolveResult::Deduplicated<SemIR::SpecificImplFunction>(
       resolver,
       {.type_id = type_id, .callee_id = callee_id, .specific_id = specific_id});
 }
@@ -2981,7 +2982,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   CompleteTypeOrCheckFail(resolver.local_context(),
                           resolver.local_insts().Get(struct_id).type_id());
 
-  return ResolveAsDeduplicated<SemIR::StructAccess>(
+  return ResolveResult::Deduplicated<SemIR::StructAccess>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -3013,7 +3014,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
         {.name_id = name_id, .type_inst_id = field_type_inst_id});
   }
 
-  return ResolveAsDeduplicated<SemIR::StructType>(
+  return ResolveResult::Deduplicated<SemIR::StructType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .fields_id = resolver.local_struct_type_fields().AddCanonical(
                      new_fields)});
@@ -3027,7 +3028,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::StructValue>(
+  return ResolveResult::Deduplicated<SemIR::StructValue>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -3046,7 +3047,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   auto entity_name_id =
       GetLocalSymbolicEntityNameId(resolver, inst.entity_name_id);
-  return ResolveAsDeduplicated<SemIR::SymbolicBindingType>(
+  return ResolveResult::Deduplicated<SemIR::SymbolicBindingType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .entity_name_id = entity_name_id,
                  .facet_value_inst_id = facet_value_inst_id});
@@ -3065,7 +3066,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
   CompleteTypeOrCheckFail(resolver.local_context(),
                           resolver.local_insts().Get(tuple_id).type_id());
 
-  return ResolveAsDeduplicated<SemIR::TupleAccess>(
+  return ResolveResult::Deduplicated<SemIR::TupleAccess>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -3082,7 +3083,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsUnique<SemIR::TuplePattern>(
+  return ResolveResult::Unique<SemIR::TuplePattern>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -3108,7 +3109,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::TupleType>(
+  return ResolveResult::Deduplicated<SemIR::TupleType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .type_elements_id = GetLocalCanonicalInstBlockId(
                      resolver, inst.type_elements_id, type_inst_ids)});
@@ -3122,7 +3123,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::TupleValue>(
+  return ResolveResult::Deduplicated<SemIR::TupleValue>(
       resolver,
       {.type_id =
            resolver.local_context().types().GetTypeIdForTypeConstantId(type_id),
@@ -3142,7 +3143,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsDeduplicated<SemIR::UnboundElementType>(
+  return ResolveResult::Deduplicated<SemIR::UnboundElementType>(
       resolver, {.type_id = SemIR::TypeType::TypeId,
                  .class_type_inst_id = class_const_inst_id,
                  .element_type_inst_id = elem_const_inst_id});
@@ -3157,7 +3158,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsUnique<SemIR::VarPattern>(
+  return ResolveResult::Unique<SemIR::VarPattern>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),
@@ -3173,7 +3174,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     return ResolveResult::Retry();
   }
 
-  return ResolveAsUnique<SemIR::VarStorage>(
+  return ResolveResult::Unique<SemIR::VarStorage>(
       resolver, import_inst_id,
       {.type_id = resolver.local_context().types().GetTypeIdForTypeConstantId(
            type_const_id),

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1154,10 +1154,10 @@ struct ResolveResult {
   // Adds `inst` to the local context as a deduplicated constant and returns a
   // successful `ResolveResult`. Requires that there is no new work.
   //
-  // This implements phases 2 and 3 of resolving the inst (as described above)
-  // for the common case where those phases are combined. Cases where that isn't
-  // applicable should instead use `AddPlaceholderImportedInst` and
-  // `ReplacePlaceholderImportedInst`.
+  // This implements phases 2 and 3 of resolving the inst (as described on
+  // `ImportRefResolver`) for the common case where those phases are combined.
+  // Cases where that isn't applicable should instead use
+  // `AddPlaceholderImportedInst` and `ReplacePlaceholderImportedInst`.
   //
   // This should not be used for instructions that represent declarations, or
   // other instructions with `constant_kind == InstConstantKind::Unique`,
@@ -1180,10 +1180,10 @@ struct ResolveResult {
   // successful `ResolveResult`. `import_inst_id` is the corresponding inst ID
   // in the local context. Requires that there is no new work.
   //
-  // This implements phases 2 and 3 of resolving the inst (as described above)
-  // for the common case where those phases are combined. Cases where that isn't
-  // applicable should instead use `AddPlaceholderImportedInst` and
-  // `ReplacePlaceholderImportedInst`.
+  // This implements phases 2 and 3 of resolving the inst (as described on
+  // `ImportRefResolver`) for the common case where those phases are combined.
+  // Cases where that isn't applicable should instead use
+  // `AddPlaceholderImportedInst` and `ReplacePlaceholderImportedInst`.
   //
   // This should only be used for instructions that represent declarations, or
   // other instructions with `constant_kind == InstConstantKind::Unique`,

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -166,8 +166,6 @@ auto VerifySameCanonicalImportIRInst(Context& context, SemIR::NameId name_id,
 }
 
 namespace {
-class ImportRefResolver;
-
 // The result of attempting to resolve an imported instruction to a constant.
 struct ResolveResult {
   // The new constant value, if known.
@@ -196,9 +194,6 @@ struct ResolveResult {
   }
 };
 }  // namespace
-
-static auto TryResolveInst(ImportRefResolver& resolver, SemIR::InstId inst_id,
-                           SemIR::ConstantId const_id) -> ResolveResult;
 
 namespace {
 // A context within which we are performing an import. Tracks information about
@@ -478,45 +473,7 @@ class ImportRefResolver : public ImportContext {
   // Iteratively resolves an imported instruction's inner references until a
   // constant ID referencing the current IR is produced. See the class comment
   // for more details.
-  auto ResolveOneInst(SemIR::InstId inst_id) -> SemIR::ConstantId {
-    work_stack_.push_back({.inst_id = inst_id});
-    while (!work_stack_.empty()) {
-      auto work = work_stack_.back();
-      CARBON_CHECK(work.inst_id.has_value());
-
-      // Step 1: check for a constant value.
-      auto existing = FindResolvedConstId(work.inst_id);
-      if (existing.const_id.has_value() && !work.retry_with_constant_value) {
-        work_stack_.pop_back();
-        continue;
-      }
-
-      // Step 2: resolve the instruction.
-      initial_work_ = work_stack_.size();
-      auto [new_const_id, _, retry] =
-          TryResolveInst(*this, work.inst_id, existing.const_id);
-      CARBON_CHECK(!HasNewWork() || retry);
-
-      CARBON_CHECK(
-          !existing.const_id.has_value() || existing.const_id == new_const_id,
-          "Constant value changed in third phase.");
-      if (!existing.const_id.has_value()) {
-        SetResolvedConstId(work.inst_id, existing.indirect_insts, new_const_id);
-      }
-
-      // Step 3: pop or retry.
-      if (retry) {
-        work_stack_[initial_work_ - 1].retry_with_constant_value =
-            new_const_id.has_value();
-      } else {
-        work_stack_.pop_back();
-      }
-    }
-    auto constant_id =
-        local_constant_values_for_import_insts().GetAttached(inst_id);
-    CARBON_CHECK(constant_id.has_value());
-    return constant_id;
-  }
+  auto ResolveOneInst(SemIR::InstId inst_id) -> SemIR::ConstantId;
 
   // Performs resolution for one instruction and then performs all work we
   // deferred.
@@ -534,26 +491,7 @@ class ImportRefResolver : public ImportContext {
   }
 
   // Wraps constant evaluation with logic to handle types.
-  // NOLINTNEXTLINE(misc-no-recursion)
-  auto ResolveType(SemIR::TypeId import_type_id) -> SemIR::TypeId {
-    if (!import_type_id.has_value()) {
-      return import_type_id;
-    }
-
-    auto import_type_const_id =
-        import_ir().types().GetConstantId(import_type_id);
-    CARBON_CHECK(import_type_const_id.has_value());
-
-    if (auto import_type_inst_id = import_ir().types().GetAsTypeInstId(
-            import_ir().constant_values().GetInstId(import_type_const_id));
-        SemIR::IsSingletonInstId(import_type_inst_id)) {
-      // Builtins don't require constant resolution; we can use them directly.
-      return GetSingletonType(local_context(), import_type_inst_id);
-    } else {
-      return local_context().types().GetTypeIdForTypeConstantId(
-          ResolveConstant(import_type_id.AsConstantId()));
-    }
-  }
+  auto ResolveType(SemIR::TypeId import_type_id) -> SemIR::TypeId;
 
   // Returns true if new unresolved constants were found as part of this
   // `Resolve` step.
@@ -565,17 +503,7 @@ class ImportRefResolver : public ImportContext {
 
   // Returns the ConstantId for an InstId. Adds unresolved constants to
   // work_stack_.
-  auto GetLocalConstantValueOrPush(SemIR::InstId inst_id) -> SemIR::ConstantId {
-    if (!inst_id.has_value()) {
-      return SemIR::ConstantId::None;
-    }
-    auto const_id =
-        local_constant_values_for_import_insts().GetAttached(inst_id);
-    if (!const_id.has_value()) {
-      work_stack_.push_back({.inst_id = inst_id});
-    }
-    return const_id;
-  }
+  auto GetLocalConstantValueOrPush(SemIR::InstId inst_id) -> SemIR::ConstantId;
 
  private:
   // A step in work_stack_.
@@ -602,80 +530,12 @@ class ImportRefResolver : public ImportContext {
   // found indirectly, sets the constant for any indirect steps that don't
   // already have the constant. If a constant isn't found, returns the indirect
   // instructions so that they can have the resolved constant assigned later.
-  auto FindResolvedConstId(SemIR::InstId inst_id) -> ResolvedConstId {
-    ResolvedConstId result;
-
-    if (auto existing_const_id =
-            local_constant_values_for_import_insts().GetAttached(inst_id);
-        existing_const_id.has_value()) {
-      result.const_id = existing_const_id;
-      return result;
-    }
-
-    const auto* cursor_ir = &import_ir();
-    auto cursor_inst_id = inst_id;
-
-    while (true) {
-      auto import_ir_inst_id =
-          cursor_ir->insts().GetImportSource(cursor_inst_id);
-      if (!import_ir_inst_id.has_value()) {
-        return result;
-      }
-      auto ir_inst = cursor_ir->import_ir_insts().Get(import_ir_inst_id);
-      if (ir_inst.ir_id() == SemIR::ImportIRId::Cpp) {
-        local_context().TODO(SemIR::LocId::None,
-                             "Unsupported: Importing C++ indirectly");
-        SetResolvedConstId(inst_id, result.indirect_insts,
-                           SemIR::ErrorInst::ConstantId);
-        result.const_id = SemIR::ErrorInst::ConstantId;
-        result.indirect_insts.clear();
-        return result;
-      }
-
-      const auto* prev_ir = cursor_ir;
-      auto prev_inst_id = cursor_inst_id;
-
-      cursor_ir = cursor_ir->import_irs().Get(ir_inst.ir_id()).sem_ir;
-      auto cursor_ir_id =
-          AddImportIR(local_context(), {.decl_id = SemIR::InstId::None,
-                                        .is_export = false,
-                                        .sem_ir = cursor_ir});
-      cursor_inst_id = ir_inst.inst_id();
-
-      CARBON_CHECK(cursor_ir != prev_ir || cursor_inst_id != prev_inst_id,
-                   "{0}", cursor_ir->insts().Get(cursor_inst_id));
-
-      if (auto const_id =
-              local_context()
-                  .import_ir_constant_values()
-                      [local_context().sem_ir().import_irs().GetRawIndex(
-                          cursor_ir_id)]
-                  .GetAttached(cursor_inst_id);
-          const_id.has_value()) {
-        SetResolvedConstId(inst_id, result.indirect_insts, const_id);
-        result.const_id = const_id;
-        result.indirect_insts.clear();
-        return result;
-      } else {
-        result.indirect_insts.push_back(
-            SemIR::ImportIRInst(cursor_ir_id, cursor_inst_id));
-      }
-    }
-  }
+  auto FindResolvedConstId(SemIR::InstId inst_id) -> ResolvedConstId;
 
   // Sets a resolved constant into the current and indirect instructions.
   auto SetResolvedConstId(SemIR::InstId inst_id,
                           llvm::ArrayRef<SemIR::ImportIRInst> indirect_insts,
-                          SemIR::ConstantId const_id) -> void {
-    local_constant_values_for_import_insts().Set(inst_id, const_id);
-    for (auto indirect_inst : indirect_insts) {
-      local_context()
-          .import_ir_constant_values()
-              [local_context().sem_ir().import_irs().GetRawIndex(
-                  indirect_inst.ir_id())]
-          .Set(indirect_inst.inst_id(), const_id);
-    }
-  }
+                          SemIR::ConstantId const_id) -> void;
 
   auto PerformPendingWork() -> void;
 
@@ -3657,6 +3517,154 @@ static auto TryResolveInst(ImportRefResolver& resolver, SemIR::InstId inst_id,
   }
 
   return result;
+}
+
+auto ImportRefResolver::ResolveOneInst(SemIR::InstId inst_id)
+    -> SemIR::ConstantId {
+  work_stack_.push_back({.inst_id = inst_id});
+  while (!work_stack_.empty()) {
+    auto work = work_stack_.back();
+    CARBON_CHECK(work.inst_id.has_value());
+
+    // Step 1: check for a constant value.
+    auto existing = FindResolvedConstId(work.inst_id);
+    if (existing.const_id.has_value() && !work.retry_with_constant_value) {
+      work_stack_.pop_back();
+      continue;
+    }
+
+    // Step 2: resolve the instruction.
+    initial_work_ = work_stack_.size();
+    auto [new_const_id, _, retry] =
+        TryResolveInst(*this, work.inst_id, existing.const_id);
+    CARBON_CHECK(!HasNewWork() || retry);
+
+    CARBON_CHECK(
+        !existing.const_id.has_value() || existing.const_id == new_const_id,
+        "Constant value changed in third phase.");
+    if (!existing.const_id.has_value()) {
+      SetResolvedConstId(work.inst_id, existing.indirect_insts, new_const_id);
+    }
+
+    // Step 3: pop or retry.
+    if (retry) {
+      work_stack_[initial_work_ - 1].retry_with_constant_value =
+          new_const_id.has_value();
+    } else {
+      work_stack_.pop_back();
+    }
+  }
+  auto constant_id =
+      local_constant_values_for_import_insts().GetAttached(inst_id);
+  CARBON_CHECK(constant_id.has_value());
+  return constant_id;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+auto ImportRefResolver::ResolveType(SemIR::TypeId import_type_id)
+    -> SemIR::TypeId {
+  if (!import_type_id.has_value()) {
+    return import_type_id;
+  }
+
+  auto import_type_const_id = import_ir().types().GetConstantId(import_type_id);
+  CARBON_CHECK(import_type_const_id.has_value());
+
+  if (auto import_type_inst_id = import_ir().types().GetAsTypeInstId(
+          import_ir().constant_values().GetInstId(import_type_const_id));
+      SemIR::IsSingletonInstId(import_type_inst_id)) {
+    // Builtins don't require constant resolution; we can use them directly.
+    return GetSingletonType(local_context(), import_type_inst_id);
+  } else {
+    return local_context().types().GetTypeIdForTypeConstantId(
+        ResolveConstant(import_type_id.AsConstantId()));
+  }
+}
+
+auto ImportRefResolver::GetLocalConstantValueOrPush(SemIR::InstId inst_id)
+    -> SemIR::ConstantId {
+  if (!inst_id.has_value()) {
+    return SemIR::ConstantId::None;
+  }
+  auto const_id = local_constant_values_for_import_insts().GetAttached(inst_id);
+  if (!const_id.has_value()) {
+    work_stack_.push_back({.inst_id = inst_id});
+  }
+  return const_id;
+}
+
+auto ImportRefResolver::FindResolvedConstId(SemIR::InstId inst_id)
+    -> ResolvedConstId {
+  ResolvedConstId result;
+
+  if (auto existing_const_id =
+          local_constant_values_for_import_insts().GetAttached(inst_id);
+      existing_const_id.has_value()) {
+    result.const_id = existing_const_id;
+    return result;
+  }
+
+  const auto* cursor_ir = &import_ir();
+  auto cursor_inst_id = inst_id;
+
+  while (true) {
+    auto import_ir_inst_id = cursor_ir->insts().GetImportSource(cursor_inst_id);
+    if (!import_ir_inst_id.has_value()) {
+      return result;
+    }
+    auto ir_inst = cursor_ir->import_ir_insts().Get(import_ir_inst_id);
+    if (ir_inst.ir_id() == SemIR::ImportIRId::Cpp) {
+      local_context().TODO(SemIR::LocId::None,
+                           "Unsupported: Importing C++ indirectly");
+      SetResolvedConstId(inst_id, result.indirect_insts,
+                         SemIR::ErrorInst::ConstantId);
+      result.const_id = SemIR::ErrorInst::ConstantId;
+      result.indirect_insts.clear();
+      return result;
+    }
+
+    const auto* prev_ir = cursor_ir;
+    auto prev_inst_id = cursor_inst_id;
+
+    cursor_ir = cursor_ir->import_irs().Get(ir_inst.ir_id()).sem_ir;
+    auto cursor_ir_id =
+        AddImportIR(local_context(), {.decl_id = SemIR::InstId::None,
+                                      .is_export = false,
+                                      .sem_ir = cursor_ir});
+    cursor_inst_id = ir_inst.inst_id();
+
+    CARBON_CHECK(cursor_ir != prev_ir || cursor_inst_id != prev_inst_id, "{0}",
+                 cursor_ir->insts().Get(cursor_inst_id));
+
+    if (auto const_id =
+            local_context()
+                .import_ir_constant_values()
+                    [local_context().sem_ir().import_irs().GetRawIndex(
+                        cursor_ir_id)]
+                .GetAttached(cursor_inst_id);
+        const_id.has_value()) {
+      SetResolvedConstId(inst_id, result.indirect_insts, const_id);
+      result.const_id = const_id;
+      result.indirect_insts.clear();
+      return result;
+    } else {
+      result.indirect_insts.push_back(
+          SemIR::ImportIRInst(cursor_ir_id, cursor_inst_id));
+    }
+  }
+}
+
+auto ImportRefResolver::SetResolvedConstId(
+    SemIR::InstId inst_id, llvm::ArrayRef<SemIR::ImportIRInst> indirect_insts,
+    SemIR::ConstantId const_id) -> void {
+  local_constant_values_for_import_insts().Set(inst_id, const_id);
+  for (auto indirect_inst : indirect_insts) {
+    local_context()
+        .import_ir_constant_values()
+            [local_context().sem_ir().import_irs().GetRawIndex(
+                indirect_inst.ir_id())]
+        .Set(indirect_inst.inst_id(), const_id);
+  }
 }
 
 // Resolves and returns the local contents for an imported instruction block


### PR DESCRIPTION
Right now some of the `ResolveResult` factories are on it, ones that involve `ImportRefResolver` aren't; this more consistently makes callers use `ResolveResult::` when returning a result.