### PR TITLE
Proposing helpers to reduce some facet type boilerplate

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2958,11 +2958,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                  .facet_value_inst_id = facet_value_inst_id});
 }
 
-// Collects and assigns constants for a `FacetTypeInfo`.
-//
-// We discard constants in a first call, where `local_facet_type_info` is null,
-// in order to avoid allocations. Instead they will be recomputed if there's no
-// work.
+// Collects and assigns constants for a `FacetTypeInfo`. Discards constants when
+// `local_facet_type_info` is null.
 static auto BuildFacetTypeInfo(
     ImportRefResolver& resolver,
     const SemIR::FacetTypeInfo& import_facet_type_info,
@@ -3035,6 +3032,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   const SemIR::FacetTypeInfo& import_facet_type_info =
       resolver.import_facet_types().Get(inst.facet_type_id);
+  // Ensure values are present, but discard them to avoid allocations.
   BuildFacetTypeInfo(resolver, import_facet_type_info,
                      /*local_facet_type_info=*/nullptr);
   if (resolver.HasNewWork()) {
@@ -3045,6 +3043,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       .builtin_constraint_mask = import_facet_type_info.builtin_constraint_mask,
       // TODO: Also process the other requirements.
       .other_requirements = import_facet_type_info.other_requirements};
+  // Re-fetch and values to the local `FacetTypeInfo`.
   BuildFacetTypeInfo(resolver, import_facet_type_info, &local_facet_type_info);
 
   SemIR::FacetTypeId facet_type_id =

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2958,31 +2958,6 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                  .facet_value_inst_id = facet_value_inst_id});
 }
 
-// For a given field on `FacetTypeInfo`, does the `reserve` and loop of
-// data/value calls.
-template <typename FieldT, typename GetDataFnT, typename GetValueFnT>
-static auto BuildFacetTypeInfoField(
-    ImportRefResolver& resolver,
-    const SemIR::FacetTypeInfo& import_facet_type_info,
-    SemIR::FacetTypeInfo* local_facet_type_info,
-    FieldT SemIR::FacetTypeInfo::* field, GetDataFnT get_data,
-    GetValueFnT get_value) -> void {
-  // If building local values, reserve first.
-  if (local_facet_type_info) {
-    (local_facet_type_info->*field)
-        .reserve((import_facet_type_info.*field).size());
-  }
-  for (auto entry : import_facet_type_info.*field) {
-    // Always get the constant value.
-    auto data = get_data(resolver, entry);
-    // On the second pass, we store the final value.
-    if (local_facet_type_info) {
-      (local_facet_type_info->*field)
-          .push_back(get_value(resolver, entry, data));
-    }
-  }
-}
-
 // Collects and assigns constants for a `FacetTypeInfo`.
 //
 // We discard constants in a first call, where `local_facet_type_info` is null,
