### PR TITLE
Import generic named constraints

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -852,6 +852,11 @@ static auto GetLocalGenericId(ImportContext& context,
           .Get(interface_type.interface_id)
           .generic_id;
     }
+    case CARBON_KIND(SemIR::GenericNamedConstraintType constraint_type): {
+      return context.local_named_constraints()
+          .Get(constraint_type.named_constraint_id)
+          .generic_id;
+    }
     case CARBON_KIND(SemIR::ImplDecl impl_decl): {
       return context.local_impls().Get(impl_decl.impl_id).generic_id;
     }
@@ -1069,6 +1074,11 @@ static auto GetLocalNameScopeIdImpl(ImportRefResolver& resolver,
         }
         case CARBON_KIND(SemIR::GenericInterfaceType inst): {
           return resolver.local_interfaces().Get(inst.interface_id).scope_id;
+        }
+        case CARBON_KIND(SemIR::GenericNamedConstraintType inst): {
+          return resolver.local_named_constraints()
+              .Get(inst.named_constraint_id)
+              .scope_id;
         }
         default: {
           break;
@@ -2288,6 +2298,24 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver.local_types().GetConstantId(interface_val.type_id()));
 }
 
+static auto TryResolveTypedInst(ImportRefResolver& resolver,
+                                SemIR::GenericNamedConstraintType inst)
+    -> ResolveResult {
+  CARBON_CHECK(inst.type_id == SemIR::TypeType::TypeId);
+  auto constraint_val_id =
+      GetLocalConstantInstId(resolver, resolver.import_named_constraints()
+                                           .Get(inst.named_constraint_id)
+                                           .first_owning_decl_id);
+  if (resolver.HasNewWork()) {
+    return ResolveResult::Retry();
+  }
+  auto constraint_val = resolver.local_insts().Get(constraint_val_id);
+  CARBON_CHECK(resolver.local_types().Is<SemIR::GenericNamedConstraintType>(
+      constraint_val.type_id()));
+  return ResolveResult::Done(
+      resolver.local_types().GetConstantId(constraint_val.type_id()));
+}
+
 // Make a declaration of an impl. This is done as a separate step from
 // importing the impl definition in order to resolve cycles.
 static auto MakeImplDeclaration(ImportContext& context,
@@ -2791,7 +2819,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
           resolver, import_named_constraint.require_impls_block_id,
           require_impls);
   SetGenericData(resolver, import_named_constraint.generic_id,
-                 import_named_constraint.generic_id, generic_data);
+                 new_named_constraint.generic_id, generic_data);
 
   if (import_named_constraint.is_complete()) {
     CARBON_CHECK(self_param_id);
@@ -3539,6 +3567,9 @@ static auto TryResolveInstCanonical(ImportRefResolver& resolver,
       return TryResolveTypedInst(resolver, inst);
     }
     case CARBON_KIND(SemIR::GenericInterfaceType inst): {
+      return TryResolveTypedInst(resolver, inst);
+    }
+    case CARBON_KIND(SemIR::GenericNamedConstraintType inst): {
       return TryResolveTypedInst(resolver, inst);
     }
     case CARBON_KIND(SemIR::LookupImplWitness inst): {

--- a/toolchain/check/testdata/impl/impl_as_named_constraint.carbon
+++ b/toolchain/check/testdata/impl/impl_as_named_constraint.carbon
@@ -133,3 +133,18 @@ constraint C {
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR:
 impl () as C {}
+
+// --- todo_fail_duplicate_through_generic_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface A(T:! type) {}
+
+constraint B(X:! type, Y:! type) {
+  extend require impls A(Y);
+}
+
+// This should impl () as A({}).
+impl () as B((), {}) {}
+
+// This should be considered a duplicate.
+impl () as A({}) {}

--- a/toolchain/check/testdata/impl/import_generic.carbon
+++ b/toolchain/check/testdata/impl/import_generic.carbon
@@ -26,6 +26,10 @@ impl forall [T:! type] C as I(T) {}
 // Only has definition.
 impl forall [T:! type] C as I(T*) {}
 
+constraint N(T:! type) {
+  extend require impls I(T);
+}
+
 // --- fail_import_generic.impl.carbon
 
 impl library "[[@TEST_NAME]]";
@@ -54,12 +58,51 @@ impl forall [T:! type] C as I(T*);
 // CHECK:STDERR:
 impl forall [T:! type] C as I(T*) {}
 
+// TODO: These should be `error: redeclaration of imported impl`.
+// GetOrAddLookupBucket is putting the impl of a named constraint in the wrong
+// bucket.
+// CHECK:STDERR: fail_import_generic.impl.carbon:[[@LINE+4]]:1: error: impl declared but not defined [ImplMissingDefinition]
+// CHECK:STDERR: impl forall [T:! type] C as N(T);
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl forall [T:! type] C as N(T);
+// CHECK:STDERR: fail_import_generic.impl.carbon:[[@LINE+4]]:1: error: impl declared but not defined [ImplMissingDefinition]
+// CHECK:STDERR: impl forall [T:! type] C as N(T*);
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl forall [T:! type] C as N(T*);
+
+// --- import_generic_with_different_specific.carbon
+
+library "[[@TEST_NAME]]";
+
+class C {}
+interface I(T:! type) {}
+
+impl forall [T:! type] C as I(T) {}
+
+constraint N(T:! type) {
+  extend require impls I(T);
+}
+
+// --- import_generic_with_different_specific.impl.carbon
+impl library "[[@TEST_NAME]]";
+
+// These have different specifics than any impl decl in the api file, so they
+// are allowed.
+impl forall [T:! type] C as I(T*) {}
+impl forall [T:! type] C as N(T**) {}
+
 // --- fail_import_generic_decl.carbon
 
 library "[[@TEST_NAME]]";
 
 class D {}
 interface J(T:! type) {}
+
+constraint N(T:! type) {
+  extend require impls J(T);
+}
 
 // CHECK:STDERR: fail_import_generic_decl.carbon:[[@LINE+4]]:1: error: impl declared but not defined [ImplMissingDefinition]
 // CHECK:STDERR: impl forall [T:! type] D as J(T);
@@ -101,6 +144,19 @@ impl forall [T:! type] D as J(T*);
 // CHECK:STDERR:
 impl forall [T:! type] D as J(T*) {}
 
+// TODO: This should be `error: redeclaration of imported impl`.
+impl forall [T:! type] D as N(T) {}
+
+// TODO: This should be `error: redeclaration of imported impl`.
+// CHECK:STDERR: fail_import_generic_decl.impl.carbon:[[@LINE+7]]:1: error: found non-final `impl` with the same type structure as another non-final `impl` [ImplNonFinalSameTypeStructure]
+// CHECK:STDERR: impl forall [T:! type] D as N(T*) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_import_generic_decl.impl.carbon:[[@LINE-6]]:1: note: other `impl` here [ImplNonFinalSameTypeStructureNote]
+// CHECK:STDERR: impl forall [T:! type] D as N(T) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl forall [T:! type] D as N(T*) {}
+
 // CHECK:STDOUT: --- import_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -122,12 +178,18 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %Self.6d0: %I.type.229 = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %require_complete.555: <witness> = require_complete_type %I.type.229 [symbolic]
 // CHECK:STDOUT:   %I.impl_witness.a0f: <witness> = impl_witness file.%I.impl_witness_table.loc12, @C.as.I.impl.1fd(%T) [symbolic]
+// CHECK:STDOUT:   %N.type.673: type = generic_named_constaint_type @N [concrete]
+// CHECK:STDOUT:   %empty_struct: %N.type.673 = struct_value () [concrete]
+// CHECK:STDOUT:   %N.type.b8d: type = facet_type <@N, @N(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.aa1: %N.type.b8d = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.aa1 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .N = %N.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [concrete = constants.%I.generic] {
@@ -171,6 +233,12 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.impl_witness_table.loc12 = impl_witness_table (), @C.as.I.impl.1fd [concrete]
 // CHECK:STDOUT:   %I.impl_witness.loc12: <witness> = impl_witness %I.impl_witness_table.loc12, @C.as.I.impl.1fd(constants.%T) [symbolic = @C.as.I.impl.1fd.%I.impl_witness (constants.%I.impl_witness.a0f)]
+// CHECK:STDOUT:   %N.decl: %N.type.673 = constraint_decl @N [concrete = constants.%empty_struct] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc14_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc14_14.1 (constants.%T)]
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic interface @I(%T.loc5_13.2: type) {
@@ -189,6 +257,44 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic constraint @N(%T.loc14_14.2: type) {
+// CHECK:STDOUT:   %T.loc14_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc14_14.1 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T.loc14_14.1)> [symbolic = %N.type (constants.%N.type.b8d)]
+// CHECK:STDOUT:   %Self.loc14_24.2: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc14_24.2 (constants.%Self.aa1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   constraint {
+// CHECK:STDOUT:     %Self.loc14_24.1: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc14_24.2 (constants.%Self.aa1)]
+// CHECK:STDOUT:     %N.require0.decl = require_decl @N.require0 [concrete] {
+// CHECK:STDOUT:       require %Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %Self.as_type: type = facet_access_type @N.%Self.loc14_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:       %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @N.%T.loc14_14.2 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %I.type.loc15_27.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc15_27.2 (constants.%I.type.070)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.loc14_24.1
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:     .T = <poisoned>
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:     @N.require0 {
+// CHECK:STDOUT:       require @N.require0.%Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic require @N.require0(@N.%T.loc14_14.2: type, @N.%Self.loc14_24.1: @N.%N.type (%N.type.b8d)) {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d)]
+// CHECK:STDOUT:   %Self: @N.require0.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %I.type.loc15_27.2: type = facet_type <@I, @I(%T)> [symbolic = %I.type.loc15_27.2 (constants.%I.type.070)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic impl @C.as.I.impl.f3e(%T.loc8_14.1: type) {
@@ -258,6 +364,18 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness.a0f
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%T) {
+// CHECK:STDOUT:   %T.loc14_14.1 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N.require0(constants.%T, constants.%Self.aa1) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %N.type => constants.%N.type.b8d
+// CHECK:STDOUT:   %Self => constants.%Self.aa1
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
+// CHECK:STDOUT:   %I.type.loc15_27.2 => constants.%I.type.070
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_generic.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -279,11 +397,20 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %Self.6d0: %I.type.229 = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %N.type.673: type = generic_named_constaint_type @N [concrete]
+// CHECK:STDOUT:   %empty_struct: %N.type.673 = struct_value () [concrete]
+// CHECK:STDOUT:   %N.type.b8d23b.1: type = facet_type <@N, @N(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.aa1: %N.type.b8d23b.1 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.aa1 [symbolic]
+// CHECK:STDOUT:   %I.impl_witness.524962.1: <witness> = impl_witness file.%I.impl_witness_table.loc35, @C.as.I.impl.3f8440.1(%T) [symbolic]
+// CHECK:STDOUT:   %N.type.b8d23b.2: type = facet_type <@N, @N(%ptr)> [symbolic]
+// CHECK:STDOUT:   %I.impl_witness.524962.2: <witness> = impl_witness file.%I.impl_witness_table.loc40, @C.as.I.impl.3f8440.2(%T) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Main.C: type = import_ref Main//import_generic, C, loaded [concrete = constants.%C]
 // CHECK:STDOUT:   %Main.I: %I.type.dac = import_ref Main//import_generic, I, loaded [concrete = constants.%I.generic]
+// CHECK:STDOUT:   %Main.N: %N.type.673 = import_ref Main//import_generic, N, loaded [concrete = constants.%empty_struct]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.1: type = import_ref Main//import_generic, loc5_13, loaded [symbolic = @I.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.769 = import_ref Main//import_generic, loc5_23, unloaded
 // CHECK:STDOUT:   %Main.import_ref.e46 = import_ref Main//import_generic, loc8_33, unloaded
@@ -291,19 +418,25 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %Main.import_ref.2c4 = import_ref Main//import_generic, inst{{[0-9A-F]+}} [no loc], unloaded
 // CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//import_generic, loc8_14, loaded [symbolic = @C.as.I.impl.f3ed6b.1.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.29aca8.1: type = import_ref Main//import_generic, loc8_24, loaded [concrete = constants.%C]
-// CHECK:STDOUT:   %Main.import_ref.464: type = import_ref Main//import_generic, loc8_32, loaded [symbolic = @C.as.I.impl.f3ed6b.1.%I.type (constants.%I.type.070)]
+// CHECK:STDOUT:   %Main.import_ref.46444d.1: type = import_ref Main//import_generic, loc8_32, loaded [symbolic = @C.as.I.impl.f3ed6b.1.%I.type (constants.%I.type.070)]
 // CHECK:STDOUT:   %I.impl_witness_table.478 = impl_witness_table (), @C.as.I.impl.f3ed6b.1 [concrete]
 // CHECK:STDOUT:   %Main.import_ref.4f8 = import_ref Main//import_generic, loc12_35, unloaded
 // CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic, loc12_14, loaded [symbolic = @C.as.I.impl.1fddff.1.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.29aca8.2: type = import_ref Main//import_generic, loc12_24, loaded [concrete = constants.%C]
 // CHECK:STDOUT:   %Main.import_ref.7b6: type = import_ref Main//import_generic, loc12_33, loaded [symbolic = @C.as.I.impl.1fddff.1.%I.type (constants.%I.type.229)]
 // CHECK:STDOUT:   %I.impl_witness_table.af9 = impl_witness_table (), @C.as.I.impl.1fddff.1 [concrete]
+// CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//import_generic, loc15_18, loaded [symbolic = constants.%Self.binding.as_type]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.4: type = import_ref Main//import_generic, loc14_14, loaded [symbolic = @N.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1) = import_ref Main//import_generic, loc14_24, loaded [symbolic = @N.%Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.5: type = import_ref Main//import_generic, loc14_14, loaded [symbolic = @N.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//import_generic, loc14_24, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .C = imports.%Main.C
 // CHECK:STDOUT:     .I = imports.%Main.I
+// CHECK:STDOUT:     .N = imports.%Main.N
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %default.import.loc2_30.1 = import <none>
 // CHECK:STDOUT:   %default.import.loc2_30.2 = import <none>
@@ -349,6 +482,31 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %T.loc26_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc26_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   impl_decl @C.as.I.impl.3f8440.1 [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
+// CHECK:STDOUT:     %N.ref: %N.type.673 = name_ref N, imports.%Main.N [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc35_14.1 [symbolic = %T.loc35_14.2 (constants.%T)]
+// CHECK:STDOUT:     %N.type.loc35_32.1: type = facet_type <@N, @N(constants.%T)> [symbolic = %N.type.loc35_32.2 (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc35_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc35_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.impl_witness_table.loc35 = impl_witness_table (), @C.as.I.impl.3f8440.1 [concrete]
+// CHECK:STDOUT:   %I.impl_witness.loc35: <witness> = impl_witness %I.impl_witness_table.loc35, @C.as.I.impl.3f8440.1(constants.%T) [symbolic = @C.as.I.impl.3f8440.1.%I.impl_witness (constants.%I.impl_witness.524962.1)]
+// CHECK:STDOUT:   impl_decl @C.as.I.impl.3f8440.2 [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
+// CHECK:STDOUT:     %N.ref: %N.type.673 = name_ref N, imports.%Main.N [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc40_14.1 [symbolic = %T.loc40_14.2 (constants.%T)]
+// CHECK:STDOUT:     %ptr.loc40_32.1: type = ptr_type %T.ref [symbolic = %ptr.loc40_32.2 (constants.%ptr)]
+// CHECK:STDOUT:     %N.type.loc40_33.1: type = facet_type <@N, @N(constants.%ptr)> [symbolic = %N.type.loc40_33.2 (constants.%N.type.b8d23b.2)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc40_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc40_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.impl_witness_table.loc40 = impl_witness_table (), @C.as.I.impl.3f8440.2 [concrete]
+// CHECK:STDOUT:   %I.impl_witness.loc40: <witness> = impl_witness %I.impl_witness_table.loc40, @C.as.I.impl.3f8440.2(constants.%T) [symbolic = @C.as.I.impl.3f8440.2.%I.impl_witness (constants.%I.impl_witness.524962.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic interface @I(imports.%Main.import_ref.efcd44.1: type) [from "import_generic.carbon"] {
@@ -367,6 +525,32 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: generic constraint @N(imports.%Main.import_ref.efcd44.5: type) [from "import_generic.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %Self: @N.%N.type (%N.type.b8d23b.1) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   constraint {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Main.import_ref.388
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:     @N.require0 {
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic require @N.require0(imports.%Main.import_ref.efcd44.4: type, imports.%Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1)) [from "import_generic.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %Self: @N.require0.%N.type (%N.type.b8d23b.1) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T)> [symbolic = %I.type (constants.%I.type.070)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: generic impl @C.as.I.impl.f3ed6b.1(imports.%Main.import_ref.efcd44.2: type) [from "import_generic.carbon"] {
 // CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T)> [symbolic = %I.type (constants.%I.type.070)]
@@ -375,7 +559,7 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type [symbolic = %require_complete (constants.%require_complete.c94)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: imports.%Main.import_ref.29aca8.1 as imports.%Main.import_ref.464 {
+// CHECK:STDOUT:   impl: imports.%Main.import_ref.29aca8.1 as imports.%Main.import_ref.46444d.1 {
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     witness = imports.%Main.import_ref.e46
 // CHECK:STDOUT:   }
@@ -434,6 +618,23 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     witness = <error>
 // CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @C.as.I.impl.3f8440.1(%T.loc35_14.1: type) {
+// CHECK:STDOUT:   %T.loc35_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc35_14.2 (constants.%T)]
+// CHECK:STDOUT:   %N.type.loc35_32.2: type = facet_type <@N, @N(%T.loc35_14.2)> [symbolic = %N.type.loc35_32.2 (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table.loc35, @C.as.I.impl.3f8440.1(%T.loc35_14.2) [symbolic = %I.impl_witness (constants.%I.impl_witness.524962.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %C.ref as %N.type.loc35_32.1;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @C.as.I.impl.3f8440.2(%T.loc40_14.1: type) {
+// CHECK:STDOUT:   %T.loc40_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc40_14.2 (constants.%T)]
+// CHECK:STDOUT:   %ptr.loc40_32.2: type = ptr_type %T.loc40_14.2 [symbolic = %ptr.loc40_32.2 (constants.%ptr)]
+// CHECK:STDOUT:   %N.type.loc40_33.2: type = facet_type <@N, @N(%ptr.loc40_32.2)> [symbolic = %N.type.loc40_33.2 (constants.%N.type.b8d23b.2)]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table.loc40, @C.as.I.impl.3f8440.2(%T.loc40_14.2) [symbolic = %I.impl_witness (constants.%I.impl_witness.524962.2)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %C.ref as %N.type.loc40_33.1;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C [from "import_generic.carbon"] {
@@ -495,6 +696,435 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %I.type.loc26_33.2 => constants.%I.type.229
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N.require0(constants.%T, constants.%Self.aa1) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %N.type => constants.%N.type.b8d23b.1
+// CHECK:STDOUT:   %Self => constants.%Self.aa1
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
+// CHECK:STDOUT:   %I.type => constants.%I.type.070
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C.as.I.impl.3f8440.1(constants.%T) {
+// CHECK:STDOUT:   %T.loc35_14.2 => constants.%T
+// CHECK:STDOUT:   %N.type.loc35_32.2 => constants.%N.type.b8d23b.1
+// CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness.524962.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%ptr) {
+// CHECK:STDOUT:   %T => constants.%ptr
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C.as.I.impl.3f8440.2(constants.%T) {
+// CHECK:STDOUT:   %T.loc40_14.2 => constants.%T
+// CHECK:STDOUT:   %ptr.loc40_32.2 => constants.%ptr
+// CHECK:STDOUT:   %N.type.loc40_33.2 => constants.%N.type.b8d23b.2
+// CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness.524962.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- import_generic_with_different_specific.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %I.type.dac: type = generic_interface_type @I [concrete]
+// CHECK:STDOUT:   %I.generic: %I.type.dac = struct_value () [concrete]
+// CHECK:STDOUT:   %I.type.070: type = facet_type <@I, @I(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.269: %I.type.070 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type.070 [symbolic]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table, @C.as.I.impl(%T) [symbolic]
+// CHECK:STDOUT:   %N.type.673: type = generic_named_constaint_type @N [concrete]
+// CHECK:STDOUT:   %empty_struct: %N.type.673 = struct_value () [concrete]
+// CHECK:STDOUT:   %N.type.b8d: type = facet_type <@N, @N(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.aa1: %N.type.b8d = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.aa1 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .N = %N.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
+// CHECK:STDOUT:   %I.decl: %I.type.dac = interface_decl @I [concrete = constants.%I.generic] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc5_13.2: type = symbolic_binding T, 0 [symbolic = %T.loc5_13.1 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   impl_decl @C.as.I.impl [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc7_14.1 [symbolic = %T.loc7_14.2 (constants.%T)]
+// CHECK:STDOUT:     %I.type.loc7_32.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc7_32.2 (constants.%I.type.070)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc7_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc7_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (), @C.as.I.impl [concrete]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table, @C.as.I.impl(constants.%T) [symbolic = @C.as.I.impl.%I.impl_witness (constants.%I.impl_witness)]
+// CHECK:STDOUT:   %N.decl: %N.type.673 = constraint_decl @N [concrete = constants.%empty_struct] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc9_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc9_14.1 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I(%T.loc5_13.2: type) {
+// CHECK:STDOUT:   %T.loc5_13.1: type = symbolic_binding T, 0 [symbolic = %T.loc5_13.1 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T.loc5_13.1)> [symbolic = %I.type (constants.%I.type.070)]
+// CHECK:STDOUT:   %Self.loc5_23.2: @I.%I.type (%I.type.070) = symbolic_binding Self, 1 [symbolic = %Self.loc5_23.2 (constants.%Self.269)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:     %Self.loc5_23.1: @I.%I.type (%I.type.070) = symbolic_binding Self, 1 [symbolic = %Self.loc5_23.2 (constants.%Self.269)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.loc5_23.1
+// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic constraint @N(%T.loc9_14.2: type) {
+// CHECK:STDOUT:   %T.loc9_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc9_14.1 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T.loc9_14.1)> [symbolic = %N.type (constants.%N.type.b8d)]
+// CHECK:STDOUT:   %Self.loc9_24.2: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc9_24.2 (constants.%Self.aa1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   constraint {
+// CHECK:STDOUT:     %Self.loc9_24.1: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc9_24.2 (constants.%Self.aa1)]
+// CHECK:STDOUT:     %N.require0.decl = require_decl @N.require0 [concrete] {
+// CHECK:STDOUT:       require %Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %Self.as_type: type = facet_access_type @N.%Self.loc9_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:       %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @N.%T.loc9_14.2 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %I.type.loc10_27.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc10_27.2 (constants.%I.type.070)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.loc9_24.1
+// CHECK:STDOUT:     .I = <poisoned>
+// CHECK:STDOUT:     .T = <poisoned>
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:     @N.require0 {
+// CHECK:STDOUT:       require @N.require0.%Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic require @N.require0(@N.%T.loc9_14.2: type, @N.%Self.loc9_24.1: @N.%N.type (%N.type.b8d)) {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d)]
+// CHECK:STDOUT:   %Self: @N.require0.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %I.type.loc10_27.2: type = facet_type <@I, @I(%T)> [symbolic = %I.type.loc10_27.2 (constants.%I.type.070)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @C.as.I.impl(%T.loc7_14.1: type) {
+// CHECK:STDOUT:   %T.loc7_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc7_14.2 (constants.%T)]
+// CHECK:STDOUT:   %I.type.loc7_32.2: type = facet_type <@I, @I(%T.loc7_14.2)> [symbolic = %I.type.loc7_32.2 (constants.%I.type.070)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type.loc7_32.2 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table, @C.as.I.impl(%T.loc7_14.2) [symbolic = %I.impl_witness (constants.%I.impl_witness)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %C.ref as %I.type.loc7_32.1 {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%I.impl_witness
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness constants.%empty_struct_type [concrete = constants.%complete_type]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I(constants.%T) {
+// CHECK:STDOUT:   %T.loc5_13.1 => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %I.type => constants.%I.type.070
+// CHECK:STDOUT:   %Self.loc5_23.2 => constants.%Self.269
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C.as.I.impl(constants.%T) {
+// CHECK:STDOUT:   %T.loc7_14.2 => constants.%T
+// CHECK:STDOUT:   %I.type.loc7_32.2 => constants.%I.type.070
+// CHECK:STDOUT:   %require_complete => constants.%require_complete
+// CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%T) {
+// CHECK:STDOUT:   %T.loc9_14.1 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N.require0(constants.%T, constants.%Self.aa1) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %N.type => constants.%N.type.b8d
+// CHECK:STDOUT:   %Self => constants.%Self.aa1
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
+// CHECK:STDOUT:   %I.type.loc10_27.2 => constants.%I.type.070
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- import_generic_with_different_specific.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %I.type.dac: type = generic_interface_type @I [concrete]
+// CHECK:STDOUT:   %I.generic: %I.type.dac = struct_value () [concrete]
+// CHECK:STDOUT:   %I.type.070: type = facet_type <@I, @I(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.269: %I.type.070 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %require_complete.c94: <witness> = require_complete_type %I.type.070 [symbolic]
+// CHECK:STDOUT:   %I.impl_witness.f13: <witness> = impl_witness imports.%I.impl_witness_table, @C.as.I.impl.f3e(%T) [symbolic]
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %ptr.4f0: type = ptr_type %T [symbolic]
+// CHECK:STDOUT:   %I.type.229: type = facet_type <@I, @I(%ptr.4f0)> [symbolic]
+// CHECK:STDOUT:   %Self.6d0: %I.type.229 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %require_complete.555: <witness> = require_complete_type %I.type.229 [symbolic]
+// CHECK:STDOUT:   %I.impl_witness.a0f: <witness> = impl_witness file.%I.impl_witness_table.loc5, @C.as.I.impl.1fd(%T) [symbolic]
+// CHECK:STDOUT:   %N.type.673: type = generic_named_constaint_type @N [concrete]
+// CHECK:STDOUT:   %empty_struct: %N.type.673 = struct_value () [concrete]
+// CHECK:STDOUT:   %N.type.b8d23b.1: type = facet_type <@N, @N(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.aa1: %N.type.b8d23b.1 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.aa1 [symbolic]
+// CHECK:STDOUT:   %ptr.3f2: type = ptr_type %ptr.4f0 [symbolic]
+// CHECK:STDOUT:   %N.type.b8d23b.2: type = facet_type <@N, @N(%ptr.3f2)> [symbolic]
+// CHECK:STDOUT:   %require_complete.a37: <witness> = require_complete_type %N.type.b8d23b.2 [symbolic]
+// CHECK:STDOUT:   %I.impl_witness.524: <witness> = impl_witness file.%I.impl_witness_table.loc6, @C.as.I.impl.3f8(%T) [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.C: type = import_ref Main//import_generic_with_different_specific, C, loaded [concrete = constants.%C]
+// CHECK:STDOUT:   %Main.I: %I.type.dac = import_ref Main//import_generic_with_different_specific, I, loaded [concrete = constants.%I.generic]
+// CHECK:STDOUT:   %Main.N: %N.type.673 = import_ref Main//import_generic_with_different_specific, N, loaded [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.1: type = import_ref Main//import_generic_with_different_specific, loc5_13, loaded [symbolic = @I.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.769 = import_ref Main//import_generic_with_different_specific, loc5_23, unloaded
+// CHECK:STDOUT:   %Main.import_ref.e46 = import_ref Main//import_generic_with_different_specific, loc7_34, unloaded
+// CHECK:STDOUT:   %Main.import_ref.8f2: <witness> = import_ref Main//import_generic_with_different_specific, loc4_10, loaded [concrete = constants.%complete_type]
+// CHECK:STDOUT:   %Main.import_ref.2c4 = import_ref Main//import_generic_with_different_specific, inst{{[0-9A-F]+}} [no loc], unloaded
+// CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//import_generic_with_different_specific, loc7_14, loaded [symbolic = @C.as.I.impl.f3e.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.29a: type = import_ref Main//import_generic_with_different_specific, loc7_24, loaded [concrete = constants.%C]
+// CHECK:STDOUT:   %Main.import_ref.46444d.1: type = import_ref Main//import_generic_with_different_specific, loc7_32, loaded [symbolic = @C.as.I.impl.f3e.%I.type (constants.%I.type.070)]
+// CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (), @C.as.I.impl.f3e [concrete]
+// CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//import_generic_with_different_specific, loc10_18, loaded [symbolic = constants.%Self.binding.as_type]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic_with_different_specific, loc9_14, loaded [symbolic = @N.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1) = import_ref Main//import_generic_with_different_specific, loc9_24, loaded [symbolic = @N.%Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.4: type = import_ref Main//import_generic_with_different_specific, loc9_14, loaded [symbolic = @N.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//import_generic_with_different_specific, loc9_24, unloaded
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .C = imports.%Main.C
+// CHECK:STDOUT:     .I = imports.%Main.I
+// CHECK:STDOUT:     .N = imports.%Main.N
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %default.import.loc1_54.1 = import <none>
+// CHECK:STDOUT:   %default.import.loc1_54.2 = import <none>
+// CHECK:STDOUT:   impl_decl @C.as.I.impl.1fd [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
+// CHECK:STDOUT:     %I.ref: %I.type.dac = name_ref I, imports.%Main.I [concrete = constants.%I.generic]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc5_14.1 [symbolic = %T.loc5_14.2 (constants.%T)]
+// CHECK:STDOUT:     %ptr.loc5_32.1: type = ptr_type %T.ref [symbolic = %ptr.loc5_32.2 (constants.%ptr.4f0)]
+// CHECK:STDOUT:     %I.type.loc5_33.1: type = facet_type <@I, @I(constants.%ptr.4f0)> [symbolic = %I.type.loc5_33.2 (constants.%I.type.229)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc5_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc5_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.impl_witness_table.loc5 = impl_witness_table (), @C.as.I.impl.1fd [concrete]
+// CHECK:STDOUT:   %I.impl_witness.loc5: <witness> = impl_witness %I.impl_witness_table.loc5, @C.as.I.impl.1fd(constants.%T) [symbolic = @C.as.I.impl.1fd.%I.impl_witness (constants.%I.impl_witness.a0f)]
+// CHECK:STDOUT:   impl_decl @C.as.I.impl.3f8 [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, imports.%Main.C [concrete = constants.%C]
+// CHECK:STDOUT:     %N.ref: %N.type.673 = name_ref N, imports.%Main.N [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc6_14.1 [symbolic = %T.loc6_14.2 (constants.%T)]
+// CHECK:STDOUT:     %ptr.loc6_32.1: type = ptr_type %T.ref [symbolic = %ptr.loc6_32.2 (constants.%ptr.4f0)]
+// CHECK:STDOUT:     %ptr.loc6_33.1: type = ptr_type %ptr.loc6_32.1 [symbolic = %ptr.loc6_33.2 (constants.%ptr.3f2)]
+// CHECK:STDOUT:     %N.type.loc6_34.1: type = facet_type <@N, @N(constants.%ptr.3f2)> [symbolic = %N.type.loc6_34.2 (constants.%N.type.b8d23b.2)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc6_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc6_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.impl_witness_table.loc6 = impl_witness_table (), @C.as.I.impl.3f8 [concrete]
+// CHECK:STDOUT:   %I.impl_witness.loc6: <witness> = impl_witness %I.impl_witness_table.loc6, @C.as.I.impl.3f8(constants.%T) [symbolic = @C.as.I.impl.3f8.%I.impl_witness (constants.%I.impl_witness.524)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic interface @I(imports.%Main.import_ref.efcd44.1: type) [from "import_generic_with_different_specific.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T)> [symbolic = %I.type (constants.%I.type.070)]
+// CHECK:STDOUT:   %Self: @I.%I.type (%I.type.070) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.269)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   interface {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Main.import_ref.769
+// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic constraint @N(imports.%Main.import_ref.efcd44.4: type) [from "import_generic_with_different_specific.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %Self: @N.%N.type (%N.type.b8d23b.1) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   constraint {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Main.import_ref.388
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:     @N.require0 {
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic require @N.require0(imports.%Main.import_ref.efcd44.3: type, imports.%Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1)) [from "import_generic_with_different_specific.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %Self: @N.require0.%N.type (%N.type.b8d23b.1) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T)> [symbolic = %I.type (constants.%I.type.070)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @C.as.I.impl.f3e(imports.%Main.import_ref.efcd44.2: type) [from "import_generic_with_different_specific.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T)> [symbolic = %I.type (constants.%I.type.070)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type [symbolic = %require_complete (constants.%require_complete.c94)]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness imports.%I.impl_witness_table, @C.as.I.impl.f3e(%T) [symbolic = %I.impl_witness (constants.%I.impl_witness.f13)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: imports.%Main.import_ref.29a as imports.%Main.import_ref.46444d.1 {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = imports.%Main.import_ref.e46
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @C.as.I.impl.1fd(%T.loc5_14.1: type) {
+// CHECK:STDOUT:   %T.loc5_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc5_14.2 (constants.%T)]
+// CHECK:STDOUT:   %ptr.loc5_32.2: type = ptr_type %T.loc5_14.2 [symbolic = %ptr.loc5_32.2 (constants.%ptr.4f0)]
+// CHECK:STDOUT:   %I.type.loc5_33.2: type = facet_type <@I, @I(%ptr.loc5_32.2)> [symbolic = %I.type.loc5_33.2 (constants.%I.type.229)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type.loc5_33.2 [symbolic = %require_complete (constants.%require_complete.555)]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table.loc5, @C.as.I.impl.1fd(%T.loc5_14.2) [symbolic = %I.impl_witness (constants.%I.impl_witness.a0f)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %C.ref as %I.type.loc5_33.1 {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%I.impl_witness.loc5
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @C.as.I.impl.3f8(%T.loc6_14.1: type) {
+// CHECK:STDOUT:   %T.loc6_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc6_14.2 (constants.%T)]
+// CHECK:STDOUT:   %ptr.loc6_32.2: type = ptr_type %T.loc6_14.2 [symbolic = %ptr.loc6_32.2 (constants.%ptr.4f0)]
+// CHECK:STDOUT:   %ptr.loc6_33.2: type = ptr_type %ptr.loc6_32.2 [symbolic = %ptr.loc6_33.2 (constants.%ptr.3f2)]
+// CHECK:STDOUT:   %N.type.loc6_34.2: type = facet_type <@N, @N(%ptr.loc6_33.2)> [symbolic = %N.type.loc6_34.2 (constants.%N.type.b8d23b.2)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %N.type.loc6_34.2 [symbolic = %require_complete (constants.%require_complete.a37)]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness file.%I.impl_witness_table.loc6, @C.as.I.impl.3f8(%T.loc6_14.2) [symbolic = %I.impl_witness (constants.%I.impl_witness.524)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %C.ref as %N.type.loc6_34.1 {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%I.impl_witness.loc6
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C [from "import_generic_with_different_specific.carbon"] {
+// CHECK:STDOUT:   complete_type_witness = imports.%Main.import_ref.8f2
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = imports.%Main.import_ref.2c4
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %I.type => constants.%I.type.070
+// CHECK:STDOUT:   %Self => constants.%Self.269
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C.as.I.impl.f3e(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %I.type => constants.%I.type.070
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.c94
+// CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness.f13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @I(constants.%ptr.4f0) {
+// CHECK:STDOUT:   %T => constants.%ptr.4f0
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %I.type => constants.%I.type.229
+// CHECK:STDOUT:   %Self => constants.%Self.6d0
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C.as.I.impl.1fd(constants.%T) {
+// CHECK:STDOUT:   %T.loc5_14.2 => constants.%T
+// CHECK:STDOUT:   %ptr.loc5_32.2 => constants.%ptr.4f0
+// CHECK:STDOUT:   %I.type.loc5_33.2 => constants.%I.type.229
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.555
+// CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness.a0f
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N.require0(constants.%T, constants.%Self.aa1) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %N.type => constants.%N.type.b8d23b.1
+// CHECK:STDOUT:   %Self => constants.%Self.aa1
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
+// CHECK:STDOUT:   %I.type => constants.%I.type.070
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%ptr.3f2) {
+// CHECK:STDOUT:   %T => constants.%ptr.3f2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @C.as.I.impl.3f8(constants.%T) {
+// CHECK:STDOUT:   %T.loc6_14.2 => constants.%T
+// CHECK:STDOUT:   %ptr.loc6_32.2 => constants.%ptr.4f0
+// CHECK:STDOUT:   %ptr.loc6_33.2 => constants.%ptr.3f2
+// CHECK:STDOUT:   %N.type.loc6_34.2 => constants.%N.type.b8d23b.2
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.a37
+// CHECK:STDOUT:   %I.impl_witness => constants.%I.impl_witness.524
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_import_generic_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -508,17 +1138,23 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %J.type.2b8: type = generic_interface_type @J [concrete]
 // CHECK:STDOUT:   %J.generic: %J.type.2b8 = struct_value () [concrete]
 // CHECK:STDOUT:   %J.type.8ec: type = facet_type <@J, @J(%T)> [symbolic]
-// CHECK:STDOUT:   %Self: %J.type.8ec = symbolic_binding Self, 1 [symbolic]
-// CHECK:STDOUT:   %J.impl_witness.224: <witness> = impl_witness file.%J.impl_witness_table.loc11, @D.as.J.impl.b47(%T) [symbolic]
+// CHECK:STDOUT:   %Self.f68: %J.type.8ec = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %N.type.673: type = generic_named_constaint_type @N [concrete]
+// CHECK:STDOUT:   %empty_struct: %N.type.673 = struct_value () [concrete]
+// CHECK:STDOUT:   %N.type.b8d: type = facet_type <@N, @N(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.aa1: %N.type.b8d = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.aa1 [symbolic]
+// CHECK:STDOUT:   %J.impl_witness.224: <witness> = impl_witness file.%J.impl_witness_table.loc15, @D.as.J.impl.b47(%T) [symbolic]
 // CHECK:STDOUT:   %ptr: type = ptr_type %T [symbolic]
 // CHECK:STDOUT:   %J.type.4fa: type = facet_type <@J, @J(%ptr)> [symbolic]
-// CHECK:STDOUT:   %J.impl_witness.537: <witness> = impl_witness file.%J.impl_witness_table.loc17, @D.as.J.impl.265(%T) [symbolic]
+// CHECK:STDOUT:   %J.impl_witness.537: <witness> = impl_witness file.%J.impl_witness_table.loc21, @D.as.J.impl.265(%T) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .D = %D.decl
 // CHECK:STDOUT:     .J = %J.decl
+// CHECK:STDOUT:     .N = %N.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [concrete = constants.%D] {} {}
 // CHECK:STDOUT:   %J.decl: %J.type.2b8 = interface_decl @J [concrete = constants.%J.generic] {
@@ -527,31 +1163,37 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %T.loc5_13.2: type = symbolic_binding T, 0 [symbolic = %T.loc5_13.1 (constants.%T)]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %N.decl: %N.type.673 = constraint_decl @N [concrete = constants.%empty_struct] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc7_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc7_14.1 (constants.%T)]
+// CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @D.as.J.impl.b47 [concrete] {
 // CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [concrete = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, file.%J.decl [concrete = constants.%J.generic]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_14.1 [symbolic = %T.loc11_14.2 (constants.%T)]
-// CHECK:STDOUT:     %J.type.loc11_32.1: type = facet_type <@J, @J(constants.%T)> [symbolic = %J.type.loc11_32.2 (constants.%J.type.8ec)]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc15_14.1 [symbolic = %T.loc15_14.2 (constants.%T)]
+// CHECK:STDOUT:     %J.type.loc15_32.1: type = facet_type <@J, @J(constants.%T)> [symbolic = %J.type.loc15_32.2 (constants.%J.type.8ec)]
 // CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T.loc11_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc11_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc15_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc15_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table.loc11 = impl_witness_table (), @D.as.J.impl.b47 [concrete]
-// CHECK:STDOUT:   %J.impl_witness.loc11: <witness> = impl_witness %J.impl_witness_table.loc11, @D.as.J.impl.b47(constants.%T) [symbolic = @D.as.J.impl.b47.%J.impl_witness (constants.%J.impl_witness.224)]
+// CHECK:STDOUT:   %J.impl_witness_table.loc15 = impl_witness_table (), @D.as.J.impl.b47 [concrete]
+// CHECK:STDOUT:   %J.impl_witness.loc15: <witness> = impl_witness %J.impl_witness_table.loc15, @D.as.J.impl.b47(constants.%T) [symbolic = @D.as.J.impl.b47.%J.impl_witness (constants.%J.impl_witness.224)]
 // CHECK:STDOUT:   impl_decl @D.as.J.impl.265 [concrete] {
 // CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %D.ref: type = name_ref D, file.%D.decl [concrete = constants.%D]
 // CHECK:STDOUT:     %J.ref: %J.type.2b8 = name_ref J, file.%J.decl [concrete = constants.%J.generic]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc17_14.1 [symbolic = %T.loc17_14.2 (constants.%T)]
-// CHECK:STDOUT:     %ptr.loc17_32.1: type = ptr_type %T.ref [symbolic = %ptr.loc17_32.2 (constants.%ptr)]
-// CHECK:STDOUT:     %J.type.loc17_33.1: type = facet_type <@J, @J(constants.%ptr)> [symbolic = %J.type.loc17_33.2 (constants.%J.type.4fa)]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc21_14.1 [symbolic = %T.loc21_14.2 (constants.%T)]
+// CHECK:STDOUT:     %ptr.loc21_32.1: type = ptr_type %T.ref [symbolic = %ptr.loc21_32.2 (constants.%ptr)]
+// CHECK:STDOUT:     %J.type.loc21_33.1: type = facet_type <@J, @J(constants.%ptr)> [symbolic = %J.type.loc21_33.2 (constants.%J.type.4fa)]
 // CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:     %T.loc17_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc17_14.2 (constants.%T)]
+// CHECK:STDOUT:     %T.loc21_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc21_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %J.impl_witness_table.loc17 = impl_witness_table (), @D.as.J.impl.265 [concrete]
-// CHECK:STDOUT:   %J.impl_witness.loc17: <witness> = impl_witness %J.impl_witness_table.loc17, @D.as.J.impl.265(constants.%T) [symbolic = @D.as.J.impl.265.%J.impl_witness (constants.%J.impl_witness.537)]
+// CHECK:STDOUT:   %J.impl_witness_table.loc21 = impl_witness_table (), @D.as.J.impl.265 [concrete]
+// CHECK:STDOUT:   %J.impl_witness.loc21: <witness> = impl_witness %J.impl_witness_table.loc21, @D.as.J.impl.265(constants.%T) [symbolic = @D.as.J.impl.265.%J.impl_witness (constants.%J.impl_witness.537)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic interface @J(%T.loc5_13.2: type) {
@@ -559,10 +1201,10 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %J.type: type = facet_type <@J, @J(%T.loc5_13.1)> [symbolic = %J.type (constants.%J.type.8ec)]
-// CHECK:STDOUT:   %Self.loc5_23.2: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self.loc5_23.2 (constants.%Self)]
+// CHECK:STDOUT:   %Self.loc5_23.2: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self.loc5_23.2 (constants.%Self.f68)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
-// CHECK:STDOUT:     %Self.loc5_23.1: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self.loc5_23.2 (constants.%Self)]
+// CHECK:STDOUT:     %Self.loc5_23.1: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self.loc5_23.2 (constants.%Self.f68)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.loc5_23.1
@@ -572,21 +1214,59 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @D.as.J.impl.b47(%T.loc11_14.1: type) {
-// CHECK:STDOUT:   %T.loc11_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc11_14.2 (constants.%T)]
-// CHECK:STDOUT:   %J.type.loc11_32.2: type = facet_type <@J, @J(%T.loc11_14.2)> [symbolic = %J.type.loc11_32.2 (constants.%J.type.8ec)]
-// CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness file.%J.impl_witness_table.loc11, @D.as.J.impl.b47(%T.loc11_14.2) [symbolic = %J.impl_witness (constants.%J.impl_witness.224)]
+// CHECK:STDOUT: generic constraint @N(%T.loc7_14.2: type) {
+// CHECK:STDOUT:   %T.loc7_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc7_14.1 (constants.%T)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: %D.ref as %J.type.loc11_32.1;
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T.loc7_14.1)> [symbolic = %N.type (constants.%N.type.b8d)]
+// CHECK:STDOUT:   %Self.loc7_24.2: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc7_24.2 (constants.%Self.aa1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   constraint {
+// CHECK:STDOUT:     %Self.loc7_24.1: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc7_24.2 (constants.%Self.aa1)]
+// CHECK:STDOUT:     %N.require0.decl = require_decl @N.require0 [concrete] {
+// CHECK:STDOUT:       require %Self.as_type impls <@J, @J(constants.%T)>
+// CHECK:STDOUT:     } {
+// CHECK:STDOUT:       %Self.as_type: type = facet_access_type @N.%Self.loc7_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:       %J.ref: %J.type.2b8 = name_ref J, file.%J.decl [concrete = constants.%J.generic]
+// CHECK:STDOUT:       %T.ref: type = name_ref T, @N.%T.loc7_14.2 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:       %J.type.loc8_27.1: type = facet_type <@J, @J(constants.%T)> [symbolic = %J.type.loc8_27.2 (constants.%J.type.8ec)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = %Self.loc7_24.1
+// CHECK:STDOUT:     .J = <poisoned>
+// CHECK:STDOUT:     .T = <poisoned>
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:     @N.require0 {
+// CHECK:STDOUT:       require @N.require0.%Self.as_type impls <@J, @J(constants.%T)>
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic impl @D.as.J.impl.265(%T.loc17_14.1: type) {
-// CHECK:STDOUT:   %T.loc17_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc17_14.2 (constants.%T)]
-// CHECK:STDOUT:   %ptr.loc17_32.2: type = ptr_type %T.loc17_14.2 [symbolic = %ptr.loc17_32.2 (constants.%ptr)]
-// CHECK:STDOUT:   %J.type.loc17_33.2: type = facet_type <@J, @J(%ptr.loc17_32.2)> [symbolic = %J.type.loc17_33.2 (constants.%J.type.4fa)]
-// CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness file.%J.impl_witness_table.loc17, @D.as.J.impl.265(%T.loc17_14.2) [symbolic = %J.impl_witness (constants.%J.impl_witness.537)]
+// CHECK:STDOUT: generic require @N.require0(@N.%T.loc7_14.2: type, @N.%Self.loc7_24.1: @N.%N.type (%N.type.b8d)) {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d)]
+// CHECK:STDOUT:   %Self: @N.require0.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %J.type.loc8_27.2: type = facet_type <@J, @J(%T)> [symbolic = %J.type.loc8_27.2 (constants.%J.type.8ec)]
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: %D.ref as %J.type.loc17_33.1;
+// CHECK:STDOUT: generic impl @D.as.J.impl.b47(%T.loc15_14.1: type) {
+// CHECK:STDOUT:   %T.loc15_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc15_14.2 (constants.%T)]
+// CHECK:STDOUT:   %J.type.loc15_32.2: type = facet_type <@J, @J(%T.loc15_14.2)> [symbolic = %J.type.loc15_32.2 (constants.%J.type.8ec)]
+// CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness file.%J.impl_witness_table.loc15, @D.as.J.impl.b47(%T.loc15_14.2) [symbolic = %J.impl_witness (constants.%J.impl_witness.224)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %D.ref as %J.type.loc15_32.1;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @D.as.J.impl.265(%T.loc21_14.1: type) {
+// CHECK:STDOUT:   %T.loc21_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc21_14.2 (constants.%T)]
+// CHECK:STDOUT:   %ptr.loc21_32.2: type = ptr_type %T.loc21_14.2 [symbolic = %ptr.loc21_32.2 (constants.%ptr)]
+// CHECK:STDOUT:   %J.type.loc21_33.2: type = facet_type <@J, @J(%ptr.loc21_32.2)> [symbolic = %J.type.loc21_33.2 (constants.%J.type.4fa)]
+// CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness file.%J.impl_witness_table.loc21, @D.as.J.impl.265(%T.loc21_14.2) [symbolic = %J.impl_witness (constants.%J.impl_witness.537)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %D.ref as %J.type.loc21_33.1;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
@@ -601,9 +1281,21 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %T.loc5_13.1 => constants.%T
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%T) {
+// CHECK:STDOUT:   %T.loc7_14.1 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N.require0(constants.%T, constants.%Self.aa1) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %N.type => constants.%N.type.b8d
+// CHECK:STDOUT:   %Self => constants.%Self.aa1
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
+// CHECK:STDOUT:   %J.type.loc8_27.2 => constants.%J.type.8ec
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: specific @D.as.J.impl.b47(constants.%T) {
-// CHECK:STDOUT:   %T.loc11_14.2 => constants.%T
-// CHECK:STDOUT:   %J.type.loc11_32.2 => constants.%J.type.8ec
+// CHECK:STDOUT:   %T.loc15_14.2 => constants.%T
+// CHECK:STDOUT:   %J.type.loc15_32.2 => constants.%J.type.8ec
 // CHECK:STDOUT:   %J.impl_witness => constants.%J.impl_witness.224
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -612,9 +1304,9 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D.as.J.impl.265(constants.%T) {
-// CHECK:STDOUT:   %T.loc17_14.2 => constants.%T
-// CHECK:STDOUT:   %ptr.loc17_32.2 => constants.%ptr
-// CHECK:STDOUT:   %J.type.loc17_33.2 => constants.%J.type.4fa
+// CHECK:STDOUT:   %T.loc21_14.2 => constants.%T
+// CHECK:STDOUT:   %ptr.loc21_32.2 => constants.%ptr
+// CHECK:STDOUT:   %J.type.loc21_33.2 => constants.%J.type.4fa
 // CHECK:STDOUT:   %J.impl_witness => constants.%J.impl_witness.537
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -625,7 +1317,7 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %J.type.2b8: type = generic_interface_type @J [concrete]
 // CHECK:STDOUT:   %J.generic: %J.type.2b8 = struct_value () [concrete]
 // CHECK:STDOUT:   %J.type.8ec: type = facet_type <@J, @J(%T)> [symbolic]
-// CHECK:STDOUT:   %Self: %J.type.8ec = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.f68: %J.type.8ec = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %D: type = class_type @D [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
@@ -636,29 +1328,46 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %J.impl_witness.537: <witness> = impl_witness imports.%J.impl_witness_table.bd9, @D.as.J.impl.265db6.1(%T) [symbolic]
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %N.type.673: type = generic_named_constaint_type @N [concrete]
+// CHECK:STDOUT:   %empty_struct: %N.type.673 = struct_value () [concrete]
+// CHECK:STDOUT:   %N.type.b8d23b.1: type = facet_type <@N, @N(%T)> [symbolic]
+// CHECK:STDOUT:   %Self.aa1: %N.type.b8d23b.1 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.aa1 [symbolic]
+// CHECK:STDOUT:   %require_complete.a37d6c.1: <witness> = require_complete_type %N.type.b8d23b.1 [symbolic]
+// CHECK:STDOUT:   %J.impl_witness.b5245e.1: <witness> = impl_witness file.%J.impl_witness_table.loc29, @D.as.J.impl.3b0484.1(%T) [symbolic]
+// CHECK:STDOUT:   %N.type.b8d23b.2: type = facet_type <@N, @N(%ptr)> [symbolic]
+// CHECK:STDOUT:   %require_complete.a37d6c.2: <witness> = require_complete_type %N.type.b8d23b.2 [symbolic]
+// CHECK:STDOUT:   %J.impl_witness.b5245e.2: <witness> = impl_witness file.%J.impl_witness_table.loc39, @D.as.J.impl.3b0484.2(%T) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Main.D: type = import_ref Main//import_generic_decl, D, loaded [concrete = constants.%D]
 // CHECK:STDOUT:   %Main.J: %J.type.2b8 = import_ref Main//import_generic_decl, J, loaded [concrete = constants.%J.generic]
+// CHECK:STDOUT:   %Main.N: %N.type.673 = import_ref Main//import_generic_decl, N, loaded [concrete = constants.%empty_struct]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.1: type = import_ref Main//import_generic_decl, loc5_13, loaded [symbolic = @J.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.b3b = import_ref Main//import_generic_decl, loc5_23, unloaded
 // CHECK:STDOUT:   %Main.import_ref.8f2: <witness> = import_ref Main//import_generic_decl, loc4_10, loaded [concrete = constants.%complete_type]
 // CHECK:STDOUT:   %Main.import_ref.cab = import_ref Main//import_generic_decl, inst{{[0-9A-F]+}} [no loc], unloaded
-// CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//import_generic_decl, loc11_14, loaded [symbolic = @D.as.J.impl.b470bf.1.%T (constants.%T)]
-// CHECK:STDOUT:   %Main.import_ref.aa9f8a.1: type = import_ref Main//import_generic_decl, loc11_24, loaded [concrete = constants.%D]
-// CHECK:STDOUT:   %Main.import_ref.03f: type = import_ref Main//import_generic_decl, loc11_32, loaded [symbolic = @D.as.J.impl.b470bf.1.%J.type (constants.%J.type.8ec)]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//import_generic_decl, loc15_14, loaded [symbolic = @D.as.J.impl.b470bf.1.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.aa9f8a.1: type = import_ref Main//import_generic_decl, loc15_24, loaded [concrete = constants.%D]
+// CHECK:STDOUT:   %Main.import_ref.03fb8f.1: type = import_ref Main//import_generic_decl, loc15_32, loaded [symbolic = @D.as.J.impl.b470bf.1.%J.type (constants.%J.type.8ec)]
 // CHECK:STDOUT:   %J.impl_witness_table.bc9 = impl_witness_table (), @D.as.J.impl.b470bf.1 [concrete]
-// CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic_decl, loc17_14, loaded [symbolic = @D.as.J.impl.265db6.1.%T (constants.%T)]
-// CHECK:STDOUT:   %Main.import_ref.aa9f8a.2: type = import_ref Main//import_generic_decl, loc17_24, loaded [concrete = constants.%D]
-// CHECK:STDOUT:   %Main.import_ref.a00: type = import_ref Main//import_generic_decl, loc17_33, loaded [symbolic = @D.as.J.impl.265db6.1.%J.type (constants.%J.type.4fa)]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic_decl, loc21_14, loaded [symbolic = @D.as.J.impl.265db6.1.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.aa9f8a.2: type = import_ref Main//import_generic_decl, loc21_24, loaded [concrete = constants.%D]
+// CHECK:STDOUT:   %Main.import_ref.a00: type = import_ref Main//import_generic_decl, loc21_33, loaded [symbolic = @D.as.J.impl.265db6.1.%J.type (constants.%J.type.4fa)]
 // CHECK:STDOUT:   %J.impl_witness_table.bd9 = impl_witness_table (), @D.as.J.impl.265db6.1 [concrete]
+// CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//import_generic_decl, loc8_18, loaded [symbolic = constants.%Self.binding.as_type]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.4: type = import_ref Main//import_generic_decl, loc7_14, loaded [symbolic = @N.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1) = import_ref Main//import_generic_decl, loc7_24, loaded [symbolic = @N.%Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Main.import_ref.efcd44.5: type = import_ref Main//import_generic_decl, loc7_14, loaded [symbolic = @N.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//import_generic_decl, loc7_24, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .D = imports.%Main.D
 // CHECK:STDOUT:     .J = imports.%Main.J
+// CHECK:STDOUT:     .N = imports.%Main.N
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %default.import.loc2_35.1 = import <none>
 // CHECK:STDOUT:   %default.import.loc2_35.2 = import <none>
@@ -704,6 +1413,31 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %T.loc26_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc26_14.2 (constants.%T)]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   impl_decl @D.as.J.impl.3b0484.1 [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [concrete = constants.%D]
+// CHECK:STDOUT:     %N.ref: %N.type.673 = name_ref N, imports.%Main.N [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc29_14.1 [symbolic = %T.loc29_14.2 (constants.%T)]
+// CHECK:STDOUT:     %N.type.loc29_32.1: type = facet_type <@N, @N(constants.%T)> [symbolic = %N.type.loc29_32.2 (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc29_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc29_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %J.impl_witness_table.loc29 = impl_witness_table (), @D.as.J.impl.3b0484.1 [concrete]
+// CHECK:STDOUT:   %J.impl_witness.loc29: <witness> = impl_witness %J.impl_witness_table.loc29, @D.as.J.impl.3b0484.1(constants.%T) [symbolic = @D.as.J.impl.3b0484.1.%J.impl_witness (constants.%J.impl_witness.b5245e.1)]
+// CHECK:STDOUT:   impl_decl @D.as.J.impl.3b0484.2 [concrete] {
+// CHECK:STDOUT:     %T.patt: %pattern_type = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %D.ref: type = name_ref D, imports.%Main.D [concrete = constants.%D]
+// CHECK:STDOUT:     %N.ref: %N.type.673 = name_ref N, imports.%Main.N [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc39_14.1 [symbolic = %T.loc39_14.2 (constants.%T)]
+// CHECK:STDOUT:     %ptr.loc39_32.1: type = ptr_type %T.ref [symbolic = %ptr.loc39_32.2 (constants.%ptr)]
+// CHECK:STDOUT:     %N.type.loc39_33.1: type = facet_type <@N, @N(constants.%ptr)> [symbolic = %N.type.loc39_33.2 (constants.%N.type.b8d23b.2)]
+// CHECK:STDOUT:     %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:     %T.loc39_14.1: type = symbolic_binding T, 0 [symbolic = %T.loc39_14.2 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %J.impl_witness_table.loc39 = impl_witness_table (), @D.as.J.impl.3b0484.2 [concrete]
+// CHECK:STDOUT:   %J.impl_witness.loc39: <witness> = impl_witness %J.impl_witness_table.loc39, @D.as.J.impl.3b0484.2(constants.%T) [symbolic = @D.as.J.impl.3b0484.2.%J.impl_witness (constants.%J.impl_witness.b5245e.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic interface @J(imports.%Main.import_ref.efcd44.1: type) [from "fail_import_generic_decl.carbon"] {
@@ -711,7 +1445,7 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %J.type: type = facet_type <@J, @J(%T)> [symbolic = %J.type (constants.%J.type.8ec)]
-// CHECK:STDOUT:   %Self: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self)]
+// CHECK:STDOUT:   %Self: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.f68)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:   !members:
@@ -722,12 +1456,38 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: generic constraint @N(imports.%Main.import_ref.efcd44.5: type) [from "fail_import_generic_decl.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %Self: @N.%N.type (%N.type.b8d23b.1) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   constraint {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     .Self = imports.%Main.import_ref.388
+// CHECK:STDOUT:
+// CHECK:STDOUT:   !requires:
+// CHECK:STDOUT:     @N.require0 {
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@J, @J(constants.%T)>
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic require @N.require0(imports.%Main.import_ref.efcd44.4: type, imports.%Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1)) [from "fail_import_generic_decl.carbon"] {
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
+// CHECK:STDOUT:   %N.type: type = facet_type <@N, @N(%T)> [symbolic = %N.type (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %Self: @N.require0.%N.type (%N.type.b8d23b.1) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.aa1)]
+// CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %J.type: type = facet_type <@J, @J(%T)> [symbolic = %J.type (constants.%J.type.8ec)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: generic impl @D.as.J.impl.b470bf.1(imports.%Main.import_ref.efcd44.2: type) [from "fail_import_generic_decl.carbon"] {
 // CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %J.type: type = facet_type <@J, @J(%T)> [symbolic = %J.type (constants.%J.type.8ec)]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness imports.%J.impl_witness_table.bc9, @D.as.J.impl.b470bf.1(%T) [symbolic = %J.impl_witness (constants.%J.impl_witness.224)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   impl: imports.%Main.import_ref.aa9f8a.1 as imports.%Main.import_ref.03f;
+// CHECK:STDOUT:   impl: imports.%Main.import_ref.aa9f8a.1 as imports.%Main.import_ref.03fb8f.1;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic impl @D.as.J.impl.265db6.1(imports.%Main.import_ref.efcd44.3: type) [from "fail_import_generic_decl.carbon"] {
@@ -779,6 +1539,35 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @D.as.J.impl.3b0484.1(%T.loc29_14.1: type) {
+// CHECK:STDOUT:   %T.loc29_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc29_14.2 (constants.%T)]
+// CHECK:STDOUT:   %N.type.loc29_32.2: type = facet_type <@N, @N(%T.loc29_14.2)> [symbolic = %N.type.loc29_32.2 (constants.%N.type.b8d23b.1)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %N.type.loc29_32.2 [symbolic = %require_complete (constants.%require_complete.a37d6c.1)]
+// CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness file.%J.impl_witness_table.loc29, @D.as.J.impl.3b0484.1(%T.loc29_14.2) [symbolic = %J.impl_witness (constants.%J.impl_witness.b5245e.1)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %D.ref as %N.type.loc29_32.1 {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%J.impl_witness.loc29
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic impl @D.as.J.impl.3b0484.2(%T.loc39_14.1: type) {
+// CHECK:STDOUT:   %T.loc39_14.2: type = symbolic_binding T, 0 [symbolic = %T.loc39_14.2 (constants.%T)]
+// CHECK:STDOUT:   %ptr.loc39_32.2: type = ptr_type %T.loc39_14.2 [symbolic = %ptr.loc39_32.2 (constants.%ptr)]
+// CHECK:STDOUT:   %N.type.loc39_33.2: type = facet_type <@N, @N(%ptr.loc39_32.2)> [symbolic = %N.type.loc39_33.2 (constants.%N.type.b8d23b.2)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %N.type.loc39_33.2 [symbolic = %require_complete (constants.%require_complete.a37d6c.2)]
+// CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness file.%J.impl_witness_table.loc39, @D.as.J.impl.3b0484.2(%T.loc39_14.2) [symbolic = %J.impl_witness (constants.%J.impl_witness.b5245e.2)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:
+// CHECK:STDOUT:   impl: %D.ref as %N.type.loc39_33.1 {
+// CHECK:STDOUT:   !members:
+// CHECK:STDOUT:     witness = file.%J.impl_witness.loc39
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: class @D [from "fail_import_generic_decl.carbon"] {
 // CHECK:STDOUT:   complete_type_witness = imports.%Main.import_ref.8f2
 // CHECK:STDOUT:
@@ -788,6 +1577,10 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @J(constants.%T) {
 // CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %J.type => constants.%J.type.8ec
+// CHECK:STDOUT:   %Self => constants.%Self.f68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @D.as.J.impl.b470bf.1(constants.%T) {
@@ -827,5 +1620,36 @@ impl forall [T:! type] D as J(T*) {}
 // CHECK:STDOUT:   %T.loc26_14.2 => constants.%T
 // CHECK:STDOUT:   %ptr.loc26_32.2 => constants.%ptr
 // CHECK:STDOUT:   %J.type.loc26_33.2 => constants.%J.type.4fa
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%T) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N.require0(constants.%T, constants.%Self.aa1) {
+// CHECK:STDOUT:   %T => constants.%T
+// CHECK:STDOUT:   %N.type => constants.%N.type.b8d23b.1
+// CHECK:STDOUT:   %Self => constants.%Self.aa1
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
+// CHECK:STDOUT:   %J.type => constants.%J.type.8ec
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @D.as.J.impl.3b0484.1(constants.%T) {
+// CHECK:STDOUT:   %T.loc29_14.2 => constants.%T
+// CHECK:STDOUT:   %N.type.loc29_32.2 => constants.%N.type.b8d23b.1
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.a37d6c.1
+// CHECK:STDOUT:   %J.impl_witness => constants.%J.impl_witness.b5245e.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @N(constants.%ptr) {
+// CHECK:STDOUT:   %T => constants.%ptr
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @D.as.J.impl.3b0484.2(constants.%T) {
+// CHECK:STDOUT:   %T.loc39_14.2 => constants.%T
+// CHECK:STDOUT:   %ptr.loc39_32.2 => constants.%ptr
+// CHECK:STDOUT:   %N.type.loc39_33.2 => constants.%N.type.b8d23b.2
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.a37d6c.2
+// CHECK:STDOUT:   %J.impl_witness => constants.%J.impl_witness.b5245e.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/type_iterator.cpp
+++ b/toolchain/sem_ir/type_iterator.cpp
@@ -98,6 +98,7 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
     case FunctionTypeWithSelfType::Kind:
     case GenericClassType::Kind:
     case GenericInterfaceType::Kind:
+    case GenericNamedConstraintType::Kind:
     case ImplWitnessAccess::Kind:
     case IntLiteralType::Kind:
     case NamespaceType::Kind:


### PR DESCRIPTION
We add tests showing that `ImplStore::GetOrAddLookupBucket` is doing the wrong thing for impls of a named constraint, as the impl-file redeclarations of impls in the api file are not getting flagged as such. To do the right thing requires us to be able to get the constraint from a require declaration with the specific of the named constraint/interface applied, which is future work as described in the [open discussion notes](https://docs.google.com/document/d/1Yt-i5AmF76LSvD4TrWRIAE_92kii6j5yFiW-S7ahzlg/edit?tab=t.1ji9ixn9bbnn#heading=h.kijomnov90rz).