### PR TITLE
Use CTAD for llvm::scope_exit

### DIFF
--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -121,7 +121,7 @@ auto RunTestFile(const FileTestBase& test_base, bool dump_output,
 
   // stdin needs to exist on-disk for compatibility. We'll use a pointer for it.
   FILE* input_stream = nullptr;
-  auto erase_input_on_exit = llvm::make_scope_exit([&input_stream]() {
+  auto erase_input_on_exit = llvm::scope_exit([&input_stream]() {
     if (input_stream) {
       // fclose should delete the tmpfile.
       fclose(input_stream);

--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -121,7 +121,7 @@ auto RunTestFile(const FileTestBase& test_base, bool dump_output,
 
   // stdin needs to exist on-disk for compatibility. We'll use a pointer for it.
   FILE* input_stream = nullptr;
-  auto erase_input_on_exit = llvm::scope_exit([&input_stream]() {
+  auto erase_input_on_exit = llvm::make_scope_exit([&input_stream]() {
     if (input_stream) {
       // fclose should delete the tmpfile.
       fclose(input_stream);

--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -121,7 +121,7 @@ auto RunTestFile(const FileTestBase& test_base, bool dump_output,
 
   // stdin needs to exist on-disk for compatibility. We'll use a pointer for it.
   FILE* input_stream = nullptr;
-  auto erase_input_on_exit = llvm::scope_exit([&input_stream]() {
+  llvm::scope_exit erase_input_on_exit ([&input_stream]() {
     if (input_stream) {
       // fclose should delete the tmpfile.
       fclose(input_stream);

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -70,7 +70,7 @@ class DriverTest : public testing::Test {
     std::filesystem::current_path(test_dir, ec);
     CARBON_CHECK(!ec, "Could not change the current working dir to '{0}': {1}",
                  test_dir, ec.message());
-    return llvm::make_scope_exit([original_dir, test_dir] {
+    return llvm::scope_exit([original_dir, test_dir] {
       std::error_code ec;
       std::filesystem::current_path(original_dir, ec);
       CARBON_CHECK(!ec,

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -70,7 +70,7 @@ class DriverTest : public testing::Test {
     std::filesystem::current_path(test_dir, ec);
     CARBON_CHECK(!ec, "Could not change the current working dir to '{0}': {1}",
                  test_dir, ec.message());
-    return llvm::scope_exit([original_dir, test_dir] {
+    return llvm::make_scope_exit([original_dir, test_dir] {
       std::error_code ec;
       std::filesystem::current_path(original_dir, ec);
       CARBON_CHECK(!ec,


### PR DESCRIPTION
Replace deprecated usage of `llvm::make_scope_exit` which was marked deprecated in https://github.com/llvm/llvm-project/pull/174109