### PR TITLE
Reduce the minimum benchmark batch size

### DIFF
--- a/toolchain/driver/compile_benchmark.cpp
+++ b/toolchain/driver/compile_benchmark.cpp
@@ -89,7 +89,7 @@ static auto ComputeFileCount(int target_lines) -> int {
   // Use a smaller number of files in debug builds where compiles are slower.
   return std::max(1, std::min(8, (1024 * 1024) / target_lines));
 #else
-  return std::max(8, std::min(1024, (1024 * 1024) / target_lines));
+  return std::max(8, std::min(128, (1024 * 1024) / target_lines));
 #endif
 }
 


### PR DESCRIPTION
Even with `--benchmark_dry_run`, the benchmarks that use _batching_ still do one batch at a minimum as that's inherent to how batching works in the benchmark framework.

This means that the minimum batch size can (and in practice does) trigger timeouts by forcing 1k iterations in the test run that is just trying to ensure the benchmark doesn't _crash_ in some way.

Reduce the minimum size to 128 instead of 1k for this benchmark which should put it (much) further from any timeout limit. It also still seems perfectly effective for getting good benchmark data -- I think the original value was set _much_ too aggressively.