### PR TITLE
Prevent accidental copies of TypeStructure

### DIFF
--- a/toolchain/check/type_structure.h
+++ b/toolchain/check/type_structure.h
@@ -24,6 +24,11 @@ namespace Carbon::Check {
 // better, more specified, match.
 class TypeStructure : public Printable<TypeStructure> {
  public:
+  // TypeStructure is a pretty heavy data structure, avoid accidental copies.
+  // TODO: Add a Clone() method if we want to make a copy of this in the future.
+  TypeStructure(TypeStructure&&) noexcept = default;
+  auto operator=(TypeStructure&&) noexcept -> TypeStructure& = default;
+
   enum class CompareTest {
     // Test whether `this` has the same structure as `other`, or `this` is
     // strictly more specific (has more concrete values) than `other` while


### PR DESCRIPTION
The TypeStructure is pretty large, with multiple vectors inside, and we don't want to do a bunch of mallocs for no reason. There is no need for a copy ever at this time.

Based on #6517