### PR TITLE
Switch CPU flags to use feature-based selection and apply to links

### DIFF
--- a/bazel/cc_toolchains/cc_toolchain_config_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_config_features.bzl
@@ -32,3 +32,18 @@ def target_os_features(os):
         fail("Unsupported target OS: %s" % os)
 
     return os_target_features[os]
+
+aarch64_target_feature = feature(name = "aarch64_target", enabled = True)
+x86_64_target_feature = feature(name = "x86_64_target", enabled = True)
+
+cpu_target_features = {
+    "aarch64": [aarch64_target_feature],
+    "arm64": [aarch64_target_feature],
+    "x86_64": [x86_64_target_feature],
+}
+
+def target_cpu_features(cpu):
+    if cpu not in cpu_target_features:
+        fail("Unsupported target CPU: %s" % cpu)
+
+    return cpu_target_features[cpu]

--- a/bazel/cc_toolchains/cc_toolchain_optimization.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_optimization.bzl
@@ -10,10 +10,12 @@ load(
     "feature_set",
     "flag_group",
     "flag_set",
+    "with_feature_set",
 )
 load(
     ":cc_toolchain_actions.bzl",
     "all_compile_actions",
+    "all_link_actions",
     "codegen_compile_actions",
 )
 
@@ -43,22 +45,21 @@ default_optimization_flags = feature(
     ],
 )
 
-aarch64_cpu_flags = feature(
+cpu_flags = feature(
     name = "aarch64_cpu_flags",
     enabled = True,
-    flag_sets = [flag_set(
-        actions = all_compile_actions,
-        flag_groups = [flag_group(flags = ["-march=armv8.2-a"])],
-    )],
-)
-
-x86_64_cpu_flags = feature(
-    name = "x86_64_cpu_flags",
-    enabled = True,
-    flag_sets = [flag_set(
-        actions = all_compile_actions,
-        flag_groups = [flag_group(flags = ["-march=x86-64-v2"])],
-    )],
+    flag_sets = [
+        flag_set(
+            actions = all_compile_actions + all_link_actions,
+            flag_groups = [flag_group(flags = ["-march=armv8.2-a"])],
+            with_features = [with_feature_set(["aarch64_target"])],
+        ),
+        flag_set(
+            actions = all_compile_actions + all_link_actions,
+            flag_groups = [flag_group(flags = ["-march=x86-64-v2"])],
+            with_features = [with_feature_set(["x86_64_target"])],
+        ),
+    ],
 )
 
 # Note that the order of features is significant in this list and determines the
@@ -66,4 +67,5 @@ x86_64_cpu_flags = feature(
 optimization_features = [
     minimal_optimization_flags,
     default_optimization_flags,
+    cpu_flags,
 ]

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -26,7 +26,11 @@ load(
     "output_flags_feature",
     "user_flags_feature",
 )
-load(":cc_toolchain_config_features.bzl", "target_os_features")
+load(
+    ":cc_toolchain_config_features.bzl",
+    "target_cpu_features",
+    "target_os_features",
+)
 load(
     ":cc_toolchain_cpp_features.bzl",
     "clang_feature",
@@ -41,12 +45,7 @@ load(
     "macos_link_libraries_feature",
 )
 load(":cc_toolchain_modules.bzl", "modules_features")
-load(
-    ":cc_toolchain_optimization.bzl",
-    "aarch64_cpu_flags",
-    "optimization_features",
-    "x86_64_cpu_flags",
-)
+load(":cc_toolchain_optimization.bzl", "optimization_features")
 load(":cc_toolchain_sanitizer_features.bzl", "sanitizer_features")
 load(
     ":cc_toolchain_tools.bzl",
@@ -128,6 +127,7 @@ def _build_features(ctx):
     features = []
     features += base_features
     features += target_os_features(ctx.attr.target_os)
+    features += target_cpu_features(ctx.attr.target_cpu)
     features += [
         # We always use Clang in the toolchain and enable all of its warnings.
         clang_feature,
@@ -140,16 +140,7 @@ def _build_features(ctx):
         project_flags_feature,
     ]
     features += sanitizer_features
-
     features += optimization_features
-
-    # TODO: Refactor target-specific feature management to be part of
-    # `optimization_features`.
-    if ctx.attr.target_cpu in ["aarch64", "arm64"]:
-        features.append(aarch64_cpu_flags)
-    else:
-        features.append(x86_64_cpu_flags)
-
     features += modules_features
     features += debugging_features
     features += linking_features


### PR DESCRIPTION
Now the CPU flags feature can be unconditionally added as part of the
optimization features and another of the conditions in the main
configuration goes away.

The failure to pass these to links was probably harmless, but it's
better to include it there as well.