### PR TITLE
Extract the `cc_toolchain` feature generation to a helper function

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -252,7 +252,7 @@
   "moduleExtensions": {
     "//bazel/cc_toolchains:clang_configuration.bzl%clang_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "owIfgyIggWlM+ycSaq7Niq1Qiq8J0/TlPl8w79qPBgY=",
+        "bzlTransitiveDigest": "44/bjnoCpU6JrWf798MGhACH/QjSv0OkcCi/jF+EGg0=",
         "usagesDigest": "lTxkeAFhR0iBEa3dg5hWvtd2HFCr5zCJx/fl27A+IKA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/cc_toolchains/cc_toolchain_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_features.bzl
@@ -1,0 +1,75 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Helpers to construct ordered sequences of `cc_toolchain` features."""
+
+load(
+    ":cc_toolchain_base_features.bzl",
+    "base_features",
+    "output_flags_feature",
+    "user_flags_feature",
+)
+load(
+    ":cc_toolchain_config_features.bzl",
+    "target_cpu_features",
+    "target_os_features",
+)
+load(
+    ":cc_toolchain_cpp_features.bzl",
+    "clang_feature",
+    "clang_warnings_feature",
+)
+load(":cc_toolchain_debugging.bzl", "debugging_features")
+load(":cc_toolchain_linking.bzl", "linking_features")
+load(":cc_toolchain_modules.bzl", "modules_features")
+load(":cc_toolchain_optimization.bzl", "optimization_features")
+load(":cc_toolchain_sanitizer_features.bzl", "sanitizer_features")
+
+def clang_cc_toolchain_features(
+        target_os,
+        target_cpu,
+        project_features = [],
+        extra_cpp_features = []):
+    """Builds a sequence of Clang-oriented `cc_toolchain_config` features.
+
+    Returns:
+        The list of features for calling `create_cc_toolchain_config_info`.
+
+    Args:
+        target_os: Used to select OS-specific features to include.
+        target_cpu: Used to select CPU-specific features to include.
+        project_features: Optional list of project-specific features to include.
+        extra_cpp_features: Optional list of extra C++ features to include, for
+            example `libcxx_feature` can be passed here to enable using libc++.
+    """
+
+    # The order of the features determines the relative order of flags used.
+    features = []
+    features += target_os_features(target_os)
+    features += target_cpu_features(target_cpu)
+    features += base_features
+    features += [
+        # We always use Clang in the toolchain and enable all of its warnings.
+        clang_feature,
+        clang_warnings_feature,
+    ]
+
+    # Enable any extra baseline C++ features here where others can override
+    # their flags if needed.
+    features += extra_cpp_features
+
+    features += sanitizer_features
+    features += optimization_features
+    features += modules_features
+    features += debugging_features
+    features += linking_features
+
+    # Lastly, we add project features and the user flags so they can override
+    # anything above, and the output flags last of all for ease of debugging.
+    features += project_features
+    features += [
+        user_flags_feature,
+        output_flags_feature,
+    ]
+    return features

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -6,29 +6,9 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
-load(
-    ":cc_toolchain_base_features.bzl",
-    "base_features",
-    "output_flags_feature",
-    "user_flags_feature",
-)
 load(":cc_toolchain_carbon_project_features.bzl", "carbon_project_features")
-load(
-    ":cc_toolchain_config_features.bzl",
-    "target_cpu_features",
-    "target_os_features",
-)
-load(
-    ":cc_toolchain_cpp_features.bzl",
-    "clang_feature",
-    "clang_warnings_feature",
-    "libcxx_feature",
-)
-load(":cc_toolchain_debugging.bzl", "debugging_features")
-load(":cc_toolchain_linking.bzl", "linking_features")
-load(":cc_toolchain_modules.bzl", "modules_features")
-load(":cc_toolchain_optimization.bzl", "optimization_features")
-load(":cc_toolchain_sanitizer_features.bzl", "sanitizer_features")
+load(":cc_toolchain_cpp_features.bzl", "libcxx_feature")
+load(":cc_toolchain_features.bzl", "clang_cc_toolchain_features")
 load(
     ":cc_toolchain_tools.bzl",
     "llvm_action_configs",
@@ -44,34 +24,6 @@ load(
     "sysroot_dir",
 )
 
-def _build_features(ctx):
-    # The order of the features determines the relative order of flags used.
-    features = []
-    features += target_os_features(ctx.attr.target_os)
-    features += target_cpu_features(ctx.attr.target_cpu)
-    features += base_features
-    features += [
-        # We always use Clang in the toolchain and enable all of its warnings.
-        clang_feature,
-        clang_warnings_feature,
-        # Enable libc++ where supported.
-        libcxx_feature(llvm_bindir, clang_bindir),
-    ]
-    features += sanitizer_features
-    features += optimization_features
-    features += modules_features
-    features += debugging_features
-    features += linking_features
-
-    # Lastly, we add project features and the user flags so they can override
-    # anything above, and the output flags last of all for ease of debugging.
-    features += carbon_project_features(clang_version_for_cache)
-    features += [
-        user_flags_feature,
-        output_flags_feature,
-    ]
-    return features
-
 def _impl(ctx):
     # Only use a sysroot if one was found when detecting Clang.
     sysroot = None
@@ -81,7 +33,12 @@ def _impl(ctx):
     identifier = "local-{0}-{1}".format(ctx.attr.target_cpu, ctx.attr.target_os)
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
-        features = _build_features(ctx),
+        features = clang_cc_toolchain_features(
+            target_os = ctx.attr.target_os,
+            target_cpu = ctx.attr.target_cpu,
+            project_features = carbon_project_features(clang_version_for_cache),
+            extra_cpp_features = [libcxx_feature(llvm_bindir, clang_bindir)],
+        ),
         action_configs = llvm_action_configs(llvm_bindir, clang_bindir),
         cxx_builtin_include_directories = clang_include_dirs_list + [
             # Add Clang's resource directory to the end of the builtin include

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -268,6 +268,7 @@ configure_clang_toolchain = repository_rule(
                 Label("//bazel/cc_toolchains:cc_toolchain_config_features.bzl"),
                 Label("//bazel/cc_toolchains:cc_toolchain_cpp_features.bzl"),
                 Label("//bazel/cc_toolchains:cc_toolchain_debugging.bzl"),
+                Label("//bazel/cc_toolchains:cc_toolchain_features.bzl"),
                 Label("//bazel/cc_toolchains:cc_toolchain_linking.bzl"),
                 Label("//bazel/cc_toolchains:cc_toolchain_modules.bzl"),
                 Label("//bazel/cc_toolchains:cc_toolchain_optimization.bzl"),


### PR DESCRIPTION
This is the last really generic part of the toolchain config that I can
see to factor out with a reasonably small API surface.