### PR TITLE
Move forward-decl-only code out to the handler of the forward decl node (Refactor Impl construction 3/7)

### DIFF
--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -259,8 +259,19 @@ static auto BuildImplDecl(Context& context, Parse::AnyImplDeclId node_id,
 }
 
 auto HandleParseNode(Context& context, Parse::ImplDeclId node_id) -> bool {
-  BuildImplDecl(context, node_id, /*is_definition=*/false);
+  auto [impl_id, impl_decl_id] =
+      BuildImplDecl(context, node_id, /*is_definition=*/false);
+  auto& impl = context.impls().Get(impl_id);
+
   context.decl_name_stack().PopScope();
+
+  // Impl definitions are required in the same file as the declaration. We skip
+  // this requirement if we've already issued an invalid redeclaration error, or
+  // there is an error that would prevent the impl from being legal to define.
+  if (impl.witness_id != SemIR::ErrorInst::InstId) {
+    context.definitions_required_by_decl().push_back(impl_decl_id);
+  }
+
   return true;
 }
 
@@ -268,20 +279,20 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionStartId node_id)
     -> bool {
   auto [impl_id, impl_decl_id] =
       BuildImplDecl(context, node_id, /*is_definition=*/true);
-  auto& impl_info = context.impls().Get(impl_id);
+  auto& impl = context.impls().Get(impl_id);
 
-  CARBON_CHECK(!impl_info.has_definition_started());
-  impl_info.definition_id = impl_decl_id;
-  impl_info.scope_id =
+  CARBON_CHECK(!impl.has_definition_started());
+  impl.definition_id = impl_decl_id;
+  impl.scope_id =
       context.name_scopes().Add(impl_decl_id, SemIR::NameId::None,
                                 context.decl_name_stack().PeekParentScopeId());
 
   context.scope_stack().PushForEntity(
-      impl_decl_id, impl_info.scope_id,
-      context.generics().GetSelfSpecific(impl_info.generic_id));
-  StartGenericDefinition(context, impl_info.generic_id);
+      impl_decl_id, impl.scope_id,
+      context.generics().GetSelfSpecific(impl.generic_id));
+  StartGenericDefinition(context, impl.generic_id);
   // This requires that the facet type is complete.
-  ImplWitnessStartDefinition(context, impl_info);
+  ImplWitnessStartDefinition(context, impl);
   context.inst_block_stack().Push();
   context.node_stack().Push(node_id, impl_id);
 
@@ -294,7 +305,7 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionStartId node_id)
   //
   // We may need to track a list of instruction blocks here, as we do for a
   // function.
-  impl_info.body_block_id = context.inst_block_stack().PeekOrAdd();
+  impl.body_block_id = context.inst_block_stack().PeekOrAdd();
   return true;
 }
 
@@ -305,9 +316,9 @@ auto HandleParseNode(Context& context, Parse::ImplDefinitionId /*node_id*/)
 
   FinishImplWitness(context, impl_id);
 
-  auto& impl_info = context.impls().Get(impl_id);
-  impl_info.defined = true;
-  FinishGenericDefinition(context, impl_info.generic_id);
+  auto& impl = context.impls().Get(impl_id);
+  impl.defined = true;
+  FinishGenericDefinition(context, impl.generic_id);
 
   context.inst_block_stack().Pop();
   // The decl_name_stack and scopes are popped by `ProcessNodeIds`.

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -585,17 +585,6 @@ auto GetOrAddImpl(Context& context, SemIR::LocId loc_id,
     }
   }
 
-  // Impl definitions are required in the same file as the declaration. We skip
-  // this requirement if we've already issued an invalid redeclaration error, or
-  // there is an error that would prevent the impl from being legal to define.
-  if (!is_definition) {
-    auto& stored_impl = context.impls().Get(impl_id);
-    if (stored_impl.witness_id != SemIR::ErrorInst::InstId) {
-      context.definitions_required_by_decl().push_back(
-          stored_impl.latest_decl_id());
-    }
-  }
-
   return impl_id;
 }
 


### PR DESCRIPTION
Rather than run the code for both decl and defn and make it conditional on not being a definition, put the code in the handler for the `Parse::ImplDeclId` node, which is handled when there's no definition. This will help lead us to no longer needing to plumb around `is_definition` later.

Make some naming consistent to call the reference to an `Impl` as `impl` instead of sometimes `impl_info`.

This is part of #6420 which is being split up into a chain of smaller PRs. It is based on #6466.