### PR TITLE
Use libc++ extensive hardening mode in debug builds

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -663,7 +663,7 @@ def _impl(ctx):
     # Clang HARDENING_MODE has 4 possible values:
     # https://libcxx.llvm.org/Hardening.html#notes-for-users
     libcpp_debug_flags = [
-        "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG",
+        "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
     ]
     libcpp_release_flags = [
         "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST",


### PR DESCRIPTION
The debug hardening mode is extremely expensive, causing ~infinite computation when building a backtrace, as it does things like linear work inside of `std::mutiset::erase`. The debug hardening mode doesn't seem suitable then for end users of libc++.