### PR TITLE
Reject unqualified private access to base members

### DIFF
--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -398,6 +398,7 @@ auto LookupQualifiedName(Context& context, SemIR::LocId loc_id,
   LookupResult result = {
       .specific_id = SemIR::SpecificId::None,
       .scope_result = SemIR::ScopeLookupResult::MakeNotFound()};
+  auto parent_const_id = SemIR::ConstantId::None;
   bool has_error = false;
   bool is_parent_access = false;
 
@@ -414,6 +415,13 @@ auto LookupQualifiedName(Context& context, SemIR::LocId loc_id,
     const SemIR::ScopeLookupResult scope_result =
         LookupNameInExactScope(context, loc_id, name_id, scope_id, name_scope);
     SemIR::AccessKind access_kind = scope_result.access_kind();
+
+    if (is_parent_access && scope_result.is_found() &&
+        !access_info.has_value()) {
+      access_info =
+          AccessInfo{.constant_id = parent_const_id,
+                     .highest_allowed_access = SemIR::AccessKind::Protected};
+    }
 
     auto is_access_prohibited =
         IsAccessProhibited(access_info, access_kind, is_parent_access);
@@ -448,6 +456,7 @@ auto LookupQualifiedName(Context& context, SemIR::LocId loc_id,
         }
       }
       is_parent_access |= !extended.empty();
+      parent_const_id = context.constant_values().Get(name_scope.inst_id());
       continue;
     }
 
@@ -467,7 +476,8 @@ auto LookupQualifiedName(Context& context, SemIR::LocId loc_id,
     result.specific_id = specific_id;
   }
 
