### PR TITLE
Carbon/C++ Interop: Importing C/C++ object-like macros

### DIFF
--- a/proposals/new.md
+++ b/proposals/new.md
@@ -1,0 +1,87 @@
+# Carbon/C++ Interop: Importing C/C++ object-like macros
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/####)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [TODO: Initial proposal setup](#todo-initial-proposal-setup)
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## TODO: Initial proposal setup
+
+> TIP: Run `./new_proposal.py "TITLE"` to do new proposal setup.
+
+1. Copy this template to `new.md`, and create a commit.
+2. Create a GitHub pull request, to get a pull request number.
+    - Add the `proposal draft` label to the pull request.
+3. Rename `new.md` to `/proposals/p####.md`, where `####` should be the pull
+   request number.
+4. Update the title of the proposal (the `TODO` on line 1).
+5. Update the link to the pull request (the `####` on line 11).
+6. Delete this section.
+
+TODOs indicate where content should be updated for a proposal. See
+[Carbon Governance and Evolution](/docs/project/evolution.md) for more details.
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p6382.md
+++ b/proposals/p6382.md
@@ -6,13 +6,12 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-[Pull request](https://github.com/carbon-language/carbon-lang/pull/####)
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/6382)
 
 <!-- toc -->
 
 ## Table of contents
 
