### PR TITLE
C++ Interop: Don't crash when trying to call a C++ function with undeduced return type

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -1575,6 +1575,9 @@ static auto GetReturnPattern(Context& context, SemIR::LocId loc_id,
     // void.
     return SemIR::InstId::None;
   }
+  if (type_inst_id == SemIR::ErrorInst::TypeInstId) {
+    return SemIR::ErrorInst::InstId;
+  }
   auto pattern_type_id = GetPatternType(context, type_id);
   clang::SourceLocation return_type_loc =
       clang_decl->getReturnTypeSourceRange().getBegin();

--- a/toolchain/check/testdata/interop/cpp/function/return.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/return.carbon
@@ -35,6 +35,26 @@ fn F() {
   //@dump-sem-ir-end
 }
 
+// ============================================================================
+// Undeduced return type
+// ============================================================================
+
+// --- fail_return_undeduced_auto.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+auto UndeducedReturn();
+''';
+
+fn Call() {
+  // CHECK:STDERR: fail_return_undeduced_auto.carbon:[[@LINE+4]]:3: error: semantics TODO: `Unsupported: return type: auto` [SemanticsTodo]
+  // CHECK:STDERR:   Cpp.UndeducedReturn();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  Cpp.UndeducedReturn();
+}
+
 // CHECK:STDOUT: --- import_multiple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {


### PR DESCRIPTION
This crashed on trying to build a C++ thunk because the error wasn't propagated.

Part of #5436.