### PR TITLE
Prune deps to reduce compiles by ~30%

### DIFF
--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -421,7 +421,6 @@ cc_binary(
         "//common:init_llvm",
         "//common:map",
         "//common:vlog",
-        "//toolchain/base:install_paths",
         "@llvm-project//llvm:Support",
     ],
 )


### PR DESCRIPTION
The `install_paths` library depends on the `llvm_tools` library, which
depends on all of LLVM in order to allow _invoking_ the LLVM tools in
addition to listing and manipulating them. The `install_paths` also
depends on the Clang version number which for some reason depends
transitively on a large fraction of LLVM. That should probably be fixed,
but we don't actually need it anyways, we can just prune our dependency.

Because the digest builder is built in the _exec_ configuration, this
was pulling in most of LLVM and Clang to build in the exec configuration
as well, adding about 4000 actions or a roughly 30% overhead to complete
rebuilds. The time impact is likely closer to 2x because many of the
slowest actions are here.

Hopefully this makes our bots take much less time when rebuilding.
