### PR TITLE
Add a dependency for the `StringRef.h` header

### DIFF
--- a/toolchain/base/runtime_sources.bzl
+++ b/toolchain/base/runtime_sources.bzl
@@ -182,6 +182,7 @@ def generate_runtime_sources_cc_library(name, deps = [], **kwargs):
         name = name,
         hdrs = ["runtime_sources.h"],
         deps = [
+            // For StringRef.h
             "@llvm-project//llvm:Support",
         ] + deps,
         **kwargs

--- a/toolchain/base/runtime_sources.bzl
+++ b/toolchain/base/runtime_sources.bzl
@@ -182,7 +182,7 @@ def generate_runtime_sources_cc_library(name, deps = [], **kwargs):
         name = name,
         hdrs = ["runtime_sources.h"],
         deps = [
-            // For StringRef.h
+            # For StringRef.h
             "@llvm-project//llvm:Support",
         ] + deps,
         **kwargs

--- a/toolchain/base/runtime_sources.bzl
+++ b/toolchain/base/runtime_sources.bzl
@@ -167,7 +167,7 @@ generate_runtime_sources_h = rule(
     },
 )
 
-def generate_runtime_sources_cc_library(name, **kwargs):
+def generate_runtime_sources_cc_library(name, deps = [], **kwargs):
     """Generates a `runtime_sources.h` header and a `cc_library` rule for it.
 
     This first generates the header file with variables describing the runtime
@@ -181,5 +181,8 @@ def generate_runtime_sources_cc_library(name, **kwargs):
     cc_library(
         name = name,
         hdrs = ["runtime_sources.h"],
+        deps = [
+            "@llvm-project//llvm:Support",
+        ] + deps,
         **kwargs
     )


### PR DESCRIPTION
Without this we have problems with builds that enable header parsing.