### PR TITLE
Remove unused code paths in EndAssociatedConstantDeclRegion

### DIFF
--- a/toolchain/check/handle_let_and_var.cpp
+++ b/toolchain/check/handle_let_and_var.cpp
@@ -35,28 +35,15 @@ namespace Carbon::Check {
 static auto EndAssociatedConstantDeclRegion(Context& context,
                                             SemIR::InterfaceId interface_id)
     -> SemIR::GenericId {
-  // TODO: Stop special-casing tuple patterns once they behave like other
-  // patterns.
-  if (context.node_stack().PeekIs(Parse::NodeKind::TuplePattern)) {
-    DiscardGenericDecl(context);
-    return SemIR::GenericId::None;
-  }
-
   // Peek the pattern. For a valid associated constant, the corresponding
   // instruction will be an `AssociatedConstantDecl` instruction.
   auto decl_id = context.node_stack().PeekPattern();
   auto assoc_const_decl =
-      context.insts().TryGetAs<SemIR::AssociatedConstantDecl>(decl_id);
-  if (!assoc_const_decl) {
-    // The pattern wasn't suitable for an associated constant. We'll detect
-    // and diagnose this later. For now, just clean up the generic stack.
-    DiscardGenericDecl(context);
-    return SemIR::GenericId::None;
-  }
+      context.insts().GetAs<SemIR::AssociatedConstantDecl>(decl_id);
 
   // Finish the declaration region of this generic.
   auto& assoc_const =
-      context.associated_constants().Get(assoc_const_decl->assoc_const_id);
+      context.associated_constants().Get(assoc_const_decl.assoc_const_id);
   assoc_const.generic_id = BuildGenericDecl(context, decl_id);
 
   // Build a corresponding associated entity and add it into scope. Note

--- a/toolchain/check/testdata/interface/assoc_const.carbon
+++ b/toolchain/check/testdata/interface/assoc_const.carbon
@@ -15,6 +15,7 @@
 interface I {
   let T:! type;
   let N:! i32;
+  let Empty:! ();
 }
 
 // CHECK:STDOUT: --- assoc_const.carbon
@@ -26,9 +27,11 @@ interface I {
 // CHECK:STDOUT:   %assoc0: %I.assoc_type = assoc_entity element0, @I.%T [concrete]
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %Int.generic: %Int.type = struct_value () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %assoc1: %I.assoc_type = assoc_entity element1, @I.%N [concrete]
+// CHECK:STDOUT:   %assoc2: %I.assoc_type = assoc_entity element2, @I.%Empty [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -57,12 +60,16 @@ interface I {
 // CHECK:STDOUT:   %N: %i32 = assoc_const_decl @N [concrete] {
 // CHECK:STDOUT:     %assoc1: %I.assoc_type = assoc_entity element1, @I.%N [concrete = constants.%assoc1]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Empty: %empty_tuple.type = assoc_const_decl @Empty [concrete] {
+// CHECK:STDOUT:     %assoc2: %I.assoc_type = assoc_entity element2, @I.%Empty [concrete = constants.%assoc2]
+// CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .T = @T.%assoc0
 // CHECK:STDOUT:   .N = @N.%assoc1
-// CHECK:STDOUT:   witness = (%T, %N)
+// CHECK:STDOUT:   .Empty = @Empty.%assoc2
+// CHECK:STDOUT:   witness = (%T, %N, %Empty)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT: }
@@ -75,7 +82,13 @@ interface I {
 // CHECK:STDOUT:   assoc_const N:! %i32;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: generic assoc_const @Empty(@I.%Self: %I.type) {
+// CHECK:STDOUT:   assoc_const Empty:! %empty_tuple.type;
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: specific @T(constants.%Self) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @N(constants.%Self) {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Empty(constants.%Self) {}
 // CHECK:STDOUT:


### PR DESCRIPTION
I think these are obsolete, at least as far as I can tell. The former appears tested (adding to be sure), the latter looks like it may no longer occur.