### PR TITLE
Replace unused bindings with anonymous binding in lower/testdata.

### DIFF
--- a/toolchain/lower/testdata/array/array_in_place.carbon
+++ b/toolchain/lower/testdata/array/array_in_place.carbon
@@ -13,7 +13,7 @@
 fn F() -> (i32, i32, i32);
 
 fn G() {
-  var v: array((i32, i32, i32), 2) = (F(), F());
+  var _: array((i32, i32, i32), 2) = (F(), F());
 }
 
 // CHECK:STDOUT: ; ModuleID = 'array_in_place.carbon'
@@ -24,11 +24,11 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca [2 x { i32, i32, i32 }], align 8, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !7
-// CHECK:STDOUT:   %.loc16_47.6.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, i64 0, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca [2 x { i32, i32, i32 }], align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
+// CHECK:STDOUT:   %.loc16_47.6.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %_.var, i32 0, i64 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_47.6.array.index), !dbg !9
-// CHECK:STDOUT:   %.loc16_47.5.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %v.var, i32 0, i64 1, !dbg !8
+// CHECK:STDOUT:   %.loc16_47.5.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %_.var, i32 0, i64 1, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_47.5.array.index), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -13,7 +13,7 @@
 fn F() -> (i32, i32) { return (12, 24); }
 
 fn Run() {
-  var t: array(i32, 2) = F();
+  var _: array(i32, 2) = F();
 }
 
 // CHECK:STDOUT: ; ModuleID = 'assign_return_value.carbon'
@@ -33,18 +33,18 @@ fn Run() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %t.var = alloca [2 x i32], align 4, !dbg !13
+// CHECK:STDOUT:   %_.var = alloca [2 x i32], align 4, !dbg !13
 // CHECK:STDOUT:   %.loc16_28.1.temp = alloca { i32, i32 }, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %t.var), !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !13
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_28.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_28.1.temp), !dbg !14
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_28.1.temp, i32 0, i32 0, !dbg !14
 // CHECK:STDOUT:   %.loc16_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.4.array.index = getelementptr inbounds [2 x i32], ptr %t.var, i32 0, i64 0, !dbg !14
+// CHECK:STDOUT:   %.loc16_28.4.array.index = getelementptr inbounds [2 x i32], ptr %_.var, i32 0, i64 0, !dbg !14
 // CHECK:STDOUT:   store i32 %.loc16_28.3, ptr %.loc16_28.4.array.index, align 4, !dbg !14
 // CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_28.1.temp, i32 0, i32 1, !dbg !14
 // CHECK:STDOUT:   %.loc16_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.7.array.index = getelementptr inbounds [2 x i32], ptr %t.var, i32 0, i64 1, !dbg !14
+// CHECK:STDOUT:   %.loc16_28.7.array.index = getelementptr inbounds [2 x i32], ptr %_.var, i32 0, i64 1, !dbg !14
 // CHECK:STDOUT:   store i32 %.loc16_28.6, ptr %.loc16_28.7.array.index, align 4, !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !15
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -11,11 +11,11 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/array/base.carbon
 
 fn Run() {
-  var a: array(i32, 1) = (1,);
-  var b: array(f64, 2) = (11.1, 2.2,);
-  var c: array((), 5) = ((), (), (), (), (),);
+  var _: array(i32, 1) = (1,);
+  var _: array(f64, 2) = (11.1, 2.2,);
+  var _: array((), 5) = ((), (), (), (), (),);
   var d: (i32, i32, i32) = (1, 2, 3);
-  var e: array(i32, 3) = d;
+  var _: array(i32, 3) = d;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'base.carbon'
@@ -29,42 +29,42 @@ fn Run() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca [1 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca [2 x double], align 8, !dbg !8
-// CHECK:STDOUT:   %c.var = alloca [5 x {}], align 8, !dbg !9
+// CHECK:STDOUT:   %_.var.loc14 = alloca [1 x i32], align 4, !dbg !7
+// CHECK:STDOUT:   %_.var.loc15 = alloca [2 x double], align 8, !dbg !8
+// CHECK:STDOUT:   %_.var.loc16 = alloca [5 x {}], align 8, !dbg !9
 // CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !10
-// CHECK:STDOUT:   %e.var = alloca [3 x i32], align 4, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !7
-// CHECK:STDOUT:   %.loc14_29.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, i64 0, !dbg !12
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @array.237.loc14_3, i64 4, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !8
-// CHECK:STDOUT:   %.loc15_37.3.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 0, !dbg !13
-// CHECK:STDOUT:   %.loc15_37.6.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i64 1, !dbg !13
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b.var, ptr align 8 @array.b91.loc15_3, i64 16, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !9
-// CHECK:STDOUT:   %.loc16_45.2.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 0, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.4.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 1, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.6.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 2, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.8.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 3, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.10.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i64 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @array.1cb.loc16_3, i64 0, i1 false), !dbg !9
+// CHECK:STDOUT:   %_.var.loc18 = alloca [3 x i32], align 4, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc14), !dbg !7
+// CHECK:STDOUT:   %.loc14_29.3.array.index = getelementptr inbounds [1 x i32], ptr %_.var.loc14, i32 0, i64 0, !dbg !12
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %_.var.loc14, ptr align 4 @array.237.loc14_3, i64 4, i1 false), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc15), !dbg !8
+// CHECK:STDOUT:   %.loc15_37.3.array.index = getelementptr inbounds [2 x double], ptr %_.var.loc15, i32 0, i64 0, !dbg !13
+// CHECK:STDOUT:   %.loc15_37.6.array.index = getelementptr inbounds [2 x double], ptr %_.var.loc15, i32 0, i64 1, !dbg !13
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc15, ptr align 8 @array.b91.loc15_3, i64 16, i1 false), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !9
+// CHECK:STDOUT:   %.loc16_45.2.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 0, !dbg !14
+// CHECK:STDOUT:   %.loc16_45.4.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 1, !dbg !14
+// CHECK:STDOUT:   %.loc16_45.6.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 2, !dbg !14
+// CHECK:STDOUT:   %.loc16_45.8.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 3, !dbg !14
+// CHECK:STDOUT:   %.loc16_45.10.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc16, ptr align 1 @array.1cb.loc16_3, i64 0, i1 false), !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !10
 // CHECK:STDOUT:   %tuple.elem0.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !15
 // CHECK:STDOUT:   %tuple.elem1.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !15
 // CHECK:STDOUT:   %tuple.elem2.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !15
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @tuple.ee6.loc17_3, i64 12, i1 false), !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %e.var), !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !11
 // CHECK:STDOUT:   %tuple.elem0.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !16
 // CHECK:STDOUT:   %.loc18_26.1 = load i32, ptr %tuple.elem0.loc18.tuple.elem, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.2.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 0, !dbg !16
+// CHECK:STDOUT:   %.loc18_26.2.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 0, !dbg !16
 // CHECK:STDOUT:   store i32 %.loc18_26.1, ptr %.loc18_26.2.array.index, align 4, !dbg !16
 // CHECK:STDOUT:   %tuple.elem1.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !16
 // CHECK:STDOUT:   %.loc18_26.4 = load i32, ptr %tuple.elem1.loc18.tuple.elem, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.5.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 1, !dbg !16
+// CHECK:STDOUT:   %.loc18_26.5.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 1, !dbg !16
 // CHECK:STDOUT:   store i32 %.loc18_26.4, ptr %.loc18_26.5.array.index, align 4, !dbg !16
 // CHECK:STDOUT:   %tuple.elem2.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !16
 // CHECK:STDOUT:   %.loc18_26.7 = load i32, ptr %tuple.elem2.loc18.tuple.elem, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.8.array.index = getelementptr inbounds [3 x i32], ptr %e.var, i32 0, i64 2, !dbg !16
+// CHECK:STDOUT:   %.loc18_26.8.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 2, !dbg !16
 // CHECK:STDOUT:   store i32 %.loc18_26.7, ptr %.loc18_26.8.array.index, align 4, !dbg !16
 // CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/builtins/maybe_unformed.carbon
+++ b/toolchain/lower/testdata/builtins/maybe_unformed.carbon
@@ -12,10 +12,10 @@
 
 fn MaybeUnformedBuiltin(t: type) -> type = "maybe_unformed.make_type";
 
-fn TakeI32(x: MaybeUnformedBuiltin(i32)) {}
+fn TakeI32(_: MaybeUnformedBuiltin(i32)) {}
 fn MakeI32() -> MaybeUnformedBuiltin(i32);
 