-  if (required && !result.scope_result.is_found()) {
+  if ((!prohibited_accesses.empty() || required) &&
+      !result.scope_result.is_found()) {
     if (!has_error) {
       if (prohibited_accesses.empty()) {
         DiagnoseMemberNameNotFound(context, loc_id, name_id, lookup_scopes);

--- a/toolchain/check/testdata/class/inheritance_access.carbon
+++ b/toolchain/check/testdata/class/inheritance_access.carbon
@@ -138,17 +138,50 @@ class C {
   fn G() { Self.F(); }
 }
 
-// --- todo_fail_noninstance_private_on_parent_unqualified.carbon
+// --- fail_noninstance_private_on_parent_unqualified.carbon
 
 library "[[@TEST_NAME]]";
 
+base class A {
+  private fn Fa() {}
+}
+
 base class B {
-  private fn F() {}
+  extend base: A;
+
+  private let SOME_PRIVATE_CONSTANT: i32 = 86;
+  private fn Fb() {}
 }
 
 class C {
   extend base: B;
-  fn G() { F(); }
+
+  // CHECK:STDERR: fail_noninstance_private_on_parent_unqualified.carbon:[[@LINE+7]]:27: error: cannot access private member `SOME_PRIVATE_CONSTANT` of type `B` [ClassInvalidMemberAccess]
+  // CHECK:STDERR:   fn G1() -> i32 { return SOME_PRIVATE_CONSTANT; }
+  // CHECK:STDERR:                           ^~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_noninstance_private_on_parent_unqualified.carbon:[[@LINE-10]]:15: note: declared here [ClassMemberDeclaration]
+  // CHECK:STDERR:   private let SOME_PRIVATE_CONSTANT: i32 = 86;
+  // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  fn G1() -> i32 { return SOME_PRIVATE_CONSTANT; }
+
+  // CHECK:STDERR: fail_noninstance_private_on_parent_unqualified.carbon:[[@LINE+7]]:13: error: cannot access private member `Fa` of type `A` [ClassInvalidMemberAccess]
+  // CHECK:STDERR:   fn G2() { Fa(); }
+  // CHECK:STDERR:             ^~
+  // CHECK:STDERR: fail_noninstance_private_on_parent_unqualified.carbon:[[@LINE-25]]:3: note: declared here [ClassMemberDeclaration]
+  // CHECK:STDERR:   private fn Fa() {}
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  fn G2() { Fa(); }
+
+  // CHECK:STDERR: fail_noninstance_private_on_parent_unqualified.carbon:[[@LINE+7]]:13: error: cannot access private member `Fb` of type `B` [ClassInvalidMemberAccess]
+  // CHECK:STDERR:   fn G3() { Fb(); }
+  // CHECK:STDERR:             ^~
+  // CHECK:STDERR: fail_noninstance_private_on_parent_unqualified.carbon:[[@LINE-27]]:3: note: declared here [ClassMemberDeclaration]
+  // CHECK:STDERR:   private fn Fb() {}
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  fn G3() { Fb(); }
 }
 
 // --- noninstance_protected_on_parent.carbon
@@ -973,76 +1006,180 @@ class B {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- todo_fail_noninstance_private_on_parent_unqualified.carbon
+// CHECK:STDOUT: --- fail_noninstance_private_on_parent_unqualified.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %B: type = class_type @B [concrete]
-// CHECK:STDOUT:   %B.F.type: type = fn_type @B.F [concrete]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %B.F: %B.F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %A: type = class_type @A [concrete]
+// CHECK:STDOUT:   %A.Fa.type: type = fn_type @A.Fa [concrete]
+// CHECK:STDOUT:   %A.Fa: %A.Fa.type = struct_value () [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %B: type = class_type @B [concrete]
+// CHECK:STDOUT:   %B.elem: type = unbound_element_type %B, %A [concrete]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %Int.type: type = generic_class_type @Int [concrete]
+// CHECK:STDOUT:   %Int.generic: %Int.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
+// CHECK:STDOUT:   %int_86.bd3: Core.IntLiteral = int_value 86 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.cc7 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.d14: type = facet_type <@ImplicitAs, @ImplicitAs(%i32)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.1b6: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i32) [concrete]
+// CHECK:STDOUT:   %To: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.412: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert, @Core.IntLiteral.as.ImplicitAs.impl(%To) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.740: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.412 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.57f: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.8c3, @Core.IntLiteral.as.ImplicitAs.impl(%int_32) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.84b: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert, @Core.IntLiteral.as.ImplicitAs.impl(%int_32) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.6f0: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.84b = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.d14 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.57f) [concrete]
+// CHECK:STDOUT:   %.dbf: type = fn_type_with_self_type %ImplicitAs.Convert.type.1b6, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_86.bd3, %Core.IntLiteral.as.ImplicitAs.impl.Convert.6f0 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.6f0, @Core.IntLiteral.as.ImplicitAs.impl.Convert(%int_32) [concrete]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %int_86.bd3, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_86.261: %i32 = int_value 86 [concrete]
+// CHECK:STDOUT:   %B.Fb.type: type = fn_type @B.Fb [concrete]
+// CHECK:STDOUT:   %B.Fb: %B.Fb.type = struct_value () [concrete]
+// CHECK:STDOUT:   %struct_type.base.5af: type = struct_type {.base: %A} [concrete]
+// CHECK:STDOUT:   %complete_type.0d1: <witness> = complete_type_witness %struct_type.base.5af [concrete]
 // CHECK:STDOUT:   %C: type = class_type @C [concrete]
 // CHECK:STDOUT:   %C.elem: type = unbound_element_type %C, %B [concrete]
-// CHECK:STDOUT:   %C.G.type: type = fn_type @C.G [concrete]
-// CHECK:STDOUT:   %C.G: %C.G.type = struct_value () [concrete]
-// CHECK:STDOUT:   %struct_type.base: type = struct_type {.base: %B} [concrete]
-// CHECK:STDOUT:   %complete_type.021: <witness> = complete_type_witness %struct_type.base [concrete]
+// CHECK:STDOUT:   %C.G1.type: type = fn_type @C.G1 [concrete]
+// CHECK:STDOUT:   %C.G1: %C.G1.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.G2.type: type = fn_type @C.G2 [concrete]
+// CHECK:STDOUT:   %C.G2: %C.G2.type = struct_value () [concrete]
+// CHECK:STDOUT:   %C.G3.type: type = fn_type @C.G3 [concrete]
+// CHECK:STDOUT:   %C.G3: %C.G3.type = struct_value () [concrete]
+// CHECK:STDOUT:   %struct_type.base.64a: type = struct_type {.base: %B} [concrete]
+// CHECK:STDOUT:   %complete_type.021: <witness> = complete_type_witness %struct_type.base.64a [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [concrete] {
+// CHECK:STDOUT:     .Int = %Core.Int
+// CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.Int: %Int.type = import_ref Core//prelude/parts/int, Int, loaded [concrete = constants.%Int.generic]
+// CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.cc7 = import_ref Core//prelude/parts/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
+// CHECK:STDOUT:   %Core.import_ref.1b5: @Core.IntLiteral.as.ImplicitAs.impl.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.412) = import_ref Core//prelude/parts/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.740)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.8c3 = impl_witness_table (%Core.import_ref.1b5), @Core.IntLiteral.as.ImplicitAs.impl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
 // CHECK:STDOUT:     .Core = imports.%Core
+// CHECK:STDOUT:     .A = %A.decl
 // CHECK:STDOUT:     .B = %B.decl
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.import = import Core
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [concrete = constants.%C] {} {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %B.F.decl: %B.F.type = fn_decl @B.F [concrete = constants.%B.F] {} {}
+// CHECK:STDOUT: class @A {
+// CHECK:STDOUT:   %A.Fa.decl: %A.Fa.type = fn_decl @A.Fa [concrete = constants.%A.Fa] {} {}
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness constants.%empty_struct_type [concrete = constants.%complete_type.357]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%A
+// CHECK:STDOUT:   .Fa [private] = %A.Fa.decl
+// CHECK:STDOUT:   .SOME_PRIVATE_CONSTANT = <poisoned>
+// CHECK:STDOUT:   .Fb = <poisoned>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @B {
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A]
+// CHECK:STDOUT:   %.loc9: %B.elem = base_decl %A.ref, element0 [concrete]
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %SOME_PRIVATE_CONSTANT.patt: %pattern_type.7ce = value_binding_pattern SOME_PRIVATE_CONSTANT [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_86: Core.IntLiteral = int_value 86 [concrete = constants.%int_86.bd3]
+// CHECK:STDOUT:   %.loc11_38: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0: %.dbf = impl_witness_access constants.%ImplicitAs.impl_witness.57f, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.6f0]
+// CHECK:STDOUT:   %bound_method.loc11_44.1: <bound method> = bound_method %int_86, %impl.elem0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Core.IntLiteral.as.ImplicitAs.impl.Convert(constants.%int_32) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc11_44.2: <bound method> = bound_method %int_86, %specific_fn [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call: init %i32 = call %bound_method.loc11_44.2(%int_86) [concrete = constants.%int_86.261]
+// CHECK:STDOUT:   %.loc11_44.1: %i32 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_86.261]
+// CHECK:STDOUT:   %.loc11_44.2: %i32 = converted %int_86, %.loc11_44.1 [concrete = constants.%int_86.261]
+// CHECK:STDOUT:   %SOME_PRIVATE_CONSTANT: %i32 = value_binding SOME_PRIVATE_CONSTANT, %.loc11_44.2
+// CHECK:STDOUT:   %B.Fb.decl: %B.Fb.type = fn_decl @B.Fb [concrete = constants.%B.Fb] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness constants.%struct_type.base.5af [concrete = constants.%complete_type.0d1]
+// CHECK:STDOUT:   complete_type_witness = %complete_type
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%B
-// CHECK:STDOUT:   .F [private] = %B.F.decl
+// CHECK:STDOUT:   .A = <poisoned>
+// CHECK:STDOUT:   .base = %.loc9
+// CHECK:STDOUT:   .SOME_PRIVATE_CONSTANT [private] = %SOME_PRIVATE_CONSTANT
+// CHECK:STDOUT:   .Fb [private] = %B.Fb.decl
+// CHECK:STDOUT:   .Fa = <poisoned>
+// CHECK:STDOUT:   extend %A.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:   %.loc9: %C.elem = base_decl %B.ref, element0 [concrete]
-// CHECK:STDOUT:   %C.G.decl: %C.G.type = fn_decl @C.G [concrete = constants.%C.G] {} {}
-// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness constants.%struct_type.base [concrete = constants.%complete_type.021]
+// CHECK:STDOUT:   %.loc16: %C.elem = base_decl %B.ref, element0 [concrete]
+// CHECK:STDOUT:   %C.G1.decl: %C.G1.type = fn_decl @C.G1 [concrete = constants.%C.G1] {
+// CHECK:STDOUT:     %return.patt: %pattern_type.7ce = return_slot_pattern [concrete]
+// CHECK:STDOUT:     %return.param_patt: %pattern_type.7ce = out_param_pattern %return.patt, call_param0 [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %int_32: Core.IntLiteral = int_value 32 [concrete = constants.%int_32]
+// CHECK:STDOUT:     %i32: type = class_type @Int, @Int(constants.%int_32) [concrete = constants.%i32]
+// CHECK:STDOUT:     %return.param: ref %i32 = out_param call_param0
+// CHECK:STDOUT:     %return: ref %i32 = return_slot %return.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.G2.decl: %C.G2.type = fn_decl @C.G2 [concrete = constants.%C.G2] {} {}
+// CHECK:STDOUT:   %C.G3.decl: %C.G3.type = fn_decl @C.G3 [concrete = constants.%C.G3] {} {}
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness constants.%struct_type.base.64a [concrete = constants.%complete_type.021]
 // CHECK:STDOUT:   complete_type_witness = %complete_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
 // CHECK:STDOUT:   .B = <poisoned>
-// CHECK:STDOUT:   .base = %.loc9
-// CHECK:STDOUT:   .G = %C.G.decl
-// CHECK:STDOUT:   .F = <poisoned>
+// CHECK:STDOUT:   .base = %.loc16
+// CHECK:STDOUT:   .G1 = %C.G1.decl
+// CHECK:STDOUT:   .G2 = %C.G2.decl
+// CHECK:STDOUT:   .G3 = %C.G3.decl
+// CHECK:STDOUT:   .SOME_PRIVATE_CONSTANT = <poisoned>
+// CHECK:STDOUT:   .Fa = <poisoned>
+// CHECK:STDOUT:   .Fb = <poisoned>
 // CHECK:STDOUT:   extend %B.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @B.F() {
+// CHECK:STDOUT: fn @A.Fa() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @C.G() {
+// CHECK:STDOUT: fn @B.Fb() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: %B.F.type = name_ref F, @B.%B.F.decl [concrete = constants.%B.F]
-// CHECK:STDOUT:   %B.F.call: init %empty_tuple.type = call %F.ref()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @C.G1() -> %i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %SOME_PRIVATE_CONSTANT.ref: <error> = name_ref SOME_PRIVATE_CONSTANT, <error> [concrete = <error>]
+// CHECK:STDOUT:   return <error> to %return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @C.G2() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Fa.ref: <error> = name_ref Fa, <error> [concrete = <error>]
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @C.G3() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %Fb.ref: <error> = name_ref Fb, <error> [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/class/access.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/access.carbon
@@ -223,7 +223,7 @@ fn F(d: Derived) {
   let base_static_data: i32 = Cpp.C.static_data;
 }
 
-// --- todo_fail_import_non_function_member_private_extend_static_within_member_function.carbon
+// --- fail_import_non_function_member_private_extend_static_within_member_function.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -233,6 +233,13 @@ class Derived {
   extend base: Cpp.C;
   fn F() {
     // TODO: `C.static_data` is private, so this should fail.
+    // CHECK:STDERR: fail_import_non_function_member_private_extend_static_within_member_function.carbon:[[@LINE+7]]:40: error: cannot access private member `static_data` of type `Cpp.C` [ClassInvalidMemberAccess]
+    // CHECK:STDERR:     let unqualified_static_data: i32 = static_data;
+    // CHECK:STDERR:                                        ^~~~~~~~~~~
+    // CHECK:STDERR: fail_import_non_function_member_private_extend_static_within_member_function.carbon:[[@LINE+4]]:40: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     let unqualified_static_data: i32 = static_data;
+    // CHECK:STDERR:                                        ^~~~~~~~~~~
+    // CHECK:STDERR:
     let unqualified_static_data: i32 = static_data;
   }
 }
@@ -364,10 +371,12 @@ class Derived {
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~
     // CHECK:STDERR:
     self.instance_fn();
-    // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE+5]]:5: error: cannot access private member `static_fn` of type `Cpp.C` [ClassInvalidMemberAccess]
+    // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE+7]]:5: error: cannot access private member `static_fn` of type `Cpp.C` [ClassInvalidMemberAccess]
     // CHECK:STDERR:     static_fn();
-    // CHECK:STDERR:     ^~~~~~~~~~~
-    // CHECK:STDERR: fail_import_function_member_private.carbon: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     ^~~~~~~~~
+    // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE+4]]:5: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     static_fn();
+    // CHECK:STDERR:     ^~~~~~~~~
     // CHECK:STDERR:
     static_fn();
     // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE+7]]:5: error: cannot access private member `static_fn` of type `Cpp.C` [ClassInvalidMemberAccess]
@@ -393,7 +402,7 @@ fn F(c: Cpp.C*) {
   // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE+7]]:3: error: cannot access private member `instance_fn` of type `Cpp.C` [ClassInvalidMemberAccess]
   // CHECK:STDERR:   c->instance_fn();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE-30]]:5: note: declared here [ClassMemberDeclaration]
+  // CHECK:STDERR: fail_import_function_member_private.carbon:[[@LINE-32]]:5: note: declared here [ClassMemberDeclaration]
   // CHECK:STDERR:     self.instance_fn();
   // CHECK:STDERR:     ^~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -746,22 +755,28 @@ class Derived {
   extend base: Cpp.Private;
 
   fn F() {
-    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+5]]:5: error: cannot access private member `Overload` of type `Cpp.Private` [ClassInvalidMemberAccess]
+    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+7]]:5: error: cannot access private member `Overload` of type `Cpp.Private` [ClassInvalidMemberAccess]
     // CHECK:STDERR:     Overload(Cpp.PublicCall.PublicCall());
-    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     ^~~~~~~~
+    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+4]]:5: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     Overload(Cpp.PublicCall.PublicCall());
+    // CHECK:STDERR:     ^~~~~~~~
     // CHECK:STDERR:
     Overload(Cpp.PublicCall.PublicCall());
-    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+5]]:5: error: cannot access private member `Overload` of type `Cpp.Private` [ClassInvalidMemberAccess]
+    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+7]]:5: error: cannot access private member `Overload` of type `Cpp.Private` [ClassInvalidMemberAccess]
     // CHECK:STDERR:     Overload(Cpp.ProtectedCall.ProtectedCall());
