### PR TITLE
Add support for installing compiler-rt provided headers

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -121,6 +121,7 @@ http_archive(
         "@carbon//bazel/llvm_project:0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch",
         "@carbon//bazel/llvm_project:0006_Add_a_filegroup_containing__all__sources_to_the_libc_build_rules.patch",
         "@carbon//bazel/llvm_project:0007_Remove_target_compatibility_restrictions_for_float128.patch",
+        "@carbon//bazel/llvm_project:0008_Add_filegroups_for_installed_compiler-rt_headers.patch",
     ],
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],

--- a/bazel/llvm_project/0008_Add_filegroups_for_installed_compiler-rt_headers.patch
+++ b/bazel/llvm_project/0008_Add_filegroups_for_installed_compiler-rt_headers.patch
@@ -1,0 +1,35 @@
+Commit ID: e92461dc72d53b737ac14fe2c4c9c539946a4318
+Change ID: xyswklonuwpozzpkzwowszwnrzvkonxu
+Author   : Chandler Carruth <chandlerc@gmail.com> (2025-12-30 10:19:01)
+Committer: Chandler Carruth <chandlerc@gmail.com> (2025-12-30 21:28:56)
+
+    Add filegroups for installed compiler-rt headers
+
+    These are installed along-side the builtin Clang headers.
+
+diff --git a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+index 115da4cb77..ebe376fcaa 100644
+--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+@@ -131,6 +131,21 @@
+     ],
+ )
+ 
++filegroup(
++    name = "fuzzer_installed_hdrs",
++    srcs = glob(["include/fuzzer/*.h"]),
++)
++
++filegroup(
++    name = "profile_installed_hdrs",
++    srcs = glob(["include/profile/*.h"]),
++)
++
++filegroup(
++    name = "sanitizer_installed_hdrs",
++    srcs = glob(["include/sanitizer/*.h"]),
++)
++
+ BUILTINS_CRTBEGIN_SRCS = ["lib/builtins/crtbegin.c"]
+ 
+ filegroup(

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -363,6 +363,23 @@ install_dirs = {
             remove_prefix = "staging/include/",
         ),
     ],
+    "lib/carbon/llvm/lib/clang/" + LLVM_VERSION_MAJOR + "/include": [
+        install_filegroup(
+            "fuzzer",
+            "@llvm-project//compiler-rt:fuzzer_installed_hdrs",
+            remove_prefix = "include/fuzzer/",
+        ),
+        install_filegroup(
+            "profile",
+            "@llvm-project//compiler-rt:profile_installed_hdrs",
+            remove_prefix = "include/profile/",
+        ),
+        install_filegroup(
+            "sanitizer",
+            "@llvm-project//compiler-rt:sanitizer_installed_hdrs",
+            remove_prefix = "include/sanitizer/",
+        ),
+    ],
 }
 
 make_install_filegroups(


### PR DESCRIPTION
These are installed as part of the builtin headers, but located in a different part of upstream LLVM.