### PR TITLE
Add support for nullptr literals in macros

### DIFF
--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2264,6 +2264,10 @@ static auto MapConstant(Context& context, SemIR::LocId loc_id,
         MakeStringLiteral(context, Parse::StringLiteralId::None, string_id);
     context.imports().push_back(inst_id);
     return inst_id;
+  } else if (isa<clang::CXXNullPtrLiteralExpr>(expr)) {
+    auto type_id = MapNullptrType(context, loc_id).type_id;
+    return GetOrAddInst<SemIR::UninitializedValue>(context, SemIR::LocId::None,
+                                                   {.type_id = type_id});
   }
 
   SemIR::TypeId type_id = MapType(context, loc_id, expr->getType()).type_id;

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -62,7 +62,8 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
   }
 
   if (isa<clang::StringLiteral>(result_expr) ||
-      isa<clang::CharacterLiteral>(result_expr)) {
+      isa<clang::CharacterLiteral>(result_expr) ||
+      isa<clang::CXXNullPtrLiteralExpr>(result_expr)) {
     return result_expr;
   }
 

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/primitives.carbon
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/full.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -594,6 +594,20 @@ fn F() {
  // CHECK:STDERR:
  Cpp.M_TRUE = false;
 }
+
+// --- nullptr.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+  #define MyNullPtr nullptr
+  void foo(int arr[2]);
+''';
+
+fn F() {
+  Cpp.foo(Cpp.MyNullPtr);
+}
+
 
 // --- lambda.carbon
 


### PR DESCRIPTION
Adding support for macros that evaluate to nullptr literal.

Demo:

```c++
// macros.h
void foo(int a[2]);
#define MyNullPtr nullptr
```
```c++
// macros.cpp
void foo(int a[2]) {
  if (!a) {
    printf("array a is nullptr\n");
    return;
  }
  printf("a[0] = %d \n", a[0]);
}
```

```c++
// main.carbon

library "Main";

import Cpp library "macros.h";

fn Run() -> i32 {
  Cpp.foo(Cpp.MyNullPtr);
  return 0;
}
```

```
$ clang -c macros.cpp;
$ bazel-bin/toolchain/carbon compile main.carbon
$ bazel-bin/toolchain/carbon link macros.o main.o \--output=demo_carbon
$ ./demo_carbon
array a is nullptr
```

Part of #6303 
