### PR TITLE
Import named constraints in a FacetType

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -966,6 +966,60 @@ static auto GetLocalSpecificInterface(
   }
 }
 
+namespace {
+struct SpecificNamedConstraintData {
+  SemIR::ConstantId constraint_const_id;
+  SpecificData specific_data;
+};
+}  // namespace
+
+static auto GetLocalSpecificNamedConstraintData(
+    ImportRefResolver& resolver,
+    SemIR::SpecificNamedConstraint import_constraint)
+    -> SpecificNamedConstraintData {
+  SemIR::ConstantId constraint_const_id = SemIR::ConstantId::None;
+  if (import_constraint.named_constraint_id.has_value()) {
+    constraint_const_id = GetLocalConstantId(
+        resolver, resolver.import_named_constraints()
+                      .Get(import_constraint.named_constraint_id)
+                      .first_owning_decl_id);
+  }
+  return {.constraint_const_id = constraint_const_id,
+          .specific_data =
+              GetLocalSpecificData(resolver, import_constraint.specific_id)};
+}
+
+static auto GetLocalSpecificNamedConstraint(
+    ImportContext& context,
+    SemIR::SpecificNamedConstraint import_specific_constraint,
+    SpecificNamedConstraintData constraint_data)
+    -> SemIR::SpecificNamedConstraint {
+  if (!constraint_data.constraint_const_id.has_value()) {
+    return SemIR::SpecificNamedConstraint::None;
+  }
+  // Find the corresponding named constraint type. For a non-generic constraint,
+  // this is the type of the named constraint declaration. For a generic
+  // constraint, build a named constraint type referencing this specialization
+  // of the generic named constraint.
+  auto constraint_const_inst =
+      context.local_insts().Get(context.local_constant_values().GetInstId(
+          constraint_data.constraint_const_id));
+  if (auto facet_type = constraint_const_inst.TryAs<SemIR::FacetType>()) {
+    const SemIR::FacetTypeInfo& new_facet_type_info =
+        context.local_facet_types().Get(facet_type->facet_type_id);
+    return std::get<SemIR::SpecificNamedConstraint>(
+        *new_facet_type_info.TryAsSingleExtend());
+  } else {
+    auto generic_constraint_type =
+        context.local_types().GetAs<SemIR::GenericNamedConstraintType>(
+            constraint_const_inst.type_id());
+    auto specific_id =
+        GetOrAddLocalSpecific(context, import_specific_constraint.specific_id,
+                              constraint_data.specific_data);
+    return {generic_constraint_type.named_constraint_id, specific_id};
+  }
+}
+
 static auto GetLocalNameScopeIdImpl(ImportRefResolver& resolver,
                                     SemIR::ConstantId const_id)
     -> SemIR::NameScopeId {
@@ -2776,6 +2830,16 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     // allocations.
     GetLocalSpecificInterfaceData(resolver, interface);
   }
+  for (auto constraint : import_facet_type_info.extend_named_constraints) {
+    // We discard this here and recompute it below instead of saving it to avoid
+    // allocations.
+    GetLocalSpecificNamedConstraintData(resolver, constraint);
+  }
+  for (auto constraint : import_facet_type_info.self_impls_named_constraints) {
+    // We discard this here and recompute it below instead of saving it to avoid
+    // allocations.
+    GetLocalSpecificNamedConstraintData(resolver, constraint);
+  }
   for (auto rewrite : import_facet_type_info.rewrite_constraints) {
     GetLocalConstantInstId(resolver, rewrite.lhs_id);
     GetLocalConstantInstId(resolver, rewrite.rhs_id);
@@ -2787,6 +2851,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   SemIR::FacetTypeInfo local_facet_type_info = {
       .builtin_constraint_mask = import_facet_type_info.builtin_constraint_mask,
+      // TODO: Also process the other requirements.
       .other_requirements = import_facet_type_info.other_requirements};
   local_facet_type_info.extend_constraints.reserve(
       import_facet_type_info.extend_constraints.size());
@@ -2802,6 +2867,20 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     local_facet_type_info.self_impls_constraints.push_back(
         GetLocalSpecificInterface(resolver, interface, data));
   }
+  local_facet_type_info.extend_named_constraints.reserve(
+      import_facet_type_info.extend_named_constraints.size());
+  for (auto constraint : import_facet_type_info.extend_named_constraints) {
+    auto data = GetLocalSpecificNamedConstraintData(resolver, constraint);
+    local_facet_type_info.extend_named_constraints.push_back(
+        GetLocalSpecificNamedConstraint(resolver, constraint, data));
+  }
+  local_facet_type_info.self_impls_named_constraints.reserve(
+      import_facet_type_info.self_impls_named_constraints.size());
+  for (auto constraint : import_facet_type_info.self_impls_named_constraints) {
+    auto data = GetLocalSpecificNamedConstraintData(resolver, constraint);
+    local_facet_type_info.self_impls_named_constraints.push_back(
+        GetLocalSpecificNamedConstraint(resolver, constraint, data));
+  }
   local_facet_type_info.rewrite_constraints.reserve(
       import_facet_type_info.rewrite_constraints.size());
   for (auto rewrite : import_facet_type_info.rewrite_constraints) {
@@ -2809,7 +2888,6 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
         {.lhs_id = GetLocalConstantInstId(resolver, rewrite.lhs_id),
          .rhs_id = GetLocalConstantInstId(resolver, rewrite.rhs_id)});
   }
