### PR TITLE
Teach `create_compdb.py` to propagate Bazel flags

### DIFF
--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -33,7 +33,10 @@ import scripts_utils
 
 
 def _build_generated_files(
-    bazel: str, logtostderr: bool, dump_files: bool
+    bazel: str,
+    logtostderr: bool,
+    dump_files: bool,
+    extra_bazel_flags: list[str] = [],
 ) -> None:
     print("Building the generated files so that tools can find them...")
 
@@ -52,7 +55,9 @@ def _build_generated_files(
     if not logtostderr:
         log_to = subprocess.DEVNULL
     generated_file_labels = subprocess.check_output(
-        [bazel, "query", "--keep_going", "--output=label", kinds_query],
+        [bazel, "query"]
+        + extra_bazel_flags
+        + ["--keep_going", "--output=label", kinds_query],
         stderr=log_to,
         encoding="utf-8",
     ).splitlines()
@@ -66,7 +71,9 @@ def _build_generated_files(
     # fail in case there are build errors in the client, and just warn the user
     # that they may be missing generated files.
     subprocess.check_call(
-        [bazel, "build", "--keep_going", "--remote_download_outputs=toplevel"]
+        [bazel, "build"]
+        + extra_bazel_flags
+        + ["--keep_going", "--remote_download_outputs=toplevel"]
         + generated_file_labels
         # We also need the Bazel C++ runfiles that aren't "generated", but are
         # not linked into place until built.
@@ -143,12 +150,20 @@ def main() -> None:
         action="store_true",
         help="Dumps the full list of generated files (default: False)",
     )
+    parser.add_argument(
+        "--extra-bazel-flags",
+        action="append",
+        default=[],
+        help="Extra flags to pass to Bazel invocations",
+    )
 
     args = parser.parse_args()
     scripts_utils.chdir_repo_root()
     bazel = scripts_utils.locate_bazel()
 
-    _build_generated_files(bazel, args.alsologtostderr, args.dump_files)
+    _build_generated_files(
+        bazel, args.alsologtostderr, args.dump_files, args.extra_bazel_flags
+    )
 
     print(
         "Generating compile_commands.json (may take a few minutes)...",
@@ -158,8 +173,14 @@ def main() -> None:
         [
             bazel,
             "run",
+        ]
+        + args.extra_bazel_flags
+        + [
             "@hedron_compile_commands//:refresh_all",
             "--",
+        ]
+        + args.extra_bazel_flags
+        + [
             "--notool_deps",
         ]
     )

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -151,10 +151,10 @@ def main() -> None:
         help="Dumps the full list of generated files (default: False)",
     )
     parser.add_argument(
-        "--extra-bazel-flags",
+        "--extra-bazel-flag",
         action="append",
         default=[],
-        help="Extra flags to pass to Bazel invocations",
+        help="Extra flag to pass to Bazel invocations, may be specified more than once",
     )
 
     args = parser.parse_args()

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -154,7 +154,10 @@ def main() -> None:
         "--extra-bazel-flag",
         action="append",
         default=[],
-        help="Extra flag to pass to Bazel invocations, may be specified more than once",
+        help=(
+            "Extra flag to pass to Bazel invocations, may be specified more "
+            "than once"
+        ),
     )
 
     args = parser.parse_args()
@@ -162,7 +165,7 @@ def main() -> None:
     bazel = scripts_utils.locate_bazel()
 
     _build_generated_files(
-        bazel, args.alsologtostderr, args.dump_files, args.extra_bazel_flags
+        bazel, args.alsologtostderr, args.dump_files, args.extra_bazel_flag
     )
 
     print(
@@ -174,12 +177,12 @@ def main() -> None:
             bazel,
             "run",
         ]
-        + args.extra_bazel_flags
+        + args.extra_bazel_flag
         + [
             "@hedron_compile_commands//:refresh_all",
             "--",
         ]
-        + args.extra_bazel_flags
+        + args.extra_bazel_flag
         + [
             "--notool_deps",
         ]


### PR DESCRIPTION
For example, when developing against a checkout of LLVM, it is useful to be able to consistently pass an override flag to Bazel for that repository.

This lets:

```console
bazel test --override_repository=+_repo_rules+llvm-raw=$HOME/src/llvm/llvm-project //toolchain/...
```

and

```console
./scripts/create_compdb.py --extra-bazel-flag=--override_repository=+_repo_rules+llvm-raw=$HOME/src/llvm/llvm-project
```

Share the same Bazel cache and use the same flags.