-fn TakeBool(x: MaybeUnformedBuiltin(bool)) {}
+fn TakeBool(_: MaybeUnformedBuiltin(bool)) {}
 fn MakeBool() -> MaybeUnformedBuiltin(bool);
 
 fn PassI32() {
@@ -39,7 +39,7 @@ class MaybeUnformedAdapter(T:! type) {
   adapt MaybeUnformedBuiltin(T);
 }
 
-fn TakeAdapterI32(x: MaybeUnformedAdapter(i32)) {}
+fn TakeAdapterI32(_: MaybeUnformedAdapter(i32)) {}
 fn MakeAdapterI32() -> MaybeUnformedAdapter(i32);
 
 fn PassAdapterI32() {
@@ -48,7 +48,7 @@ fn PassAdapterI32() {
   TakeAdapterI32(MakeAdapterI32());
 }
 
-fn TakeAdapterBool(x: MaybeUnformedAdapter(bool)) {}
+fn TakeAdapterBool(_: MaybeUnformedAdapter(bool)) {}
 fn MakeAdapterBool() -> MaybeUnformedAdapter(bool);
 
 fn PassAdapterBool() {
@@ -59,7 +59,7 @@ fn PassAdapterBool() {
 // CHECK:STDOUT: source_filename = "maybe_unformed.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CTakeI32.Main(i32 %x) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CTakeI32.Main(i32 %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
@@ -67,7 +67,7 @@ fn PassAdapterBool() {
 // CHECK:STDOUT: declare i32 @_CMakeI32.Main()
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CTakeBool.Main(ptr %x) #0 !dbg !11 {
+// CHECK:STDOUT: define void @_CTakeBool.Main(ptr %_) #0 !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
@@ -100,7 +100,7 @@ fn PassAdapterBool() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CTakeAdapterI32.Main(i32 %x) #0 !dbg !33 {
+// CHECK:STDOUT: define void @_CTakeAdapterI32.Main(i32 %_) #0 !dbg !33 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !36
 // CHECK:STDOUT: }
@@ -120,7 +120,7 @@ fn PassAdapterBool() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CTakeAdapterBool.Main(ptr %x) #0 !dbg !41 {
+// CHECK:STDOUT: define void @_CTakeAdapterBool.Main(ptr %_) #0 !dbg !41 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !44
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/builtins/type.carbon
+++ b/toolchain/lower/testdata/builtins/type.carbon
@@ -16,7 +16,7 @@ library "[[@TEST_NAME]]";
 fn CanDestroy() -> type = "type.can_destroy";
 
 fn F() {
-  let t: type = CanDestroy();
+  let _: type = CanDestroy();
 }
 
 // --- destroy.carbon

--- a/toolchain/lower/testdata/class/basic.carbon
+++ b/toolchain/lower/testdata/class/basic.carbon
@@ -19,7 +19,7 @@ fn F(c: C) -> C;
 
 fn Run() {
   var c: C;
-  var d: C = F(c);
+  var _: C = F(c);
 }
 
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
@@ -31,10 +31,10 @@ fn Run() {
 // CHECK:STDOUT: define void @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca { i32, ptr }, align 8, !dbg !7
-// CHECK:STDOUT:   %d.var = alloca { i32, ptr }, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { i32, ptr }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !8
-// CHECK:STDOUT:   call void @_CF.Main(ptr %d.var, ptr %c.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
+// CHECK:STDOUT:   call void @_CF.Main(ptr %_.var, ptr %c.var), !dbg !9
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/convert.carbon
+++ b/toolchain/lower/testdata/class/convert.carbon
@@ -18,7 +18,7 @@ impl IntWrapper as Core.ImplicitAs(i32) {
   fn Convert[self: Self]() -> i32 { return self.n; }
 }
 
-fn Consume(n: i32) {}
+fn Consume(_: i32) {}
 
 fn DoIt() {
   var w: IntWrapper = {.n = 42};
@@ -39,7 +39,7 @@ fn DoIt() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CConsume.Main(i32 %n) #0 !dbg !13 {
+// CHECK:STDOUT: define void @_CConsume.Main(i32 %_) #0 !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !18
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/class/field.carbon
+++ b/toolchain/lower/testdata/class/field.carbon
@@ -45,7 +45,7 @@ fn Run() {
   var o: Other;
   // .a is initialized with a non-constant expression
   // .b is initialized with in-place class_init
-  var u: Use = {.a = &o, .b = {}};
+  var _: Use = {.a = &o, .b = {}};
 }
 
 // --- implicit_init_with_nonempty_nonconst.carbon
@@ -65,7 +65,7 @@ fn Run() {
   var o: Other;
   // .a is initialized with a non-constant expression
   // .b is initialized with in-place class_init
-  var u: Use = {.a = &o, .b = {.v = 42}};
+  var _: Use = {.a = &o, .b = {.v = 42}};
 }
 
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
@@ -134,12 +134,12 @@ fn Run() {
 // CHECK:STDOUT: define void @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %o.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %u.var = alloca { ptr, {} }, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { ptr, {} }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %u.var), !dbg !8
-// CHECK:STDOUT:   %.loc15_33.2.a = getelementptr inbounds nuw { ptr, {} }, ptr %u.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
+// CHECK:STDOUT:   %.loc15_33.2.a = getelementptr inbounds nuw { ptr, {} }, ptr %_.var, i32 0, i32 0, !dbg !9
 // CHECK:STDOUT:   store ptr %o.var, ptr %.loc15_33.2.a, align 8, !dbg !9
-// CHECK:STDOUT:   %.loc15_33.4.b = getelementptr inbounds nuw { ptr, {} }, ptr %u.var, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   %.loc15_33.4.b = getelementptr inbounds nuw { ptr, {} }, ptr %_.var, i32 0, i32 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc15_33.4.b, ptr align 1 @Other.val.loc15_33.5, i64 0, i1 false), !dbg !9
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
@@ -180,12 +180,12 @@ fn Run() {
 // CHECK:STDOUT: define void @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %o.var = alloca { i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %u.var = alloca { ptr, { i32 } }, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { ptr, { i32 } }, align 8, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %u.var), !dbg !8
-// CHECK:STDOUT:   %.loc17_40.2.a = getelementptr inbounds nuw { ptr, { i32 } }, ptr %u.var, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
+// CHECK:STDOUT:   %.loc17_40.2.a = getelementptr inbounds nuw { ptr, { i32 } }, ptr %_.var, i32 0, i32 0, !dbg !9
 // CHECK:STDOUT:   store ptr %o.var, ptr %.loc17_40.2.a, align 8, !dbg !9
-// CHECK:STDOUT:   %.loc17_40.4.b = getelementptr inbounds nuw { ptr, { i32 } }, ptr %u.var, i32 0, i32 1, !dbg !9
+// CHECK:STDOUT:   %.loc17_40.4.b = getelementptr inbounds nuw { ptr, { i32 } }, ptr %_.var, i32 0, i32 1, !dbg !9
 // CHECK:STDOUT:   %.loc17_39.3.v = getelementptr inbounds nuw { i32 }, ptr %.loc17_40.4.b, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc17_40.4.b, ptr align 4 @Other.val.loc17_40.5, i64 4, i1 false), !dbg !9
 // CHECK:STDOUT:   ret void, !dbg !11

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -34,12 +34,12 @@ package Create;
 import Classes;
 
 fn Create() {
-  var b: Classes.Base = {};
-  var i: Classes.Intermediate = {.base = {}};
-  var d: Classes.Derived = {.base = {.base = {}}};
+  var _: Classes.Base = {};
+  var _: Classes.Intermediate = {.base = {}};
+  var _: Classes.Derived = {.base = {.base = {}}};
   // Implicit initialization creates an object with the unformed state, which
   // doesn't include vptr initialization.
-  var d2: Classes.Derived;
+  var _: Classes.Derived;
 }
 
 fn Use(v: Classes.Intermediate*) {
@@ -59,7 +59,7 @@ fn Fn() {
   var i: i32 = 3;
   var v: Base = {.m = i};
   v.m = 5;
-  var u: Base = {.m = 3};
+  var _: Base = {.m = 3};
 }
 
 // --- member_brace_init.carbon
@@ -75,7 +75,7 @@ class Derived {
 }
 
 fn Use() {
-  var v : Derived = {.base = {}};
+  var _ : Derived = {.base = {}};
 }
 
 // --- call.carbon
@@ -122,7 +122,7 @@ library "[[@TEST_NAME]]";
 
 base class Base(T:! Core.Destroy) {
   virtual fn F[self: Self]() {
-    var v: T;
+    var _: T;
   }
 }
 
@@ -132,8 +132,8 @@ class T2 {
 }
 
 fn F() {
-  var t1: Base(T1) = {};
-  var t2: Base(T2) = {};
+  var _: Base(T1) = {};
+  var _: Base(T2) = {};
 }
 
 // --- generic_base.carbon
@@ -151,7 +151,7 @@ class Derived {
 }
 
 fn Make() {
-  var v: Derived;
+  var _: Derived;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'classes.carbon'
@@ -204,22 +204,22 @@ fn Make() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCreate.Create() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %i.var = alloca { ptr, {} }, align 8, !dbg !8
-// CHECK:STDOUT:   %d.var = alloca { { ptr, {} } }, align 8, !dbg !9
-// CHECK:STDOUT:   %d2.var = alloca { { ptr, {} } }, align 8, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %b.var, ptr align 1 @Base.val.loc7_3, i64 0, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %i.var), !dbg !8
-// CHECK:STDOUT:   %.loc8_44.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %i.var, i32 0, i32 0, !dbg !11
-// CHECK:STDOUT:   %.loc8_44.4.base = getelementptr inbounds nuw { ptr, {} }, ptr %i.var, i32 0, i32 1, !dbg !11
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %i.var, ptr align 8 @Intermediate.val.ec2.loc8_3, i64 8, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !9
-// CHECK:STDOUT:   %.loc9_49.2.base = getelementptr inbounds nuw { { ptr, {} } }, ptr %d.var, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   %_.var.loc7 = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %_.var.loc8 = alloca { ptr, {} }, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var.loc9 = alloca { { ptr, {} } }, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var.loc12 = alloca { { ptr, {} } }, align 8, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc7), !dbg !7
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc7, ptr align 1 @Base.val.loc7_3, i64 0, i1 false), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc8), !dbg !8
+// CHECK:STDOUT:   %.loc8_44.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %_.var.loc8, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc8_44.4.base = getelementptr inbounds nuw { ptr, {} }, ptr %_.var.loc8, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc8, ptr align 8 @Intermediate.val.ec2.loc8_3, i64 8, i1 false), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc9), !dbg !9
+// CHECK:STDOUT:   %.loc9_49.2.base = getelementptr inbounds nuw { { ptr, {} } }, ptr %_.var.loc9, i32 0, i32 0, !dbg !12
 // CHECK:STDOUT:   %.loc9_48.2.vptr = getelementptr inbounds nuw { ptr, {} }, ptr %.loc9_49.2.base, i32 0, i32 0, !dbg !13
 // CHECK:STDOUT:   %.loc9_48.4.base = getelementptr inbounds nuw { ptr, {} }, ptr %.loc9_49.2.base, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %d.var, ptr align 8 @Derived.val.loc9_3, i64 8, i1 false), !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d2.var), !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc9, ptr align 8 @Derived.val.loc9_3, i64 8, i1 false), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc12), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -297,7 +297,7 @@ fn Make() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %i.var = alloca i32, align 4, !dbg !14
 // CHECK:STDOUT:   %v.var = alloca { ptr, i32 }, align 8, !dbg !15
-// CHECK:STDOUT:   %u.var = alloca { ptr, i32 }, align 8, !dbg !16
+// CHECK:STDOUT:   %_.var = alloca { ptr, i32 }, align 8, !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %i.var), !dbg !14
 // CHECK:STDOUT:   store i32 3, ptr %i.var, align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !15
@@ -308,10 +308,10 @@ fn Make() {
 // CHECK:STDOUT:   store ptr @"_CBase.MemberInit.$vtable", ptr %.loc11_24.2.vptr, align 8, !dbg !17
 // CHECK:STDOUT:   %.loc12_4.m = getelementptr inbounds nuw { ptr, i32 }, ptr %v.var, i32 0, i32 1, !dbg !19
 // CHECK:STDOUT:   store i32 5, ptr %.loc12_4.m, align 4, !dbg !19
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %u.var), !dbg !16
-// CHECK:STDOUT:   %.loc13_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %u.var, i32 0, i32 0, !dbg !20
-// CHECK:STDOUT:   %.loc13_24.5.m = getelementptr inbounds nuw { ptr, i32 }, ptr %u.var, i32 0, i32 1, !dbg !20
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %u.var, ptr align 8 @Base.val.loc13_3, i64 16, i1 false), !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !16
+// CHECK:STDOUT:   %.loc13_24.2.vptr = getelementptr inbounds nuw { ptr, i32 }, ptr %_.var, i32 0, i32 0, !dbg !20
+// CHECK:STDOUT:   %.loc13_24.5.m = getelementptr inbounds nuw { ptr, i32 }, ptr %_.var, i32 0, i32 1, !dbg !20
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var, ptr align 8 @Base.val.loc13_3, i64 16, i1 false), !dbg !16
 // CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -365,11 +365,11 @@ fn Make() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CUse.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { { ptr } }, align 8, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !7
-// CHECK:STDOUT:   %.loc13_32.2.base = getelementptr inbounds nuw { { ptr } }, ptr %v.var, i32 0, i32 0, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { { ptr } }, align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
+// CHECK:STDOUT:   %.loc13_32.2.base = getelementptr inbounds nuw { { ptr } }, ptr %_.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   %.loc13_31.2.vptr = getelementptr inbounds nuw { ptr }, ptr %.loc13_32.2.base, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %v.var, ptr align 8 @Derived.val.loc13_3, i64 8, i1 false), !dbg !7
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var, ptr align 8 @Derived.val.loc13_3, i64 8, i1 false), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -509,30 +509,30 @@ fn Make() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %t1.var = alloca { ptr }, align 8, !dbg !7
-// CHECK:STDOUT:   %t2.var = alloca { ptr }, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %t1.var), !dbg !7
-// CHECK:STDOUT:   %.loc16_23.2.vptr = getelementptr inbounds nuw { ptr }, ptr %t1.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %t1.var, ptr align 8 @Base.val.439.loc16_3, i64 8, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %t2.var), !dbg !8
-// CHECK:STDOUT:   %.loc17_23.2.vptr = getelementptr inbounds nuw { ptr }, ptr %t2.var, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %t2.var, ptr align 8 @Base.val.5bf.loc17_3, i64 8, i1 false), !dbg !8
+// CHECK:STDOUT:   %_.var.loc16 = alloca { ptr }, align 8, !dbg !7
+// CHECK:STDOUT:   %_.var.loc17 = alloca { ptr }, align 8, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !7
+// CHECK:STDOUT:   %.loc16_22.2.vptr = getelementptr inbounds nuw { ptr }, ptr %_.var.loc16, i32 0, i32 0, !dbg !9
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc16, ptr align 8 @Base.val.439.loc16_3, i64 8, i1 false), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc17), !dbg !8
+// CHECK:STDOUT:   %.loc17_22.2.vptr = getelementptr inbounds nuw { ptr }, ptr %_.var.loc17, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc17, ptr align 8 @Base.val.5bf.loc17_3, i64 8, i1 false), !dbg !8
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Base.Main.4ff89889d3f52e25(ptr %self) #0 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca {}, align 8, !dbg !18
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !18
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !18
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !18
 // CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Base.Main.af40b72a3cc0ef58(ptr %self) #0 !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { {} }, align 8, !dbg !23
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !23
+// CHECK:STDOUT:   %_.var = alloca { {} }, align 8, !dbg !23
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !23
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -562,8 +562,8 @@ fn Make() {
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 16, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 17, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 22, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 22, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 21, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 21, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 15, column: 1, scope: !4)
 // CHECK:STDOUT: !12 = distinct !DISubprogram(name: "F", linkageName: "_CF.Base.Main.4ff89889d3f52e25", scope: null, file: !3, line: 5, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !16)
 // CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
@@ -586,8 +586,8 @@ fn Make() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMake.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { { ptr } }, align 8, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !7
+// CHECK:STDOUT:   %_.var = alloca { { ptr } }, align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/for/bindings.carbon
+++ b/toolchain/lower/testdata/for/bindings.carbon
@@ -15,7 +15,7 @@ class EmptyRange(T:! Core.Copy) {
     fn NewCursor[self: Self]() -> {} {
       return {};
     }
-    fn Next[self: Self](cursor: {}*) -> Core.Optional(T) {
+    fn Next[self: Self](_: {}*) -> Core.Optional(T) {
       return Core.Optional(T).None();
     }
   }
@@ -87,7 +87,7 @@ fn For() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CNext.EmptyRange.Main:Iterate.Core.f3fd01d4dee2d7f7"(ptr sret({ { i32, i32 }, i1 }) %return, ptr %self, ptr %cursor) #0 !dbg !20 {
+// CHECK:STDOUT: define linkonce_odr void @"_CNext.EmptyRange.Main:Iterate.Core.f3fd01d4dee2d7f7"(ptr sret({ { i32, i32 }, i1 }) %return, ptr %self, ptr %_) #0 !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CNone.Optional.Core.9925d053027dadb9(ptr %return), !dbg !26
 // CHECK:STDOUT:   ret void, !dbg !27

--- a/toolchain/lower/testdata/for/break_continue.carbon
+++ b/toolchain/lower/testdata/for/break_continue.carbon
@@ -17,7 +17,7 @@ fn G() -> bool;
 fn H();
 
 fn For() {
-  for (n: i32 in Core.Range(100)) {
+  for (_: i32 in Core.Range(100)) {
     if (F()) { break; }
     if (G()) { continue; }
     H();

--- a/toolchain/lower/testdata/for/for.carbon
+++ b/toolchain/lower/testdata/for/for.carbon
@@ -18,7 +18,7 @@ fn H();
 
 fn For() {
   F();
-  for (n: i32 in Core.Range(100)) {
+  for (_: i32 in Core.Range(100)) {
     G();
   }
   H();

--- a/toolchain/lower/testdata/function/call/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/call/empty_struct.carbon
@@ -10,12 +10,12 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/empty_struct.carbon
 
-fn Echo(a: {}) -> {} {
+fn Echo(_: {}) -> {} {
   return {};
 }
 
 fn Main() {
-  var b: {} = Echo({});
+  var _: {} = Echo({});
 }
 
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !9 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !12
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !12
 // CHECK:STDOUT:   call void @_CEcho.Main(), !dbg !13
 // CHECK:STDOUT:   ret void, !dbg !14
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lower/testdata/function/call/empty_tuple.carbon
@@ -15,7 +15,7 @@ fn Echo(a: ()) -> () {
 }
 
 fn Main() {
-  var b: () = Echo(());
+  var _: () = Echo(());
 }
 
 // CHECK:STDOUT: ; ModuleID = 'empty_tuple.carbon'
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !9 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !12
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !12
 // CHECK:STDOUT:   call void @_CEcho.Main(), !dbg !13
 // CHECK:STDOUT:   ret void, !dbg !14
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/i32.carbon
+++ b/toolchain/lower/testdata/function/call/i32.carbon
@@ -15,7 +15,7 @@ fn Echo(a: i32) -> i32 {
 }
 
 fn Main() {
-  var b: i32 = Echo(1);
+  var _: i32 = Echo(1);
 }
 
 // CHECK:STDOUT: ; ModuleID = 'i32.carbon'
@@ -30,10 +30,10 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !14
+// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   %Echo.call = call i32 @_CEcho.Main(i32 1), !dbg !15
-// CHECK:STDOUT:   store i32 %Echo.call, ptr %b.var, align 4, !dbg !14
+// CHECK:STDOUT:   store i32 %Echo.call, ptr %_.var, align 4, !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
+++ b/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
@@ -16,7 +16,7 @@ fn Foo() {}
 fn Bar(a: ()) -> () { return a; }
 
 fn Main() {
-  var x: () = Bar(Foo());
+  var _: () = Bar(Foo());
 }
 
 // CHECK:STDOUT: ; ModuleID = 'implicit_empty_tuple_as_arg.carbon'
@@ -37,9 +37,9 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !13 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !14
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !14
 // CHECK:STDOUT:   %.loc19_23.1.temp = alloca {}, align 8, !dbg !15
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @_CFoo.Main(), !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_23.1.temp), !dbg !15
 // CHECK:STDOUT:   call void @_CBar.Main(), !dbg !16

--- a/toolchain/lower/testdata/function/call/params_one.carbon
+++ b/toolchain/lower/testdata/function/call/params_one.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/params_one.carbon
 
-fn Foo(a: i32) {}
+fn Foo(_: i32) {}
 
 fn Main() {
   Foo(1);
@@ -20,7 +20,7 @@ fn Main() {
 // CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFoo.Main(i32 %a) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CFoo.Main(i32 %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/lower/testdata/function/call/params_one_comma.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/params_one_comma.carbon
 
-fn Foo(a: i32,) {}
+fn Foo(_: i32,) {}
 
 fn Main() {
   Foo(1);
@@ -21,7 +21,7 @@ fn Main() {
 // CHECK:STDOUT: source_filename = "params_one_comma.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFoo.Main(i32 %a) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CFoo.Main(i32 %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/params_two.carbon
+++ b/toolchain/lower/testdata/function/call/params_two.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/params_two.carbon
 
-fn Foo(a: i32, b: i32) {}
+fn Foo(_: i32, _: i32) {}
 
 fn Main() {
   Foo(1, 2);
@@ -20,7 +20,7 @@ fn Main() {
 // CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFoo.Main(i32 %a, i32 %b) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CFoo.Main(i32 %_, i32 %_1) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/lower/testdata/function/call/params_two_comma.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/params_two_comma.carbon
 
-fn Foo(a: i32, b: i32,) {}
+fn Foo(_: i32, _: i32,) {}
 
 fn Main() {
   Foo(1, 2);
@@ -21,7 +21,7 @@ fn Main() {
 // CHECK:STDOUT: source_filename = "params_two_comma.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFoo.Main(i32 %a, i32 %b) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CFoo.Main(i32 %_, i32 %_1) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/ref_param.carbon
+++ b/toolchain/lower/testdata/function/call/ref_param.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/ref_param.carbon
 
-fn DoNothing(ref a: i32) {}
+fn DoNothing(ref _: i32) {}
 
 fn Main() {
   var a: i32 = 0;
@@ -21,7 +21,7 @@ fn Main() {
 // CHECK:STDOUT: source_filename = "ref_param.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CDoNothing.Main(ptr %a) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CDoNothing.Main(ptr %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/return_implicit.carbon
+++ b/toolchain/lower/testdata/function/call/return_implicit.carbon
@@ -15,7 +15,7 @@ fn MakeImplicitEmptyTuple() {
 }
 
 fn Main() {
-  var b: () = MakeImplicitEmptyTuple();
+  var _: () = MakeImplicitEmptyTuple();
 }
 
 // CHECK:STDOUT: ; ModuleID = 'return_implicit.carbon'
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !8 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !9
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   call void @_CMakeImplicitEmptyTuple.Main(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/struct_param.carbon
+++ b/toolchain/lower/testdata/function/call/struct_param.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/struct_param.carbon
 
-fn F(a: {}, b: {.a: i32}, c: {.a: i32, .b: i32}) {}
+fn F(_: {}, _: {.a: i32}, _: {.a: i32, .b: i32}) {}
 
 fn Main() {
   F({}, {.a = 1}, {.a = 2, .b = 3});
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT: @struct.9ae.loc16_34.6 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF.Main({ i32 } %b, ptr %c) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CF.Main({ i32 } %_, ptr %_1) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/tuple_param.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/tuple_param.carbon
 
-fn F(a: (), b: (i32,), c: (i32, i32)) {}
+fn F(_: (), _: (i32,), _: (i32, i32)) {}
 
 fn Main() {
   F((), (1,), (2, 3));
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT: @tuple.11a.loc16_20.6 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF.Main({ i32 } %b, ptr %c) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CF.Main({ i32 } %_, ptr %_1) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
 
-fn F(a: (), b: (i32,), c: (i32, i32)) -> (i32, i32, i32) {
+fn F(_: (), b: (i32,), c: (i32, i32)) -> (i32, i32, i32) {
   return (b.0, c.0, c.1);
 }
 

--- a/toolchain/lower/testdata/function/call/var_param.carbon
+++ b/toolchain/lower/testdata/function/call/var_param.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/call/var_param.carbon
 
-fn DoNothing(a: i32) {}
+fn DoNothing(_: i32) {}
 
 fn Main() {
   var a: i32 = 0;
@@ -21,7 +21,7 @@ fn Main() {
 // CHECK:STDOUT: source_filename = "var_param.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CDoNothing.Main(i32 %a) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CDoNothing.Main(i32 %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/definition/destroy.carbon
+++ b/toolchain/lower/testdata/function/definition/destroy.carbon
@@ -16,7 +16,7 @@ library "[[@TEST_NAME]]";
 
 class C {}
 
-fn F(x: C) {
+fn F(_: C) {
 }
 
 fn G();
@@ -34,7 +34,7 @@ library "[[@TEST_NAME]]";
 
 class C {}
 
-fn F(var x: C) {
+fn F(var _: C) {
 }
 
 fn G();
@@ -63,12 +63,12 @@ fn Forward() -> C {
 }
 
 fn InitVar() {
-  var local: C = F();
+  var _: C = F();
   G();
 }
 
 fn InitLet() {
-  let local: C = F();
+  let _: C = F();
   G();
 }
 
@@ -78,7 +78,7 @@ fn InitLet() {
 // CHECK:STDOUT: @C.val.loc12_6.3 = internal constant {} zeroinitializer
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF.Main(ptr %x) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CF.Main(ptr %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
@@ -133,7 +133,7 @@ fn InitLet() {
 // CHECK:STDOUT: @C.val.loc6_6.2 = internal constant {} zeroinitializer
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF.Main(ptr %x) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CF.Main(ptr %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
@@ -206,9 +206,9 @@ fn InitLet() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitVar.Main() #0 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %local.var = alloca {}, align 8, !dbg !15
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %local.var), !dbg !15
-// CHECK:STDOUT:   call void @_CF.Main(ptr %local.var), !dbg !16
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !15
+// CHECK:STDOUT:   call void @_CF.Main(ptr %_.var), !dbg !16
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !17
 // CHECK:STDOUT:   ret void, !dbg !18
 // CHECK:STDOUT: }
@@ -216,9 +216,9 @@ fn InitLet() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitLet.Main() #0 !dbg !19 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc22_20.1.temp = alloca {}, align 8, !dbg !20
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_20.1.temp), !dbg !20
-// CHECK:STDOUT:   call void @_CF.Main(ptr %.loc22_20.1.temp), !dbg !20
+// CHECK:STDOUT:   %.loc22_16.1.temp = alloca {}, align 8, !dbg !20
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_16.1.temp), !dbg !20
+// CHECK:STDOUT:   call void @_CF.Main(ptr %.loc22_16.1.temp), !dbg !20
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !21
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
@@ -255,10 +255,10 @@ fn InitLet() {
 // CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
 // CHECK:STDOUT: !14 = !{null}
 // CHECK:STDOUT: !15 = !DILocation(line: 17, column: 3, scope: !12)
-// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 18, scope: !12)
+// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 14, scope: !12)
 // CHECK:STDOUT: !17 = !DILocation(line: 18, column: 3, scope: !12)
 // CHECK:STDOUT: !18 = !DILocation(line: 16, column: 1, scope: !12)
 // CHECK:STDOUT: !19 = distinct !DISubprogram(name: "InitLet", linkageName: "_CInitLet.Main", scope: null, file: !3, line: 21, type: !13, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 18, scope: !19)
+// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 14, scope: !19)
 // CHECK:STDOUT: !21 = !DILocation(line: 23, column: 3, scope: !19)
 // CHECK:STDOUT: !22 = !DILocation(line: 21, column: 1, scope: !19)

--- a/toolchain/lower/testdata/function/definition/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/definition/empty_struct.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/definition/empty_struct.carbon
 
-fn Echo(a: {}) {
+fn Echo(_: {}) {
 }
 
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'

--- a/toolchain/lower/testdata/function/definition/params_one.carbon
+++ b/toolchain/lower/testdata/function/definition/params_one.carbon
@@ -10,13 +10,13 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/definition/params_one.carbon
 
-fn Foo(a: i32) {}
+fn Foo(_: i32) {}
 
 // CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
 // CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFoo.Main(i32 %a) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CFoo.Main(i32 %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/definition/params_two.carbon
+++ b/toolchain/lower/testdata/function/definition/params_two.carbon
@@ -10,13 +10,13 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/definition/params_two.carbon
 
-fn Foo(a: i32, b: i32) {}
+fn Foo(_: i32, _: i32) {}
 
 // CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
 // CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFoo.Main(i32 %a, i32 %b) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CFoo.Main(i32 %_, i32 %_1) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/definition/var_param.carbon
+++ b/toolchain/lower/testdata/function/definition/var_param.carbon
@@ -12,13 +12,13 @@
 
 class X {}
 
-fn OneVar_i32(var n: i32) {}
-fn OneVar_X(var x: X) {}
+fn OneVar_i32(var _: i32) {}
+fn OneVar_X(var _: X) {}
 
-fn TwoVars(var a: i32, var b: X) {}
+fn TwoVars(var _: i32, var _: X) {}
 
-fn VarThenLet(var a: i32, b: X) {}
-fn LetThenVar(a: i32, var b: X) {}
+fn VarThenLet(var _: i32, _: X) {}
+fn LetThenVar(_: i32, var _: X) {}
 
 fn Call() {
   OneVar_i32(1);
@@ -34,31 +34,31 @@ fn Call() {
 // CHECK:STDOUT: @X.val.loc16_13.2 = internal constant {} zeroinitializer
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_COneVar_i32.Main(ptr %n) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_COneVar_i32.Main(ptr %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_COneVar_X.Main(ptr %x) #0 !dbg !11 {
+// CHECK:STDOUT: define void @_COneVar_X.Main(ptr %_) #0 !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CTwoVars.Main(ptr %a, ptr %b) #0 !dbg !18 {
+// CHECK:STDOUT: define void @_CTwoVars.Main(ptr %_, ptr %_1) #0 !dbg !18 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CVarThenLet.Main(ptr %a, ptr %b) #0 !dbg !25 {
+// CHECK:STDOUT: define void @_CVarThenLet.Main(ptr %_, ptr %_1) #0 !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !29
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CLetThenVar.Main(i32 %a, ptr %b) #0 !dbg !30 {
+// CHECK:STDOUT: define void @_CLetThenVar.Main(i32 %_, ptr %_1) #0 !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !34
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call.carbon
+++ b/toolchain/lower/testdata/function/generic/call.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/function/generic/call.carbon
 
-fn F[T:! type](x: T) {
+fn F[T:! type](_: T) {
 }
 
 class C {}
@@ -69,25 +69,25 @@ fn G() {
 // CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.0c4ab795cec6cb27(ptr %x) #0 !dbg !19 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.0c4ab795cec6cb27(ptr %_) #0 !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %x) #0 !dbg !26 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %_) #0 !dbg !26 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.d4b5665541d5d7a8(double %x) #0 !dbg !33 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.d4b5665541d5d7a8(double %_) #0 !dbg !33 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !36
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.5754c7a55c7cbe4a(%type %x) #0 !dbg !37 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.5754c7a55c7cbe4a(%type %_) #0 !dbg !37 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !40
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -16,7 +16,7 @@ class C {
   }
 }
 
-fn F[T:! type](x: T) {
+fn F[T:! type](_: T) {
 }
 
 fn H[T:! Core.Copy](x: T) -> T {
@@ -47,14 +47,12 @@ fn G[T:! Core.Copy & Core.Destroy](x: T) -> T {
 
 fn M() {
   var n: i32 = 0;
-  var m: i32;
   var p: f64 = 1.0;
-  var q: f64;
 
   F(n);
-  m = G(n);
+  let _: i32 = G(n);
   F(p);
-  q = G(p);
+  let _: f64 = G(p);
 }
 
 // CHECK:STDOUT: ; ModuleID = 'call_basic.carbon'
@@ -75,26 +73,20 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !14
-// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !15
-// CHECK:STDOUT:   %p.var = alloca double, align 8, !dbg !16
-// CHECK:STDOUT:   %q.var = alloca double, align 8, !dbg !17
+// CHECK:STDOUT:   %p.var = alloca double, align 8, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !14
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %m.var), !dbg !15
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %p.var), !dbg !16
-// CHECK:STDOUT:   store double 1.000000e+00, ptr %p.var, align 8, !dbg !16
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %q.var), !dbg !17
-// CHECK:STDOUT:   %.loc54 = load i32, ptr %n.var, align 4, !dbg !18
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc54), !dbg !19
-// CHECK:STDOUT:   %.loc55_9 = load i32, ptr %n.var, align 4, !dbg !20
-// CHECK:STDOUT:   %G.call.loc55 = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc55_9), !dbg !21
-// CHECK:STDOUT:   store i32 %G.call.loc55, ptr %m.var, align 4, !dbg !22
-// CHECK:STDOUT:   %.loc56 = load double, ptr %p.var, align 8, !dbg !23
-// CHECK:STDOUT:   call void @_CF.Main.d4b5665541d5d7a8(double %.loc56), !dbg !24
-// CHECK:STDOUT:   %.loc57_9 = load double, ptr %p.var, align 8, !dbg !25
-// CHECK:STDOUT:   %G.call.loc57 = call double @_CG.Main.c274f22d2c1ca5ee(double %.loc57_9), !dbg !26
-// CHECK:STDOUT:   store double %G.call.loc57, ptr %q.var, align 8, !dbg !27
-// CHECK:STDOUT:   ret void, !dbg !28
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %p.var), !dbg !15
+// CHECK:STDOUT:   store double 1.000000e+00, ptr %p.var, align 8, !dbg !15
+// CHECK:STDOUT:   %.loc52 = load i32, ptr %n.var, align 4, !dbg !16
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc52), !dbg !17
+// CHECK:STDOUT:   %.loc53_18 = load i32, ptr %n.var, align 4, !dbg !18
+// CHECK:STDOUT:   %G.call.loc53 = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc53_18), !dbg !19
+// CHECK:STDOUT:   %.loc54 = load double, ptr %p.var, align 8, !dbg !20
+// CHECK:STDOUT:   call void @_CF.Main.d4b5665541d5d7a8(double %.loc54), !dbg !21
+// CHECK:STDOUT:   %.loc55_18 = load double, ptr %p.var, align 8, !dbg !22
+// CHECK:STDOUT:   %G.call.loc55 = call double @_CG.Main.c274f22d2c1ca5ee(double %.loc55_18), !dbg !23
+// CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
@@ -104,132 +96,132 @@ fn M() {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %x) #0 !dbg !29 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %_) #0 !dbg !25 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !35
+// CHECK:STDOUT:   ret void, !dbg !31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.68e44d468a50c22e(i32 %x) #0 !dbg !36 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.68e44d468a50c22e(i32 %x) #0 !dbg !32 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc29_6.3.temp = alloca i32, align 4, !dbg !41
-// CHECK:STDOUT:   %.loc31_8.3.temp = alloca i32, align 4, !dbg !42
-// CHECK:STDOUT:   %.loc31_9.3.temp = alloca i32, align 4, !dbg !43
-// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !44
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !45
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !46
-// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !47
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !48
-// CHECK:STDOUT:   %.loc43_6.3.temp = alloca {}, align 8, !dbg !49
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_6.3.temp), !dbg !41
-// CHECK:STDOUT:   %H.call.loc29 = call i32 @_CH.Main.3440082c84c3c17b(i32 %x), !dbg !41
-// CHECK:STDOUT:   store i32 %H.call.loc29, ptr %.loc29_6.3.temp, align 4, !dbg !41
-// CHECK:STDOUT:   %H.call.loc30 = call %type @_CH.Main.93e33f284107e304(%type zeroinitializer), !dbg !50
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_8.3.temp), !dbg !42
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %x), !dbg !42
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_9.3.temp), !dbg !43
-// CHECK:STDOUT:   store i32 %G.call, ptr %.loc31_8.3.temp, align 4, !dbg !42
-// CHECK:STDOUT:   %.loc31_8.5 = load i32, ptr %.loc31_8.3.temp, align 4, !dbg !42
-// CHECK:STDOUT:   %H.call.loc31 = call i32 @_CH.Main.3440082c84c3c17b(i32 %.loc31_8.5), !dbg !43
-// CHECK:STDOUT:   store i32 %H.call.loc31, ptr %.loc31_9.3.temp, align 4, !dbg !43
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %var_f64.var), !dbg !44
-// CHECK:STDOUT:   %.loc35_5 = load double, ptr %var_f64.var, align 8, !dbg !51
-// CHECK:STDOUT:   %H.call.loc35 = call double @_CH.Main.286b0f7890e5304c(double %.loc35_5), !dbg !52
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i32.var), !dbg !45
-// CHECK:STDOUT:   %.loc37_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !53
-// CHECK:STDOUT:   %H.call.loc37 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc37_5), !dbg !54
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_f64.var), !dbg !46
-// CHECK:STDOUT:   %.loc39_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !55
-// CHECK:STDOUT:   %H.call.loc39 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc39_5), !dbg !56
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i8.var), !dbg !47
-// CHECK:STDOUT:   %.loc41_5 = load ptr, ptr %ptr_i8.var, align 8, !dbg !57
-// CHECK:STDOUT:   %H.call.loc41 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc41_5), !dbg !58
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !48
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc43_6.3.temp), !dbg !49
-// CHECK:STDOUT:   call void @_CH.Main.f8e70200fd9d8b37(ptr %.loc43_6.3.temp, ptr %c.var), !dbg !49
-// CHECK:STDOUT:   ret i32 %x, !dbg !59
+// CHECK:STDOUT:   %.loc29_6.3.temp = alloca i32, align 4, !dbg !37
+// CHECK:STDOUT:   %.loc31_8.3.temp = alloca i32, align 4, !dbg !38
+// CHECK:STDOUT:   %.loc31_9.3.temp = alloca i32, align 4, !dbg !39
+// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !40
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !41
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !42
+// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !43
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !44
+// CHECK:STDOUT:   %.loc43_6.3.temp = alloca {}, align 8, !dbg !45
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_6.3.temp), !dbg !37
+// CHECK:STDOUT:   %H.call.loc29 = call i32 @_CH.Main.3440082c84c3c17b(i32 %x), !dbg !37
+// CHECK:STDOUT:   store i32 %H.call.loc29, ptr %.loc29_6.3.temp, align 4, !dbg !37
+// CHECK:STDOUT:   %H.call.loc30 = call %type @_CH.Main.93e33f284107e304(%type zeroinitializer), !dbg !46
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_8.3.temp), !dbg !38
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %x), !dbg !38
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_9.3.temp), !dbg !39
+// CHECK:STDOUT:   store i32 %G.call, ptr %.loc31_8.3.temp, align 4, !dbg !38
+// CHECK:STDOUT:   %.loc31_8.5 = load i32, ptr %.loc31_8.3.temp, align 4, !dbg !38
+// CHECK:STDOUT:   %H.call.loc31 = call i32 @_CH.Main.3440082c84c3c17b(i32 %.loc31_8.5), !dbg !39
+// CHECK:STDOUT:   store i32 %H.call.loc31, ptr %.loc31_9.3.temp, align 4, !dbg !39
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %var_f64.var), !dbg !40
+// CHECK:STDOUT:   %.loc35_5 = load double, ptr %var_f64.var, align 8, !dbg !47
+// CHECK:STDOUT:   %H.call.loc35 = call double @_CH.Main.286b0f7890e5304c(double %.loc35_5), !dbg !48
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i32.var), !dbg !41
+// CHECK:STDOUT:   %.loc37_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !49
+// CHECK:STDOUT:   %H.call.loc37 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc37_5), !dbg !50
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_f64.var), !dbg !42
+// CHECK:STDOUT:   %.loc39_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !51
+// CHECK:STDOUT:   %H.call.loc39 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc39_5), !dbg !52
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i8.var), !dbg !43
+// CHECK:STDOUT:   %.loc41_5 = load ptr, ptr %ptr_i8.var, align 8, !dbg !53
+// CHECK:STDOUT:   %H.call.loc41 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc41_5), !dbg !54
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !44
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc43_6.3.temp), !dbg !45
+// CHECK:STDOUT:   call void @_CH.Main.f8e70200fd9d8b37(ptr %.loc43_6.3.temp, ptr %c.var), !dbg !45
+// CHECK:STDOUT:   ret i32 %x, !dbg !55
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.d4b5665541d5d7a8(double %x) #0 !dbg !60 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.d4b5665541d5d7a8(double %_) #0 !dbg !56 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !65
+// CHECK:STDOUT:   ret void, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr double @_CG.Main.c274f22d2c1ca5ee(double %x) #0 !dbg !66 {
+// CHECK:STDOUT: define linkonce_odr double @_CG.Main.c274f22d2c1ca5ee(double %x) #0 !dbg !62 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc29_6.3.temp = alloca double, align 8, !dbg !69
-// CHECK:STDOUT:   %.loc31_8.3.temp = alloca double, align 8, !dbg !70
-// CHECK:STDOUT:   %.loc31_9.3.temp = alloca double, align 8, !dbg !71
-// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !72
-// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !73
-// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !74
-// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !75
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !76
-// CHECK:STDOUT:   %.loc43_6.3.temp = alloca {}, align 8, !dbg !77
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_6.3.temp), !dbg !69
-// CHECK:STDOUT:   %H.call.loc29 = call double @_CH.Main.286b0f7890e5304c(double %x), !dbg !69
-// CHECK:STDOUT:   store double %H.call.loc29, ptr %.loc29_6.3.temp, align 8, !dbg !69
-// CHECK:STDOUT:   %H.call.loc30 = call %type @_CH.Main.93e33f284107e304(%type zeroinitializer), !dbg !78
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_8.3.temp), !dbg !70
-// CHECK:STDOUT:   %G.call = call double @_CG.Main.c274f22d2c1ca5ee(double %x), !dbg !70
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_9.3.temp), !dbg !71
-// CHECK:STDOUT:   store double %G.call, ptr %.loc31_8.3.temp, align 8, !dbg !70
-// CHECK:STDOUT:   %.loc31_8.5 = load double, ptr %.loc31_8.3.temp, align 8, !dbg !70
-// CHECK:STDOUT:   %H.call.loc31 = call double @_CH.Main.286b0f7890e5304c(double %.loc31_8.5), !dbg !71
-// CHECK:STDOUT:   store double %H.call.loc31, ptr %.loc31_9.3.temp, align 8, !dbg !71
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %var_f64.var), !dbg !72
-// CHECK:STDOUT:   %.loc35_5 = load double, ptr %var_f64.var, align 8, !dbg !79
-// CHECK:STDOUT:   %H.call.loc35 = call double @_CH.Main.286b0f7890e5304c(double %.loc35_5), !dbg !80
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i32.var), !dbg !73
-// CHECK:STDOUT:   %.loc37_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !81
-// CHECK:STDOUT:   %H.call.loc37 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc37_5), !dbg !82
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_f64.var), !dbg !74
-// CHECK:STDOUT:   %.loc39_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !83
-// CHECK:STDOUT:   %H.call.loc39 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc39_5), !dbg !84
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i8.var), !dbg !75
-// CHECK:STDOUT:   %.loc41_5 = load ptr, ptr %ptr_i8.var, align 8, !dbg !85
-// CHECK:STDOUT:   %H.call.loc41 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc41_5), !dbg !86
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !76
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc43_6.3.temp), !dbg !77
-// CHECK:STDOUT:   call void @_CH.Main.f8e70200fd9d8b37(ptr %.loc43_6.3.temp, ptr %c.var), !dbg !77
-// CHECK:STDOUT:   ret double %x, !dbg !87
+// CHECK:STDOUT:   %.loc29_6.3.temp = alloca double, align 8, !dbg !65
+// CHECK:STDOUT:   %.loc31_8.3.temp = alloca double, align 8, !dbg !66
+// CHECK:STDOUT:   %.loc31_9.3.temp = alloca double, align 8, !dbg !67
+// CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !68
+// CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !69
+// CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !70
+// CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !71
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !72
+// CHECK:STDOUT:   %.loc43_6.3.temp = alloca {}, align 8, !dbg !73
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_6.3.temp), !dbg !65
+// CHECK:STDOUT:   %H.call.loc29 = call double @_CH.Main.286b0f7890e5304c(double %x), !dbg !65
+// CHECK:STDOUT:   store double %H.call.loc29, ptr %.loc29_6.3.temp, align 8, !dbg !65
+// CHECK:STDOUT:   %H.call.loc30 = call %type @_CH.Main.93e33f284107e304(%type zeroinitializer), !dbg !74
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_8.3.temp), !dbg !66
+// CHECK:STDOUT:   %G.call = call double @_CG.Main.c274f22d2c1ca5ee(double %x), !dbg !66
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc31_9.3.temp), !dbg !67
+// CHECK:STDOUT:   store double %G.call, ptr %.loc31_8.3.temp, align 8, !dbg !66
+// CHECK:STDOUT:   %.loc31_8.5 = load double, ptr %.loc31_8.3.temp, align 8, !dbg !66
+// CHECK:STDOUT:   %H.call.loc31 = call double @_CH.Main.286b0f7890e5304c(double %.loc31_8.5), !dbg !67
+// CHECK:STDOUT:   store double %H.call.loc31, ptr %.loc31_9.3.temp, align 8, !dbg !67
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %var_f64.var), !dbg !68
+// CHECK:STDOUT:   %.loc35_5 = load double, ptr %var_f64.var, align 8, !dbg !75
+// CHECK:STDOUT:   %H.call.loc35 = call double @_CH.Main.286b0f7890e5304c(double %.loc35_5), !dbg !76
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i32.var), !dbg !69
+// CHECK:STDOUT:   %.loc37_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !77
+// CHECK:STDOUT:   %H.call.loc37 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc37_5), !dbg !78
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_f64.var), !dbg !70
+// CHECK:STDOUT:   %.loc39_5 = load ptr, ptr %ptr_f64.var, align 8, !dbg !79
+// CHECK:STDOUT:   %H.call.loc39 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc39_5), !dbg !80
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i8.var), !dbg !71
+// CHECK:STDOUT:   %.loc41_5 = load ptr, ptr %ptr_i8.var, align 8, !dbg !81
+// CHECK:STDOUT:   %H.call.loc41 = call ptr @_CH.Main.4b30cda44e16b9ec(ptr %.loc41_5), !dbg !82
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !72
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc43_6.3.temp), !dbg !73
+// CHECK:STDOUT:   call void @_CH.Main.f8e70200fd9d8b37(ptr %.loc43_6.3.temp, ptr %c.var), !dbg !73
+// CHECK:STDOUT:   ret double %x, !dbg !83
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.3440082c84c3c17b(i32 %x) #0 !dbg !88 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.3440082c84c3c17b(i32 %x) #0 !dbg !84 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret i32 %x, !dbg !91
+// CHECK:STDOUT:   ret i32 %x, !dbg !87
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr %type @_CH.Main.93e33f284107e304(%type %x) #0 !dbg !92 {
+// CHECK:STDOUT: define linkonce_odr %type @_CH.Main.93e33f284107e304(%type %x) #0 !dbg !88 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret %type %x, !dbg !95
+// CHECK:STDOUT:   ret %type %x, !dbg !91
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr double @_CH.Main.286b0f7890e5304c(double %x) #0 !dbg !96 {
+// CHECK:STDOUT: define linkonce_odr double @_CH.Main.286b0f7890e5304c(double %x) #0 !dbg !92 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret double %x, !dbg !99
+// CHECK:STDOUT:   ret double %x, !dbg !95
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CH.Main.4b30cda44e16b9ec(ptr %x) #0 !dbg !100 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CH.Main.4b30cda44e16b9ec(ptr %x) #0 !dbg !96 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret ptr %x, !dbg !103
+// CHECK:STDOUT:   ret ptr %x, !dbg !99
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CH.Main.f8e70200fd9d8b37(ptr sret({}) %return, ptr %x) #0 !dbg !104 {
+// CHECK:STDOUT: define linkonce_odr void @_CH.Main.f8e70200fd9d8b37(ptr sret({}) %return, ptr %x) #0 !dbg !100 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @"_COp.C.Main:Copy.Core"(ptr %return, ptr %x), !dbg !107
-// CHECK:STDOUT:   ret void, !dbg !108
+// CHECK:STDOUT:   call void @"_COp.C.Main:Copy.Core"(ptr %return, ptr %x), !dbg !103
+// CHECK:STDOUT:   ret void, !dbg !104
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 21, 20, 19, 18 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 18 }
 // CHECK:STDOUT: uselistorder ptr @_CH.Main.3440082c84c3c17b, { 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @_CH.Main.93e33f284107e304, { 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @_CH.Main.286b0f7890e5304c, { 3, 2, 1, 0 }
