### PR TITLE
Switch benchmark tests to dry_run from min_time

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -283,7 +283,7 @@ sh_test(
     size = "small",
     srcs = [":filesystem_benchmark"],
     args = [
-        "--benchmark_min_time=1x",
+        "--benchmark_dry_run",
         # Restrict the sizes to 4-digit ones or smaller to keep test times low.
         # The `$$` is repeated for Bazel escaping of `$`.
         "--benchmark_filter=^[^/]+(/[0-9]{1,4}(/[0-9]+)?)?/real_time$$",
@@ -484,7 +484,7 @@ sh_test(
     timeout = "moderate",
     srcs = [":map_benchmark"],
     args = [
-        "--benchmark_min_time=1x",
+        "--benchmark_dry_run",
         # The `$$` is repeated for Bazel escaping of `$`.
         "--benchmark_filter=^[^/]*/[1-9][0-9]{0,3}(/[0-9]+)?$$",
     ],
@@ -554,7 +554,7 @@ sh_test(
     size = "small",
     srcs = ["raw_hashtable_metadata_group_benchmark"],
     args = [
-        "--benchmark_min_time=1x",
+        "--benchmark_dry_run",
     ],
 )
 
@@ -657,7 +657,7 @@ sh_test(
     timeout = "moderate",
     srcs = [":set_benchmark"],
     args = [
-        "--benchmark_min_time=1x",
+        "--benchmark_dry_run",
         # The `$$` is repeated for Bazel escaping of `$`.
         "--benchmark_filter=^[^/]*/[1-9][0-9]{0,3}(/[0-9]+)?$$",
     ],

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -128,7 +128,7 @@ sh_test(
     size = "small",
     srcs = [":compile_benchmark"],
     args = [
-        "--benchmark_min_time=1x",
+        "--benchmark_dry_run",
         # The `$$` is repeated for Bazel escaping of `$`.
         "--benchmark_filter=/256$$",
     ],


### PR DESCRIPTION
Trying to work around failures such as https://github.com/carbon-language/carbon-lang/actions/runs/19680163053/job/56371861907... min_time is only setting the minimum number of iterations, so the benchmark framework is validly choosing to run 1k times. dry_run should only run 1 repetition, making this both faster and more reliable in terms of execution time. https://google.github.io/benchmark/user_guide.html#running-benchmarks for flag documentation.