### PR TITLE
Make a couple of parts of our infrastructure more robust.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2082,7 +2082,8 @@ static auto TryEvalTypedInst(EvalContext& eval_context, SemIR::InstId inst_id,
     // Build a constant instruction by replacing each non-constant operand with
     // its constant value.
     Phase phase = Phase::Concrete;
-    if (!ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase) ||
+    if ((SemIR::Internal::HasTypeIdMember<InstT> &&
+         !ReplaceTypeWithConstantValue(eval_context, inst_id, &inst, &phase)) ||
         !ReplaceAllFieldsWithConstantValues(eval_context, &inst, &phase)) {
       if constexpr (ConstantKind == SemIR::InstConstantKind::Always) {
         CARBON_FATAL("{0} should always be constant", InstT::Kind);

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -769,8 +769,8 @@ auto InstNamer::NamingContext::AddWitnessTableName(InstId witness_table_inst_id,
   auto witness_table =
       sem_ir().insts().TryGetAs<ImplWitnessTable>(witness_table_inst_id);
   if (!witness_table || !witness_table->impl_id.has_value()) {
-    // TODO: If `impl_id` is None, the witness comes from a facet value. Can we get the
-    // interface names from it? Store the facet value instruction in the
+    // TODO: If `impl_id` is None, the witness comes from a facet value. Can we
+    // get the interface names from it? Store the facet value instruction in the
     // table?
     AddInstName(name);
     return;

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -767,15 +767,15 @@ auto InstNamer::NamingContext::AddIntOrFloatTypeName(char type_literal_prefix,
 auto InstNamer::NamingContext::AddWitnessTableName(InstId witness_table_inst_id,
                                                    std::string name) -> void {
   auto witness_table =
-      sem_ir().insts().GetAs<ImplWitnessTable>(witness_table_inst_id);
-  if (!witness_table.impl_id.has_value()) {
+      sem_ir().insts().TryGetAs<ImplWitnessTable>(witness_table_inst_id);
+  if (!witness_table || !witness_table->impl_id.has_value()) {
     // TODO: The witness comes from a facet value. Can we get the
     // interface names from it? Store the facet value instruction in the
     // table?
     AddInstName(name);
     return;
   }
-  const auto& impl = sem_ir().impls().Get(witness_table.impl_id);
+  const auto& impl = sem_ir().impls().Get(witness_table->impl_id);
   auto name_id = sem_ir().interfaces().Get(impl.interface.interface_id).name_id;
 
   std::string suffix = llvm::formatv(".{}", name);

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -769,7 +769,7 @@ auto InstNamer::NamingContext::AddWitnessTableName(InstId witness_table_inst_id,
   auto witness_table =
       sem_ir().insts().TryGetAs<ImplWitnessTable>(witness_table_inst_id);
   if (!witness_table || !witness_table->impl_id.has_value()) {
-    // TODO: The witness comes from a facet value. Can we get the
+    // TODO: If `impl_id` is None, the witness comes from a facet value. Can we get the
     // interface names from it? Store the facet value instruction in the
     // table?
     AddInstName(name);


### PR DESCRIPTION
Don't CHECK-fail when trying to format invalid SemIR with an ImplWitness whose table_id isn't an ImplWitnessTable. We use SemIR formatting as a debugging aid, so it's good for it to be robust even in the presence of invalid SemIR.

Don't crash if a typed instruction has no type_id field and has a constant kind of Always. We don't have any instructions like that at the moment.

These caused problems while working on #6451, and while I ended up not needing either fix for that PR, they both seem like they may be worth keeping to save some trouble for the next person who hits these.