@@ -259,96 +251,92 @@ fn M() {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 49, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 50, column: 3, scope: !11)
-// CHECK:STDOUT: !16 = !DILocation(line: 51, column: 3, scope: !11)
+// CHECK:STDOUT: !16 = !DILocation(line: 52, column: 5, scope: !11)
 // CHECK:STDOUT: !17 = !DILocation(line: 52, column: 3, scope: !11)
-// CHECK:STDOUT: !18 = !DILocation(line: 54, column: 5, scope: !11)
-// CHECK:STDOUT: !19 = !DILocation(line: 54, column: 3, scope: !11)
-// CHECK:STDOUT: !20 = !DILocation(line: 55, column: 9, scope: !11)
-// CHECK:STDOUT: !21 = !DILocation(line: 55, column: 7, scope: !11)
-// CHECK:STDOUT: !22 = !DILocation(line: 55, column: 3, scope: !11)
-// CHECK:STDOUT: !23 = !DILocation(line: 56, column: 5, scope: !11)
-// CHECK:STDOUT: !24 = !DILocation(line: 56, column: 3, scope: !11)
-// CHECK:STDOUT: !25 = !DILocation(line: 57, column: 9, scope: !11)
-// CHECK:STDOUT: !26 = !DILocation(line: 57, column: 7, scope: !11)
-// CHECK:STDOUT: !27 = !DILocation(line: 57, column: 3, scope: !11)
-// CHECK:STDOUT: !28 = !DILocation(line: 48, column: 1, scope: !11)
-// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 19, type: !30, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !33)
-// CHECK:STDOUT: !30 = !DISubroutineType(types: !31)
-// CHECK:STDOUT: !31 = !{null, !32}
-// CHECK:STDOUT: !32 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !33 = !{!34}
-// CHECK:STDOUT: !34 = !DILocalVariable(arg: 1, scope: !29, type: !32)
-// CHECK:STDOUT: !35 = !DILocation(line: 19, column: 1, scope: !29)
-// CHECK:STDOUT: !36 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.68e44d468a50c22e", scope: null, file: !3, line: 28, type: !37, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !39)
-// CHECK:STDOUT: !37 = !DISubroutineType(types: !38)
-// CHECK:STDOUT: !38 = !{!32, !32}
-// CHECK:STDOUT: !39 = !{!40}
-// CHECK:STDOUT: !40 = !DILocalVariable(arg: 1, scope: !36, type: !32)
-// CHECK:STDOUT: !41 = !DILocation(line: 29, column: 3, scope: !36)
-// CHECK:STDOUT: !42 = !DILocation(line: 31, column: 5, scope: !36)
-// CHECK:STDOUT: !43 = !DILocation(line: 31, column: 3, scope: !36)
-// CHECK:STDOUT: !44 = !DILocation(line: 34, column: 3, scope: !36)
-// CHECK:STDOUT: !45 = !DILocation(line: 36, column: 3, scope: !36)
-// CHECK:STDOUT: !46 = !DILocation(line: 38, column: 3, scope: !36)
-// CHECK:STDOUT: !47 = !DILocation(line: 40, column: 3, scope: !36)
-// CHECK:STDOUT: !48 = !DILocation(line: 42, column: 3, scope: !36)
-// CHECK:STDOUT: !49 = !DILocation(line: 43, column: 3, scope: !36)
-// CHECK:STDOUT: !50 = !DILocation(line: 30, column: 3, scope: !36)
-// CHECK:STDOUT: !51 = !DILocation(line: 35, column: 5, scope: !36)
-// CHECK:STDOUT: !52 = !DILocation(line: 35, column: 3, scope: !36)
-// CHECK:STDOUT: !53 = !DILocation(line: 37, column: 5, scope: !36)
-// CHECK:STDOUT: !54 = !DILocation(line: 37, column: 3, scope: !36)
-// CHECK:STDOUT: !55 = !DILocation(line: 39, column: 5, scope: !36)
-// CHECK:STDOUT: !56 = !DILocation(line: 39, column: 3, scope: !36)
-// CHECK:STDOUT: !57 = !DILocation(line: 41, column: 5, scope: !36)
-// CHECK:STDOUT: !58 = !DILocation(line: 41, column: 3, scope: !36)
-// CHECK:STDOUT: !59 = !DILocation(line: 45, column: 3, scope: !36)
-// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.d4b5665541d5d7a8", scope: null, file: !3, line: 19, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !63)
-// CHECK:STDOUT: !61 = !DISubroutineType(types: !62)
-// CHECK:STDOUT: !62 = !{null, !7}
+// CHECK:STDOUT: !18 = !DILocation(line: 53, column: 18, scope: !11)
+// CHECK:STDOUT: !19 = !DILocation(line: 53, column: 16, scope: !11)
+// CHECK:STDOUT: !20 = !DILocation(line: 54, column: 5, scope: !11)
+// CHECK:STDOUT: !21 = !DILocation(line: 54, column: 3, scope: !11)
+// CHECK:STDOUT: !22 = !DILocation(line: 55, column: 18, scope: !11)
+// CHECK:STDOUT: !23 = !DILocation(line: 55, column: 16, scope: !11)
+// CHECK:STDOUT: !24 = !DILocation(line: 48, column: 1, scope: !11)
+// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 19, type: !26, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !29)
+// CHECK:STDOUT: !26 = !DISubroutineType(types: !27)
+// CHECK:STDOUT: !27 = !{null, !28}
+// CHECK:STDOUT: !28 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !29 = !{!30}
+// CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !25, type: !28)
+// CHECK:STDOUT: !31 = !DILocation(line: 19, column: 1, scope: !25)
+// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.68e44d468a50c22e", scope: null, file: !3, line: 28, type: !33, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !35)
+// CHECK:STDOUT: !33 = !DISubroutineType(types: !34)
+// CHECK:STDOUT: !34 = !{!28, !28}
+// CHECK:STDOUT: !35 = !{!36}
+// CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !32, type: !28)
+// CHECK:STDOUT: !37 = !DILocation(line: 29, column: 3, scope: !32)
+// CHECK:STDOUT: !38 = !DILocation(line: 31, column: 5, scope: !32)
+// CHECK:STDOUT: !39 = !DILocation(line: 31, column: 3, scope: !32)
+// CHECK:STDOUT: !40 = !DILocation(line: 34, column: 3, scope: !32)
+// CHECK:STDOUT: !41 = !DILocation(line: 36, column: 3, scope: !32)
+// CHECK:STDOUT: !42 = !DILocation(line: 38, column: 3, scope: !32)
+// CHECK:STDOUT: !43 = !DILocation(line: 40, column: 3, scope: !32)
+// CHECK:STDOUT: !44 = !DILocation(line: 42, column: 3, scope: !32)
+// CHECK:STDOUT: !45 = !DILocation(line: 43, column: 3, scope: !32)
+// CHECK:STDOUT: !46 = !DILocation(line: 30, column: 3, scope: !32)
+// CHECK:STDOUT: !47 = !DILocation(line: 35, column: 5, scope: !32)
+// CHECK:STDOUT: !48 = !DILocation(line: 35, column: 3, scope: !32)
+// CHECK:STDOUT: !49 = !DILocation(line: 37, column: 5, scope: !32)
+// CHECK:STDOUT: !50 = !DILocation(line: 37, column: 3, scope: !32)
+// CHECK:STDOUT: !51 = !DILocation(line: 39, column: 5, scope: !32)
+// CHECK:STDOUT: !52 = !DILocation(line: 39, column: 3, scope: !32)
+// CHECK:STDOUT: !53 = !DILocation(line: 41, column: 5, scope: !32)
+// CHECK:STDOUT: !54 = !DILocation(line: 41, column: 3, scope: !32)
+// CHECK:STDOUT: !55 = !DILocation(line: 45, column: 3, scope: !32)
+// CHECK:STDOUT: !56 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.d4b5665541d5d7a8", scope: null, file: !3, line: 19, type: !57, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !59)
+// CHECK:STDOUT: !57 = !DISubroutineType(types: !58)
+// CHECK:STDOUT: !58 = !{null, !7}
+// CHECK:STDOUT: !59 = !{!60}
+// CHECK:STDOUT: !60 = !DILocalVariable(arg: 1, scope: !56, type: !7)
+// CHECK:STDOUT: !61 = !DILocation(line: 19, column: 1, scope: !56)
+// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.c274f22d2c1ca5ee", scope: null, file: !3, line: 28, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !63)
 // CHECK:STDOUT: !63 = !{!64}
