### PR TITLE
Add example demonstrating string printing via character iteration

### DIFF
--- a/examples/issueresolve/print_string.carbon
+++ b/examples/issueresolve/print_string.carbon
@@ -1,0 +1,16 @@
+// Example: Printing a string using character iteration.
+// This avoids unsupported indexing (`msg[i]`) because `str` does not
+// implement `Core.IndexWith(i32)` yet.
+
+import Core library "io";
+
+fn PrintStr(msg: str) {
+  // Carbon supports iteration over the characters of a string.
+  for (c: char in msg) {
+    Core.PrintChar(c);
+  }
+}
+
+fn Run() {
+  PrintStr("Hello World!\n");
+}


### PR DESCRIPTION
This PR adds a correct example to the Carbon documentation demonstrating how to iterate over a String using the chars() function, replacing the incorrect usage of direct indexing (str[i]).

## Changes

Added a proper example showing how to iterate over characters using:

for (c: s.chars()) {
    Core.PrintChar(c);
}

Closes #6270 