@@ -2992,23 +2967,53 @@ static auto BuildFacetTypeInfo(
     ImportRefResolver& resolver,
     const SemIR::FacetTypeInfo& import_facet_type_info,
     SemIR::FacetTypeInfo* local_facet_type_info) -> void {
-  BuildFacetTypeInfoField(
-      resolver, import_facet_type_info, local_facet_type_info,
-      &SemIR::FacetTypeInfo::extend_constraints, GetLocalSpecificInterfaceData,
-      GetLocalSpecificInterface);
-  BuildFacetTypeInfoField(
-      resolver, import_facet_type_info, local_facet_type_info,
-      &SemIR::FacetTypeInfo::self_impls_constraints,
-      GetLocalSpecificInterfaceData, GetLocalSpecificInterface);
+  if (local_facet_type_info) {
+    local_facet_type_info->extend_constraints.reserve(
+        import_facet_type_info.extend_constraints.size());
+  }
+  for (auto interface : import_facet_type_info.extend_constraints) {
+    auto data = GetLocalSpecificInterfaceData(resolver, interface);
+    if (local_facet_type_info) {
+      local_facet_type_info->extend_constraints.push_back(
+          GetLocalSpecificInterface(resolver, interface, data));
+    }
+  }
 
-  BuildFacetTypeInfoField(
-      resolver, import_facet_type_info, local_facet_type_info,
-      &SemIR::FacetTypeInfo::extend_named_constraints,
-      GetLocalSpecificNamedConstraintData, GetLocalSpecificNamedConstraint);
-  BuildFacetTypeInfoField(
-      resolver, import_facet_type_info, local_facet_type_info,
-      &SemIR::FacetTypeInfo::self_impls_named_constraints,
-      GetLocalSpecificNamedConstraintData, GetLocalSpecificNamedConstraint);
+  if (local_facet_type_info) {
+    local_facet_type_info->self_impls_constraints.reserve(
+        import_facet_type_info.self_impls_constraints.size());
+  }
+  for (auto interface : import_facet_type_info.self_impls_constraints) {
+    auto data = GetLocalSpecificInterfaceData(resolver, interface);
+    if (local_facet_type_info) {
+      local_facet_type_info->self_impls_constraints.push_back(
+          GetLocalSpecificInterface(resolver, interface, data));
+    }
+  }
+
+  if (local_facet_type_info) {
+    local_facet_type_info->extend_named_constraints.reserve(
+        import_facet_type_info.extend_named_constraints.size());
+  }
+  for (auto constraint : import_facet_type_info.extend_named_constraints) {
+    auto data = GetLocalSpecificNamedConstraintData(resolver, constraint);
+    if (local_facet_type_info) {
+      local_facet_type_info->extend_named_constraints.push_back(
+          GetLocalSpecificNamedConstraint(resolver, constraint, data));
+    }
+  }
+
+  if (local_facet_type_info) {
+    local_facet_type_info->self_impls_named_constraints.reserve(
+        import_facet_type_info.self_impls_named_constraints.size());
+  }
+  for (auto constraint : import_facet_type_info.self_impls_named_constraints) {
+    auto data = GetLocalSpecificNamedConstraintData(resolver, constraint);
+    if (local_facet_type_info) {
+      local_facet_type_info->self_impls_named_constraints.push_back(
+          GetLocalSpecificNamedConstraint(resolver, constraint, data));
+    }
+  }
 
   if (local_facet_type_info) {
     local_facet_type_info->rewrite_constraints.reserve(

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2960,7 +2960,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
 // Collects and assigns constants for a `FacetTypeInfo`. Discards constants when
 // `local_facet_type_info` is null.
-static auto BuildFacetTypeInfo(
+static auto ResolveFacetTypeInfo(
     ImportRefResolver& resolver,
     const SemIR::FacetTypeInfo& import_facet_type_info,
     SemIR::FacetTypeInfo* local_facet_type_info) -> void {
@@ -3034,7 +3034,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver.import_facet_types().Get(inst.facet_type_id);
   // Ensure values are imported, but discard them to avoid allocations.
   ResolveFacetTypeInfo(resolver, import_facet_type_info,
-                     /*local_facet_type_info=*/nullptr);
+                       /*local_facet_type_info=*/nullptr);
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
@@ -3044,7 +3044,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       // TODO: Also process the other requirements.
       .other_requirements = import_facet_type_info.other_requirements};
   // Re-resolve and add values to the local `FacetTypeInfo`.
-  BuildFacetTypeInfo(resolver, import_facet_type_info, &local_facet_type_info);
+  ResolveFacetTypeInfo(resolver, import_facet_type_info,
+                       &local_facet_type_info);
 
   SemIR::FacetTypeId facet_type_id =
       resolver.local_facet_types().Add(std::move(local_facet_type_info));

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -3032,8 +3032,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
 
   const SemIR::FacetTypeInfo& import_facet_type_info =
       resolver.import_facet_types().Get(inst.facet_type_id);
-  // Ensure values are present, but discard them to avoid allocations.
-  BuildFacetTypeInfo(resolver, import_facet_type_info,
+  // Ensure values are imported, but discard them to avoid allocations.
+  ResolveFacetTypeInfo(resolver, import_facet_type_info,
                      /*local_facet_type_info=*/nullptr);
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
@@ -3043,7 +3043,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       .builtin_constraint_mask = import_facet_type_info.builtin_constraint_mask,
       // TODO: Also process the other requirements.
       .other_requirements = import_facet_type_info.other_requirements};
-  // Re-fetch and values to the local `FacetTypeInfo`.
+  // Re-resolve and add values to the local `FacetTypeInfo`.
   BuildFacetTypeInfo(resolver, import_facet_type_info, &local_facet_type_info);
 
   SemIR::FacetTypeId facet_type_id =

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2958,37 +2958,80 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
                  .facet_value_inst_id = facet_value_inst_id});
 }
 