-// CHECK:STDOUT: !64 = !DILocalVariable(arg: 1, scope: !60, type: !7)
-// CHECK:STDOUT: !65 = !DILocation(line: 19, column: 1, scope: !60)
-// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.c274f22d2c1ca5ee", scope: null, file: !3, line: 28, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !67)
-// CHECK:STDOUT: !67 = !{!68}
-// CHECK:STDOUT: !68 = !DILocalVariable(arg: 1, scope: !66, type: !7)
-// CHECK:STDOUT: !69 = !DILocation(line: 29, column: 3, scope: !66)
-// CHECK:STDOUT: !70 = !DILocation(line: 31, column: 5, scope: !66)
-// CHECK:STDOUT: !71 = !DILocation(line: 31, column: 3, scope: !66)
-// CHECK:STDOUT: !72 = !DILocation(line: 34, column: 3, scope: !66)
-// CHECK:STDOUT: !73 = !DILocation(line: 36, column: 3, scope: !66)
-// CHECK:STDOUT: !74 = !DILocation(line: 38, column: 3, scope: !66)
-// CHECK:STDOUT: !75 = !DILocation(line: 40, column: 3, scope: !66)
-// CHECK:STDOUT: !76 = !DILocation(line: 42, column: 3, scope: !66)
-// CHECK:STDOUT: !77 = !DILocation(line: 43, column: 3, scope: !66)
-// CHECK:STDOUT: !78 = !DILocation(line: 30, column: 3, scope: !66)
-// CHECK:STDOUT: !79 = !DILocation(line: 35, column: 5, scope: !66)
-// CHECK:STDOUT: !80 = !DILocation(line: 35, column: 3, scope: !66)
-// CHECK:STDOUT: !81 = !DILocation(line: 37, column: 5, scope: !66)
-// CHECK:STDOUT: !82 = !DILocation(line: 37, column: 3, scope: !66)
-// CHECK:STDOUT: !83 = !DILocation(line: 39, column: 5, scope: !66)
-// CHECK:STDOUT: !84 = !DILocation(line: 39, column: 3, scope: !66)
-// CHECK:STDOUT: !85 = !DILocation(line: 41, column: 5, scope: !66)
-// CHECK:STDOUT: !86 = !DILocation(line: 41, column: 3, scope: !66)
-// CHECK:STDOUT: !87 = !DILocation(line: 45, column: 3, scope: !66)
-// CHECK:STDOUT: !88 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.3440082c84c3c17b", scope: null, file: !3, line: 22, type: !37, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !89)
+// CHECK:STDOUT: !64 = !DILocalVariable(arg: 1, scope: !62, type: !7)
+// CHECK:STDOUT: !65 = !DILocation(line: 29, column: 3, scope: !62)
+// CHECK:STDOUT: !66 = !DILocation(line: 31, column: 5, scope: !62)
+// CHECK:STDOUT: !67 = !DILocation(line: 31, column: 3, scope: !62)
+// CHECK:STDOUT: !68 = !DILocation(line: 34, column: 3, scope: !62)
+// CHECK:STDOUT: !69 = !DILocation(line: 36, column: 3, scope: !62)
+// CHECK:STDOUT: !70 = !DILocation(line: 38, column: 3, scope: !62)
+// CHECK:STDOUT: !71 = !DILocation(line: 40, column: 3, scope: !62)
+// CHECK:STDOUT: !72 = !DILocation(line: 42, column: 3, scope: !62)
+// CHECK:STDOUT: !73 = !DILocation(line: 43, column: 3, scope: !62)
+// CHECK:STDOUT: !74 = !DILocation(line: 30, column: 3, scope: !62)
+// CHECK:STDOUT: !75 = !DILocation(line: 35, column: 5, scope: !62)
+// CHECK:STDOUT: !76 = !DILocation(line: 35, column: 3, scope: !62)
+// CHECK:STDOUT: !77 = !DILocation(line: 37, column: 5, scope: !62)
+// CHECK:STDOUT: !78 = !DILocation(line: 37, column: 3, scope: !62)
+// CHECK:STDOUT: !79 = !DILocation(line: 39, column: 5, scope: !62)
+// CHECK:STDOUT: !80 = !DILocation(line: 39, column: 3, scope: !62)
+// CHECK:STDOUT: !81 = !DILocation(line: 41, column: 5, scope: !62)
+// CHECK:STDOUT: !82 = !DILocation(line: 41, column: 3, scope: !62)
+// CHECK:STDOUT: !83 = !DILocation(line: 45, column: 3, scope: !62)
+// CHECK:STDOUT: !84 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.3440082c84c3c17b", scope: null, file: !3, line: 22, type: !33, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !85)
+// CHECK:STDOUT: !85 = !{!86}
+// CHECK:STDOUT: !86 = !DILocalVariable(arg: 1, scope: !84, type: !28)
+// CHECK:STDOUT: !87 = !DILocation(line: 23, column: 3, scope: !84)
+// CHECK:STDOUT: !88 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.93e33f284107e304", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !89)
 // CHECK:STDOUT: !89 = !{!90}
-// CHECK:STDOUT: !90 = !DILocalVariable(arg: 1, scope: !88, type: !32)
+// CHECK:STDOUT: !90 = !DILocalVariable(arg: 1, scope: !88, type: !7)
 // CHECK:STDOUT: !91 = !DILocation(line: 23, column: 3, scope: !88)
-// CHECK:STDOUT: !92 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.93e33f284107e304", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !93)
+// CHECK:STDOUT: !92 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.286b0f7890e5304c", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !93)
 // CHECK:STDOUT: !93 = !{!94}
 // CHECK:STDOUT: !94 = !DILocalVariable(arg: 1, scope: !92, type: !7)
 // CHECK:STDOUT: !95 = !DILocation(line: 23, column: 3, scope: !92)
-// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.286b0f7890e5304c", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !97)
+// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.4b30cda44e16b9ec", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !97)
 // CHECK:STDOUT: !97 = !{!98}
 // CHECK:STDOUT: !98 = !DILocalVariable(arg: 1, scope: !96, type: !7)
 // CHECK:STDOUT: !99 = !DILocation(line: 23, column: 3, scope: !96)
-// CHECK:STDOUT: !100 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.4b30cda44e16b9ec", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !101)
+// CHECK:STDOUT: !100 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.f8e70200fd9d8b37", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !101)
 // CHECK:STDOUT: !101 = !{!102}
 // CHECK:STDOUT: !102 = !DILocalVariable(arg: 1, scope: !100, type: !7)
-// CHECK:STDOUT: !103 = !DILocation(line: 23, column: 3, scope: !100)
-// CHECK:STDOUT: !104 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.f8e70200fd9d8b37", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !105)
-// CHECK:STDOUT: !105 = !{!106}
-// CHECK:STDOUT: !106 = !DILocalVariable(arg: 1, scope: !104, type: !7)
-// CHECK:STDOUT: !107 = !DILocation(line: 23, column: 10, scope: !104)
-// CHECK:STDOUT: !108 = !DILocation(line: 23, column: 3, scope: !104)
+// CHECK:STDOUT: !103 = !DILocation(line: 23, column: 10, scope: !100)
+// CHECK:STDOUT: !104 = !DILocation(line: 23, column: 3, scope: !100)

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -13,7 +13,7 @@
 // Builds on `call_basic.carbon`. Checks definitions are emitted with deeper
 // call stack, i.e., when functions can be type checked without looking at the
 // specific calling context.
-fn F[T:! type](x: T) {
+fn F[T:! type](_: T) {
 }
 
 fn H[T:! Core.Copy](x: T) -> T {
@@ -29,10 +29,9 @@ fn G[T:! Core.Copy & Core.Destroy](x: T) -> T {
 
 fn M() {
   var n: i32 = 0;
-  var m: i32;
 
   F(n);
-  m = G(n);
+  var _: i32 = G(n);
 }
 
 // CHECK:STDOUT: ; ModuleID = 'call_basic_depth.carbon'
@@ -42,43 +41,43 @@ fn M() {
 // CHECK:STDOUT: define void @_CM.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !7
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %m.var), !dbg !8
-// CHECK:STDOUT:   %.loc34 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc34), !dbg !10
-// CHECK:STDOUT:   %.loc35_9 = load i32, ptr %n.var, align 4, !dbg !11
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc35_9), !dbg !12
-// CHECK:STDOUT:   store i32 %G.call, ptr %m.var, align 4, !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !9
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
+// CHECK:STDOUT:   %.loc34_18 = load i32, ptr %n.var, align 4, !dbg !11
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc34_18), !dbg !12
+// CHECK:STDOUT:   store i32 %G.call, ptr %_.var, align 4, !dbg !8
+// CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %x) #0 !dbg !15 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %_) #0 !dbg !14 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT:   ret void, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.68e44d468a50c22e(i32 %x) #0 !dbg !22 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.68e44d468a50c22e(i32 %x) #0 !dbg !21 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc25_6.3.temp = alloca i32, align 4, !dbg !27
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_6.3.temp), !dbg !27
-// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.3440082c84c3c17b(i32 %x), !dbg !27
-// CHECK:STDOUT:   store i32 %H.call, ptr %.loc25_6.3.temp, align 4, !dbg !27
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !28
-// CHECK:STDOUT:   ret i32 %x, !dbg !29
+// CHECK:STDOUT:   %.loc25_6.3.temp = alloca i32, align 4, !dbg !26
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_6.3.temp), !dbg !26
+// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.3440082c84c3c17b(i32 %x), !dbg !26
+// CHECK:STDOUT:   store i32 %H.call, ptr %.loc25_6.3.temp, align 4, !dbg !26
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !27
+// CHECK:STDOUT:   ret i32 %x, !dbg !28
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.3440082c84c3c17b(i32 %x) #0 !dbg !30 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.3440082c84c3c17b(i32 %x) #0 !dbg !29 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !33
-// CHECK:STDOUT:   ret i32 %x, !dbg !34
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !32
+// CHECK:STDOUT:   ret i32 %x, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -98,30 +97,29 @@ fn M() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 31, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 32, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 34, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 34, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 35, column: 9, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 35, column: 7, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 35, column: 3, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 30, column: 1, scope: !4)
-// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !16, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
-// CHECK:STDOUT: !16 = !DISubroutineType(types: !17)
-// CHECK:STDOUT: !17 = !{null, !18}
-// CHECK:STDOUT: !18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !19 = !{!20}
-// CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !15, type: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 16, column: 1, scope: !15)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.68e44d468a50c22e", scope: null, file: !3, line: 24, type: !23, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !25)
-// CHECK:STDOUT: !23 = !DISubroutineType(types: !24)
-// CHECK:STDOUT: !24 = !{!18, !18}
-// CHECK:STDOUT: !25 = !{!26}
-// CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !22, type: !18)
-// CHECK:STDOUT: !27 = !DILocation(line: 25, column: 3, scope: !22)
-// CHECK:STDOUT: !28 = !DILocation(line: 26, column: 3, scope: !22)
-// CHECK:STDOUT: !29 = !DILocation(line: 27, column: 3, scope: !22)
-// CHECK:STDOUT: !30 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.3440082c84c3c17b", scope: null, file: !3, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !31)
-// CHECK:STDOUT: !31 = !{!32}
-// CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !30, type: !18)
-// CHECK:STDOUT: !33 = !DILocation(line: 20, column: 3, scope: !30)
-// CHECK:STDOUT: !34 = !DILocation(line: 21, column: 3, scope: !30)
+// CHECK:STDOUT: !8 = !DILocation(line: 34, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 33, column: 5, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 33, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 34, column: 18, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 34, column: 16, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 30, column: 1, scope: !4)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !18)
+// CHECK:STDOUT: !15 = !DISubroutineType(types: !16)
+// CHECK:STDOUT: !16 = !{null, !17}
+// CHECK:STDOUT: !17 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !18 = !{!19}
+// CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !14, type: !17)
+// CHECK:STDOUT: !20 = !DILocation(line: 16, column: 1, scope: !14)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.68e44d468a50c22e", scope: null, file: !3, line: 24, type: !22, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !24)
+// CHECK:STDOUT: !22 = !DISubroutineType(types: !23)
+// CHECK:STDOUT: !23 = !{!17, !17}
+// CHECK:STDOUT: !24 = !{!25}
+// CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !21, type: !17)
+// CHECK:STDOUT: !26 = !DILocation(line: 25, column: 3, scope: !21)
+// CHECK:STDOUT: !27 = !DILocation(line: 26, column: 3, scope: !21)
+// CHECK:STDOUT: !28 = !DILocation(line: 27, column: 3, scope: !21)
+// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.3440082c84c3c17b", scope: null, file: !3, line: 19, type: !22, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !30)
+// CHECK:STDOUT: !30 = !{!31}
+// CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !17)
+// CHECK:STDOUT: !32 = !DILocation(line: 20, column: 3, scope: !29)
+// CHECK:STDOUT: !33 = !DILocation(line: 21, column: 3, scope: !29)

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -30,6 +30,7 @@ fn G[T:! Core.Copy & Core.Destroy](x: T) -> T {
 fn M() -> i32 {
   var n: i32 = 0;
   var m: i32;
+
   F(n);
   m = G(n);
   return m;
@@ -46,13 +47,13 @@ fn M() -> i32 {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !8
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %m.var), !dbg !9
-// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !10
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !11
-// CHECK:STDOUT:   %.loc34_9 = load i32, ptr %n.var, align 4, !dbg !12
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc34_9), !dbg !13
+// CHECK:STDOUT:   %.loc34 = load i32, ptr %n.var, align 4, !dbg !10
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc34), !dbg !11
+// CHECK:STDOUT:   %.loc35_9 = load i32, ptr %n.var, align 4, !dbg !12
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc35_9), !dbg !13
 // CHECK:STDOUT:   store i32 %G.call, ptr %m.var, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc35 = load i32, ptr %m.var, align 4, !dbg !15
