### PR TITLE
Disable build stamping by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,12 +2,15 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Ensure all builds have Carbon's workspace status attached. We have carefully
-# factored the stamping done by this to avoid excessive build performance impact
-# and so enable stamping with it by default. CI and systems especially dependent
-# on caching should explicitly use `--nostamp`.
+# Setup stamping with Carbon's workspace status attached but disable it by
+# default.
+#
+# Note that while we have minimized the impact of stamping on build caching, it
+# still has a meaningful impact, especially during development. So we disable
+# stamping by default and builds that need to include the workspace status
+# should explicitly enable it with `--stamp`.
 common --workspace_status_command=./scripts/workspace_status.py
-common --stamp
+common --nostamp
 
 # Provide aliases for configuring the release and pre-release version being
 # built. For documentation of these flags, see //bazel/version/BUILD.

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           ./scripts/run_bazel.py \
             --attempts=5 --jobs-on-last-attempt=4 \
-            test -c opt --remote_download_toplevel \
+            test -c opt --stamp --remote_download_toplevel \
             --pre_release=nightly --nightly_date=${{ env.nightly_date }} \
             //toolchain \
             //toolchain/install:carbon_toolchain_tar_gz_rule \


### PR DESCRIPTION
Previously, we left it on by default and only disabled it in CI. However, as we have grown more and more examples, the cost of stamping has steadily risen: every example has to be rebuilt because the busybox binary and installation contain an updated stamp.

I noticed that I was almost never getting cache hits for these even when I should and it seems like what was once true is no more for daily development.

I've updated the default, the docs for the default, and explicitly enabled stamping in the nightly release workflow. I left the explicit disabling in the CI workflows as that seems harmless and a good defense in case we want to shift the default again.

One alternative that I didn't pursue because of the complexity was to create two distinct installation prefixes automatically, one with the `.nostamp` suffixed binaries installed and one without that suffix. We could then point example builds and other within-Bazel uses at the non-stamped tree to get maximal caching. But it would create two whole installation trees without much benefit. It seemed simpler to just disable stamping by default for development builds.