### PR TITLE
Small additional change to use core identifiers

### DIFF
--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -204,16 +204,14 @@ auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
   if (!context.name_scopes().IsCorePackage(interface.parent_scope_id)) {
     return SemIR::InstId::None;
   }
-  if (!interface.name_id.AsIdentifierId().has_value()) {
-    return SemIR::InstId::None;
-  }
 
-  if (context.identifiers().Get(interface.name_id.AsIdentifierId()) == "Copy") {
+  if (interface.name_id ==
+      context.core_identifiers().AddNameId(CoreIdentifier::Copy)) {
     return LookupCopyImpl(context, loc_id, self_type_id, specific_interface);
   }
 
-  if (context.identifiers().Get(interface.name_id.AsIdentifierId()) ==
-      "Destroy") {
+  if (interface.name_id ==
+      context.core_identifiers().AddNameId(CoreIdentifier::Destroy)) {
     return LookupDestroyImpl(context, loc_id, self_type_id, specific_interface);
   }
 


### PR DESCRIPTION
I'm not adding this to #6486 since that's in the merge queue, but this is an additional commit on top of that to adjust cpp impl lookup to use the identifiers. (reminded of this because I'm looking at the impl lookup code for destroy)

For contrast:
- `context.identifiers().Get(interface.name_id.AsIdentifierId()) == "Destroy"` is a table-of-tables lookup for a StringRef plus string comparison
  - Not clear `context.identifiers().Get` needed the repeated calls here, but this moots that (and the string comparison is what'd likely be expensive anyways).
- `interface.name_id == context.core_identifiers().AddNameId(CoreIdentifier::Destroy)` is a single table lookup for a cached map lookup plus integer comparison