### PR TITLE
Reduce libc++ hardening mode from debug to extensive in `-c dbg`.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -609,8 +609,13 @@ def _impl(ctx):
 
     # Clang HARDENING_MODE has 4 possible values:
     # https://libcxx.llvm.org/Hardening.html#notes-for-users
+    #
+    # Do not enable DEBUG hardening mode, even for -c dbg, because its
+    # performance impact on llvm-symbolizer is too severe -- this flag
+    # results in symbolization becoming quadratic in the number of debug
+    # symbols, in practice meaning it never completes.
     libcpp_debug_flags = [
-        "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG",
+        "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
     ]
     libcpp_release_flags = [
         "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST",


### PR DESCRIPTION
These checks include a full check that a red-black tree satisfies its invariants on every erase. This leads to
`llvm::DWARFDebugAranges::construct` becoming quadratic in the number of debug symbols in the binary, which means that in `-c dbg`, symbolization of backtraces is astronomically slow, and in practice never completes. (I left it for over 12 hours and it did not finish.)

Reduce the libc++ hardening mode from *debug* to *extensive* to turn off the checks that have unbounded performance impact.