-    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     ^~~~~~~~
+    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE-4]]:5: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     Overload(Cpp.PublicCall.PublicCall());
+    // CHECK:STDERR:     ^~~~~~~~
     // CHECK:STDERR:
     Overload(Cpp.ProtectedCall.ProtectedCall());
-    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+5]]:5: error: cannot access private member `Overload` of type `Cpp.Private` [ClassInvalidMemberAccess]
+    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE+7]]:5: error: cannot access private member `Overload` of type `Cpp.Private` [ClassInvalidMemberAccess]
     // CHECK:STDERR:     Overload(Cpp.PrivateCall.PrivateCall());
-    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     ^~~~~~~~
+    // CHECK:STDERR: fail_import_overload_set_private_base_class_derived.carbon:[[@LINE-12]]:5: note: declared here [ClassMemberDeclaration]
+    // CHECK:STDERR:     Overload(Cpp.PublicCall.PublicCall());
+    // CHECK:STDERR:     ^~~~~~~~
     // CHECK:STDERR:
     Overload(Cpp.PrivateCall.PrivateCall());
   }


### PR DESCRIPTION
### Description
Currently, unqualified access to private members of the base class compiles without error. This is due to `LookupUnqualifiedName` calling `LookupQualifiedName` internally with `access_info` parameter set to `std::nullopt`. This causes `IsAccessProhibited` to return `false` immediately.
This PR fixes this issue.

### Changes
- Added a check where if the `access_info` is null and the current scope we are looking is an extended scope (parent), initializes the `access_info` with `highest_allowed_access` set to `Protected`.

Fixes #6239