-// CHECK:STDOUT:   ret i32 %.loc35, !dbg !16
+// CHECK:STDOUT:   %.loc36 = load i32, ptr %m.var, align 4, !dbg !15
+// CHECK:STDOUT:   ret i32 %.loc36, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -101,13 +102,13 @@ fn M() -> i32 {
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 31, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 32, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 33, column: 5, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 33, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 34, column: 9, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 34, column: 7, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 34, column: 3, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 35, column: 10, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 35, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 34, column: 5, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 34, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 35, column: 9, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 35, column: 7, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 35, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 36, column: 10, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 36, column: 3, scope: !4)
 // CHECK:STDOUT: !17 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !18, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
 // CHECK:STDOUT: !18 = !DISubroutineType(types: !19)
 // CHECK:STDOUT: !19 = !{null, !7}

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -27,57 +27,59 @@ fn G[T:! Core.Copy & Core.Destroy](x: T) -> T {
   return x;
 }
 
-fn M() {
+fn M() -> i32 {
   var n: i32 = 0;
-
+  var m: i32;
   F(n);
-  var _: i32 = G(n);
+  m = G(n);
+  return m;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'call_basic_depth.carbon'
 // CHECK:STDOUT: source_filename = "call_basic_depth.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CM.Main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @_CM.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !7
-// CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !7
-// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   %.loc34_18 = load i32, ptr %n.var, align 4, !dbg !11
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc34_18), !dbg !12
-// CHECK:STDOUT:   store i32 %G.call, ptr %_.var, align 4, !dbg !8
-// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   %m.var = alloca i32, align 4, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !8
+// CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %m.var), !dbg !9
+// CHECK:STDOUT:   %.loc33 = load i32, ptr %n.var, align 4, !dbg !10
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %.loc33), !dbg !11
+// CHECK:STDOUT:   %.loc34_9 = load i32, ptr %n.var, align 4, !dbg !12
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.68e44d468a50c22e(i32 %.loc34_9), !dbg !13
+// CHECK:STDOUT:   store i32 %G.call, ptr %m.var, align 4, !dbg !14
+// CHECK:STDOUT:   %.loc35 = load i32, ptr %m.var, align 4, !dbg !15
+// CHECK:STDOUT:   ret i32 %.loc35, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %_) #0 !dbg !14 {
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.b88d1103f417c6d4(i32 %_) #0 !dbg !17 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !20
+// CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.68e44d468a50c22e(i32 %x) #0 !dbg !21 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.68e44d468a50c22e(i32 %x) #0 !dbg !23 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc25_6.3.temp = alloca i32, align 4, !dbg !26
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_6.3.temp), !dbg !26
-// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.3440082c84c3c17b(i32 %x), !dbg !26
-// CHECK:STDOUT:   store i32 %H.call, ptr %.loc25_6.3.temp, align 4, !dbg !26
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !27
-// CHECK:STDOUT:   ret i32 %x, !dbg !28
+// CHECK:STDOUT:   %.loc25_6.3.temp = alloca i32, align 4, !dbg !28
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_6.3.temp), !dbg !28
+// CHECK:STDOUT:   %H.call = call i32 @_CH.Main.3440082c84c3c17b(i32 %x), !dbg !28
+// CHECK:STDOUT:   store i32 %H.call, ptr %.loc25_6.3.temp, align 4, !dbg !28
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !29
+// CHECK:STDOUT:   ret i32 %x, !dbg !30
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.3440082c84c3c17b(i32 %x) #0 !dbg !29 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CH.Main.3440082c84c3c17b(i32 %x) #0 !dbg !31 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !32
-// CHECK:STDOUT:   ret i32 %x, !dbg !33
+// CHECK:STDOUT:   call void @_CF.Main.b88d1103f417c6d4(i32 %x), !dbg !34
+// CHECK:STDOUT:   ret i32 %x, !dbg !35
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -95,31 +97,33 @@ fn M() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "call_basic_depth.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "M", linkageName: "_CM.Main", scope: null, file: !3, line: 30, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 31, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 34, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 33, column: 5, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 33, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 34, column: 18, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 34, column: 16, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 30, column: 1, scope: !4)
-// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !18)
-// CHECK:STDOUT: !15 = !DISubroutineType(types: !16)
-// CHECK:STDOUT: !16 = !{null, !17}
-// CHECK:STDOUT: !17 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !18 = !{!19}
-// CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !14, type: !17)
-// CHECK:STDOUT: !20 = !DILocation(line: 16, column: 1, scope: !14)
-// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.68e44d468a50c22e", scope: null, file: !3, line: 24, type: !22, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !24)
-// CHECK:STDOUT: !22 = !DISubroutineType(types: !23)
-// CHECK:STDOUT: !23 = !{!17, !17}
-// CHECK:STDOUT: !24 = !{!25}
-// CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !21, type: !17)
-// CHECK:STDOUT: !26 = !DILocation(line: 25, column: 3, scope: !21)
-// CHECK:STDOUT: !27 = !DILocation(line: 26, column: 3, scope: !21)
-// CHECK:STDOUT: !28 = !DILocation(line: 27, column: 3, scope: !21)
-// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.3440082c84c3c17b", scope: null, file: !3, line: 19, type: !22, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !30)
-// CHECK:STDOUT: !30 = !{!31}
-// CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !17)
-// CHECK:STDOUT: !32 = !DILocation(line: 20, column: 3, scope: !29)
-// CHECK:STDOUT: !33 = !DILocation(line: 21, column: 3, scope: !29)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 31, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 32, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 33, column: 5, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 33, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 34, column: 9, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 34, column: 7, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 34, column: 3, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 35, column: 10, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 35, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.b88d1103f417c6d4", scope: null, file: !3, line: 16, type: !18, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
+// CHECK:STDOUT: !18 = !DISubroutineType(types: !19)
+// CHECK:STDOUT: !19 = !{null, !7}
+// CHECK:STDOUT: !20 = !{!21}
+// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !17, type: !7)
+// CHECK:STDOUT: !22 = !DILocation(line: 16, column: 1, scope: !17)
+// CHECK:STDOUT: !23 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.68e44d468a50c22e", scope: null, file: !3, line: 24, type: !24, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !26)
+// CHECK:STDOUT: !24 = !DISubroutineType(types: !25)
+// CHECK:STDOUT: !25 = !{!7, !7}
+// CHECK:STDOUT: !26 = !{!27}
+// CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !23, type: !7)
+// CHECK:STDOUT: !28 = !DILocation(line: 25, column: 3, scope: !23)
+// CHECK:STDOUT: !29 = !DILocation(line: 26, column: 3, scope: !23)
+// CHECK:STDOUT: !30 = !DILocation(line: 27, column: 3, scope: !23)
+// CHECK:STDOUT: !31 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main.3440082c84c3c17b", scope: null, file: !3, line: 19, type: !24, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !32)
+// CHECK:STDOUT: !32 = !{!33}
+// CHECK:STDOUT: !33 = !DILocalVariable(arg: 1, scope: !31, type: !7)
+// CHECK:STDOUT: !34 = !DILocation(line: 20, column: 3, scope: !31)
+// CHECK:STDOUT: !35 = !DILocation(line: 21, column: 3, scope: !31)

--- a/toolchain/lower/testdata/function/generic/call_different_associated_const.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_associated_const.carbon
@@ -20,7 +20,7 @@ interface I {
 }
 
 fn G(U:! I) {
-  var x: U.T*;
+  var _: U.T*;
 }
 
 class C {}
@@ -51,8 +51,8 @@ fn H() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CG.Main.105e251602f0e987() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca ptr, align 8, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !11
+// CHECK:STDOUT:   %_.var = alloca ptr, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !11
 // CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_different_impls_with_const.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_impls_with_const.carbon