--   [TODO: Initial proposal setup](#todo-initial-proposal-setup)
 -   [Abstract](#abstract)
 -   [Problem](#problem)
 -   [Background](#background)
@@ -22,22 +21,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Alternatives considered](#alternatives-considered)
 
 <!-- tocstop -->
-
-## TODO: Initial proposal setup
-
-> TIP: Run `./new_proposal.py "TITLE"` to do new proposal setup.
-
-1. Copy this template to `new.md`, and create a commit.
-2. Create a GitHub pull request, to get a pull request number.
-    - Add the `proposal draft` label to the pull request.
-3. Rename `new.md` to `/proposals/p####.md`, where `####` should be the pull
-   request number.
-4. Update the title of the proposal (the `TODO` on line 1).
-5. Update the link to the pull request (the `####` on line 11).
-6. Delete this section.
-
-TODOs indicate where content should be updated for a proposal. See
-[Carbon Governance and Evolution](/docs/project/evolution.md) for more details.
 
 ## Abstract
 

--- a/proposals/p6382.md
+++ b/proposals/p6382.md
@@ -22,8 +22,18 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Swift / C interop [GitHub][documentation]](#swift--c-interop-githubdocumentation)
 -   [Proposal](#proposal)
 -   [Details](#details)
+    -   [Namespace](#namespace)
+    -   [Constant type](#constant-type)
+    -   [Constant value](#constant-value)
+    -   [Constant expressions](#constant-expressions)
+    -   [Empty macros](#empty-macros)
+    -   [Implementation](#implementation)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+-   [Open questions](#open-questions)
+    -   [Object-like macros](#object-like-macros-1)
+    -   [Function-like macros](#function-like-macros-1)
+    -   [Predefined macros](#predefined-macros-1)
 
 <!-- tocstop -->
 
@@ -112,32 +122,208 @@ generics is recommended.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+An object-like macro that evaluates to a constant expression is imported from
+C++ as constant in Carbon. For example:
+
+C++:
+
+```
+#define BUFFER_SIZE 4096
+```
+
+Carbon:
+
+```
+let a: i32 = Cpp.BUFFER_SIZE; // Cpp.BUFFER_SIZE is imported as an int value of type i32 with a value of 4096
+
+```
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+### Namespace
+
+The macro is evaluated in the global Cpp namespace and accessible as
+Cpp.BUFFER_SIZE.
+
+### Constant type
+
+The type of the imported constant is deduced by Clang by evaluating the constant
+expression and then mapped to a Carbon type following the existing Carbon <->
+C++ type mapping rules.
+
+### Constant value
+
+The value is deduced by evaluating the tokens of a replacement list as a
+constant expression.
+
+### Constant expressions
+
+Any object-like macro that expands to a constant expression shall be supported.
+That means, the replacement list can contain:
+
+-   **Operators**: arithmetic: `+, -, *, /`; bitwise: `|, &, ^, <<, >>` ;
+    logical: `||, &&`; comparison: `<, >, <=, >=, ==`; casts etc.
+
+For example:
+
+```
+#define ADDITION 1+2
+```
+
+-   **Chained macros**: macros that expand to another macro which evaluates to a
+    constant.
+
+For example:
+
+```
+#define VALUE 123
+#define MY_VALUE VALUE
+```
+
+-   **Enums and constant variables**: if a macro contains a const variable in
+    the replacement list, it will be imported to Carbon as a constant.
+
+For example:
+
+C++:
+
+```
+const int kValue = 123;
+#define VALUE kValue
+```
+
+Carbon:
+
+```
+let a: i32 = Cpp.VALUE;
+```
+
+The macro will be evaluated by default in the global namespace (for example
+`Cpp.VALUE`). Evaluating it in a child namespace (`Cpp.SomeNamespace.VALUE`)
+shall also be possible, though details about are outside of the scope of this
+proposal.
+
+### Empty macros
+
+The macro should have at least one value in the replacement-list so that it’s
+imported. For example, the following macro won’t have a Carbon equivalent:
+
+```
+#define EMPTY
+```
+
+### Implementation
+
+1. _Name lookup_: When a C++ macro name is encountered in Carbon it is looked-up
+   before any other name. Following the C++ rules, this allows the macro to be
+   found in case there is a non-macro with the same name (for example named
+   variable).
+
+2. _Macro import_: If a macro is found, it is imported as a constant to Carbon,
+   by parsing the tokens of the replacement list to a constant expression and
+   evaluating the result.
+
+For example, given a macro:
+
+```
+#define MY_MACRO <some tokens>
+```
+
+The following constexpr will be (effectively) generated and imported:
+
+```
+constexpr inline decltype(auto) __carbon_import_MY_MACRO = (MY_MACRO);
+```
+
+That is, we would try to generate such a `constexpr` and import the macro if
+that succeeds.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+This work contributes to the Carbon’s goal for seamless interoperability with
+C++
+([Interoperability with and migration from existing C++ code](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)),
+by enabling reusing and migrating existing macros, while adhering to the best
+practices to use constant variables.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+-   Implementation
+
+    a) Reuse Swift/C implementation
+
+    -   _Reason to do this_: use existing implementation.
+    -   _Reason not to do this_: this implementation is much more limited,
+        longer and harder to maintain than the proposed one, as it manually
+        scans the replacement tokens and tries to evaluate them, instead of
+        using Clang for that. Limitations include for example type of supported
+        operators, number and type of operands etc. Also, due to the licensing,
+        it is not directly available.
+
+    b) Manually scanning tokens (own implementation)
+
+    -   _Reason not to do this_: this is a much longer implementation compared
+        to the proposed one, with much more limitatations compared to using
+        Clang to do that.
+
+-   Aliases for macros that evaluate to constant variables
+
+    -   _Reason to do this_: TODO
+    -   _Reason not to do this_: TODO
+
+-   Support _only_ macros in the global namespace (Cpp.MACRO)
+    -   _Reason to do this_: TODO
+    -   _Reason not to do this_: TODO
+
+## Open questions
+
+### Object-like macros
+
+The support for the following cases for still needs to be clarified:
+
+-   non-constant variable name
+
+```
+int x;
+#define VAL x
+```
+
+-   types:
+
+```
+#define SHORT_TYPE short
+```
+
+-   Statements or keywords:
+
+```
+#define RET return
+#define FOREVER for(;;)
+```
+
+-   Expanding macros in child namespaces (`Cpp.SubNamespace.MACRO`)
+
+### Function-like macros
+
+The support for function-like macros will still need to be discussed in detail.
+The current proposal could be extended for function-like macros in the following
+direction:
+
+Given a function-like macro:
+
+```
+#define MY_MACRO(a, b) ((a) + (b))
+```
+
+A function template whose body invokes the macro could be (eventually) generated
+and imported:
+
+```
+constexpr decltype(auto) __carbon_import_MY_MACRO(auto a, auto b) {
+return (MY_MACRO(a, b));
+}
+```
+
+### Predefined macros
+
+Details on the support for predefined macros remains open as well.

--- a/proposals/p6382.md
+++ b/proposals/p6382.md
@@ -15,6 +15,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Abstract](#abstract)
 -   [Problem](#problem)
 -   [Background](#background)
+    -   [Macros in C++](#macros-in-c)
+        -   [Object-like macros](#object-like-macros)
+        -   [Function-like macros](#function-like-macros)
+        -   [Predefined macros](#predefined-macros)
+    -   [Swift / C interop [GitHub][documentation]](#swift--c-interop-githubdocumentation)
 -   [Proposal](#proposal)
 -   [Details](#details)
 -   [Rationale](#rationale)
@@ -24,18 +29,86 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+This proposal addresses importing object-like C/C++ macros into Carbon.
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+C/C++ object-like macros are used to define constants, conditional compilation,
+header guards, etc. and are common for low-level, cross-platform libraries, with
+C like APIs. Despite the recommendations for replacing them in C++ with safer
+techniques (for example `constexpr`), they remain to be present in C++ code
+bases. Of particular interest for the interoperability are cases such as macros
+present in the APIs of the standard C++ library (for example error codes in
+`<errno.h>`), which can't be easily changed, but remain to be widely used in
+low-level C++ libraries. A mechanism for properly importing and handling these
+macros is necessary for a seamless interoperability.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+### Macros in C++
+
+Macros are defined with the `#define` directive and processed by the
+preprocessor, which replaces the occurrences of the defined identifier with a
+replacement-list. There are two types of macros: _object-like_ and
+_function-like_ macros. The directive `#undef` undefines a defined macro.
+
+#### Object-like macros
+
+```
+#define identifier replacement-list (optional)
+```
+
+Replacement-lists can have elements that are:
+
+-   Literals: integer, floating-point, string, char, bool etc.
+-   Non-literal types: structs, classes etc.
+-   Identifiers: pointing to other macros, variables, types, keywords etc.
+-   Operators: `+, -, <<, >>, |` etc. to one or more elements.
+
+#### Function-like macros
+
+```
+#define identifier(parameters) replacement-list (optional)
+#define identifier(parameters, ...) replacement-list (optional)
+#define identifier(...) replacement-list (optional)
+```
+
+The syntax of function-like macros is similar to the syntax of a function call.
+They accept a list of arguments and replace their occurrence in the
+replacement-list.
+
+As this is only a text replacement, it can lead to unexpected behaviour if the
+arguments are not properly separated with brackets.
+
+In function-like macros, the operators `#` and `##` enable:
+
+-   `#operator (stringification)` - the arguments of the macro are converted to
+    a string literal without expanding the argument. When `#` is used in front
+    of a parameter in a macro definition (`#param`), the preprocessor replaces
+    `#param` with the argument tokens as a string literal.
+
+-   `##operator (concatenation or token pasting)` - two tokens are merged in a
+    single token during a macro expansion. For example, when `a##b` is used as
+    part of the macro definition, the preprocessor merges `a` and `b`, removing
+    any white spaces in between to form a single token. When some of the tokens
+    on either side of the `##` operator are parameter names, they are replaced
+    by the actual argument before the execution of `##`. This is used for
+    example to create new identifiers like variables, function names etc. and in
+    general to avoid creating repeated boilerplate code.
+
+#### Predefined macros
+
+There are also predefined macros available in every translation unit. Examples
+include: `__cplusplus`, `__FILE__`, `__LINE__`, `__DATE__`, `__TIME__` etc.
+
+### Swift / C interop [[GitHub](https://github.com/swiftlang/swift/blob/main/lib/ClangImporter/ImportMacro.cpp)][[documentation](https://developer.apple.com/documentation/swift/using-imported-c-macros-in-swift)]
+
+Swift supports importing object-like C macros as global constants. Macros that
+use integer, floating-point and string literals are supported. Also simple
+operators like `+, -, <<, >>` etc. between literals or macros are supported.
+
+Function-like macros are not supported. Instead, using Swift functions and
+generics is recommended.
 
 ## Proposal
 


### PR DESCRIPTION
A proposal for importing C/C++ object-like macros into Carbon.

Based on the design doc: [Carbon: C++ interop for C/C++ object-like macros](https://docs.google.com/document/d/1CCB05gi3uHfDAXUy6DvOHxsn0spXcSrL_2Ye9QOSwrs/edit?tab=t.0).

Part of #6303 
