### PR TITLE
Document the relationship of AddCanonicalWitnessesBlock to IdentifiedFacetType

### DIFF
--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -267,6 +267,10 @@ auto AddCanonicalWitnessesBlock(File& sem_ir,
         CARBON_FATAL("Unhandled inst: {0}", inst);
     }
   }
+  // This matches the sort order of IdentifiedFacetType::required_interfaces,
+  // which is the order of the witnesses returned from impl lookup, and is
+  // canonical order in which the witnesses must appear for a given facet type
+  // so that ImplWitnessAccess can find the appropriate witness.
   llvm::sort(sortable, [](auto& lhs, auto& rhs) {
     return ImplsLess(lhs.first, rhs.first);
   });

--- a/toolchain/sem_ir/facet_type_info.h
+++ b/toolchain/sem_ir/facet_type_info.h
@@ -213,9 +213,11 @@ inline auto CarbonHashValue(const FacetTypeInfo& value, uint64_t seed)
   return static_cast<HashCode>(hasher);
 }
 
-// Given an array of witnesses, sorts them to match the FacetTypeInfo ordering
-// and returns the resulting block ID. This assumes witnesses have already been
-// deduplicated, because it's mainly for imports.
+// Given an array of witnesses, sorts them to match the ordering of the specific
+// interfaces in the IdentifiedFacetType that produced the witness set, which is
+// the canonical witness order, and returns the resulting block ID. This assumes
+// witnesses have already been deduplicated, and do not contain errors, because
+// it's mainly for imports.
 auto AddCanonicalWitnessesBlock(File& sem_ir,
                                 llvm::SmallVector<InstId>& witnesses)
     -> InstBlockId;


### PR DESCRIPTION
The ordering of FacetTypeInfo is not important to the canonical ordering of witnesses. The order that must match is that of the IdentifiedFacetType::required_interfaces.