### PR TITLE
Rename `TypeLiteralInfo` to `RecognizedTypeInfo`

### DIFF
--- a/toolchain/check/cpp/type_mapping.cpp
+++ b/toolchain/check/cpp/type_mapping.cpp
@@ -119,20 +119,21 @@ static auto TryMapClassType(Context& context, SemIR::ClassType class_type)
 
   // If the class represents a Carbon type literal, map it to the corresponding
   // C++ builtin type.
-  auto literal = SemIR::TypeLiteralInfo::ForType(context.sem_ir(), class_type);
-  switch (literal.kind) {
-    case SemIR::TypeLiteralInfo::None: {
+  auto type_info =
+      SemIR::RecognizedTypeInfo::ForType(context.sem_ir(), class_type);
+  switch (type_info.kind) {
+    case SemIR::RecognizedTypeInfo::None: {
       break;
     }
-    case SemIR::TypeLiteralInfo::Numeric: {
+    case SemIR::RecognizedTypeInfo::Numeric: {
       // Carbon supports large bit width beyond C++ builtins; we don't need to
       // translate those.
-      if (!literal.numeric.bit_width_id.is_embedded_value()) {
+      if (!type_info.numeric.bit_width_id.is_embedded_value()) {
         return clang::QualType();
       }
-      int bit_width = literal.numeric.bit_width_id.AsValue();
+      int bit_width = type_info.numeric.bit_width_id.AsValue();
 
-      switch (literal.numeric.kind) {
+      switch (type_info.numeric.kind) {
         case SemIR::NumericTypeLiteralInfo::None: {
           CARBON_FATAL("Unexpected invalid numeric type literal");
         }
@@ -148,19 +149,19 @@ static auto TryMapClassType(Context& context, SemIR::ClassType class_type)
         }
       }
     }
-    case SemIR::TypeLiteralInfo::Char: {
+    case SemIR::RecognizedTypeInfo::Char: {
       return ast_context.CharTy;
     }
-    case SemIR::TypeLiteralInfo::CppLong32: {
+    case SemIR::RecognizedTypeInfo::CppLong32: {
       if (ast_context.getIntWidth(ast_context.LongTy) == 32) {
         return ast_context.LongTy;
       }
       break;
     }
-    case SemIR::TypeLiteralInfo::CppNullptrT: {
+    case SemIR::RecognizedTypeInfo::CppNullptrT: {
       return ast_context.NullPtrTy;
     }
-    case SemIR::TypeLiteralInfo::Str: {
+    case SemIR::RecognizedTypeInfo::Str: {
       return LookupCppType(context, {"std", "string_view"});
     }
   }

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -869,9 +869,9 @@ auto InstNamer::NamingContext::NameInst() -> void {
       return;
     }
     case CARBON_KIND(ClassType inst): {
-      if (auto literal_info = TypeLiteralInfo::ForType(sem_ir(), inst);
-          literal_info.is_valid()) {
-        AddInstName(literal_info.GetLiteralAsString(sem_ir()));
+      if (auto type_info = RecognizedTypeInfo::ForType(sem_ir(), inst);
+          type_info.is_valid()) {
+        AddInstName(type_info.GetLiteralAsString(sem_ir()));
       } else {
         AddEntityNameAndMaybePush(inst.class_id);
       }

--- a/toolchain/sem_ir/stringify.cpp
+++ b/toolchain/sem_ir/stringify.cpp
@@ -300,9 +300,9 @@ class Stringifier {
 
   auto StringifyInst(InstId /*inst_id*/, ClassType inst) -> void {
     const auto& class_info = sem_ir_->classes().Get(inst.class_id);
-    if (auto literal_info = TypeLiteralInfo::ForType(*sem_ir_, inst);
-        literal_info.is_valid()) {
-      literal_info.PrintLiteral(*sem_ir_, *out_);
+    if (auto type_info = RecognizedTypeInfo::ForType(*sem_ir_, inst);
+        type_info.is_valid()) {
+      type_info.PrintLiteral(*sem_ir_, *out_);
       return;
     }
     step_stack_->PushEntityName(class_info, inst.specific_id);
@@ -787,13 +787,13 @@ auto StringifySpecific(const File& sem_ir, SpecificId specific_id)
       // Print `Core.Int(N)` as `iN`.
       // TODO: This duplicates work done in StringifyInst for ClassType.
       const auto& class_info = sem_ir.classes().Get(class_decl.class_id);
-      if (auto literal_info = TypeLiteralInfo::ForType(
+      if (auto type_info = RecognizedTypeInfo::ForType(
               sem_ir, ClassType{.type_id = TypeType::TypeId,
                                 .class_id = class_decl.class_id,
                                 .specific_id = specific_id});
-          literal_info.is_valid()) {
+          type_info.is_valid()) {
         RawStringOstream out;
-        literal_info.PrintLiteral(sem_ir, out);
+        type_info.PrintLiteral(sem_ir, out);
         return out.TakeStr();
       }
       step_stack.PushEntityName(class_info, specific_id);

--- a/toolchain/sem_ir/type_info.cpp
+++ b/toolchain/sem_ir/type_info.cpp
@@ -133,8 +133,8 @@ auto NumericTypeLiteralInfo::GetLiteralAsString(const File& file) const
   return out.TakeStr();
 }
 
-auto TypeLiteralInfo::ForType(const File& file, ClassType class_type)
-    -> TypeLiteralInfo {
+auto RecognizedTypeInfo::ForType(const File& file, ClassType class_type)
+    -> RecognizedTypeInfo {
   if (class_type.specific_id.has_value()) {
     auto numeric = NumericTypeLiteralInfo::ForType(file, class_type);
     if (numeric.is_valid()) {
@@ -185,8 +185,8 @@ auto TypeLiteralInfo::ForType(const File& file, ClassType class_type)
   return {.kind = None};
 }
 
-auto TypeLiteralInfo::PrintLiteral(const File& file,
-                                   llvm::raw_ostream& out) const -> void {
+auto RecognizedTypeInfo::PrintLiteral(const File& file,
+                                      llvm::raw_ostream& out) const -> void {
   switch (kind) {
     case None:
       CARBON_FATAL("Printing invalid type literal");
@@ -216,7 +216,7 @@ auto TypeLiteralInfo::PrintLiteral(const File& file,
   }
 }
 
-auto TypeLiteralInfo::GetLiteralAsString(const File& file) const
+auto RecognizedTypeInfo::GetLiteralAsString(const File& file) const
     -> std::string {
   RawStringOstream out;
   PrintLiteral(file, out);

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -228,8 +228,7 @@ struct NumericTypeLiteralInfo {
 };
 
 // Information about a literal that corresponds to a type.
-// TODO: Rename to `RecognizedTypeInfo` (Cpp types are not type literals).
-struct TypeLiteralInfo {
+struct RecognizedTypeInfo {
   enum Kind : char {
     None,
     // A numeric type literal such as `i8`; see `numeric` field for details.
@@ -247,7 +246,7 @@ struct TypeLiteralInfo {
 
   // Returns the type literal that would evaluate to this class type, if any.
   static auto ForType(const File& file, ClassType class_type)
-      -> TypeLiteralInfo;
+      -> RecognizedTypeInfo;
 
   // Prints the type literal that corresponds to this type.
   auto PrintLiteral(const File& file, llvm::raw_ostream& out) const -> void;

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -227,7 +227,8 @@ struct NumericTypeLiteralInfo {
   IntId bit_width_id;
 };
 
-// Information about a recognized type.
+// Information about a recognized type, which is either a literal type, or a C++
+// builtin.
 struct RecognizedTypeInfo {
   enum Kind : char {
     None,

--- a/toolchain/sem_ir/type_info.h
+++ b/toolchain/sem_ir/type_info.h
@@ -227,7 +227,7 @@ struct NumericTypeLiteralInfo {
   IntId bit_width_id;
 };
 
-// Information about a literal that corresponds to a type.
+// Information about a recognized type.
 struct RecognizedTypeInfo {
   enum Kind : char {
     None,


### PR DESCRIPTION
Following https://github.com/carbon-language/carbon-lang/pull/6364/files/d6f19812d2350df8714e6022560e7443470c1a18#r2525516156.

Part of #5263.