### PR TITLE
Remove the FacetTypeId in RequireImpls

### DIFF
--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -157,9 +157,9 @@ static auto TypeStructureReferencesSelf(
 }
 
 struct ValidateRequireResult {
-  SemIR::FacetType facet_type;
-  SemIR::TypeId facet_type_type_id;
-  const SemIR::IdentifiedFacetType* identified;
+  // The TypeId of a FacetType.
+  SemIR::TypeId constraint_type_id;
+  const SemIR::IdentifiedFacetType* identified_facet_type;
 };
 
 // Returns nullopt if a diagnostic has been emitted and the `require` decl is
@@ -224,9 +224,8 @@ static auto ValidateRequire(Context& context, SemIR::LocId loc_id,
     return std::nullopt;
   }
 
-  return ValidateRequireResult{.facet_type = *constraint_facet_type,
-                               .facet_type_type_id = constraint_type_id,
-                               .identified = &identified};
+  return ValidateRequireResult{.constraint_type_id = constraint_type_id,
+                               .identified_facet_type = &identified};
 }
 
 auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
@@ -252,8 +251,8 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
     return true;
   }
 
-  auto [constraint_facet_type, constraint_type_id, identified] = *validated;
-  if (identified->required_interfaces().empty()) {
+  auto [constraint_type_id, identified_facet_type] = *validated;
+  if (identified_facet_type->required_interfaces().empty()) {
     // A `require T impls type` adds no actual constraints, so nothing to do.
     DiscardGenericDecl(context);
     return true;
@@ -270,7 +269,6 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
       {.self_id = self_inst_id,
        .facet_type_inst_id =
            context.types().GetAsTypeInstId(constraint_inst_id),
-       .facet_type_id = constraint_facet_type.facet_type_id,
        .extend_self = extend,
        .decl_id = decl_id,
        .parent_scope_id = context.scope_stack().PeekNameScopeId(),

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2613,7 +2613,6 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     require_impls_id = resolver.local_require_impls().Add(
         {.self_id = SemIR::TypeInstId::None,
          .facet_type_inst_id = SemIR::TypeInstId::None,
-         .facet_type_id = SemIR::FacetTypeId::None,
          .decl_id = require_decl_id,
          .parent_scope_id = SemIR::NameScopeId::None,
          .generic_id = MakeIncompleteGeneric(resolver, require_decl_id,
@@ -2651,13 +2650,6 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver, import_require.self_id, self_const_id);
   new_require.facet_type_inst_id = AddLoadedImportRefForType(
       resolver, import_require.facet_type_inst_id, facet_type_const_id);
-  auto new_canonical_facet_type_inst_id =
-      resolver.local_constant_values().GetConstantInstId(
-          new_require.facet_type_inst_id);
-  auto new_canonical_facet_type =
-      resolver.local_insts().GetAs<SemIR::FacetType>(
-          new_canonical_facet_type_inst_id);
-  new_require.facet_type_id = new_canonical_facet_type.facet_type_id;
   new_require.extend_self = import_require.extend_self;
   new_require.parent_scope_id = parent_scope_id;
 

--- a/toolchain/check/testdata/facet/require_import.carbon
+++ b/toolchain/check/testdata/facet/require_import.carbon
@@ -36,6 +36,7 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %X.type: type = facet_type <@X> [concrete]
 // CHECK:STDOUT:   %Self.861: %X.type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [concrete]
 // CHECK:STDOUT:   %Self.binding.as_type.1a1: type = symbolic_binding_type Self, 0, %Self.861 [symbolic]
 // CHECK:STDOUT:   %A: %X.type = symbolic_binding A, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type.e25: type = pattern_type %X.type [concrete]
@@ -54,9 +55,11 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:   %Main.X: type = import_ref Main//a, X, loaded [concrete = constants.%X.type]
 // CHECK:STDOUT:   %Main.import_ref.462 = import_ref Main//a, loc3_13, unloaded
 // CHECK:STDOUT:   %Main.import_ref.b7c: type = import_ref Main//a, loc10_18, loaded [symbolic = @X.require0.%Self.binding.as_type (constants.%Self.binding.as_type.1a1)]
+// CHECK:STDOUT:   %Main.import_ref.df1cc4.1: type = import_ref Main//a, loc10_24, loaded [concrete = constants.%Z.type]
 // CHECK:STDOUT:   %Main.import_ref.dec: %X.type = import_ref Main//a, loc9_14, loaded [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Main.import_ref.cae = import_ref Main//a, loc9_14, unloaded
 // CHECK:STDOUT:   %Main.import_ref.3e6: type = import_ref Main//a, loc6_11, loaded [symbolic = @Y.require1.%Self.binding.as_type (constants.%Self.binding.as_type.384)]
+// CHECK:STDOUT:   %Main.import_ref.df1cc4.2: type = import_ref Main//a, loc6_17, loaded [concrete = constants.%Z.type]
 // CHECK:STDOUT:   %Main.import_ref.35b: %Y.type = import_ref Main//a, loc5_13, loaded [symbolic = constants.%Self.29b]
 // CHECK:STDOUT:   %Main.import_ref.581 = import_ref Main//a, loc5_13, unloaded
 // CHECK:STDOUT: }
@@ -102,7 +105,7 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Y.require1 {
-// CHECK:STDOUT:     require imports.%Main.import_ref.3e6 impls <@Z>
+// CHECK:STDOUT:     require imports.%Main.import_ref.3e6 impls imports.%Main.import_ref.df1cc4.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -112,7 +115,7 @@ fn F(A:! X, B:! Y) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @X.require0 {
-// CHECK:STDOUT:     require imports.%Main.import_ref.b7c impls <@Z>
+// CHECK:STDOUT:     require imports.%Main.import_ref.b7c impls imports.%Main.import_ref.df1cc4.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/import_generic.carbon
+++ b/toolchain/check/testdata/impl/import_generic.carbon
@@ -247,7 +247,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.loc4_23.1: @J.%J.type (%J.type.8ec) = symbolic_binding Self, 1 [symbolic = %Self.loc4_23.2 (constants.%Self.f68)]
 // CHECK:STDOUT:     %J.require0.decl = require_decl @J.require0 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require %Self.as_type impls %I.type.loc5_27.1
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @J.%Self.loc4_23.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:       %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
@@ -263,7 +263,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @J.require0 {
-// CHECK:STDOUT:       require @J.require0.%Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require @J.require0.%Self.as_type impls @J.require0.%I.type.loc5_27.1
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -324,6 +324,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Main.import_ref.769 = import_ref Main//basic_import_generic_interface, loc3_23, unloaded
 // CHECK:STDOUT:   %Main.import_ref.efcd44.1: type = import_ref Main//basic_import_generic_interface, loc3_13, loaded [symbolic = @I.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.ce5: type = import_ref Main//basic_import_generic_interface, loc5_18, loaded [symbolic = @J.require0.%Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %Main.import_ref.464: type = import_ref Main//basic_import_generic_interface, loc5_27, loaded [symbolic = @J.require0.%I.type (constants.%I.type.070)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//basic_import_generic_interface, loc4_13, loaded [symbolic = @J.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.cc4: @J.%J.type (%J.type.8ec) = import_ref Main//basic_import_generic_interface, loc4_23, loaded [symbolic = @J.%Self (constants.%Self.f68)]
 // CHECK:STDOUT:   %Main.import_ref.b3b = import_ref Main//basic_import_generic_interface, loc4_23, unloaded
@@ -365,7 +366,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @J.require0 {
-// CHECK:STDOUT:       require imports.%Main.import_ref.ce5 impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require imports.%Main.import_ref.ce5 impls imports.%Main.import_ref.464
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -505,7 +506,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   constraint {
 // CHECK:STDOUT:     %Self.loc4_24.1: @J.%J.type (%J.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc4_24.2 (constants.%Self.aa1)]
 // CHECK:STDOUT:     %J.require0.decl = require_decl @J.require0 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require %Self.as_type impls %I.type.loc5_27.1
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @J.%Self.loc4_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:       %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
@@ -520,7 +521,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @J.require0 {
-// CHECK:STDOUT:       require @J.require0.%Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require @J.require0.%Self.as_type impls @J.require0.%I.type.loc5_27.1
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -581,6 +582,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Main.import_ref.769 = import_ref Main//basic_import_generic_constraint, loc3_23, unloaded
 // CHECK:STDOUT:   %Main.import_ref.efcd44.1: type = import_ref Main//basic_import_generic_constraint, loc3_13, loaded [symbolic = @I.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//basic_import_generic_constraint, loc5_18, loaded [symbolic = @J.require0.%Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %Main.import_ref.464: type = import_ref Main//basic_import_generic_constraint, loc5_27, loaded [symbolic = @J.require0.%I.type (constants.%I.type.070)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//basic_import_generic_constraint, loc4_14, loaded [symbolic = @J.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.d4d: @J.%J.type (%J.type.b8d23b.1) = import_ref Main//basic_import_generic_constraint, loc4_24, loaded [symbolic = @J.%Self (constants.%Self.aa1546.1)]
 // CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//basic_import_generic_constraint, loc4_24, unloaded
@@ -637,7 +639,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @J.require0 {
-// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls imports.%Main.import_ref.464
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -815,7 +817,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   constraint {
 // CHECK:STDOUT:     %Self.loc14_24.1: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc14_24.2 (constants.%Self.aa1)]
 // CHECK:STDOUT:     %N.require0.decl = require_decl @N.require0 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require %Self.as_type impls %I.type.loc15_27.1
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @N.%Self.loc14_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:       %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
@@ -830,7 +832,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @N.require0 {
-// CHECK:STDOUT:       require @N.require0.%Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require @N.require0.%Self.as_type impls @N.require0.%I.type.loc15_27.1
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -970,6 +972,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Main.import_ref.7b6: type = import_ref Main//import_generic, loc12_33, loaded [symbolic = @C.as.I.impl.1fddff.1.%I.type (constants.%I.type.229)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic, loc12_14, loaded [symbolic = @C.as.I.impl.1fddff.1.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//import_generic, loc15_18, loaded [symbolic = @N.require0.%Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %Main.import_ref.46444d.2: type = import_ref Main//import_generic, loc15_27, loaded [symbolic = @N.require0.%I.type (constants.%I.type.070)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.4: type = import_ref Main//import_generic, loc14_14, loaded [symbolic = @N.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1) = import_ref Main//import_generic, loc14_24, loaded [symbolic = @N.%Self (constants.%Self.aa1)]
 // CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//import_generic, loc14_24, unloaded
@@ -1080,7 +1083,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @N.require0 {
-// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls imports.%Main.import_ref.46444d.2
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -1357,7 +1360,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   constraint {
 // CHECK:STDOUT:     %Self.loc9_24.1: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc9_24.2 (constants.%Self.aa1)]
 // CHECK:STDOUT:     %N.require0.decl = require_decl @N.require0 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require %Self.as_type impls %I.type.loc10_27.1
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @N.%Self.loc9_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:       %I.ref: %I.type.dac = name_ref I, file.%I.decl [concrete = constants.%I.generic]
@@ -1372,7 +1375,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @N.require0 {
-// CHECK:STDOUT:       require @N.require0.%Self.as_type impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require @N.require0.%Self.as_type impls @N.require0.%I.type.loc10_27.1
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -1483,6 +1486,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Main.import_ref.46444d.1: type = import_ref Main//import_generic_with_different_specific, loc7_32, loaded [symbolic = @C.as.I.impl.f3e.%I.type (constants.%I.type.070)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.2: type = import_ref Main//import_generic_with_different_specific, loc7_14, loaded [symbolic = @C.as.I.impl.f3e.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//import_generic_with_different_specific, loc10_18, loaded [symbolic = @N.require0.%Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %Main.import_ref.46444d.2: type = import_ref Main//import_generic_with_different_specific, loc10_27, loaded [symbolic = @N.require0.%I.type (constants.%I.type.070)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic_with_different_specific, loc9_14, loaded [symbolic = @N.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1) = import_ref Main//import_generic_with_different_specific, loc9_24, loaded [symbolic = @N.%Self (constants.%Self.aa1546.1)]
 // CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//import_generic_with_different_specific, loc9_24, unloaded
@@ -1557,7 +1561,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @N.require0 {
-// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@I, @I(constants.%T)>
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls imports.%Main.import_ref.46444d.2
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -1798,7 +1802,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   constraint {
 // CHECK:STDOUT:     %Self.loc7_24.1: @N.%N.type (%N.type.b8d) = symbolic_binding Self, 1 [symbolic = %Self.loc7_24.2 (constants.%Self.aa1)]
 // CHECK:STDOUT:     %N.require0.decl = require_decl @N.require0 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@J, @J(constants.%T)>
+// CHECK:STDOUT:       require %Self.as_type impls %J.type.loc8_27.1
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @N.%Self.loc7_24.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:       %J.ref: %J.type.2b8 = name_ref J, file.%J.decl [concrete = constants.%J.generic]
@@ -1813,7 +1817,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @N.require0 {
-// CHECK:STDOUT:       require @N.require0.%Self.as_type impls <@J, @J(constants.%T)>
+// CHECK:STDOUT:       require @N.require0.%Self.as_type impls @N.require0.%J.type.loc8_27.1
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -1932,6 +1936,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Main.import_ref.a00: type = import_ref Main//import_generic_decl, loc21_33, loaded [symbolic = @D.as.J.impl.265db6.1.%J.type (constants.%J.type.4fa)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.3: type = import_ref Main//import_generic_decl, loc21_14, loaded [symbolic = @D.as.J.impl.265db6.1.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.f92: type = import_ref Main//import_generic_decl, loc8_18, loaded [symbolic = @N.require0.%Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %Main.import_ref.03fb8f.2: type = import_ref Main//import_generic_decl, loc8_27, loaded [symbolic = @N.require0.%J.type (constants.%J.type.8ec)]
 // CHECK:STDOUT:   %Main.import_ref.efcd44.4: type = import_ref Main//import_generic_decl, loc7_14, loaded [symbolic = @N.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.d4d: @N.%N.type (%N.type.b8d23b.1) = import_ref Main//import_generic_decl, loc7_24, loaded [symbolic = @N.%Self (constants.%Self.aa1)]
 // CHECK:STDOUT:   %Main.import_ref.388 = import_ref Main//import_generic_decl, loc7_24, unloaded
@@ -2042,7 +2047,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @N.require0 {
-// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls <@J, @J(constants.%T)>
+// CHECK:STDOUT:       require imports.%Main.import_ref.f92 impls imports.%Main.import_ref.03fb8f.2
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/incomplete.carbon
+++ b/toolchain/check/testdata/impl/incomplete.carbon
@@ -761,7 +761,7 @@ interface B {
 // CHECK:STDOUT: interface @X {
 // CHECK:STDOUT:   %Self: %X.type = symbolic_binding Self, 0 [symbolic = constants.%Self.40f]
 // CHECK:STDOUT:   %X.require1.decl = require_decl @X.require1 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y>
+// CHECK:STDOUT:     require %Self.as_type impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @X.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type.dcc)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -774,14 +774,14 @@ interface B {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @X.require1 {
-// CHECK:STDOUT:     require @X.require1.%Self.as_type impls <@Y>
+// CHECK:STDOUT:     require @X.require1.%Self.as_type impls @X.require1.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constraint @Y {
 // CHECK:STDOUT:   %Self: %Y.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Y.require0.decl = require_decl @Y.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Z>
+// CHECK:STDOUT:     require %Self.as_type impls %Z.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Y.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type.1a1)]
 // CHECK:STDOUT:     %Z.ref: type = name_ref Z, file.%Z.decl [concrete = constants.%Z.type]
@@ -793,7 +793,7 @@ interface B {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Y.require0 {
-// CHECK:STDOUT:     require @Y.require0.%Self.as_type impls <@Z>
+// CHECK:STDOUT:     require @Y.require0.%Self.as_type impls @Y.require0.%Z.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/incomplete.carbon
+++ b/toolchain/check/testdata/interface/incomplete.carbon
@@ -162,7 +162,7 @@ interface A(T:! type) {
 // CHECK:STDOUT: interface @A {
 // CHECK:STDOUT:   %Self: %A.type = symbolic_binding Self, 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %A.require0.decl = require_decl @A.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@A>
+// CHECK:STDOUT:     require %Self.as_type impls %A.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @A.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
@@ -225,7 +225,7 @@ interface A(T:! type) {
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.loc3_23.1: @A.%A.type (%A.type.c1c) = symbolic_binding Self, 1 [symbolic = %Self.loc3_23.2 (constants.%Self)]
 // CHECK:STDOUT:     %A.require0.decl = require_decl @A.require0 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@A, @A(constants.%empty_struct_type)>
+// CHECK:STDOUT:       require %Self.as_type impls %A.type.loc11_28
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @A.%Self.loc3_23.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:       %A.ref: %A.type.495 = name_ref A, file.%A.decl [concrete = constants.%A.generic]

--- a/toolchain/check/testdata/interface/require.carbon
+++ b/toolchain/check/testdata/interface/require.carbon
@@ -288,7 +288,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: interface @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.3b3]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y>
+// CHECK:STDOUT:     require %Self.as_type impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -302,7 +302,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -335,7 +335,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: interface @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.3b3]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y>
+// CHECK:STDOUT:     require %Self.as_type impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -348,7 +348,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -381,7 +381,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: interface @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.3b3]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %.loc9 impls <@Y>
+// CHECK:STDOUT:     require %.loc9 impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.ref: %Z.type = name_ref Self, @Z.%Self [symbolic = %Self (constants.%Self.3b3)]
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type %Self.ref [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
@@ -396,7 +396,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%.loc9 impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%.loc9 impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -432,7 +432,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: interface @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.3b3]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %C.loc9_17.1 impls <@Y>
+// CHECK:STDOUT:     require %C.loc9_17.1 impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
 // CHECK:STDOUT:     %Self.ref: %Z.type = name_ref Self, @Z.%Self [symbolic = %Self (constants.%Self.3b3)]
@@ -450,7 +450,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%C.loc9_17.1 impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%C.loc9_17.1 impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -494,7 +494,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: interface @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.3b3]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y where constants.%impl.elem0 = constants.%empty_tuple.type>
+// CHECK:STDOUT:     require %Self.as_type impls %.loc7_19
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -519,7 +519,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls <@Y where constants.%impl.elem0 = constants.%empty_tuple.type>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls @Z.require0.%.loc7_19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -568,7 +568,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.loc4_23.1: @Z.%Z.type (%Z.type.4d7) = symbolic_binding Self, 1 [symbolic = %Self.loc4_23.2 (constants.%Self)]
 // CHECK:STDOUT:     %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:       require %T.ref impls <@Z, @Z(constants.%Self.binding.as_type)>
+// CHECK:STDOUT:       require %T.ref impls %Z.type.loc5_25.1
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %T.ref: type = name_ref T, @Z.%T.loc4_13.2 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %Z.ref: %Z.type.9fb = name_ref Z, file.%Z.decl [concrete = constants.%Z.generic]
@@ -587,7 +587,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @Z.require0 {
-// CHECK:STDOUT:       require @Z.require0.%T.ref impls <@Z, @Z(constants.%Self.binding.as_type)>
+// CHECK:STDOUT:       require @Z.require0.%T.ref impls @Z.require0.%Z.type.loc5_25.1
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -642,7 +642,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: interface @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.3b3]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type.loc10_11 impls <@Y where constants.%impl.elem0 = constants.%Self.binding.as_type>
+// CHECK:STDOUT:     require %Self.as_type.loc10_11 impls %.loc10_19
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type.loc10_11: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -668,7 +668,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type.loc10_11 impls <@Y where constants.%impl.elem0 = constants.%Self.binding.as_type>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type.loc10_11 impls @Z.require0.%.loc10_19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -718,7 +718,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.loc8_23.1: @Z.%Z.type (%Z.type.4d7) = symbolic_binding Self, 1 [symbolic = %Self.loc8_23.2 (constants.%Self.c41)]
 // CHECK:STDOUT:     %Z.require1.decl = require_decl @Z.require1 [concrete] {
-// CHECK:STDOUT:       require %Self.as_type impls <@Z, @Z(constants.%T)>
+// CHECK:STDOUT:       require %Self.as_type impls %Z.type.loc11_20
 // CHECK:STDOUT:     } {
 // CHECK:STDOUT:       %Self.as_type: type = facet_access_type @Z.%Self.loc8_23.1 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type.6a8)]
 // CHECK:STDOUT:       %Z.ref: %Z.type.9fb = name_ref Z, file.%Z.decl [concrete = constants.%Z.generic]
@@ -734,7 +734,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @Z.require1 {
-// CHECK:STDOUT:       require @Z.require1.%Self.as_type impls <@Z, @Z(constants.%T)>
+// CHECK:STDOUT:       require @Z.require1.%Self.as_type impls @Z.require1.%Z.type.loc11_20
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+++ b/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
@@ -83,6 +83,7 @@ impl C as B {}
 // CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %B.type: type = facet_type <@B> [concrete]
 // CHECK:STDOUT:   %Self.861: %B.type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.861 [symbolic]
 // CHECK:STDOUT:   %T: %B.type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %B.type [concrete]
@@ -95,6 +96,7 @@ impl C as B {}
 // CHECK:STDOUT:   %Main.B: type = import_ref Main//b, B, loaded [concrete = constants.%B.type]
 // CHECK:STDOUT:   %Main.import_ref.8df = import_ref Main//b, loc3_13, unloaded
 // CHECK:STDOUT:   %Main.import_ref.b7c: type = import_ref Main//b, loc5_18, loaded [symbolic = @B.require0.%Self.binding.as_type (constants.%Self.binding.as_type)]
+// CHECK:STDOUT:   %Main.import_ref.301: type = import_ref Main//b, loc5_24, loaded [concrete = constants.%I.type]
 // CHECK:STDOUT:   %Main.import_ref.dec: %B.type = import_ref Main//b, loc4_14, loaded [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Main.import_ref.cae = import_ref Main//b, loc4_14, unloaded
 // CHECK:STDOUT: }
@@ -132,7 +134,7 @@ impl C as B {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @B.require0 {
-// CHECK:STDOUT:     require imports.%Main.import_ref.b7c impls <@I>
+// CHECK:STDOUT:     require imports.%Main.import_ref.b7c impls imports.%Main.import_ref.301
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -304,7 +304,7 @@ constraint Z {
 // CHECK:STDOUT: constraint @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y>
+// CHECK:STDOUT:     require %Self.as_type impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -316,7 +316,7 @@ constraint Z {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -349,7 +349,7 @@ constraint Z {
 // CHECK:STDOUT: constraint @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y>
+// CHECK:STDOUT:     require %Self.as_type impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -361,7 +361,7 @@ constraint Z {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -394,7 +394,7 @@ constraint Z {
 // CHECK:STDOUT: constraint @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %.loc9 impls <@Y>
+// CHECK:STDOUT:     require %.loc9 impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.ref: %Z.type = name_ref Self, @Z.%Self [symbolic = %Self (constants.%Self.861)]
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type %Self.ref [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
@@ -408,7 +408,7 @@ constraint Z {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%.loc9 impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%.loc9 impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -444,7 +444,7 @@ constraint Z {
 // CHECK:STDOUT: constraint @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %C.loc9_17.1 impls <@Y>
+// CHECK:STDOUT:     require %C.loc9_17.1 impls %Y.ref
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
 // CHECK:STDOUT:     %Self.ref: %Z.type = name_ref Self, @Z.%Self [symbolic = %Self (constants.%Self.861)]
@@ -461,7 +461,7 @@ constraint Z {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%C.loc9_17.1 impls <@Y>
+// CHECK:STDOUT:     require @Z.require0.%C.loc9_17.1 impls @Z.require0.%Y.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -505,7 +505,7 @@ constraint Z {
 // CHECK:STDOUT: constraint @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type impls <@Y where constants.%impl.elem0 = constants.%empty_tuple.type>
+// CHECK:STDOUT:     require %Self.as_type impls %.loc7_19
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -529,7 +529,7 @@ constraint Z {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls <@Y where constants.%impl.elem0 = constants.%empty_tuple.type>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type impls @Z.require0.%.loc7_19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -714,7 +714,7 @@ constraint Z {
 // CHECK:STDOUT: constraint @Z {
 // CHECK:STDOUT:   %Self: %Z.type = symbolic_binding Self, 0 [symbolic = constants.%Self.861]
 // CHECK:STDOUT:   %Z.require0.decl = require_decl @Z.require0 [concrete] {
-// CHECK:STDOUT:     require %Self.as_type.loc10_11 impls <@Y where constants.%impl.elem0 = constants.%Self.binding.as_type>
+// CHECK:STDOUT:     require %Self.as_type.loc10_11 impls %.loc10_19
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type.loc10_11: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
@@ -739,7 +739,7 @@ constraint Z {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.require0 {
-// CHECK:STDOUT:     require @Z.require0.%Self.as_type.loc10_11 impls <@Y where constants.%impl.elem0 = constants.%Self.binding.as_type>
+// CHECK:STDOUT:     require @Z.require0.%Self.as_type.loc10_11 impls @Z.require0.%.loc10_19
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1377,7 +1377,7 @@ auto Formatter::FormatRequireImpls(RequireImplsId id) -> void {
   out_ << "require ";
   FormatArg(require.self_id);
   out_ << " impls ";
-  FormatArg(require.facet_type_id);
+  FormatArg(require.facet_type_inst_id);
   out_ << "\n";
   CloseBrace();
 }

--- a/toolchain/sem_ir/require_impls.h
+++ b/toolchain/sem_ir/require_impls.h
@@ -22,10 +22,6 @@ struct RequireImpls : Printable<RequireImpls> {
   TypeInstId self_id;
   // Evaluates to the `FacetType` that the self-type must implement.
   TypeInstId facet_type_inst_id;
-  // The `FacetTypeInfo` derived from the `facet_type_inst_id` instruction.
-  // TODO: Remove this, we need to use the inst to get a constant value in the
-  // appropriate specific.
-  FacetTypeId facet_type_id;
   // If the facet type extends `Self`. When true, the `self_id` will be `Self`.
   bool extend_self;
 
@@ -41,6 +37,7 @@ struct RequireImpls : Printable<RequireImpls> {
     out << '{';
     out << "self_id: " << self_id
         << ", facet_type_inst_id: " << facet_type_inst_id
+        << ", extend_self: " << extend_self
         << ", parent_scope: " << parent_scope_id;
     out << '}';
   }


### PR DESCRIPTION
The FacetTypeId should never be used directly, since the RequireImpls is a generic and the facet type may be parameterized by generic bindings. So instead, it should be accessed through GetConstantValueInSpecific, which works with the facet type InstId that is also already present on RequireImpls. This change to use GetConstantValueInSpecific was done in #6435, so the FacetTypeId is now unused except in formatting. So we can remove it.

This depends on #6435.