+// For a given field on `FacetTypeInfo`, does the `reserve` and loop of
+// data/value calls.
+template <typename FieldT, typename GetDataFnT, typename GetValueFnT>
+static auto BuildFacetTypeInfoField(
+    ImportRefResolver& resolver,
+    const SemIR::FacetTypeInfo& import_facet_type_info,
+    SemIR::FacetTypeInfo* local_facet_type_info,
+    FieldT SemIR::FacetTypeInfo::* field, GetDataFnT get_data,
+    GetValueFnT get_value) -> void {
+  // If building local values, reserve first.
+  if (local_facet_type_info) {
+    (local_facet_type_info->*field)
+        .reserve((import_facet_type_info.*field).size());
+  }
+  for (auto entry : import_facet_type_info.*field) {
+    // Always get the constant value.
+    auto data = get_data(resolver, entry);
+    // On the second pass, we store the final value.
+    if (local_facet_type_info) {
+      (local_facet_type_info->*field)
+          .push_back(get_value(resolver, entry, data));
+    }
+  }
+}
+
+// Collects and assigns constants for a `FacetTypeInfo`.
+//
+// We discard constants in a first call, where `local_facet_type_info` is null,
+// in order to avoid allocations. Instead they will be recomputed if there's no
+// work.
+static auto BuildFacetTypeInfo(
+    ImportRefResolver& resolver,
+    const SemIR::FacetTypeInfo& import_facet_type_info,
+    SemIR::FacetTypeInfo* local_facet_type_info) -> void {
+  BuildFacetTypeInfoField(
+      resolver, import_facet_type_info, local_facet_type_info,
+      &SemIR::FacetTypeInfo::extend_constraints, GetLocalSpecificInterfaceData,
+      GetLocalSpecificInterface);
+  BuildFacetTypeInfoField(
+      resolver, import_facet_type_info, local_facet_type_info,
+      &SemIR::FacetTypeInfo::self_impls_constraints,
+      GetLocalSpecificInterfaceData, GetLocalSpecificInterface);
+
+  BuildFacetTypeInfoField(
+      resolver, import_facet_type_info, local_facet_type_info,
+      &SemIR::FacetTypeInfo::extend_named_constraints,
+      GetLocalSpecificNamedConstraintData, GetLocalSpecificNamedConstraint);
+  BuildFacetTypeInfoField(
+      resolver, import_facet_type_info, local_facet_type_info,
+      &SemIR::FacetTypeInfo::self_impls_named_constraints,
+      GetLocalSpecificNamedConstraintData, GetLocalSpecificNamedConstraint);
+
+  if (local_facet_type_info) {
+    local_facet_type_info->rewrite_constraints.reserve(
+        import_facet_type_info.rewrite_constraints.size());
+  }
+  for (auto rewrite : import_facet_type_info.rewrite_constraints) {
+    auto lhs_id = GetLocalConstantInstId(resolver, rewrite.lhs_id);
+    auto rhs_id = GetLocalConstantInstId(resolver, rewrite.rhs_id);
+    if (local_facet_type_info) {
+      local_facet_type_info->rewrite_constraints.push_back(
+          {.lhs_id = lhs_id, .rhs_id = rhs_id});
+    }
+  }
+}
+
 static auto TryResolveTypedInst(ImportRefResolver& resolver,
                                 SemIR::FacetType inst) -> ResolveResult {
   CARBON_CHECK(inst.type_id == SemIR::TypeType::TypeId);
 
   const SemIR::FacetTypeInfo& import_facet_type_info =
       resolver.import_facet_types().Get(inst.facet_type_id);
-  for (auto interface : import_facet_type_info.extend_constraints) {
-    // We discard this here and recompute it below instead of saving it to avoid
-    // allocations.
-    GetLocalSpecificInterfaceData(resolver, interface);
-  }
-  for (auto interface : import_facet_type_info.self_impls_constraints) {
-    // We discard this here and recompute it below instead of saving it to avoid
-    // allocations.
-    GetLocalSpecificInterfaceData(resolver, interface);
-  }
-  for (auto constraint : import_facet_type_info.extend_named_constraints) {
-    // We discard this here and recompute it below instead of saving it to avoid
-    // allocations.
-    GetLocalSpecificNamedConstraintData(resolver, constraint);
-  }
-  for (auto constraint : import_facet_type_info.self_impls_named_constraints) {
-    // We discard this here and recompute it below instead of saving it to avoid
-    // allocations.
-    GetLocalSpecificNamedConstraintData(resolver, constraint);
-  }
-  for (auto rewrite : import_facet_type_info.rewrite_constraints) {
-    GetLocalConstantInstId(resolver, rewrite.lhs_id);
-    GetLocalConstantInstId(resolver, rewrite.rhs_id);
-  }
-  // TODO: Import named constraints in the facet type.
+  BuildFacetTypeInfo(resolver, import_facet_type_info,
+                     /*local_facet_type_info=*/nullptr);
   if (resolver.HasNewWork()) {
     return ResolveResult::Retry();
   }
@@ -2997,41 +3040,8 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       .builtin_constraint_mask = import_facet_type_info.builtin_constraint_mask,
       // TODO: Also process the other requirements.
       .other_requirements = import_facet_type_info.other_requirements};
