### PR TITLE
Update `tree-sitter-bazel` to `0.26.3`.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,7 +37,7 @@ bazel_dep(name = "rules_cc", version = "0.1.4")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "rules_shell", version = "0.5.0")
 bazel_dep(name = "tcmalloc", version = "0.0.0-20250331-43fcf6e")
-bazel_dep(name = "tree-sitter-bazel", version = "0.24.4")
+bazel_dep(name = "tree-sitter-bazel", version = "0.26.3")
 
 # The registry only has an old version. We use that here to avoid a miss but
 # override it with a newer version.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -55,7 +55,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20240530-2db0eb3/MODULE.bazel": "d0405b762c5e87cd445b7015f2b8da5400ef9a8dbca0bfefa6c1cea79d528a97",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20240530-2db0eb3/source.json": "0d413869349e82e5d679802abe9ce23e0326bbf56daa97ae9e7dbdcec72982fc",
     "https://bcr.bazel.build/modules/brotli/1.1.0/MODULE.bazel": "3b5b90488995183419c4b5c9b063a164f6c0bc4d0d6b40550a612a5e860cc0fe",
@@ -210,7 +211,8 @@
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.5.0/MODULE.bazel": "8c8447370594d45539f66858b602b0bb2cb2d3401a4ebb9ad25830c59c0f366d",
-    "https://bcr.bazel.build/modules/rules_shell/0.5.0/source.json": "3038276f07cbbdd1c432d1f80a2767e34143ffbb03cfa043f017e66adbba324c",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
@@ -229,8 +231,8 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
     "https://bcr.bazel.build/modules/tcmalloc/0.0.0-20250331-43fcf6e/MODULE.bazel": "2c96170a724216604dd73a8295eeb234cdd45a34bfd212ed2e951d4463422ab8",
     "https://bcr.bazel.build/modules/tcmalloc/0.0.0-20250331-43fcf6e/source.json": "ee9f0745abbe18ae6e3c848409058d870cab6add7fa1daaf02443e502aa500a3",
-    "https://bcr.bazel.build/modules/tree-sitter-bazel/0.24.4/MODULE.bazel": "5f23d216376ea547e4b8f8819c201e70c59010ca2badd2a89a226b03e048b847",
-    "https://bcr.bazel.build/modules/tree-sitter-bazel/0.24.4/source.json": "0ad3631cf2c38fb32445968acbc800f5bcff3503f7ca136c0b2d2c7b7d06a60c",
+    "https://bcr.bazel.build/modules/tree-sitter-bazel/0.26.3/MODULE.bazel": "a8fd6d719b263ddcee9798ec4863ea38a1cca43f125d41a2b7a0af4031af407f",
+    "https://bcr.bazel.build/modules/tree-sitter-bazel/0.26.3/source.json": "dc86f3ffec415a00bd652f5db12f7d7b6121e389874be2f12cc9be9215e409c4",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.1/MODULE.bazel": "c037f75fa1b7e1ff15fbd15d807a8ce545e9b02f02df0a9777aa9aa7d8b268bb",
@@ -404,7 +406,7 @@
     },
     "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
       "general": {
-        "bzlTransitiveDigest": "V5ev1FhHLOcCEg5Z+fZoGF9viuAmug8oiJgV5I6kuO8=",
+        "bzlTransitiveDigest": "DKG756yy334fy13r7XW5ZeBLFQP1GZnmqVpCsytUDKk=",
         "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -861,8 +863,8 @@
     },
     "@@tree-sitter-bazel+//:extensions.bzl%tree_sitter_source_code": {
       "general": {
-        "bzlTransitiveDigest": "ZERlJhvjMDpy/7u2yrFDBPTwzbnpEvgLwn1Y0qlM/vQ=",
-        "usagesDigest": "+A8gOKWptG2ZhzIqOP3jb/D4vpatFdmbOLuveV6t1Yw=",
+        "bzlTransitiveDigest": "rNrgpnNDI9R9A9T4s43fAzagKIEdj9tmYTfKzHLEMPI=",
+        "usagesDigest": "ft88BfUhh6lgsY8yqWgisxpNtX/OxzdOe47UvaI+/Us=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -871,11 +873,11 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.24.4.tar.gz"
+                "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.26.3.tar.gz"
               ],
               "sha256": "",
-              "integrity": "sha384-Af1RSXWjSyY7gKQ9W4kaUrJm6EaDFXfCDb1Ca25yZTBQ3hS9Ye7ev57dEGTvAbpz",
-              "strip_prefix": "tree-sitter-0.24.4",
+              "integrity": "sha384-hjXxOdrMwTow3ji5CeIL5UchJHXQYTIU/MOZ4cG+TPqS0kQaEF9HsGianilGFIY+",
+              "strip_prefix": "tree-sitter-0.26.3",
               "build_file_content": "exports_files(glob([\"lib/**\"]))"
             }
           }


### PR DESCRIPTION
Hi, `tree-sitter-bazel`'s maintainer here. :)

I just [updated](https://github.com/bazelbuild/bazel-central-registry/pull/6486) `tree-sitter-bazel` to `0.26.3`.

I figured that you may want to update as well, since `0.24.4` is one year old.