@@ -34,7 +34,7 @@ impl Y as I where .T = i32 {
 // Cannot coalesce the lowering for G specifics, as they call different functions.
 // Check different functions are still emitted when trying to deduplicate emitted definitons.
 fn G(U:! I) {
-  let x: U.T = U.F();
+  let _: U.T = U.F();
 }
 
 fn Run() {

--- a/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
+++ b/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
@@ -40,7 +40,7 @@ fn M() {
   F(var_i32);
   var var_f64: f64 = 0.0;
   F(var_f64);
-  var c: C;
+  var _: C;
   F(C);
 }
 
@@ -57,7 +57,7 @@ fn M() {
 // CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !9
 // CHECK:STDOUT:   %var_i32.var = alloca i32, align 4, !dbg !10
 // CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !11
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !12
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i32.var), !dbg !7
 // CHECK:STDOUT:   %.loc34_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !13
 // CHECK:STDOUT:   %F.call.loc34 = call ptr @_CF.Main.4b30cda44e16b9ec(ptr %.loc34_5), !dbg !14
@@ -75,7 +75,7 @@ fn M() {
 // CHECK:STDOUT:   store double 0.000000e+00, ptr %var_f64.var, align 8, !dbg !11
 // CHECK:STDOUT:   %.loc42_5 = load double, ptr %var_f64.var, align 8, !dbg !21
 // CHECK:STDOUT:   %F.call.loc42 = call double @_CF.Main.286b0f7890e5304c(double %.loc42_5), !dbg !22
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !12
 // CHECK:STDOUT:   %F.call.loc44 = call %type @_CF.Main.93e33f284107e304(%type zeroinitializer), !dbg !23
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/generic/cross_library_name_collision_private.carbon
+++ b/toolchain/lower/testdata/function/generic/cross_library_name_collision_private.carbon
@@ -14,7 +14,7 @@
 
 library "[[@TEST_NAME]]";
 
-private fn F[T:! Core.Copy](a: T, b: T) -> T {
+private fn F[T:! Core.Copy](a: T, _: T) -> T {
   return a;
 }
 
@@ -29,7 +29,7 @@ library "[[@TEST_NAME]]";
 // Duplicate function name in different files. Shouldn't be a name conflict
 // because of `private`. However, we currently use the same mangling for both
 // functions.
-private fn F[T:! Core.Copy](a: T, b: T) -> T {
+private fn F[T:! Core.Copy](_: T, b: T) -> T {
   return b;
 }
 
@@ -47,8 +47,8 @@ import library "lib1";
 import library "lib2";
 
 fn Run() {
-  let a: i32 = Lib1CallF(1 as i32, 2 as i32);
-  let b: i32 = Lib2CallF(1 as i32, 2 as i32);
+  let _: i32 = Lib1CallF(1 as i32, 2 as i32);
+  let _: i32 = Lib2CallF(1 as i32, 2 as i32);
 }
 
 // CHECK:STDOUT: ; ModuleID = 'lib1.carbon'
@@ -95,7 +95,7 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.d7c78c5f84c57c86(i32 %a, i32 %b) #0 !dbg !27 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.d7c78c5f84c57c86(i32 %a, i32 %_) #0 !dbg !27 {
 // CHECK:STDOUT:   ret i32 %a, !dbg !31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/type_param.carbon
+++ b/toolchain/lower/testdata/function/generic/type_param.carbon
@@ -12,7 +12,7 @@
 
 fn F(T:! type) {
   var p: T*;
-  let n: T = *p;
+  let _: T = *p;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'type_param.carbon'

--- a/toolchain/lower/testdata/function/generic/type_representation.carbon
+++ b/toolchain/lower/testdata/function/generic/type_representation.carbon
@@ -15,7 +15,7 @@ interface Copy {
 }
 
 fn F[T:! Copy & Core.Destroy](a: T) -> T {
-  var v: T = a.(Copy.Op)();
+  var _: T = a.(Copy.Op)();
   return a.(Copy.Op)();
 }
 
@@ -169,10 +169,10 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.4301ec5c5ecd651f(i32 %a) #0 !dbg !60 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca i32, align 4, !dbg !63
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !63
+// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !63
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !63
 // CHECK:STDOUT:   %Copy.Op.call.loc18 = call i32 @"_COp.Int.Core:Copy.Main"(i32 %a), !dbg !64
-// CHECK:STDOUT:   store i32 %Copy.Op.call.loc18, ptr %v.var, align 4, !dbg !63
+// CHECK:STDOUT:   store i32 %Copy.Op.call.loc18, ptr %_.var, align 4, !dbg !63
 // CHECK:STDOUT:   %Copy.Op.call.loc19 = call i32 @"_COp.Int.Core:Copy.Main"(i32 %a), !dbg !65
 // CHECK:STDOUT:   ret i32 %Copy.Op.call.loc19, !dbg !66
 // CHECK:STDOUT: }
@@ -180,9 +180,9 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.8bb618905c12e223(ptr sret({ i32, i32 }) %return, ptr %a) #0 !dbg !67 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { i32, i32 }, align 8, !dbg !70
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !70
-// CHECK:STDOUT:   call void @"_COp.X.Main:Copy.Main"(ptr %v.var, ptr %a), !dbg !71
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !70
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !70
+// CHECK:STDOUT:   call void @"_COp.X.Main:Copy.Main"(ptr %_.var, ptr %a), !dbg !71
 // CHECK:STDOUT:   call void @"_COp.X.Main:Copy.Main"(ptr %return, ptr %a), !dbg !72
 // CHECK:STDOUT:   ret void, !dbg !73
 // CHECK:STDOUT: }
@@ -190,8 +190,8 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.92c61b43c9f740f5() #0 !dbg !74 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca {}, align 8, !dbg !75
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !75
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !75
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !75
 // CHECK:STDOUT:   call void @"_COp.61ea2aba74ab3bf1:Copy.Main"(), !dbg !76
 // CHECK:STDOUT:   call void @"_COp.61ea2aba74ab3bf1:Copy.Main"(), !dbg !77
 // CHECK:STDOUT:   ret void, !dbg !78
@@ -200,9 +200,9 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.444df219ccd81c52(ptr sret({ i32, i32 }) %return, ptr %a) #0 !dbg !79 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { i32, i32 }, align 8, !dbg !82
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !82
-// CHECK:STDOUT:   call void @"_COp.d07e2731f1087d49:Copy.Main"(ptr %v.var, ptr %a), !dbg !83
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !82
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !82
+// CHECK:STDOUT:   call void @"_COp.d07e2731f1087d49:Copy.Main"(ptr %_.var, ptr %a), !dbg !83
 // CHECK:STDOUT:   call void @"_COp.d07e2731f1087d49:Copy.Main"(ptr %return, ptr %a), !dbg !84
 // CHECK:STDOUT:   ret void, !dbg !85
 // CHECK:STDOUT: }
@@ -210,9 +210,9 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.ce36b8714ed574a4(ptr sret({ { i32, i32 }, { i32, i32 } }) %return, ptr %a) #0 !dbg !86 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { { i32, i32 }, { i32, i32 } }, align 8, !dbg !89
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !89
-// CHECK:STDOUT:   call void @"_COp.a6c7c55658a5a74c:Copy.Main"(ptr %v.var, ptr %a), !dbg !90
+// CHECK:STDOUT:   %_.var = alloca { { i32, i32 }, { i32, i32 } }, align 8, !dbg !89
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !89
+// CHECK:STDOUT:   call void @"_COp.a6c7c55658a5a74c:Copy.Main"(ptr %_.var, ptr %a), !dbg !90
 // CHECK:STDOUT:   call void @"_COp.a6c7c55658a5a74c:Copy.Main"(ptr %return, ptr %a), !dbg !91
 // CHECK:STDOUT:   ret void, !dbg !92
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/impl/thunk.carbon
+++ b/toolchain/lower/testdata/impl/thunk.carbon
@@ -55,7 +55,7 @@ interface I(T:! type) {
 class C(U:! type) {}
 
 impl forall [V:! type] C(V) as I(V) {
-  fn F[self: Self](x: A) -> B { return {}; }
+  fn F[self: Self](_: A) -> B { return {}; }
 }
 
 fn Call(c: C(()), b: B) -> A {
@@ -225,7 +225,7 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CF.C.Main:I.Main.e43630e9a6c38c3f"(ptr sret({}) %return, ptr %self, ptr %x) #0 !dbg !26 {
+// CHECK:STDOUT: define linkonce_odr void @"_CF.C.Main:I.Main.e43630e9a6c38c3f"(ptr sret({}) %return, ptr %self, ptr %_) #0 !dbg !26 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %return, ptr align 1 @B.val.loc18_42, i64 0, i1 false), !dbg !30
 // CHECK:STDOUT:   ret void, !dbg !30

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -16,8 +16,8 @@ fn B() -> array(i32, 2) { return (1, 2); }
 fn Run() {
   var a: array(i32, 2) = A();
   var b: i32 = 1;
-  var c: i32 = a[b];
-  var d: i32 = B()[1];
+  var _: i32 = a[b];
+  var _: i32 = B()[1];
 }
 
 // CHECK:STDOUT: ; ModuleID = 'array_element_access.carbon'
@@ -50,8 +50,8 @@ fn Run() {
 // CHECK:STDOUT:   %a.var = alloca [2 x i32], align 4, !dbg !16
 // CHECK:STDOUT:   %.loc17_28.1.temp = alloca { i32, i32 }, align 8, !dbg !17
 // CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !18
-// CHECK:STDOUT:   %c.var = alloca i32, align 4, !dbg !19
-// CHECK:STDOUT:   %d.var = alloca i32, align 4, !dbg !20
+// CHECK:STDOUT:   %_.var.loc19 = alloca i32, align 4, !dbg !19
+// CHECK:STDOUT:   %_.var.loc20 = alloca i32, align 4, !dbg !20
 // CHECK:STDOUT:   %.loc20_18.1.temp = alloca [2 x i32], align 4, !dbg !21
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_28.1.temp), !dbg !17
@@ -66,17 +66,17 @@ fn Run() {
 // CHECK:STDOUT:   store i32 %.loc17_28.6, ptr %.loc17_28.7.array.index, align 4, !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !18
 // CHECK:STDOUT:   store i32 1, ptr %b.var, align 4, !dbg !18
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc19), !dbg !19
 // CHECK:STDOUT:   %.loc19_18 = load i32, ptr %b.var, align 4, !dbg !22
 // CHECK:STDOUT:   %.loc19_19.1.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i32 %.loc19_18, !dbg !23
 // CHECK:STDOUT:   %.loc19_19.2 = load i32, ptr %.loc19_19.1.array.index, align 4, !dbg !23
-// CHECK:STDOUT:   store i32 %.loc19_19.2, ptr %c.var, align 4, !dbg !19
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !20
+// CHECK:STDOUT:   store i32 %.loc19_19.2, ptr %_.var.loc19, align 4, !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc20), !dbg !20
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_18.1.temp), !dbg !21
 // CHECK:STDOUT:   call void @_CB.Main(ptr %.loc20_18.1.temp), !dbg !21
 // CHECK:STDOUT:   %.loc20_21.1.array.index = getelementptr inbounds [2 x i32], ptr %.loc20_18.1.temp, i32 0, i32 1, !dbg !21
 // CHECK:STDOUT:   %.loc20_21.2 = load i32, ptr %.loc20_21.1.array.index, align 4, !dbg !21
-// CHECK:STDOUT:   store i32 %.loc20_21.2, ptr %d.var, align 4, !dbg !20
+// CHECK:STDOUT:   store i32 %.loc20_21.2, ptr %_.var.loc20, align 4, !dbg !20
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/interface/basic.carbon
+++ b/toolchain/lower/testdata/interface/basic.carbon
@@ -16,7 +16,7 @@ interface I {
 
 // There are no interesting runtime operations here, but there's no rule saying
 // you can't pass a facet around at runtime, so make sure it works.
-fn F(T: I) {}
+fn F(_: I) {}
 
 fn G() -> I;
 
@@ -26,7 +26,7 @@ fn H() -> I { return G(); }
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF.Main({} %T) #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CF.Main({} %_) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/interop/cpp/constructor.carbon
+++ b/toolchain/lower/testdata/interop/cpp/constructor.carbon
@@ -32,7 +32,7 @@ library "[[@TEST_NAME]]";
 import Cpp library "default.h";
 
 fn F() {
-  let c: Cpp.C = Cpp.C.C();
+  let _: Cpp.C = Cpp.C.C();
 }
 
 // ============================================================================

--- a/toolchain/lower/testdata/interop/cpp/function_decl.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function_decl.carbon
@@ -121,7 +121,7 @@ library "[[@TEST_NAME]]";
 
 import Cpp library "with_default_args.h";
 
-fn MyF() {
+fn MyF() -> i32 {
   Cpp.NoReturnValue();
   Cpp.NoReturnValue(3);
   Cpp.NoReturnValue(3, 4);
@@ -129,7 +129,7 @@ fn MyF() {
   var value: i32 = Cpp.SimpleReturnValue();
   value = Cpp.SimpleReturnValue(3);
   value = Cpp.SimpleReturnValue(3, 4);
-  let _: i32 = value;
+  return value;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'import_function_decl.carbon'
@@ -356,21 +356,21 @@ fn MyF() {
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CMyF.Main() #0 !dbg !7 {
+// CHECK:STDOUT: define i32 @_CMyF.Main() #0 !dbg !7 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %value.var = alloca i32, align 4, !dbg !10
-// CHECK:STDOUT:   call void @_Z13NoReturnValueii.carbon_thunk0(), !dbg !11
-// CHECK:STDOUT:   call void @_Z13NoReturnValueii.carbon_thunk1(i32 3), !dbg !12
-// CHECK:STDOUT:   call void @_Z13NoReturnValueii(i32 3, i32 4), !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %value.var), !dbg !10
-// CHECK:STDOUT:   %SimpleReturnValue__carbon_thunk.call.loc11 = call i32 @_Z17SimpleReturnValueii.carbon_thunk0(), !dbg !14
-// CHECK:STDOUT:   store i32 %SimpleReturnValue__carbon_thunk.call.loc11, ptr %value.var, align 4, !dbg !10
-// CHECK:STDOUT:   %SimpleReturnValue__carbon_thunk.call.loc12 = call i32 @_Z17SimpleReturnValueii.carbon_thunk1(i32 3), !dbg !15
-// CHECK:STDOUT:   store i32 %SimpleReturnValue__carbon_thunk.call.loc12, ptr %value.var, align 4, !dbg !16
-// CHECK:STDOUT:   %SimpleReturnValue.call = call i32 @_Z17SimpleReturnValueii(i32 3, i32 4), !dbg !17
-// CHECK:STDOUT:   store i32 %SimpleReturnValue.call, ptr %value.var, align 4, !dbg !18
-// CHECK:STDOUT:   %.loc14_16 = load i32, ptr %value.var, align 4, !dbg !19
-// CHECK:STDOUT:   ret void, !dbg !20
+// CHECK:STDOUT:   %value.var = alloca i32, align 4, !dbg !11
+// CHECK:STDOUT:   call void @_Z13NoReturnValueii.carbon_thunk0(), !dbg !12
+// CHECK:STDOUT:   call void @_Z13NoReturnValueii.carbon_thunk1(i32 3), !dbg !13
+// CHECK:STDOUT:   call void @_Z13NoReturnValueii(i32 3, i32 4), !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %value.var), !dbg !11
+// CHECK:STDOUT:   %SimpleReturnValue__carbon_thunk.call.loc11 = call i32 @_Z17SimpleReturnValueii.carbon_thunk0(), !dbg !15
+// CHECK:STDOUT:   store i32 %SimpleReturnValue__carbon_thunk.call.loc11, ptr %value.var, align 4, !dbg !11
+// CHECK:STDOUT:   %SimpleReturnValue__carbon_thunk.call.loc12 = call i32 @_Z17SimpleReturnValueii.carbon_thunk1(i32 3), !dbg !16
+// CHECK:STDOUT:   store i32 %SimpleReturnValue__carbon_thunk.call.loc12, ptr %value.var, align 4, !dbg !17
+// CHECK:STDOUT:   %SimpleReturnValue.call = call i32 @_Z17SimpleReturnValueii(i32 3, i32 4), !dbg !18
+// CHECK:STDOUT:   store i32 %SimpleReturnValue.call, ptr %value.var, align 4, !dbg !19
+// CHECK:STDOUT:   %.loc14 = load i32, ptr %value.var, align 4, !dbg !20
+// CHECK:STDOUT:   ret i32 %.loc14, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_Z13NoReturnValueii(i32, i32)
@@ -430,15 +430,16 @@ fn MyF() {
 // CHECK:STDOUT: !6 = !DIFile(filename: "call_with_default_args.carbon", directory: "")
 // CHECK:STDOUT: !7 = distinct !DISubprogram(name: "MyF", linkageName: "_CMyF.Main", scope: null, file: !6, line: 6, type: !8, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !8 = !DISubroutineType(types: !9)
-// CHECK:STDOUT: !9 = !{null}
-// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 3, scope: !7)
-// CHECK:STDOUT: !11 = !DILocation(line: 7, column: 3, scope: !7)
-// CHECK:STDOUT: !12 = !DILocation(line: 8, column: 3, scope: !7)
-// CHECK:STDOUT: !13 = !DILocation(line: 9, column: 3, scope: !7)
-// CHECK:STDOUT: !14 = !DILocation(line: 11, column: 20, scope: !7)
-// CHECK:STDOUT: !15 = !DILocation(line: 12, column: 11, scope: !7)
-// CHECK:STDOUT: !16 = !DILocation(line: 12, column: 3, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 13, column: 11, scope: !7)
-// CHECK:STDOUT: !18 = !DILocation(line: 13, column: 3, scope: !7)
-// CHECK:STDOUT: !19 = !DILocation(line: 14, column: 16, scope: !7)
-// CHECK:STDOUT: !20 = !DILocation(line: 6, column: 1, scope: !7)
+// CHECK:STDOUT: !9 = !{!10}
+// CHECK:STDOUT: !10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !11 = !DILocation(line: 11, column: 3, scope: !7)
+// CHECK:STDOUT: !12 = !DILocation(line: 7, column: 3, scope: !7)
+// CHECK:STDOUT: !13 = !DILocation(line: 8, column: 3, scope: !7)
+// CHECK:STDOUT: !14 = !DILocation(line: 9, column: 3, scope: !7)
+// CHECK:STDOUT: !15 = !DILocation(line: 11, column: 20, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 12, column: 11, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 12, column: 3, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 13, column: 11, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 13, column: 3, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 14, column: 10, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 14, column: 3, scope: !7)

--- a/toolchain/lower/testdata/interop/cpp/function_decl.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function_decl.carbon
@@ -129,6 +129,7 @@ fn MyF() {
   var value: i32 = Cpp.SimpleReturnValue();
   value = Cpp.SimpleReturnValue(3);
   value = Cpp.SimpleReturnValue(3, 4);
+  let _: i32 = value;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'import_function_decl.carbon'
@@ -368,7 +369,8 @@ fn MyF() {
 // CHECK:STDOUT:   store i32 %SimpleReturnValue__carbon_thunk.call.loc12, ptr %value.var, align 4, !dbg !16
 // CHECK:STDOUT:   %SimpleReturnValue.call = call i32 @_Z17SimpleReturnValueii(i32 3, i32 4), !dbg !17
 // CHECK:STDOUT:   store i32 %SimpleReturnValue.call, ptr %value.var, align 4, !dbg !18
-// CHECK:STDOUT:   ret void, !dbg !19
+// CHECK:STDOUT:   %.loc14_16 = load i32, ptr %value.var, align 4, !dbg !19
+// CHECK:STDOUT:   ret void, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_Z13NoReturnValueii(i32, i32)
@@ -438,4 +440,5 @@ fn MyF() {
 // CHECK:STDOUT: !16 = !DILocation(line: 12, column: 3, scope: !7)
 // CHECK:STDOUT: !17 = !DILocation(line: 13, column: 11, scope: !7)
 // CHECK:STDOUT: !18 = !DILocation(line: 13, column: 3, scope: !7)
-// CHECK:STDOUT: !19 = !DILocation(line: 6, column: 1, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 14, column: 16, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 6, column: 1, scope: !7)

--- a/toolchain/lower/testdata/interop/cpp/globals.carbon
+++ b/toolchain/lower/testdata/interop/cpp/globals.carbon
@@ -26,7 +26,7 @@ library "[[@TEST_NAME]]";
 import Cpp library "global.h";
 
 fn MyF() {
-  let local: Cpp.C = Cpp.global;
+  let _: Cpp.C = Cpp.global;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'import_global.carbon'

--- a/toolchain/lower/testdata/interop/cpp/pointer.carbon
+++ b/toolchain/lower/testdata/interop/cpp/pointer.carbon
@@ -62,7 +62,7 @@ auto TakePtrWithThunk(C*, int = 0) -> void;
 auto ReturnPtrWithThunk(int = 0) -> C*;
 ''';
 
-fn PassPtr(p: Core.Optional(Cpp.C*)) {
+fn PassPtr(_: Core.Optional(Cpp.C*)) {
   // TODO: Add support for passing an optional here.
   // Cpp.TakePtr(p);
 }
@@ -77,7 +77,7 @@ fn ReturnPtr() -> Core.Optional(Cpp.C*) {
   return Cpp.ReturnPtr();
 }
 
-fn PassPtrWithThunk(p: Core.Optional(Cpp.C*)) {
+fn PassPtrWithThunk(_: Core.Optional(Cpp.C*)) {
   // TODO: Add support for passing an optional here.
   // Cpp.TakePtrWithThunk(p);
 }
@@ -189,7 +189,7 @@ fn ReturnPtrWithThunk() -> Core.Optional(Cpp.C*) {
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CPassPtr.Main(ptr %p) #0 !dbg !7 {
+// CHECK:STDOUT: define void @_CPassPtr.Main(ptr %_) #0 !dbg !7 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
@@ -218,7 +218,7 @@ fn ReturnPtrWithThunk() -> Core.Optional(Cpp.C*) {
 // CHECK:STDOUT: declare ptr @_Z9ReturnPtrv()
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CPassPtrWithThunk.Main(ptr %p) #0 !dbg !25 {
+// CHECK:STDOUT: define void @_CPassPtrWithThunk.Main(ptr %_) #0 !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !28
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/interop/cpp/reference.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reference.carbon
@@ -92,13 +92,13 @@ auto ReturnConstIntRef() -> const int&;
 ''';
 
 fn GetRefs() {
-  var c1: Cpp.C* = Cpp.ReturnCRef();
-  var c2: Cpp.C* = Cpp.ReturnCRRef();
-  var c3: const Cpp.C* = Cpp.ReturnConstCRef();
+  var _: Cpp.C* = Cpp.ReturnCRef();
+  var _: Cpp.C* = Cpp.ReturnCRRef();
+  var _: const Cpp.C* = Cpp.ReturnConstCRef();
 
-  var n1: i32* = Cpp.ReturnIntRef();
-  var n2: i32* = Cpp.ReturnIntRRef();
-  var n3: const i32* = Cpp.ReturnConstIntRef();
+  var _: i32* = Cpp.ReturnIntRef();
+  var _: i32* = Cpp.ReturnIntRRef();
+  var _: const i32* = Cpp.ReturnConstIntRef();
 }
 
 // --- return_references_via_thunk.carbon
@@ -119,13 +119,13 @@ auto ReturnConstIntRef(ForceThunk = {}) -> const int&;
 ''';
 
 fn GetRefs() {
-  var c1: Cpp.C* = Cpp.ReturnCRef();
-  var c2: Cpp.C* = Cpp.ReturnCRRef();
-  var c3: const Cpp.C* = Cpp.ReturnConstCRef();
+  var _: Cpp.C* = Cpp.ReturnCRef();
+  var _: Cpp.C* = Cpp.ReturnCRRef();
+  var _: const Cpp.C* = Cpp.ReturnConstCRef();
 
-  var n1: i32* = Cpp.ReturnIntRef();
-  var n2: i32* = Cpp.ReturnIntRRef();
-  var n3: const i32* = Cpp.ReturnConstIntRef();
+  var _: i32* = Cpp.ReturnIntRef();
+  var _: i32* = Cpp.ReturnIntRRef();
+  var _: const i32* = Cpp.ReturnConstIntRef();
 }
 
 // CHECK:STDOUT: ; ModuleID = 'pass_references.carbon'
@@ -426,30 +426,30 @@ fn GetRefs() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CGetRefs.Main() #0 !dbg !7 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c1.var = alloca ptr, align 8, !dbg !10
-// CHECK:STDOUT:   %c2.var = alloca ptr, align 8, !dbg !11
-// CHECK:STDOUT:   %c3.var = alloca ptr, align 8, !dbg !12
-// CHECK:STDOUT:   %n1.var = alloca ptr, align 8, !dbg !13
-// CHECK:STDOUT:   %n2.var = alloca ptr, align 8, !dbg !14
-// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !15
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c1.var), !dbg !10
+// CHECK:STDOUT:   %_.var.loc17 = alloca ptr, align 8, !dbg !10
+// CHECK:STDOUT:   %_.var.loc18 = alloca ptr, align 8, !dbg !11
+// CHECK:STDOUT:   %_.var.loc19 = alloca ptr, align 8, !dbg !12
+// CHECK:STDOUT:   %_.var.loc21 = alloca ptr, align 8, !dbg !13
+// CHECK:STDOUT:   %_.var.loc22 = alloca ptr, align 8, !dbg !14
+// CHECK:STDOUT:   %_.var.loc23 = alloca ptr, align 8, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc17), !dbg !10
 // CHECK:STDOUT:   %ReturnCRef.call = call ptr @_Z10ReturnCRefv(), !dbg !16
-// CHECK:STDOUT:   store ptr %ReturnCRef.call, ptr %c1.var, align 8, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c2.var), !dbg !11
+// CHECK:STDOUT:   store ptr %ReturnCRef.call, ptr %_.var.loc17, align 8, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !11
 // CHECK:STDOUT:   %ReturnCRRef.call = call ptr @_Z11ReturnCRRefv(), !dbg !17
-// CHECK:STDOUT:   store ptr %ReturnCRRef.call, ptr %c2.var, align 8, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c3.var), !dbg !12
+// CHECK:STDOUT:   store ptr %ReturnCRRef.call, ptr %_.var.loc18, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc19), !dbg !12
 // CHECK:STDOUT:   %ReturnConstCRef.call = call ptr @_Z15ReturnConstCRefv(), !dbg !18
-// CHECK:STDOUT:   store ptr %ReturnConstCRef.call, ptr %c3.var, align 8, !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n1.var), !dbg !13
+// CHECK:STDOUT:   store ptr %ReturnConstCRef.call, ptr %_.var.loc19, align 8, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc21), !dbg !13
 // CHECK:STDOUT:   %ReturnIntRef.call = call ptr @_Z12ReturnIntRefv(), !dbg !19
-// CHECK:STDOUT:   store ptr %ReturnIntRef.call, ptr %n1.var, align 8, !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n2.var), !dbg !14
+// CHECK:STDOUT:   store ptr %ReturnIntRef.call, ptr %_.var.loc21, align 8, !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc22), !dbg !14
 // CHECK:STDOUT:   %ReturnIntRRef.call = call ptr @_Z13ReturnIntRRefv(), !dbg !20
-// CHECK:STDOUT:   store ptr %ReturnIntRRef.call, ptr %n2.var, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !15
+// CHECK:STDOUT:   store ptr %ReturnIntRRef.call, ptr %_.var.loc22, align 8, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc23), !dbg !15
 // CHECK:STDOUT:   %ReturnConstIntRef.call = call ptr @_Z17ReturnConstIntRefv(), !dbg !21
-// CHECK:STDOUT:   store ptr %ReturnConstIntRef.call, ptr %n3.var, align 8, !dbg !15
+// CHECK:STDOUT:   store ptr %ReturnConstIntRef.call, ptr %_.var.loc23, align 8, !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -493,12 +493,12 @@ fn GetRefs() {
 // CHECK:STDOUT: !13 = !DILocation(line: 21, column: 3, scope: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 22, column: 3, scope: !7)
 // CHECK:STDOUT: !15 = !DILocation(line: 23, column: 3, scope: !7)
-// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 20, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 18, column: 20, scope: !7)
-// CHECK:STDOUT: !18 = !DILocation(line: 19, column: 26, scope: !7)
-// CHECK:STDOUT: !19 = !DILocation(line: 21, column: 18, scope: !7)
-// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 18, scope: !7)
-// CHECK:STDOUT: !21 = !DILocation(line: 23, column: 24, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 19, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 18, column: 19, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 19, column: 25, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 21, column: 17, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 17, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 23, column: 23, scope: !7)
 // CHECK:STDOUT: !22 = !DILocation(line: 16, column: 1, scope: !7)
 // CHECK:STDOUT: ; ModuleID = 'return_references_via_thunk.carbon'
 // CHECK:STDOUT: source_filename = "return_references_via_thunk.carbon"
@@ -510,30 +510,30 @@ fn GetRefs() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CGetRefs.Main() #0 !dbg !7 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c1.var = alloca ptr, align 8, !dbg !10
-// CHECK:STDOUT:   %c2.var = alloca ptr, align 8, !dbg !11
-// CHECK:STDOUT:   %c3.var = alloca ptr, align 8, !dbg !12
-// CHECK:STDOUT:   %n1.var = alloca ptr, align 8, !dbg !13
-// CHECK:STDOUT:   %n2.var = alloca ptr, align 8, !dbg !14
-// CHECK:STDOUT:   %n3.var = alloca ptr, align 8, !dbg !15
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c1.var), !dbg !10
+// CHECK:STDOUT:   %_.var.loc18 = alloca ptr, align 8, !dbg !10
+// CHECK:STDOUT:   %_.var.loc19 = alloca ptr, align 8, !dbg !11
+// CHECK:STDOUT:   %_.var.loc20 = alloca ptr, align 8, !dbg !12
+// CHECK:STDOUT:   %_.var.loc22 = alloca ptr, align 8, !dbg !13
+// CHECK:STDOUT:   %_.var.loc23 = alloca ptr, align 8, !dbg !14
+// CHECK:STDOUT:   %_.var.loc24 = alloca ptr, align 8, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !10
 // CHECK:STDOUT:   %ReturnCRef__carbon_thunk.call = call ptr @_Z10ReturnCRef10ForceThunk.carbon_thunk0(), !dbg !16
-// CHECK:STDOUT:   store ptr %ReturnCRef__carbon_thunk.call, ptr %c1.var, align 8, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c2.var), !dbg !11
+// CHECK:STDOUT:   store ptr %ReturnCRef__carbon_thunk.call, ptr %_.var.loc18, align 8, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc19), !dbg !11
 // CHECK:STDOUT:   %ReturnCRRef__carbon_thunk.call = call ptr @_Z11ReturnCRRef10ForceThunk.carbon_thunk0(), !dbg !17
-// CHECK:STDOUT:   store ptr %ReturnCRRef__carbon_thunk.call, ptr %c2.var, align 8, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c3.var), !dbg !12
+// CHECK:STDOUT:   store ptr %ReturnCRRef__carbon_thunk.call, ptr %_.var.loc19, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc20), !dbg !12
 // CHECK:STDOUT:   %ReturnConstCRef__carbon_thunk.call = call ptr @_Z15ReturnConstCRef10ForceThunk.carbon_thunk0(), !dbg !18
-// CHECK:STDOUT:   store ptr %ReturnConstCRef__carbon_thunk.call, ptr %c3.var, align 8, !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n1.var), !dbg !13
+// CHECK:STDOUT:   store ptr %ReturnConstCRef__carbon_thunk.call, ptr %_.var.loc20, align 8, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc22), !dbg !13
 // CHECK:STDOUT:   %ReturnIntRef__carbon_thunk.call = call ptr @_Z12ReturnIntRef10ForceThunk.carbon_thunk0(), !dbg !19
-// CHECK:STDOUT:   store ptr %ReturnIntRef__carbon_thunk.call, ptr %n1.var, align 8, !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n2.var), !dbg !14
+// CHECK:STDOUT:   store ptr %ReturnIntRef__carbon_thunk.call, ptr %_.var.loc22, align 8, !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc23), !dbg !14
 // CHECK:STDOUT:   %ReturnIntRRef__carbon_thunk.call = call ptr @_Z13ReturnIntRRef10ForceThunk.carbon_thunk0(), !dbg !20
-// CHECK:STDOUT:   store ptr %ReturnIntRRef__carbon_thunk.call, ptr %n2.var, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n3.var), !dbg !15
+// CHECK:STDOUT:   store ptr %ReturnIntRRef__carbon_thunk.call, ptr %_.var.loc23, align 8, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc24), !dbg !15
 // CHECK:STDOUT:   %ReturnConstIntRef__carbon_thunk.call = call ptr @_Z17ReturnConstIntRef10ForceThunk.carbon_thunk0(), !dbg !21
-// CHECK:STDOUT:   store ptr %ReturnConstIntRef__carbon_thunk.call, ptr %n3.var, align 8, !dbg !15
+// CHECK:STDOUT:   store ptr %ReturnConstIntRef__carbon_thunk.call, ptr %_.var.loc24, align 8, !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -627,10 +627,10 @@ fn GetRefs() {
 // CHECK:STDOUT: !13 = !DILocation(line: 22, column: 3, scope: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 23, column: 3, scope: !7)
 // CHECK:STDOUT: !15 = !DILocation(line: 24, column: 3, scope: !7)
-// CHECK:STDOUT: !16 = !DILocation(line: 18, column: 20, scope: !7)
-// CHECK:STDOUT: !17 = !DILocation(line: 19, column: 20, scope: !7)
-// CHECK:STDOUT: !18 = !DILocation(line: 20, column: 26, scope: !7)
-// CHECK:STDOUT: !19 = !DILocation(line: 22, column: 18, scope: !7)
-// CHECK:STDOUT: !20 = !DILocation(line: 23, column: 18, scope: !7)
-// CHECK:STDOUT: !21 = !DILocation(line: 24, column: 24, scope: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 18, column: 19, scope: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 19, column: 19, scope: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 20, column: 25, scope: !7)
+// CHECK:STDOUT: !19 = !DILocation(line: 22, column: 17, scope: !7)
+// CHECK:STDOUT: !20 = !DILocation(line: 23, column: 17, scope: !7)
+// CHECK:STDOUT: !21 = !DILocation(line: 24, column: 23, scope: !7)
 // CHECK:STDOUT: !22 = !DILocation(line: 17, column: 1, scope: !7)

--- a/toolchain/lower/testdata/interop/cpp/return.carbon
+++ b/toolchain/lower/testdata/interop/cpp/return.carbon
@@ -91,11 +91,11 @@ import Cpp library "class.h";
 fn GetX() -> Cpp.X { return Cpp.Make(); }
 
 fn Let() {
-  let x: Cpp.X = Cpp.Make();
+  let _: Cpp.X = Cpp.Make();
 }
 
 fn Var() {
-  var x: Cpp.X = Cpp.Make();
+  var _: Cpp.X = Cpp.Make();
 }
 
 // --- indirect_return_with_args.carbon
@@ -471,10 +471,10 @@ fn Call(x: Cpp.D) -> Cpp.C {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CVar.Main() #0 !dbg !18 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca [16 x i8], align 1, !dbg !19
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !19
-// CHECK:STDOUT:   call void @_Z4Makev.carbon_thunk(ptr %x.var), !dbg !20
-// CHECK:STDOUT:   call void @_ZN1XD1Ev(ptr %x.var), !dbg !19
+// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 1, !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !19
+// CHECK:STDOUT:   call void @_Z4Makev.carbon_thunk(ptr %_.var), !dbg !20
+// CHECK:STDOUT:   call void @_ZN1XD1Ev(ptr %_.var), !dbg !19
 // CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/virtual_base.carbon
+++ b/toolchain/lower/testdata/interop/cpp/virtual_base.carbon
@@ -54,7 +54,7 @@ fn Make() {
   // mangled name for D (a complete object constructor), which should call
   // constructors with `...C2` mangled names for A, B, and C (base subobject
   // constructors).
-  var d: Cpp.D = Cpp.D.D();
+  var _: Cpp.D = Cpp.D.D();
 }
 
 fn AccessD(d: Cpp.D) -> i32 {
@@ -111,10 +111,10 @@ fn AccessD(d: Cpp.D) -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMake.Main() #0 !dbg !7 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %d.var = alloca [40 x i8], align 1, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !10
-// CHECK:STDOUT:   call void @_ZN1DC1Ev.carbon_thunk(ptr %d.var), !dbg !11
-// CHECK:STDOUT:   call void @_ZN1DD1Ev(ptr %d.var), !dbg !10
+// CHECK:STDOUT:   %_.var = alloca [40 x i8], align 1, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !10
+// CHECK:STDOUT:   call void @_ZN1DC1Ev.carbon_thunk(ptr %_.var), !dbg !11
+// CHECK:STDOUT:   call void @_ZN1DD1Ev(ptr %_.var), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -10,13 +10,13 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/operators/assignment.carbon
 
-fn Main() -> i32 {
+fn F() -> i32 {
   var a: i32 = 12;
   a = 9;
   return a;
 }
 
-fn Sane() -> (i32, i32) {
+fn G() -> (i32, i32) {
   var b: (i32, i32);
   b = (1, 2);
   return b;
@@ -28,7 +28,7 @@ fn Sane() -> (i32, i32) {
 // CHECK:STDOUT: @tuple.21c.loc21_5 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define i32 @_CMain.Main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8
@@ -39,7 +39,7 @@ fn Sane() -> (i32, i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CSane.Main(ptr sret({ i32, i32 }) %return) #0 !dbg !12 {
+// CHECK:STDOUT: define void @_CG.Main(ptr sret({ i32, i32 }) %return) #0 !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !16
@@ -77,7 +77,7 @@ fn Sane() -> (i32, i32) {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "assignment.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
@@ -85,7 +85,7 @@ fn Sane() -> (i32, i32) {
 // CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 16, column: 10, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 16, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Sane", linkageName: "_CSane.Main", scope: null, file: !3, line: 19, type: !13, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main", scope: null, file: !3, line: 19, type: !13, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 8)

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -10,43 +10,51 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/operators/assignment.carbon
 
-fn Main() {
+fn Main() -> i32 {
   var a: i32 = 12;
   a = 9;
-  let _: i32 = a;
+  return a;
+}
+
+fn Sane() -> (i32, i32) {
   var b: (i32, i32);
   b = (1, 2);
-  let _: (i32, i32) = b;
+  return b;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'assignment.carbon'
 // CHECK:STDOUT: source_filename = "assignment.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @tuple.21c.loc18_5 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @tuple.21c.loc21_5 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @_CMain.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !7
-// CHECK:STDOUT:   store i32 12, ptr %a.var, align 4, !dbg !7
+// CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8
+// CHECK:STDOUT:   store i32 12, ptr %a.var, align 4, !dbg !8
 // CHECK:STDOUT:   store i32 9, ptr %a.var, align 4, !dbg !9
-// CHECK:STDOUT:   %.loc16_16 = load i32, ptr %a.var, align 4, !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !8
-// CHECK:STDOUT:   %tuple.elem0.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !11
-// CHECK:STDOUT:   %tuple.elem1.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !11
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.21c.loc18_5, i64 8, i1 false), !dbg !12
-// CHECK:STDOUT:   %tuple.elem0.loc19.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !13
-// CHECK:STDOUT:   %.loc19_23.1 = load i32, ptr %tuple.elem0.loc19.tuple.elem, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple.elem1.loc19.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   %.loc19_23.2 = load i32, ptr %tuple.elem1.loc19.tuple.elem, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple = alloca { i32, i32 }, align 8, !dbg !13
-// CHECK:STDOUT:   %tuple1 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple, i32 0, i32 0, !dbg !13
-// CHECK:STDOUT:   store i32 %.loc19_23.1, ptr %tuple1, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple2 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   store i32 %.loc19_23.2, ptr %tuple2, align 4, !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT:   %.loc16 = load i32, ptr %a.var, align 4, !dbg !10
+// CHECK:STDOUT:   ret i32 %.loc16, !dbg !11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CSane.Main(ptr sret({ i32, i32 }) %return) #0 !dbg !12 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !16
+// CHECK:STDOUT:   %tuple.elem0.loc21.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !17
+// CHECK:STDOUT:   %tuple.elem1.loc21.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !17
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.21c.loc21_5, i64 8, i1 false), !dbg !18
+// CHECK:STDOUT:   %tuple.elem0.loc22_10.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !19
+// CHECK:STDOUT:   %.loc22_10.1 = load i32, ptr %tuple.elem0.loc22_10.1.tuple.elem, align 4, !dbg !19
+// CHECK:STDOUT:   %tuple.elem0.loc22_10.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 0, !dbg !19
+// CHECK:STDOUT:   store i32 %.loc22_10.1, ptr %tuple.elem0.loc22_10.2.tuple.elem, align 4, !dbg !19
+// CHECK:STDOUT:   %tuple.elem1.loc22_10.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !19
+// CHECK:STDOUT:   %.loc22_10.3 = load i32, ptr %tuple.elem1.loc22_10.1.tuple.elem, align 4, !dbg !19
+// CHECK:STDOUT:   %tuple.elem1.loc22_10.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %return, i32 0, i32 1, !dbg !19
+// CHECK:STDOUT:   store i32 %.loc22_10.3, ptr %tuple.elem1.loc22_10.2.tuple.elem, align 4, !dbg !19
+// CHECK:STDOUT:   ret void, !dbg !20
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -71,12 +79,18 @@ fn Main() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "assignment.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 17, column: 3, scope: !4)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 16, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 18, column: 7, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 18, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 19, column: 23, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 10, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Sane", linkageName: "_CSane.Main", scope: null, file: !3, line: 19, type: !13, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{!15}
+// CHECK:STDOUT: !15 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 8)
+// CHECK:STDOUT: !16 = !DILocation(line: 20, column: 3, scope: !12)
+// CHECK:STDOUT: !17 = !DILocation(line: 21, column: 7, scope: !12)
+// CHECK:STDOUT: !18 = !DILocation(line: 21, column: 3, scope: !12)
+// CHECK:STDOUT: !19 = !DILocation(line: 22, column: 10, scope: !12)
+// CHECK:STDOUT: !20 = !DILocation(line: 22, column: 3, scope: !12)

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -13,14 +13,16 @@
 fn Main() {
   var a: i32 = 12;
   a = 9;
+  let _: i32 = a;
   var b: (i32, i32);
   b = (1, 2);
+  let _: (i32, i32) = b;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'assignment.carbon'
 // CHECK:STDOUT: source_filename = "assignment.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @tuple.21c.loc17_5 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @tuple.21c.loc18_5 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !4 {
@@ -30,11 +32,21 @@ fn Main() {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !7
 // CHECK:STDOUT:   store i32 12, ptr %a.var, align 4, !dbg !7
 // CHECK:STDOUT:   store i32 9, ptr %a.var, align 4, !dbg !9
+// CHECK:STDOUT:   %.loc16_16 = load i32, ptr %a.var, align 4, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !8
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !10
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.21c.loc17_5, i64 8, i1 false), !dbg !11
-// CHECK:STDOUT:   ret void, !dbg !12
+// CHECK:STDOUT:   %tuple.elem0.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %tuple.elem1.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.21c.loc18_5, i64 8, i1 false), !dbg !12
+// CHECK:STDOUT:   %tuple.elem0.loc19.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !13
+// CHECK:STDOUT:   %.loc19_23.1 = load i32, ptr %tuple.elem0.loc19.tuple.elem, align 4, !dbg !13
+// CHECK:STDOUT:   %tuple.elem1.loc19.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !13
+// CHECK:STDOUT:   %.loc19_23.2 = load i32, ptr %tuple.elem1.loc19.tuple.elem, align 4, !dbg !13
+// CHECK:STDOUT:   %tuple = alloca { i32, i32 }, align 8, !dbg !13
+// CHECK:STDOUT:   %tuple1 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple, i32 0, i32 0, !dbg !13
+// CHECK:STDOUT:   store i32 %.loc19_23.1, ptr %tuple1, align 4, !dbg !13
+// CHECK:STDOUT:   %tuple2 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple, i32 0, i32 1, !dbg !13
+// CHECK:STDOUT:   store i32 %.loc19_23.2, ptr %tuple2, align 4, !dbg !13
+// CHECK:STDOUT:   ret void, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -61,8 +73,10 @@ fn Main() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 17, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 7, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 17, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 16, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 18, column: 7, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 19, column: 23, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 13, column: 1, scope: !4)

--- a/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
+++ b/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
@@ -11,7 +11,7 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
 
 fn F(p: i32**) -> i32 {
-  var a: i32** = p;
+  var _: i32** = p;
   var b: i32* = *p;
   var c: i32** = &b;
   return **c;
@@ -23,11 +23,11 @@ fn F(p: i32**) -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CF.Main(ptr %p) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca ptr, align 8, !dbg !11
+// CHECK:STDOUT:   %_.var = alloca ptr, align 8, !dbg !11
 // CHECK:STDOUT:   %b.var = alloca ptr, align 8, !dbg !12
 // CHECK:STDOUT:   %c.var = alloca ptr, align 8, !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !11
-// CHECK:STDOUT:   store ptr %p, ptr %a.var, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !11
+// CHECK:STDOUT:   store ptr %p, ptr %_.var, align 8, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !12
 // CHECK:STDOUT:   %.loc15_17.2 = load ptr, ptr %p, align 8, !dbg !14
 // CHECK:STDOUT:   store ptr %.loc15_17.2, ptr %b.var, align 8, !dbg !12

--- a/toolchain/lower/testdata/primitives/numeric_literals.carbon
+++ b/toolchain/lower/testdata/primitives/numeric_literals.carbon
@@ -13,13 +13,13 @@
 fn F() {
   // 8 and 9 trigger special behavior in APInt when mishandling signed versus
   // unsigned, so we pay extra attention to those.
-  var ints: array(i32, 4) = (
+  var _: array(i32, 4) = (
     8,
     9,
     0x8,
     0b1000,
   );
-  var floats: array(f64, 6) = (
+  var _: array(f64, 6) = (
     0.9,
     8.0,
     80.0,
@@ -38,22 +38,22 @@ fn F() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %ints.var = alloca [4 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %floats.var = alloca [6 x double], align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ints.var), !dbg !7
-// CHECK:STDOUT:   %.loc21_3.3.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 0, !dbg !9
-// CHECK:STDOUT:   %.loc21_3.6.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 1, !dbg !9
-// CHECK:STDOUT:   %.loc21_3.9.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 2, !dbg !9
-// CHECK:STDOUT:   %.loc21_3.12.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i64 3, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %ints.var, ptr align 4 @array.712.loc16_3, i64 16, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %floats.var), !dbg !8
-// CHECK:STDOUT:   %.loc29_3.3.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 0, !dbg !10
-// CHECK:STDOUT:   %.loc29_3.6.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 1, !dbg !10
-// CHECK:STDOUT:   %.loc29_3.9.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 2, !dbg !10
-// CHECK:STDOUT:   %.loc29_3.12.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 3, !dbg !10
-// CHECK:STDOUT:   %.loc29_3.15.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 4, !dbg !10
-// CHECK:STDOUT:   %.loc29_3.18.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i64 5, !dbg !10
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %floats.var, ptr align 8 @array.6e0.loc22_3, i64 48, i1 false), !dbg !8
+// CHECK:STDOUT:   %_.var.loc16 = alloca [4 x i32], align 4, !dbg !7
+// CHECK:STDOUT:   %_.var.loc22 = alloca [6 x double], align 8, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !7
+// CHECK:STDOUT:   %.loc21_3.3.array.index = getelementptr inbounds [4 x i32], ptr %_.var.loc16, i32 0, i64 0, !dbg !9
+// CHECK:STDOUT:   %.loc21_3.6.array.index = getelementptr inbounds [4 x i32], ptr %_.var.loc16, i32 0, i64 1, !dbg !9
+// CHECK:STDOUT:   %.loc21_3.9.array.index = getelementptr inbounds [4 x i32], ptr %_.var.loc16, i32 0, i64 2, !dbg !9
+// CHECK:STDOUT:   %.loc21_3.12.array.index = getelementptr inbounds [4 x i32], ptr %_.var.loc16, i32 0, i64 3, !dbg !9
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %_.var.loc16, ptr align 4 @array.712.loc16_3, i64 16, i1 false), !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc22), !dbg !8
+// CHECK:STDOUT:   %.loc29_3.3.array.index = getelementptr inbounds [6 x double], ptr %_.var.loc22, i32 0, i64 0, !dbg !10
+// CHECK:STDOUT:   %.loc29_3.6.array.index = getelementptr inbounds [6 x double], ptr %_.var.loc22, i32 0, i64 1, !dbg !10
+// CHECK:STDOUT:   %.loc29_3.9.array.index = getelementptr inbounds [6 x double], ptr %_.var.loc22, i32 0, i64 2, !dbg !10
+// CHECK:STDOUT:   %.loc29_3.12.array.index = getelementptr inbounds [6 x double], ptr %_.var.loc22, i32 0, i64 3, !dbg !10
+// CHECK:STDOUT:   %.loc29_3.15.array.index = getelementptr inbounds [6 x double], ptr %_.var.loc22, i32 0, i64 4, !dbg !10
+// CHECK:STDOUT:   %.loc29_3.18.array.index = getelementptr inbounds [6 x double], ptr %_.var.loc22, i32 0, i64 5, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc22, ptr align 8 @array.6e0.loc22_3, i64 48, i1 false), !dbg !8
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -83,6 +83,6 @@ fn F() {
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 16, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 22, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 29, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 22, column: 31, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 26, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 22, column: 26, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 13, column: 1, scope: !4)

--- a/toolchain/lower/testdata/primitives/optional.carbon
+++ b/toolchain/lower/testdata/primitives/optional.carbon
@@ -21,14 +21,14 @@ fn Convert(o: Core.Optional(i32*)) -> Core.Optional(i32) {
 }
 
 fn AddOrRemoveConst(a: i32, b: const i32) {
-  var oa: Core.Optional(i32) = a;
-  var coa: const Core.Optional(i32) = a;
-  var oca: Core.Optional(const i32) = a;
-  var coca: const Core.Optional(const i32) = a;
-  var ob: Core.Optional(i32) = b;
-  var cob: const Core.Optional(i32) = b;
-  var ocb: Core.Optional(const i32) = b;
-  var cocb: const Core.Optional(const i32) = b;
+  var _: Core.Optional(i32) = a;
+  var _: const Core.Optional(i32) = a;
+  var _: Core.Optional(const i32) = a;
+  var _: const Core.Optional(const i32) = a;
+  var _: Core.Optional(i32) = b;
+  var _: const Core.Optional(i32) = b;
+  var _: Core.Optional(const i32) = b;
+  var _: const Core.Optional(const i32) = b;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'optional.carbon'
@@ -54,30 +54,30 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CAddOrRemoveConst.Main(i32 %a, i32 %b) #0 !dbg !17 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %oa.var = alloca { i32, i1 }, align 8, !dbg !24
-// CHECK:STDOUT:   %coa.var = alloca { i32, i1 }, align 8, !dbg !25
-// CHECK:STDOUT:   %oca.var = alloca { i32, i1 }, align 8, !dbg !26
-// CHECK:STDOUT:   %coca.var = alloca { i32, i1 }, align 8, !dbg !27
-// CHECK:STDOUT:   %ob.var = alloca { i32, i1 }, align 8, !dbg !28
-// CHECK:STDOUT:   %cob.var = alloca { i32, i1 }, align 8, !dbg !29
-// CHECK:STDOUT:   %ocb.var = alloca { i32, i1 }, align 8, !dbg !30
-// CHECK:STDOUT:   %cocb.var = alloca { i32, i1 }, align 8, !dbg !31
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %oa.var), !dbg !24
-// CHECK:STDOUT:   call void @"_CConvert.8432e4edee1e3855:ImplicitAs.Core.76895dc907db9a3f"(ptr %oa.var, i32 %a), !dbg !24
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %coa.var), !dbg !25
-// CHECK:STDOUT:   call void @"_CConvert.b911a754667cc32d:ImplicitAs.Core.2ad288ff76f5b81b"(ptr %coa.var, i32 %a), !dbg !25
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %oca.var), !dbg !26
-// CHECK:STDOUT:   call void @"_CConvert.8432e4edee1e3855:ImplicitAs.Core.e4d8d712312f87c7"(ptr %oca.var, i32 %a), !dbg !26
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %coca.var), !dbg !27
-// CHECK:STDOUT:   call void @"_CConvert.b911a754667cc32d:ImplicitAs.Core.cb259d1cd9f87a45"(ptr %coca.var, i32 %a), !dbg !27
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ob.var), !dbg !28
-// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.2ad288ff76f5b81b"(ptr %ob.var, i32 %b), !dbg !28
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %cob.var), !dbg !29
-// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.4625c39d8336f8c2"(ptr %cob.var, i32 %b), !dbg !29
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ocb.var), !dbg !30
-// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.cb259d1cd9f87a45"(ptr %ocb.var, i32 %b), !dbg !30
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %cocb.var), !dbg !31
-// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.84138ae972513b15"(ptr %cocb.var, i32 %b), !dbg !31
+// CHECK:STDOUT:   %_.var.loc24 = alloca { i32, i1 }, align 8, !dbg !24
+// CHECK:STDOUT:   %_.var.loc25 = alloca { i32, i1 }, align 8, !dbg !25
+// CHECK:STDOUT:   %_.var.loc26 = alloca { i32, i1 }, align 8, !dbg !26
+// CHECK:STDOUT:   %_.var.loc27 = alloca { i32, i1 }, align 8, !dbg !27
+// CHECK:STDOUT:   %_.var.loc28 = alloca { i32, i1 }, align 8, !dbg !28
+// CHECK:STDOUT:   %_.var.loc29 = alloca { i32, i1 }, align 8, !dbg !29
+// CHECK:STDOUT:   %_.var.loc30 = alloca { i32, i1 }, align 8, !dbg !30
+// CHECK:STDOUT:   %_.var.loc31 = alloca { i32, i1 }, align 8, !dbg !31
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc24), !dbg !24
+// CHECK:STDOUT:   call void @"_CConvert.8432e4edee1e3855:ImplicitAs.Core.76895dc907db9a3f"(ptr %_.var.loc24, i32 %a), !dbg !24
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc25), !dbg !25
+// CHECK:STDOUT:   call void @"_CConvert.b911a754667cc32d:ImplicitAs.Core.2ad288ff76f5b81b"(ptr %_.var.loc25, i32 %a), !dbg !25
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc26), !dbg !26
+// CHECK:STDOUT:   call void @"_CConvert.8432e4edee1e3855:ImplicitAs.Core.e4d8d712312f87c7"(ptr %_.var.loc26, i32 %a), !dbg !26
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc27), !dbg !27
+// CHECK:STDOUT:   call void @"_CConvert.b911a754667cc32d:ImplicitAs.Core.cb259d1cd9f87a45"(ptr %_.var.loc27, i32 %a), !dbg !27
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc28), !dbg !28
+// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.2ad288ff76f5b81b"(ptr %_.var.loc28, i32 %b), !dbg !28
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc29), !dbg !29
+// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.4625c39d8336f8c2"(ptr %_.var.loc29, i32 %b), !dbg !29
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc30), !dbg !30
+// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.cb259d1cd9f87a45"(ptr %_.var.loc30, i32 %b), !dbg !30
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc31), !dbg !31
+// CHECK:STDOUT:   call void @"_CConvert.342b90dd3c63ffbd:ImplicitAs.Core.84138ae972513b15"(ptr %_.var.loc31, i32 %b), !dbg !31
 // CHECK:STDOUT:   ret void, !dbg !32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/empty.carbon
+++ b/toolchain/lower/testdata/struct/empty.carbon
@@ -12,7 +12,7 @@
 
 fn Run() -> i32 {
   var x: {} = {};
-  var y: {} = x;
+  var _: {} = x;
   return 0;
 }
 
@@ -23,9 +23,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !8
-// CHECK:STDOUT:   %y.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/member_access.carbon
+++ b/toolchain/lower/testdata/struct/member_access.carbon
@@ -13,7 +13,7 @@
 fn Run() -> i32 {
   var x: {.a: f64, .b: i32} = {.a = 0.0, .b = 1};
   var y: i32 = x.b;
-  var z: i32 = y;
+  var _: i32 = y;
   return 0;
 }
 
@@ -27,7 +27,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { double, i32 }, align 8, !dbg !8
 // CHECK:STDOUT:   %y.var = alloca i32, align 4, !dbg !9
-// CHECK:STDOUT:   %z.var = alloca i32, align 4, !dbg !10
+// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %.loc14_48.3.a = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc14_48.6.b = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 1, !dbg !11
@@ -36,9 +36,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %.loc15_17.1.b = getelementptr inbounds nuw { double, i32 }, ptr %x.var, i32 0, i32 1, !dbg !12
 // CHECK:STDOUT:   %.loc15_17.2 = load i32, ptr %.loc15_17.1.b, align 4, !dbg !12
 // CHECK:STDOUT:   store i32 %.loc15_17.2, ptr %y.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %z.var), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !10
 // CHECK:STDOUT:   %.loc16_16 = load i32, ptr %y.var, align 4, !dbg !13
-// CHECK:STDOUT:   store i32 %.loc16_16, ptr %z.var, align 4, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_16, ptr %_.var, align 4, !dbg !10
 // CHECK:STDOUT:   ret i32 0, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
@@ -13,7 +13,7 @@
 fn F() -> (i32, i32, i32);
 
 fn G() {
-  var v: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = {.a = F(), .b = F()};
+  var _: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = {.a = F(), .b = F()};
 }
 
 // CHECK:STDOUT: ; ModuleID = 'nested_struct_in_place.carbon'
@@ -24,11 +24,11 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !7
-// CHECK:STDOUT:   %.loc16_74.1.a = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %v.var, i32 0, i32 0, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
+// CHECK:STDOUT:   %.loc16_74.1.a = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %_.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_74.1.a), !dbg !9
-// CHECK:STDOUT:   %.loc16_74.2.b = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %v.var, i32 0, i32 1, !dbg !8
+// CHECK:STDOUT:   %.loc16_74.2.b = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %_.var, i32 0, i32 1, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_74.2.b), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/struct/one_entry.carbon
+++ b/toolchain/lower/testdata/struct/one_entry.carbon
@@ -12,7 +12,7 @@
 
 fn Run() -> i32 {
   var x: {.a: i32} = {.a = 4};
-  var y: {.a: i32} = x;
+  var _: {.a: i32} = x;
   return 0;
 }
 
@@ -23,14 +23,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %y.var = alloca { i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca { i32 }, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   store { i32 } { i32 4 }, ptr %x.var, align 4, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   %.loc15_22.1.a = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   %.loc15_22.2 = load i32, ptr %.loc15_22.1.a, align 4, !dbg !10
 // CHECK:STDOUT:   %.loc15_22.3.struct.init = insertvalue { i32 } poison, i32 %.loc15_22.2, 0, !dbg !10
-// CHECK:STDOUT:   store { i32 } %.loc15_22.3.struct.init, ptr %y.var, align 4, !dbg !9
+// CHECK:STDOUT:   store { i32 } %.loc15_22.3.struct.init, ptr %_.var, align 4, !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/two_entries.carbon
+++ b/toolchain/lower/testdata/struct/two_entries.carbon
@@ -12,7 +12,7 @@
 
 fn Run() -> i32 {
   var x: {.a: i32, .b: i32} = {.a = 1, .b = 2};
-  var y: {.a: i32, .b: i32} = x;
+  var _: {.a: i32, .b: i32} = x;
   return 0;
 }
 
@@ -25,19 +25,19 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %.loc14_46.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   %.loc14_46.6.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @struct.ed5.loc14_3, i64 8, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   %.loc15_31.1.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc15_31.2 = load i32, ptr %.loc15_31.1.a, align 4, !dbg !11
-// CHECK:STDOUT:   %.loc15_31.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc15_31.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %_.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc15_31.2, ptr %.loc15_31.3.a, align 4, !dbg !11
 // CHECK:STDOUT:   %.loc15_31.5.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !11
 // CHECK:STDOUT:   %.loc15_31.6 = load i32, ptr %.loc15_31.5.b, align 4, !dbg !11
-// CHECK:STDOUT:   %.loc15_31.7.b = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   %.loc15_31.7.b = getelementptr inbounds nuw { i32, i32 }, ptr %_.var, i32 0, i32 1, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc15_31.6, ptr %.loc15_31.7.b, align 4, !dbg !11
 // CHECK:STDOUT:   ret i32 0, !dbg !12
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/tuple/access/element_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/element_access.carbon
@@ -12,8 +12,8 @@
 
 fn Run() -> i32 {
   var a: (i32, i32, i32) = (0, 1, 2);
-  var b: i32 = a.0;
-  var c: i32 = a.2;
+  var _: i32 = a.0;
+  var _: i32 = a.2;
   return 0;
 }
 
@@ -26,21 +26,21 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !9
-// CHECK:STDOUT:   %c.var = alloca i32, align 4, !dbg !10
+// CHECK:STDOUT:   %_.var.loc15 = alloca i32, align 4, !dbg !9
+// CHECK:STDOUT:   %_.var.loc16 = alloca i32, align 4, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8
 // CHECK:STDOUT:   %tuple.elem0.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !11
 // CHECK:STDOUT:   %tuple.elem2.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !11
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.d9f.loc14_3, i64 12, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc15), !dbg !9
 // CHECK:STDOUT:   %tuple.elem0.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !12
 // CHECK:STDOUT:   %.loc15_17 = load i32, ptr %tuple.elem0.loc15.tuple.elem, align 4, !dbg !12
-// CHECK:STDOUT:   store i32 %.loc15_17, ptr %b.var, align 4, !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !10
+// CHECK:STDOUT:   store i32 %.loc15_17, ptr %_.var.loc15, align 4, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !10
 // CHECK:STDOUT:   %tuple.elem2.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !13
 // CHECK:STDOUT:   %.loc16_17 = load i32, ptr %tuple.elem2.loc16.tuple.elem, align 4, !dbg !13
-// CHECK:STDOUT:   store i32 %.loc16_17, ptr %c.var, align 4, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_17, ptr %_.var.loc16, align 4, !dbg !10
 // CHECK:STDOUT:   ret i32 0, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/access/return_value_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/return_value_access.carbon
@@ -13,7 +13,7 @@
 fn F() -> (i32, i32) { return (12, 24); }
 
 fn Run() {
-  var t: i32 = F().1;
+  var _: i32 = F().1;
 }
 
 // CHECK:STDOUT: ; ModuleID = 'return_value_access.carbon'
@@ -33,14 +33,14 @@ fn Run() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %t.var = alloca i32, align 4, !dbg !13
+// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !13
 // CHECK:STDOUT:   %.loc16_18.1.temp = alloca { i32, i32 }, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %t.var), !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !13
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_18.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_18.1.temp), !dbg !14
 // CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_18.1.temp, i32 0, i32 1, !dbg !14
 // CHECK:STDOUT:   %.loc16_19 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   store i32 %.loc16_19, ptr %t.var, align 4, !dbg !13
+// CHECK:STDOUT:   store i32 %.loc16_19, ptr %_.var, align 4, !dbg !13
 // CHECK:STDOUT:   ret void, !dbg !15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/empty.carbon
+++ b/toolchain/lower/testdata/tuple/empty.carbon
@@ -12,7 +12,7 @@
 
 fn Run() -> i32 {
   var x: () = ();
-  var y: () = x;
+  var _: () = x;
   return 0;
 }
 
@@ -23,9 +23,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !8
-// CHECK:STDOUT:   %y.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
+++ b/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
@@ -13,7 +13,7 @@
 fn F() -> (i32, i32, i32);
 
 fn G() {
-  var v: ((i32, i32, i32), (i32, i32, i32)) = (F(), F());
+  var _: ((i32, i32, i32), (i32, i32, i32)) = (F(), F());
 }
 
 // CHECK:STDOUT: ; ModuleID = 'nested_tuple_in_place.carbon'
@@ -24,11 +24,11 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %v.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %v.var), !dbg !7
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %v.var, i32 0, i32 0, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
+// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %_.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %tuple.elem0.tuple.elem), !dbg !9
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %v.var, i32 0, i32 1, !dbg !8
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %_.var, i32 0, i32 1, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %tuple.elem1.tuple.elem), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/tuple/one_entry.carbon
+++ b/toolchain/lower/testdata/tuple/one_entry.carbon
@@ -12,7 +12,7 @@
 
 fn Run() -> i32 {
   var x: (i32, ) = (1, );
-  var y: (i32, ) = x;
+  var _: (i32, ) = x;
   return 0;
 }
 
@@ -23,14 +23,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %y.var = alloca { i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca { i32 }, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   store { i32 } { i32 1 }, ptr %x.var, align 4, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   %.loc15_20.1 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !10
 // CHECK:STDOUT:   %.loc15_20.2.tuple.init = insertvalue { i32 } poison, i32 %.loc15_20.1, 0, !dbg !10
-// CHECK:STDOUT:   store { i32 } %.loc15_20.2.tuple.init, ptr %y.var, align 4, !dbg !9
+// CHECK:STDOUT:   store { i32 } %.loc15_20.2.tuple.init, ptr %_.var, align 4, !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/two_entries.carbon
+++ b/toolchain/lower/testdata/tuple/two_entries.carbon
@@ -12,7 +12,7 @@
 
 fn Run() -> i32 {
   var x: (i32, i32) = (12, 7);
-  var y: (i32, i32) = x;
+  var _: (i32, i32) = x;
   return 0;
 }
 
@@ -25,19 +25,19 @@ fn Run() -> i32 {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %tuple.elem0.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   %tuple.elem1.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @tuple.d1d.loc14_3, i64 8, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   %tuple.elem0.loc15_23.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc15_23.1 = load i32, ptr %tuple.elem0.loc15_23.1.tuple.elem, align 4, !dbg !11
-// CHECK:STDOUT:   %tuple.elem0.loc15_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %tuple.elem0.loc15_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %_.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc15_23.1, ptr %tuple.elem0.loc15_23.2.tuple.elem, align 4, !dbg !11
 // CHECK:STDOUT:   %tuple.elem1.loc15_23.1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !11
 // CHECK:STDOUT:   %.loc15_23.3 = load i32, ptr %tuple.elem1.loc15_23.1.tuple.elem, align 4, !dbg !11
-// CHECK:STDOUT:   %tuple.elem1.loc15_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %y.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   %tuple.elem1.loc15_23.2.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %_.var, i32 0, i32 1, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc15_23.3, ptr %tuple.elem1.loc15_23.2.tuple.elem, align 4, !dbg !11
 // CHECK:STDOUT:   ret i32 0, !dbg !12
 // CHECK:STDOUT: }


### PR DESCRIPTION
This updates lower/testdata to use _ instead of proper names, in order to avoid the "unused binding" warnings from #2022 which are being implemented. These changes do not depend on the implementation which should make everything easier to review.

See #6460 with part 1 of the implementation. It was split upon request in order to make reviewing easier, the original state of the PR was updating hundreds of test cases.
The PR has thus been split, part 2 including test cases changes can be viewed at https://github.com/burakemir/carbon-lang/tree/unused_pattern_bindings_p2022_impl_part2 ... many tests need to be updated, so it seems best to get those tests out of the way that are not interesting.

These are not all tests in lower/testdata - a few of them are interesting in the sense that they cannot use '_' because it leads to failed redeclaration check. This is exactly the scenario described in #3763 which requires the 'unused' marker. Those are left untouched here but are updated in https://github.com/burakemir/carbon-lang/tree/unused_pattern_bindings_p2022_impl_part2



