### PR TITLE
Remove unused parts of configuring a `cc_toolchain`

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -94,19 +94,10 @@ def _impl(ctx):
         # This configuration only supports local non-cross builds so derive
         # everything from the target CPU selected.
         toolchain_identifier = identifier,
-        host_system_name = identifier,
-        target_system_name = identifier,
-        target_cpu = ctx.attr.target_cpu,
 
         # This is used to expose a "flag" that `config_setting` rules can use to
         # determine if the compiler is Clang.
         compiler = "clang",
-
-        # These attributes aren't meaningful at all so just use placeholder
-        # values.
-        target_libc = "local",
-        abi_version = "local",
-        abi_libc_version = "local",
 
         # We do have to pass in our tool paths.
         tool_paths = llvm_tool_paths(llvm_bindir, clang_bindir),


### PR DESCRIPTION
These can be completely skipped at this point without issue.