-  // TODO: Also process the other requirements.
   SemIR::FacetTypeId facet_type_id =
       resolver.local_facet_types().Add(std::move(local_facet_type_info));
   return ResolveResult::Deduplicated<SemIR::FacetType>(

--- a/toolchain/check/testdata/facet/require_import.carbon
+++ b/toolchain/check/testdata/facet/require_import.carbon
@@ -35,7 +35,7 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %X.type: type = facet_type <@X> [concrete]
-// CHECK:STDOUT:   %Self.861: %type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %Self.861: %X.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type.1a1: type = symbolic_binding_type Self, 0, %Self.861 [symbolic]
 // CHECK:STDOUT:   %A: %X.type = symbolic_binding A, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type.e25: type = pattern_type %X.type [concrete]
@@ -54,7 +54,7 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:   %Main.X: type = import_ref Main//a, X, loaded [concrete = constants.%X.type]
 // CHECK:STDOUT:   %Main.import_ref.462 = import_ref Main//a, loc3_13, unloaded
 // CHECK:STDOUT:   %Main.import_ref.b7c: type = import_ref Main//a, loc10_18, loaded [symbolic = constants.%Self.binding.as_type.1a1]
-// CHECK:STDOUT:   %Main.import_ref.dec: %type = import_ref Main//a, loc9_14, loaded [symbolic = constants.%Self.861]
+// CHECK:STDOUT:   %Main.import_ref.dec: %X.type = import_ref Main//a, loc9_14, loaded [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Main.import_ref.cae = import_ref Main//a, loc9_14, unloaded
 // CHECK:STDOUT:   %Main.import_ref.3e6: type = import_ref Main//a, loc6_11, loaded [symbolic = constants.%Self.binding.as_type.384]
 // CHECK:STDOUT:   %Main.import_ref.35b: %Y.type = import_ref Main//a, loc5_13, loaded [symbolic = constants.%Self.29b]
@@ -116,8 +116,8 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic require @X.require0(imports.%Main.import_ref.dec: %type) [from "a.carbon"] {
-// CHECK:STDOUT:   %Self: %type = symbolic_binding Self, 0 [symbolic = %Self (constants.%Self.861)]
+// CHECK:STDOUT: generic require @X.require0(imports.%Main.import_ref.dec: %X.type) [from "a.carbon"] {
+// CHECK:STDOUT:   %Self: %X.type = symbolic_binding Self, 0 [symbolic = %Self (constants.%Self.861)]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type.1a1)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+++ b/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
@@ -92,7 +92,7 @@ impl C as B {}
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %B.type: type = facet_type <@B> [concrete]
-// CHECK:STDOUT:   %Self.861: %type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %Self.861: %B.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.861 [symbolic]
 // CHECK:STDOUT:   %T: %B.type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %B.type [concrete]
@@ -105,7 +105,7 @@ impl C as B {}
 // CHECK:STDOUT:   %Main.B: type = import_ref Main//b, B, loaded [concrete = constants.%B.type]
 // CHECK:STDOUT:   %Main.import_ref.8df = import_ref Main//b, loc3_13, unloaded
 // CHECK:STDOUT:   %Main.import_ref.b7c: type = import_ref Main//b, loc5_18, loaded [symbolic = constants.%Self.binding.as_type]
-// CHECK:STDOUT:   %Main.import_ref.dec: %type = import_ref Main//b, loc4_14, loaded [symbolic = constants.%Self.861]
+// CHECK:STDOUT:   %Main.import_ref.dec: %B.type = import_ref Main//b, loc4_14, loaded [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Main.import_ref.cae = import_ref Main//b, loc4_14, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -146,8 +146,8 @@ impl C as B {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic require @B.require0(imports.%Main.import_ref.dec: %type) [from "b.carbon"] {
-// CHECK:STDOUT:   %Self: %type = symbolic_binding Self, 0 [symbolic = %Self (constants.%Self.861)]
+// CHECK:STDOUT: generic require @B.require0(imports.%Main.import_ref.dec: %B.type) [from "b.carbon"] {
+// CHECK:STDOUT:   %Self: %B.type = symbolic_binding Self, 0 [symbolic = %Self (constants.%Self.861)]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
When importing a FacetType instruction, and the FacetTypeInfo, import requirements on named constraints.