### PR TITLE
Update dependency testing for the internal LLVM repo

### DIFF
--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -68,6 +68,10 @@ for dep in deps:
     if repo == "" and not rule.startswith("third_party"):
         continue
 
+    # LLVM code managed in the Carbon repository is still LLVM code and OK.
+    if repo == "" and rule.startswith("third_party/llvm:"):
+        continue
+
     # Utility libraries provided by Bazel that are under a compatible license.
     if repo in ("@@rules_cc+", "@@bazel_tools"):
         continue


### PR DESCRIPTION
This test started failing with #6405, but it wasn't caught by our PR testing or the merge queue as the test didn't _appear_ to be impacted by the change (I think).

When run explicitly, as the post-commit actions do, it started failing because of the new dependency edge.