-  local_facet_type_info.extend_constraints.reserve(
-      import_facet_type_info.extend_constraints.size());
-  for (auto interface : import_facet_type_info.extend_constraints) {
-    auto data = GetLocalSpecificInterfaceData(resolver, interface);
-    local_facet_type_info.extend_constraints.push_back(
-        GetLocalSpecificInterface(resolver, interface, data));
-  }
-  local_facet_type_info.self_impls_constraints.reserve(
-      import_facet_type_info.self_impls_constraints.size());
-  for (auto interface : import_facet_type_info.self_impls_constraints) {
-    auto data = GetLocalSpecificInterfaceData(resolver, interface);
-    local_facet_type_info.self_impls_constraints.push_back(
-        GetLocalSpecificInterface(resolver, interface, data));
-  }
-  local_facet_type_info.extend_named_constraints.reserve(
-      import_facet_type_info.extend_named_constraints.size());
-  for (auto constraint : import_facet_type_info.extend_named_constraints) {
-    auto data = GetLocalSpecificNamedConstraintData(resolver, constraint);
-    local_facet_type_info.extend_named_constraints.push_back(
-        GetLocalSpecificNamedConstraint(resolver, constraint, data));
-  }
-  local_facet_type_info.self_impls_named_constraints.reserve(
-      import_facet_type_info.self_impls_named_constraints.size());
-  for (auto constraint : import_facet_type_info.self_impls_named_constraints) {
-    auto data = GetLocalSpecificNamedConstraintData(resolver, constraint);
-    local_facet_type_info.self_impls_named_constraints.push_back(
-        GetLocalSpecificNamedConstraint(resolver, constraint, data));
-  }
-  local_facet_type_info.rewrite_constraints.reserve(
-      import_facet_type_info.rewrite_constraints.size());
-  for (auto rewrite : import_facet_type_info.rewrite_constraints) {
-    local_facet_type_info.rewrite_constraints.push_back(
-        {.lhs_id = GetLocalConstantInstId(resolver, rewrite.lhs_id),
-         .rhs_id = GetLocalConstantInstId(resolver, rewrite.rhs_id)});
-  }
+  BuildFacetTypeInfo(resolver, import_facet_type_info, &local_facet_type_info);
+
   SemIR::FacetTypeId facet_type_id =
       resolver.local_facet_types().Add(std::move(local_facet_type_info));
   return ResolveResult::Deduplicated<SemIR::FacetType>(


### PR DESCRIPTION
About the same # of LOC, but maybe less work to analyze correctness?

Versus the template, could also stamp that out in the helper function and still avoid the duplication of calls before/after HasNewWork. Similar to how I've left `rewrite_constraints`.

Alternately I'm also kind of tempted to rename GetLocalSpecificInterface and GetLocalSpecificNamedConstraint to instead be overloaded functions (or to provide overloaded versions), which would allow this to drop the function type parameters. But, naming is hard.