### PR TITLE
Propagate tags on `prebuilt_runtimes` to the filegroup

### DIFF
--- a/toolchain/driver/prebuilt_runtimes.bzl
+++ b/toolchain/driver/prebuilt_runtimes.bzl
@@ -174,4 +174,5 @@ def prebuilt_runtimes(name, target = None, tags = []):
         srcs = [
             ":" + name + "_clang",
         ],
+        tags = tags,
     )


### PR DESCRIPTION
These were already applied to the internal rule for the Clang-built runtimes, but were then dropped from the filegroup which would often negate their effect.