### PR TITLE
C++ Interop: API importing and semantics

### DIFF
--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -12,27 +12,27 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 -   [Philosophy and goals](#philosophy-and-goals)
 -   [Overview](#overview)
--   [C++ Interoperability Model: Introduction and Principles](#c-interoperability-model-introduction-and-principles)
-    -   [The "Successor Language" Mandate](#the-successor-language-mandate)
-    -   [The `Cpp` Associated Type: The Interop Trigger](#the-cpp-associated-type-the-interop-trigger)
+-   [C++ interoperability model: introduction and principles](#c-interoperability-model-introduction-and-principles)
+    -   [The "successor language" mandate](#the-successor-language-mandate)
+    -   [The `Cpp` associated type: the interop trigger](#the-cpp-associated-type-the-interop-trigger)
 -   [Importing C++ APIs into Carbon](#importing-c-apis-into-carbon)
-    -   [Importing C++ Libraries (Header-Based)](#importing-c-libraries-header-based)
-    -   [TODO: Importing C++ Code (Inline)](#todo-importing-c-code-inline)
-    -   [Accessing Built-in C++ Entities (File-less)](#accessing-built-in-c-entities-file-less)
-    -   [The `Cpp` Namespace](#the-cpp-namespace)
-    -   [TODO: Importing C++ Macros](#todo-importing-c-macros)
--   [Calling C++ Code from Carbon](#calling-c-code-from-carbon)
-    -   [Function Call Syntax and Semantics](#function-call-syntax-and-semantics)
-    -   [TODO: Overload Resolution](#todo-overload-resolution)
+    -   [Importing C++ libraries (header-based)](#importing-c-libraries-header-based)
+    -   [TODO: Importing C++ code (inline)](#todo-importing-c-code-inline)
+    -   [Accessing built-in C++ entities (file-less)](#accessing-built-in-c-entities-file-less)
+    -   [The `Cpp` namespace](#the-cpp-namespace)
+    -   [TODO: Importing C++ macros](#todo-importing-c-macros)
+-   [Calling C++ code from Carbon](#calling-c-code-from-carbon)
+    -   [Function call syntax and semantics](#function-call-syntax-and-semantics)
+    -   [TODO: Overload resolution](#todo-overload-resolution)
     -   [TODO: Thunks](#todo-thunks)
     -   [TODO: Constructors](#todo-constructors)
-    -   [TODO: Struct Literals](#todo-struct-literals)
--   [TODO: Accessing C++ Classes, Structs, and Members](#todo-accessing-c-classes-structs-and-members)
--   [TODO: Accessing Global Variables](#todo-accessing-global-variables)
--   [TODO: Bi-directional Type Mapping: Primitives and Core Types](#todo-bi-directional-type-mapping-primitives-and-core-types)
--   [TODO: Advanced Type Mapping: Pointers, References, and `const`](#todo-advanced-type-mapping-pointers-references-and-const)
--   [TODO: Bi-directional Type Mapping: Standard Library Types](#todo-bi-directional-type-mapping-standard-library-types)
--   [TODO: The Operator Interoperability Model](#todo-the-operator-interoperability-model)
+    -   [TODO: Struct literals](#todo-struct-literals)
+-   [TODO: Accessing C++ classes, structs, and members](#todo-accessing-c-classes-structs-and-members)
+-   [TODO: Accessing global variables](#todo-accessing-global-variables)
+-   [TODO: Bi-directional type mapping: primitives and core types](#todo-bi-directional-type-mapping-primitives-and-core-types)
+-   [TODO: Advanced type mapping: pointers, references, and `const`](#todo-advanced-type-mapping-pointers-references-and-const)
+-   [TODO: Bi-directional type mapping: standard library types](#todo-bi-directional-type-mapping-standard-library-types)
+-   [TODO: The operator interoperability model](#todo-the-operator-interoperability-model)
 
 <!-- tocstop -->
 
@@ -71,9 +71,9 @@ fidelity. This includes preserving the nominal distinctions between C++ types
 like `long` and `long long`, or `T*` and `T&`, which is critical for correct
 overload resolution and template instantiation.
 
-## C++ Interoperability Model: Introduction and Principles
+## C++ interoperability model: introduction and principles
 
-### The "Successor Language" Mandate
+### The "successor language" mandate
 
 The design of Carbon's C++ interoperability is governed by its foundational
 goal: [to be a successor language](/README.md), not merely a language with a
@@ -92,7 +92,7 @@ therefore, operate at the semantic analysis (SemIR) level, not just at the
 linking (ABI) level. This document specifies the design of this semantic
 contract.
 
-### The `Cpp` Associated Type: The Interop Trigger
+### The `Cpp` associated type: the interop trigger
 
 A core mechanism in this design is the `Cpp` associated type. This concept
 defines the "trigger" that activates C++-specific semantic rules within the
@@ -125,7 +125,7 @@ implementation simplicity.
 
 ## Importing C++ APIs into Carbon
 
-### Importing C++ Libraries (Header-Based)
+### Importing C++ libraries (header-based)
 
 The primary mechanism for importing existing, user-defined C++ code is through
 header file inclusion. The Carbon toolchain must be able to parse and analyze
@@ -165,9 +165,9 @@ This model allows Carbon to leverage Clang's mature and correct implementation
 of C++'s complex parsing and semantic rules, including template instantiation,
 without having to reimplement them.
 
-### TODO: Importing C++ Code (Inline)
+### TODO: Importing C++ code (inline)
 
-### Accessing Built-in C++ Entities (File-less)
+### Accessing built-in C++ entities (file-less)
 
 Some C++ entities, particularly built-in primitive types, are not defined in any
 header file. They are "intrinsic" to the C++ compiler. These entities are
@@ -181,7 +181,7 @@ ensures that types like `long` or `float` are available seamlessly within the
 explicitly import them. This approach provides a clean, file-less way to access
 the foundational types required for C++ interoperability.
 
-### The `Cpp` Namespace
+### The `Cpp` namespace
 
 A critical design choice for managing C++ imports is the mandatory use of a
 containing namespace, `Cpp`. All imported C++ entities—functions, classes,
@@ -207,11 +207,11 @@ The `Cpp.` prefix makes the _origin_ of every symbol explicit and unambiguous.
 It ensures that C++ entities cannot collide with Carbon code, thereby "learning
 from" one of C++'s most significant legacy design issues.
 
-### TODO: Importing C++ Macros
+### TODO: Importing C++ macros
 
-## Calling C++ Code from Carbon
+## Calling C++ code from Carbon
 
-### Function Call Syntax and Semantics
+### Function call syntax and semantics
 
 Once imported, C++ functions are invoked using standard Carbon function call
 syntax, prefixed with the `Cpp` namespace. The Carbon compiler is responsible
@@ -237,22 +237,22 @@ fn Run() {
 }
 ```
 
-### TODO: Overload Resolution
+### TODO: Overload resolution
 
 ### TODO: Thunks
 
 ### TODO: Constructors
 
-### TODO: Struct Literals
+### TODO: Struct literals
 
-## TODO: Accessing C++ Classes, Structs, and Members
+## TODO: Accessing C++ classes, structs, and members
 
-## TODO: Accessing Global Variables
+## TODO: Accessing global variables
 
-## TODO: Bi-directional Type Mapping: Primitives and Core Types
+## TODO: Bi-directional type mapping: primitives and core types
 
-## TODO: Advanced Type Mapping: Pointers, References, and `const`
+## TODO: Advanced type mapping: pointers, references, and `const`
 
-## TODO: Bi-directional Type Mapping: Standard Library Types
+## TODO: Bi-directional type mapping: standard library types
 
-## TODO: The Operator Interoperability Model
+## TODO: The operator interoperability model

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -106,7 +106,7 @@ C++ type in any of the following ways:
     `MyCarbonVector(Cpp.Widget)`).
 
 More generally, a C++ interop type is any type for which Carbon's
-[orphan rule](https://docs.carbon-lang.dev/docs/design/generics/details.html#orphan-rule) 
+[orphan rule](https://docs.carbon-lang.dev/docs/design/generics/details.html#orphan-rule)
 would allow an impl to be provided by a library in `package Cpp`.
 
 This "pervasive" model of C++-awareness is a fundamental design choice. The C++

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -104,8 +104,8 @@ C++ type in any of the following ways:
 2.  A pointer to a C++ interop type (for example, `Cpp.Widget*`).
 3.  A Carbon generic type parameterized with a C++ interop type (for example,
     `MyCarbonVector(Cpp.Widget)`).
-4.  A Carbon struct or class containing a C++ interop type as a member (for
-    example, `MyCarbonStruct { x: Cpp.Widget }`).
+4.  A Carbon class extending a C++ interop type as a member (for example,
+    `class MyCarbonClass { extend base: Cpp.Widget; }`).
 
 This "pervasive" model of C++-awareness is a fundamental design choice. The C++
 semantics are not confined to a specific `unsafe` or `extern "C++"` block; they

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Philosophy and goals](#philosophy-and-goals)
 -   [Overview](#overview)
 -   [C++ interoperability model: introduction and principles](#c-interoperability-model-introduction-and-principles)
-    -   [The "successor language" mandate](#the-successor-language-mandate)
+    -   [The successor language mandate](#the-successor-language-mandate)
     -   [The C++ interop type](#the-c-interop-type)
 -   [Importing C++ APIs into Carbon](#importing-c-apis-into-carbon)
     -   [Importing C++ libraries (header-based)](#importing-c-libraries-header-based)
@@ -70,18 +70,18 @@ allocations or copies when calling between the two languages.
 
 ## C++ interoperability model: introduction and principles
 
-### The "successor language" mandate
+### The successor language mandate
 
 The design of Carbon's C++ interoperability is governed by its foundational
 goal: [to be a successor language](/README.md), not merely a language with a
 foreign function interface (FFI). This mandate dictates a design that moves
 beyond the C-style FFI adopted by most modern languages and instead provides
-"seamless, bidirectional interoperability". The objective is to support deep
-integration with existing C++ code, encompassing its most complex features,
-"from inheritance to templates".
+seamless, bidirectional interoperability. The objective is to support deep
+integration with existing C++ code, encompassing its most complex features, from
+inheritance to templates.
 
 This goal has profound implications for the Carbon compiler and language
-semantics. It requires that C++ is not treated as a "foreign" entity. Instead,
+semantics. It requires that C++ is not treated as a foreign entity. Instead,
 Carbon's semantic model must be _co-designed_ to understand, map, and interact
 with C++'s semantic constructs—including templates, class hierarchies, and
 complex overload resolution—with high fidelity. The interoperability layer must,
@@ -115,8 +115,8 @@ system must be aware that the `Cpp.Widget` parameter carries C++-specific rules.
 This mandates that Carbon's own generic system, struct layout logic, overload
 resolution and operator lookup must query the type system for the presence of a
 C++ interop type. If present, Carbon must consider C++ rules when operating over
-C++ interop types. This design prioritizes the goal of a "seamless" and
-"intuitive" user experience.
+C++ interop types. This design prioritizes the goal of a seamless and intuitive
+user experience.
 
 ## Importing C++ APIs into Carbon
 

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -127,9 +127,9 @@ header file inclusion. Carbon must be able to parse and analyze C++ header files
 to make their declarations available within Carbon.
 
 **Syntax:** The syntax for this operation is `import Cpp library "header_name"`.
-This syntax is used for both C-style standard libraries and C++ headers:
+This syntax is used for both standard library headers and user-defined headers:
 
--   **C Standard Library:**
+-   **Standard Library:**
 
     ```carbon
     import Cpp library "<cstdio>";

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -104,7 +104,7 @@ C++ type in any of the following ways:
 2.  A pointer to a C++ interop type (for example, `Cpp.Widget*`).
 3.  A Carbon generic type parameterized with a C++ interop type (for example,
     `MyCarbonVector(Cpp.Widget)`).
-4.  A Carbon class extending a C++ interop type as a member (for example,
+4.  A Carbon class extending a C++ interop type (for example,
     `class MyCarbonClass { extend base: Cpp.Widget; }`).
 
 This "pervasive" model of C++-awareness is a fundamental design choice. The C++

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -104,8 +104,10 @@ C++ type in any of the following ways:
 2.  A pointer to a C++ interop type (for example, `Cpp.Widget*`).
 3.  A Carbon generic type parameterized with a C++ interop type (for example,
     `MyCarbonVector(Cpp.Widget)`).
-4.  A Carbon class extending a C++ interop type (for example,
-    `class MyCarbonClass { extend base: Cpp.Widget; }`).
+
+More generally, a C++ interop type is any type for which Carbon's
+[orphan rule](https://docs.carbon-lang.dev/docs/design/generics/details.html#orphan-rule) 
+would allow an impl to be provided by a library in `package Cpp`.
 
 This "pervasive" model of C++-awareness is a fundamental design choice. The C++
 semantics are not confined to a specific `unsafe` or `extern "C++"` block; they

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -95,7 +95,7 @@ the "trigger" that activates C++-specific semantic rules within the Carbon
 compiler. Any operation involving a type that is designated as a C++ interop
 type could invoke the specialized interoperability logic, such as C++ overload
 resolution or operator overload resolution that involves both Carbon and C++
-operator overloads..
+operator overloads.
 
 A type is considered a C++ interop type if its definition involves an imported
 C++ type in any of the following ways:

--- a/proposals/p6358.md
+++ b/proposals/p6358.md
@@ -122,7 +122,6 @@ interoperability tasks as smooth as possible.
 
 ## Rationale
 
-01234567890123456789012345678901234567890123456789012345678901234567890123456789
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
     -   **Explicitness and Clarity:** The `import Cpp library "..."` directives
         make all dependencies on C++ headers.

--- a/proposals/p6358.md
+++ b/proposals/p6358.md
@@ -28,11 +28,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Abstract
 
 This proposal defines the concrete technical mechanisms for C++
-interoperability. It builds on the high-level directional agreement of #6254
-("Calling C++ Functions") by specifying the precise syntax and semantics for
-importing C++ APIs. This includes the `import Cpp library "..."` and implicitly
-importing C++ built-in entities, and the establishment of the `Cpp` package as
-the dedicated namespace for all imported entities.
+interoperability. It specifies the precise syntax and semantics for importing
+C++ APIs. This includes the `import Cpp library "..."` and implicitly importing
+C++ built-in entities, and the establishment of the `Cpp` package as the
+dedicated namespace for all imported entities.
 
 ## Problem
 
@@ -48,8 +47,7 @@ One of Carbon's primary goals is to be a successor language. This strategy is
 entirely dependent on seamless, bidirectional interoperability with C++ to
 enable large-scale adoption and migration for existing C++ codebases.
 
-Proposal #6254 describes how C++ function should be called. This proposal
-provides the necessary details on how C++ APIs should be imported.
+This proposal provides the necessary details on how C++ APIs should be imported.
 
 ## Proposal
 

--- a/proposals/p6358.md
+++ b/proposals/p6358.md
@@ -122,11 +122,15 @@ interoperability tasks as smooth as possible.
 
 ## Rationale
 
--   **Explicitness and Clarity:** The `import Cpp library "..."` directives make
-    all dependencies on C++ headers.
--   **Preventing Name Collisions:** The `Cpp` package is a critical design
-    element. It provides a clean, unambiguous namespace for all imported C++
-    code.
+01234567890123456789012345678901234567890123456789012345678901234567890123456789
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+    -   **Explicitness and Clarity:** The `import Cpp library "..."` directives
+        make all dependencies on C++ headers.
+    -   **Preventing Name Collisions:** The `Cpp` package is a critical design
+        element. It provides a clean, unambiguous namespace for all imported C++
+        code.
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+    -   This proposal defines a foundation for seamless C++ interoperability.
 
 ## Alternatives considered
 

--- a/proposals/p6358.md
+++ b/proposals/p6358.md
@@ -17,6 +17,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Background](#background)
 -   [Proposal](#proposal)
 -   [Details](#details)
+    -   [The `Cpp` package and namespace mapping](#the-cpp-package-and-namespace-mapping)
+    -   [`import Cpp library` directive](#import-cpp-library-directive)
+    -   [C++ built-in types](#c-built-in-types)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
 
@@ -24,47 +27,113 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+This proposal defines the concrete technical mechanisms for C++
+interoperability. It builds on the high-level directional agreement of #6254
+("Calling C++ Functions") by specifying the precise syntax and semantics for
+importing C++ APIs. This includes the `import Cpp library "..."` and implicitly
+importing C++ built-in entities, and the establishment of the `Cpp` package as
+the dedicated namespace for all imported entities.
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+While Carbon has a stated goal of seamless C++ interoperability, and a
+high-level direction has been agreed upon, there is currently no concrete,
+specified mechanism for developers to actually import and use C++ APIs. This
+proposal aims to address that by defining the specific syntax and semantics for
+C++ interoperability.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+One of Carbon's primary goals is to be a successor language. This strategy is
+entirely dependent on seamless, bidirectional interoperability with C++ to
+enable large-scale adoption and migration for existing C++ codebases.
+
+Proposal #6254 describes how C++ function should be called. This proposal
+provides the necessary details on how C++ APIs should be imported.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+We propose to formalize the following specific design elements for C++
+interoperability:
+
+1.  **The `Cpp` Package:** All imported C++ entities, whether from built-ins or
+    library headers (see below), will be nested within a dedicated `Cpp`
+    package. This prevents name collisions with Carbon code and makes the
+    language boundary explicit.
+
+    ```carbon
+    fn UseCppTypes() {
+      // Access C++ types and functions by way of the Cpp package
+      var circle: Cpp.Circle = Cpp.GenerateCircle();
+      Cpp.PrintCircle(circle);
+    }
+    ```
+
+2.  **Importing C++ Header-Defined APIs:** To import C++ APIs from a specific
+    library header file (for example, `<vector>` or `"my_library.h"`), Carbon
+    code will use the `import Cpp library "..."` directive.
+
+    ```carbon
+    import Cpp library "<vector>";
+    import Cpp library "circle.h";
+    ```
+
+3.  **Importing C++ Built-in Entities:** To access fundamental C++ types (such
+    as `int`, `bool`, etc.), no explicit importing is needed and writing
+    `Cpp.int` and `Cpp.bool` would just work.
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+### The `Cpp` package and namespace mapping
+
+All C++ declarations will be imported into the `Cpp` package. C++ namespaces
+will be mapped to nested packages within `Cpp`. For example, a C++ function
+`std::string::find` would be accessible in Carbon as `Cpp.std.string.find`. The
+C++ global namespace will be mapped to the `Cpp` package itself. So a function
+`MyGlobalFunction` in the C++ global namespace will be `Cpp.MyGlobalFunction` in
+Carbon.
+
+### `import Cpp library` directive
+
+The `import Cpp library "..."` directive will instruct the Carbon compiler to
+parse the specified C++ header file. The compiler will use the standard C++
+include paths to locate the header. Additional paths can be provided through
+compiler flags.
+
+The Carbon compiler will leverage a C++ front-end, like Clang, to parse the
+headers. This ensures a high degree of compatibility with existing C++ code.
+Only the declarations from the header will be imported, not the definitions
+(unless they are inline).
+
+### C++ built-in types
+
+A set of fundamental C++ types will be available within the `Cpp` package
+without any explicit `import` directive. Mapping examples:
+
+| C++ Type       | Carbon Type        |
+| -------------- | ------------------ |
+| `int`          | `Cpp.int`          |
+| `unsigned int` | `Cpp.unsigned_int` |
+| `double`       | `Cpp.double`       |
+| `float`        | `Cpp.float`        |
+| `bool`         | `Cpp.bool`         |
+| `char`         | `Cpp.char`         |
+
+This automatic availability of built-in types is designed to make basic
+interoperability tasks as smooth as possible.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+-   **Explicitness and Clarity:** The `import Cpp library "..."` directives make
+    all dependencies on C++ headers.
+-   **Preventing Name Collisions:** The `Cpp` package is a critical design
+    element. It provides a clean, unambiguous namespace for all imported C++
+    code.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+-   **Alternative: Explicitly importing built-ins:** We considered making C++
+    built-in types (like `int`) require some `import Cpp` directive like
+    `import Cpp;`.
+    -   **Reason for Rejection:** Since `Cpp` is a special package, it should be
+        implicitly imported, similar to Carbon's prelude.

--- a/proposals/p6358.md
+++ b/proposals/p6358.md
@@ -1,0 +1,70 @@
+# C++ Interop: API importing and semantics
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/6358)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?


### PR DESCRIPTION
This proposal defines the concrete technical mechanisms for C++
interoperability. It specifies the precise syntax and semantics for importing
C++ APIs. This includes the `import Cpp library "..."` and implicitly importing
C++ built-in entities, and the establishment of the `Cpp` package as the
dedicated namespace for all imported entities.

This PR also includes high level language C++ Interop design and the basics of importing C++ APIs and function calling.
Leaving plenty of TODOs to make it easier to fill in more details in followups.

Part of #4666.
