### PR TITLE
Clean up ConstantValueStore getters.

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -221,6 +221,20 @@ class ValueStore
     return chunks_[chunk_index].Get(pos);
   }
 
+  // Returns the value for an ID, or a specified default value if a value has
+  // not yet been added for this ID.
+  auto GetWithDefault(IdType id,  //
+                      ConstRefType default_value [[clang::lifetimebound]]) const
+      -> ConstRefType {
+    auto index = tag_.Remove(id.index);
+    if (index >= size_) {
+      return default_value;
+    }
+    CARBON_DCHECK(index >= 0, "{0}", id);
+    auto [chunk_index, pos] = RawIndexToChunkIndices(index);
+    return chunks_[chunk_index].Get(pos);
+  }
+
   // Reserves space.
   auto Reserve(int32_t size) -> void {
     if (size <= size_) {

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -136,9 +136,7 @@ class ConstantValueStore {
   auto GetAttached(InstId inst_id) const -> ConstantId {
     CARBON_CHECK(insts_,
                  "Used ConstantValueStores must have an associated InstStore.");
-    auto index = insts_->GetRawIndex(inst_id);
-    return static_cast<size_t>(index) >= values_.size() ? default_
-                                                        : values_.Get(inst_id);
+    return values_.GetWithDefault(inst_id, default_);
   }
 
   // Sets the constant value of the given instruction, or sets that it is known
@@ -189,7 +187,7 @@ class ConstantValueStore {
   // For any other constant ID, returns the ID unchanged.
   auto GetUnattachedConstant(ConstantId const_id) const -> ConstantId {
     if (const_id.is_symbolic()) {
-      return GetAttached(GetSymbolicConstant(const_id).inst_id);
+      return values_.Get(GetSymbolicConstant(const_id).inst_id);
     }
     return const_id;
   }


### PR DESCRIPTION
Move `GetWithDefault` into the `ValueStore` base class, and avoid doing the tag -> index mapping twice.

Call `ValueStore::Get` instead of `ConstantValueStore::GetAttached` in `GetUnattachedConstant`. This is equivalent, since we never need a default value here, and should be faster and less surprising.
